### PR TITLE
Don't use xlrd for xlsx files

### DIFF
--- a/datasets/ajgt_twitter_ar/ajgt_twitter_ar.py
+++ b/datasets/ajgt_twitter_ar/ajgt_twitter_ar.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
 import pandas as pd
 
 import datasets
@@ -96,8 +97,8 @@ class AjgtTwitterAr(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """Generate examples."""
-        # For labeled examples, extract the label from the path.
-        df = pd.read_excel(filepath)
-        for id_, record in df.iterrows():
-            tweet, sentiment = record["Feed"], record["Sentiment"]
-            yield str(id_), {"text": tweet, "label": sentiment}
+        with open(filepath, "rb") as f:
+            df = pd.read_excel(f, engine="openpyxl")
+            for id_, record in df.iterrows():
+                tweet, sentiment = record["Feed"], record["Sentiment"]
+                yield str(id_), {"text": tweet, "label": sentiment}

--- a/datasets/chr_en/chr_en.py
+++ b/datasets/chr_en/chr_en.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+# import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
 import pandas as pd
 
 import datasets
@@ -176,19 +177,21 @@ class ChrEn(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepaths, split):
         if self.config.name == "monolingual_raw":
             keys = ["text_sentence", "text_title", "speaker", "date", "type", "dialect"]
-            monolingual = pd.read_excel(filepaths["monolingual_raw"])
-            for id_, row in enumerate(monolingual.itertuples()):
-                yield id_, dict(zip(keys, row[1:]))
+            with open(filepaths["monolingual_raw"], "rb") as f:
+                monolingual = pd.read_excel(f, engine="openpyxl")
+                for id_, row in enumerate(monolingual.itertuples()):
+                    yield id_, dict(zip(keys, row[1:]))
         elif self.config.name == "parallel_raw":
             keys = ["line_number", "en_sent", "chr_sent", "text_title", "speaker", "date", "type", "dialect"]
-            parallel = pd.read_excel(filepaths["parallel_raw"])
-            for id_, row in enumerate(parallel.itertuples()):
-                res = dict(zip(keys, row[1:]))
-                res["sentence_pair"] = {"en": res["en_sent"], "chr": res["chr_sent"]}
-                res["line_number"] = str(res["line_number"])
-                del res["en_sent"]
-                del res["chr_sent"]
-                yield id_, res
+            with open(filepaths["parallel_raw"], "rb") as f:
+                parallel = pd.read_excel(f, engine="openpyxl")
+                for id_, row in enumerate(parallel.itertuples()):
+                    res = dict(zip(keys, row[1:]))
+                    res["sentence_pair"] = {"en": res["en_sent"], "chr": res["chr_sent"]}
+                    res["line_number"] = str(res["line_number"])
+                    del res["en_sent"]
+                    del res["chr_sent"]
+                    yield id_, res
         elif self.config.name == "monolingual":
             f = open(filepaths[f"monolingual_{split}"], encoding="utf-8")
             for id_, line in enumerate(f):

--- a/datasets/chr_en/chr_en.py
+++ b/datasets/chr_en/chr_en.py
@@ -16,7 +16,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-# import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
+import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
 import pandas as pd
 
 import datasets

--- a/datasets/clickbait_news_bg/clickbait_news_bg.py
+++ b/datasets/clickbait_news_bg/clickbait_news_bg.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
 import pandas as pd
 
 import datasets
@@ -105,14 +106,15 @@ class ClickbaitNewsBG(datasets.GeneratorBasedBuilder):
             "content_published_time",
             "content",
         ]
-        data = pd.read_excel(filepath)
-        for id_, row in enumerate(data.itertuples()):
-            row_dict = dict()
-            for key, value in zip(keys, row[1:]):
-                if key == "fake_news_score":
-                    row_dict[key] = "legitimate" if value == 1 else "fake"
-                elif key == "click_bait_score":
-                    row_dict[key] = "normal" if value == 1 else "clickbait"
-                else:
-                    row_dict[key] = str(value)
-            yield id_, row_dict
+        with open(filepath, "rb") as f:
+            data = pd.read_excel(f, engine="openpyxl")
+            for id_, row in enumerate(data.itertuples()):
+                row_dict = dict()
+                for key, value in zip(keys, row[1:]):
+                    if key == "fake_news_score":
+                        row_dict[key] = "legitimate" if value == 1 else "fake"
+                    elif key == "click_bait_score":
+                        row_dict[key] = "normal" if value == 1 else "clickbait"
+                    else:
+                        row_dict[key] = str(value)
+                yield id_, row_dict

