### PR TITLE
Fix squad V2 metric script

### DIFF
--- a/metrics/squad_v2/evaluate.py
+++ b/metrics/squad_v2/evaluate.py
@@ -51,7 +51,7 @@ def make_qid_to_has_ans(dataset):
     for article in dataset:
         for p in article["paragraphs"]:
             for qa in p["qas"]:
-                qid_to_has_ans[qa["id"]] = bool(qa["answers"])
+                qid_to_has_ans[qa["id"]] = bool(qa["answers"]["text"])
     return qid_to_has_ans
 
 

--- a/metrics/squad_v2/evaluate.py
+++ b/metrics/squad_v2/evaluate.py
@@ -108,7 +108,7 @@ def get_raw_scores(dataset, preds):
         for p in article["paragraphs"]:
             for qa in p["qas"]:
                 qid = qa["id"]
-                gold_answers = [a["text"] for a in qa["answers"] if normalize_answer(a["text"])]
+                gold_answers = [t for t in qa["answers"]["text"] if normalize_answer(t)]
                 if not gold_answers:
                     # For unanswerable questions, only correct answer is empty string
                     gold_answers = [""]

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -16,7 +16,14 @@
 
 import datasets
 
-from .evaluate import apply_no_ans_threshold, get_raw_scores, make_eval_dict, make_qid_to_has_ans, merge_eval
+from .evaluate import (
+    apply_no_ans_threshold,
+    find_all_best_thresh,
+    get_raw_scores,
+    make_eval_dict,
+    make_qid_to_has_ans,
+    merge_eval,
+)
 
 
 _CITATION = """\
@@ -116,4 +123,5 @@ class SquadV2(datasets.Metric):
         if no_ans_qids:
             no_ans_eval = make_eval_dict(exact_thresh, f1_thresh, qid_list=no_ans_qids)
             merge_eval(out_eval, no_ans_eval, "NoAns")
+        find_all_best_thresh(out_eval, predictions, exact_raw, f1_raw, no_answer_probabilities, qid_to_has_ans)
         return out_eval


### PR DESCRIPTION
The current squad v2 metric doesn't work with the squad (v1 or v2) datasets. The script is copied from `squad_evaluate` in transformers that requires the labels (with multiple answers) to be like this:
```
references = [{'id': 'a', 'answers': [
    {'text': 'Denver Broncos', 'answer_start': 177},
    {'text': 'Denver Broncos', 'answer_start': 177}
]}]
```
while the dataset had references like this:
```
references = [{'id': 'a', 'answers': 
    {'text': ['Denver Broncos' 'Denver Broncos'], 'answer_start': [177, 177]}
}]
```

Using one or the other format fails with the current squad v2 metric:
```
from datasets import load_metric
metric = load_metric("squad_v2")
predictions = [{'id': 'a', 'prediction_text': 'Denver Broncos', 'no_answer_probability': 0.0}]
references = [{'id': 'a', 'answers': [
    {'text': 'Denver Broncos', 'answer_start': 177},
    {'text': 'Denver Broncos', 'answer_start': 177}
]}]
metric.compute(predictions=predictions, references=references)
```
fails as well as
```
from datasets import load_metric
metric = load_metric("squad_v2")
predictions = [{'id': 'a', 'prediction_text': 'Denver Broncos', 'no_answer_probability': 0.0}]
references = [{'id': 'a', 'answers': 
    {'text': ['Denver Broncos' 'Denver Broncos'], 'answer_start': [177, 177]}
}]
metric.compute(predictions=predictions, references=references)
```

This is because arrow reformats the references behind the scene.

With this PR (tested locally), both the snippets up there work and return proper results.