### PR TITLE
Fast start up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,9 @@ REQUIRED_PKGS = [
     # for fast hashing
     "xxhash",
     # for better multiprocessing
-    "multiprocess"
+    "multiprocess",
+    # to get metadata of optional dependencies such as torch or tensorflow for Python versions that don't have it
+    "importlib_metadata"
 ]
 
 BENCHMARKS_REQUIRE = [

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -26,18 +26,11 @@ from pandas.api.extensions import ExtensionArray as PandasExtensionArray
 from pandas.api.extensions import ExtensionDtype as PandasExtensionDtype
 
 from . import utils
-from .utils.file_utils import _tf_available, _torch_available
+from .utils.file_utils import is_tf_available, is_torch_available
 from .utils.logging import get_logger
 
 
 logger = get_logger(__name__)
-
-
-if _torch_available:
-    import torch
-
-if _tf_available:
-    import tensorflow as tf
 
 
 def string_to_arrow(type_str: str) -> pa.DataType:
@@ -71,11 +64,18 @@ def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
         casted_obj: the casted object
         has_changed (bool): True if the object has been changed, False if it is identical
     """
+
+    if is_tf_available():
+        import tensorflow as tf
+
+    if is_torch_available():
+        import torch
+
     if isinstance(obj, np.ndarray):
         return obj.tolist(), True
-    elif _torch_available and isinstance(obj, torch.Tensor):
+    elif is_torch_available() and isinstance(obj, torch.Tensor):
         return obj.detach().cpu().numpy().tolist(), True
-    elif _tf_available and isinstance(obj, tf.Tensor):
+    elif is_tf_available() and isinstance(obj, tf.Tensor):
         return obj.numpy().tolist(), True
     elif isinstance(obj, pd.Series):
         return obj.values.tolist(), True

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
     from .arrow_dataset import Dataset  # noqa: F401
 
     try:
-        from elasticsearch import Elasticsearch
+        from elasticsearch import Elasticsearch  # noqa: F401
 
     except ImportError:
         pass
     try:
-        import faiss
+        import faiss  # noqa: F401
 
     except ImportError:
         pass
@@ -111,7 +111,7 @@ class ElasticSearchIndex(BaseIndex):
         port = port or 9200
 
         import elasticsearch.helpers  # noqa: need this to properly load all the es features
-        from elasticsearch import Elasticsearch
+        from elasticsearch import Elasticsearch  # noqa: F114
 
         self.es_client = es_client if es_client is not None else Elasticsearch([{"host": host, "port": str(port)}])
         self.es_index_name = (
@@ -233,7 +233,7 @@ class FaissIndex(BaseIndex):
         Add vectors to the index.
         If the arrays are inside a certain column, you can specify it using the `column` argument.
         """
-        import faiss
+        import faiss  # noqa: F114
 
         # Create index
         if self.faiss_index is None:
@@ -316,7 +316,7 @@ class FaissIndex(BaseIndex):
 
     def save(self, file: str):
         """Serialize the FaissIndex on disk"""
-        import faiss
+        import faiss  # noqa: F114
 
         if (
             hasattr(self.faiss_index, "device")
@@ -335,7 +335,7 @@ class FaissIndex(BaseIndex):
         device: Optional[int] = None,
     ) -> "FaissIndex":
         """Deserialize the FaissIndex from disk"""
-        import faiss
+        import faiss  # noqa: F114
 
         faiss_index = cls(device=device)
         index = faiss.read_index(file)

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import os
 import tempfile
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Union

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -111,7 +111,7 @@ class ElasticSearchIndex(BaseIndex):
         port = port or 9200
 
         import elasticsearch.helpers  # noqa: need this to properly load all the es features
-        from elasticsearch import Elasticsearch  # noqa: F114
+        from elasticsearch import Elasticsearch  # noqa: F811
 
         self.es_client = es_client if es_client is not None else Elasticsearch([{"host": host, "port": str(port)}])
         self.es_index_name = (
@@ -233,7 +233,7 @@ class FaissIndex(BaseIndex):
         Add vectors to the index.
         If the arrays are inside a certain column, you can specify it using the `column` argument.
         """
-        import faiss  # noqa: F114
+        import faiss  # noqa: F811
 
         # Create index
         if self.faiss_index is None:
@@ -316,7 +316,7 @@ class FaissIndex(BaseIndex):
 
     def save(self, file: str):
         """Serialize the FaissIndex on disk"""
-        import faiss  # noqa: F114
+        import faiss  # noqa: F811
 
         if (
             hasattr(self.faiss_index, "device")
@@ -335,7 +335,7 @@ class FaissIndex(BaseIndex):
         device: Optional[int] = None,
     ) -> "FaissIndex":
         """Deserialize the FaissIndex from disk"""
-        import faiss  # noqa: F114
+        import faiss  # noqa: F811
 
         faiss_index = cls(device=device)
         index = faiss.read_index(file)


### PR DESCRIPTION
Currently if optional dependencies such as tensorflow, torch, apache_beam, faiss and elasticsearch are installed, then it takes a long time to do `import datasets` since it imports all of these heavy dependencies.

To make a fast start up for `datasets` I changed that so that they are not imported when `datasets` is being imported. On my side it changed the import time of `datasets` from 5sec to 0.5sec, which is enjoyable.

To be able to check if optional dependencies are available without importing them I'm using `importlib_metadata`, which is part of the standard lib in python>=3.8 and was backported. The difference with `importlib` is that it also enables to get the versions of the libraries without importing them.
I added this dependency in `setup.py`.