### PR TITLE
Fix text delimiter

### DIFF
--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -45,8 +45,11 @@ class TextConfig(datasets.BuilderConfig):
         if self.parse_options is not None:
             parse_options = self.parse_options
         else:
+            # To force the one-column setting, we set an arbitrary character
+            # that is not in text files as delimiter, such as \b or \v.
+            # The bell character, \b, was used to make beeps back in the days
             parse_options = pac.ParseOptions(
-                delimiter="\r",
+                delimiter="\b",
                 quote_char=False,
                 double_quote=False,
                 escape_char=False,


### PR DESCRIPTION
I changed the delimiter in the `text` dataset script.
It should fix the `pyarrow.lib.ArrowInvalid: CSV parse error` from #622 

I changed the delimiter to an unused ascii character that is not present in text files : `\b`