### PR TITLE
Use GitHub instead of aws in remote dataset tests

### DIFF
--- a/docs/source/loading_datasets.rst
+++ b/docs/source/loading_datasets.rst
@@ -51,7 +51,7 @@ Let's load the **SQuAD dataset for Question Answering**. You can explore this da
 
 This call to :func:`datasets.load_dataset` does the following steps under the hood:
 
-1. Download and import in the library the **SQuAD python processing script** from HuggingFace AWS bucket if it's not already stored in the library.
+1. Download and import in the library the **SQuAD python processing script** from HuggingFace github repository or AWS bucket if it's not already stored in the library.
 
 .. note::
 

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -56,4 +56,4 @@ if int(pyarrow.__version__.split(".")[1]) < 16 and int(pyarrow.__version__.split
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."
     )
 
-SCRIPTS_VERIONS = "master"
+SCRIPTS_VERSION = "master"

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -201,9 +201,9 @@ def head_hf_s3(identifier: str, filename: str, use_cdn=False, dataset=True) -> r
 
 
 def hf_github_url(path: str, name: str, dataset=True, version: Optional[str] = None) -> str:
-    from .. import SCRIPTS_VERIONS
+    from .. import SCRIPTS_VERSION
 
-    version = version or os.getenv("HF_SCRIPTS_VERSION", SCRIPTS_VERIONS)
+    version = version or os.getenv("HF_SCRIPTS_VERSION", SCRIPTS_VERSION)
     if dataset:
         return REPO_DATASETS_URL.format(version=version, path=path, name=name)
     else:

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -20,7 +20,7 @@ import os
 import urllib.parse
 from pathlib import Path
 
-from .file_utils import cached_path, hf_bucket_url
+from .file_utils import cached_path, hf_github_url
 from .logging import get_logger
 
 
@@ -63,7 +63,7 @@ class MockDownloadManager(object):
 
     def download_dummy_data(self):
         path_to_dummy_data_dir = (
-            self.local_path_to_dummy_data if self.is_local is True else self.aws_path_to_dummy_data
+            self.local_path_to_dummy_data if self.is_local is True else self.github_path_to_dummy_data
         )
 
         local_path = cached_path(
@@ -77,9 +77,9 @@ class MockDownloadManager(object):
         return os.path.join("datasets", self.dataset_name, self.dummy_zip_file)
 
     @property
-    def aws_path_to_dummy_data(self):
+    def github_path_to_dummy_data(self):
         if self._bucket_url is None:
-            self._bucket_url = hf_bucket_url(self.dataset_name, filename=self.dummy_zip_file.replace(os.sep, "/"))
+            self._bucket_url = hf_github_url(self.dataset_name, self.dummy_zip_file.replace(os.sep, "/"))
         return self._bucket_url
 
     @property

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -20,16 +20,9 @@ import tempfile
 
 from absl.testing import parameterized
 
-from datasets import DownloadConfig, hf_api, load_metric
+from datasets import DownloadConfig, load_metric
 
-from .utils import aws, local, slow
-
-
-def get_aws_metric_names():
-    api = hf_api.HfApi()
-    # fetch all metric names
-    metrics = [x.id for x in api.metric_list()]
-    return [{"testcase_name": x, "metric_name": x} for x in metrics]
+from .utils import remote, local, slow
 
 
 def get_local_metric_names():
@@ -37,9 +30,9 @@ def get_local_metric_names():
     return [{"testcase_name": x, "metric_name": x} for x in metrics]
 
 
-@parameterized.named_parameters(get_aws_metric_names())
-@aws
-class AWSMetricTest(parameterized.TestCase):
+@parameterized.named_parameters(get_local_metric_names())
+@remote
+class RemoteMetricTest(parameterized.TestCase):
     metric_name = None
 
     @slow

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -22,7 +22,7 @@ from absl.testing import parameterized
 
 from datasets import DownloadConfig, load_metric
 
-from .utils import remote, local, slow
+from .utils import local, remote, slow
 
 
 def get_local_metric_names():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,7 @@ def parse_flag_from_env(key, default=False):
 
 
 _run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
-_run_aws_tests = parse_flag_from_env("RUN_AWS", default=True)
+_run_remote_tests = parse_flag_from_env("RUN_REMOTE", default=True)
 _run_local_tests = parse_flag_from_env("RUN_LOCAL", default=True)
 
 
@@ -144,15 +144,15 @@ def local(test_case):
     return test_case
 
 
-def aws(test_case):
+def remote(test_case):
     """
-    Decorator marking a test as one that relies on AWS.
+    Decorator marking a test as one that relies on github or aws.
 
-    AWS tests are skipped by default. Set the RUN_AWS environment variable
+    Remote tests are skipped by default. Set the RUN_REMOTE environment variable
     to a falsy value to not run them.
     """
-    if not _run_aws_tests or _run_aws_tests == 0:
-        test_case = unittest.skip("test requires aws")(test_case)
+    if not _run_remote_tests or _run_remote_tests == 0:
+        test_case = unittest.skip("test requires remote")(test_case)
     return test_case
 
 


### PR DESCRIPTION
Recently we switched from aws s3 to github to download dataset scripts.
However in the tests, the dummy data were still downloaded from s3.
So I changed that to download them from github instead, in the MockDownloadManager.

Moreover I noticed that `anli`'s dummy data were quite heavy (18MB compressed, i.e. the entire dataset) so I replaced them with dummy data with few examples.