### PR TITLE
amazon description fields as bullets

### DIFF
--- a/datasets/amazon_us_reviews/amazon_us_reviews.py
+++ b/datasets/amazon_us_reviews/amazon_us_reviews.py
@@ -32,23 +32,21 @@ Over 130+ million customer reviews are available to researchers as part of this 
 
 Each Dataset contains the following columns:
 
-    marketplace       - 2 letter country code of the marketplace where the review was written.
-    customer_id       - Random identifier that can be used to aggregate reviews written by a single author.
-    review_id         - The unique ID of the review.
-    product_id        - The unique Product ID the review pertains to. In the multilingual dataset the reviews
-                        for the same product in different countries can be grouped by the same product_id.
-    product_parent    - Random identifier that can be used to aggregate reviews for the same product.
-    product_title     - Title of the product.
-    product_category  - Broad product category that can be used to group reviews
-                        (also used to group the dataset into coherent parts).
-    star_rating       - The 1-5 star rating of the review.
-    helpful_votes     - Number of helpful votes.
-    total_votes       - Number of total votes the review received.
-    vine              - Review was written as part of the Vine program.
-    verified_purchase - The review is on a verified purchase.
-    review_headline   - The title of the review.
-    review_body       - The review text.
-    review_date       - The date the review was written.
+- marketplace: 2 letter country code of the marketplace where the review was written.
+- customer_id: Random identifier that can be used to aggregate reviews written by a single author.
+- review_id: The unique ID of the review.
+- product_id: The unique Product ID the review pertains to. In the multilingual dataset the reviews for the same product in different countries can be grouped by the same product_id.
+- product_parent: Random identifier that can be used to aggregate reviews for the same product.
+- product_title: Title of the product.
+- product_category: Broad product category that can be used to group reviews (also used to group the dataset into coherent parts).
+- star_rating: The 1-5 star rating of the review.
+- helpful_votes: Number of helpful votes.
+- total_votes: Number of total votes the review received.
+- vine: Review was written as part of the Vine program.
+- verified_purchase: The review is on a verified purchase.
+- review_headline: The title of the review.
+- review_body: The review text.
+- review_date: The date the review was written.
 """
 
 _DATA_OPTIONS = [


### PR DESCRIPTION
One more minor formatting change to amazon reviews's description (in addition to #844). Just reformatting the fields to display as a bulleted list in markdown.