### PR TITLE
Make shuffle compatible with temp_seed

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1889,6 +1889,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         ), "The provided generator must be an instance of numpy.random.Generator"
 
         if generator is None:
+            if seed is None:
+                seed = np.random.get_state()[1][0]
+                _ = np.random.random()  # do 1 step of rng
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)
@@ -2048,6 +2051,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             )
 
         if generator is None and shuffle is True:
+            if seed is None:
+                seed = np.random.get_state()[1][0]
+                _ = np.random.random()  # do 1 step of rng
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -143,7 +143,7 @@ def fingerprint(inplace, use_kwargs=None, ignore_kwargs=None, fingerprint_names=
                 kwargs_for_fingerprint = {k: v for k, v in kwargs_for_fingerprint.items() if k not in ignore_kwargs}
             if randomized_function:  # randomized functions have `seed` and `generator` parameters
                 if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
-                    kwargs_for_fingerprint["generator"] = np.random.default_rng(None)
+                    kwargs_for_fingerprint["generator"] = np.random.default_rng(np.random.get_state()[1][0])
 
             # compute new_fingerprint and add it to the args of not in-place transforms
             transform = func.__module__ + "." + func.__qualname__


### PR DESCRIPTION
This code used to return different dataset at each run
```python
import dataset as ds

dataset = ...

with ds.temp_seed(42):
    shuffled = dataset.shuffle()
```

Now it returns the same one since the seed is set