### PR TITLE
Consistent metric outputs

### DIFF
--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -39,16 +39,31 @@ Returns:
     accuracy: Accuracy score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class Accuracy(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html"],
@@ -56,5 +71,5 @@ class Accuracy(datasets.Metric):
 
     def _compute(self, predictions, references, normalize=True, sample_weight=None):
         return {
-            "accuracy": accuracy_score(references, predictions, normalize, sample_weight),
+            "accuracy": accuracy_score(references, predictions, normalize=normalize, sample_weight=sample_weight),
         }

--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -60,6 +60,7 @@ class Accuracy(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["accuracy"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("int32"),

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -74,6 +74,7 @@ class BERTScore(datasets.Metric):
             citation=_CITATION,
             homepage="https://github.com/Tiiiger/bert_score",
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["f1", "precision", "recall"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("string", id="sequence"),
@@ -117,7 +118,6 @@ class BERTScore(datasets.Metric):
             rescale_with_baseline=rescale_with_baseline,
             use_custom_baseline=baseline_path is not None,
         )
-
         if not hasattr(self, "cached_bertscorer") or self.cached_bertscorer.hash != hashcode:
             self.cached_bertscorer = bert_score.BERTScorer(
                 model_type=model_type,
@@ -142,7 +142,6 @@ class BERTScore(datasets.Metric):
             "precision": P,
             "recall": R,
             "f1": F,
-            "hashcode": hashcode,
         }
         return output_dict
 

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -82,7 +82,7 @@ class Bleu(datasets.Metric):
         if self.config_name == "default":
             self.max_order = 4
         else:
-            if not re.match("^max_order\.[0-9]+$", self.config_name):
+            if not re.match(r"^max_order\.[0-9]+$", self.config_name):
                 raise KeyError(
                     "You should supply a valid configuration name. "
                     "For example 'max_order.1' for max_order=1 or 'max_order.1' for max_order=2. "

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -17,6 +17,7 @@
 import os
 from logging import getLogger
 
+import numpy as np
 from bleurt import score  # From: git+https://github.com/google-research/bleurt.git
 
 import datasets
@@ -73,6 +74,7 @@ class BLEURT(datasets.Metric):
             citation=_CITATION,
             homepage="https://github.com/google-research/bleurt",
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["bleurt_mean", "bleurt_std"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("string", id="sequence"),
@@ -103,4 +105,4 @@ class BLEURT(datasets.Metric):
 
     def _compute(self, predictions, references):
         scores = self.scorer.score(references=references, candidates=predictions)
-        return {"scores": scores}
+        return {"bleurt_mean": np.mean(scores), "bleurt_std": np.std(scores)}

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -55,16 +55,31 @@ Returns:
     f1: F1 score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class F1(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"],
@@ -72,5 +87,12 @@ class F1(datasets.Metric):
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
         return {
-            "f1": f1_score(references, predictions, labels, pos_label, average, sample_weight),
+            "f1": f1_score(
+                references,
+                predictions,
+                labels=labels,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight,
+            ),
         }

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -76,6 +76,7 @@ class F1(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["f1"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("int32"),

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -94,10 +94,25 @@ class Glue(datasets.Metric):
                 '["sst2", "mnli", "mnli_mismatched", "mnli_matched", '
                 '"cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]'
             )
+        output_names_per_config = {
+            "sst2": ["accuracy"],
+            "mnli": ["accuracy"],
+            "mnli_mismatched": ["accuracy"],
+            "mnli_matched": ["accuracy"],
+            "cola": ["matthews_correlation"],
+            "stsb": ["pearson", "spearmanr"],
+            "mrpc": ["accuracy", "f1"],
+            "qqp": ["accuracy", "f1"],
+            "qnli": ["accuracy"],
+            "rte": ["accuracy"],
+            "wnli": ["accuracy"],
+            "hans": ["accuracy"],
+        }
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=output_names_per_config[self.config_name],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("int64" if self.config_name != "stsb" else "float32"),

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -74,6 +74,7 @@ class Meteor(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["meteor_mean", "meteor_std"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("string", id="sequence"),
@@ -93,4 +94,4 @@ class Meteor(datasets.Metric):
             for ref, pred in zip(references, predictions)
         ]
 
-        return {"meteor": np.mean(scores)}
+        return {"meteor_mean": np.mean(scores), "meteor_std": np.std(scores)}

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -57,16 +57,31 @@ Returns:
     precision: Precision score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class Precision(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html"],
@@ -74,5 +89,12 @@ class Precision(datasets.Metric):
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
         return {
-            "precision": precision_score(references, predictions, labels, pos_label, average, sample_weight),
+            "precision": precision_score(
+                references,
+                predictions,
+                labels=labels,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight,
+            ),
         }

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -78,6 +78,7 @@ class Precision(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["precision"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("int32"),

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -57,16 +57,31 @@ Returns:
     recall: Recall score.
 """
 
+_CITATION = """\
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+"""
+
 
 class Recall(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
+            citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int"),
-                    "references": datasets.Value("int"),
+                    "predictions": datasets.Value("int32"),
+                    "references": datasets.Value("int32"),
                 }
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html"],
@@ -74,5 +89,12 @@ class Recall(datasets.Metric):
 
     def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
         return {
-            "recall": recall_score(references, predictions, labels, pos_label, average, sample_weight),
+            "recall": recall_score(
+                references,
+                predictions,
+                labels=labels,
+                pos_label=pos_label,
+                average=average,
+                sample_weight=sample_weight,
+            ),
         }

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -78,6 +78,7 @@ class Recall(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["recall"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("int32"),

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -66,11 +66,14 @@ Returns:
 
 class Sacrebleu(datasets.Metric):
     def _info(self):
+        output_names = ["score", "counts", "totals", "bp", "sys_len", "ref_len"]
+        output_names += [f"precision_{i}" for i in range(1, scb.BLEU.NGRAM_ORDER + 1)]
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/mjpost/sacreBLEU",
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=output_names,
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("string", id="sequence"),
@@ -114,9 +117,10 @@ class Sacrebleu(datasets.Metric):
             "score": output.score,
             "counts": output.counts,
             "totals": output.totals,
-            "precisions": output.precisions,
             "bp": output.bp,
             "sys_len": output.sys_len,
             "ref_len": output.ref_len,
         }
+        for i in range(1, scb.BLEU.NGRAM_ORDER + 1):
+            output_dict[f"precision_{i}"] = output.precisions[i - 1]
         return output_dict

--- a/metrics/squad/squad.py
+++ b/metrics/squad/squad.py
@@ -62,6 +62,7 @@ class Squad(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["exact_match", "f1"],
             features=datasets.Features(
                 {
                     "predictions": {"id": datasets.Value("string"), "prediction_text": datasets.Value("string")},

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -77,6 +77,7 @@ class SquadV2(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["exact", "f1", "total"],
             features=datasets.Features(
                 {
                     "predictions": {

--- a/metrics/xnli/xnli.py
+++ b/metrics/xnli/xnli.py
@@ -63,6 +63,7 @@ class Xnli(datasets.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
+            output_names=["accuracy"],
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("int64" if self.config_name != "sts-b" else "float32"),

--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -260,6 +260,7 @@ class MetricInfo:
     license: str = field(default_factory=str)
     codebase_urls: List[str] = field(default_factory=list)
     reference_urls: List[str] = field(default_factory=list)
+    output_names: List[str] = field(default_factory=list)
     streamable: bool = False
     format: Optional[str] = None
 

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -91,6 +91,10 @@ class MetricInfoMixin(object):
         return self._metric_info.citation
 
     @property
+    def output_names(self) -> Optional[List[str]]:
+        return self._metric_info.output_names
+
+    @property
     def features(self) -> Features:
         return self._metric_info.features
 


### PR DESCRIPTION
To automate the use of metrics, they should return consistent outputs.
In particular I'm working on adding a conversion of metrics to keras metrics.
To achieve this we need two things:
- have each metric return dictionaries of string -> floats since each keras metrics should return one float
- define in the metric info the different fields of the output dictionary

In this PR I'm adding these two features.
I also fixed a few bugs in some metrics

#867 needs to be merged first