### PR TITLE
[Features] Strip str key before dict look-up

### DIFF
--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -142,8 +142,12 @@ class ClassLabel:
 
     def str2int(self, str_value):
         """Conversion class name string => integer."""
-        str_value = str(str_value).strip()
+        str_value = str(str_value)
+
         if self._str2int:
+            # strip key if not in dict
+            if str_value not in self._str2int:
+                str_value = str_value.strip()
             return self._str2int[str_value]
 
         # No names provided, try to integerize


### PR DESCRIPTION
The dataset `anli.py` currently fails because it tries to look up a key `1\n` in a dict that only has the key `1`. Added an if statement to strip key if it cannot be found in dict.