### PR TITLE
[Tests] allow tests for builders without config

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -69,7 +69,7 @@ class DatasetTester(object):
     def load_all_configs(self, dataset_name):
         builder_cls = load_dataset_module(dataset_name, force_reload=True)
         builder = builder_cls()
-        if not hasattr(builder, "BUILDER_CONFIGS"):
+        if len(builder.BUILDER_CONFIGS) == 0:
             return [None]
         return builder.BUILDER_CONFIGS
 


### PR DESCRIPTION
Some dataset scripts have no configs - the tests have to be adapted for this case. 
In this case the dummy data will be saved as:
- natural_questions
  -> dummy
  -> -> 1.0.0 (version num)
  -> -> -> dummy_data.zip
   