### PR TITLE
[Testing] Improved testing structure

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -30,7 +30,7 @@ from nlp import (
     load_dataset_module,
 )
 
-from .utils import slow, MockDataLoaderManager
+from .utils import MockDataLoaderManager, slow
 
 
 logging.basicConfig(level=logging.INFO)
@@ -60,7 +60,9 @@ class DatasetTester(object):
                 dataset_builder = self.load_builder(dataset_name, config, data_dir=processed_temp_dir)
 
                 # create mock data loader manager that has a special download_and_extract() method to download dummy data instead of real data
-                mock_dl_manager = MockDataLoaderManager(dataset_name=dataset_name, config=config, version=dataset_builder.version, cache_dir=raw_temp_dir)
+                mock_dl_manager = MockDataLoaderManager(
+                    dataset_name=dataset_name, config=config, version=dataset_builder.version, cache_dir=raw_temp_dir
+                )
 
                 # inject our fake download manager to the dataset_builder._make_download_manager fn
                 dataset_builder._make_download_manager = lambda **kwargs: mock_dl_manager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,9 @@
+import logging
 import os
 import unittest
 from distutils.util import strtobool
 
-import logging
-
-from nlp import (
-    cached_path,
-    hf_bucket_url,
-)
+from nlp import cached_path, hf_bucket_url
 
 
 def parse_flag_from_env(key, default=False):
@@ -57,7 +53,9 @@ class MockDataLoaderManager(object):
         self.version_name = str(version.major) + "." + str(version.minor) + "." + str(version.patch)
 
         # structure is dummy / config_name / version_name / dummy_data.zip
-        self.path_to_dummy_file = os.path.join(self.dummy_data_folder_name, self.config_name, self.version_name, self.dummy_data_file_name)
+        self.path_to_dummy_file = os.path.join(
+            self.dummy_data_folder_name, self.config_name, self.version_name, self.dummy_data_file_name
+        )
 
     # this function has to be in the manager under this name to work
     def download_and_extract(self, data_url, *args):
@@ -90,18 +88,23 @@ class MockDataLoaderManager(object):
         # special case when data_url is a dict
         if isinstance(data_url, dict):
             dummy_data_folder = self.create_dummy_data_dict(self.dummy_data_extracted_folder_name, data_url)
-            logging.info(str(20 * "-" + " EXPECTED STRUCTURE OF {} " + 10 * '-').format(self.dummy_data_file_name))
+            logging.info(str(20 * "-" + " EXPECTED STRUCTURE OF {} " + 10 * "-").format(self.dummy_data_file_name))
             for key, value in dummy_data_folder.items():
                 logging.info("{} contains folder/file: {}".format(self.dummy_data_file_name, value))
         else:
-            logging.info("{} contains folder/file: {}".format(self.dummy_data_file_name, os.path.join(self.dummy_data_extracted_folder_name, data_url.split('/')[-1])))
+            logging.info(
+                "{} contains folder/file: {}".format(
+                    self.dummy_data_file_name,
+                    os.path.join(self.dummy_data_extracted_folder_name, data_url.split("/")[-1]),
+                )
+            )
         logging.info(68 * "*")
 
     def create_dummy_data_dict(self, path_to_dummy_data, data_url):
         dummy_data_dict = {}
         for key, abs_path in data_url.items():
             # we force the name of each key to be the last file / folder name of the url path
-            rel_path = abs_path.split('/')[-1]
+            rel_path = abs_path.split("/")[-1]
             dummy_data_dict[key] = os.path.join(path_to_dummy_data, rel_path)
         return dummy_data_dict
 


### PR DESCRIPTION
This PR refactors the test design a bit and puts the mock download manager in the `utils` files as it is just a test helper class.

as @mariamabarham pointed out, creating a dummy folder structure can be quite hard to grasp.
This PR tries to change that to some extent.

It follows the following logic for the `dummy` folder structure now:
1.) The data bulider has no config -> the  `dummy` folder structure is:
`dummy/<version>/dummy_data.zip`
2) The data builder has >= 1 configs -> the `dummy` folder structure is: 
`dummy/<config_name_1>/<version>/dummy_data.zip`
`dummy/<config_name_2>/<version>/dummy_data.zip`

Now, the difficult part is how to create the `dummy_data.zip` file. There are two cases:
A) The `data_urs` parameter inserted into the `download_and_extract` fn is a **string**:
-> the `dummy_data.zip` file zips the folder: 
`dummy_data/<relative_path_of_folder_structure_of_url>`
B) The `data_urs` parameter inserted into the `download_and_extract` fn is a **dict**:
-> the `dummy_data.zip` file zips the folder: 
`dummy_data/<relative_path_of_folder_structure_of_url_behind _key_1>`
`dummy_data/<relative_path_of_folder_structure_of_url_behind _key_2>`

By relative folder structure I mean `url_path.split('./')[-1]`. As an example the dataset **xquad** by deepmind has the following url path behind the key `de`: `https://github.com/deepmind/xquad/blob/master/xquad.de.json` 
-> This means that the relative url path should be `xquad.de.json`.


@mariamabarham B) is a change from how is was before and I think is makes more sense. 
While before the `dummy_data.zip` file for xquad with config `de` looked like:
`dummy_data/de` it would now look like `dummy_data/xquad.de.json`. I think this is better and easier to understand. 

Therefore there are currently 6 tests that would have to have changed their dummy folder structure, but which can easily be done (30min). 

I also added a function: `print_dummy_data_folder_structure` that prints out the expected structures when testing which should be quite helpful.