### PR TITLE
Allow several tags sets

### DIFF
--- a/datasets/allocine/README.md
+++ b/datasets/allocine/README.md
@@ -1,21 +1,25 @@
-annotations_creators:
-- no-annotation
-language_creators:
-- found
-languages:
-- fr
-licenses:
-- mit
-multilinguality:
-- monolingual
-size_categories:
-- 100K<n<1M
-source_datasets:
-- original
-task_categories:
-- text-classification
-task_ids:
-- sentiment-classification
+---
+tags:
+- annotations_creators:
+    - no-annotation
+  language_creators:
+    - found
+  languages:
+    - fr
+  licenses:
+    - mit
+  multilinguality:
+    - monolingual
+  size_categories:
+    - 100K<n<1M
+  source_datasets:
+    - original
+  task_categories:
+    - text-classification
+  task_ids:
+    - sentiment-classification
+  configurations:
+    - allocine
 ---
 # Dataset Card for Allociné
 

--- a/datasets/cnn_dailymail/README.md
+++ b/datasets/cnn_dailymail/README.md
@@ -1,22 +1,27 @@
 ---
-annotations_creators:
-- no-annotation
-language_creators:
-- found
-languages:
-- en
-licenses:
-- apache-2.0
-multilinguality:
-- monolingual
-size_categories:
-- 100K<n<1M
-source_datasets:
-- original
-task_categories:
-- conditional-text-generation
-task_ids:
-- summarization
+tags:
+- annotations_creators:
+    - no-annotation
+  language_creators:
+    - found
+  languages:
+    - en
+  licenses:
+    - apache-2.0
+  multilinguality:
+    - monolingual
+  size_categories:
+    - 100K<n<1M
+  source_datasets:
+    - original
+  task_categories:
+    - conditional-text-generation
+  task_ids:
+    - summarization
+  configurations:
+    - 3.0.0
+    - 2.0.0
+    - 1.0.0
 ---
 # Dataset Card for CNN Dailymail Dataset
 

--- a/datasets/snli/README.md
+++ b/datasets/snli/README.md
@@ -1,19 +1,25 @@
 ---
-language: 
-- en
-task:
-- text-classification
-purpose:
-- NLI
-size:
-- ">100k"
-language producers:
-- crowdsourced
-annotation:
-- crowdsourced
 tags:
-- extended-from-other-datasets
-license: "CC BY-SA 4.0"
+- annotations_creators:
+    - crowdsourced
+  language_creators:
+    - crowdsourced
+  languages:
+    - en
+  licenses:
+    - cc-by-nc-4.0
+  multilinguality:
+    - monolingual
+  size_categories:
+    - 100K<n<1M
+  source_datasets:
+    - original
+  task_categories:
+    - text-classification
+  task_ids:
+    - natural-language-inference
+  configurations:
+    - plain_text
 ---
 # Dataset Card for SNLI
 


### PR DESCRIPTION
Hi !

Currently we have three dataset cards : snli, cnn_dailymail and allocine.
For each one of those datasets a set of tag is defined. The set of tags contains fields like `multilinguality`, `task_ids`, `licenses` etc.

For certain datasets like `glue` for example, there exist several configurations: `sst2`, `mnli` etc. Therefore we should define one set of tags per configuration. However the current format used for tags only supports one set of tags per dataset.

In this PR I propose a simple change in the yaml format used for tags to allow for several sets of tags.

Let me know what you think, especially @julien-c let me know if it's good for you since it's going to be parsed by moon-landing