### PR TITLE
Allow empty inputs in metrics

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -167,6 +167,10 @@ class BaseReader:
             pa_table: pa.Table = self._get_dataset_from_filename(f_dict)
             pa_tables.append(pa_table)
         pa_tables = [t for t in pa_tables if len(t) > 0]
+        if not pa_tables and (self._info is None or self._info.features is None):
+            raise ValueError(
+                "Tried to read an empty table. Please specify at least info.features to create an empty table with the right type."
+            )
         pa_tables = pa_tables or [pa.Table.from_batches([], schema=pa.schema(self._info.features.type))]
         pa_table = pa.concat_tables(pa_tables)
         return pa_table

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -28,7 +28,7 @@ from .arrow_dataset import Dataset
 from .arrow_reader import ArrowReader
 from .arrow_writer import ArrowWriter
 from .features import Features
-from .info import MetricInfo
+from .info import DatasetInfo, MetricInfo
 from .naming import camelcase_to_snakecase
 from .utils import HF_METRICS_CACHE, copyfunc, temp_seed
 from .utils.download_manager import DownloadManager
@@ -337,7 +337,7 @@ class Metric(MetricInfoMixin):
 
         if self.keep_in_memory:
             # Read the predictions and references
-            reader = ArrowReader(path=self.data_dir, info=None)
+            reader = ArrowReader(path=self.data_dir, info=DatasetInfo(features=self.features))
             self.data = Dataset.from_buffer(self.buf_writer.getvalue())
 
         elif self.process_id == 0:
@@ -346,7 +346,7 @@ class Metric(MetricInfoMixin):
 
             # Read the predictions and references
             try:
-                reader = ArrowReader(path=self.data_dir, info=None)
+                reader = ArrowReader(path=self.data_dir, info=DatasetInfo(features=self.features))
                 self.data = Dataset(**reader.read_files([{"filename": f} for f in file_paths]))
             except FileNotFoundError:
                 raise ValueError(

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -20,10 +20,14 @@ class DummyMetric(Metric):
         )
 
     def _compute(self, predictions, references):
-        return {
-            "accuracy": sum(i == j for i, j in zip(predictions, references)) / len(predictions),
-            "set_equality": set(predictions) == set(references),
-        }
+        return (
+            {
+                "accuracy": sum(i == j for i, j in zip(predictions, references)) / len(predictions),
+                "set_equality": set(predictions) == set(references),
+            }
+            if predictions
+            else {}
+        )
 
     @classmethod
     def predictions_and_references(cls):
@@ -124,6 +128,9 @@ class TestMetric(TestCase):
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
         self.assertDictEqual(expected_results, metric.compute())
+
+        metric = DummyMetric(keep_in_memory=True, experiment_id="test_dummy_metric")
+        self.assertDictEqual({}, metric.compute(predictions=[], references=[]))
 
     def test_concurrent_metrics(self):
         preds, refs = DummyMetric.predictions_and_references()


### PR DESCRIPTION
There was an arrow error when trying to compute a metric with empty inputs. The error was occurring when reading the arrow file, before calling metric._compute.