### PR TITLE
Add retries to HTTP requests

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -260,7 +260,7 @@ def prepare_module(
         local_path = path
     else:
         # Try github (canonical datasets/metrics) and then S3 (users datasets/metrics)
-        head_hf_s3(path, filename=name, dataset=dataset)
+        head_hf_s3(path, filename=name, dataset=dataset, max_retries=download_config.max_retries)
         script_version = str(script_version) if script_version is not None else None
         file_path = hf_github_url(path=path, name=name, dataset=dataset, version=script_version)
         try:

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -131,6 +131,7 @@ class DownloadManager(object):
                 url_or_urls.
         """
         cache_dir = self._download_config.cache_dir or os.path.join(HF_DATASETS_CACHE, "downloads")
+        max_retries = self._download_config.max_retries
 
         def url_to_downloaded_path(url):
             return os.path.join(cache_dir, hash_url_to_filename(url))
@@ -140,13 +141,17 @@ class DownloadManager(object):
         flattened_downloaded_path_or_paths = flatten_nested(downloaded_path_or_paths)
         for url, path in zip(flattened_urls_or_urls, flattened_downloaded_path_or_paths):
             try:
-                get_from_cache(url, cache_dir=cache_dir, local_files_only=True, use_etag=False)
+                get_from_cache(
+                    url, cache_dir=cache_dir, local_files_only=True, use_etag=False, max_retries=max_retries
+                )
                 cached = True
             except FileNotFoundError:
                 cached = False
             if not cached or self._download_config.force_download:
                 custom_download(url, path)
-                get_from_cache(url, cache_dir=cache_dir, local_files_only=True, use_etag=False)
+                get_from_cache(
+                    url, cache_dir=cache_dir, local_files_only=True, use_etag=False, max_retries=max_retries
+                )
         self._record_sizes_checksums(url_or_urls, downloaded_path_or_paths)
         return downloaded_path_or_paths
 


### PR DESCRIPTION
## What does this PR do ?

Adding retries to HTTP GET & HEAD requests, when they fail with a `ConnectTimeout` exception.

The "canonical" way to do this is to use [urllib's Retry class](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.Retry) and wrap it in a [HttpAdapter](https://requests.readthedocs.io/en/master/api/#requests.adapters.HTTPAdapter). Seems a bit overkill to me, plus it forces us to use the `requests.Session` object. I prefer this simpler implementation. I'm open to remarks and suggestions @lhoestq @yjernite 

Fixes #1102 