### PR TITLE
sync logging utils with transformers

### DIFF
--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -29,7 +29,7 @@ verbose to the most verbose), those levels (with their corresponding int values 
   critical errors.
 - :obj:`datasets.logging.ERROR` (int value, 40): only report errors.
 - :obj:`datasets.logging.WARNING` or :obj:`datasets.logging.WARN` (int value, 30): only reports error and
-  warnings. This the default level used by the library.
+  warnings.
 - :obj:`datasets.logging.INFO` (int value, 20): reports error, warnings and basic information.
 - :obj:`datasets.logging.DEBUG` (int value, 10): report all information.
 

--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -1,8 +1,38 @@
 Logging methods
 ----------------------------------------------------
 
-`datasets` tries to be very transparent and explicit about it's inner working bt this can be quite verbose at some time.
+`datasets` tries to be very transparent and explicit about its inner working, but this can be quite verbose at some times.
+
 A series of logging methods let you easily adjust the level of logging of the whole library.
+
+Currently the default verbosity of the library is ``WARNING``.
+
+To change the level of verbosity, just use one of the direct setters. For instance, here is how to change the verbosity to the INFO level.
+
+.. code-block:: python
+
+    import datasets
+    datasets.logging.set_verbosity_info()
+
+You can also use the environment variable ``DATASETS_VERBOSITY`` to override the default verbosity. You can set it to one of the following: ``debug``, ``info``, ``warning``, ``error``, ``critical``. For example:
+
+.. code-block:: bash
+               
+    DATASETS_VERBOSITY=error ./myprogram.py
+
+All the methods of this logging module are documented below, the main ones are
+:func:`datasets.logging.get_verbosity` to get the current level of verbosity in the logger and
+:func:`datasets.logging.set_verbosity` to set the verbosity to the level of your choice. In order (from the least
+verbose to the most verbose), those levels (with their corresponding int values in parenthesis) are:
+
+- :obj:`datasets.logging.CRITICAL` or :obj:`datasets.logging.FATAL` (int value, 50): only report the most
+  critical errors.
+- :obj:`datasets.logging.ERROR` (int value, 40): only report errors.
+- :obj:`datasets.logging.WARNING` or :obj:`datasets.logging.WARN` (int value, 30): only reports error and
+  warnings. This the default level used by the library.
+- :obj:`datasets.logging.INFO` (int value, 20): reports error, warnings and basic information.
+- :obj:`datasets.logging.DEBUG` (int value, 10): report all information.
+
 
 Functions
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -1,9 +1,9 @@
 Logging methods
 ----------------------------------------------------
 
-`datasets` tries to be very transparent and explicit about its inner working, but this can be quite verbose at some times.
+`datasets` tries to be very transparent and explicit about its inner working, but this can be quite verbose at times.
 
-A series of logging methods let you easily adjust the level of logging of the whole library.
+A series of logging methods let you easily adjust the level of verbosity of the whole library.
 
 Currently the default verbosity of the library is ``WARNING``.
 

--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -5,7 +5,7 @@ Logging methods
 
 A series of logging methods let you easily adjust the level of verbosity of the whole library.
 
-Currently the default verbosity of the library is ``WARNING``.
+Currently the default verbosity of the library is ``INFO``.
 
 To change the level of verbosity, just use one of the direct setters. For instance, here is how to change the verbosity to the INFO level.
 

--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -39,7 +39,7 @@ log_levels = {
     "critical": logging.CRITICAL,
 }
 
-_default_log_level = logging.WARNING
+_default_log_level = logging.INFO
 
 
 def _get_default_logging_level():

--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -41,6 +41,7 @@ log_levels = {
 
 _default_log_level = logging.WARNING
 
+
 def _get_default_logging_level():
     """
     If DATASETS_VERBOSITY env var is set to one of the valid choices return that as the new default level.

--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -15,6 +15,7 @@
 """ Logging utilities. """
 
 import logging
+import os
 import threading
 from logging import CRITICAL  # NOQA
 from logging import DEBUG  # NOQA

--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -30,6 +30,32 @@ from typing import Optional
 _lock = threading.Lock()
 _default_handler: Optional[logging.Handler] = None
 
+log_levels = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+_default_log_level = logging.WARNING
+
+def _get_default_logging_level():
+    """
+    If DATASETS_VERBOSITY env var is set to one of the valid choices return that as the new default level.
+    If it is not - fall back to ``_default_log_level``
+    """
+    env_level_str = os.getenv("DATASETS_VERBOSITY", None)
+    if env_level_str:
+        if env_level_str in log_levels:
+            return log_levels[env_level_str]
+        else:
+            logging.getLogger().warning(
+                f"Unknown option DATASETS_VERBOSITY={env_level_str}, "
+                f"has to be one of: { ', '.join(log_levels.keys()) }"
+            )
+    return _default_log_level
+
 
 def _get_library_name() -> str:
 
@@ -54,7 +80,7 @@ def _configure_library_root_logger() -> None:
         # Apply our default configuration to the library root logger.
         library_root_logger = _get_library_root_logger()
         library_root_logger.addHandler(_default_handler)
-        library_root_logger.setLevel(logging.INFO)
+        library_root_logger.setLevel(_get_default_logging_level())
         library_root_logger.propagate = False
 
 


### PR DESCRIPTION
sync the docs/code with the recent changes in transformers' `logging` utils:
1. change the default level to `WARNING`
2. add `DATASETS_VERBOSITY` env var
3. expand docs