### PR TITLE
Better messages regarding split naming

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, List, Optional
 import pyarrow as pa
 import pyarrow.parquet
 
-from .naming import filename_for_dataset_split
+from .naming import _split_re, filename_for_dataset_split
 from .utils import cached_path, logging
 
 
@@ -37,13 +37,12 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
-_BUFFER_SIZE = 8 << 20  # 8 MiB per file.
 HF_GCP_BASE_URL = "https://storage.googleapis.com/huggingface-nlp/cache/datasets"
 
 _SUB_SPEC_RE = re.compile(
     r"""
 ^
- (?P<split>\w+)
+ (?P<split>{split_re})
  (\[
     ((?P<from>-?\d+)
      (?P<from_pct>%)?)?
@@ -52,7 +51,9 @@ _SUB_SPEC_RE = re.compile(
      (?P<to_pct>%)?)?
  \])?
 $
-""",
+""".format(
+        split_re=_split_re[1:-1]
+    ),  # remove ^ and $
     re.X,
 )
 

--- a/src/datasets/naming.py
+++ b/src/datasets/naming.py
@@ -23,6 +23,8 @@ import re
 _first_cap_re = re.compile("(.)([A-Z][a-z0-9]+)")
 _all_cap_re = re.compile("([a-z0-9])([A-Z])")
 
+_split_re = r"^[a-zA-Z0-9_\-]+$"
+
 
 def camelcase_to_snakecase(name):
     """Convert camel-case string to snake-case."""
@@ -44,6 +46,8 @@ def filename_prefix_for_name(name):
 def filename_prefix_for_split(name, split):
     if os.path.basename(name) != name:
         raise ValueError("Should be a dataset name, not a path: %s" % name)
+    if not re.match(_split_re, split):
+        raise ValueError(f"Split name should match '{_split_re}'' but got '{split}'.")
     return "%s-%s" % (filename_prefix_for_name(name), split)
 
 

--- a/src/datasets/naming.py
+++ b/src/datasets/naming.py
@@ -23,7 +23,7 @@ import re
 _first_cap_re = re.compile("(.)([A-Z][a-z0-9]+)")
 _all_cap_re = re.compile("([a-z0-9])([A-Z])")
 
-_split_re = r"^[a-zA-Z0-9_\-]+$"
+_split_re = r"^\w+$"
 
 
 def camelcase_to_snakecase(name):

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -20,10 +20,12 @@ from __future__ import absolute_import, division, print_function
 
 import abc
 import collections
+import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from .arrow_reader import FileInstructions, make_file_instructions
+from .naming import _split_re
 from .utils.py_utils import NonMutableDict
 
 
@@ -347,6 +349,8 @@ class NamedSplit(SplitBase):
 
     def __init__(self, name):
         self._name = name
+        if not re.match(_split_re, name):
+            raise ValueError(f"Split name should match '{_split_re}'' but got '{name}'.")
 
     def __str__(self):
         return self._name
@@ -571,3 +575,5 @@ class SplitGenerator:
     def __post_init__(self):
         self.name = str(self.name)  # Make sure we convert NamedSplits in strings
         self.split_info = SplitInfo(name=self.name)
+        if not re.match(_split_re, self.name):
+            raise ValueError(f"Split name should match '{_split_re}'' but got '{self.name}'.")

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -349,8 +349,10 @@ class NamedSplit(SplitBase):
 
     def __init__(self, name):
         self._name = name
-        if not re.match(_split_re, name):
-            raise ValueError(f"Split name should match '{_split_re}'' but got '{name}'.")
+        split_names_from_instruction = [split_instruction.split("[")[0] for split_instruction in name.split("+")]
+        for split_name in split_names_from_instruction:
+            if not re.match(_split_re, split_name):
+                raise ValueError(f"Split name should match '{_split_re}'' but got '{split_name}'.")
 
     def __str__(self):
         return self._name
@@ -574,6 +576,5 @@ class SplitGenerator:
 
     def __post_init__(self):
         self.name = str(self.name)  # Make sure we convert NamedSplits in strings
+        NamedSplit(self.name)  # check that it's a valid split name
         self.split_info = SplitInfo(name=self.name)
-        if not re.match(_split_re, self.name):
-            raise ValueError(f"Split name should match '{_split_re}'' but got '{self.name}'.")


### PR DESCRIPTION
I made explicit the error message when a bad split name is used.

Also I wanted to allow the `-` symbol for split names but actually this symbol is used to name the arrow files `{dataset_name}-{dataset_split}.arrow` so we should probably keep it this way, i.e. not allowing the `-` symbol in split names. Moreover in the future we might want to use `{dataset_name}-{dataset_split}-{shard_id}_of_{n_shards}.arrow` and reuse the `-` symbol.