### PR TITLE
Add features parameter to CSV

### DIFF
--- a/datasets/csv/csv.py
+++ b/datasets/csv/csv.py
@@ -20,6 +20,7 @@ class CsvConfig(datasets.BuilderConfig):
     read_options: pac.ReadOptions = None
     parse_options: pac.ParseOptions = None
     convert_options: pac.ConvertOptions = None
+    features: datasets.Features = None
 
     @property
     def pa_read_options(self):
@@ -43,7 +44,9 @@ class CsvConfig(datasets.BuilderConfig):
 
     @property
     def pa_convert_options(self):
-        convert_options = self.convert_options or pac.ConvertOptions()
+        convert_options = self.convert_options or pac.ConvertOptions(
+            column_types=self.features.type if self.features is not None else None
+        )
         return convert_options
 
 
@@ -78,6 +81,6 @@ class Csv(datasets.ArrowBasedBuilder):
                 file,
                 read_options=self.config.pa_read_options,
                 parse_options=self.config.pa_parse_options,
-                convert_options=self.config.convert_options,
+                convert_options=self.config.pa_convert_options,
             )
             yield i, pa_table

--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -104,7 +104,7 @@ class Text(datasets.ArrowBasedBuilder):
                 file,
                 read_options=self.config.pa_read_options,
                 parse_options=self.config.pa_parse_options,
-                convert_options=self.config.convert_options,
+                convert_options=self.config.pa_convert_options,
             )
             # Uncomment for debugging (will print the Arrow table size and elements)
             # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")


### PR DESCRIPTION
Add support for the `features` parameter when loading a csv dataset:

```python
from datasets import load_dataset, Features

features = Features({...})
csv_dataset = load_dataset("csv", data_files=["path/to/my/file.csv"], features=features)
```

I added tests to make sure that it is also compatible with the caching system

Fix #623 