### PR TITLE
Add script_version suggestion when dataset/metric not found

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -278,9 +278,9 @@ def prepare_module(
                 local_path = cached_path(file_path, download_config=download_config)
             except FileNotFoundError:
                 raise FileNotFoundError(
-                    "Couldn't find file locally at {}, or remotely at {} or {}".format(
-                        combined_path, github_file_path, file_path
-                    )
+                    "Couldn't find file locally at {}, or remotely at {} or {}.\n"
+                    'If the dataset was added recently, you may need to to pass script_version="master" to find '
+                    "the loading script in the master branch.".format(combined_path, github_file_path, file_path)
                 )
 
     # Load the module in two steps:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -279,8 +279,10 @@ def prepare_module(
             except FileNotFoundError:
                 raise FileNotFoundError(
                     "Couldn't find file locally at {}, or remotely at {} or {}.\n"
-                    'If the dataset was added recently, you may need to to pass script_version="master" to find '
-                    "the loading script in the master branch.".format(combined_path, github_file_path, file_path)
+                    'If the {} was added recently, you may need to to pass script_version="master" to find '
+                    "the loading script on the master branch.".format(
+                        combined_path, github_file_path, file_path, "dataset" if dataset else "metric"
+                    )
                 )
 
     # Load the module in two steps:


### PR DESCRIPTION
Adds a helpful prompt to the error message when a dataset/metric is not found, suggesting the user might need to pass `script_version="master"` if the dataset was added recently. The whole error looks like:

> Couldn't find file locally at blah/blah.py, or remotely at https://raw.githubusercontent.com/huggingface/datasets/1.1/metrics/blah/blah.py or https://s3.amazonaws.com/datasets.huggingface.co/datasets/met
rics/blah/blah.py.
If the dataset was added recently, you may need to to pass script_version="master" to find the loading script on the master branch.