### PR TITLE
[PyArrow Feature] fix py arrow bool

### DIFF
--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -28,11 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 def type_to_arrow(type_str: str):
-    if type_str is not pa.__dict__:
+    if type_str not in pa.__dict__:
         assert (
-            type_str + "_" in pa.__dict__
-        ), "Neither {} nor {} seems to be a pyarrow data type. Please make sure to use a correct data type, see: https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions"
-        arrow_data_type_str = type_str
+            str(type_str + "_") in pa.__dict__
+        ), "Neither {} nor {} seems to be a pyarrow data type. Please make sure to use a correct data type, see: https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions".format(
+            type_str, type_str + "_"
+        )
+        arrow_data_type_str = str(type_str + "_")
     else:
         arrow_data_type_str = type_str
 


### PR DESCRIPTION
To me it seems that `bool` can only be accessed with `bool_` when looking at the pyarrow types: https://arrow.apache.org/docs/python/api/datatypes.html. 