--- a/datasets/fake_news_english/fake_news_english.py
+++ b/datasets/fake_news_english/fake_news_english.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
 import pandas as pd
 
 import datasets
@@ -80,11 +81,12 @@ class FakeNewsEnglish(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """ Yields examples. """
-        f = pd.read_excel(filepath)
-        for id_, row in f.iterrows():
-            yield id_, {
-                "article_number": row["Article Number"],
-                "url_of_article": str(row["URL of article"]),
-                "fake_or_satire": str(row["Fake or Satire?"]),
-                "url_of_rebutting_article": str(row["URL of rebutting article"]),
-            }
+        with open(filepath, "rb") as f:
+            f = pd.read_excel(f, engine="openpyxl")
+            for id_, row in f.iterrows():
+                yield id_, {
+                    "article_number": row["Article Number"],
+                    "url_of_article": str(row["URL of article"]),
+                    "fake_or_satire": str(row["Fake or Satire?"]),
+                    "url_of_rebutting_article": str(row["URL of rebutting article"]),
+                }

--- a/datasets/snow_simplified_japanese_corpus/snow_simplified_japanese_corpus.py
+++ b/datasets/snow_simplified_japanese_corpus/snow_simplified_japanese_corpus.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import openpyxl  # noqa: requires this pandas optional dependency for reading xlsx files
 import pandas as pd
 
 import datasets
@@ -147,22 +148,23 @@ class SnowSimplifiedJapaneseCorpus(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath, split):
         """ Yields examples. """
 
-        df = pd.read_excel(filepath).astype("str")
+        with open(filepath, "rb") as f:
+            df = pd.read_excel(f, engine="openpyxl").astype("str")
 
-        if self.config.name == "snow_t15":
-            for id_, row in df.iterrows():
-                yield id_, {
-                    "ID": row["ID"],
-                    "original_ja": row["#日本語(原文)"],
-                    "simplified_ja": row["#やさしい日本語"],
-                    "original_en": row["#英語(原文)"],
-                }
-        else:
-            for id_, row in df.iterrows():
-                yield id_, {
-                    "ID": row["ID"],
-                    "original_ja": row["#日本語(原文)"],
-                    "simplified_ja": row["#やさしい日本語"],
-                    "original_en": row["#英語(原文)"],
-                    "proper_noun": row["#固有名詞"],
-                }
+            if self.config.name == "snow_t15":
+                for id_, row in df.iterrows():
+                    yield id_, {
+                        "ID": row["ID"],
+                        "original_ja": row["#日本語(原文)"],
+                        "simplified_ja": row["#やさしい日本語"],
+                        "original_en": row["#英語(原文)"],
+                    }
+            else:
+                for id_, row in df.iterrows():
+                    yield id_, {
+                        "ID": row["ID"],
+                        "original_ja": row["#日本語(原文)"],
+                        "simplified_ja": row["#やさしい日本語"],
+                        "original_en": row["#英語(原文)"],
+                        "proper_noun": row["#固有名詞"],
+                    }

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ TESTS_REQUIRE = [
     'lxml',
     'mwparserfromhell',
     'nltk',
+    'openpyxl',
     'py7zr',
     'pytest',
     'pytest-xdist',
@@ -109,7 +110,6 @@ TESTS_REQUIRE = [
     'torch',
     'tldextract',
     'transformers',
-    'xlrd==1.2.0',  # pinning to keep the xlsx support. We should eventually use something else
     'zstandard',
     'rarfile',
 ]


### PR DESCRIPTION
Since the latest release of `xlrd` (2.0), the support for xlsx files stopped.
Therefore we needed to use something else.
A good alternative is `openpyxl` which has also an integration with pandas si we can still call `pd.read_excel`.

I left the unused import of `openpyxl` in the dataset scripts to show users that this is a required dependency to use the scripts.

I tested the different datasets using `datasets-cli test` and the tests are successful (no missing examples).