### PR TITLE
Fix metric deletion when attribuets are missing

### DIFF
--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -545,5 +545,7 @@ class Metric(MetricInfoMixin):
             self.filelock.release()
         if self.rendez_vous_lock is not None:
             self.rendez_vous_lock.release()
-        del self.writer
-        del self.data
+        if hasattr(self, "writer"):  # in case it was already deleted
+            del self.writer
+        if hasattr(self, "data"):  # in case it was already deleted
+            del self.data


### PR DESCRIPTION
When you call `del` on a metric we want to make sure that the arrow attributes are not already deleted.
I just added `if hasattr(...)` to make sure it doesn't crash