### PR TITLE
Remove os.path.join from all URLs

### DIFF
--- a/datasets/arcd/arcd.py
+++ b/datasets/arcd/arcd.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import logging
-import os
 
 import datasets
 
@@ -30,6 +29,12 @@ _DESCRIPTION = """\
       posed by crowdworkers on Wikipedia articles.
 """
 
+_URL = "https://raw.githubusercontent.com/husseinmozannar/SOQAL/master/data/"
+_URLs = {
+    "train": _URL + "arcd-train.json",
+    "dev": _URL + "arcd-test.json",
+}
+
 
 class ArcdConfig(datasets.BuilderConfig):
     """BuilderConfig for ARCD."""
@@ -45,10 +50,6 @@ class ArcdConfig(datasets.BuilderConfig):
 
 class Arcd(datasets.GeneratorBasedBuilder):
     """ARCD: Arabic Reading Comprehension Dataset."""
-
-    _URL = "https://raw.githubusercontent.com/husseinmozannar/SOQAL/master/data/"
-    _DEV_FILE = "arcd-test.json"
-    _TRAINING_FILE = "arcd-train.json"
 
     BUILDER_CONFIGS = [
         ArcdConfig(
@@ -80,10 +81,7 @@ class Arcd(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        urls_to_download = {
-            "train": os.path.join(self._URL, self._TRAINING_FILE),
-            "dev": os.path.join(self._URL, self._DEV_FILE),
-        }
+        urls_to_download = _URLs
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         return [

--- a/datasets/cos_e/cos_e.py
+++ b/datasets/cos_e/cos_e.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -50,9 +49,9 @@ _CQA_V1_11_URL_TRAIN = "https://s3.amazonaws.com/commensenseqa/train_rand_split.
 _CQA_V1_11_URL_DEV = "https://s3.amazonaws.com/commensenseqa/dev_rand_split.jsonl"
 _CQA_V1_11_URL_TEST = "https://s3.amazonaws.com/commensenseqa/test_rand_split_no_answers.jsonl"
 
-_CQA_V1_0_URL_TRAIN = os.path.join(_COS_E_URL, "v1.0/train_rand_split.jsonl")
-_CQA_V1_0_URL_DEV = os.path.join(_COS_E_URL, "v1.0/dev_rand_split.jsonl")
-_CQA_V1_0_URL_TEST = os.path.join(_COS_E_URL, "v1.0/test_rand_split_no_answers.jsonl")
+_CQA_V1_0_URL_TRAIN = _COS_E_URL + "v1.0/train_rand_split.jsonl"
+_CQA_V1_0_URL_DEV = _COS_E_URL + "v1.0/dev_rand_split.jsonl"
+_CQA_V1_0_URL_TEST = _COS_E_URL + "v1.0/test_rand_split_no_answers.jsonl"
 
 
 def _download_and_index_cqa(dl_manager, name):
@@ -151,16 +150,16 @@ class CosE(datasets.GeneratorBasedBuilder):
         if self.config.name == "v1.11":
             files = dl_manager.download_and_extract(
                 {
-                    "dev": [os.path.join(_COS_E_URL, "v1.11/cose_dev_v1.11_processed.jsonl")],
-                    "train": [os.path.join(_COS_E_URL, "v1.11/cose_train_v1.11_processed.jsonl")],
+                    "dev": [_COS_E_URL, + "v1.11/cose_dev_v1.11_processed.jsonl"],
+                    "train": [_COS_E_URL + "v1.11/cose_train_v1.11_processed.jsonl"],
                 }
             )
 
         elif self.config.name == "v1.0":
             files = dl_manager.download_and_extract(
                 {
-                    "dev": [os.path.join(_COS_E_URL, "v1.0/cose_dev_v1.0_processed.jsonl")],
-                    "train": [os.path.join(_COS_E_URL, "v1.0/cose_train_v1.0_processed.jsonl")],
+                    "dev": [_COS_E_URL + "v1.0/cose_dev_v1.0_processed.jsonl"],
+                    "train": [_COS_E_URL + "v1.0/cose_train_v1.0_processed.jsonl"],
                 }
             )
         else:

--- a/datasets/cos_e/cos_e.py
+++ b/datasets/cos_e/cos_e.py
@@ -150,7 +150,7 @@ class CosE(datasets.GeneratorBasedBuilder):
         if self.config.name == "v1.11":
             files = dl_manager.download_and_extract(
                 {
-                    "dev": [_COS_E_URL, + "v1.11/cose_dev_v1.11_processed.jsonl"],
+                    "dev": [_COS_E_URL + "v1.11/cose_dev_v1.11_processed.jsonl"],
                     "train": [_COS_E_URL + "v1.11/cose_train_v1.11_processed.jsonl"],
                 }
             )

--- a/datasets/cosmos_qa/cosmos_qa.py
+++ b/datasets/cosmos_qa/cosmos_qa.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function
 
 import csv
 import json
-import os
 
 import datasets
 
@@ -24,10 +23,13 @@ _CITATION = """\
 _DESCRIPTION = """\
 Cosmos QA is a large-scale dataset of 35.6K problems that require commonsense-based reading comprehension, formulated as multiple-choice questions. It focuses on reading between the lines over a diverse collection of people's everyday narratives, asking questions concerning on the likely causes or effects of events that require reasoning beyond the exact text spans in the context
 """
+
 _URL = "https://github.com/wilburOne/cosmosqa/raw/master/data/"
-_TEST_FILE = "test.jsonl"
-_TRAIN_FILE = "train.csv"
-_DEV_FILE = "valid.csv"
+_URLS = {
+    "train": _URL + "train.csv",
+    "test": _URL + "test.jsonl",
+    "dev": _URL + "valid.csv",
+}
 
 
 class CosmosQa(datasets.GeneratorBasedBuilder):
@@ -69,11 +71,7 @@ class CosmosQa(datasets.GeneratorBasedBuilder):
         # TODO(cosmos_qa): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {
-            "train": os.path.join(_URL, _TRAIN_FILE),
-            "test": os.path.join(_URL, _TEST_FILE),
-            "dev": os.path.join(_URL, _DEV_FILE),
-        }
+        urls_to_download = _URLS
         dl_dir = dl_manager.download_and_extract(urls_to_download)
         return [
             datasets.SplitGenerator(

--- a/datasets/esnli/esnli.py
+++ b/datasets/esnli/esnli.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import, division, print_function
 
 import csv
-import os
 
 import datasets
 
@@ -83,9 +82,9 @@ class Esnli(datasets.GeneratorBasedBuilder):
 
         files = dl_manager.download_and_extract(
             {
-                "train": [os.path.join(_URL, "esnli_train_1.csv"), os.path.join(_URL, "esnli_train_2.csv")],
-                "validation": [os.path.join(_URL, "esnli_dev.csv")],
-                "test": [os.path.join(_URL, "esnli_test.csv")],
+                "train": [_URL + "esnli_train_1.csv", _URL + "esnli_train_2.csv"],
+                "validation": [_URL + "esnli_dev.csv"],
+                "test": [_URL + "esnli_test.csv"],
             }
         )
 

--- a/datasets/hansards/hansards.py
+++ b/datasets/hansards/hansards.py
@@ -106,13 +106,13 @@ class Hansards(datasets.GeneratorBasedBuilder):
         name = self.config.name
         if name == "house":
             urls_to_download = {
-                "train": os.path.join(_DATA_URL, _HOUSE_DEBATES_TRAIN_SET_FILE),
-                "test": os.path.join(_DATA_URL, _HOUSE_DEBATES_TEST_SET_FILE),
+                "train": _DATA_URL + _HOUSE_DEBATES_TRAIN_SET_FILE,
+                "test": _DATA_URL + _HOUSE_DEBATES_TEST_SET_FILE,
             }
         elif name == "senate":
             urls_to_download = {
-                "train": os.path.join(_DATA_URL, _SENATE_DEBATES_TRAIN_SET_FILE),
-                "test": os.path.join(_DATA_URL, _SENATE_DEBATES_TEST_SET_FILE),
+                "train": _DATA_URL + _SENATE_DEBATES_TRAIN_SET_FILE,
+                "test": _DATA_URL + _SENATE_DEBATES_TEST_SET_FILE,
             }
         else:
             raise ValueError("Wrong builder config name '{}', it has to be either 'house' or 'senate'.".format(name))

--- a/datasets/hellaswag/hellaswag.py
+++ b/datasets/hellaswag/hellaswag.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -22,9 +21,11 @@ _CITATION = """\
 _DESCRIPTION = """
 """
 _URL = "https://github.com/rowanz/hellaswag/raw/master/data/"
-_TEST_FILE = "hellaswag_test.jsonl"
-_TRAIN_FILE = "hellaswag_train.jsonl"
-_DEV_FILE = "hellaswag_val.jsonl"
+_URLS = {
+    "train": _URL + "hellaswag_train.jsonl",
+    "test": _URL + "hellaswag_test.jsonl",
+    "dev": _URL + "hellaswag_val.jsonl",
+}
 
 
 class Hellaswag(datasets.GeneratorBasedBuilder):
@@ -68,11 +69,7 @@ class Hellaswag(datasets.GeneratorBasedBuilder):
         # TODO(hellaswag): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {
-            "train": os.path.join(_URL, _TRAIN_FILE),
-            "test": os.path.join(_URL, _TEST_FILE),
-            "dev": os.path.join(_URL, _DEV_FILE),
-        }
+        urls_to_download = _URLS
         dl_dir = dl_manager.download_and_extract(urls_to_download)
         return [
             datasets.SplitGenerator(

--- a/datasets/hotpot_qa/hotpot_qa.py
+++ b/datasets/hotpot_qa/hotpot_qa.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 import textwrap
 
 import datasets
@@ -109,11 +108,11 @@ class HotpotQA(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
         paths = {
-            datasets.Split.TRAIN: os.path.join(_URL_BASE, "hotpot_train_v1.1.json"),
-            datasets.Split.VALIDATION: os.path.join(_URL_BASE, "hotpot_dev_" + self.config.name + "_v1.json"),
+            datasets.Split.TRAIN: _URL_BASE + "hotpot_train_v1.1.json",
+            datasets.Split.VALIDATION: _URL_BASE + "hotpot_dev_" + self.config.name + "_v1.json",
         }
         if self.config.name == "fullwiki":
-            paths[datasets.Split.TEST] = os.path.join(_URL_BASE, "hotpot_test_fullwiki_v1.json")
+            paths[datasets.Split.TEST] = _URL_BASE + "hotpot_test_fullwiki_v1.json"
 
         files = dl_manager.download(paths)
 

--- a/datasets/mlsum/mlsum.py
+++ b/datasets/mlsum/mlsum.py
@@ -69,9 +69,9 @@ class Mlsum(datasets.GeneratorBasedBuilder):
 
         lang = str(self.config.name)
         urls_to_download = {
-            "test": os.path.join(_URL, lang + "_test.zip"),
-            "train": os.path.join(_URL, lang + "_train.zip"),
-            "validation": os.path.join(_URL, lang + "_val.zip"),
+            "test": _URL + lang + "_test.zip",
+            "train": _URL + lang + "_train.zip",
+            "validation": _URL + lang + "_val.zip",
         }
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 

--- a/datasets/piaf/piaf.py
+++ b/datasets/piaf/piaf.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import logging
-import os
 
 import datasets
 
@@ -45,6 +44,8 @@ Piaf is a reading comprehension \
 dataset. This version, published in February 2020, contains 3835 questions on French Wikipedia.
 """
 
+_URLS = {"train": "https://github.com/etalab-ia/piaf-code/raw/master/piaf-v1.0.json"}
+
 
 class PiafConfig(datasets.BuilderConfig):
     """BuilderConfig for PIAF."""
@@ -60,9 +61,6 @@ class PiafConfig(datasets.BuilderConfig):
 
 class Piaf(datasets.GeneratorBasedBuilder):
     """The Piaf Question Answering Dataset. Version 1.0."""
-
-    _URL = "https://github.com/etalab-ia/piaf-code/raw/master/"
-    _TRAINING_FILE = "piaf-v1.0.json"
 
     BUILDER_CONFIGS = [
         PiafConfig(
@@ -97,7 +95,7 @@ class Piaf(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        urls_to_download = {"train": os.path.join(self._URL, self._TRAINING_FILE)}
+        urls_to_download = _URLS
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         return [

--- a/datasets/qa4mre/qa4mre.py
+++ b/datasets/qa4mre/qa4mre.py
@@ -19,7 +19,6 @@
 from __future__ import division, print_function
 
 import logging
-import os
 import xml.etree.ElementTree as ET
 
 import datasets
@@ -224,17 +223,19 @@ class Qa4mre(datasets.GeneratorBasedBuilder):
         download_urls = dict()
 
         if cfg.track == "main":
-            download_urls["{}.main.{}".format(cfg.year, cfg.lang)] = os.path.join(
-                _BASE_URL, PATHS[cfg.year]["_PATH_TMPL_MAIN_GS"].format(cfg.lang)
+            download_urls["{}.main.{}".format(cfg.year, cfg.lang)] = (
+                _BASE_URL + PATHS[cfg.year]["_PATH_TMPL_MAIN_GS"].format(cfg.lang)
             )
 
         if cfg.year in ["2012", "2013"] and cfg.track == "alzheimers":
-            download_urls["{}.alzheimers.EN".format(cfg.year)] = os.path.join(
-                _BASE_URL, PATHS[cfg.year]["_PATH_ALZHEIMER"]
+            download_urls["{}.alzheimers.EN".format(cfg.year)] = (
+                _BASE_URL + PATHS[cfg.year]["_PATH_ALZHEIMER"]
             )
 
         if cfg.year == "2013" and cfg.track == "entrance_exam":
-            download_urls["2013.entrance_exam.EN"] = os.path.join(_BASE_URL, PATHS[cfg.year]["_PATH_ENTRANCE_EXAM"])
+            download_urls["2013.entrance_exam.EN"] = (
+                _BASE_URL + PATHS[cfg.year]["_PATH_ENTRANCE_EXAM"]
+            )
 
         downloaded_files = dl_manager.download_and_extract(download_urls)
 

--- a/datasets/qa4mre/qa4mre.py
+++ b/datasets/qa4mre/qa4mre.py
@@ -223,19 +223,15 @@ class Qa4mre(datasets.GeneratorBasedBuilder):
         download_urls = dict()
 
         if cfg.track == "main":
-            download_urls["{}.main.{}".format(cfg.year, cfg.lang)] = (
-                _BASE_URL + PATHS[cfg.year]["_PATH_TMPL_MAIN_GS"].format(cfg.lang)
-            )
+            download_urls["{}.main.{}".format(cfg.year, cfg.lang)] = _BASE_URL + PATHS[cfg.year][
+                "_PATH_TMPL_MAIN_GS"
+            ].format(cfg.lang)
 
         if cfg.year in ["2012", "2013"] and cfg.track == "alzheimers":
-            download_urls["{}.alzheimers.EN".format(cfg.year)] = (
-                _BASE_URL + PATHS[cfg.year]["_PATH_ALZHEIMER"]
-            )
+            download_urls["{}.alzheimers.EN".format(cfg.year)] = _BASE_URL + PATHS[cfg.year]["_PATH_ALZHEIMER"]
 
         if cfg.year == "2013" and cfg.track == "entrance_exam":
-            download_urls["2013.entrance_exam.EN"] = (
-                _BASE_URL + PATHS[cfg.year]["_PATH_ENTRANCE_EXAM"]
-            )
+            download_urls["2013.entrance_exam.EN"] = _BASE_URL + PATHS[cfg.year]["_PATH_ENTRANCE_EXAM"]
 
         downloaded_files = dl_manager.download_and_extract(download_urls)
 

--- a/datasets/squad/squad.py
+++ b/datasets/squad/squad.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import logging
-import os
 
 import datasets
 
@@ -46,6 +45,12 @@ articles, where the answer to every question is a segment of text, or span, \
 from the corresponding reading passage, or the question might be unanswerable.
 """
 
+_URL = "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
+_URLS = {
+    "train": _URL + "train-v1.1.json",
+    "dev": _URL + "dev-v1.1.json",
+}
+
 
 class SquadConfig(datasets.BuilderConfig):
     """BuilderConfig for SQUAD."""
@@ -61,10 +66,6 @@ class SquadConfig(datasets.BuilderConfig):
 
 class Squad(datasets.GeneratorBasedBuilder):
     """SQUAD: The Stanford Question Answering Dataset. Version 1.1."""
-
-    _URL = "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
-    _DEV_FILE = "dev-v1.1.json"
-    _TRAINING_FILE = "train-v1.1.json"
 
     BUILDER_CONFIGS = [
         SquadConfig(
@@ -99,11 +100,7 @@ class Squad(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        urls_to_download = {
-            "train": os.path.join(self._URL, self._TRAINING_FILE),
-            "dev": os.path.join(self._URL, self._DEV_FILE),
-        }
-        downloaded_files = dl_manager.download_and_extract(urls_to_download)
+        downloaded_files = dl_manager.download_and_extract(_URLS)
 
         return [
             datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"filepath": downloaded_files["train"]}),

--- a/datasets/squad_es/squad_es.py
+++ b/datasets/squad_es/squad_es.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -29,6 +28,14 @@ automatic translation of the Stanford Question Answering Dataset (SQuAD) v2 into
 """
 
 _URL = "https://raw.githubusercontent.com/ccasimiro88/TranslateAlignRetrieve/master/"
+_URLS_V1 = {
+    "train": _URL + "SQuAD-es-v1.1/train-v1.1-es.json",
+    "dev": _URL + "SQuAD-es-v1.1/dev-v1.1-es.json",
+}
+_URLS_V2 = {
+    "train": _URL + "SQuAD-es-v2.0/train-v2.0-es.json",
+    "dev": _URL + "SQuAD-es-v2.0/dev-v2.0-es.json",
+}
 
 
 class SquadEsConfig(datasets.BuilderConfig):
@@ -98,18 +105,10 @@ class SquadEs(datasets.GeneratorBasedBuilder):
         # dl_manager is a datasets.download.DownloadManager that can be used to
 
         # download and extract URLs
-        v1_urls = {
-            "train": os.path.join(_URL, "SQuAD-es-v1.1/train-v1.1-es.json"),
-            "dev": os.path.join(_URL, "SQuAD-es-v1.1/dev-v1.1-es.json"),
-        }
-        v2_urls = {
-            "train": os.path.join(_URL, "SQuAD-es-v2.0/train-v2.0-es.json"),
-            "dev": os.path.join(_URL, "SQuAD-es-v2.0/dev-v2.0-es.json"),
-        }
         if self.config.name == "v1.1.0":
-            dl_dir = dl_manager.download_and_extract(v1_urls)
+            dl_dir = dl_manager.download_and_extract(_URLS_V1)
         elif self.config.name == "v2.0.0":
-            dl_dir = dl_manager.download_and_extract(v2_urls)
+            dl_dir = dl_manager.download_and_extract(_URLS_V2)
         else:
             raise Exception("version does not match any existing one")
         return [

--- a/datasets/squad_v2/squad_v2.py
+++ b/datasets/squad_v2/squad_v2.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import datasets
 
@@ -30,8 +29,10 @@ combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable questio
 """
 
 _URL = "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
-_DEV_FILE = "dev-v2.0.json"
-_TRAINING_FILE = "train-v2.0.json"
+_URLS = {
+    "train": _URL + "train-v2.0.json",
+    "dev": _URL + "dev-v2.0.json",
+}
 
 
 class SquadV2Config(datasets.BuilderConfig):
@@ -89,7 +90,7 @@ class SquadV2(datasets.GeneratorBasedBuilder):
         # TODO(squad_v2): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        urls_to_download = {"train": os.path.join(_URL, _TRAINING_FILE), "dev": os.path.join(_URL, _DEV_FILE)}
+        urls_to_download = _URLS
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         return [

--- a/datasets/tydiqa/tydiqa.py
+++ b/datasets/tydiqa/tydiqa.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 import textwrap
 
 import datasets
@@ -29,11 +28,16 @@ information-seeking task and avoid priming effects, questions are written by peo
 don’t know the answer yet, (unlike SQuAD and its descendents) and the data is collected directly in each language without
 the use of translation (unlike MLQA and XQuAD).
 """
+
 _URL = "https://storage.googleapis.com/tydiqa/"
-_PRIMARY_TASK_TRAIN = "v1.0/tydiqa-v1.0-train.jsonl.gz"
-_PRIMARY_TASK_DEV = "v1.0/tydiqa-v1.0-dev.jsonl.gz"
-_SECONDARY_TASK_TRAIN = "v1.1/tydiqa-goldp-v1.1-train.json"
-_SECONDARY_TASK_DEV = "v1.1/tydiqa-goldp-v1.1-dev.json"
+_PRIMARY_URLS = {
+    "train": _URL + "v1.0/tydiqa-v1.0-train.jsonl.gz",
+    "dev": _URL + "v1.0/tydiqa-v1.0-dev.jsonl.gz",
+}
+_SECONDARY_URLS = {
+    "train": _URL + "v1.1/tydiqa-goldp-v1.1-train.json",
+    "dev": _URL + "v1.1/tydiqa-goldp-v1.1-dev.json",
+}
 
 
 class TydiqaConfig(datasets.BuilderConfig):
@@ -155,16 +159,8 @@ class Tydiqa(datasets.GeneratorBasedBuilder):
         # TODO(tydiqa): Downloads the data and defines the splits
         # dl_manager is a datasets.download.DownloadManager that can be used to
         # download and extract URLs
-        primary_urls_to_download = {
-            "train": os.path.join(_URL, _PRIMARY_TASK_TRAIN),
-            "dev": os.path.join(_URL, _PRIMARY_TASK_DEV),
-        }
-        secondary_urls_to_download = {
-            "train": os.path.join(_URL, _SECONDARY_TASK_TRAIN),
-            "dev": os.path.join(_URL, _SECONDARY_TASK_DEV),
-        }
-        primary_downloaded = dl_manager.download_and_extract(primary_urls_to_download)
-        secondary_downloaded = dl_manager.download_and_extract(secondary_urls_to_download)
+        primary_downloaded = dl_manager.download_and_extract(_PRIMARY_URLS)
+        secondary_downloaded = dl_manager.download_and_extract(_SECONDARY_URLS)
         if self.config.name == "primary_task":
             return [
                 datasets.SplitGenerator(

--- a/datasets/wiki40b/wiki40b.py
+++ b/datasets/wiki40b/wiki40b.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import os
 
 import datasets
 
@@ -144,15 +143,15 @@ class Wiki40b(datasets.BeamBasedBuilder):
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
-                gen_kwargs={"filepaths": os.path.join(_DATA_DIRECTORY, "train", "{}_examples-*".format(lang))},
+                gen_kwargs={"filepaths": f"{_DATA_DIRECTORY}/train/{lang}_examples-*"},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
-                gen_kwargs={"filepaths": os.path.join(_DATA_DIRECTORY, "dev", "{}_examples-*".format(lang))},
+                gen_kwargs={"filepaths": f"{_DATA_DIRECTORY}/dev/{lang}_examples-*"},
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
-                gen_kwargs={"filepaths": os.path.join(_DATA_DIRECTORY, "test", "{}_examples-*".format(lang))},
+                gen_kwargs={"filepaths": f"{_DATA_DIRECTORY}/test/{lang}_examples-*"},
             ),
         ]
 

--- a/docs/source/add_dataset.rst
+++ b/docs/source/add_dataset.rst
@@ -158,14 +158,13 @@ Let's have a look at a simple example of a :func:`datasets.DatasetBuilder._split
 		"""SQUAD: The Stanford Question Answering Dataset. Version 1.1."""
 
 		_URL = "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
-		_DEV_FILE = "dev-v1.1.json"
-		_TRAINING_FILE = "train-v1.1.json"
+		_URLS = {
+			"train": _URL + "train-v1.1.json",
+			"dev": _URL + "dev-v1.1.json",
+		}
 
 		def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
-			urls_to_download = {
-				"train": os.path.join(self._URL, self._TRAINING_FILE),
-				"dev": os.path.join(self._URL, self._DEV_FILE),
-			}
+			urls_to_download = self._URLS
 			downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
 			return [


### PR DESCRIPTION
Remove `os.path.join` from all URLs in dataset scripts.