### PR TITLE
Fix docs typos

### DIFF
--- a/docs/source/processing.rst
+++ b/docs/source/processing.rst
@@ -283,7 +283,7 @@ In other words, the mapped function should accept an input with the format of a 
 
 Let's take an example with a fast tokenizer of the 🤗transformers library.
 
-Firsst install this library if you haven't already done it:
+First install this library if you haven't already done it:
 
 .. code-block::
 

--- a/docs/source/share_dataset.rst
+++ b/docs/source/share_dataset.rst
@@ -96,7 +96,7 @@ Push the changes to your account using:
 
 **8.** We also recommend adding **tests** and **metadata** to the dataset script if possible. Go through the :ref:`adding-tests` section to do so.
 
-**9.** Once you are satisfied with the dataset, go the webpage of your fork on GitHub and cick on "Pull request" to **open a pull-request** on the `main github repository <https://github.com/huggingface/datasets>`__ for review.
+**9.** Once you are satisfied with the dataset, go the webpage of your fork on GitHub and click on "Pull request" to **open a pull-request** on the `main github repository <https://github.com/huggingface/datasets>`__ for review.
 
 .. _community-dataset:
 

--- a/docs/source/torch_tensorflow.rst
+++ b/docs/source/torch_tensorflow.rst
@@ -25,8 +25,8 @@ The format of a :class:`datasets.Dataset` instance can be set using the :func:`d
     - ``'numpy'``/``'np'``: return Numpy arrays,
     - ``'pandas'``/``'pd'``: return Pandas DataFrames.
 
-- ``columns`` an optional list of column names (string) defining the list of the column which should be formated and returned by :func:`datasets.Dataset.__getitem__`. Set to None to return all the columns in the dataset (default).
-- ``output_all_columns`` an optional boolean to return as python object the columns which are not selected to be formated (see the above arguments). This can be used for instance if you cannot format some columns (e.g. string columns cannot be formated as PyTorch Tensors) but would still like to have these columns returned. See an example below.
+- ``columns``: an optional list of column names (string) defining the list of the columns which should be formated and returned by :func:`datasets.Dataset.__getitem__`. Set to None to return all the columns in the dataset (default).
+- ``output_all_columns``: an optional boolean to return as python object the columns which are not selected to be formated (see the above arguments). This can be used for instance if you cannot format some columns (e.g. string columns cannot be formated as PyTorch Tensors) but would still like to have these columns returned. See an example below.
 
 Here is how we can apply a format to a simple dataset using :func:`datasets.Dataset.set_format` and wrap it in a ``torch.utils.data.DataLoader`` or a ``tf.data.Dataset``:
 
@@ -38,9 +38,9 @@ Here is how we can apply a format to a simple dataset using :func:`datasets.Data
     >>> from transformers import AutoTokenizer
     >>> dataset = load_dataset('glue', 'mrpc', split='train')
     >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-cased')
-    >>> dataset = dataset.map(lambda e: tokenizer(e['sentence1']), batched=True)
+    >>> dataset = dataset.map(lambda e: tokenizer(e['sentence1'], truncation=True, padding='max_length'), batched=True)
     >>>
-    >>> dataset.set_format(type='torch', columns=['input_ids', 'token_type_ids', 'attention_mask', 'labels'])
+    >>> dataset.set_format(type='torch', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
     >>> dataloader = torch.utils.data.DataLoader(dataset, batch_size=32)
     >>> next(iter(dataloader))
     {'attention_mask': tensor([[1, 1, 1,  ..., 0, 0, 0],
@@ -59,11 +59,11 @@ Here is how we can apply a format to a simple dataset using :func:`datasets.Data
     >>> from transformers import AutoTokenizer
     >>> dataset = load_dataset('glue', 'mrpc', split='train')
     >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-cased')
-    >>> dataset = dataset.map(lambda e: tokenizer(e['sentence1']), batched=True)
+    >>> dataset = dataset.map(lambda e: tokenizer(e['sentence1'], truncation=True, padding='max_length'), batched=True)
     >>>
-    >>> dataset.set_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'labels'])
+    >>> dataset.set_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
     >>> features = {x: dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.max_len]) for x in ['input_ids', 'token_type_ids', 'attention_mask']}
-    >>> tfdataset = tf.data.Dataset.from_tensor_slices((features, dataset["labels"])).batch(32)
+    >>> tfdataset = tf.data.Dataset.from_tensor_slices((features, dataset["label"])).batch(32)
     >>> next(iter(tfdataset))
     ({'input_ids': <tf.Tensor: shape=(32, 512), dtype=int32, numpy=
     array([[  101,  7277,  2180, ...,     0,     0,     0],


### PR DESCRIPTION
This PR fixes few typos in the docs and the error in the code snippet in the set_format section in docs/source/torch_tensorflow.rst. `torch.utils.data.Dataloader` expects padded batches so it throws an error due to not being able to stack the unpadded tensors. If we follow the Quick tour from the docs where they add the `truncation=True, padding='max_length'` arguments to the tokenizer before passing data to Dataloader, we can easily fix the issue. 