### PR TITLE
Fix config creation for data files with NamedSplit

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -265,7 +265,7 @@ class DatasetBuilder:
                 data_files = {"train": builder_config.data_files}
             elif isinstance(builder_config.data_files, dict):
                 data_files = {
-                    key: files if isinstance(files, (tuple, list)) else [files]
+                    str(key): files if isinstance(files, (tuple, list)) else [files]
                     for key, files in builder_config.data_files.items()
                 }
             else:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -434,6 +434,10 @@ class BuilderTest(TestCase):
             )
             self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={Split.TRAIN: dummy_data1}
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1]}
             )
             self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)


### PR DESCRIPTION
During config creation, we need to iterate through the data files of all the splits to compute a hash.
To make sure the hash is unique given a certain combination of files/splits, we sort the split names.
However the `NamedSplit` objects can't be passed to `sorted` and currently it raises an error: we need to sort the string of their names instead.

Fix #705 