### PR TITLE
Fix wikipedia custom config

### DIFF
--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -395,7 +395,7 @@ class Wikipedia(datasets.BeamBasedBuilder):
     """Wikipedia dataset."""
 
     # Use mirror (your.org) to avoid download caps.
-
+    BUILDER_CONFIG_CLASS = WikipediaConfig
     BUILDER_CONFIGS = [
         WikipediaConfig(
             version=_VERSION,


### PR DESCRIPTION
It should be possible to use the wikipedia dataset with any `language` and `date`.
However it was not working as noticed in #784 . Indeed the custom wikipedia configurations were not enabled for some reason.

I fixed that and was able to run 
```python
from datasets import load_dataset
load_dataset("./datasets/wikipedia", language="zh", date="20201120", beam_runner='DirectRunner')
```

cc @stvhuang @SamuelCahyawijaya

Fix #784