### PR TITLE
Update ADD_NEW_DATASET.md

### DIFF
--- a/ADD_NEW_DATASET.md
+++ b/ADD_NEW_DATASET.md
@@ -13,13 +13,16 @@ This creates a copy of the code under your GitHub user account.
 	git remote add upstream https://github.com/huggingface/datasets.git
 	```
 
-3. Set up a development environment, for instance by running the following command:
+3. (**For Windows**) You will need to install [the right version](https://pytorch.org/get-started/locally/) of PyTorch before continuing because `pip install torch` may not work well for PyTorch on Windows.
+
+4. Set up a development environment, for instance by running the following command:
 
 	```bash
 	conda create -n env python=3.7 --y
 	conda activate env
 	pip install -e ".[dev]"
 	```
+
 
 Now you are ready, each time you want to add a new dataset, follow the steps in the following section:
 


### PR DESCRIPTION
Windows needs special treatment again: unfortunately adding `torch` to the requirements does not work well (crashing the installation). Users should first install torch manually and then continue with the other commands.

This issue arises all the time when adding torch as a dependency, but because so many novice users seem to participate in adding datasets, it may be useful to add an explicit note for Windows users to ensure that they do not run into issues.