### PR TITLE
Better error message for uninitialized metric

### DIFF
--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -269,6 +269,11 @@ class Metric(MetricInfoMixin):
         We wait for timeout second to let all the distributed node finish their tasks (default is 100 seconds).
         """
         if self.num_process == 1:
+            if self.cache_file_name is None:
+                raise ValueError(
+                    "Metric cache file doesn't exist. Please make sure that you call `add` or `add_batch` "
+                    "at least once before calling `compute`."
+                )
             file_paths = [self.cache_file_name]
         else:
             file_paths = [


### PR DESCRIPTION
When calling `metric.compute()` without having called `metric.add` or `metric.add_batch` at least once, the error was quite cryptic. I added a better error message

Fix #729 