### PR TITLE
Fix namedsplit docs

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -75,7 +75,7 @@ class DatasetInfoMixin(object):
 
     @property
     def split(self):
-        """ :class:`datasets.DatasetInfo` object containing all the metadata in the dataset."""
+        """ :class:`datasets.NamedSplit` object corresponding to a named dataset split."""
         return self._split
 
     @property

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -76,7 +76,7 @@ class SplitBase(metaclass=abc.ABCMeta):
     """Abstract base class for Split compositionality.
 
     See the
-    [guide on splits](https://github.com/huggingface/datasets/tree/master/docs/splits.md)
+    [guide on splits](https://github.com/huggingface/datasets/blob/master/docs/source/splits.rst)
     for more information.
 
     There are three parts to the composition:
@@ -254,7 +254,7 @@ class PercentSlice(metaclass=PercentSliceMeta):
     """Syntactic sugar for defining slice subsplits: `datasets.percent[75:-5]`.
 
     See the
-    [guide on splits](https://github.com/huggingface/datasets/tree/master/docs/splits.md)
+    [guide on splits](https://github.com/huggingface/datasets/blob/master/docs/source/splits.rst)
     for more information.
     """
     # pylint: enable=line-too-long
@@ -410,7 +410,7 @@ class Split(object):
     Note: All splits, including compositions inherit from `datasets.SplitBase`
 
     See the
-    [guide on splits](https://github.com/huggingface/datasets/tree/master/docs/splits.md)
+    [guide on splits](https://github.com/huggingface/datasets/blob/master/docs/source/splits.rst)
     for more information.
     """
     # pylint: enable=line-too-long


### PR DESCRIPTION
Fixes a broken link and `DatasetInfoMixin.split`'s docstring.