### PR TITLE
Fix train_test_split output format

### DIFF
--- a/run_train_test_split.py
+++ b/run_train_test_split.py
@@ -1,8 +1,0 @@
-# Let's import the library. We typically only need at most four methods:
-from datasets import list_datasets, list_metrics, load_dataset, load_metric, Dataset, concatenate_datasets
-
-from pprint import pprint
-
-datasets = [Dataset.from_dict({"foo": [i for i in range(100)]}) for _ in range(2)] 
-ds2 = concatenate_datasets(datasets)
-ds3 = ds2.train_test_split(0.1)

--- a/run_train_test_split.py
+++ b/run_train_test_split.py
@@ -1,0 +1,8 @@
+# Let's import the library. We typically only need at most four methods:
+from datasets import list_datasets, list_metrics, load_dataset, load_metric, Dataset, concatenate_datasets
+
+from pprint import pprint
+
+datasets = [Dataset.from_dict({"foo": [i for i in range(100)]}) for _ in range(2)] 
+ds2 = concatenate_datasets(datasets)
+ds3 = ds2.train_test_split(0.1)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -153,11 +153,13 @@ def transmit_format(func):
             "columns": self._format_columns,
             "output_all_columns": self._output_all_columns,
         }
+        # apply actual function
         out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
         datasets: List["Dataset"] = list(out.values()) if isinstance(out, dict) else [out]
+        # re-apply format to the output
         for dataset in datasets:
             new_format = dict(self_format)
-            if new_format["columns"] is not None:
+            if new_format["columns"] is not None:  # new formatted columns = (columns - previously unformatted columns)
                 new_format["columns"] = list(set(dataset.column_names) - unformatted_columns)
             out_format = {
                 "type": dataset._format_type,
@@ -165,7 +167,7 @@ def transmit_format(func):
                 "columns": dataset._format_columns,
                 "output_all_columns": dataset._output_all_columns,
             }
-            if out_format != new_format:
+            if out_format != new_format:  # only apply if there's a change not to update the fingerprint for nothing
                 dataset.set_format(**new_format)
         return out
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -147,17 +147,18 @@ def transmit_format(func):
             self: "Dataset" = kwargs.pop("self")
         # don't use self.format since it returns a list of columns for 'columns' even if self_format_columns is None
         unformatted_columns = set(self.column_names) - set(self._format_columns or [])
-        new_format = {
+        self_format = {
             "type": self._format_type,
             "format_kwargs": self._format_kwargs,
             "columns": self._format_columns,
             "output_all_columns": self._output_all_columns,
         }
         out: Union["Dataset", "DatasetDict"] = func(self, *args, **kwargs)
-        if new_format["columns"] is not None:
-            new_format["columns"] = list(set(out.column_names) - unformatted_columns)
         datasets: List["Dataset"] = list(out.values()) if isinstance(out, dict) else [out]
         for dataset in datasets:
+            new_format = dict(self_format)
+            if new_format["columns"] is not None:
+                new_format["columns"] = list(set(dataset.column_names) - unformatted_columns)
             out_format = {
                 "type": dataset._format_type,
                 "format_kwargs": dataset._format_kwargs,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -65,8 +65,11 @@ class BaseDatasetTest(TestCase):
         if in_memory:
             datasets = [dataset.map(keep_in_memory=True) for dataset in datasets]
         else:
+            start = 0
+            while os.path.isfile(os.path.join(tmp_dir, f"dataset{start}.arrow")):
+                start += 1
             datasets = [
-                dataset.map(cache_file_name=os.path.join(tmp_dir, f"dataset{i}.arrow"))
+                dataset.map(cache_file_name=os.path.join(tmp_dir, f"dataset{start + i}.arrow"))
                 for i, dataset in enumerate(datasets)
             ]
         return datasets if len(datasets) > 1 else datasets[0]


### PR DESCRIPTION
There was an issue in the `transmit_format` wrapper that returned bad formats when using train_test_split.
This was due to `column_names` being handled as a List[str] instead of Dict[str, List[str]] when the dataset transform (train_test_split) returns a DatasetDict (one set of column names per split).

This should fix @timothyjlaurent 's issue in #620 and fix #676 

I added tests for `transmit_format` so that it doesn't happen again