### PR TITLE
Fix reading text files with carriage return symbols

### DIFF
--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -45,7 +45,11 @@ class Text(datasets.ArrowBasedBuilder):
                 files = [files]
             return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"files": files})]
         splits = []
-        for split_name in [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]:
+        for split_name in [
+            datasets.Split.TRAIN,
+            datasets.Split.VALIDATION,
+            datasets.Split.TEST,
+        ]:
             if split_name in data_files:
                 files = data_files[split_name]
                 if isinstance(files, str):
@@ -64,6 +68,7 @@ class Text(datasets.ArrowBasedBuilder):
                 chunksize=self.config.chunksize,
                 encoding=self.config.encoding,
                 sep="\n",
+                lineterminator="\n",
             )
             for j, df in enumerate(text_file_reader):
                 pa_table = pa.Table.from_pandas(df)


### PR DESCRIPTION
The new pandas-based text reader isn't able to work properly with files that contain carriage return symbols (`\r`). 

It fails with the following error message:

```
...
  File "pandas/_libs/parsers.pyx", line 847, in pandas._libs.parsers.TextReader.read
  File "pandas/_libs/parsers.pyx", line 874, in pandas._libs.parsers.TextReader._read_low_memory
  File "pandas/_libs/parsers.pyx", line 918, in pandas._libs.parsers.TextReader._read_rows
  File "pandas/_libs/parsers.pyx", line 905, in pandas._libs.parsers.TextReader._tokenize_rows
  File "pandas/_libs/parsers.pyx", line 2042, in pandas._libs.parsers.raise_parser_error
pandas.errors.ParserError: Error tokenizing data. C error: Buffer overflow caught - possible malformed input file.
```

___
I figured out the pandas uses those symbols as line terminators and this eventually causes the error. Explicitly specifying the `lineterminator` fixes that issue and everything works fine. 

Please, consider this PR as it seems to be a common issue to solve.