### PR TITLE
Fix remote tests for new datasets

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -32,6 +32,7 @@ from datasets import (
     MockDownloadManager,
     Value,
     cached_path,
+    hf_api,
     import_main_class,
     load_dataset,
     logging,
@@ -292,7 +293,14 @@ class DistributedDatasetTest(TestCase):
                     del dataset
 
 
-@parameterized.named_parameters(get_local_dataset_names())
+def get_remote_dataset_names():
+    api = hf_api.HfApi()
+    # fetch all dataset names
+    datasets = api.dataset_list(with_community_datasets=False, id_only=True)
+    return [{"testcase_name": x, "dataset_name": x} for x in datasets]
+
+
+@parameterized.named_parameters(get_remote_dataset_names())
 @for_all_test_methods(skip_if_dataset_requires_faiss, skip_if_not_compatible_with_windows)
 @remote
 class RemoteDatasetTest(parameterized.TestCase):

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -20,7 +20,7 @@ import tempfile
 
 from absl.testing import parameterized
 
-from datasets import DownloadConfig, load_metric
+from datasets import DownloadConfig, hf_api, load_metric
 
 from .utils import local, remote, slow
 
@@ -30,7 +30,14 @@ def get_local_metric_names():
     return [{"testcase_name": x, "metric_name": x} for x in metrics]
 
 
-@parameterized.named_parameters(get_local_metric_names())
+def get_remote_metric_names():
+    api = hf_api.HfApi()
+    # fetch all metric names
+    metrics = [x.id for x in api.metric_list()]
+    return [{"testcase_name": x, "metric_name": x} for x in metrics]
+
+
+@parameterized.named_parameters(get_remote_metric_names())
 @remote
 class RemoteMetricTest(parameterized.TestCase):
     metric_name = None


### PR DESCRIPTION
When adding a new dataset, the remote tests fail because they try to get the new dataset from the master branch (i.e., where the dataset doesn't exist yet)
To fix that I reverted to the use of the HF API that fetch the available datasets on S3 that is synced with the master branch