### PR TITLE
Use passed --cache_dir for modules cache

### DIFF
--- a/src/datasets/commands/test.py
+++ b/src/datasets/commands/test.py
@@ -93,7 +93,7 @@ class TestCommand(BaseTransformersCLICommand):
             print("Both parameters `config` and `all_configs` can't be used at once.")
             exit(1)
         path, name = self._dataset, self._name
-        module_path, hash = prepare_module(path)
+        module_path, hash = prepare_module(path, cache_dir=self._cache_dir)
         builder_cls = import_main_class(module_path)
 
         if self._all_configs and len(builder_cls.BUILDER_CONFIGS) > 0:

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -107,6 +107,14 @@ CLOUDFRONT_METRICS_DISTRIB_PREFIX = "https://cdn-datasets.huggingface.co/dataset
 REPO_METRICS_URL = "https://raw.githubusercontent.com/huggingface/datasets/{version}/metrics/{path}/{name}"
 
 
+def create_modules_cache(modules_cache):
+    sys.path.append(str(modules_cache))
+    os.makedirs(modules_cache, exist_ok=True)
+    if not os.path.exists(os.path.join(modules_cache, "__init__.py")):
+        with open(os.path.join(modules_cache, "__init__.py"), "w"):
+            pass
+
+
 default_modules_cache_path = os.path.join(hf_cache_home, "modules")
 try:
     from pathlib import Path
@@ -114,12 +122,7 @@ try:
     HF_MODULES_CACHE = Path(os.getenv("HF_MODULES_CACHE", default_modules_cache_path))
 except (AttributeError, ImportError):
     HF_MODULES_CACHE = os.getenv(os.getenv("HF_MODULES_CACHE", default_modules_cache_path))
-sys.path.append(str(HF_MODULES_CACHE))
 
-os.makedirs(HF_MODULES_CACHE, exist_ok=True)
-if not os.path.exists(os.path.join(HF_MODULES_CACHE, "__init__.py")):
-    with open(os.path.join(HF_MODULES_CACHE, "__init__.py"), "w"):
-        pass
 
 INCOMPLETE_SUFFIX = ".incomplete"
 


### PR DESCRIPTION
When passed `--cache_dir` arg:
```shell
python datasets-cli test datasets/<my-dataset-folder> --save_infos --all_configs --cache_dir <my-cache-dir>
```
it is not used for caching the modules, which are cached in the default location at `.cache/huggingface/modules`.

With this fix, the modules will be cached at `<my-cache-dir>/modules`.