### PR TITLE
Allow GitHub releases as dataset source

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -9,6 +9,7 @@ import gzip
 import json
 import lzma
 import os
+import re
 import shutil
 import sys
 import tarfile
@@ -474,8 +475,13 @@ def get_from_cache(
                         cookies = response.cookies
                 connected = True
             # In some edge cases, head request returns 400 but the connection is actually ok
-            elif (response.status_code == 400 and "firebasestorage.googleapis.com" in url) or (
-                response.status_code == 405 and "drive.google.com" in url
+            elif (
+                (response.status_code == 400 and "firebasestorage.googleapis.com" in url)
+                or (response.status_code == 405 and "drive.google.com" in url)
+                or (
+                    response.status_code == 403
+                    and re.match(r"^https?://github.com/.*?/.*?/releases/download/.*?/.*?$", url)
+                )
             ):
                 connected = True
                 logger.info("Couldn't get ETag version for url {}".format(url))


### PR DESCRIPTION
# Summary

Providing a GitHub release URL to `DownloadManager.download()` currently throws a `ConnectionError: Couldn't reach [DOWNLOAD_URL]`. This PR fixes this problem by adding an exception for GitHub releases in `datasets.utils.file_utils.get_from_cache()`.

# Reproduce

```
import datasets
url = 'http://github.com/benjaminvdb/DBRD/releases/download/v3.0/DBRD_v3.tgz'
result = datasets.utils.file_utils.get_from_cache(url)

# Returns: ConnectionError: Couldn't reach http://github.com/benjaminvdb/DBRD/releases/download/v3.0/DBRD_v3.tgz
```

# Cause

GitHub releases returns a HTTP status 403 (FOUND), indicating that the request is being redirected (to AWS S3, in this case). `get_from_cache()` checks whether the status is 200 (OK) or if it is part of two exceptions (Google Drive or Firebase), otherwise the mentioned error is thrown.

# Solution

Just like the exceptions for Google Drive and Firebase, add a condition for GitHub releases URLs that return the HTTP status 403. If this is the case, continue normally.