### PR TITLE
[Load module] allow kwargs into load module

### DIFF
--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -370,7 +370,7 @@ def builder(path: str, name: Optional[str] = None, **builder_init_kwargs):
         builder_kwargs.update(builder_init_kwargs)
     else:
         builder_kwargs = builder_init_kwargs
-    builder_cls = load_dataset_module(path, name=name)
+    builder_cls = load_dataset_module(path, name=name, **builder_kwargs)
     builder_instance = builder_cls(**builder_kwargs)
     return builder_instance
 


### PR DESCRIPTION
Currenly it is not possible to force a re-download of the dataset script. 

This simple change allows to pass ``force_reload=True`` as ``builder_kwargs`` in the ``load.py`` function.