### PR TITLE
Specify file encoding

### DIFF
--- a/templates/new_dataset_script.py
+++ b/templates/new_dataset_script.py
@@ -159,7 +159,7 @@ class NewDataset(datasets.GeneratorBasedBuilder):
         # It is in charge of opening the given file and yielding (key, example) tuples from the dataset
         # The key is not important, it's more here for legacy reason (legacy from tfds)
 
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             for id_, row in enumerate(f):
                 data = json.loads(row)
                 if self.config.name == "first_domain":


### PR DESCRIPTION
If not specified, Python uses system default, which for Windows is not "utf-8".