### PR TITLE
[Datasets] Transmit format to children

### DIFF
--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1085,6 +1085,20 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(dset[:2]["vec"].shape, (2, 3))
             self.assertEqual(dset["vec"][:2].shape, (2, 3))
 
+    def test_format_transmitted(self, in_memory):
+        import numpy as np
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dset = self._create_dummy_dataset(in_memory, tmp_dir)
+
+            self.assertEqual(dset.format["type"], None)
+
+            dset.set_format("numpy")
+            self.assertEqual(dset.format["type"], "numpy")
+
+            dset2 = dset.map(lambda x: x, batched=True)
+            self.assertEqual(dset2.format["type"], "numpy")
+
     def test_format_ragged_vectors(self, in_memory):
         import numpy as np
         import tensorflow as tf

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1086,8 +1086,6 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(dset["vec"][:2].shape, (2, 3))
 
     def test_format_transmitted(self, in_memory):
-        import numpy as np
-
         with tempfile.TemporaryDirectory() as tmp_dir:
             dset = self._create_dummy_dataset(in_memory, tmp_dir)
 


### PR DESCRIPTION
Transmit format to children obtained when processing a dataset.

Added a test.

When concatenating datasets, if the formats are disparate, the concatenated dataset has a format reset to defaults.