### PR TITLE
Fix some metrics feature types

### DIFF
--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -39,16 +39,31 @@ Returns:
     accuracy: Accuracy score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class Accuracy(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html"],
@@ -56,5 +71,5 @@ class Accuracy(datasets.Metric):
 
     def _compute(self, predictions, references, normalize=True, sample_weight=None):
         return {
-            "accuracy": accuracy_score(references, predictions, normalize, sample_weight),
+            "accuracy": accuracy_score(references, predictions, normalize=normalize, sample_weight=sample_weight),
         }

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -55,16 +55,31 @@ Returns:
     f1: F1 score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class F1(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"],
@@ -72,5 +87,12 @@ class F1(datasets.Metric):
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
         return {
-            "f1": f1_score(references, predictions, labels, pos_label, average, sample_weight),
+            "f1": f1_score(
+                references,
+                predictions,
+                labels=labels,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight,
+            ),
         }

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -57,16 +57,31 @@ Returns:
     precision: Precision score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class Precision(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html"],
@@ -74,5 +89,12 @@ class Precision(datasets.Metric):
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
         return {
-            "precision": precision_score(references, predictions, labels, pos_label, average, sample_weight),
+            "precision": precision_score(
+                references,
+                predictions,
+                labels=labels,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight,
+            ),
         }

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -57,16 +57,31 @@ Returns:
     recall: Recall score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class Recall(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html"],
@@ -74,5 +89,12 @@ class Recall(datasets.Metric):
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
         return {
-            "recall": recall_score(references, predictions, labels, pos_label, average, sample_weight),
+            "recall": recall_score(
+                references,
+                predictions,
+                labels=labels,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight,
+            ),
         }


### PR DESCRIPTION
Replace `int` feature type to `int32` since `int` is not a pyarrow dtype in those metrics:
- accuracy
- precision
- recall
- f1
I also added the sklearn citation and used keyword arguments to remove future warnings