### PR TITLE
Fix URL with backslash in Windows

### DIFF
--- a/datasets/boolq/boolq.py
+++ b/datasets/boolq/boolq.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -26,9 +25,11 @@ Each example is a triplet of (question, passage, answer), with the title of the 
 The text-pair classification setup is similar to existing natural language inference tasks.
 """
 
-_URL = "https://storage.googleapis.com/boolq"
-_TRAIN_FILE_NAME = "train.jsonl"
-_DEV_FILE_NAME = "dev.jsonl"
+_URL = "https://storage.googleapis.com/boolq/"
+_URLS = {
+    "train": _URL + "train.jsonl",
+    "dev": _URL + "dev.jsonl",
+}
 
 
 class Boolq(datasets.GeneratorBasedBuilder):
@@ -65,10 +66,7 @@ class Boolq(datasets.GeneratorBasedBuilder):
         # TODO(boolq): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {
-            "train": os.path.join(_URL, _TRAIN_FILE_NAME),
-            "dev": os.path.join(_URL, _DEV_FILE_NAME),
-        }
+        urls_to_download = _URLS
         downloaded_files = dl_manager.download(urls_to_download)
 
         return [

--- a/datasets/com_qa/com_qa.py
+++ b/datasets/com_qa/com_qa.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -40,10 +39,13 @@ in ComQA are grouped into 4,834 paraphrase clusters that express the same inform
 with its answer(s). ComQA answers come in the form of Wikipedia entities wherever possible. Wherever the answers are
 temporal or measurable quantities, TIMEX3 and the International System of Units (SI) are used for normalization.
 """
-_URL = "https://qa.mpi-inf.mpg.de/comqa"
-_TRAIN_FILE = "comqa_train.json"
-_DEV_FILE = "comqa_dev.json"
-_TEST_FILE = "comqa_test.json"
+
+_URL = "https://qa.mpi-inf.mpg.de/comqa/"
+_URLS = {
+    "train": _URL + "comqa_train.json",
+    "dev": _URL + "comqa_dev.json",
+    "test": _URL + "comqa_test.json",
+}
 
 
 class ComQa(datasets.GeneratorBasedBuilder):
@@ -80,11 +82,7 @@ class ComQa(datasets.GeneratorBasedBuilder):
         # TODO(com_qa): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {
