### PR TITLE
Fix "'BertTokenizerFast' object has no attribute 'max_len'"

### DIFF
--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -232,7 +232,7 @@ Here is how we can apply the right format to our dataset using :func:`datasets.D
     >>> ## TENSORFLOW CODE
     >>> import tensorflow as tf
     >>> dataset.set_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'labels'])
-    >>> features = {x: dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.max_len]) for x in ['input_ids', 'token_type_ids', 'attention_mask']}
+    >>> features = {x: dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.model_max_length]) for x in ['input_ids', 'token_type_ids', 'attention_mask']}
     >>> tfdataset = tf.data.Dataset.from_tensor_slices((features, dataset["labels"])).batch(32)
     >>> next(iter(tfdataset))
     ({'input_ids': <tf.Tensor: shape=(32, 512), dtype=int32, numpy=

--- a/docs/source/torch_tensorflow.rst
+++ b/docs/source/torch_tensorflow.rst
@@ -62,7 +62,7 @@ Here is how we can apply a format to a simple dataset using :func:`datasets.Data
     >>> dataset = dataset.map(lambda e: tokenizer(e['sentence1'], truncation=True, padding='max_length'), batched=True)
     >>>
     >>> dataset.set_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
-    >>> features = {x: dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.max_len]) for x in ['input_ids', 'token_type_ids', 'attention_mask']}
+    >>> features = {x: dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.model_max_length]) for x in ['input_ids', 'token_type_ids', 'attention_mask']}
     >>> tfdataset = tf.data.Dataset.from_tensor_slices((features, dataset["label"])).batch(32)
     >>> next(iter(tfdataset))
     ({'input_ids': <tf.Tensor: shape=(32, 512), dtype=int32, numpy=

--- a/notebooks/Overview.ipynb
+++ b/notebooks/Overview.ipynb
@@ -3111,7 +3111,7 @@
         "train_tf_dataset = train_tf_dataset.filter(remove_none_values, load_from_cache_file=False)\n",
         "columns = ['input_ids', 'token_type_ids', 'attention_mask', 'start_positions', 'end_positions']\n",
         "train_tf_dataset.set_format(type='tensorflow', columns=columns)\n",
-        "features = {x: train_tf_dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.max_len]) for x in columns[:3]} \n",
+        "features = {x: train_tf_dataset[x].to_tensor(default_value=0, shape=[None, tokenizer.model_max_length]) for x in columns[:3]} \n",
         "labels = {\"output_1\": train_tf_dataset[\"start_positions\"].to_tensor(default_value=0, shape=[None, 1])}\n",
         "labels[\"output_2\"] = train_tf_dataset[\"end_positions\"].to_tensor(default_value=0, shape=[None, 1])\n",
         "tfdataset = tf.data.Dataset.from_tensor_slices((features, labels)).batch(8)"


### PR DESCRIPTION
Tensorflow 2.3.0 gives:
 FutureWarning: The `max_len` attribute has been deprecated and will be removed in a future version, use `model_max_length` instead.

Tensorflow 2.4.0 gives:
AttributeError 'BertTokenizerFast' object has no attribute 'max_len'