### PR TITLE
[Map Function] add assert statement if map function does not return dict or None

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -390,12 +390,13 @@ class Dataset(object):
             """ Does the function returns a dict. """
             processed_inputs = function(inputs, indices) if with_indices else function(inputs)
             does_return_dict = isinstance(processed_inputs, Mapping)
-            all_dict_values_are_lists = all(isinstance(value, list) for value in processed_inputs.values())
 
             if does_return_dict is False and processed_inputs is not None:
                 raise TypeError("Provided `function` which is applied to all elements of table returns a variable of type {}. Make sure provided `function` returns a variable of type `dict` to update the dataset or `None` if you are only interested in side effects.".format(type(processed_inputs)))
-            elif does_return_dict is True and all_dict_values_are_lists is False:
-                raise TypeError("Provided `function` which is applied to all elements of table returns a `dict` of types {}. Make sure provided `function` returns a `dict` of types `list`.".format([type(x) for x in processed_inputs.values()]))
+            elif isinstance(test_indices, list) and does_return_dict is True:
+                all_dict_values_are_lists = all(isinstance(value, list) for value in processed_inputs.values())
+                if all_dict_values_are_lists is False:
+                    raise TypeError("Provided `function` which is applied to all elements of table returns a `dict` of types {}. When using `batched=True`, make sure provided `function` returns a `dict` of types `list`.".format([type(x) for x in processed_inputs.values()]))
 
             return does_return_dict
 


### PR DESCRIPTION
IMO, if a function is provided that is not a print statement (-> returns variable of type `None`) or a function that updates the datasets (-> returns variable of type `dict`), then a `TypeError` should be raised. 

Not sure whether you had cases in mind where the user should do something else @thomwolf , but I think a lot of silent errors can be avoided with this assert statement.