-            "train": os.path.join(_URL, _TRAIN_FILE),
-            "dev": os.path.join(_URL, _DEV_FILE),
-            "test": os.path.join(_URL, _TEST_FILE),
-        }
+        urls_to_download = _URLS
         dl_dir = dl_manager.download_and_extract(urls_to_download)
         return [
             datasets.SplitGenerator(

--- a/datasets/commonsense_qa/commonsense_qa.py
+++ b/datasets/commonsense_qa/commonsense_qa.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -25,10 +24,13 @@ CommonsenseQA is a new multiple-choice question answering dataset that requires 
  The dataset is provided in two major training/validation/testing set splits: "Random split" which is the main evaluation
   split, and "Question token split", see paper for details.
 """
-_URL = "https://s3.amazonaws.com/commensenseqa"
-_TRAINING_FILE = "train_rand_split.jsonl"
-_DEV_FILE = "dev_rand_split.jsonl"
-_TEST_FILE = "test_rand_split_no_answers.jsonl"
+
+_URL = "https://s3.amazonaws.com/commensenseqa/"
+_URLS = {
+    "train": _URL + "train_rand_split.jsonl",
+    "dev": _URL + "dev_rand_split.jsonl",
+    "test": _URL + "test_rand_split_no_answers.jsonl",
+}
 
 
 class CommonsenseQa(datasets.GeneratorBasedBuilder):
@@ -68,11 +70,7 @@ class CommonsenseQa(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
 
-        download_urls = {
-            "train": os.path.join(_URL, _TRAINING_FILE),
-            "test": os.path.join(_URL, _TEST_FILE),
-            "dev": os.path.join(_URL, _DEV_FILE),
-        }
+        download_urls = _URLS
 
         downloaded_files = dl_manager.download_and_extract(download_urls)
 

--- a/datasets/fquad/fquad.py
+++ b/datasets/fquad/fquad.py
@@ -33,9 +33,12 @@ We introduce FQuAD, a native French Question Answering Dataset. FQuAD contains 2
 Finetuning CamemBERT on FQuAD yields a F1 score of 88% and an exact match of 77.9%.
 
 """
-_URL = "https://storage.googleapis.com/illuin/fquad"
-_TRAIN_DATA = "train.json.zip"
-_VALID_DATA = "valid.json.zip"
+
+_URL = "https://storage.googleapis.com/illuin/fquad/"
+_URLS = {
+    "train": _URL + "train.json.zip",
+    "valid": _URL + "valid.json.zip",
+}
 
 
 class Fquad(datasets.GeneratorBasedBuilder):
@@ -74,7 +77,7 @@ class Fquad(datasets.GeneratorBasedBuilder):
         # TODO(fquad): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        download_urls = {"train": os.path.join(_URL, _TRAIN_DATA), "valid": os.path.join(_URL, _VALID_DATA)}
+        download_urls = _URLS
         dl_dir = dl_manager.download_and_extract(download_urls)
         return [
             datasets.SplitGenerator(

--- a/datasets/squad_it/squad_it.py
+++ b/datasets/squad_it/squad_it.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -30,9 +29,12 @@ into Italian. It represents a large-scale dataset for open question answering pr
  The dataset contains more than 60,000 question/answer pairs derived from the original English dataset. The dataset is
  split into training and test sets to support the replicability of the benchmarking of QA systems:
 """
-_URL = "https://github.com/crux82/squad-it/raw/master"
-_TRAIN_FILE = "SQuAD_it-train.json.gz"
-_TEST_FILE = "SQuAD_it-test.json.gz"
+
+_URL = "https://github.com/crux82/squad-it/raw/master/"
+_URLS = {
+    "train": _URL + "SQuAD_it-train.json.gz",
+    "test": _URL + "SQuAD_it-test.json.gz",
+}
 
 
 class SquadIt(datasets.GeneratorBasedBuilder):
@@ -75,7 +77,7 @@ class SquadIt(datasets.GeneratorBasedBuilder):
         # TODO(squad_it): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {"train": os.path.join(_URL, _TRAIN_FILE), "test": os.path.join(_URL, _TEST_FILE)}
+        urls_to_download = _URLS
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         return [

--- a/datasets/squad_v1_pt/squad_v1_pt.py
+++ b/datasets/squad_v1_pt/squad_v1_pt.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -27,9 +26,12 @@ archivePrefix = {arXiv},
 _DESCRIPTION = """\
 Portuguese translation of the SQuAD dataset. The translation was performed automatically using the Google Cloud API.
 """
-_URL = "https://github.com/nunorc/squad-v1.1-pt/raw/master"
-_TRAIN_FILE = "train-v1.1-pt.json"
-_DEV_FILE = "dev-v1.1-pt.json"
+
+_URL = "https://github.com/nunorc/squad-v1.1-pt/raw/master/"
+_URLS = {
+    "train": _URL + "train-v1.1-pt.json",
+    "dev": _URL + "dev-v1.1-pt.json",
+}
 
 
 class SquadV1Pt(datasets.GeneratorBasedBuilder):
@@ -73,7 +75,7 @@ class SquadV1Pt(datasets.GeneratorBasedBuilder):
         # TODO(squad_v1_pt): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {"train": os.path.join(_URL, _TRAIN_FILE), "dev": os.path.join(_URL, _DEV_FILE)}
+        urls_to_download = _URLS
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         return [

--- a/datasets/squadshifts/squadshifts.py
+++ b/datasets/squadshifts/squadshifts.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import logging
-import os
 
 import datasets
 
@@ -46,6 +45,14 @@ robustness to natural distribution shifts. We encourage SQuAD model developers \
 to also evaluate their methods on these new datasets! \
 """
 
+_URL = "https://raw.githubusercontent.com/modestyachts/squadshifts-website/master/datasets/"
+_URLS = {
+    "new_wiki": _URL + "new_wiki_v1.0.json",
+    "nyt": _URL + "nyt_v1.0.json",
+    "reddit": _URL + "reddit_v1.0.json",
+    "amazon": _URL + "amazon_reviews_v1.0.json",
+}
+
 
 class SquadShiftsConfig(datasets.BuilderConfig):
     """BuilderConfig for SquadShifts."""
@@ -61,12 +68,6 @@ class SquadShiftsConfig(datasets.BuilderConfig):
 
 class SquadShifts(datasets.GeneratorBasedBuilder):
     """SquadShifts consists of four new test sets for the SQUAD dataset."""
-
-    _URL = "https://raw.githubusercontent.com/modestyachts/squadshifts-website/master/datasets"
-    _NEW_WIKI_FILE = "new_wiki_v1.0.json"
-    _NYT_FILE = "nyt_v1.0.json"
-    _REDDIT_FILE = "reddit_v1.0.json"
-    _AMAZON_FILE = "amazon_reviews_v1.0.json"
 
     BUILDER_CONFIGS = [
         SquadShiftsConfig(
@@ -116,12 +117,7 @@ class SquadShifts(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        urls_to_download = {
-            "new_wiki": os.path.join(self._URL, self._NEW_WIKI_FILE),
-            "nyt": os.path.join(self._URL, self._NYT_FILE),
-            "reddit": os.path.join(self._URL, self._REDDIT_FILE),
-            "amazon": os.path.join(self._URL, self._AMAZON_FILE),
-        }
+        urls_to_download = _URLS
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         if self.config.name == "new_wiki" or self.config.name == "default":

--- a/datasets/wiki_split/wiki_split.py
+++ b/datasets/wiki_split/wiki_split.py
@@ -26,10 +26,13 @@ One million English sentences, each split into two sentences that together prese
 Google's WikiSplit dataset was constructed automatically from the publicly available Wikipedia revision history. Although
 the dataset contains some inherent noise, it can serve as valuable training data for models that split or merge sentences.
 """
-_URL = "https://github.com/google-research-datasets/wiki-split/raw/master"
-_TRAIN_FILE = "train.tsv.zip"
-_TEST_FILE = "test.tsv"
-_DEV_FILE = "validation.tsv"
+
+_URL = "https://github.com/google-research-datasets/wiki-split/raw/master/"
+_URLS = {
+    "train": _URL + "train.tsv.zip",
+    "test": _URL + "test.tsv",
+    "dev": _URL + "validation.tsv",
+}
 
 
 class WikiSplit(datasets.GeneratorBasedBuilder):
@@ -66,11 +69,7 @@ class WikiSplit(datasets.GeneratorBasedBuilder):
         # TODO(wiki_split): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {
-            "train": os.path.join(_URL, _TRAIN_FILE),
-            "test": os.path.join(_URL, _TEST_FILE),
-            "dev": os.path.join(_URL, _DEV_FILE),
-        }
+        urls_to_download = _URLS
         dl_dir = dl_manager.download_and_extract(urls_to_download)
         return [
             datasets.SplitGenerator(


### PR DESCRIPTION
In Windows, `os.path.join` generates URLs containing backslashes, when the first "path" does not end with a slash. 

In general, `os.path.join` should be avoided to generate URLs.