### PR TITLE
Add accuracy, precision, recall and F1 metrics

### DIFF
--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 """Accuracy metric."""
 
-import datasets
 from sklearn.metrics import accuracy_score
+
+import datasets
 
 
 _DESCRIPTION = """
@@ -44,11 +45,13 @@ class Accuracy(datasets.Metric):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features({
-                'predictions': datasets.Value('int'),
-                'references': datasets.Value('int'),
-            }),
-            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html"]
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("int"),
+                    "references": datasets.Value("int"),
+                }
+            ),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html"],
         )
 
     def _compute(self, predictions, references, normalize=True, sample_weight=None):

--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Accuracy metric."""
+
+import datasets
+from sklearn.metrics import accuracy_score
+
+
+_DESCRIPTION = """
+Accuracy is the proportion of correct predictions among the total number of cases processed. It can be computed with:
+Accuracy = (TP + TN) / (TP + TN + FP + FN)
+TP: True positive
+TN: True negative
+FP: False positive
+FN: False negative
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions: Ground truth labels.
+    references: Predicted labels, as returned by a model.
+    normalize: If False, return the number of correctly classified samples.
+        Otherwise, return the fraction of correctly classified samples.
+    sample_weight: Sample weights.
+Returns:
+    accuracy: Accuracy score.
+"""
+
+
+class Accuracy(datasets.Metric):
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features({
+                'predictions': datasets.Value('int'),
+                'references': datasets.Value('int'),
+            }),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html"]
+        )
+
+    def _compute(self, predictions, references, normalize=True, sample_weight=None):
+        return {
+            "accuracy": accuracy_score(references, predictions, normalize, sample_weight),
+        }

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""F1 metric."""
+
+import datasets
+from sklearn.metrics import f1_score
+
+
+_DESCRIPTION = """
+The F1 score is the harmonic mean of the precision and recall. It can be computed with:
+F1 = 2 * (precision * recall) / (precision + recall)
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions: Ground truth labels.
+    references: Predicted labels, as returned by a model.
+    labels: The set of labels to include when average != 'binary', and
+        their order if average is None. Labels present in the data can
+        be excluded, for example to calculate a multiclass average ignoring
+        a majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in y_true and
+        y_pred are used in sorted order.
+    average: This parameter is required for multiclass/multilabel targets.
+        If None, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+            binary: Only report results for the class specified by pos_label.
+                This is applicable only if targets (y_{true,pred}) are binary.
+            micro: Calculate metrics globally by counting the total true positives,
+                false negatives and false positives.
+            macro: Calculate metrics for each label, and find their unweighted mean.
+                This does not take label imbalance into account.
+            weighted: Calculate metrics for each label, and find their average
+                weighted by support (the number of true instances for each label).
+                This alters ‘macro’ to account for label imbalance; it can result
+                in an F-score that is not between precision and recall.
+            samples: Calculate metrics for each instance, and find their average
+                (only meaningful for multilabel classification).
+    sample_weight: Sample weights.
+Returns:
+    f1: F1 score.
+"""
+
+
+class F1(datasets.Metric):
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features({
+                'predictions': datasets.Value('int'),
+                'references': datasets.Value('int'),
+            }),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"]
+        )
+
+    def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
+        return {
+            "f1": f1_score(references, predictions, labels, pos_label, average, sample_weight),
+        }

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 """F1 metric."""
 
-import datasets
 from sklearn.metrics import f1_score
+
+import datasets
 
 
 _DESCRIPTION = """
