### PR TITLE
add xlrd to test package requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ TESTS_REQUIRE = [
     'torch',
     'tldextract',
     'transformers',
+    'xlrd',
     'zstandard',
 ]
 


### PR DESCRIPTION
Adds `xlrd` package to the test requirements to handle scripts that use `pandas` to load excel files