### PR TITLE
Fix wrong delimiter in text dataset

### DIFF
--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -49,7 +49,7 @@ class TextConfig(datasets.BuilderConfig):
             # that is not in text files as delimiter, such as \b or \v.
             # The bell character, \b, was used to make beeps back in the days
             parse_options = pac.ParseOptions(
-                delimiter="\b",
+                delimiter="\a",
                 quote_char=False,
                 double_quote=False,
                 escape_char=False,


### PR DESCRIPTION
The delimiter is set to the bell character as it is used nowhere is text files usually.
However in the text dataset the delimiter was set to `\b` which is backspace in python, while the bell character is `\a`.
I replace \b by \a

Hopefully it fixes issues mentioned by some users in #622 