### PR TITLE
Allow custom split names in text dataset

### DIFF
--- a/datasets/csv/csv.py
+++ b/datasets/csv/csv.py
@@ -67,12 +67,10 @@ class Csv(datasets.ArrowBasedBuilder):
                 files = [files]
             return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"files": files})]
         splits = []
-        for split_name in [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]:
-            if split_name in data_files:
-                files = data_files[split_name]
-                if isinstance(files, str):
-                    files = [files]
-                splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _generate_tables(self, files):

--- a/datasets/json/json.py
+++ b/datasets/json/json.py
@@ -50,12 +50,10 @@ class Json(datasets.ArrowBasedBuilder):
                 files = [files]
             return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"files": files})]
         splits = []
-        for split_name in [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]:
-            if split_name in data_files:
-                files = data_files[split_name]
-                if isinstance(files, str):
-                    files = [files]
-                splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _generate_tables(self, files):

--- a/datasets/pandas/pandas.py
+++ b/datasets/pandas/pandas.py
@@ -21,12 +21,10 @@ class Pandas(datasets.ArrowBasedBuilder):
                 files = [files]
             return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"files": files})]
         splits = []
-        for split_name in [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]:
-            if split_name in data_files:
-                files = data_files[split_name]
-                if isinstance(files, str):
-                    files = [files]
-                splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _generate_tables(self, files):

--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -44,12 +44,10 @@ class Text(datasets.ArrowBasedBuilder):
                 files = [files]
             return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"files": files})]
         splits = []
-        for split_name in [datasets.Split.TRAIN, datasets.Split.VALIDATION, datasets.Split.TEST]:
-            if split_name in data_files:
-                files = data_files[split_name]
-                if isinstance(files, str):
-                    files = [files]
-                splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _generate_tables(self, files):

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -528,7 +528,7 @@ class SplitDict(dict):
             split_infos = list(split_infos.values())
 
         if dataset_name is None:
-            dataset_name = split_infos[0]["dataset_name"]
+            dataset_name = split_infos[0]["dataset_name"] if split_infos else None
 
         split_dict = cls(dataset_name=dataset_name)
 


### PR DESCRIPTION
The `text` dataset used to return only splits like train, test and validation. Other splits were ignored.
Now any split name is allowed.

I did the same for `json`, `pandas` and `csv`

Fix #735 