### PR TITLE
Fixes #712 Error in the Overview.ipynb notebook

### DIFF
--- a/notebooks/Overview.ipynb
+++ b/notebooks/Overview.ipynb
@@ -1225,7 +1225,7 @@
       },
       "source": [
         "# You can access various attributes of the datasets before downloading them\n",
-        "squad_dataset = list_datasets()[datasets.index('squad')]\n",
+        "squad_dataset = list_datasets(with_details=True)[datasets.index('squad')]\n",
         "\n",
         "pprint(squad_dataset.__dict__)  # It's a simple python dataclass"
       ],


### PR DESCRIPTION
Fixes #712 Error in the Overview.ipynb notebook by adding `with_details=True` parameter to `list_datasets` function in Cell 3 of **overview** notebook