### PR TITLE
Add rouge-2 in rouge_types for metric calculation

### DIFF
--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -83,7 +83,7 @@ class Rouge(datasets.Metric):
 
     def _compute(self, predictions, references, rouge_types=None, use_agregator=True, use_stemmer=False):
         if rouge_types is None:
-            rouge_types = ["rouge1", "rougeL"]
+            rouge_types = ["rouge1", "rouge2", "rougeL"]
 
         scorer = rouge_scorer.RougeScorer(rouge_types=rouge_types, use_stemmer=use_stemmer)
         if use_agregator:


### PR DESCRIPTION
The description of the ROUGE metric says, 
```
_KWARGS_DESCRIPTION = """
Calculates average rouge scores for a list of hypotheses and references
Args:
    predictions: list of predictions to score. Each predictions
        should be a string with tokens separated by spaces.
    references: list of reference for each prediction. Each
        reference should be a string with tokens separated by spaces.
Returns:
    rouge1: rouge_1 f1,
    rouge2: rouge_2 f1,
    rougeL: rouge_l f1,
    rougeLsum: rouge_l precision
"""
```

but the `rouge_types` argument defaults to  `rouge_types = ["rouge1", "rougeL"]`, this PR updates and add `rouge2` to the list so as to reflect the description card.