@@ -60,11 +61,13 @@ class F1(datasets.Metric):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features({
-                'predictions': datasets.Value('int'),
-                'references': datasets.Value('int'),
-            }),
-            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"]
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("int"),
+                    "references": datasets.Value("int"),
+                }
+            ),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"],
         )
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Precision metric."""
+
+import datasets
+from sklearn.metrics import precision_score
+
+
+_DESCRIPTION = """
+Precision is the fraction of the true examples among the predicted examples. It can be computed with:
+Precision = TP / (TP + FP)
+TP: True positive
+FP: False positive
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions: Ground truth labels.
+    references: Predicted labels, as returned by a model.
+    labels: The set of labels to include when average != 'binary', and
+        their order if average is None. Labels present in the data can
+        be excluded, for example to calculate a multiclass average ignoring
+        a majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in y_true and
+        y_pred are used in sorted order.
+    average: This parameter is required for multiclass/multilabel targets.
+        If None, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+            binary: Only report results for the class specified by pos_label.
+                This is applicable only if targets (y_{true,pred}) are binary.
+            micro: Calculate metrics globally by counting the total true positives,
+                false negatives and false positives.
+            macro: Calculate metrics for each label, and find their unweighted mean.
+                This does not take label imbalance into account.
+            weighted: Calculate metrics for each label, and find their average
+                weighted by support (the number of true instances for each label).
+                This alters ‘macro’ to account for label imbalance; it can result
+                in an F-score that is not between precision and recall.
+            samples: Calculate metrics for each instance, and find their average
+                (only meaningful for multilabel classification).
+    sample_weight: Sample weights.
+Returns:
+    precision: Precision score.
+"""
+
+
+class Precision(datasets.Metric):
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features({
+                'predictions': datasets.Value('int'),
+                'references': datasets.Value('int'),
+            }),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html"]
+        )
+
+    def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
+        return {
+            "precision": precision_score(references, predictions, labels, pos_label, average, sample_weight),
+        }

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 """Precision metric."""
 
-import datasets
 from sklearn.metrics import precision_score
+
+import datasets
 
 
 _DESCRIPTION = """
@@ -62,11 +63,13 @@ class Precision(datasets.Metric):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features({
-                'predictions': datasets.Value('int'),
-                'references': datasets.Value('int'),
-            }),
-            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html"]
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("int"),
+                    "references": datasets.Value("int"),
+                }
+            ),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html"],
         )
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Recall metric."""
+
+import datasets
+from sklearn.metrics import recall_score
+
+
+_DESCRIPTION = """
+Recall is the fraction of the total amount of relevant examples that were actually retrieved. It can be computed with:
+Precision = TP / (TP + FN)
+TP: True positive
+FN: False negative
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions: Ground truth labels.
+    references: Predicted labels, as returned by a model.
+    labels: The set of labels to include when average != 'binary', and
+        their order if average is None. Labels present in the data can
+        be excluded, for example to calculate a multiclass average ignoring
+        a majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in y_true and
+        y_pred are used in sorted order.
+    average: This parameter is required for multiclass/multilabel targets.
+        If None, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+            binary: Only report results for the class specified by pos_label.
+                This is applicable only if targets (y_{true,pred}) are binary.
+            micro: Calculate metrics globally by counting the total true positives,
+                false negatives and false positives.
+            macro: Calculate metrics for each label, and find their unweighted mean.
+                This does not take label imbalance into account.
+            weighted: Calculate metrics for each label, and find their average
+                weighted by support (the number of true instances for each label).
+                This alters ‘macro’ to account for label imbalance; it can result
+                in an F-score that is not between precision and recall.
+            samples: Calculate metrics for each instance, and find their average
+                (only meaningful for multilabel classification).
+    sample_weight: Sample weights.
+Returns:
+    recall: Recall score.
+"""
+
+
+class Recall(datasets.Metric):
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features({
+                'predictions': datasets.Value('int'),
+                'references': datasets.Value('int'),
+            }),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html"]
+        )
+
+    def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
+        return {
+            "recall": recall_score(references, predictions, labels, pos_label, average, sample_weight),
+        }

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 """Recall metric."""
 
-import datasets
 from sklearn.metrics import recall_score
+
+import datasets
 
 
 _DESCRIPTION = """
@@ -62,11 +63,13 @@ class Recall(datasets.Metric):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features({
-                'predictions': datasets.Value('int'),
-                'references': datasets.Value('int'),
-            }),
-            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html"]
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("int"),
+                    "references": datasets.Value("int"),
+                }
+            ),
+            reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html"],
         )
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):


### PR DESCRIPTION
This PR adds several single metrics, namely:

- Accuracy
- Precision
- Recall
- F1

They all uses under the hood the sklearn metrics of the same name. They allow different useful features when training a multilabel/multiclass model:
- have a macro/micro/per label/weighted/binary/per sample score
- score only the selected labels (usually what we call the positive labels) and ignore the negative ones. For example in case of a Named Entity Recognition task, positive labels are (`PERSON`, `LOCATION` or `ORGANIZATION`) and the negative one is `O`.