### PR TITLE
Fix arrow writer for big datasets using writer_batch_size

### DIFF
--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -104,12 +104,18 @@ class ArrowWriter(object):
             pa_array = pa.array(self.current_rows, type=self._type)
             if pa_array.nbytes > MAX_BATCH_BYTES:
                 new_batch_size = int((MAX_BATCH_BYTES * 0.9 / pa_array.nbytes) * self.writer_batch_size)
-                logger.warning("Batch size is too big (>2Go). Reducing it from {} to {}".format(self.writer_batch_size, new_batch_size))
+                logger.warning(
+                    "Batch size is too big (>2Go). Reducing it from {} to {}".format(
+                        self.writer_batch_size, new_batch_size
+                    )
+                )
                 self.writer_batch_size = new_batch_size
                 n_batches = len(self.current_rows) // new_batch_size
                 n_batches += int(len(self.current_rows) % new_batch_size != 0)
                 for i in range(n_batches):
-                    pa_array = pa.array(self.current_rows[i * new_batch_size: (i + 1) * new_batch_size], type=self._type)
+                    pa_array = pa.array(
+                        self.current_rows[i * new_batch_size : (i + 1) * new_batch_size], type=self._type
+                    )
                     self._write_array_on_file(pa_array)
             else:
                 self._write_array_on_file(pa_array)


### PR DESCRIPTION
This PR fixes Yacine's bug.
According to [this](https://github.com/apache/arrow/blob/master/docs/source/cpp/arrays.rst#size-limitations-and-recommendations), it is not recommended to have pyarrow arrays bigger than 2Go.

Therefore I set a default batch size of 100 000 examples per batch. In general it shouldn't exceed 2Go. If it does, I reduce the batch_size on the fly, and I notify the user with a warning.