### PR TITLE
handle data alteration when trying type

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -98,7 +98,9 @@ class TypedSequence:
             else:
                 out = pa.array(self.data, type=type)
             if trying_type and out[0].as_py() != self.data[0]:
-                raise TypeError("Specified try_type alters data")
+                raise TypeError(
+                    "Specified try_type alters data. Please check that the type/feature that you provided match the type/features of the data."
+                )
             return out
         except (TypeError, pa.lib.ArrowInvalid) as e:  # handle type errors and overflows
             if trying_type:

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -94,9 +94,12 @@ class TypedSequence:
             type = self.type
         try:
             if isinstance(type, _ArrayXDExtensionType):
-                return pa.ExtensionArray.from_storage(type, pa.array(self.data, type.storage_dtype))
+                out = pa.ExtensionArray.from_storage(type, pa.array(self.data, type.storage_dtype))
             else:
-                return pa.array(self.data, type=type)
+                out = pa.array(self.data, type=type)
+            if trying_type and out[0].as_py() != self.data[0]:
+                raise TypeError("Specified try_type alters data")
+            return out
         except (TypeError, pa.lib.ArrowInvalid) as e:  # handle type errors and overflows
             if trying_type:
                 try:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -583,6 +583,14 @@ class BaseDatasetTest(TestCase):
                 Features({"filename": Value("string"), "filename_new": Value("string")}),
             )
 
+    def test_map_nested(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dset = Dataset.from_dict({"field": ["a", "b"]})
+            dset = self._to(in_memory, tmp_dir, dset)
+            dset = dset.map(lambda example: {"otherfield": {"capital": example["field"].capitalize()}})
+            dset = dset.map(lambda example: {"otherfield": {"append_x": example["field"] + "x"}})
+            self.assertEqual(dset[0], {"field": "a", "otherfield": {"append_x": "ax"}})
+
     @require_torch
     def test_map_torch(self, in_memory):
         import torch


### PR DESCRIPTION
Fix #649 

The bug came from the type inference that didn't handle a weird case in Pyarrow.
Indeed this code runs without error but alters the data in arrow:
```python
import pyarrow as pa

type = pa.struct({"a": pa.struct({"b": pa.string()})})
array_with_altered_data = pa.array([{"a": {"b": "foo", "c": "bar"}}] * 10, type=type)
print(array_with_altered_data[0].as_py())
# {'a': {'b': 'foo'}} -> the sub-field "c" is missing
```
(I don't know if this is intended in pyarrow tbh)

We didn't take this case into account during type inference. By default it was keeping old features and maybe alter data.
To fix that I added a line that checks that the first element of the array is not altered.