### PR TITLE
[Circle ci] Install a virtual env before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         resource_class: medium
         steps:
             - checkout
-            - run: python -m --system-site-packages venv venv
+            - run: python -m venv venv
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: python -m pytest -sv ./tests/test_dataset_common.py


### PR DESCRIPTION
Install a virtual env before running tests to not running into sudo issues when dynamically downloading files. 

Same number of tests now pass / fail as on my local computer: 
![Screenshot from 2020-05-01 12-14-44](https://user-images.githubusercontent.com/23423619/80798814-8a0a0a80-8ba5-11ea-8db8-599d33bbfccd.png)

