### PR TITLE
Replace seqeval code with original classification_report for simplicity

### DIFF
--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -14,14 +14,27 @@
 # limitations under the License.
 """ seqeval metric. """
 
-from collections import defaultdict
-
-from seqeval.metrics import accuracy_score, f1_score, precision_score, recall_score
+from seqeval.metrics import accuracy_score, classification_report
 
 import datasets
 
 
 _CITATION = """\
+@inproceedings{ramshaw-marcus-1995-text,
+    title = "Text Chunking using Transformation-Based Learning",
+    author = "Ramshaw, Lance  and
+      Marcus, Mitch",
+    booktitle = "Third Workshop on Very Large Corpora",
+    year = "1995",
+    url = "https://www.aclweb.org/anthology/W95-0107",
+}
+@misc{seqeval,
+  title={{seqeval}: A Python framework for sequence labeling evaluation},
+  url={https://github.com/chakki-works/seqeval},
+  note={Software available from https://github.com/chakki-works/seqeval},
+  author={Hiroki Nakayama},
+  year={2018},
+}
 """
 
 _DESCRIPTION = """\
@@ -62,80 +75,6 @@ Returns:
 """
 
 
-def end_of_chunk(prev_tag, tag, prev_type, type_):
-    """Checks if a chunk ended between the previous and current word.
-    Args:
-        prev_tag: previous chunk tag.
-        tag: current chunk tag.
-        prev_type: previous type.
-        type_: current type.
-    Returns:
-        chunk_end: boolean.
-    """
-    chunk_end = False
-
-    if (prev_tag in ["B", "I"] and tag in ["B", "S", "O"]) or prev_tag in ["E", "S"]:
-        chunk_end = True
-
-    if prev_tag not in ["O", "."] and prev_type != type_:
-        chunk_end = True
-
-    return chunk_end
-
-
-def start_of_chunk(prev_tag, tag, prev_type, type_):
-    """Checks if a chunk started between the previous and current word.
-    Args:
-        prev_tag: previous chunk tag.
-        tag: current chunk tag.
-        prev_type: previous type.
-        type_: current type.
-    Returns:
-        chunk_start: boolean.
-    """
-    chunk_start = False
-
-    if (prev_tag in ["E", "S", "O"] and tag in ["E", "I"]) or tag in ["B", "S"]:
-        chunk_start = True
-
-    if tag not in ["O", "."] and prev_type != type_:
-        chunk_start = True
-
-    return chunk_start
-
-
-def get_entities(seq, suffix=False):
-    """Gets entities from sequence.
-    Args:
-        seq (list): sequence of labels.
-    Returns:
-        list: list of (chunk_type, chunk_start, chunk_end).
-    """
-    if any(isinstance(s, list) for s in seq):
-        seq = [item for sublist in seq for item in sublist + ["O"]]
-
-    prev_tag = "O"
-    prev_type = ""
-    begin_offset = 0
-    chunks = []
-    for i, chunk in enumerate(seq + ["O"]):
-        if suffix:
-            tag = chunk[-1]
-            type_ = chunk[:-1].rsplit("-", maxsplit=1)[0] or "_"
-        else:
-            tag = chunk[0]
-            type_ = chunk[1:].split("-", maxsplit=1)[-1] or "_"
-
-        if end_of_chunk(prev_tag, tag, prev_type, type_):
-            chunks.append((prev_type, begin_offset, i - 1))
-        if start_of_chunk(prev_tag, tag, prev_type, type_):
-            begin_offset = i
-        prev_tag = tag
-        prev_type = type_
-
-    return chunks
-
-
 class Seqeval(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
@@ -154,37 +93,21 @@ class Seqeval(datasets.Metric):
         )
 
     def _compute(self, predictions, references, suffix=False):
-        true_entities = set(get_entities(references, suffix))
-        pred_entities = set(get_entities(predictions, suffix))
-        d1 = defaultdict(set)
-        d2 = defaultdict(set)
+        report = classification_report(y_true=references, y_pred=predictions, suffix=suffix, output_dict=True)
+        report.pop("macro avg")
+        report.pop("weighted avg")
+        overall_score = report.pop("micro avg")
+
         scores = {}
+        for type_name, score in report.items():
+            scores[type_name]["precision"] = score["precision"]
+            scores[type_name]["recall"] = score["recall"]
+            scores[type_name]["f1"] = score["f1-score"]
+            scores[type_name]["number"] = score["support"]
 
-        for e in true_entities:
-            d1[e[0]].add((e[1], e[2]))
-
-        for e in pred_entities:
-            d2[e[0]].add((e[1], e[2]))
-
-        for type_name, true_entities in d1.items():
-            scores[type_name] = {}
-            pred_entities = d2[type_name]
-            nb_correct = len(true_entities & pred_entities)
-            nb_pred = len(pred_entities)
-            nb_true = len(true_entities)
-
-            p = nb_correct / nb_pred if nb_pred > 0 else 0
-            r = nb_correct / nb_true if nb_true > 0 else 0
-            f1 = 2 * p * r / (p + r) if p + r > 0 else 0
-
-            scores[type_name]["precision"] = p
-            scores[type_name]["recall"] = r
-            scores[type_name]["f1"] = f1
-            scores[type_name]["number"] = nb_true
-
-        scores["overall_precision"] = precision_score(y_true=references, y_pred=predictions, suffix=suffix)
-        scores["overall_recall"] = recall_score(y_true=references, y_pred=predictions, suffix=suffix)
-        scores["overall_f1"] = f1_score(y_true=references, y_pred=predictions, suffix=suffix)
+        scores["overall_precision"] = overall_score["precision"]
+        scores["overall_recall"] = overall_score["recall"]
+        scores["overall_f1"] = overall_score["f1-score"]
         scores["overall_accuracy"] = accuracy_score(y_true=references, y_pred=predictions)
 
         return scores

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -61,17 +61,18 @@ from a source against one or more references.
 Args:
     predictions: List of List of predicted labels (Estimated targets as returned by a tagger)
     references: List of List of reference labels (Ground truth (correct) target values)
-    suffix: True if the types are not in IOBs format False otherwise. default: False
+    suffix: True if the IOB prefix is after type, False otherwise. default: False
 Returns:
-    Overall:
-        'accuracy': accuracy,
-        'precision': precision,
-        'recall': recall,
-        'f1': F1 score, also known as balanced F-score or F-measure,
-    Per type:
-        'precision': precision,
-        'recall': recall,
-        'f1': F1 score, also known as balanced F-score or F-measure,
+    'scores': dict. Summary of the scores for overall and per type
+        Overall:
+            'accuracy': accuracy,
+            'precision': precision,
+            'recall': recall,
+            'f1': F1 score, also known as balanced F-score or F-measure,
+        Per type:
+            'precision': precision,
+            'recall': recall,
+            'f1': F1 score, also known as balanced F-score or F-measure
 """
 
 


### PR DESCRIPTION
Recently, the original seqeval has enabled us to get per type scores and overall scores as a dictionary.

This PR replaces the current code with the original function(`classification_report`) to simplify it.

Also, the original code has been updated to fix #352.
- Related issue: https://github.com/chakki-works/seqeval/pull/38


```python
from datasets import load_metric
metric = load_metric("seqeval")
y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
y_pred = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
metric.compute(predictions=y_pred, references=y_true)
# Output: {'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0, 'number': 1}, 'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'overall_precision': 0.5, 'overall_recall': 0.5, 'overall_f1': 0.5, 'overall_accuracy': 0.8}
```