### PR TITLE
Fixed errors in bertscore related to custom baseline

### DIFF
--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -97,6 +97,8 @@ class BERTScore(datasets.Metric):
         nthreads=4,
         all_layers=False,
         rescale_with_baseline=False,
+        baseline_path=None,
+
     ):
         if model_type is None:
             assert lang is not None, "either lang or model_type should be specified"
@@ -105,7 +107,7 @@ class BERTScore(datasets.Metric):
         if num_layers is None:
             num_layers = bert_score.utils.model2layers[model_type]
 
-        hashcode = bert_score.utils.get_hash(model_type, num_layers, idf, rescale_with_baseline)
+        hashcode = bert_score.utils.get_hash(model_type, num_layers, idf, rescale_with_baseline, baseline_path is not None)
         if not hasattr(self, "cached_bertscorer") or self.cached_bertscorer.hash != hashcode:
             self.cached_bertscorer = bert_score.BERTScorer(
                 model_type=model_type,
@@ -117,6 +119,7 @@ class BERTScore(datasets.Metric):
                 device=device,
                 lang=lang,
                 rescale_with_baseline=rescale_with_baseline,
+                baseline_path=baseline_path,
             )
 
         (P, R, F) = self.cached_bertscorer.score(

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -15,7 +15,6 @@
 """ BERTScore metric. """
 
 import bert_score
-
 import datasets
 
 
@@ -76,11 +75,16 @@ class BERTScore(datasets.Metric):
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    "references": datasets.Sequence(
+                        datasets.Value("string", id="sequence"), id="references"
+                    ),
                 }
             ),
             codebase_urls=["https://github.com/Tiiiger/bert_score"],
-            reference_urls=["https://github.com/Tiiiger/bert_score", "https://arxiv.org/abs/1904.09675"],
+            reference_urls=[
+                "https://github.com/Tiiiger/bert_score",
+                "https://arxiv.org/abs/1904.09675",
+            ],
         )
 
     def _compute(
@@ -98,7 +102,6 @@ class BERTScore(datasets.Metric):
         all_layers=False,
         rescale_with_baseline=False,
         baseline_path=None,
-
     ):
         if model_type is None:
             assert lang is not None, "either lang or model_type should be specified"
@@ -107,8 +110,18 @@ class BERTScore(datasets.Metric):
         if num_layers is None:
             num_layers = bert_score.utils.model2layers[model_type]
 
-        hashcode = bert_score.utils.get_hash(model_type, num_layers, idf, rescale_with_baseline, baseline_path is not None)
-        if not hasattr(self, "cached_bertscorer") or self.cached_bertscorer.hash != hashcode:
+        hashcode = bert_score.utils.get_hash(
+            model_type,
+            num_layers,
+            idf,
+            rescale_with_baseline,
+            baseline_path is not None,
+        )
+
+        if (
+            not hasattr(self, "cached_bertscorer")
+            or self.cached_bertscorer.hash != hashcode
+        ):
             self.cached_bertscorer = bert_score.BERTScorer(
                 model_type=model_type,
                 num_layers=num_layers,

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -58,6 +58,7 @@ Args:
     at least one of `model_type` or `lang`. `lang` needs to be
     specified when `rescale_with_baseline` is True.
     `rescale_with_baseline` (bool): rescale bertscore with pre-computed baseline
+    `baseline_path` (str): customized baseline file.
 Returns:
     'precision': Precision,
     'recall': Recall,
@@ -110,11 +111,11 @@ class BERTScore(datasets.Metric):
             num_layers = bert_score.utils.model2layers[model_type]
 
         hashcode = bert_score.utils.get_hash(
-            model_type,
-            num_layers,
-            idf,
-            rescale_with_baseline,
-            baseline_path is not None,
+            model=model_type,
+            num_layers=num_layers,
+            idf=idf,
+            rescale_with_baseline=rescale_with_baseline,
+            use_custom_baseline=baseline_path is not None,
         )
 
         if not hasattr(self, "cached_bertscorer") or self.cached_bertscorer.hash != hashcode:

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -75,9 +75,7 @@ class BERTScore(datasets.Metric):
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(
-                        datasets.Value("string", id="sequence"), id="references"
-                    ),
+                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
                 }
             ),
             codebase_urls=["https://github.com/Tiiiger/bert_score"],
@@ -118,10 +116,7 @@ class BERTScore(datasets.Metric):
             baseline_path is not None,
         )
 
-        if (
-            not hasattr(self, "cached_bertscorer")
-            or self.cached_bertscorer.hash != hashcode
-        ):
+        if not hasattr(self, "cached_bertscorer") or self.cached_bertscorer.hash != hashcode:
             self.cached_bertscorer = bert_score.BERTScorer(
                 model_type=model_type,
                 num_layers=num_layers,

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -15,6 +15,7 @@
 """ BERTScore metric. """
 
 import bert_score
+
 import datasets
 
 


### PR DESCRIPTION
[bertscore version 0.3.6 ](https://github.com/Tiiiger/bert_score) added support for custom baseline files. This update added extra argument `baseline_path` to BERTScorer class as well as some extra boolean parameters `use_custom_baseline` in functions like `get_hash(model, num_layers, idf, rescale_with_baseline, use_custom_baseline)`.

This PR fix those matching errors in bertscore metric implementation.