### PR TITLE
Fix metric with cache dir

### DIFF
--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -346,7 +346,7 @@ class Metric(MetricInfoMixin):
 
             # Read the predictions and references
             try:
-                reader = ArrowReader(path=self.data_dir, info=DatasetInfo(features=self.features))
+                reader = ArrowReader(path="", info=DatasetInfo(features=self.features))
                 self.data = Dataset(**reader.read_files([{"filename": f} for f in file_paths]))
             except FileNotFoundError:
                 raise ValueError(


### PR DESCRIPTION
The cache_dir provided by the user was concatenated twice and therefore causing FileNotFound errors.
The tests didn't cover the case of providing `cache_dir=` for metrics because of a stupid issue (it was not using the right parameter).

I remove the double concatenation and I fixed the tests

Fix #728 