### PR TITLE
Disallow backslash in urls

### DIFF
--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -19,9 +19,11 @@
 import os
 import urllib.parse
 from pathlib import Path
+from typing import Callable, List, Optional, Union
 
 from .file_utils import cached_path, hf_github_url
 from .logging import get_logger
+from .version import Version
 
 
 logger = get_logger(__name__)
@@ -33,20 +35,21 @@ class MockDownloadManager(object):
 
     def __init__(
         self,
-        dataset_name,
-        config,
-        version,
-        cache_dir=None,
-        is_local=False,
-        load_existing_dummy_data=True,
-        download_callbacks=False,
+        dataset_name: str,
+        config: str,
+        version: Union[Version, str],
+        cache_dir: Optional[str] = None,
+        is_local: bool = False,
+        load_existing_dummy_data: bool = True,
+        download_callbacks: Optional[List[Callable]] = None,
     ):
         self.downloaded_size = 0
         self.dataset_name = dataset_name
         self.cache_dir = cache_dir
         self.is_local = is_local
         self.config = config
-        self.download_callbacks = download_callbacks or []
+        # download_callbacks take a single url as input
+        self.download_callbacks: List[Callable] = download_callbacks or []
         # if False, it doesn't load existing files and it returns the paths of the dummy files relative
         # to the dummy_data zip file root
         self.load_existing_dummy_data = load_existing_dummy_data

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -20,7 +20,7 @@ import os
 import urllib.parse
 from pathlib import Path
 
-from .file_utils import cached_path, hf_github_url
+from .file_utils import cached_path, hf_github_url, is_remote_url
 from .logging import get_logger
 
 
@@ -31,12 +31,22 @@ class MockDownloadManager(object):
     dummy_file_name = "dummy_data"
     datasets_scripts_dir = "datasets"
 
-    def __init__(self, dataset_name, config, version, cache_dir=None, is_local=False, load_existing_dummy_data=True):
+    def __init__(
+        self,
+        dataset_name,
+        config,
+        version,
+        cache_dir=None,
+        is_local=False,
+        load_existing_dummy_data=True,
+        download_callbacks=False,
+    ):
         self.downloaded_size = 0
         self.dataset_name = dataset_name
         self.cache_dir = cache_dir
         self.is_local = is_local
         self.config = config
+        self.download_callbacks = download_callbacks or []
         # if False, it doesn't load existing files and it returns the paths of the dummy files relative
         # to the dummy_data zip file root
         self.load_existing_dummy_data = load_existing_dummy_data
@@ -129,13 +139,15 @@ class MockDownloadManager(object):
 
     def create_dummy_data_dict(self, path_to_dummy_data, data_url):
         dummy_data_dict = {}
-        for key, abs_path in data_url.items():
+        for key, single_url in data_url.items():
+            for download_callback in self.download_callbacks:
+                download_callback(single_url)
             # we force the name of each key to be the last file / folder name of the url path
             # if the url has arguments, we need to encode them with urllib.parse.quote_plus
-            if isinstance(abs_path, list):
-                value = [os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(x).name)) for x in abs_path]
+            if isinstance(single_url, list):
+                value = [os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(x).name)) for x in single_url]
             else:
-                value = os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(abs_path).name))
+                value = os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(single_url).name))
             dummy_data_dict[key] = value
 
         # make sure that values are unique
@@ -148,14 +160,18 @@ class MockDownloadManager(object):
 
     def create_dummy_data_list(self, path_to_dummy_data, data_url):
         dummy_data_list = []
-        for abs_path in data_url:
+        for single_url in data_url:
+            for download_callback in self.download_callbacks:
+                download_callback(single_url)
             # we force the name of each key to be the last file / folder name of the url path
             # if the url has arguments, we need to encode them with urllib.parse.quote_plus
-            value = os.path.join(path_to_dummy_data, urllib.parse.quote_plus(abs_path.split("/")[-1]))
+            value = os.path.join(path_to_dummy_data, urllib.parse.quote_plus(single_url.split("/")[-1]))
             dummy_data_list.append(value)
         return dummy_data_list
 
     def create_dummy_data_single(self, path_to_dummy_data, data_url):
+        for download_callback in self.download_callbacks:
+            download_callback(data_url)
         # we force the name of each key to be the last file / folder name of the url path
         # if the url has arguments, we need to encode them with urllib.parse.quote_plus
         value = os.path.join(path_to_dummy_data, urllib.parse.quote_plus(data_url.split("/")[-1]))

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -139,14 +139,20 @@ class MockDownloadManager(object):
 
     def create_dummy_data_dict(self, path_to_dummy_data, data_url):
         dummy_data_dict = {}
-        for key, single_url in data_url.items():
+        for key, single_urls in data_url.items():
             for download_callback in self.download_callbacks:
-                download_callback(single_url)
+                if isinstance(single_urls, list):
+                    for single_url in single_urls:
+                        download_callback(single_url)
+                else:
+                    single_url = single_urls
+                    download_callback(single_url)
             # we force the name of each key to be the last file / folder name of the url path
             # if the url has arguments, we need to encode them with urllib.parse.quote_plus
-            if isinstance(single_url, list):
-                value = [os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(x).name)) for x in single_url]
+            if isinstance(single_urls, list):
+                value = [os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(x).name)) for x in single_urls]
             else:
+                single_url = single_urls
                 value = os.path.join(path_to_dummy_data, urllib.parse.quote_plus(Path(single_url).name))
             dummy_data_dict[key] = value
 

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -20,7 +20,7 @@ import os
 import urllib.parse
 from pathlib import Path
 
-from .file_utils import cached_path, hf_github_url, is_remote_url
+from .file_utils import cached_path, hf_github_url
 from .logging import get_logger
 
 

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -39,6 +39,7 @@ from datasets import (
     prepare_module,
 )
 from datasets.search import _has_faiss
+from datasets.utils.file_utils import is_remote_url
 
 from .utils import for_all_test_methods, local, remote, slow
 
@@ -122,6 +123,10 @@ class DatasetTester(object):
                 else:
                     version = dataset_builder.VERSION
 
+                def check_if_url_is_valid(url):
+                    if is_remote_url(url) and "\\" in url:
+                        raise ValueError(f"Bad remote url '{url}'' since it contains a backslash")
+
                 # create mock data loader manager that has a special download_and_extract() method to download dummy data instead of real data
                 mock_dl_manager = MockDownloadManager(
                     dataset_name=dataset_name,
@@ -129,6 +134,7 @@ class DatasetTester(object):
                     version=version,
                     cache_dir=raw_temp_dir,
                     is_local=is_local,
+                    download_callbacks=[check_if_url_is_valid],
                 )
 
                 if dataset_builder.__class__.__name__ == "Csv":


### PR DESCRIPTION
Following #903 @albertvillanova noticed that there are sometimes bad usage of `os.path.join` in datasets scripts to create URLS. However this should be avoided since it doesn't work on windows.

I'm suggesting a test to make sure we that all the urls don't have backslashes in them in the datasets scripts.
The tests works by adding a callback feature to the MockDownloadManager used to test the dataset scripts. In a download callback I just make sure that the url is valid.