### PR TITLE
Make save function use deterministic global vars order

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -524,7 +524,7 @@ def save_function(pickler, obj):
     """
     if not dill._dill._locate_function(obj):
         dill._dill.log.info("F1: %s" % obj)
-        if getattr(pickler, '_recurse', False):
+        if getattr(pickler, "_recurse", False):
             # recurse to get all globals referred to by obj
             globalvars = dill.detect.globalvars
             globs = globalvars(obj, recurse=True, builtin=True)
@@ -539,41 +539,51 @@ def save_function(pickler, obj):
         # Only this line is different from the original implementation:
         globs = {k: globs[k] for k in sorted(globs.keys())}
         # The rest is the same as in the original dill implementation
-        _byref = getattr(pickler, '_byref', None)
-        _recurse = getattr(pickler, '_recurse', None)
+        _byref = getattr(pickler, "_byref", None)
+        _recurse = getattr(pickler, "_recurse", None)
         _memo = (id(obj) in dill._dill.stack) and (_recurse is not None)
         dill._dill.stack[id(obj)] = len(dill._dill.stack), obj
         if dill._dill.PY3:
-            _super = ('super' in getattr(obj.__code__, 'co_names', ())) and (_byref is not None)
+            _super = ("super" in getattr(obj.__code__, "co_names", ())) and (_byref is not None)
             if _super:
                 pickler._byref = True
             if _memo:
                 pickler._recurse = False
-            fkwdefaults = getattr(obj, '__kwdefaults__', None)
-            pickler.save_reduce(dill._dill._create_function, (obj.__code__,
-                                globs, obj.__name__,
-                                obj.__defaults__, obj.__closure__,
-                                obj.__dict__, fkwdefaults), obj=obj)
+            fkwdefaults = getattr(obj, "__kwdefaults__", None)
+            pickler.save_reduce(
+                dill._dill._create_function,
+                (obj.__code__, globs, obj.__name__, obj.__defaults__, obj.__closure__, obj.__dict__, fkwdefaults),
+                obj=obj,
+            )
         else:
-            _super = ('super' in getattr(obj.func_code, 'co_names', ())) and (_byref is not None) and getattr(pickler, '_recurse', False)
+            _super = (
+                ("super" in getattr(obj.func_code, "co_names", ()))
+                and (_byref is not None)
+                and getattr(pickler, "_recurse", False)
+            )
             if _super:
                 pickler._byref = True
             if _memo:
                 pickler._recurse = False
-            pickler.save_reduce(dill._dill._create_function, (obj.func_code,
-                                globs, obj.func_name,
-                                obj.func_defaults, obj.func_closure,
-                                obj.__dict__), obj=obj)
+            pickler.save_reduce(
+                dill._dill._create_function,
+                (obj.func_code, globs, obj.func_name, obj.func_defaults, obj.func_closure, obj.__dict__),
+                obj=obj,
+            )
         if _super:
             pickler._byref = _byref
         if _memo:
             pickler._recurse = _recurse
-        if dill._dill.OLDER and not _byref and (_super or (not _super and _memo) or (not _super and not _memo and _recurse)):
+        if (
+            dill._dill.OLDER
+            and not _byref
+            and (_super or (not _super and _memo) or (not _super and not _memo and _recurse))
+        ):
             pickler.clear_memo()
         dill._dill.log.info("# F1")
     else:
         dill._dill.log.info("F2: %s" % obj)
-        name = getattr(obj, '__qualname__', getattr(obj, '__name__', None))
+        name = getattr(obj, "__qualname__", getattr(obj, "__name__", None))
         dill._dill.StockPickler.save_global(pickler, obj, name=name)
         dill._dill.log.info("# F2")
     return

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -28,7 +28,7 @@ import types
 from io import BytesIO as StringIO
 from multiprocessing import Pool, RLock
 from shutil import disk_usage
-from types import CodeType
+from types import CodeType, FunctionType
 from typing import Callable, ClassVar, Generic, Optional, Tuple, Union
 
 import dill
@@ -512,6 +512,70 @@ def _save_code(pickler, obj):
         )
     pickler.save_reduce(CodeType, args, obj=obj)
     dill._dill.log.info("# Co")
+    return
+
+
+@pklregister(FunctionType)
+def save_function(pickler, obj):
+    """
+    From dill._dill.save_function
+    This is a modified version that make globs deterministic since the order of
+    the keys in the output dictionary of globalvars can change.
+    """
+    if not dill._dill._locate_function(obj):
+        dill._dill.log.info("F1: %s" % obj)
+        if getattr(pickler, '_recurse', False):
+            # recurse to get all globals referred to by obj
+            globalvars = dill.detect.globalvars
+            globs = globalvars(obj, recurse=True, builtin=True)
+            if id(obj) in dill._dill.stack:
+                globs = obj.__globals__ if dill._dill.PY3 else obj.func_globals
+        else:
+            globs = obj.__globals__ if dill._dill.PY3 else obj.func_globals
+        # globs is a dictionary with keys = var names (str) and values = python objects
+        # however the dictionary is not always loaded in the same order
+        # therefore we have to sort the keys to make deterministic.
+        # This is important to make `dump` deterministic.
+        # Only this line is different from the original implementation:
+        globs = {k: globs[k] for k in sorted(globs.keys())}
+        # The rest is the same as in the original dill implementation
+        _byref = getattr(pickler, '_byref', None)
+        _recurse = getattr(pickler, '_recurse', None)
+        _memo = (id(obj) in dill._dill.stack) and (_recurse is not None)
+        dill._dill.stack[id(obj)] = len(dill._dill.stack), obj
+        if dill._dill.PY3:
+            _super = ('super' in getattr(obj.__code__, 'co_names', ())) and (_byref is not None)
+            if _super:
+                pickler._byref = True
+            if _memo:
+                pickler._recurse = False
+            fkwdefaults = getattr(obj, '__kwdefaults__', None)
+            pickler.save_reduce(dill._dill._create_function, (obj.__code__,
+                                globs, obj.__name__,
+                                obj.__defaults__, obj.__closure__,
+                                obj.__dict__, fkwdefaults), obj=obj)
+        else:
+            _super = ('super' in getattr(obj.func_code, 'co_names', ())) and (_byref is not None) and getattr(pickler, '_recurse', False)
+            if _super:
+                pickler._byref = True
+            if _memo:
+                pickler._recurse = False
+            pickler.save_reduce(dill._dill._create_function, (obj.func_code,
+                                globs, obj.func_name,
+                                obj.func_defaults, obj.func_closure,
+                                obj.__dict__), obj=obj)
+        if _super:
+            pickler._byref = _byref
+        if _memo:
+            pickler._recurse = _recurse
+        if dill._dill.OLDER and not _byref and (_super or (not _super and _memo) or (not _super and not _memo and _recurse)):
+            pickler.clear_memo()
+        dill._dill.log.info("# F1")
+    else:
+        dill._dill.log.info("F2: %s" % obj)
+        name = getattr(obj, '__qualname__', getattr(obj, '__name__', None))
+        dill._dill.StockPickler.save_global(pickler, obj, name=name)
+        dill._dill.log.info("# F2")
     return
 
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,9 +1,9 @@
 from hashlib import md5
 from types import CodeType, FunctionType
 from unittest import TestCase
+from unittest.mock import patch
 
 import datasets
-from unittest.mock import patch
 
 from .utils import require_regex, require_transformers
 
@@ -140,6 +140,7 @@ class RecurseDumpTest(TestCase):
 
         def func():
             return foo, bar
+
         func.__module__ = "__main__"
 
         def globalvars_mock1_side_effect(func, *args, **kwargs):


### PR DESCRIPTION
The `dumps` function need to be deterministic for the caching mechanism.
However in #816 I noticed that one of dill's method to recursively check the globals of a function may return the globals in different orders each time it's used. To fix that I sort the globals by key in the `globs` dictionary.
I had to add a rectified `save_function` to the saving functions registry of the Pickler to make it work.

This should fix #816 