### PR TITLE
[Tests] fix typo

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -151,5 +151,5 @@ class DatasetTest(parameterized.TestCase):
     def test_load_real_dataset(self, dataset_name):
         with tempfile.TemporaryDirectory() as temp_data_dir:
             dataset = load(dataset_name, data_dir=temp_data_dir)
-            for split in dataset.info.splits.keys():
+            for split in dataset.keys():
                 self.assertTrue(len(dataset[split]) > 0)


### PR DESCRIPTION
@lhoestq - currently the slow test fail with:

```
_____________________________________________________________________________________ DatasetTest.test_load_real_dataset_xnli _____________________________________________________________________________________
                                                                     
self = <tests.test_dataset_common.DatasetTest testMethod=test_load_real_dataset_xnli>, dataset_name = 'xnli'
                                   
    @slow                                                                                               
    def test_load_real_dataset(self, dataset_name):
        with tempfile.TemporaryDirectory() as temp_data_dir:                                                                                                                                                      
>           dataset = load(dataset_name, data_dir=temp_data_dir)
                                                                                                                                                                                                                   
tests/test_dataset_common.py:153:                                                                                                                                                                                  
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../python_bin/nlp/load.py:497: in load                                                                     
    dbuilder.download_and_prepare(**download_and_prepare_kwargs)
../../python_bin/nlp/builder.py:383: in download_and_prepare
    self._download_and_prepare(dl_manager=dl_manager, download_config=download_config)
../../python_bin/nlp/builder.py:627: in _download_and_prepare
    dl_manager=dl_manager, max_examples_per_split=download_config.max_examples_per_split,
../../python_bin/nlp/builder.py:431: in _download_and_prepare
    split_generators = self._split_generators(dl_manager, **split_generators_kwargs)
../../python_bin/nlp/datasets/xnli/8bf4185a2da1ef2a523186dd660d9adcf0946189e7fa5942ea31c63c07b68a7f/xnli.py:95: in _split_generators                                                                               
    dl_dir = dl_manager.download_and_extract(_DATA_URL)
../../python_bin/nlp/utils/download_manager.py:246: in download_and_extract
    return self.extract(self.download(url_or_urls))         
../../python_bin/nlp/utils/download_manager.py:186: in download                       
    self._record_sizes_checksums(url_or_urls, downloaded_path_or_paths)
../../python_bin/nlp/utils/download_manager.py:166: in _record_sizes_checksums           
    self._recorded_sizes_checksums[url] = get_size_checksum(path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                                                                              
path = ('', '/tmp/tmpkajlg9yc/downloads/c0f7773c480a3f2d85639d777e0e17e65527460310d80760fd3fc2b2f2960556.c952a63cb17d3d46e412ceb7dbcd656ce2b15cc9ef17f50c28f81c48a7c853b5')
                                                                                                                                                                                                                   
    def get_size_checksum(path: str) -> Tuple[int, str]:
        """Compute the file size and the sha256 checksum of a file"""                                                                                            
        m = sha256()
>       with open(path, "rb") as f:                       
E       TypeError: expected str, bytes or os.PathLike object, not tuple
                                              
../../python_bin/nlp/utils/checksums_utils.py:81: TypeError     
```

- the checksums probably need to be updated no? And we should also think about how to write a test for the checksums.