### PR TITLE
Rename "part-of-speech-tagging" tag in some dataset cards

### DIFF
--- a/datasets/arabic_pos_dialect/README.md
+++ b/datasets/arabic_pos_dialect/README.md
@@ -16,7 +16,7 @@ source_datasets:
 task_categories:
 - structure-prediction
 task_ids:
-- structure-prediction-other-pos-tagging
+- part-of-speech-tagging
 ---
 
 # Dataset Card for Arabic POS Dialect

--- a/datasets/conll2002/README.md
+++ b/datasets/conll2002/README.md
@@ -20,7 +20,7 @@ task_categories:
 - structure-prediction
 task_ids:
 - named-entity-recognition
-- parsing
+- part-of-speech-tagging
 ---
 
 # Dataset Card Creation Guide

--- a/datasets/dane/README.md
+++ b/datasets/dane/README.md
@@ -16,6 +16,7 @@ task_categories:
 - structure-prediction
 task_ids:
 - named-entity-recognition
+- part-of-speech-tagging
 ---
 
 # Dataset Card for [Dataset Name]

--- a/datasets/indonlu/README.md
+++ b/datasets/indonlu/README.md
@@ -63,7 +63,7 @@ task_categories:
   - text-classification
 task_ids:
   bapos:
-  - structure-prediction-other-part-of-speech-tagging
+  - part-of-speech-tagging
   casa:
   - text-classification-other-aspect-based-sentiment-analysis
   emot:
@@ -79,7 +79,7 @@ task_ids:
   nerp:
   - named-entity-recognition
   posp:
-  - structure-prediction-other-part-of-speech-tagging
+  - part-of-speech-tagging
   smsa:
   - sentiment-classification
   terma:

--- a/datasets/lst20/README.md
+++ b/datasets/lst20/README.md
@@ -17,7 +17,7 @@ task_categories:
 - structure-prediction
 task_ids:
 - named-entity-recognition
-- parsing
+- part-of-speech-tagging
 - structure-prediction-other-clause-segmentation
 - structure-prediction-other-sentence-segmentation
 - structure-prediction-other-word-segmentation

--- a/datasets/mac_morpho/README.md
+++ b/datasets/mac_morpho/README.md
@@ -16,7 +16,7 @@ source_datasets:
 task_categories:
 - structure-prediction
 task_ids:
-- structure-prediction-other-part-of-speech-tagging
+- part-of-speech-tagging
 ---
 
 # Dataset Card for Mac-Morpho

--- a/datasets/thainer/README.md
+++ b/datasets/thainer/README.md
@@ -19,7 +19,7 @@ task_categories:
 - structure-prediction
 task_ids:
 - named-entity-recognition
-- parsing
+- part-of-speech-tagging
 ---
 
 # Dataset Card for `thainer`

--- a/datasets/wikicorpus/README.md
+++ b/datasets/wikicorpus/README.md
@@ -71,15 +71,15 @@ task_ids:
   - language-modeling
   tagged_ca:
   - structure-prediction-other-lemmatization
-  - structure-prediction-other-pos-tagging
+  - part-of-speech-tagging
   - text-classification-other-word-sense-disambiguation
   tagged_en:
   - structure-prediction-other-lemmatization
-  - structure-prediction-other-pos-tagging
+  - part-of-speech-tagging
   - text-classification-other-word-sense-disambiguation
   tagged_es:
   - structure-prediction-other-lemmatization
-  - structure-prediction-other-pos-tagging
+  - part-of-speech-tagging
   - text-classification-other-word-sense-disambiguation
 ---
 

--- a/datasets/wino_bias/README.md
+++ b/datasets/wino_bias/README.md
@@ -18,7 +18,7 @@ task_categories:
 task_ids:
 - coreference-resolution
 - named-entity-recognition
-- parsing
+- part-of-speech-tagging
 ---
 
 # Dataset Card for Wino_Bias dataset


### PR DESCRIPTION
`part-of-speech-tagging` was not part of the tagging taxonomy under `structure-prediction`