### PR TITLE
pretty print dataset objects

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -702,7 +702,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             )
 
     def __repr__(self):
-        return f"Dataset(features: {self.features}, num_rows: {self.num_rows})"
+        return f"  Dataset(\n    features: {self.features.keys()},\n    num_rows: {self.num_rows}\n  )"
 
     @property
     def format(self):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -702,7 +702,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             )
 
     def __repr__(self):
-        return f"  Dataset(\n    features: {self.features.keys()},\n    num_rows: {self.num_rows}\n  )"
+        return f"  Dataset({{\n    features: {list(self.features.keys())},\n    num_rows: {self.num_rows}\n  }})"
 
     @property
     def format(self):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -702,7 +702,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             )
 
     def __repr__(self):
-        return f"  Dataset({{\n    features: {list(self.features.keys())},\n    num_rows: {self.num_rows}\n  }})"
+        return f"Dataset({{\n    features: {list(self.features.keys())},\n    num_rows: {self.num_rows}\n}})"
 
     @property
     def format(self):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -106,7 +106,7 @@ class DatasetDict(dict):
             dataset.cleanup_cache_files()
 
     def __repr__(self):
-        return f"DatasetDict({super().__repr__()})"
+        return "\n".join(["DatasetDict({"] + [f"  {k}: {v}" for k, v in self.items()] + ["})"])
 
     def cast_(self, features: Features):
         """

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -106,7 +107,9 @@ class DatasetDict(dict):
             dataset.cleanup_cache_files()
 
     def __repr__(self):
-        return "\n".join(["DatasetDict({"] + [f"  {k}: {v}" for k, v in self.items()] + ["})"])
+        repr = "\n".join([f"{k}: {v}" for k, v in self.items()])
+        repr = re.sub(r"^", " " * 4, repr, 0, re.M)
+        return f"DatasetDict({{\n{repr}\n}})"
 
     def cast_(self, features: Features):
         """


### PR DESCRIPTION
Currently, if I do:
```
from datasets import load_dataset
load_dataset("wikihow", 'all', data_dir="/hf/pegasus-datasets/wikihow/")
```
I get:
```

DatasetDict({'train': Dataset(features: {'text': Value(dtype='string', id=None),
'headline': Value(dtype='string', id=None), 'title': Value(dtype='string',
id=None)}, num_rows: 157252), 'validation': Dataset(features: {'text':
Value(dtype='string', id=None), 'headline': Value(dtype='string', id=None),
'title': Value(dtype='string', id=None)}, num_rows: 5599), 'test':
Dataset(features: {'text': Value(dtype='string', id=None), 'headline':
Value(dtype='string', id=None), 'title': Value(dtype='string', id=None)},
num_rows: 5577)})
```

This is not very readable. 

Can we either have a better `__repr__` or have a custom method to nicely pprint the dataset object? 

Here is my very simple attempt. With this PR, it produces:
```
DatasetDict({
  train:   Dataset({
    features: ['text', 'headline', 'title'],
    num_rows: 157252
  })
  validation:   Dataset({
    features: ['text', 'headline', 'title'],
    num_rows: 5599
  })
  test:   Dataset({
    features: ['text', 'headline', 'title'],
    num_rows: 5577
  })
})
```
I did omit the data types on purpose to make it more readable, but it shouldn't be too difficult to integrate those too.

note that this PR also fixes the inconsistency in output that in master misses enclosing `{}` for Dataset, but it is there for `DatasetDict` - or perhaps it was by design.

I'm totally not attached to this format, just wanting something more readable. One approach could be to serialize to `json.dumps` or something similar. It'd make the indentation simpler.

Thank you.