### PR TITLE
Added generated READMEs for datasets that were missing one.

### DIFF
--- a/datasets/aeslc/README.md
+++ b/datasets/aeslc/README.md
@@ -1,0 +1,145 @@
+---
+---
+
+# Dataset Card for "aeslc"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/ryanzhumich/AESLC](https://github.com/ryanzhumich/AESLC)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 11.10 MB
+- **Size of the generated dataset:** 14.26 MB
+- **Total amount of disk used:** 25.36 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A collection of email messages of employees in the Enron Corporation.
+
+There are two features:
+  - email_body: email body text.
+  - subject_line: email subject text.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 11.10 MB
+- **Size of the generated dataset:** 14.26 MB
+- **Total amount of disk used:** 25.36 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "email_body": "B/C\n<<some doc>>\n",
+    "subject_line": "Service Agreement"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `email_body`: a `string` feature.
+- `subject_line`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|14436|      1960|1906|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{zhang2019email,
+    title={This Email Could Save Your Life: Introducing the Task of Email Subject Line Generation},
+    author={Rui Zhang and Joel Tetreault},
+    year={2019},
+    eprint={1906.03497},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/ag_news/README.md
+++ b/datasets/ag_news/README.md
@@ -1,0 +1,151 @@
+---
+---
+
+# Dataset Card for "ag_news"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://groups.di.unipi.it/~gulli/AG_corpus_of_news_articles.html](http://groups.di.unipi.it/~gulli/AG_corpus_of_news_articles.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 29.88 MB
+- **Size of the generated dataset:** 30.23 MB
+- **Total amount of disk used:** 60.10 MB
+
+### [Dataset Summary](#dataset-summary)
+
+AG is a collection of more than 1 million news articles. News articles have been
+gathered from more than 2000 news sources by ComeToMyHead in more than 1 year of
+activity. ComeToMyHead is an academic news search engine which has been running
+since July, 2004. The dataset is provided by the academic comunity for research
+purposes in data mining (clustering, classification, etc), information retrieval
+(ranking, search, etc), xml, data compression, data streaming, and any other
+non-commercial activity. For more information, please refer to the link
+http://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html .
+
+The AG's news topic classification dataset is constructed by Xiang Zhang
+(xiang.zhang@nyu.edu) from the dataset above. It is used as a text
+classification benchmark in the following paper: Xiang Zhang, Junbo Zhao, Yann
+LeCun. Character-level Convolutional Networks for Text Classification. Advances
+in Neural Information Processing Systems 28 (NIPS 2015).
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 29.88 MB
+- **Size of the generated dataset:** 30.23 MB
+- **Total amount of disk used:** 60.10 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "label": 3,
+    "text": "New iPad released Just like every other September, this one is no different. Apple is planning to release a bigger, heavier, fatter iPad that..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `World` (0), `Sports` (1), `Business` (2), `Sci/Tech` (3).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |test|
+|-------|-----:|---:|
+|default|120000|7600|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{Zhang2015CharacterlevelCN,
+  title={Character-level Convolutional Networks for Text Classification},
+  author={Xiang Zhang and Junbo Jake Zhao and Yann LeCun},
+  booktitle={NIPS},
+  year={2015}
+}
+
+```
+

--- a/datasets/ai2_arc/README.md
+++ b/datasets/ai2_arc/README.md
@@ -1,0 +1,179 @@
+---
+---
+
+# Dataset Card for "ai2_arc"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/arc](https://allenai.org/data/arc)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1298.60 MB
+- **Size of the generated dataset:** 2.17 MB
+- **Total amount of disk used:** 1300.77 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A new dataset of 7,787 genuine grade-school level, multiple-choice science questions, assembled to encourage research in
+ advanced question-answering. The dataset is partitioned into a Challenge Set and an Easy Set, where the former contains
+ only questions answered incorrectly by both a retrieval-based algorithm and a word co-occurrence algorithm. We are also
+ including a corpus of over 14 million science sentences relevant to the task, and an implementation of three neural baseline models for this dataset. We pose ARC as a challenge to the community.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### ARC-Challenge
+
+- **Size of downloaded dataset files:** 649.30 MB
+- **Size of the generated dataset:** 0.79 MB
+- **Total amount of disk used:** 650.09 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answerKey": "B",
+    "choices": {
+        "label": ["A", "B", "C", "D"],
+        "text": ["Shady areas increased.", "Food sources increased.", "Oxygen levels increased.", "Available water increased."]
+    },
+    "id": "Mercury_SC_405487",
+    "question": "One year, the oak trees in a park began producing more acorns than usual. The next year, the population of chipmunks in the park also increased. Which best explains why there were more chipmunks the next year?"
+}
+```
+
+#### ARC-Easy
+
+- **Size of downloaded dataset files:** 649.30 MB
+- **Size of the generated dataset:** 1.38 MB
+- **Total amount of disk used:** 650.68 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answerKey": "B",
+    "choices": {
+        "label": ["A", "B", "C", "D"],
+        "text": ["Shady areas increased.", "Food sources increased.", "Oxygen levels increased.", "Available water increased."]
+    },
+    "id": "Mercury_SC_405487",
+    "question": "One year, the oak trees in a park began producing more acorns than usual. The next year, the population of chipmunks in the park also increased. Which best explains why there were more chipmunks the next year?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### ARC-Challenge
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `answerKey`: a `string` feature.
+
+#### ARC-Easy
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `answerKey`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|    name     |train|validation|test|
+|-------------|----:|---------:|---:|
+|ARC-Challenge| 1119|       299|1172|
+|ARC-Easy     | 2251|       570|2376|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{allenai:arc,
+      author    = {Peter Clark  and Isaac Cowhey and Oren Etzioni and Tushar Khot and
+                    Ashish Sabharwal and Carissa Schoenick and Oyvind Tafjord},
+      title     = {Think you have Solved Question Answering? Try ARC, the AI2 Reasoning Challenge},
+      journal   = {arXiv:1803.05457v1},
+      year      = {2018},
+}
+
+```
+

--- a/datasets/amazon_us_reviews/README.md
+++ b/datasets/amazon_us_reviews/README.md
@@ -1,0 +1,361 @@
+---
+---
+
+# Dataset Card for "amazon_us_reviews"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://s3.amazonaws.com/amazon-reviews-pds/readme.html](https://s3.amazonaws.com/amazon-reviews-pds/readme.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 30877.39 MB
+- **Size of the generated dataset:** 78983.49 MB
+- **Total amount of disk used:** 109860.89 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Amazon Customer Reviews (a.k.a. Product Reviews) is one of Amazons iconic products. In a period of over two decades since the first review in 1995, millions of Amazon customers have contributed over a hundred million reviews to express opinions and describe their experiences regarding products on the Amazon.com website. This makes Amazon Customer Reviews a rich source of information for academic researchers in the fields of Natural Language Processing (NLP), Information Retrieval (IR), and Machine Learning (ML), amongst others. Accordingly, we are releasing this data to further research in multiple disciplines related to understanding customer product experiences. Specifically, this dataset was constructed to represent a sample of customer evaluations and opinions, variation in the perception of a product across geographical regions, and promotional intent or bias in reviews.
+Over 130+ million customer reviews are available to researchers as part of this release. The data is available in TSV files in the amazon-reviews-pds S3 bucket in AWS US East Region. Each line in the data files corresponds to an individual review (tab delimited, with no quote and escape characters).
+Each Dataset contains the following columns :
+    marketplace       - 2 letter country code of the marketplace where the review was written.
+    customer_id       - Random identifier that can be used to aggregate reviews written by a single author.
+    review_id         - The unique ID of the review.
+    product_id        - The unique Product ID the review pertains to. In the multilingual dataset the reviews
+                        for the same product in different countries can be grouped by the same product_id.
+    product_parent    - Random identifier that can be used to aggregate reviews for the same product.
+    product_title     - Title of the product.
+    product_category  - Broad product category that can be used to group reviews
+                        (also used to group the dataset into coherent parts).
+    star_rating       - The 1-5 star rating of the review.
+    helpful_votes     - Number of helpful votes.
+    total_votes       - Number of total votes the review received.
+    vine              - Review was written as part of the Vine program.
+    verified_purchase - The review is on a verified purchase.
+    review_headline   - The title of the review.
+    review_body       - The review text.
+    review_date       - The date the review was written.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### Apparel_v1_00
+
+- **Size of downloaded dataset files:** 618.59 MB
+- **Size of the generated dataset:** 2149.93 MB
+- **Total amount of disk used:** 2768.52 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "customer_id": "45223824",
+    "helpful_votes": 0,
+    "marketplace": "US",
+    "product_category": "Apparel",
+    "product_id": "B016PUU3VO",
+    "product_parent": "893588059",
+    "product_title": "Fruit of the Loom Boys' A-Shirt (Pack of 4)",
+    "review_body": "I ordered the same size as I ordered last time, and these shirts were much larger than the previous order. They were also about 6 inches longer. It was like they sent men's shirts instead of boys' shirts. I'll be returning these...",
+    "review_date": "2015-01-01",
+    "review_headline": "Sizes not correct, too big overall and WAY too long",
+    "review_id": "R1N3Z13931J3O9",
+    "star_rating": 2,
+    "total_votes": 0,
+    "verified_purchase": 1,
+    "vine": 0
+}
+```
+
+#### Automotive_v1_00
+
+- **Size of downloaded dataset files:** 555.18 MB
+- **Size of the generated dataset:** 1448.52 MB
+- **Total amount of disk used:** 2003.70 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "customer_id": "16825098",
+    "helpful_votes": 0,
+    "marketplace": "US",
+    "product_category": "Automotive",
+    "product_id": "B000E4PCGE",
+    "product_parent": "694793259",
+    "product_title": "00-03 NISSAN SENTRA MIRROR RH (PASSENGER SIDE), Power, Non-Heated (2000 00 2001 01 2002 02 2003 03) NS35ER 963015M000",
+    "review_body": "Product was as described, new and a great look. Only bad thing is that one of the screws was stripped so I couldn't tighten all three.",
+    "review_date": "2015-08-31",
+    "review_headline": "new and a great look. Only bad thing is that one of ...",
+    "review_id": "R2RUIDUMDKG7P",
+    "star_rating": 3,
+    "total_votes": 0,
+    "verified_purchase": 1,
+    "vine": 0
+}
+```
+
+#### Baby_v1_00
+
+- **Size of downloaded dataset files:** 340.84 MB
+- **Size of the generated dataset:** 912.00 MB
+- **Total amount of disk used:** 1252.84 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "customer_id": "23299101",
+    "helpful_votes": 2,
+    "marketplace": "US",
+    "product_category": "Baby",
+    "product_id": "B00SN6F9NG",
+    "product_parent": "3470998",
+    "product_title": "Rhoost Nail Clipper for Baby - Ergonomically Designed and Easy to Use Baby Nail Clipper, Natural Wooden Bamboo - Baby Health and Personal Care Kits",
+    "review_body": "\"This is an absolute MUST item to have!  I was scared to death to clip my baby's nails.  I tried other baby nail clippers and th...",
+    "review_date": "2015-08-31",
+    "review_headline": "If fits so comfortably in my hand and I feel like I have ...",
+    "review_id": "R2DRL5NRODVQ3Z",
+    "star_rating": 5,
+    "total_votes": 2,
+    "verified_purchase": 1,
+    "vine": 0
+}
+```
+
+#### Beauty_v1_00
+
+- **Size of downloaded dataset files:** 871.73 MB
+- **Size of the generated dataset:** 2286.33 MB
+- **Total amount of disk used:** 3158.06 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "customer_id": "24655453",
+    "helpful_votes": 1,
+    "marketplace": "US",
+    "product_category": "Beauty",
+    "product_id": "B00SAQ9DZY",
+    "product_parent": "292127037",
+    "product_title": "12 New, High Quality, Amber 2 ml (5/8 Dram) Glass Bottles, with Orifice Reducer and Black Cap.",
+    "review_body": "These are great for small mixtures for EO's, especially for traveling.  I only gave this 4 stars because of the orifice reducer.  The hole is so small it is hard to get the oil out.  Just needs to be slightly bigger.",
+    "review_date": "2015-08-31",
+    "review_headline": "Good Product",
+    "review_id": "R2A30ALEGLMCGN",
+    "star_rating": 4,
+    "total_votes": 1,
+    "verified_purchase": 1,
+    "vine": 0
+}
+```
+
+#### Books_v1_00
+
+- **Size of downloaded dataset files:** 2613.39 MB
+- **Size of the generated dataset:** 6860.60 MB
+- **Total amount of disk used:** 9473.99 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "customer_id": "49735028",
+    "helpful_votes": 0,
+    "marketplace": "US",
+    "product_category": "Books",
+    "product_id": "0664254969",
+    "product_parent": "248307276",
+    "product_title": "Presbyterian Creeds: A Guide to the Book of Confessions",
+    "review_body": "\"The Presbyterian Book of Confessions contains multiple Creeds for use by the denomination. This guidebook helps he lay person t...",
+    "review_date": "2015-08-31",
+    "review_headline": "The Presbyterian Book of Confessions contains multiple Creeds for use ...",
+    "review_id": "R2G519UREHRO8M",
+    "star_rating": 3,
+    "total_votes": 1,
+    "verified_purchase": 1,
+    "vine": 0
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### Apparel_v1_00
+- `marketplace`: a `string` feature.
+- `customer_id`: a `string` feature.
+- `review_id`: a `string` feature.
+- `product_id`: a `string` feature.
+- `product_parent`: a `string` feature.
+- `product_title`: a `string` feature.
+- `product_category`: a `string` feature.
+- `star_rating`: a `int32` feature.
+- `helpful_votes`: a `int32` feature.
+- `total_votes`: a `int32` feature.
+- `vine`: a classification label, with possible values including `Y` (0), `N` (1).
+- `verified_purchase`: a classification label, with possible values including `Y` (0), `N` (1).
+- `review_headline`: a `string` feature.
+- `review_body`: a `string` feature.
+- `review_date`: a `string` feature.
+
+#### Automotive_v1_00
+- `marketplace`: a `string` feature.
+- `customer_id`: a `string` feature.
+- `review_id`: a `string` feature.
+- `product_id`: a `string` feature.
+- `product_parent`: a `string` feature.
+- `product_title`: a `string` feature.
+- `product_category`: a `string` feature.
+- `star_rating`: a `int32` feature.
+- `helpful_votes`: a `int32` feature.
+- `total_votes`: a `int32` feature.
+- `vine`: a classification label, with possible values including `Y` (0), `N` (1).
+- `verified_purchase`: a classification label, with possible values including `Y` (0), `N` (1).
+- `review_headline`: a `string` feature.
+- `review_body`: a `string` feature.
+- `review_date`: a `string` feature.
+
+#### Baby_v1_00
+- `marketplace`: a `string` feature.
+- `customer_id`: a `string` feature.
+- `review_id`: a `string` feature.
+- `product_id`: a `string` feature.
+- `product_parent`: a `string` feature.
+- `product_title`: a `string` feature.
+- `product_category`: a `string` feature.
+- `star_rating`: a `int32` feature.
+- `helpful_votes`: a `int32` feature.
+- `total_votes`: a `int32` feature.
+- `vine`: a classification label, with possible values including `Y` (0), `N` (1).
+- `verified_purchase`: a classification label, with possible values including `Y` (0), `N` (1).
+- `review_headline`: a `string` feature.
+- `review_body`: a `string` feature.
+- `review_date`: a `string` feature.
+
+#### Beauty_v1_00
+- `marketplace`: a `string` feature.
+- `customer_id`: a `string` feature.
+- `review_id`: a `string` feature.
+- `product_id`: a `string` feature.
+- `product_parent`: a `string` feature.
+- `product_title`: a `string` feature.
+- `product_category`: a `string` feature.
+- `star_rating`: a `int32` feature.
+- `helpful_votes`: a `int32` feature.
+- `total_votes`: a `int32` feature.
+- `vine`: a classification label, with possible values including `Y` (0), `N` (1).
+- `verified_purchase`: a classification label, with possible values including `Y` (0), `N` (1).
+- `review_headline`: a `string` feature.
+- `review_body`: a `string` feature.
+- `review_date`: a `string` feature.
+
+#### Books_v1_00
+- `marketplace`: a `string` feature.
+- `customer_id`: a `string` feature.
+- `review_id`: a `string` feature.
+- `product_id`: a `string` feature.
+- `product_parent`: a `string` feature.
+- `product_title`: a `string` feature.
+- `product_category`: a `string` feature.
+- `star_rating`: a `int32` feature.
+- `helpful_votes`: a `int32` feature.
+- `total_votes`: a `int32` feature.
+- `vine`: a classification label, with possible values including `Y` (0), `N` (1).
+- `verified_purchase`: a classification label, with possible values including `Y` (0), `N` (1).
+- `review_headline`: a `string` feature.
+- `review_body`: a `string` feature.
+- `review_date`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|      name      | train  |
+|----------------|-------:|
+|Apparel_v1_00   | 5906333|
+|Automotive_v1_00| 3514942|
+|Baby_v1_00      | 1752932|
+|Beauty_v1_00    | 5115666|
+|Books_v1_00     |10319090|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/anli/README.md
+++ b/datasets/anli/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "anli"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/facebookresearch/anli/](https://github.com/facebookresearch/anli/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 17.76 MB
+- **Size of the generated dataset:** 73.55 MB
+- **Total amount of disk used:** 91.31 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Adversarial Natural Language Inference (ANLI) is a new large-scale NLI benchmark dataset,
+The dataset is collected via an iterative, adversarial human-and-model-in-the-loop procedure.
+ANLI is much more difficult than its predecessors including SNLI and MNLI.
+It contains three rounds. Each round has train/dev/test splits.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 17.76 MB
+- **Size of the generated dataset:** 73.55 MB
+- **Total amount of disk used:** 91.31 MB
+
+An example of 'train_r2' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hypothesis": "Idris Sultan was born in the first month of the year preceding 1994.",
+    "label": 0,
+    "premise": "\"Idris Sultan (born January 1993) is a Tanzanian Actor and comedian, actor and radio host who won the Big Brother Africa-Hotshot...",
+    "reason": "",
+    "uid": "ed5c37ab-77c5-4dbc-ba75-8fd617b19712"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `uid`: a `string` feature.
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+- `reason`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train_r1|dev_r1|train_r2|dev_r2|train_r3|dev_r3|test_r1|test_r2|test_r3|
+|----------|-------:|-----:|-------:|-----:|-------:|-----:|------:|------:|------:|
+|plain_text|   16946|  1000|   45460|  1000|  100459|  1200|   1000|   1000|   1200|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{nie2019adversarial,
+    title={Adversarial NLI: A New Benchmark for Natural Language Understanding},
+    author={Nie, Yixin
+                and Williams, Adina
+                and Dinan, Emily
+                and Bansal, Mohit
+                and Weston, Jason
+                and Kiela, Douwe},
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    year = "2020",
+    publisher = "Association for Computational Linguistics",
+}
+
+```
+

--- a/datasets/arcd/README.md
+++ b/datasets/arcd/README.md
@@ -1,0 +1,158 @@
+---
+---
+
+# Dataset Card for "arcd"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/husseinmozannar/SOQAL/tree/master/data](https://github.com/husseinmozannar/SOQAL/tree/master/data)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.85 MB
+- **Size of the generated dataset:** 1.62 MB
+- **Total amount of disk used:** 3.47 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ Arabic Reading Comprehension Dataset (ARCD) composed of 1,395 questions      posed by crowdworkers on Wikipedia articles.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 1.85 MB
+- **Size of the generated dataset:** 1.62 MB
+- **Total amount of disk used:** 3.47 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": "{\"answer_start\": [34], \"text\": [\"صحابي من صحابة رسول الإسلام محمد، وعمُّه وأخوه من الرضاعة وأحد وزرائه الأربعة عشر،\"]}...",
+    "context": "\"حمزة بن عبد المطلب الهاشمي القرشي صحابي من صحابة رسول الإسلام محمد، وعمُّه وأخوه من الرضاعة وأحد وزرائه الأربعة عشر، وهو خير أع...",
+    "id": "621723207492",
+    "question": "من هو حمزة بن عبد المطلب؟",
+    "title": "حمزة بن عبد المطلب"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|validation|
+|----------|----:|---------:|
+|plain_text|  693|       702|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{mozannar-etal-2019-neural,
+    title = "Neural {A}rabic Question Answering",
+    author = "Mozannar, Hussein  and
+      Maamary, Elie  and
+      El Hajal, Karl  and
+      Hajj, Hazem",
+    booktitle = "Proceedings of the Fourth Arabic Natural Language Processing Workshop",
+    month = aug,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W19-4612",
+    doi = "10.18653/v1/W19-4612",
+    pages = "108--118",
+    abstract = "This paper tackles the problem of open domain factual Arabic question answering (QA) using Wikipedia as our knowledge source. This constrains the answer of any question to be a span of text in Wikipedia. Open domain QA for Arabic entails three challenges: annotated QA datasets in Arabic, large scale efficient information retrieval and machine reading comprehension. To deal with the lack of Arabic QA datasets we present the Arabic Reading Comprehension Dataset (ARCD) composed of 1,395 questions posed by crowdworkers on Wikipedia articles, and a machine translation of the Stanford Question Answering Dataset (Arabic-SQuAD). Our system for open domain question answering in Arabic (SOQAL) is based on two components: (1) a document retriever using a hierarchical TF-IDF approach and (2) a neural reading comprehension model using the pre-trained bi-directional transformer BERT. Our experiments on ARCD indicate the effectiveness of our approach with our BERT-based reader achieving a 61.3 F1 score, and our open domain system SOQAL achieving a 27.6 F1 score.",
+}
+
+```
+

--- a/datasets/art/README.md
+++ b/datasets/art/README.md
@@ -1,0 +1,150 @@
+---
+---
+
+# Dataset Card for "art"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://leaderboard.allenai.org/anli/submissions/get-started](https://leaderboard.allenai.org/anli/submissions/get-started)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4.88 MB
+- **Size of the generated dataset:** 32.77 MB
+- **Total amount of disk used:** 37.65 MB
+
+### [Dataset Summary](#dataset-summary)
+
+the Abductive Natural Language Inference Dataset from AI2
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### anli
+
+- **Size of downloaded dataset files:** 4.88 MB
+- **Size of the generated dataset:** 32.77 MB
+- **Total amount of disk used:** 37.65 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "hypothesis_1": "Chad's car had all sorts of other problems besides alignment.",
+    "hypothesis_2": "Chad's car had all sorts of benefits other than being sexy.",
+    "label": 1,
+    "observation_1": "Chad went to get the wheel alignment measured on his car.",
+    "observation_2": "The mechanic provided a working alignment with new body work."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### anli
+- `observation_1`: a `string` feature.
+- `observation_2`: a `string` feature.
+- `hypothesis_1`: a `string` feature.
+- `hypothesis_2`: a `string` feature.
+- `label`: a classification label, with possible values including `0` (0), `1` (1), `2` (2).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name|train |validation|
+|----|-----:|---------:|
+|anli|169654|      1532|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{anli,
+  author = "Chandra, Bhagavatula
+    and Ronan, Le Bras
+    and Chaitanya, Malaviya
+    and Keisuke, Sakaguchi
+    and Ari, Holtzman
+    and Hannah, Rashkin
+    and Doug, Downey
+    and Scott, Wen-tau Yih
+    and Yejin, Choi",
+  title = "Abductive Commonsense Reasoning",
+  year = "2020",
+}
+```
+

--- a/datasets/aslg_pc12/README.md
+++ b/datasets/aslg_pc12/README.md
@@ -1,0 +1,138 @@
+---
+---
+
+# Dataset Card for "aslg_pc12"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://achrafothman.net/site/asl-smt/](https://achrafothman.net/site/asl-smt/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 12.18 MB
+- **Size of the generated dataset:** 12.87 MB
+- **Total amount of disk used:** 25.05 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Synthetic English-ASL Gloss Parallel Corpus 2012
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 12.18 MB
+- **Size of the generated dataset:** 12.87 MB
+- **Total amount of disk used:** 25.05 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "gloss": "WRITE STATEMENT AND DESC-ORAL QUESTION TABLE SEE MINUTE\n",
+    "text": "written statements and oral questions tabling see minutes\n"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `gloss`: a `string` feature.
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|
+|-------|----:|
+|default|87710|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{othman2012english,
+  title={English-asl gloss parallel corpus 2012: Aslg-pc12},
+  author={Othman, Achraf and Jemni, Mohamed},
+  booktitle={5th Workshop on the Representation and Processing of Sign Languages: Interactions between Corpus and Lexicon LREC},
+  year={2012}
+}
+
+```
+

--- a/datasets/asnq/README.md
+++ b/datasets/asnq/README.md
@@ -1,0 +1,157 @@
+---
+---
+
+# Dataset Card for "asnq"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/alexa/wqa_tanda#answer-sentence-natural-questions-asnq](https://github.com/alexa/wqa_tanda#answer-sentence-natural-questions-asnq)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3398.76 MB
+- **Size of the generated dataset:** 3647.70 MB
+- **Total amount of disk used:** 7046.46 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ASNQ is a dataset for answer sentence selection derived from
+Google's Natural Questions (NQ) dataset (Kwiatkowski et al. 2019).
+
+Each example contains a question, candidate sentence, label indicating whether or not
+the sentence answers the question, and two additional features --
+sentence_in_long_answer and short_answer_in_sentence indicating whether ot not the
+candidate sentence is contained in the long_answer and if the short_answer is in the candidate sentence.
+
+For more details please see
+https://arxiv.org/pdf/1911.04118.pdf
+
+and
+
+https://research.google/pubs/pub47761/
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 3398.76 MB
+- **Size of the generated dataset:** 3647.70 MB
+- **Total amount of disk used:** 7046.46 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "label": 0,
+    "question": "when did somewhere over the rainbow come out",
+    "sentence": "In films and TV shows ( edit ) In the film Third Finger , Left Hand ( 1940 ) with Myrna Loy , Melvyn Douglas , and Raymond Walburn , the tune played throughout the film in short sequences .",
+    "sentence_in_long_answer": false,
+    "short_answer_in_sentence": false
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `question`: a `string` feature.
+- `sentence`: a `string` feature.
+- `label`: a classification label, with possible values including `neg` (0), `pos` (1).
+- `sentence_in_long_answer`: a `bool` feature.
+- `short_answer_in_sentence`: a `bool` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train  |validation|
+|-------|-------:|---------:|
+|default|20377568|    930062|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{garg2019tanda,
+    title={TANDA: Transfer and Adapt Pre-Trained Transformer Models for Answer Sentence Selection},
+    author={Siddhant Garg and Thuy Vu and Alessandro Moschitti},
+    year={2019},
+    eprint={1911.04118},
+}
+
+```
+

--- a/datasets/billsum/README.md
+++ b/datasets/billsum/README.md
@@ -1,0 +1,151 @@
+---
+---
+
+# Dataset Card for "billsum"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/FiscalNote/BillSum](https://github.com/FiscalNote/BillSum)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 64.14 MB
+- **Size of the generated dataset:** 259.80 MB
+- **Total amount of disk used:** 323.94 MB
+
+### [Dataset Summary](#dataset-summary)
+
+BillSum, summarization of US Congressional and California state bills.
+
+There are several features:
+  - text: bill text.
+  - summary: summary of the bills.
+  - title: title of the bills.
+features for us bills. ca bills does not have.
+  - text_len: number of chars in text.
+  - sum_len: number of chars in summary.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 64.14 MB
+- **Size of the generated dataset:** 259.80 MB
+- **Total amount of disk used:** 323.94 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "summary": "some summary",
+    "text": "some text.",
+    "title": "An act to amend Section xxx."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `title`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|ca_test|test|
+|-------|----:|------:|---:|
+|default|18949|   1237|3269|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{kornilova2019billsum,
+    title={BillSum: A Corpus for Automatic Summarization of US Legislation},
+    author={Anastassia Kornilova and Vlad Eidelman},
+    year={2019},
+    eprint={1910.00523},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/biomrc/README.md
+++ b/datasets/biomrc/README.md
@@ -1,0 +1,275 @@
+---
+---
+
+# Dataset Card for "biomrc"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://nlp.cs.aueb.gr/](http://nlp.cs.aueb.gr/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1226.28 MB
+- **Size of the generated dataset:** 5539.64 MB
+- **Total amount of disk used:** 6765.92 MB
+
+### [Dataset Summary](#dataset-summary)
+
+We introduce BIOMRC, a large-scale cloze-style biomedical MRC dataset. Care was taken to reduce noise, compared to the previous BIOREAD dataset of Pappas et al. (2018). Experiments show that simple heuristics do not perform well on the new dataset and that two neural MRC models that had been tested on BIOREAD perform much better on BIOMRC, indicating that the new dataset is indeed less noisy or at least that its task is more feasible. Non-expert human performance is also higher on the new dataset compared to BIOREAD, and biomedical experts perform even better. We also introduce a new BERT-based MRC model, the best version of which substantially outperforms all other methods tested, reaching or surpassing the accuracy of biomedical experts in some experiments. We make the new dataset available in three different sizes, also releasing our code, and providing a leaderboard.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### biomrc_large_A
+
+- **Size of downloaded dataset files:** 389.18 MB
+- **Size of the generated dataset:** 1831.85 MB
+- **Total amount of disk used:** 2221.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\"OBJECTIVES: @entity9 is a @entity10 that may result from greater occipital nerve entrapment. Entrapped peripheral nerves typica...",
+    "answer": "@entity9 :: (MESH:D009437,Disease) :: ['unilateral occipital neuralgia']\n",
+    "entities_list": ["@entity1 :: ('9606', 'Species') :: ['patients']", "@entity10 :: ('MESH:D006261', 'Disease') :: ['headache', 'Headache']", "@entity9 :: ('MESH:D009437', 'Disease') :: ['Occipital neuralgia', 'unilateral occipital neuralgia']"],
+    "title": "Sonographic evaluation of the greater occipital nerve in XXXX .\n"
+}
+```
+
+#### biomrc_large_B
+
+- **Size of downloaded dataset files:** 327.17 MB
+- **Size of the generated dataset:** 1469.61 MB
+- **Total amount of disk used:** 1796.78 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\"BACKGROUND: Adults with physical disabilities are less likely than others to receive @entity2 screening. It is not known, howev...",
+    "answer": "@entity2",
+    "entities_list": ["@entity2", "@entity1", "@entity0", "@entity3"],
+    "title": "Does a standard measure of self-reported physical disability correlate with clinician perception of impairment related to XXXX screening?\n"
+}
+```
+
+#### biomrc_small_A
+
+- **Size of downloaded dataset files:** 65.69 MB
+- **Size of the generated dataset:** 225.37 MB
+- **Total amount of disk used:** 291.06 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\"PURPOSE: @entity120 ( @entity120 ) is a life-limiting @entity102 that presents as an elevated blood pressure in the pulmonary a...",
+    "answer": "@entity148 :: (MESH:D001008,Disease) :: ['anxiety']\n",
+    "entities_list": "[\"@entity1 :: ('9606', 'Species') :: ['patients']\", \"@entity308 :: ('MESH:D003866', 'Disease') :: ['depression']\", \"@entity146 :...",
+    "title": "A predictive model of the effects of @entity308 , XXXX , stress, 6-minute-walk distance, and social support on health-related quality of life in an adult pulmonary hypertension population.\n"
+}
+```
+
+#### biomrc_small_B
+
+- **Size of downloaded dataset files:** 55.03 MB
+- **Size of the generated dataset:** 180.84 MB
+- **Total amount of disk used:** 235.87 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\"Single-agent activity for @entity12 reflected by response rates of 10%-30% has been reported in @entity0 with @entity3 ( @entit...",
+    "answer": "@entity10",
+    "entities_list": ["@entity0", "@entity6", "@entity2", "@entity5", "@entity12", "@entity11", "@entity1", "@entity7", "@entity9", "@entity10", "@entity3", "@entity4", "@entity8"],
+    "title": "No synergistic activity of @entity7 and XXXX in the treatment of @entity3 .\n"
+}
+```
+
+#### biomrc_tiny_A
+
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.07 MB
+- **Total amount of disk used:** 0.09 MB
+
+An example of 'test' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\"OBJECTIVE: Decompressive craniectomy (DC) requires later cranioplasty (CP) in survivors. However, if additional ventriculoperit...",
+    "answer": "@entity260 :: (MESH:D011183,Disease) :: ['Postoperative Complications']\n",
+    "entities_list": ["@entity1 :: ('9606', 'Species') :: ['Patients', 'patients', 'Patient']", "@entity260 :: ('MESH:D011183', 'Disease') :: ['VPS regarding postoperative complications']", "@entity1276 :: ('MESH:D006849', 'Disease') :: ['hydrocephalus']"],
+    "title": "Cranioplasty and Ventriculoperitoneal Shunt Placement after Decompressive Craniectomy: Staged Surgery Is Associated with Fewer XXXX .\n"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### biomrc_large_A
+- `abstract`: a `string` feature.
+- `title`: a `string` feature.
+- `entities_list`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+#### biomrc_large_B
+- `abstract`: a `string` feature.
+- `title`: a `string` feature.
+- `entities_list`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+#### biomrc_small_A
+- `abstract`: a `string` feature.
+- `title`: a `string` feature.
+- `entities_list`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+#### biomrc_small_B
+- `abstract`: a `string` feature.
+- `title`: a `string` feature.
+- `entities_list`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+#### biomrc_tiny_A
+- `abstract`: a `string` feature.
+- `title`: a `string` feature.
+- `entities_list`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### biomrc_large_A
+
+|              |train |validation|test |
+|--------------|-----:|---------:|----:|
+|biomrc_large_A|700000|     50000|62707|
+
+#### biomrc_large_B
+
+|              |train |validation|test |
+|--------------|-----:|---------:|----:|
+|biomrc_large_B|700000|     50000|62707|
+
+#### biomrc_small_A
+
+|              |train|validation|test|
+|--------------|----:|---------:|---:|
+|biomrc_small_A|87500|      6250|6250|
+
+#### biomrc_small_B
+
+|              |train|validation|test|
+|--------------|----:|---------:|---:|
+|biomrc_small_B|87500|      6250|6250|
+
+#### biomrc_tiny_A
+
+|             |test|
+|-------------|---:|
+|biomrc_tiny_A|  30|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{pappas-etal-2020-biomrc,
+    title = "{B}io{MRC}: A Dataset for Biomedical Machine Reading Comprehension",
+    author = "Pappas, Dimitris  and
+      Stavropoulos, Petros  and
+      Androutsopoulos, Ion  and
+      McDonald, Ryan",
+    booktitle = "Proceedings of the 19th SIGBioMed Workshop on Biomedical Language Processing",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.bionlp-1.15",
+    pages = "140--149",
+    abstract = "We introduce BIOMRC, a large-scale cloze-style biomedical MRC dataset. Care was taken to reduce noise, compared to the previous BIOREAD dataset of Pappas et al. (2018). Experiments show that simple heuristics do not perform well on the new dataset and that two neural MRC models that had been tested on BIOREAD perform much better on BIOMRC, indicating that the new dataset is indeed less noisy or at least that its task is more feasible. Non-expert human performance is also higher on the new dataset compared to BIOREAD, and biomedical experts perform even better. We also introduce a new BERT-based MRC model, the best version of which substantially outperforms all other methods tested, reaching or surpassing the accuracy of biomedical experts in some experiments. We make the new dataset available in three different sizes, also releasing our code, and providing a leaderboard.",
+}
+
+```
+

--- a/datasets/blended_skill_talk/README.md
+++ b/datasets/blended_skill_talk/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "blended_skill_talk"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://parl.ai/projects/bst/](https://parl.ai/projects/bst/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 36.34 MB
+- **Size of the generated dataset:** 14.38 MB
+- **Total amount of disk used:** 50.71 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A dataset of 7k conversations explicitly designed to exhibit multiple conversation modes: displaying personality, having empathy, and demonstrating knowledge.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 36.34 MB
+- **Size of the generated dataset:** 14.38 MB
+- **Total amount of disk used:** 50.71 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "additional_context": "Electrician",
+    "context": "wizard_of_wikipedia",
+    "free_messages": "[\"Which level are you at?\", \"Thats great! How long have you been doing this work? \", \"Sounds like it could be a dangerous job at...",
+    "guided_messages": ["I received on-the-job training when i first started", "For a good number of years now.", "That it is,especially if you dont take the proper measures", "Thats true,especially in this economy", "Do you enjoy it?", "I feel you. Stretch along the halls"],
+    "personas": ["i work as an electrician.", "i always sleep 8 hours a day."],
+    "previous_utterance": ["That sounds dangerous. Is it worth doing such a dangerous job?", "Wekk it is okay is you are well trained.  There are three levels: Apprentice, journeyman and Master."],
+    "suggestions": "{\"convai2\": [\"i'm a grandmaster . i think they rank bridge players like chess .\", \"since i can remember . i enjoy it a lot .\", \"..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `personas`: a `list` of `string` features.
+- `additional_context`: a `string` feature.
+- `previous_utterance`: a `list` of `string` features.
+- `context`: a `string` feature.
+- `free_messages`: a `list` of `string` features.
+- `guided_messgaes`: a `list` of `string` features.
+- `suggestions`: a dictionary feature containing:
+  - `convai2`: a `string` feature.
+  - `empathetic_dialogues`: a `string` feature.
+  - `wizard_of_wikipedia`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 4819|      1009| 980|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc{smith2020evaluating,
+    title={Can You Put it All Together: Evaluating Conversational Agents' Ability to Blend Skills},
+    author={Eric Michael Smith and Mary Williamson and Kurt Shuster and Jason Weston and Y-Lan Boureau},
+    year={2020},
+    eprint={2004.08449},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/blimp/README.md
+++ b/datasets/blimp/README.md
@@ -1,0 +1,299 @@
+---
+---
+
+# Dataset Card for "blimp"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/alexwarstadt/blimp/tree/master/](https://github.com/alexwarstadt/blimp/tree/master/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 28.21 MB
+- **Size of the generated dataset:** 10.92 MB
+- **Total amount of disk used:** 39.13 MB
+
+### [Dataset Summary](#dataset-summary)
+
+BLiMP is a challenge set for evaluating what language models (LMs) know about
+major grammatical phenomena in English. BLiMP consists of 67 sub-datasets, each
+containing 1000 minimal pairs isolating specific contrasts in syntax,
+morphology, or semantics. The data is automatically generated according to
+expert-crafted grammars.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### adjunct_island
+
+- **Size of downloaded dataset files:** 0.34 MB
+- **Size of the generated dataset:** 0.16 MB
+- **Total amount of disk used:** 0.50 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "UID": "tough_vs_raising_1",
+    "field": "syntax_semantics",
+    "lexically_identical": false,
+    "linguistics_term": "control_raising",
+    "one_prefix_method": false,
+    "pair_id": 2,
+    "sentence_bad": "Benjamin's tutor was certain to boast about.",
+    "sentence_good": "Benjamin's tutor was easy to boast about.",
+    "simple_LM_method": true,
+    "two_prefix_method": false
+}
+```
+
+#### anaphor_gender_agreement
+
+- **Size of downloaded dataset files:** 0.42 MB
+- **Size of the generated dataset:** 0.13 MB
+- **Total amount of disk used:** 0.54 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "UID": "tough_vs_raising_1",
+    "field": "syntax_semantics",
+    "lexically_identical": false,
+    "linguistics_term": "control_raising",
+    "one_prefix_method": false,
+    "pair_id": 2,
+    "sentence_bad": "Benjamin's tutor was certain to boast about.",
+    "sentence_good": "Benjamin's tutor was easy to boast about.",
+    "simple_LM_method": true,
+    "two_prefix_method": false
+}
+```
+
+#### anaphor_number_agreement
+
+- **Size of downloaded dataset files:** 0.43 MB
+- **Size of the generated dataset:** 0.13 MB
+- **Total amount of disk used:** 0.56 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "UID": "tough_vs_raising_1",
+    "field": "syntax_semantics",
+    "lexically_identical": false,
+    "linguistics_term": "control_raising",
+    "one_prefix_method": false,
+    "pair_id": 2,
+    "sentence_bad": "Benjamin's tutor was certain to boast about.",
+    "sentence_good": "Benjamin's tutor was easy to boast about.",
+    "simple_LM_method": true,
+    "two_prefix_method": false
+}
+```
+
+#### animate_subject_passive
+
+- **Size of downloaded dataset files:** 0.44 MB
+- **Size of the generated dataset:** 0.14 MB
+- **Total amount of disk used:** 0.58 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "UID": "tough_vs_raising_1",
+    "field": "syntax_semantics",
+    "lexically_identical": false,
+    "linguistics_term": "control_raising",
+    "one_prefix_method": false,
+    "pair_id": 2,
+    "sentence_bad": "Benjamin's tutor was certain to boast about.",
+    "sentence_good": "Benjamin's tutor was easy to boast about.",
+    "simple_LM_method": true,
+    "two_prefix_method": false
+}
+```
+
+#### animate_subject_trans
+
+- **Size of downloaded dataset files:** 0.41 MB
+- **Size of the generated dataset:** 0.12 MB
+- **Total amount of disk used:** 0.54 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "UID": "tough_vs_raising_1",
+    "field": "syntax_semantics",
+    "lexically_identical": false,
+    "linguistics_term": "control_raising",
+    "one_prefix_method": false,
+    "pair_id": 2,
+    "sentence_bad": "Benjamin's tutor was certain to boast about.",
+    "sentence_good": "Benjamin's tutor was easy to boast about.",
+    "simple_LM_method": true,
+    "two_prefix_method": false
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### adjunct_island
+- `sentence_good`: a `string` feature.
+- `sentence_bad`: a `string` feature.
+- `field`: a `string` feature.
+- `linguistics_term`: a `string` feature.
+- `UID`: a `string` feature.
+- `simple_LM_method`: a `bool` feature.
+- `one_prefix_method`: a `bool` feature.
+- `two_prefix_method`: a `bool` feature.
+- `lexically_identical`: a `bool` feature.
+- `pair_id`: a `int32` feature.
+
+#### anaphor_gender_agreement
+- `sentence_good`: a `string` feature.
+- `sentence_bad`: a `string` feature.
+- `field`: a `string` feature.
+- `linguistics_term`: a `string` feature.
+- `UID`: a `string` feature.
+- `simple_LM_method`: a `bool` feature.
+- `one_prefix_method`: a `bool` feature.
+- `two_prefix_method`: a `bool` feature.
+- `lexically_identical`: a `bool` feature.
+- `pair_id`: a `int32` feature.
+
+#### anaphor_number_agreement
+- `sentence_good`: a `string` feature.
+- `sentence_bad`: a `string` feature.
+- `field`: a `string` feature.
+- `linguistics_term`: a `string` feature.
+- `UID`: a `string` feature.
+- `simple_LM_method`: a `bool` feature.
+- `one_prefix_method`: a `bool` feature.
+- `two_prefix_method`: a `bool` feature.
+- `lexically_identical`: a `bool` feature.
+- `pair_id`: a `int32` feature.
+
+#### animate_subject_passive
+- `sentence_good`: a `string` feature.
+- `sentence_bad`: a `string` feature.
+- `field`: a `string` feature.
+- `linguistics_term`: a `string` feature.
+- `UID`: a `string` feature.
+- `simple_LM_method`: a `bool` feature.
+- `one_prefix_method`: a `bool` feature.
+- `two_prefix_method`: a `bool` feature.
+- `lexically_identical`: a `bool` feature.
+- `pair_id`: a `int32` feature.
+
+#### animate_subject_trans
+- `sentence_good`: a `string` feature.
+- `sentence_bad`: a `string` feature.
+- `field`: a `string` feature.
+- `linguistics_term`: a `string` feature.
+- `UID`: a `string` feature.
+- `simple_LM_method`: a `bool` feature.
+- `one_prefix_method`: a `bool` feature.
+- `two_prefix_method`: a `bool` feature.
+- `lexically_identical`: a `bool` feature.
+- `pair_id`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|          name          |train|
+|------------------------|----:|
+|adjunct_island          | 1000|
+|anaphor_gender_agreement| 1000|
+|anaphor_number_agreement| 1000|
+|animate_subject_passive | 1000|
+|animate_subject_trans   | 1000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{warstadt2019blimp,
+  title={BLiMP: A Benchmark of Linguistic Minimal Pairs for English},
+  author={Warstadt, Alex and Parrish, Alicia and Liu, Haokun and Mohananey, Anhad and Peng, Wei, and Wang, Sheng-Fu and Bowman, Samuel R},
+  journal={arXiv preprint arXiv:1912.00582},
+  year={2019}
+}
+
+```
+

--- a/datasets/blog_authorship_corpus/README.md
+++ b/datasets/blog_authorship_corpus/README.md
@@ -1,0 +1,164 @@
+---
+---
+
+# Dataset Card for "blog_authorship_corpus"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://u.cs.biu.ac.il/~koppel/BlogCorpus.htm](https://u.cs.biu.ac.il/~koppel/BlogCorpus.htm)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 298.45 MB
+- **Size of the generated dataset:** 617.75 MB
+- **Total amount of disk used:** 916.20 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Blog Authorship Corpus consists of the collected posts of 19,320 bloggers gathered from blogger.com in August 2004. The corpus incorporates a total of 681,288 posts and over 140 million words - or approximately 35 posts and 7250 words per person.
+
+Each blog is presented as a separate file, the name of which indicates a blogger id# and the blogger’s self-provided gender, age, industry and astrological sign. (All are labeled for gender and age but for many, industry and/or sign is marked as unknown.)
+
+All bloggers included in the corpus fall into one of three age groups:
+
+·          8240 "10s" blogs (ages 13-17),
+
+·          8086 "20s" blogs(ages 23-27)
+
+·          2994 "30s" blogs (ages 33-47).
+
+For each age group there are an equal number of male and female bloggers.
+
+Each blog in the corpus includes at least 200 occurrences of common English words. All formatting has been stripped with two exceptions. Individual posts within a single blogger are separated by the date of the following post and links within a post are denoted by the label urllink.
+
+The corpus may be freely used for non-commercial research purposes
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### blog-authorship-corpus
+
+- **Size of downloaded dataset files:** 298.45 MB
+- **Size of the generated dataset:** 617.75 MB
+- **Total amount of disk used:** 916.20 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "age": 23,
+    "date": "27,July,2003",
+    "gender": "female",
+    "horoscope": "Scorpion",
+    "job": "Student",
+    "text": "This is a second test file."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### blog-authorship-corpus
+- `text`: a `string` feature.
+- `date`: a `string` feature.
+- `gender`: a `string` feature.
+- `age`: a `int32` feature.
+- `horoscope`: a `string` feature.
+- `job`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|         name         |train |validation|
+|----------------------|-----:|---------:|
+|blog-authorship-corpus|532812|     31277|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{schler2006effects,
+    title={Effects of age and gender on blogging.},
+    author={Schler, Jonathan and Koppel, Moshe and Argamon, Shlomo and Pennebaker, James W},
+    booktitle={AAAI spring symposium: Computational approaches to analyzing weblogs},
+    volume={6},
+    pages={199--205},
+    year={2006}
+}
+
+```
+

--- a/datasets/bookcorpus/README.md
+++ b/datasets/bookcorpus/README.md
@@ -1,0 +1,137 @@
+---
+---
+
+# Dataset Card for "bookcorpus"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://yknzhu.wixsite.com/mbweb](https://yknzhu.wixsite.com/mbweb)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1124.87 MB
+- **Size of the generated dataset:** 4629.00 MB
+- **Total amount of disk used:** 5753.87 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Books are a rich source of both fine-grained information, how a character, an object or a scene looks like, as well as high-level semantics, what someone is thinking, feeling and how these states evolve through a story.This work aims to align books to their movie releases in order to providerich descriptive explanations for visual content that go semantically farbeyond the captions available in current datasets.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 1124.87 MB
+- **Size of the generated dataset:** 4629.00 MB
+- **Total amount of disk used:** 5753.87 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "text": "But I traded all my life for some lovin' and some gold"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   | train  |
+|----------|-------:|
+|plain_text|74004228|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{Zhu_2015_ICCV,
+    title = {Aligning Books and Movies: Towards Story-Like Visual Explanations by Watching Movies and Reading Books},
+    author = {Zhu, Yukun and Kiros, Ryan and Zemel, Rich and Salakhutdinov, Ruslan and Urtasun, Raquel and Torralba, Antonio and Fidler, Sanja},
+    booktitle = {The IEEE International Conference on Computer Vision (ICCV)},
+    month = {December},
+    year = {2015}
+}
+
+```
+

--- a/datasets/bookcorpusopen/README.md
+++ b/datasets/bookcorpusopen/README.md
@@ -1,0 +1,142 @@
+---
+---
+
+# Dataset Card for "bookcorpusopen"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/soskek/bookcorpus/issues/27](https://github.com/soskek/bookcorpus/issues/27)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2292.89 MB
+- **Size of the generated dataset:** 6336.36 MB
+- **Total amount of disk used:** 8629.25 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Books are a rich source of both fine-grained information, how a character, an object or a scene looks like, as well as high-level semantics, what someone is thinking, feeling and how these states evolve through a story.
+This version of bookcorpus has 17868 dataset items (books). Each item contains two fields: title and text. The title is the name of the book (just the file name) while text contains unprocessed book text. The bookcorpus has been prepared by Shawn Presser and is generously hosted by The-Eye. The-Eye is a non-profit, community driven platform dedicated to the archiving and long-term preservation of any and all data including but by no means limited to... websites, books, games, software, video, audio, other digital-obscura and ideas.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 2292.89 MB
+- **Size of the generated dataset:** 6336.36 MB
+- **Total amount of disk used:** 8629.25 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "text": "\"\\n\\nzONE\\n\\n## The end and the beginning\\n\\nby\\n\\nPhilip F. Blood\\n\\nSMASHWORDS EDITION\\n\\nVersion 3.55\\n\\nPUBLISHED BY:\\n\\nPhi...",
+    "title": "zone-the-end-and-the-beginning.epub.txt"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `title`: a `string` feature.
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|
+|----------|----:|
+|plain_text|17868|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{Zhu_2015_ICCV,
+    title = {Aligning Books and Movies: Towards Story-Like Visual Explanations by Watching Movies and Reading Books},
+    author = {Zhu, Yukun and Kiros, Ryan and Zemel, Rich and Salakhutdinov, Ruslan and Urtasun, Raquel and Torralba, Antonio and Fidler, Sanja},
+    booktitle = {The IEEE International Conference on Computer Vision (ICCV)},
+    month = {December},
+    year = {2015}
+}
+
+```
+

--- a/datasets/boolq/README.md
+++ b/datasets/boolq/README.md
@@ -1,0 +1,145 @@
+---
+---
+
+# Dataset Card for "boolq"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research-datasets/boolean-questions](https://github.com/google-research-datasets/boolean-questions)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 8.36 MB
+- **Size of the generated dataset:** 7.47 MB
+- **Total amount of disk used:** 15.82 MB
+
+### [Dataset Summary](#dataset-summary)
+
+BoolQ is a question answering dataset for yes/no questions containing 15942 examples. These questions are naturally
+occurring ---they are generated in unprompted and unconstrained settings.
+Each example is a triplet of (question, passage, answer), with the title of the page as optional additional context.
+The text-pair classification setup is similar to existing natural language inference tasks.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 8.36 MB
+- **Size of the generated dataset:** 7.47 MB
+- **Total amount of disk used:** 15.82 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": false,
+    "passage": "\"All biomass goes through at least some of these steps: it needs to be grown, collected, dried, fermented, distilled, and burned...",
+    "question": "does ethanol take more energy make that produces"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `question`: a `string` feature.
+- `answer`: a `bool` feature.
+- `passage`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default| 9427|      3270|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{clark2019boolq,
+  title =     {BoolQ: Exploring the Surprising Difficulty of Natural Yes/No Questions},
+  author =    {Clark, Christopher and Lee, Kenton and Chang, Ming-Wei, and Kwiatkowski, Tom and Collins, Michael, and Toutanova, Kristina},
+  booktitle = {NAACL},
+  year =      {2019},
+}
+
+```
+

--- a/datasets/break_data/README.md
+++ b/datasets/break_data/README.md
@@ -1,0 +1,240 @@
+---
+---
+
+# Dataset Card for "break_data"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/allenai/Break](https://github.com/allenai/Break)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 76.16 MB
+- **Size of the generated dataset:** 148.34 MB
+- **Total amount of disk used:** 224.49 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Break is a human annotated dataset of natural language questions and their Question Decomposition Meaning Representations
+(QDMRs). Break consists of 83,978 examples sampled from 10 question answering datasets over text, images and databases.
+This repository contains the Break dataset along with information on the exact data format.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### QDMR
+
+- **Size of downloaded dataset files:** 15.23 MB
+- **Size of the generated dataset:** 15.19 MB
+- **Total amount of disk used:** 30.42 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "decomposition": "return flights ;return #1 from  denver ;return #2 to philadelphia ;return #3 if  available",
+    "operators": "['select', 'filter', 'filter', 'filter']",
+    "question_id": "ATIS_dev_0",
+    "question_text": "what flights are available tomorrow from denver to philadelphia ",
+    "split": "dev"
+}
+```
+
+#### QDMR-high-level
+
+- **Size of downloaded dataset files:** 15.23 MB
+- **Size of the generated dataset:** 6.24 MB
+- **Total amount of disk used:** 21.47 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "decomposition": "return ground transportation ;return #1 which  is  available ;return #2 from  the pittsburgh airport ;return #3 to downtown ;return the cost of #4",
+    "operators": "['select', 'filter', 'filter', 'filter', 'project']",
+    "question_id": "ATIS_dev_102",
+    "question_text": "what ground transportation is available from the pittsburgh airport to downtown and how much does it cost ",
+    "split": "dev"
+}
+```
+
+#### QDMR-high-level-lexicon
+
+- **Size of downloaded dataset files:** 15.23 MB
+- **Size of the generated dataset:** 30.17 MB
+- **Total amount of disk used:** 45.40 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "allowed_tokens": "\"['higher than', 'same as', 'what ', 'and ', 'than ', 'at most', 'he', 'distinct', 'House', 'two', 'at least', 'or ', 'date', 'o...",
+    "source": "What office, also held by a member of the Maine House of Representatives, did James K. Polk hold before he was president?"
+}
+```
+
+#### QDMR-lexicon
+
+- **Size of downloaded dataset files:** 15.23 MB
+- **Size of the generated dataset:** 73.61 MB
+- **Total amount of disk used:** 88.84 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "allowed_tokens": "\"['higher than', 'same as', 'what ', 'and ', 'than ', 'at most', 'distinct', 'two', 'at least', 'or ', 'date', 'on ', '@@14@@', ...",
+    "source": "what flights are available tomorrow from denver to philadelphia "
+}
+```
+
+#### logical-forms
+
+- **Size of downloaded dataset files:** 15.23 MB
+- **Size of the generated dataset:** 23.13 MB
+- **Total amount of disk used:** 38.36 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "decomposition": "return ground transportation ;return #1 which  is  available ;return #2 from  the pittsburgh airport ;return #3 to downtown ;return the cost of #4",
+    "operators": "['select', 'filter', 'filter', 'filter', 'project']",
+    "program": "some program",
+    "question_id": "ATIS_dev_102",
+    "question_text": "what ground transportation is available from the pittsburgh airport to downtown and how much does it cost ",
+    "split": "dev"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### QDMR
+- `question_id`: a `string` feature.
+- `question_text`: a `string` feature.
+- `decomposition`: a `string` feature.
+- `operators`: a `string` feature.
+- `split`: a `string` feature.
+
+#### QDMR-high-level
+- `question_id`: a `string` feature.
+- `question_text`: a `string` feature.
+- `decomposition`: a `string` feature.
+- `operators`: a `string` feature.
+- `split`: a `string` feature.
+
+#### QDMR-high-level-lexicon
+- `source`: a `string` feature.
+- `allowed_tokens`: a `string` feature.
+
+#### QDMR-lexicon
+- `source`: a `string` feature.
+- `allowed_tokens`: a `string` feature.
+
+#### logical-forms
+- `question_id`: a `string` feature.
+- `question_text`: a `string` feature.
+- `decomposition`: a `string` feature.
+- `operators`: a `string` feature.
+- `split`: a `string` feature.
+- `program`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|         name          |train|validation|test|
+|-----------------------|----:|---------:|---:|
+|QDMR                   |44321|      7760|8069|
+|QDMR-high-level        |17503|      3130|3195|
+|QDMR-high-level-lexicon|17503|      3130|3195|
+|QDMR-lexicon           |44321|      7760|8069|
+|logical-forms          |44098|      7719|8006|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{Wolfson2020Break,
+  title={Break It Down: A Question Understanding Benchmark},
+  author={Wolfson, Tomer and Geva, Mor and Gupta, Ankit and Gardner, Matt and Goldberg, Yoav and Deutch, Daniel and Berant, Jonathan},
+  journal={Transactions of the Association for Computational Linguistics},
+  year={2020},
+}
+
+```
+

--- a/datasets/cfq/README.md
+++ b/datasets/cfq/README.md
@@ -1,0 +1,226 @@
+---
+---
+
+# Dataset Card for "cfq"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research/google-research/tree/master/cfq](https://github.com/google-research/google-research/tree/master/cfq)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2041.62 MB
+- **Size of the generated dataset:** 345.30 MB
+- **Total amount of disk used:** 2386.92 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The CFQ dataset (and it's splits) for measuring compositional generalization.
+
+See https://arxiv.org/abs/1912.09713.pdf for background.
+
+Example usage:
+data = datasets.load_dataset('cfq/mcd1')
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### mcd1
+
+- **Size of downloaded dataset files:** 255.20 MB
+- **Size of the generated dataset:** 40.91 MB
+- **Total amount of disk used:** 296.11 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "query": "SELECT /producer M0 . /director M0 . ",
+    "question": "Who produced and directed M0?"
+}
+```
+
+#### mcd2
+
+- **Size of downloaded dataset files:** 255.20 MB
+- **Size of the generated dataset:** 42.70 MB
+- **Total amount of disk used:** 297.91 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "query": "SELECT /producer M0 . /director M0 . ",
+    "question": "Who produced and directed M0?"
+}
+```
+
+#### mcd3
+
+- **Size of downloaded dataset files:** 255.20 MB
+- **Size of the generated dataset:** 41.58 MB
+- **Total amount of disk used:** 296.78 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "query": "SELECT /producer M0 . /director M0 . ",
+    "question": "Who produced and directed M0?"
+}
+```
+
+#### query_complexity_split
+
+- **Size of downloaded dataset files:** 255.20 MB
+- **Size of the generated dataset:** 43.82 MB
+- **Total amount of disk used:** 299.02 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "query": "SELECT /producer M0 . /director M0 . ",
+    "question": "Who produced and directed M0?"
+}
+```
+
+#### query_pattern_split
+
+- **Size of downloaded dataset files:** 255.20 MB
+- **Size of the generated dataset:** 43.98 MB
+- **Total amount of disk used:** 299.19 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "query": "SELECT /producer M0 . /director M0 . ",
+    "question": "Who produced and directed M0?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### mcd1
+- `question`: a `string` feature.
+- `query`: a `string` feature.
+
+#### mcd2
+- `question`: a `string` feature.
+- `query`: a `string` feature.
+
+#### mcd3
+- `question`: a `string` feature.
+- `query`: a `string` feature.
+
+#### query_complexity_split
+- `question`: a `string` feature.
+- `query`: a `string` feature.
+
+#### query_pattern_split
+- `question`: a `string` feature.
+- `query`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|         name         |train |test |
+|----------------------|-----:|----:|
+|mcd1                  | 95743|11968|
+|mcd2                  | 95743|11968|
+|mcd3                  | 95743|11968|
+|query_complexity_split|100654| 9512|
+|query_pattern_split   | 94600|12589|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{Keysers2020,
+  title={Measuring Compositional Generalization: A Comprehensive Method on
+         Realistic Data},
+  author={Daniel Keysers and Nathanael Sch"{a}rli and Nathan Scales and
+          Hylke Buisman and Daniel Furrer and Sergii Kashubin and
+          Nikola Momchev and Danila Sinopalnikov and Lukasz Stafiniak and
+          Tibor Tihon and Dmitry Tsarkov and Xiao Wang and Marc van Zee and
+          Olivier Bousquet},
+  booktitle={ICLR},
+  year={2020},
+  url={https://arxiv.org/abs/1912.09713.pdf},
+}
+
+```
+

--- a/datasets/civil_comments/README.md
+++ b/datasets/civil_comments/README.md
@@ -1,0 +1,174 @@
+---
+---
+
+# Dataset Card for "civil_comments"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification/data](https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification/data)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 395.73 MB
+- **Size of the generated dataset:** 630.60 MB
+- **Total amount of disk used:** 1026.33 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The comments in this dataset come from an archive of the Civil Comments
+platform, a commenting plugin for independent news sites. These public comments
+were created from 2015 - 2017 and appeared on approximately 50 English-language
+news sites across the world. When Civil Comments shut down in 2017, they chose
+to make the public comments available in a lasting open archive to enable future
+research. The original data, published on figshare, includes the public comment
+text, some associated metadata such as article IDs, timestamps and
+commenter-generated "civility" labels, but does not include user ids. Jigsaw
+extended this dataset by adding additional labels for toxicity and identity
+mentions. This data set is an exact replica of the data released for the
+Jigsaw Unintended Bias in Toxicity Classification Kaggle challenge.  This
+dataset is released under CC0, as is the underlying comment text.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 395.73 MB
+- **Size of the generated dataset:** 630.60 MB
+- **Total amount of disk used:** 1026.33 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "identity_attack": 0.0,
+    "insult": 0.0,
+    "obscene": 0.0,
+    "severe_toxicity": 0.0,
+    "sexual_explicit": 0.0,
+    "text": "The public test.",
+    "threat": 0.0,
+    "toxicity": 0.0
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+- `toxicity`: a `float32` feature.
+- `severe_toxicity`: a `float32` feature.
+- `obscene`: a `float32` feature.
+- `threat`: a `float32` feature.
+- `insult`: a `float32` feature.
+- `identity_attack`: a `float32` feature.
+- `sexual_explicit`: a `float32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train |validation|test |
+|-------|------:|---------:|----:|
+|default|1804874|     97320|97320|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{DBLP:journals/corr/abs-1903-04561,
+  author    = {Daniel Borkan and
+               Lucas Dixon and
+               Jeffrey Sorensen and
+               Nithum Thain and
+               Lucy Vasserman},
+  title     = {Nuanced Metrics for Measuring Unintended Bias with Real Data for Text
+               Classification},
+  journal   = {CoRR},
+  volume    = {abs/1903.04561},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1903.04561},
+  archivePrefix = {arXiv},
+  eprint    = {1903.04561},
+  timestamp = {Sun, 31 Mar 2019 19:01:24 +0200},
+  biburl    = {https://dblp.org/rec/bib/journals/corr/abs-1903-04561},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+```
+

--- a/datasets/clue/README.md
+++ b/datasets/clue/README.md
@@ -1,0 +1,258 @@
+---
+---
+
+# Dataset Card for "clue"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://dc.cloud.alipay.com/index#/topic/data?id=8](https://dc.cloud.alipay.com/index#/topic/data?id=8)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 189.48 MB
+- **Size of the generated dataset:** 463.81 MB
+- **Total amount of disk used:** 653.29 MB
+
+### [Dataset Summary](#dataset-summary)
+
+CLUE, A Chinese Language Understanding Evaluation Benchmark
+(https://www.cluebenchmarks.com/) is a collection of resources for training,
+evaluating, and analyzing Chinese language understanding systems.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### afqmc
+
+- **Size of downloaded dataset files:** 1.14 MB
+- **Size of the generated dataset:** 4.01 MB
+- **Total amount of disk used:** 5.15 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "idx": 0,
+    "label": 0,
+    "sentence1": "双十一花呗提额在哪",
+    "sentence2": "里可以提花呗额度"
+}
+```
+
+#### c3
+
+- **Size of downloaded dataset files:** 3.05 MB
+- **Size of the generated dataset:** 14.96 MB
+- **Total amount of disk used:** 18.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": "比人的灵敏",
+    "choice": ["没有人的灵敏", "和人的差不多", "和人的一样好", "比人的灵敏"],
+    "context": "[\"许多动物的某些器官感觉特别灵敏，它们能比人类提前知道一些灾害事件的发生，例如，海洋中的水母能预报风暴，老鼠能事先躲避矿井崩塌或有害气体，等等。地震往往能使一些动物的某些感觉器官受到刺激而发生异常反应。如一个地区的重力发生变异，某些动物可能通过它们的平衡...",
+    "id": 1,
+    "question": "动物的器官感觉与人的相比有什么不同?"
+}
+```
+
+#### chid
+
+- **Size of downloaded dataset files:** 127.15 MB
+- **Size of the generated dataset:** 259.71 MB
+- **Total amount of disk used:** 386.86 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "candidate_id": [3, 5, 6, 1, 7, 4, 0],
+        "text": ["碌碌无为", "无所作为", "苦口婆心", "得过且过", "未雨绸缪", "软硬兼施", "传宗接代"]
+    },
+    "candidates": "[\"传宗接代\", \"得过且过\", \"咄咄逼人\", \"碌碌无为\", \"软硬兼施\", \"无所作为\", \"苦口婆心\", \"未雨绸缪\", \"和衷共济\", \"人老珠黄\"]...",
+    "content": "[\"谈到巴萨目前的成就，瓜迪奥拉用了“坚持”两个字来形容。自从上世纪90年代克鲁伊夫带队以来，巴萨就坚持每年都有拉玛西亚球员进入一队的传统。即便是范加尔时代，巴萨强力推出的“巴萨五鹰”德拉·佩纳、哈维、莫雷罗、罗杰·加西亚和贝拉乌桑几乎#idiom0000...",
+    "idx": 0
+}
+```
+
+#### cluewsc2020
+
+- **Size of downloaded dataset files:** 0.08 MB
+- **Size of the generated dataset:** 0.41 MB
+- **Total amount of disk used:** 0.49 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "idx": 0,
+    "label": 1,
+    "target": {
+        "span1_index": 3,
+        "span1_text": "伤口",
+        "span2_index": 27,
+        "span2_text": "它们"
+    },
+    "text": "裂开的伤口涂满尘土，里面有碎石子和木头刺，我小心翼翼把它们剔除出去。"
+}
+```
+
+#### cmnli
+
+- **Size of downloaded dataset files:** 29.95 MB
+- **Size of the generated dataset:** 68.78 MB
+- **Total amount of disk used:** 98.73 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "idx": 0,
+    "label": 0,
+    "sentence1": "从概念上讲，奶油略读有两个基本维度-产品和地理。",
+    "sentence2": "产品和地理位置是使奶油撇油起作用的原因。"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### afqmc
+- `sentence1`: a `string` feature.
+- `sentence2`: a `string` feature.
+- `label`: a classification label, with possible values including `0` (0), `1` (1).
+- `idx`: a `int32` feature.
+
+#### c3
+- `id`: a `int32` feature.
+- `context`: a `list` of `string` features.
+- `question`: a `string` feature.
+- `choice`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+#### chid
+- `idx`: a `int32` feature.
+- `candidates`: a `list` of `string` features.
+- `content`: a `list` of `string` features.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `candidate_id`: a `int32` feature.
+
+#### cluewsc2020
+- `idx`: a `int32` feature.
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `true` (0), `false` (1).
+- `span1_text`: a `string` feature.
+- `span2_text`: a `string` feature.
+- `span1_index`: a `int32` feature.
+- `span2_index`: a `int32` feature.
+
+#### cmnli
+- `sentence1`: a `string` feature.
+- `sentence2`: a `string` feature.
+- `label`: a classification label, with possible values including `neutral` (0), `entailment` (1), `contradiction` (2).
+- `idx`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name    |train |validation|test |
+|-----------|-----:|---------:|----:|
+|afqmc      | 34334|      4316| 3861|
+|c3         | 11869|      3816| 3892|
+|chid       | 84709|      3218| 3231|
+|cluewsc2020|  1244|       304|  290|
+|cmnli      |391783|     12241|13880|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{xu2020clue,
+    title={CLUE: A Chinese Language Understanding Evaluation Benchmark},
+    author={Liang Xu and Xuanwei Zhang and Lu Li and Hai Hu and Chenjie Cao and Weitang Liu and Junyi Li and Yudong Li and Kai Sun and Yechen Xu and Yiming Cui and Cong Yu and Qianqian Dong and Yin Tian and Dian Yu and Bo Shi and Jun Zeng and Rongzhao Wang and Weijian Xie and Yanting Li and Yina Patterson and Zuoyu Tian and Yiwen Zhang and He Zhou and Shaoweihua Liu and Qipeng Zhao and Cong Yue and Xinrui Zhang and Zhengliang Yang and Zhenzhong Lan},
+    year={2020},
+    eprint={2004.05986},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/cmrc2018/README.md
+++ b/datasets/cmrc2018/README.md
@@ -1,0 +1,166 @@
+---
+---
+
+# Dataset Card for "cmrc2018"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/ymcui/cmrc2018](https://github.com/ymcui/cmrc2018)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 10.97 MB
+- **Size of the generated dataset:** 21.28 MB
+- **Total amount of disk used:** 32.26 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A Span-Extraction dataset for Chinese machine reading comprehension to add language
+diversities in this area. The dataset is composed by near 20,000 real questions annotated
+on Wikipedia paragraphs by human experts. We also annotated a challenge set which
+contains the questions that need comprehensive understanding and multi-sentence
+inference throughout the context.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 10.97 MB
+- **Size of the generated dataset:** 21.28 MB
+- **Total amount of disk used:** 32.26 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [11, 11],
+        "text": ["光荣和ω-force", "光荣和ω-force"]
+    },
+    "context": "\"《战国无双3》（）是由光荣和ω-force开发的战国无双系列的正统第三续作。本作以三大故事为主轴，分别是以武田信玄等人为主的《关东三国志》，织田信长等人为主的《战国三杰》，石田三成等人为主的《关原的年轻武者》，丰富游戏内的剧情。此部份专门介绍角色，欲知武...",
+    "id": "DEV_0_QUERY_0",
+    "question": "《战国无双3》是由哪两个公司合作开发的？"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|10142|      3219|1002|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{cui-emnlp2019-cmrc2018,
+    title = "A Span-Extraction Dataset for {C}hinese Machine Reading Comprehension",
+    author = "Cui, Yiming  and
+      Liu, Ting  and
+      Che, Wanxiang  and
+      Xiao, Li  and
+      Chen, Zhipeng  and
+      Ma, Wentao  and
+      Wang, Shijin  and
+      Hu, Guoping",
+    booktitle = "Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)",
+    month = nov,
+    year = "2019",
+    address = "Hong Kong, China",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/D19-1600",
+    doi = "10.18653/v1/D19-1600",
+    pages = "5886--5891",
+}
+
+```
+

--- a/datasets/coarse_discourse/README.md
+++ b/datasets/coarse_discourse/README.md
@@ -1,0 +1,158 @@
+---
+---
+
+# Dataset Card for "coarse_discourse"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research-datasets/coarse-discourse](https://github.com/google-research-datasets/coarse-discourse)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4.42 MB
+- **Size of the generated dataset:** 43.34 MB
+- **Total amount of disk used:** 47.76 MB
+
+### [Dataset Summary](#dataset-summary)
+
+dataset contains discourse annotation and relation on threads from reddit during 2016
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 4.42 MB
+- **Size of the generated dataset:** 43.34 MB
+- **Total amount of disk used:** 47.76 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "annotations": {
+        "annotator": ["fc96a15ab87f02dd1998ff55a64f6478", "e9e4b3ab355135fa954badcc06bfccc6", "31ac59c1734c1547d4d0723ff254c247"],
+        "link_to_post": ["", "", ""],
+        "main_type": ["elaboration", "elaboration", "elaboration"]
+    },
+    "id_post": "t1_c9b30i1",
+    "in_reply_to": "t1_c9b2nyd",
+    "is_first_post": false,
+    "is_self_post": true,
+    "majority_link": "t1_c9b2nyd",
+    "majority_type": "elaboration",
+    "post_depth": 2,
+    "subreddit": "100movies365days",
+    "title": "DTX120: #87 - Nashville",
+    "url": "https://www.reddit.com/r/100movies365days/comments/1bx6qw/dtx120_87_nashville/"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `title`: a `string` feature.
+- `is_self_post`: a `bool` feature.
+- `subreddit`: a `string` feature.
+- `url`: a `string` feature.
+- `majority_link`: a `string` feature.
+- `is_first_post`: a `bool` feature.
+- `majority_type`: a `string` feature.
+- `id_post`: a `string` feature.
+- `post_depth`: a `int32` feature.
+- `in_reply_to`: a `string` feature.
+- `annotations`: a dictionary feature containing:
+  - `annotator`: a `string` feature.
+  - `link_to_post`: a `string` feature.
+  - `main_type`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |
+|-------|-----:|
+|default|116357|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{coarsediscourse, title={Characterizing Online Discussion Using Coarse Discourse Sequences}, author={Zhang, Amy X. and Culbertson, Bryan and Paritosh, Praveen}, booktitle={Proceedings of the 11th International AAAI Conference on Weblogs and Social Media}, series={ICWSM '17}, year={2017}, location = {Montreal, Canada} }
+
+```
+

--- a/datasets/com_qa/README.md
+++ b/datasets/com_qa/README.md
@@ -1,0 +1,158 @@
+---
+---
+
+# Dataset Card for "com_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://qa.mpi-inf.mpg.de/comqa/](http://qa.mpi-inf.mpg.de/comqa/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.59 MB
+- **Size of the generated dataset:** 1.05 MB
+- **Total amount of disk used:** 2.65 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ComQA is a dataset of 11,214 questions, which were collected from WikiAnswers, a community question answering website.
+By collecting questions from such a site we ensure that the information needs are ones of interest to actual users.
+Moreover, questions posed there are often cannot be answered by commercial search engines or QA technology, making them
+more interesting for driving future research compared to those collected from an engine's query log. The dataset contains
+questions with various challenging phenomena such as the need for temporal reasoning, comparison (e.g., comparatives,
+superlatives, ordinals), compositionality (multiple, possibly nested, subquestions with multiple entities), and
+unanswerable questions (e.g., Who was the first human being on Mars?). Through a large crowdsourcing effort, questions
+in ComQA are grouped into 4,834 paraphrase clusters that express the same information need. Each cluster is annotated
+with its answer(s). ComQA answers come in the form of Wikipedia entities wherever possible. Wherever the answers are
+temporal or measurable quantities, TIMEX3 and the International System of Units (SI) are used for normalization.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.59 MB
+- **Size of the generated dataset:** 1.05 MB
+- **Total amount of disk used:** 2.65 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answers": ["https://en.wikipedia.org/wiki/north_sea"],
+    "cluster_id": "cluster-922",
+    "questions": ["what sea separates the scandinavia peninsula from britain?", "which sea separates britain from scandinavia?"]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `cluster_id`: a `string` feature.
+- `questions`: a `list` of `string` features.
+- `answers`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 3966|       966|2243|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{abujabal-etal-2019-comqa,
+    title = "{ComQA: A Community-sourced Dataset for Complex Factoid Question Answering with Paraphrase Clusters",
+    author = {Abujabal, Abdalghani  and
+      Saha Roy, Rishiraj  and
+      Yahya, Mohamed  and
+      Weikum, Gerhard},
+    booktitle = {Proceedings of the 2019 Conference of the North {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 1 (Long and Short Papers)},
+    month = {jun},
+    year = {2019},
+    address = {Minneapolis, Minnesota},
+    publisher = {Association for Computational Linguistics},
+    url = {https://www.aclweb.org/anthology/N19-1027},
+    doi = {10.18653/v1/N19-1027{,
+    pages = {307--317},
+    }
+
+```
+

--- a/datasets/common_gen/README.md
+++ b/datasets/common_gen/README.md
@@ -1,0 +1,150 @@
+---
+---
+
+# Dataset Card for "common_gen"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://inklab.usc.edu/CommonGen/index.html](https://inklab.usc.edu/CommonGen/index.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.76 MB
+- **Size of the generated dataset:** 6.88 MB
+- **Total amount of disk used:** 8.64 MB
+
+### [Dataset Summary](#dataset-summary)
+
+CommonGen is a constrained text generation task, associated with a benchmark dataset,
+to explicitly test machines for the ability of generative commonsense reasoning. Given
+a set of common concepts; the task is to generate a coherent sentence describing an
+everyday scenario using these concepts.
+
+CommonGen is challenging because it inherently requires 1) relational reasoning using
+background commonsense knowledge, and 2) compositional generalization ability to work
+on unseen concept combinations. Our dataset, constructed through a combination of
+crowd-sourcing from AMT and existing caption corpora, consists of 30k concept-sets and
+50k sentences in total.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.76 MB
+- **Size of the generated dataset:** 6.88 MB
+- **Total amount of disk used:** 8.64 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "concept_set_idx": 0,
+    "concepts": ["ski", "mountain", "skier"],
+    "target": "Three skiers are skiing on a snowy mountain."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `concept_set_idx`: a `int32` feature.
+- `concepts`: a `list` of `string` features.
+- `target`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|67389|      4018|1497|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{lin2019comgen,
+     author = {Bill Yuchen Lin and Ming Shen and Wangchunshu Zhou and Pei Zhou and Chandra Bhagavatula and Yejin Choi and Xiang Ren},
+     title = {CommonGen: A Constrained Text Generation Challenge for Generative Commonsense Reasoning},
+     journal = {CoRR},
+     volume = {abs/1911.03705},
+     year = {2019}
+}
+
+```
+

--- a/datasets/commonsense_qa/README.md
+++ b/datasets/commonsense_qa/README.md
@@ -1,0 +1,147 @@
+---
+---
+
+# Dataset Card for "commonsense_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.tau-nlp.org/commonsenseqa](https://www.tau-nlp.org/commonsenseqa)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4.46 MB
+- **Size of the generated dataset:** 2.08 MB
+- **Total amount of disk used:** 6.54 MB
+
+### [Dataset Summary](#dataset-summary)
+
+CommonsenseQA is a new multiple-choice question answering dataset that requires different types of commonsense knowledge
+ to predict the correct answers . It contains 12,102 questions with one correct answer and four distractor answers.
+ The dataset is provided in two major training/validation/testing set splits: "Random split" which is the main evaluation
+  split, and "Question token split", see paper for details.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 4.46 MB
+- **Size of the generated dataset:** 2.08 MB
+- **Total amount of disk used:** 6.54 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answerKey": "B",
+    "choices": {
+        "label": ["A", "B", "C", "D", "E"],
+        "text": ["mildred's coffee shop", "mexico", "diner", "kitchen", "canteen"]
+    },
+    "question": "In what Spanish speaking North American country can you get a great cup of coffee?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `answerKey`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `label`: a `string` feature.
+  - `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 9741|      1221|1140|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{commonsense_QA,
+title={COMMONSENSEQA: A Question Answering Challenge Targeting Commonsense Knowledge},
+author={Alon, Talmor and Jonathan, Herzig and Nicholas, Lourie and Jonathan ,Berant},
+journal={arXiv preprint arXiv:1811.00937v2},
+year={2019}
+
+```
+

--- a/datasets/compguesswhat/README.md
+++ b/datasets/compguesswhat/README.md
@@ -1,0 +1,244 @@
+---
+---
+
+# Dataset Card for "compguesswhat"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://compguesswhat.github.io/](https://compguesswhat.github.io/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 106.86 MB
+- **Size of the generated dataset:** 258.55 MB
+- **Total amount of disk used:** 365.41 MB
+
+### [Dataset Summary](#dataset-summary)
+
+        CompGuessWhat?! is an instance of a multi-task framework for evaluating the quality of learned neural representations,
+        in particular concerning attribute grounding. Use this dataset if you want to use the set of games whose reference
+        scene is an image in VisualGenome. Visit the website for more details: https://compguesswhat.github.io
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### compguesswhat-original
+
+- **Size of downloaded dataset files:** 102.24 MB
+- **Size of the generated dataset:** 166.29 MB
+- **Total amount of disk used:** 268.53 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 2424,
+    "image": "{\"coco_url\": \"http://mscoco.org/images/270512\", \"file_name\": \"COCO_train2014_000000270512.jpg\", \"flickr_url\": \"http://farm6.stat...",
+    "objects": "{\"area\": [1723.5133056640625, 4838.5361328125, 287.44476318359375, 44918.7109375, 3688.09375, 522.1935424804688], \"bbox\": [[5.61...",
+    "qas": {
+        "answer": ["Yes", "No", "No", "Yes"],
+        "id": [4983, 4996, 5006, 5017],
+        "question": ["Is it in the foreground?", "Does it have wings?", "Is it a person?", "Is it a vehicle?"]
+    },
+    "status": "success",
+    "target_id": 1197044,
+    "timestamp": "2016-07-08 15:07:38"
+}
+```
+
+#### compguesswhat-zero_shot
+
+- **Size of downloaded dataset files:** 4.62 MB
+- **Size of the generated dataset:** 92.26 MB
+- **Total amount of disk used:** 96.88 MB
+
+An example of 'nd_valid' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "image": {
+        "coco_url": "https://s3.amazonaws.com/nocaps/val/004e21eb2e686f40.jpg",
+        "date_captured": "2018-11-06 11:04:33",
+        "file_name": "004e21eb2e686f40.jpg",
+        "height": 1024,
+        "id": 6,
+        "license": 0,
+        "open_images_id": "004e21eb2e686f40",
+        "width": 768
+    },
+    "objects": "{\"IsOccluded\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], \"IsTruncated\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], \"area\": [3...",
+    "status": "incomplete",
+    "target_id": "004e21eb2e686f40_30"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### compguesswhat-original
+- `id`: a `int32` feature.
+- `target_id`: a `int32` feature.
+- `timestamp`: a `string` feature.
+- `status`: a `string` feature.
+- `id`: a `int32` feature.
+- `file_name`: a `string` feature.
+- `flickr_url`: a `string` feature.
+- `coco_url`: a `string` feature.
+- `height`: a `int32` feature.
+- `width`: a `int32` feature.
+- `width`: a `int32` feature.
+- `height`: a `int32` feature.
+- `url`: a `string` feature.
+- `coco_id`: a `int32` feature.
+- `flickr_id`: a `string` feature.
+- `image_id`: a `string` feature.
+- `qas`: a dictionary feature containing:
+  - `question`: a `string` feature.
+  - `answer`: a `string` feature.
+  - `id`: a `int32` feature.
+- `objects`: a dictionary feature containing:
+  - `id`: a `int32` feature.
+  - `bbox`: a `list` of `float32` features.
+  - `category`: a `string` feature.
+  - `area`: a `float32` feature.
+  - `category_id`: a `int32` feature.
+  - `segment`: a dictionary feature containing:
+    - `feature`: a `float32` feature.
+
+#### compguesswhat-zero_shot
+- `id`: a `int32` feature.
+- `target_id`: a `string` feature.
+- `status`: a `string` feature.
+- `id`: a `int32` feature.
+- `file_name`: a `string` feature.
+- `coco_url`: a `string` feature.
+- `height`: a `int32` feature.
+- `width`: a `int32` feature.
+- `license`: a `int32` feature.
+- `open_images_id`: a `string` feature.
+- `date_captured`: a `string` feature.
+- `objects`: a dictionary feature containing:
+  - `id`: a `string` feature.
+  - `bbox`: a `list` of `float32` features.
+  - `category`: a `string` feature.
+  - `area`: a `float32` feature.
+  - `category_id`: a `int32` feature.
+  - `IsOccluded`: a `int32` feature.
+  - `IsTruncated`: a `int32` feature.
+  - `segment`: a dictionary feature containing:
+    - `MaskPath`: a `string` feature.
+    - `LabelName`: a `string` feature.
+    - `BoxID`: a `string` feature.
+    - `BoxXMin`: a `string` feature.
+    - `BoxXMax`: a `string` feature.
+    - `BoxYMin`: a `string` feature.
+    - `BoxYMax`: a `string` feature.
+    - `PredictedIoU`: a `string` feature.
+    - `Clicks`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### compguesswhat-original
+
+|                      |train|validation|test|
+|----------------------|----:|---------:|---:|
+|compguesswhat-original|46341|      9738|9621|
+
+#### compguesswhat-zero_shot
+
+|                       |nd_valid|od_valid|nd_test|od_test|
+|-----------------------|-------:|-------:|------:|------:|
+|compguesswhat-zero_shot|    5343|    5372|  13836|  13300|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+        @inproceedings{suglia2020compguesswhat,
+          title={CompGuessWhat?!: a Multi-task Evaluation Framework for Grounded Language Learning},
+          author={Suglia, Alessandro, Konstas, Ioannis, Vanzo, Andrea, Bastianelli, Emanuele, Desmond Elliott, Stella Frank and Oliver Lemon},
+          booktitle={Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics},
+          year={2020}
+        }
+
+```
+

--- a/datasets/conll2000/README.md
+++ b/datasets/conll2000/README.md
@@ -1,0 +1,157 @@
+---
+---
+
+# Dataset Card for "conll2000"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.clips.uantwerpen.be/conll2000/chunking/](https://www.clips.uantwerpen.be/conll2000/chunking/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.32 MB
+- **Size of the generated dataset:** 6.25 MB
+- **Total amount of disk used:** 9.57 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ Text chunking consists of dividing a text in syntactically correlated parts of words. For example, the sentence
+ He reckons the current account deficit will narrow to only # 1.8 billion in September . can be divided as follows:
+[NP He ] [VP reckons ] [NP the current account deficit ] [VP will narrow ] [PP to ] [NP only # 1.8 billion ]
+[PP in ] [NP September ] .
+
+Text chunking is an intermediate step towards full parsing. It was the shared task for CoNLL-2000. Training and test
+data for this task is available. This data consists of the same partitions of the Wall Street Journal corpus (WSJ)
+as the widely used data for noun phrase chunking: sections 15-18 as training data (211727 tokens) and section 20 as
+test data (47377 tokens). The annotation of the data has been derived from the WSJ corpus by a program written by
+Sabine Buchholz from Tilburg University, The Netherlands.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### conll2000
+
+- **Size of downloaded dataset files:** 3.32 MB
+- **Size of the generated dataset:** 6.25 MB
+- **Total amount of disk used:** 9.57 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "chunk_tags": [11, 13, 11, 12, 21, 22, 22, 22, 22, 11, 12, 12, 17, 11, 12, 13, 11, 0, 1, 13, 11, 11, 0, 21, 22, 22, 11, 12, 12, 13, 11, 12, 12, 11, 12, 12, 0],
+    "id": "0",
+    "pos_tags": [19, 14, 11, 19, 39, 27, 37, 32, 34, 11, 15, 19, 14, 19, 22, 14, 20, 5, 15, 14, 19, 19, 5, 34, 32, 34, 11, 15, 19, 14, 20, 9, 20, 24, 15, 22, 6],
+    "tokens": "[\"Confidence\", \"in\", \"the\", \"pound\", \"is\", \"widely\", \"expected\", \"to\", \"take\", \"another\", \"sharp\", \"dive\", \"if\", \"trade\", \"figur..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### conll2000
+- `id`: a `string` feature.
+- `tokens`: a `list` of `string` features.
+- `pos_tags`: a `list` of classification labels, with possible values including `''` (0), `#` (1), `$` (2), `(` (3), `)` (4).
+- `chunk_tags`: a `list` of classification labels, with possible values including `O` (0), `B-ADJP` (1), `I-ADJP` (2), `B-ADVP` (3), `I-ADVP` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name   |train|test|
+|---------|----:|---:|
+|conll2000| 8937|2013|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{tksbuchholz2000conll,
+   author     = "Tjong Kim Sang, Erik F. and Sabine Buchholz",
+   title      = "Introduction to the CoNLL-2000 Shared Task: Chunking",
+   editor     = "Claire Cardie and Walter Daelemans and Claire
+                 Nedellec and Tjong Kim Sang, Erik",
+   booktitle  = "Proceedings of CoNLL-2000 and LLL-2000",
+   publisher  = "Lisbon, Portugal",
+   pages      = "127--132",
+   year       = "2000"
+}
+
+```
+

--- a/datasets/conll2003/README.md
+++ b/datasets/conll2003/README.md
@@ -1,0 +1,161 @@
+---
+---
+
+# Dataset Card for "conll2003"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.aclweb.org/anthology/W03-0419/](https://www.aclweb.org/anthology/W03-0419/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4.63 MB
+- **Size of the generated dataset:** 9.78 MB
+- **Total amount of disk used:** 14.41 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The shared task of CoNLL-2003 concerns language-independent named entity recognition. We will concentrate on
+four types of named entities: persons, locations, organizations and names of miscellaneous entities that do
+not belong to the previous three groups.
+
+The CoNLL-2003 shared task data files contain four columns separated by a single space. Each word has been put on
+a separate line and there is an empty line after each sentence. The first item on each line is a word, the second
+a part-of-speech (POS) tag, the third a syntactic chunk tag and the fourth the named entity tag. The chunk tags
+and the named entity tags have the format I-TYPE which means that the word is inside a phrase of type TYPE. Only
+if two phrases of the same type immediately follow each other, the first word of the second phrase will have tag
+B-TYPE to show that it starts a new phrase. A word with tag O is not part of a phrase. Note the dataset uses IOB2
+tagging scheme, whereas the original dataset uses IOB1.
+
+For more details see https://www.clips.uantwerpen.be/conll2003/ner/ and https://www.aclweb.org/anthology/W03-0419
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### conll2003
+
+- **Size of downloaded dataset files:** 4.63 MB
+- **Size of the generated dataset:** 9.78 MB
+- **Total amount of disk used:** 14.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "chunk_tags": [11, 12, 12, 21, 13, 11, 11, 21, 13, 11, 12, 13, 11, 21, 22, 11, 12, 17, 11, 21, 17, 11, 12, 12, 21, 22, 22, 13, 11, 0],
+    "id": "0",
+    "ner_tags": [0, 3, 4, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "pos_tags": [12, 22, 22, 38, 15, 22, 28, 38, 15, 16, 21, 35, 24, 35, 37, 16, 21, 15, 24, 41, 15, 16, 21, 21, 20, 37, 40, 35, 21, 7],
+    "tokens": "[\"The\", \"European\", \"Commission\", \"said\", \"on\", \"Thursday\", \"it\", \"disagreed\", \"with\", \"German\", \"advice\", \"to\", \"consumers\", \"t..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### conll2003
+- `id`: a `string` feature.
+- `tokens`: a `list` of `string` features.
+- `pos_tags`: a `list` of classification labels, with possible values including `"` (0), `''` (1), `#` (2), `$` (3), `(` (4).
+- `chunk_tags`: a `list` of classification labels, with possible values including `O` (0), `B-ADJP` (1), `I-ADJP` (2), `B-ADVP` (3), `I-ADVP` (4).
+- `ner_tags`: a `list` of classification labels, with possible values including `O` (0), `B-PER` (1), `I-PER` (2), `B-ORG` (3), `I-ORG` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name   |train|validation|test|
+|---------|----:|---------:|---:|
+|conll2003|14041|      3250|3453|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{tjong-kim-sang-de-meulder-2003-introduction,
+    title = "Introduction to the {C}o{NLL}-2003 Shared Task: Language-Independent Named Entity Recognition",
+    author = "Tjong Kim Sang, Erik F.  and
+      De Meulder, Fien",
+    booktitle = "Proceedings of the Seventh Conference on Natural Language Learning at {HLT}-{NAACL} 2003",
+    year = "2003",
+    url = "https://www.aclweb.org/anthology/W03-0419",
+    pages = "142--147",
+}
+
+```
+

--- a/datasets/coqa/README.md
+++ b/datasets/coqa/README.md
@@ -1,0 +1,148 @@
+---
+---
+
+# Dataset Card for "coqa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://stanfordnlp.github.io/coqa/](https://stanfordnlp.github.io/coqa/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 55.40 MB
+- **Size of the generated dataset:** 18.35 MB
+- **Total amount of disk used:** 73.75 MB
+
+### [Dataset Summary](#dataset-summary)
+
+CoQA: A Conversational Question Answering Challenge
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 55.40 MB
+- **Size of the generated dataset:** 18.35 MB
+- **Total amount of disk used:** 73.75 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": "{\"answer_end\": [179, 494, 511, 545, 879, 1127, 1128, 94, 150, 412, 1009, 1046, 643, -1, 764, 724, 125, 1384, 881, 910], \"answer_...",
+    "questions": "[\"When was the Vat formally opened?\", \"what is the library for?\", \"for what subjects?\", \"and?\", \"what was started in 2014?\", \"ho...",
+    "source": "wikipedia",
+    "story": "\"The Vatican Apostolic Library (), more commonly called the Vatican Library or simply the Vat, is the library of the Holy See, l..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `source`: a `string` feature.
+- `story`: a `string` feature.
+- `questions`: a `list` of `string` features.
+- `answers`: a dictionary feature containing:
+  - `input_text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+  - `answer_end`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default| 7199|       500|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{SivaAndAl:Coca,
+       author = {Siva, Reddy and Danqi, Chen and  Christopher D., Manning},
+        title = {WikiQA: A Challenge Dataset for Open-Domain Question Answering},
+      journal = { arXiv},
+         year = {2018},
+
+}
+
+```
+

--- a/datasets/cornell_movie_dialog/README.md
+++ b/datasets/cornell_movie_dialog/README.md
@@ -1,0 +1,181 @@
+---
+---
+
+# Dataset Card for "cornell_movie_dialog"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.cs.cornell.edu/~cristian/Cornell_Movie-Dialogs_Corpus.html](http://www.cs.cornell.edu/~cristian/Cornell_Movie-Dialogs_Corpus.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 9.46 MB
+- **Size of the generated dataset:** 18.64 MB
+- **Total amount of disk used:** 28.10 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This corpus contains a large metadata-rich collection of fictional conversations extracted from raw movie scripts:
+- 220,579 conversational exchanges between 10,292 pairs of movie characters
+- involves 9,035 characters from 617 movies
+- in total 304,713 utterances
+- movie metadata included:
+    - genres
+    - release year
+    - IMDB rating
+    - number of IMDB votes
+    - IMDB rating
+- character metadata included:
+    - gender (for 3,774 characters)
+    - position on movie credits (3,321 characters)
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 9.46 MB
+- **Size of the generated dataset:** 18.64 MB
+- **Total amount of disk used:** 28.10 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "characterID1": "u0 ",
+    "characterID2": " u2 ",
+    "characterName1": " m0 ",
+    "characterName2": " m0 ",
+    "movieGenres": ["comedy", "romance"],
+    "movieID": " m0 ",
+    "movieIMDBRating": " 6.90 ",
+    "movieNoIMDBVotes": " 62847 ",
+    "movieTitle": " f ",
+    "movieYear": " 1999 ",
+    "utterance": {
+        "LineID": ["L1"],
+        "text": ["L1 "]
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `movieID`: a `string` feature.
+- `movieTitle`: a `string` feature.
+- `movieYear`: a `string` feature.
+- `movieIMDBRating`: a `string` feature.
+- `movieNoIMDBVotes`: a `string` feature.
+- `movieGenres`: a `list` of `string` features.
+- `characterID1`: a `string` feature.
+- `characterID2`: a `string` feature.
+- `characterName1`: a `string` feature.
+- `characterName2`: a `string` feature.
+- `utterance`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `LineID`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|
+|-------|----:|
+|default|83097|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+  @InProceedings{Danescu-Niculescu-Mizil+Lee:11a,
+
+  author={Cristian Danescu-Niculescu-Mizil and Lillian Lee},
+
+  title={Chameleons in imagined conversations:
+  A new approach to understanding coordination of linguistic style in dialogs.},
+
+  booktitle={Proceedings of the
+
+        Workshop on Cognitive Modeling and Computational Linguistics, ACL 2011},
+
+  year={2011}
+
+}
+
+```
+

--- a/datasets/cos_e/README.md
+++ b/datasets/cos_e/README.md
@@ -1,0 +1,180 @@
+---
+---
+
+# Dataset Card for "cos_e"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/salesforce/cos-e](https://github.com/salesforce/cos-e)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 10.33 MB
+- **Size of the generated dataset:** 5.14 MB
+- **Total amount of disk used:** 15.47 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Common Sense Explanations (CoS-E) allows for training language models to
+automatically generate explanations that can be used during training and
+inference in a novel Commonsense Auto-Generated Explanation (CAGE) framework.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### v1.0
+
+- **Size of downloaded dataset files:** 4.10 MB
+- **Size of the generated dataset:** 2.23 MB
+- **Total amount of disk used:** 6.33 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "abstractive_explanation": "this is open-ended",
+    "answer": "b",
+    "choices": ["a", "b", "c"],
+    "extractive_explanation": "this is selected train",
+    "id": "42",
+    "question": "question goes here."
+}
+```
+
+#### v1.11
+
+- **Size of downloaded dataset files:** 6.23 MB
+- **Size of the generated dataset:** 2.91 MB
+- **Total amount of disk used:** 9.14 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "abstractive_explanation": "this is open-ended",
+    "answer": "b",
+    "choices": ["a", "b", "c"],
+    "extractive_explanation": "this is selected train",
+    "id": "42",
+    "question": "question goes here."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### v1.0
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a `list` of `string` features.
+- `answer`: a `string` feature.
+- `abstractive_explanation`: a `string` feature.
+- `extractive_explanation`: a `string` feature.
+
+#### v1.11
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a `list` of `string` features.
+- `answer`: a `string` feature.
+- `abstractive_explanation`: a `string` feature.
+- `extractive_explanation`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train|validation|
+|-----|----:|---------:|
+|v1.0 | 7610|       950|
+|v1.11| 9741|      1221|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{rajani2019explain,
+     title = "Explain Yourself! Leveraging Language models for Commonsense Reasoning",
+    author = "Rajani, Nazneen Fatema  and
+      McCann, Bryan  and
+      Xiong, Caiming  and
+      Socher, Richard",
+      year="2019",
+    booktitle = "Proceedings of the 2019 Conference of the Association for Computational Linguistics (ACL2019)",
+    url ="https://arxiv.org/abs/1906.02361"
+}
+
+```
+

--- a/datasets/cosmos_qa/README.md
+++ b/datasets/cosmos_qa/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "cosmos_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://wilburone.github.io/cosmos/](https://wilburone.github.io/cosmos/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 23.27 MB
+- **Size of the generated dataset:** 23.37 MB
+- **Total amount of disk used:** 46.64 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Cosmos QA is a large-scale dataset of 35.6K problems that require commonsense-based reading comprehension, formulated as multiple-choice questions. It focuses on reading between the lines over a diverse collection of people's everyday narratives, asking questions concerning on the likely causes or effects of events that require reasoning beyond the exact text spans in the context
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 23.27 MB
+- **Size of the generated dataset:** 23.37 MB
+- **Total amount of disk used:** 46.64 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer0": "If he gets married in the church he wo nt have to get a divorce .",
+    "answer1": "He wants to get married to a different person .",
+    "answer2": "He wants to know if he does nt like this girl can he divorce her ?",
+    "answer3": "None of the above choices .",
+    "context": "\"Do i need to go for a legal divorce ? I wanted to marry a woman but she is not in the same religion , so i am not concern of th...",
+    "id": "3BFF0DJK8XA7YNK4QYIGCOG1A95STE##3180JW2OT5AF02OISBX66RFOCTG5J7##A2LTOS0AZ3B28A##Blog_56156##q1_a1##378G7J1SJNCDAAIN46FM2P7T6KZEW2",
+    "label": 1,
+    "question": "Why is this person asking about divorce ?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answer0`: a `string` feature.
+- `answer1`: a `string` feature.
+- `answer2`: a `string` feature.
+- `answer3`: a `string` feature.
+- `label`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|25262|      2985|6963|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{cosmos,
+    title={COSMOS QA: Machine Reading Comprehension
+    with Contextual Commonsense Reasoning},
+    author={Lifu Huang and Ronan Le Bras and Chandra Bhagavatula and Yejin Choi},
+    booktitle ={arXiv:1909.00277v2},
+    year={2019}
+}
+
+```
+

--- a/datasets/crd3/README.md
+++ b/datasets/crd3/README.md
@@ -1,0 +1,160 @@
+---
+---
+
+# Dataset Card for "crd3"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/RevanthRameshkumar/CRD3](https://github.com/RevanthRameshkumar/CRD3)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 279.93 MB
+- **Size of the generated dataset:** 4020.33 MB
+- **Total amount of disk used:** 4300.25 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Storytelling with Dialogue: A Critical Role Dungeons and Dragons Dataset.
+Critical Role is an unscripted, live-streamed show where a fixed group of people play Dungeons and Dragons, an open-ended role-playing game.
+The dataset is collected from 159 Critical Role episodes transcribed to text dialogues, consisting of 398,682 turns. It also includes corresponding
+abstractive summaries collected from the Fandom wiki. The dataset is linguistically unique in that the narratives are generated entirely through player
+collaboration and spoken interaction. For each dialogue, there are a large number of turns, multiple abstractive summaries with varying levels of detail,
+and semantic ties to the previous dialogues.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 279.93 MB
+- **Size of the generated dataset:** 4020.33 MB
+- **Total amount of disk used:** 4300.25 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "alignment_score": 3.679936647415161,
+    "chunk": "Wish them a Happy Birthday on their Facebook and Twitter pages! Also, as a reminder: D&D Beyond streams their weekly show (\"And Beyond\") every Wednesday on twitch.tv/dndbeyond.",
+    "chunk_id": 1,
+    "turn_end": 6,
+    "turn_num": 4,
+    "turn_start": 4,
+    "turns": {
+        "names": ["SAM"],
+        "utterances": ["Yesterday, guys, was D&D Beyond's first one--", "first one-year anniversary. Take two. Hey guys,", "yesterday was D&D Beyond's one-year anniversary.", "Wish them a happy birthday on their Facebook and", "Twitter pages."]
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `chunk`: a `string` feature.
+- `chunk_id`: a `int32` feature.
+- `turn_start`: a `int32` feature.
+- `turn_end`: a `int32` feature.
+- `alignment_score`: a `float32` feature.
+- `turn_num`: a `int32` feature.
+- `turns`: a dictionary feature containing:
+  - `names`: a `string` feature.
+  - `utterances`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train |validation| test  |
+|-------|------:|---------:|------:|
+|default|2942362|   2942362|2942362|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{
+title = {Storytelling with Dialogue: A Critical Role Dungeons and Dragons Dataset},
+author = {Rameshkumar, Revanth  and Bailey, Peter},
+year = {2020},
+publisher = {Association for Computational Linguistics},
+conference = {ACL}
+}
+
+```
+

--- a/datasets/crime_and_punish/README.md
+++ b/datasets/crime_and_punish/README.md
@@ -1,0 +1,128 @@
+---
+---
+
+# Dataset Card for "crime_and_punish"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.gutenberg.org/files/2554/2554-h/2554-h.htm](https://www.gutenberg.org/files/2554/2554-h/2554-h.htm)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.15 MB
+- **Size of the generated dataset:** 1.21 MB
+- **Total amount of disk used:** 2.36 MB
+
+### [Dataset Summary](#dataset-summary)
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### crime-and-punish
+
+- **Size of downloaded dataset files:** 1.15 MB
+- **Size of the generated dataset:** 1.21 MB
+- **Total amount of disk used:** 2.36 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "line": "CRIME AND PUNISHMENT\n"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### crime-and-punish
+- `line`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|      name      |train|
+|----------------|----:|
+|crime-and-punish|21969|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/daily_dialog/README.md
+++ b/datasets/daily_dialog/README.md
@@ -1,0 +1,146 @@
+---
+---
+
+# Dataset Card for "daily_dialog"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://yanran.li/dailydialog](http://yanran.li/dailydialog)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4.27 MB
+- **Size of the generated dataset:** 8.23 MB
+- **Total amount of disk used:** 12.50 MB
+
+### [Dataset Summary](#dataset-summary)
+
+We develop a high-quality multi-turn dialog dataset, DailyDialog, which is intriguing in several aspects.
+The language is human-written and less noisy. The dialogues in the dataset reflect our daily communication way
+and cover various topics about our daily life. We also manually label the developed dataset with communication
+intention and emotion information. Then, we evaluate existing approaches on DailyDialog dataset and hope it
+benefit the research field of dialog systems.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 4.27 MB
+- **Size of the generated dataset:** 8.23 MB
+- **Total amount of disk used:** 12.50 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "act": [2, 1, 1, 1, 1, 2, 3, 2, 3, 4],
+    "dialog": "[\"Good afternoon . This is Michelle Li speaking , calling on behalf of IBA . Is Mr Meng available at all ? \", \" This is Mr Meng ...",
+    "emotion": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `dialog`: a `list` of `string` features.
+- `act`: a `list` of classification labels, with possible values including `__dummy__` (0), `inform` (1), `question` (2), `directive` (3), `commissive` (4).
+- `emotion`: a `list` of classification labels, with possible values including `no emotion` (0), `anger` (1), `disgust` (2), `fear` (3), `happiness` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|11118|      1000|1000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{li2017dailydialog,
+    author = {Li, Yanran and Su, Hui and Shen, Xiaoyu and Li, Wenjie and Cao, Ziqiang and Niu, Shuzi},
+    title = {DailyDialog: A Manually Labelled Multi-turn Dialogue Dataset},
+    booktitle = {Proceedings of The 8th International Joint Conference on Natural Language Processing (IJCNLP 2017)},
+    year = {2017}
+}
+
+```
+

--- a/datasets/definite_pronoun_resolution/README.md
+++ b/datasets/definite_pronoun_resolution/README.md
@@ -1,0 +1,151 @@
+---
+---
+
+# Dataset Card for "definite_pronoun_resolution"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.hlt.utdallas.edu/~vince/data/emnlp12/](http://www.hlt.utdallas.edu/~vince/data/emnlp12/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.22 MB
+- **Size of the generated dataset:** 0.23 MB
+- **Total amount of disk used:** 0.45 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Composed by 30 students from one of the author's undergraduate classes. These
+sentence pairs cover topics ranging from real events (e.g., Iran's plan to
+attack the Saudi ambassador to the U.S.) to events/characters in movies (e.g.,
+Batman) and purely imaginary situations, largely reflecting the pop culture as
+perceived by the American kids born in the early 90s. Each annotated example
+spans four lines: the first line contains the sentence, the second line contains
+the target pronoun, the third line contains the two candidate antecedents, and
+the fourth line contains the correct antecedent. If the target pronoun appears
+more than once in the sentence, its first occurrence is the one to be resolved.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 0.22 MB
+- **Size of the generated dataset:** 0.23 MB
+- **Total amount of disk used:** 0.45 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "candidates": ["coreference resolution", "chunking"],
+    "label": 0,
+    "pronoun": "it",
+    "sentence": "There is currently more work on coreference resolution than on chunking because it is a problem that is still far from being solved."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `sentence`: a `string` feature.
+- `pronoun`: a `string` feature.
+- `candidates`: a `list` of `string` features.
+- `label`: a classification label, with possible values including `0` (0), `1` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|test|
+|----------|----:|---:|
+|plain_text| 1322| 564|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{rahman2012resolving,
+  title={Resolving complex cases of definite pronouns: the winograd schema challenge},
+  author={Rahman, Altaf and Ng, Vincent},
+  booktitle={Proceedings of the 2012 Joint Conference on Empirical Methods in Natural Language Processing and Computational Natural Language Learning},
+  pages={777--789},
+  year={2012},
+  organization={Association for Computational Linguistics}
+}
+```
+

--- a/datasets/discofuse/README.md
+++ b/datasets/discofuse/README.md
@@ -1,0 +1,182 @@
+---
+---
+
+# Dataset Card for "discofuse"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research-datasets/discofuse](https://github.com/google-research-datasets/discofuse)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 5764.06 MB
+- **Size of the generated dataset:** 20547.64 MB
+- **Total amount of disk used:** 26311.70 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ DISCOFUSE is a large scale dataset for discourse-based sentence fusion.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### discofuse-sport
+
+- **Size of downloaded dataset files:** 4126.20 MB
+- **Size of the generated dataset:** 14341.49 MB
+- **Total amount of disk used:** 18467.70 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "coherent_first_sentence": "Four LPr and three LC2000r HP Netservers handle customer management and web server functions .",
+    "coherent_second_sentence": "Finally , an HP Netserver LT6000r hosts i2 Demand Planner and i2 Collaboration Planner .",
+    "connective_string": "finally ,",
+    "discourse_type": "PAIR_CONN",
+    "has_coref_type_nominal": 0.0,
+    "has_coref_type_pronoun": 0.0,
+    "incoherent_first_sentence": "Four LPr and three LC2000r HP Netservers handle customer management and web server functions .",
+    "incoherent_second_sentence": "An HP Netserver LT6000r hosts i2 Demand Planner and i2 Collaboration Planner ."
+}
+```
+
+#### discofuse-wikipedia
+
+- **Size of downloaded dataset files:** 1637.86 MB
+- **Size of the generated dataset:** 6206.14 MB
+- **Total amount of disk used:** 7844.01 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "coherent_first_sentence": "Four LPr and three LC2000r HP Netservers handle customer management and web server functions .",
+    "coherent_second_sentence": "Finally , an HP Netserver LT6000r hosts i2 Demand Planner and i2 Collaboration Planner .",
+    "connective_string": "finally ,",
+    "discourse_type": "PAIR_CONN",
+    "has_coref_type_nominal": 0.0,
+    "has_coref_type_pronoun": 0.0,
+    "incoherent_first_sentence": "Four LPr and three LC2000r HP Netservers handle customer management and web server functions .",
+    "incoherent_second_sentence": "An HP Netserver LT6000r hosts i2 Demand Planner and i2 Collaboration Planner ."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### discofuse-sport
+- `connective_string`: a `string` feature.
+- `discourse_type`: a `string` feature.
+- `coherent_second_sentence`: a `string` feature.
+- `has_coref_type_pronoun`: a `float32` feature.
+- `incoherent_first_sentence`: a `string` feature.
+- `incoherent_second_sentence`: a `string` feature.
+- `has_coref_type_nominal`: a `float32` feature.
+- `coherent_first_sentence`: a `string` feature.
+
+#### discofuse-wikipedia
+- `connective_string`: a `string` feature.
+- `discourse_type`: a `string` feature.
+- `coherent_second_sentence`: a `string` feature.
+- `has_coref_type_pronoun`: a `float32` feature.
+- `incoherent_first_sentence`: a `string` feature.
+- `incoherent_second_sentence`: a `string` feature.
+- `has_coref_type_nominal`: a `float32` feature.
+- `coherent_first_sentence`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|       name        | train  |validation| test |
+|-------------------|-------:|---------:|-----:|
+|discofuse-sport    |43291020|    440902|445521|
+|discofuse-wikipedia|16310585|    168081|163657|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{GevaEtAl2019,
+  title = {DiscoFuse: A Large-Scale Dataset for Discourse-Based Sentence Fusion},
+  author = {Geva, Mor and Malmi, Eric and Szpektor, Idan and Berant, Jonathan},
+  booktitle = {Proceedings of the 2019 Annual Conference of the North American Chapter of the Association for Computational Linguistics},
+  note = {arXiv preprint arXiv:1902.10526},
+  year = {2019}
+}
+
+```
+

--- a/datasets/docred/README.md
+++ b/datasets/docred/README.md
@@ -1,0 +1,175 @@
+---
+---
+
+# Dataset Card for "docred"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/thunlp/DocRED](https://github.com/thunlp/DocRED)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 20.03 MB
+- **Size of the generated dataset:** 19.19 MB
+- **Total amount of disk used:** 39.23 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Multiple entities in a document generally exhibit complex inter-sentence relations, and cannot be well handled by existing relation extraction (RE) methods that typically focus on extracting intra-sentence relations for single entity pairs. In order to accelerate the research on document-level RE, we introduce DocRED, a new dataset constructed from Wikipedia and Wikidata with three features:
+    - DocRED annotates both named entities and relations, and is the largest human-annotated dataset for document-level RE from plain text.
+    - DocRED requires reading multiple sentences in a document to extract entities and infer their relations by synthesizing all information of the document.
+    - Along with the human-annotated data, we also offer large-scale distantly supervised data, which enables DocRED to be adopted for both supervised and weakly supervised scenarios.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 20.03 MB
+- **Size of the generated dataset:** 19.19 MB
+- **Total amount of disk used:** 39.23 MB
+
+An example of 'train_annotated' looks as follows.
+```
+{
+    "labels": {
+        "evidence": [[0]],
+        "head": [0],
+        "relation_id": ["P1"],
+        "relation_text": ["is_a"],
+        "tail": [0]
+    },
+    "sents": [["This", "is", "a", "sentence"], ["This", "is", "another", "sentence"]],
+    "title": "Title of the document",
+    "vertexSet": [[{
+        "name": "sentence",
+        "pos": [3],
+        "sent_id": 0,
+        "type": "NN"
+    }, {
+        "name": "sentence",
+        "pos": [3],
+        "sent_id": 1,
+        "type": "NN"
+    }], [{
+        "name": "This",
+        "pos": [0],
+        "sent_id": 0,
+        "type": "NN"
+    }]]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `title`: a `string` feature.
+- `sents`: a dictionary feature containing:
+  - `feature`: a `string` feature.
+- `name`: a `string` feature.
+- `sent_id`: a `int32` feature.
+- `pos`: a `list` of `int32` features.
+- `type`: a `string` feature.
+- `labels`: a dictionary feature containing:
+  - `head`: a `int32` feature.
+  - `tail`: a `int32` feature.
+  - `relation_id`: a `string` feature.
+  - `relation_text`: a `string` feature.
+  - `evidence`: a `list` of `int32` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train_annotated|train_distant|validation|test|
+|-------|--------------:|------------:|---------:|---:|
+|default|           3053|         1000|      1000|1000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{yao2019DocRED,
+  title={{DocRED}: A Large-Scale Document-Level Relation Extraction Dataset},
+  author={Yao, Yuan and Ye, Deming and Li, Peng and Han, Xu and Lin, Yankai and Liu, Zhenghao and Liu,   Zhiyuan and Huang, Lixin and Zhou, Jie and Sun, Maosong},
+  booktitle={Proceedings of ACL 2019},
+  year={2019}
+}
+
+```
+

--- a/datasets/doqa/README.md
+++ b/datasets/doqa/README.md
@@ -1,0 +1,279 @@
+---
+---
+
+# Dataset Card for "doqa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/RevanthRameshkumar/CRD3](https://github.com/RevanthRameshkumar/CRD3)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 12.01 MB
+- **Size of the generated dataset:** 16.88 MB
+- **Total amount of disk used:** 28.88 MB
+
+### [Dataset Summary](#dataset-summary)
+
+DoQA is a dataset for accessing Domain Specific FAQs via conversational QA that contains 2,437 information-seeking question/answer dialogues
+(10,917 questions in total) on three different domains: cooking, travel and movies. Note that we include in the generic concept of FAQs also
+Community Question Answering sites, as well as corporate information in intranets which is maintained in textual form similar to FAQs, often
+referred to as internal “knowledge bases”.
+
+These dialogues are created by crowd workers that play the following two roles: the user who asks questions about a given topic posted in Stack
+Exchange (https://stackexchange.com/), and the domain expert who replies to the questions by selecting a short span of text from the long textual
+reply in the original post. The expert can rephrase the selected span, in order to make it look more natural. The dataset covers unanswerable
+questions and some relevant dialogue acts.
+
+DoQA enables the development and evaluation of conversational QA systems that help users access the knowledge buried in domain specific FAQs.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cooking
+
+- **Size of downloaded dataset files:** 4.00 MB
+- **Size of the generated dataset:** 10.79 MB
+- **Total amount of disk used:** 14.79 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [852],
+        "text": ["CANNOTANSWER"]
+    },
+    "background": "\"So, over mixing batter forms gluten, which in turn hardens the cake. Fine.The problem is that I don't want lumps in the cakes, ...",
+    "context": "\"Milk won't help you - it's mostly water, and gluten develops from flour (more accurately, specific proteins in flour) and water...",
+    "followup": "n",
+    "id": "C_64ce44d5f14347f488eb04b50387f022_q#2",
+    "orig_answer": {
+        "answer_start": [852],
+        "text": ["CANNOTANSWER"]
+    },
+    "question": "Ok. What can I add to make it more softer and avoid hardening?",
+    "title": "What to add to the batter of the cake to avoid hardening when the gluten formation can't be avoided?",
+    "yesno": "x"
+}
+```
+
+#### movies
+
+- **Size of downloaded dataset files:** 4.00 MB
+- **Size of the generated dataset:** 3.02 MB
+- **Total amount of disk used:** 7.02 MB
+
+An example of 'test' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [852],
+        "text": ["CANNOTANSWER"]
+    },
+    "background": "\"So, over mixing batter forms gluten, which in turn hardens the cake. Fine.The problem is that I don't want lumps in the cakes, ...",
+    "context": "\"Milk won't help you - it's mostly water, and gluten develops from flour (more accurately, specific proteins in flour) and water...",
+    "followup": "n",
+    "id": "C_64ce44d5f14347f488eb04b50387f022_q#2",
+    "orig_answer": {
+        "answer_start": [852],
+        "text": ["CANNOTANSWER"]
+    },
+    "question": "Ok. What can I add to make it more softer and avoid hardening?",
+    "title": "What to add to the batter of the cake to avoid hardening when the gluten formation can't be avoided?",
+    "yesno": "x"
+}
+```
+
+#### travel
+
+- **Size of downloaded dataset files:** 4.00 MB
+- **Size of the generated dataset:** 3.07 MB
+- **Total amount of disk used:** 7.07 MB
+
+An example of 'test' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [852],
+        "text": ["CANNOTANSWER"]
+    },
+    "background": "\"So, over mixing batter forms gluten, which in turn hardens the cake. Fine.The problem is that I don't want lumps in the cakes, ...",
+    "context": "\"Milk won't help you - it's mostly water, and gluten develops from flour (more accurately, specific proteins in flour) and water...",
+    "followup": "n",
+    "id": "C_64ce44d5f14347f488eb04b50387f022_q#2",
+    "orig_answer": {
+        "answer_start": [852],
+        "text": ["CANNOTANSWER"]
+    },
+    "question": "Ok. What can I add to make it more softer and avoid hardening?",
+    "title": "What to add to the batter of the cake to avoid hardening when the gluten formation can't be avoided?",
+    "yesno": "x"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cooking
+- `title`: a `string` feature.
+- `background`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `id`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+- `followup`: a `string` feature.
+- `yesno`: a `string` feature.
+- `orig_answer`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### movies
+- `title`: a `string` feature.
+- `background`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `id`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+- `followup`: a `string` feature.
+- `yesno`: a `string` feature.
+- `orig_answer`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### travel
+- `title`: a `string` feature.
+- `background`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `id`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+- `followup`: a `string` feature.
+- `yesno`: a `string` feature.
+- `orig_answer`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### cooking
+
+|       |train|validation|test|
+|-------|----:|---------:|---:|
+|cooking| 4612|       911|1797|
+
+#### movies
+
+|      |test|
+|------|---:|
+|movies|1884|
+
+#### travel
+
+|      |test|
+|------|---:|
+|travel|1713|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{campos2020doqa,
+    title={DoQA -- Accessing Domain-Specific FAQs via Conversational QA},
+    author={Jon Ander Campos and Arantxa Otegi and Aitor Soroa and Jan Deriu and Mark Cieliebak and Eneko Agirre},
+    year={2020},
+    eprint={2005.01328},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/drop/README.md
+++ b/datasets/drop/README.md
@@ -1,0 +1,149 @@
+---
+---
+
+# Dataset Card for "drop"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allennlp.org/drop](https://allennlp.org/drop)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 7.92 MB
+- **Size of the generated dataset:** 105.77 MB
+- **Total amount of disk used:** 113.69 MB
+
+### [Dataset Summary](#dataset-summary)
+
+DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs.
+. DROP is a crowdsourced, adversarially-created, 96k-question benchmark, in which a system must resolve references in a
+question, perhaps to multiple input positions, and perform discrete operations over them (such as addition, counting, or
+ sorting). These operations require a much more comprehensive understanding of the content of paragraphs than what was
+ necessary for prior datasets.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 7.92 MB
+- **Size of the generated dataset:** 105.77 MB
+- **Total amount of disk used:** 113.69 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers_spans": {
+        "spans": ["Chaz Schilens"]
+    },
+    "passage": "\" Hoping to rebound from their loss to the Patriots, the Raiders stayed at home for a Week 16 duel with the Houston Texans.  Oak...",
+    "question": "Who scored the first touchdown of the game?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `passage`: a `string` feature.
+- `question`: a `string` feature.
+- `answers_spans`: a dictionary feature containing:
+  - `spans`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default|77409|      9536|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{Dua2019DROP,
+  author={Dheeru Dua and Yizhong Wang and Pradeep Dasigi and Gabriel Stanovsky and Sameer Singh and Matt Gardner},
+  title={  {DROP}: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs},
+  booktitle={Proc. of NAACL},
+  year={2019}
+}
+
+```
+

--- a/datasets/emo/README.md
+++ b/datasets/emo/README.md
@@ -1,0 +1,144 @@
+---
+---
+
+# Dataset Card for "emo"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.aclweb.org/anthology/S19-2005/](https://www.aclweb.org/anthology/S19-2005/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.21 MB
+- **Size of the generated dataset:** 2.72 MB
+- **Total amount of disk used:** 5.93 MB
+
+### [Dataset Summary](#dataset-summary)
+
+In this dataset, given a textual dialogue i.e. an utterance along with two previous turns of context, the goal was to infer the underlying emotion of the utterance by choosing from four emotion classes - Happy, Sad, Angry and Others.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### emo2019
+
+- **Size of downloaded dataset files:** 3.21 MB
+- **Size of the generated dataset:** 2.72 MB
+- **Total amount of disk used:** 5.93 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "label": 0,
+    "text": "don't worry  i'm girl hmm how do i know if you are what's ur name"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### emo2019
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `others` (0), `happy` (1), `sad` (2), `angry` (3).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|test|
+|-------|----:|---:|
+|emo2019|30160|5509|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{chatterjee-etal-2019-semeval,
+    title={SemEval-2019 Task 3: EmoContext Contextual Emotion Detection in Text},
+    author={Ankush Chatterjee and Kedhar Nath Narahari and Meghana Joshi and Puneet Agrawal},
+    booktitle={Proceedings of the 13th International Workshop on Semantic Evaluation},
+    year={2019},
+    address={Minneapolis, Minnesota, USA},
+    publisher={Association for Computational Linguistics},
+    url={https://www.aclweb.org/anthology/S19-2005},
+    doi={10.18653/v1/S19-2005},
+    pages={39--48},
+    abstract={In this paper, we present the SemEval-2019 Task 3 - EmoContext: Contextual Emotion Detection in Text. Lack of facial expressions and voice modulations make detecting emotions in text a challenging problem. For instance, as humans, on reading ''Why don't you ever text me!'' we can either interpret it as a sad or angry emotion and the same ambiguity exists for machines. However, the context of dialogue can prove helpful in detection of the emotion. In this task, given a textual dialogue i.e. an utterance along with two previous turns of context, the goal was to infer the underlying emotion of the utterance by choosing from four emotion classes - Happy, Sad, Angry and Others. To facilitate the participation in this task, textual dialogues from user interaction with a conversational agent were taken and annotated for emotion classes after several data processing steps. A training data set of 30160 dialogues, and two evaluation data sets, Test1 and Test2, containing 2755 and 5509 dialogues respectively were released to the participants. A total of 311 teams made submissions to this task. The final leader-board was evaluated on Test2 data set, and the highest ranked submission achieved 79.59 micro-averaged F1 score. Our analysis of systems submitted to the task indicate that Bi-directional LSTM was the most common choice of neural architecture used, and most of the systems had the best performance for the Sad emotion class, and the worst for the Happy emotion class}
+}
+
+```
+

--- a/datasets/emotion/README.md
+++ b/datasets/emotion/README.md
@@ -1,0 +1,165 @@
+---
+---
+
+# Dataset Card for "emotion"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/dair-ai/emotion_dataset](https://github.com/dair-ai/emotion_dataset)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.95 MB
+- **Size of the generated dataset:** 4.16 MB
+- **Total amount of disk used:** 8.11 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Emotion is a dataset of English Twitter messages with six basic emotions: anger, fear, joy, love, sadness, and surprise. For more detailed information please refer to the paper.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.97 MB
+- **Size of the generated dataset:** 2.07 MB
+- **Total amount of disk used:** 4.05 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "label": 0,
+    "text": "im feeling quite sad and sorry for myself but ill snap out of it soon"
+}
+```
+
+#### emotion
+
+- **Size of downloaded dataset files:** 1.97 MB
+- **Size of the generated dataset:** 2.09 MB
+- **Total amount of disk used:** 4.06 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `sadness` (0), `joy` (1), `love` (2), `anger` (3), `fear` (4).
+
+#### emotion
+- `text`: a `string` feature.
+- `label`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|16000|      2000|2000|
+|emotion|16000|      2000|2000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{saravia-etal-2018-carer,
+    title = "{CARER}: Contextualized Affect Representations for Emotion Recognition",
+    author = "Saravia, Elvis  and
+      Liu, Hsien-Chi Toby  and
+      Huang, Yen-Hao  and
+      Wu, Junlin  and
+      Chen, Yi-Shin",
+    booktitle = "Proceedings of the 2018 Conference on Empirical Methods in Natural Language Processing",
+    month = oct # "-" # nov,
+    year = "2018",
+    address = "Brussels, Belgium",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/D18-1404",
+    doi = "10.18653/v1/D18-1404",
+    pages = "3687--3697",
+    abstract = "Emotions are expressed in nuanced ways, which varies by collective or individual experiences, knowledge, and beliefs. Therefore, to understand emotion, as conveyed through text, a robust mechanism capable of capturing and modeling different linguistic nuances and phenomena is needed. We propose a semi-supervised, graph-based algorithm to produce rich structural descriptors which serve as the building blocks for constructing contextualized affect representations from text. The pattern-based representations are further enriched with word embeddings and evaluated through several emotion recognition tasks. Our experimental results demonstrate that the proposed method outperforms state-of-the-art techniques on emotion recognition tasks.",
+}
+
+```
+

--- a/datasets/empathetic_dialogues/README.md
+++ b/datasets/empathetic_dialogues/README.md
@@ -1,0 +1,150 @@
+---
+---
+
+# Dataset Card for "empathetic_dialogues"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/facebookresearch/EmpatheticDialogues](https://github.com/facebookresearch/EmpatheticDialogues)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 26.72 MB
+- **Size of the generated dataset:** 23.97 MB
+- **Total amount of disk used:** 50.69 MB
+
+### [Dataset Summary](#dataset-summary)
+
+PyTorch original implementation of Towards Empathetic Open-domain Conversation Models: a New Benchmark and Dataset
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 26.72 MB
+- **Size of the generated dataset:** 23.97 MB
+- **Total amount of disk used:** 50.69 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "context": "sentimental",
+    "conv_id": "hit:0_conv:1",
+    "prompt": "I remember going to the fireworks with my best friend. There was a lot of people_comma_ but it only felt like us in the world.",
+    "selfeval": "5|5|5_2|2|5",
+    "speaker_idx": 1,
+    "tags": "",
+    "utterance": "I remember going to see the fireworks with my best friend. It was the first time we ever spent time alone together. Although there was a lot of people_comma_ we felt like the only people in the world.",
+    "utterance_idx": 1
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `conv_id`: a `string` feature.
+- `utterance_idx`: a `int32` feature.
+- `context`: a `string` feature.
+- `prompt`: a `string` feature.
+- `speaker_idx`: a `int32` feature.
+- `utterance`: a `string` feature.
+- `selfeval`: a `string` feature.
+- `tags`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test |
+|-------|----:|---------:|----:|
+|default|76673|     12030|10943|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{rashkin2019towards,
+  title = {Towards Empathetic Open-domain Conversation Models: a New Benchmark and Dataset},
+  author = {Hannah Rashkin and Eric Michael Smith and Margaret Li and Y-Lan Boureau},
+  booktitle = {ACL},
+  year = {2019},
+}
+
+```
+

--- a/datasets/eraser_multi_rc/README.md
+++ b/datasets/eraser_multi_rc/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "eraser_multi_rc"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://cogcomp.seas.upenn.edu/multirc/](https://cogcomp.seas.upenn.edu/multirc/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.59 MB
+- **Size of the generated dataset:** 60.70 MB
+- **Total amount of disk used:** 62.29 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Eraser Multi RC is a dataset for queries over multi-line passages, along with
+answers and a rationalte. Each example in this dataset has the following 5 parts
+1. A Mutli-line Passage
+2. A Query about the passage
+3. An Answer to the query
+4. A Classification as to whether the answer is right or wrong
+5. An Explanation justifying the classification
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.59 MB
+- **Size of the generated dataset:** 60.70 MB
+- **Total amount of disk used:** 62.29 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "evidences": "[\"Allan sat down at his desk and pulled the chair in close .\", \"Opening a side drawer , he took out a piece of paper and his ink...",
+    "label": 0,
+    "passage": "\"Allan sat down at his desk and pulled the chair in close .\\nOpening a side drawer , he took out a piece of paper and his inkpot...",
+    "query_and_answer": "Name few objects said to be in or on Allan 's desk || Eraser"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `passage`: a `string` feature.
+- `query_and_answer`: a `string` feature.
+- `label`: a classification label, with possible values including `False` (0), `True` (1).
+- `evidences`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|24029|      3214|4848|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@unpublished{eraser2019,
+    title = {ERASER: A Benchmark to Evaluate Rationalized NLP Models},
+    author = {Jay DeYoung and Sarthak Jain and Nazneen Fatema Rajani and Eric Lehman and Caiming Xiong and Richard Socher and Byron C. Wallace}
+}
+@inproceedings{MultiRC2018,
+    author = {Daniel Khashabi and Snigdha Chaturvedi and Michael Roth and Shyam Upadhyay and Dan Roth},
+    title = {Looking Beyond the Surface:A Challenge Set for Reading Comprehension over Multiple Sentences},
+    booktitle = {NAACL},
+    year = {2018}
+}
+
+```
+

--- a/datasets/esnli/README.md
+++ b/datasets/esnli/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "esnli"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/OanaMariaCamburu/e-SNLI](https://github.com/OanaMariaCamburu/e-SNLI)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 195.04 MB
+- **Size of the generated dataset:** 109.52 MB
+- **Total amount of disk used:** 304.56 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The e-SNLI dataset extends the Stanford Natural Language Inference Dataset to
+include human-annotated natural language explanations of the entailment
+relations.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 195.04 MB
+- **Size of the generated dataset:** 109.52 MB
+- **Total amount of disk used:** 304.56 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "explanation_1": "A woman must be present to smile.",
+    "explanation_2": "A woman smiling implies that she is present.",
+    "explanation_3": "A smiling woman is also present.",
+    "hypothesis": "A woman is present.",
+    "label": 0,
+    "premise": "A woman smiles at the child."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+- `explanation_1`: a `string` feature.
+- `explanation_2`: a `string` feature.
+- `explanation_3`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train |validation|test|
+|----------|-----:|---------:|---:|
+|plain_text|549367|      9842|9824|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@incollection{NIPS2018_8163,
+title = {e-SNLI: Natural Language Inference with Natural Language Explanations},
+author = {Camburu, Oana-Maria and Rockt"{a}schel, Tim and Lukasiewicz, Thomas and Blunsom, Phil},
+booktitle = {Advances in Neural Information Processing Systems 31},
+editor = {S. Bengio and H. Wallach and H. Larochelle and K. Grauman and N. Cesa-Bianchi and R. Garnett},
+pages = {9539--9549},
+year = {2018},
+publisher = {Curran Associates, Inc.},
+url = {http://papers.nips.cc/paper/8163-e-snli-natural-language-inference-with-natural-language-explanations.pdf}
+}
+
+```
+

--- a/datasets/event2Mind/README.md
+++ b/datasets/event2Mind/README.md
@@ -1,0 +1,147 @@
+---
+---
+
+# Dataset Card for "event2Mind"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://uwnlp.github.io/event2mind/](https://uwnlp.github.io/event2mind/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.24 MB
+- **Size of the generated dataset:** 6.90 MB
+- **Total amount of disk used:** 8.14 MB
+
+### [Dataset Summary](#dataset-summary)
+
+In Event2Mind, we explore the task of understanding stereotypical intents and reactions to events. Through crowdsourcing, we create a large corpus with 25,000 events and free-form descriptions of their intents and reactions, both of the event's subject and (potentially implied) other participants.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.24 MB
+- **Size of the generated dataset:** 6.90 MB
+- **Total amount of disk used:** 8.14 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "Event": "It shrinks in the wash",
+    "Osent": "1",
+    "Otheremotion": "[\"upset\", \"angry\"]",
+    "Source": "it_events",
+    "Xemotion": "[\"none\"]",
+    "Xintent": "[\"none\"]",
+    "Xsent": ""
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `Source`: a `string` feature.
+- `Event`: a `string` feature.
+- `Xintent`: a `string` feature.
+- `Xemotion`: a `string` feature.
+- `Otheremotion`: a `string` feature.
+- `Xsent`: a `string` feature.
+- `Osent`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|46472|      5401|5221|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{event2Mind,
+    title={Event2Mind: Commonsense Inference on Events, Intents, and Reactions},
+    author={Hannah Rashkin and Maarten Sap and Emily Allaway and Noah A. Smith† Yejin Choi},
+    year={2018}
+}
+
+```
+

--- a/datasets/fever/README.md
+++ b/datasets/fever/README.md
@@ -1,0 +1,196 @@
+---
+---
+
+# Dataset Card for "fever"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://fever.ai/](https://fever.ai/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1677.26 MB
+- **Size of the generated dataset:** 6959.34 MB
+- **Total amount of disk used:** 8636.60 MB
+
+### [Dataset Summary](#dataset-summary)
+
+With billions of individual pages on the web providing information on almost every conceivable topic, we should have the ability to collect facts that answer almost every conceivable question. However, only a small fraction of this information is contained in structured sources (Wikidata, Freebase, etc.) – we are therefore limited by our ability to transform free-form text to structured knowledge. There is, however, another problem that has become the focus of a lot of recent research and media coverage: false information coming from unreliable sources. [1] [2]
+
+The FEVER workshops are a venue for work in verifiable knowledge extraction and to stimulate progress in this direction.
+
+FEVER  V1.0
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### v1.0
+
+- **Size of downloaded dataset files:** 42.78 MB
+- **Size of the generated dataset:** 38.39 MB
+- **Total amount of disk used:** 81.17 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### v2.0
+
+- **Size of downloaded dataset files:** 0.37 MB
+- **Size of the generated dataset:** 0.29 MB
+- **Total amount of disk used:** 0.67 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### wiki_pages
+
+- **Size of downloaded dataset files:** 1634.11 MB
+- **Size of the generated dataset:** 6920.65 MB
+- **Total amount of disk used:** 8554.76 MB
+
+An example of 'wikipedia_pages' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### v1.0
+- `id`: a `int32` feature.
+- `label`: a `string` feature.
+- `claim`: a `string` feature.
+- `evidence_annotation_id`: a `int32` feature.
+- `evidence_id`: a `int32` feature.
+- `evidence_wiki_url`: a `string` feature.
+- `evidence_sentence_id`: a `int32` feature.
+
+#### v2.0
+- `id`: a `int32` feature.
+- `label`: a `string` feature.
+- `claim`: a `string` feature.
+- `evidence_annotation_id`: a `int32` feature.
+- `evidence_id`: a `int32` feature.
+- `evidence_wiki_url`: a `string` feature.
+- `evidence_sentence_id`: a `int32` feature.
+
+#### wiki_pages
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `lines`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### v1.0
+
+|    |train |unlabelled_dev|labelled_dev|paper_dev|unlabelled_test|paper_test|
+|----|-----:|-------------:|-----------:|--------:|--------------:|---------:|
+|v1.0|311431|         19998|       37566|    18999|          19998|     18567|
+
+#### v2.0
+
+|    |validation|
+|----|---------:|
+|v2.0|      2384|
+
+#### wiki_pages
+
+|          |wikipedia_pages|
+|----------|--------------:|
+|wiki_pages|        5416537|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{Thorne18Fever,
+    author = {Thorne, James and Vlachos, Andreas and Christodoulopoulos, Christos and Mittal, Arpit},
+    title = {{FEVER}: a Large-scale Dataset for Fact Extraction and VERification},
+    booktitle = {NAACL-HLT},
+    year = {2018}
+}
+}
+
+```
+

--- a/datasets/flores/README.md
+++ b/datasets/flores/README.md
@@ -1,0 +1,159 @@
+---
+---
+
+# Dataset Card for "flores"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/facebookresearch/flores/](https://github.com/facebookresearch/flores/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2.94 MB
+- **Size of the generated dataset:** 3.69 MB
+- **Total amount of disk used:** 6.63 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Evaluation datasets for low-resource machine translation: Nepali-English and Sinhala-English.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### neen
+
+- **Size of downloaded dataset files:** 1.47 MB
+- **Size of the generated dataset:** 1.77 MB
+- **Total amount of disk used:** 3.24 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"en\": \"This is the wrong translation!\", \"ne\": \"यस वाहेक आगम पूजा, तारा पूजा, व्रत आदि पनि घरभित्र र वाहिर दुवै स्थानमा गरेको पा..."
+}
+```
+
+#### sien
+
+- **Size of downloaded dataset files:** 1.47 MB
+- **Size of the generated dataset:** 1.92 MB
+- **Total amount of disk used:** 3.40 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"en\": \"This is the wrong translation!\", \"si\": \"එවැනි ආවරණයක් ලබාදීමට රක්ෂණ සපයන්නෙකු කැමති වුවත් ඒ සාමාන් යයෙන් බොහෝ රටවල පොදු ..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### neen
+- `translation`: a multilingual `string` variable, with possible languages including `ne`, `en`.
+
+#### sien
+- `translation`: a multilingual `string` variable, with possible languages including `si`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name|validation|test|
+|----|---------:|---:|
+|neen|      2560|2836|
+|sien|      2899|2767|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc{guzmn2019new,
+    title={Two New Evaluation Datasets for Low-Resource Machine Translation: Nepali-English and Sinhala-English},
+    author={Francisco Guzman and Peng-Jen Chen and Myle Ott and Juan Pino and Guillaume Lample and Philipp Koehn and Vishrav Chaudhary and Marc'Aurelio Ranzato},
+    year={2019},
+    eprint={1902.01382},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/fquad/README.md
+++ b/datasets/fquad/README.md
@@ -1,0 +1,157 @@
+---
+---
+
+# Dataset Card for "fquad"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://fquad.illuin.tech/](https://fquad.illuin.tech/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.14 MB
+- **Size of the generated dataset:** 6.62 MB
+- **Total amount of disk used:** 9.76 MB
+
+### [Dataset Summary](#dataset-summary)
+
+FQuAD: French Question Answering Dataset
+We introduce FQuAD, a native French Question Answering Dataset. FQuAD contains 25,000+ question and answer pairs.
+Finetuning CamemBERT on FQuAD yields a F1 score of 88% and an exact match of 77.9%.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 3.14 MB
+- **Size of the generated dataset:** 6.62 MB
+- **Total amount of disk used:** 9.76 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answers_starts": [161, 46, 204],
+        "texts": ["La Vierge aux rochers", "documents contemporains", "objets de spéculations"]
+    },
+    "context": "\"Les deux tableaux sont certes décrits par des documents contemporains à leur création mais ceux-ci ne le font qu'indirectement ...",
+    "questions": ["Que concerne principalement les documents ?", "Par quoi sont décrit les deux tableaux ?", "Quels types d'objets sont les deux tableaux aux yeux des chercheurs ?"]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `context`: a `string` feature.
+- `questions`: a `list` of `string` features.
+- `answers`: a dictionary feature containing:
+  - `texts`: a `string` feature.
+  - `answers_starts`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default| 4921|       768|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@ARTICLE{2020arXiv200206071
+       author = {Martin, d'Hoffschmidt and Maxime, Vidal and
+         Wacim, Belblidia and Tom, Brendlé},
+        title = "{FQuAD: French Question Answering Dataset}",
+      journal = {arXiv e-prints},
+     keywords = {Computer Science - Computation and Language},
+         year = "2020",
+        month = "Feb",
+          eid = {arXiv:2002.06071},
+        pages = {arXiv:2002.06071},
+archivePrefix = {arXiv},
+       eprint = {2002.06071},
+ primaryClass = {cs.CL}
+}
+
+```
+

--- a/datasets/gap/README.md
+++ b/datasets/gap/README.md
@@ -1,0 +1,170 @@
+---
+---
+
+# Dataset Card for "gap"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research-datasets/gap-coreference](https://github.com/google-research-datasets/gap-coreference)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2.29 MB
+- **Size of the generated dataset:** 2.32 MB
+- **Total amount of disk used:** 4.61 MB
+
+### [Dataset Summary](#dataset-summary)
+
+GAP is a gender-balanced dataset containing 8,908 coreference-labeled pairs of
+(ambiguous pronoun, antecedent name), sampled from Wikipedia and released by
+Google AI Language for the evaluation of coreference resolution in practical
+applications.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 2.29 MB
+- **Size of the generated dataset:** 2.32 MB
+- **Total amount of disk used:** 4.61 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "A": "aliquam ultrices sagittis",
+    "A-coref": false,
+    "A-offset": 208,
+    "B": "elementum curabitur vitae",
+    "B-coref": false,
+    "B-offset": 435,
+    "ID": "validation-1",
+    "Pronoun": "condimentum mattis pellentesque",
+    "Pronoun-offset": 948,
+    "Text": "Lorem ipsum dolor",
+    "URL": "sem fringilla ut"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `ID`: a `string` feature.
+- `Text`: a `string` feature.
+- `Pronoun`: a `string` feature.
+- `Pronoun-offset`: a `int32` feature.
+- `A`: a `string` feature.
+- `A-offset`: a `int32` feature.
+- `A-coref`: a `bool` feature.
+- `B`: a `string` feature.
+- `B-offset`: a `int32` feature.
+- `B-coref`: a `bool` feature.
+- `URL`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 2000|       454|2000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{DBLP:journals/corr/abs-1810-05201,
+  author    = {Kellie Webster and
+               Marta Recasens and
+               Vera Axelrod and
+               Jason Baldridge},
+  title     = {Mind the {GAP:} {A} Balanced Corpus of Gendered Ambiguous Pronouns},
+  journal   = {CoRR},
+  volume    = {abs/1810.05201},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1810.05201},
+  archivePrefix = {arXiv},
+  eprint    = {1810.05201},
+  timestamp = {Tue, 30 Oct 2018 20:39:56 +0100},
+  biburl    = {https://dblp.org/rec/bib/journals/corr/abs-1810-05201},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+```
+

--- a/datasets/germeval_14/README.md
+++ b/datasets/germeval_14/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "germeval_14"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://sites.google.com/site/germeval2014ner/](https://sites.google.com/site/germeval2014ner/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 9.81 MB
+- **Size of the generated dataset:** 17.19 MB
+- **Total amount of disk used:** 27.00 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The GermEval 2014 NER Shared Task builds on a new dataset with German Named Entity annotation with the following properties:    - The data was sampled from German Wikipedia and News Corpora as a collection of citations.    - The dataset covers over 31,000 sentences corresponding to over 590,000 tokens.    - The NER annotation uses the NoSta-D guidelines, which extend the Tübingen Treebank guidelines,      using four main NER categories with sub-structure, and annotating embeddings among NEs      such as [ORG FC Kickers [LOC Darmstadt]].
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### germeval_14
+
+- **Size of downloaded dataset files:** 9.81 MB
+- **Size of the generated dataset:** 17.19 MB
+- **Total amount of disk used:** 27.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": "11",
+    "ner_tags": [13, 14, 14, 14, 14, 0, 0, 0, 0, 0, 0, 0, 19, 20, 13, 0, 1, 0, 0, 0, 0, 0, 19, 20, 20, 0, 0, 0, 0, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "nested_ner_tags": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "source": "http://de.wikipedia.org/wiki/Liste_von_Filmen_mit_homosexuellem_Inhalt [2010-01-11] ",
+    "tokens": "[\"Scenes\", \"of\", \"a\", \"Sexual\", \"Nature\", \"(\", \"GB\", \"2006\", \")\", \"-\", \"Regie\", \":\", \"Ed\", \"Blum\", \"Shortbus\", \"(\", \"USA\", \"2006..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### germeval_14
+- `id`: a `string` feature.
+- `source`: a `string` feature.
+- `tokens`: a `list` of `string` features.
+- `ner_tags`: a `list` of classification labels, with possible values including `O` (0), `B-LOC` (1), `I-LOC` (2), `B-LOCderiv` (3), `I-LOCderiv` (4).
+- `nested_ner_tags`: a `list` of classification labels, with possible values including `O` (0), `B-LOC` (1), `I-LOC` (2), `B-LOCderiv` (3), `I-LOCderiv` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name    |train|validation|test|
+|-----------|----:|---------:|---:|
+|germeval_14|24000|      2200|5100|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{benikova-etal-2014-nosta,
+    title = {NoSta-D Named Entity Annotation for German: Guidelines and Dataset},
+    author = {Benikova, Darina  and
+      Biemann, Chris  and
+      Reznicek, Marc},
+    booktitle = {Proceedings of the Ninth International Conference on Language Resources and Evaluation ({LREC}'14)},
+    month = {may},
+    year = {2014},
+    address = {Reykjavik, Iceland},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {http://www.lrec-conf.org/proceedings/lrec2014/pdf/276_Paper.pdf},
+    pages = {2524--2531},
+}
+
+```
+

--- a/datasets/gigaword/README.md
+++ b/datasets/gigaword/README.md
@@ -1,0 +1,159 @@
+---
+---
+
+# Dataset Card for "gigaword"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/harvardnlp/sent-summary](https://github.com/harvardnlp/sent-summary)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 551.61 MB
+- **Size of the generated dataset:** 918.35 MB
+- **Total amount of disk used:** 1469.96 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Headline-generation on a corpus of article pairs from Gigaword consisting of
+around 4 million articles. Use the 'org_data' provided by
+https://github.com/microsoft/unilm/ which is identical to
+https://github.com/harvardnlp/sent-summary but with better format.
+
+There are two features:
+  - document: article.
+  - summary: headline.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 551.61 MB
+- **Size of the generated dataset:** 918.35 MB
+- **Total amount of disk used:** 1469.96 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "document": "train source",
+    "summary": "train target"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `document`: a `string` feature.
+- `summary`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train |validation|test|
+|-------|------:|---------:|---:|
+|default|3803957|    189651|1951|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{graff2003english,
+  title={English gigaword},
+  author={Graff, David and Kong, Junbo and Chen, Ke and Maeda, Kazuaki},
+  journal={Linguistic Data Consortium, Philadelphia},
+  volume={4},
+  number={1},
+  pages={34},
+  year={2003}
+}
+
+@article{Rush_2015,
+   title={A Neural Attention Model for Abstractive Sentence Summarization},
+   url={http://dx.doi.org/10.18653/v1/D15-1044},
+   DOI={10.18653/v1/d15-1044},
+   journal={Proceedings of the 2015 Conference on Empirical Methods in Natural Language Processing},
+   publisher={Association for Computational Linguistics},
+   author={Rush, Alexander M. and Chopra, Sumit and Weston, Jason},
+   year={2015}
+}
+
+```
+

--- a/datasets/glue/README.md
+++ b/datasets/glue/README.md
@@ -1,0 +1,240 @@
+---
+---
+
+# Dataset Card for "glue"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://nyu-mll.github.io/CoLA/](https://nyu-mll.github.io/CoLA/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 955.33 MB
+- **Size of the generated dataset:** 229.68 MB
+- **Total amount of disk used:** 1185.01 MB
+
+### [Dataset Summary](#dataset-summary)
+
+GLUE, the General Language Understanding Evaluation benchmark
+(https://gluebenchmark.com/) is a collection of resources for training,
+evaluating, and analyzing natural language understanding systems.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### ax
+
+- **Size of downloaded dataset files:** 0.21 MB
+- **Size of the generated dataset:** 0.23 MB
+- **Total amount of disk used:** 0.44 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### cola
+
+- **Size of downloaded dataset files:** 0.36 MB
+- **Size of the generated dataset:** 0.58 MB
+- **Total amount of disk used:** 0.94 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### mnli
+
+- **Size of downloaded dataset files:** 298.29 MB
+- **Size of the generated dataset:** 78.65 MB
+- **Total amount of disk used:** 376.95 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### mnli_matched
+
+- **Size of downloaded dataset files:** 298.29 MB
+- **Size of the generated dataset:** 3.52 MB
+- **Total amount of disk used:** 301.82 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### mnli_mismatched
+
+- **Size of downloaded dataset files:** 298.29 MB
+- **Size of the generated dataset:** 3.73 MB
+- **Total amount of disk used:** 302.02 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### ax
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+- `idx`: a `int32` feature.
+
+#### cola
+- `sentence`: a `string` feature.
+- `label`: a classification label, with possible values including `unacceptable` (0), `acceptable` (1).
+- `idx`: a `int32` feature.
+
+#### mnli
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+- `idx`: a `int32` feature.
+
+#### mnli_matched
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+- `idx`: a `int32` feature.
+
+#### mnli_mismatched
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+- `idx`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### ax
+
+|   |test|
+|---|---:|
+|ax |1104|
+
+#### cola
+
+|    |train|validation|test|
+|----|----:|---------:|---:|
+|cola| 8551|      1043|1063|
+
+#### mnli
+
+|    |train |validation_matched|validation_mismatched|test_matched|test_mismatched|
+|----|-----:|-----------------:|--------------------:|-----------:|--------------:|
+|mnli|392702|              9815|                 9832|        9796|           9847|
+
+#### mnli_matched
+
+|            |validation|test|
+|------------|---------:|---:|
+|mnli_matched|      9815|9796|
+
+#### mnli_mismatched
+
+|               |validation|test|
+|---------------|---------:|---:|
+|mnli_mismatched|      9832|9847|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{warstadt2018neural,
+  title={Neural Network Acceptability Judgments},
+  author={Warstadt, Alex and Singh, Amanpreet and Bowman, Samuel R},
+  journal={arXiv preprint arXiv:1805.12471},
+  year={2018}
+}
+@inproceedings{wang2019glue,
+  title={{GLUE}: A Multi-Task Benchmark and Analysis Platform for Natural Language Understanding},
+  author={Wang, Alex and Singh, Amanpreet and Michael, Julian and Hill, Felix and Levy, Omer and Bowman, Samuel R.},
+  note={In the Proceedings of ICLR.},
+  year={2019}
+}
+
+Note that each GLUE dataset has its own citation. Please see the source to see
+the correct citation for each contained dataset.
+```
+

--- a/datasets/guardian_authorship/README.md
+++ b/datasets/guardian_authorship/README.md
@@ -1,0 +1,249 @@
+---
+---
+
+# Dataset Card for "guardian_authorship"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.icsd.aegean.gr/lecturers/stamatatos/papers/JLP2013.pdf](http://www.icsd.aegean.gr/lecturers/stamatatos/papers/JLP2013.pdf)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 47.31 MB
+- **Size of the generated dataset:** 37.17 MB
+- **Total amount of disk used:** 84.49 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A dataset cross-topic authorship attribution. The dataset is provided by Stamatatos 2013.
+1- The cross-topic scenarios are based on Table-4 in Stamatatos 2017 (Ex. cross_topic_1 => row 1:P S U&W ).
+2- The cross-genre scenarios are based on Table-5 in the same paper. (Ex. cross_genre_1 => row 1:B P S&U&W).
+
+3- The same-topic/genre scenario is created by grouping all the datasts as follows.
+For ex., to use same_topic and split the data 60-40 use:
+train_ds = load_dataset('guardian_authorship', name="cross_topic_<<#>>",
+                        split='train[:60%]+validation[:60%]+test[:60%]')
+tests_ds = load_dataset('guardian_authorship', name="cross_topic_<<#>>",
+                        split='train[-40%:]+validation[-40%:]+test[-40%:]')
+
+IMPORTANT: train+validation+test[:60%] will generate the wrong splits becasue the data is imbalanced
+
+* See https://huggingface.co/docs/datasets/splits.html for detailed/more examples
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cross_genre_1
+
+- **Size of downloaded dataset files:** 2.96 MB
+- **Size of the generated dataset:** 2.61 MB
+- **Total amount of disk used:** 5.57 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "article": "File 1a\n",
+    "author": 0,
+    "topic": 4
+}
+```
+
+#### cross_genre_2
+
+- **Size of downloaded dataset files:** 2.96 MB
+- **Size of the generated dataset:** 2.61 MB
+- **Total amount of disk used:** 5.57 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "article": "File 1a\n",
+    "author": 0,
+    "topic": 1
+}
+```
+
+#### cross_genre_3
+
+- **Size of downloaded dataset files:** 2.96 MB
+- **Size of the generated dataset:** 2.61 MB
+- **Total amount of disk used:** 5.57 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "article": "File 1a\n",
+    "author": 0,
+    "topic": 2
+}
+```
+
+#### cross_genre_4
+
+- **Size of downloaded dataset files:** 2.96 MB
+- **Size of the generated dataset:** 2.61 MB
+- **Total amount of disk used:** 5.57 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "article": "File 1a\n",
+    "author": 0,
+    "topic": 3
+}
+```
+
+#### cross_topic_1
+
+- **Size of downloaded dataset files:** 2.96 MB
+- **Size of the generated dataset:** 2.23 MB
+- **Total amount of disk used:** 5.18 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "article": "File 1a\n",
+    "author": 0,
+    "topic": 1
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cross_genre_1
+- `author`: a classification label, with possible values including `catherinebennett` (0), `georgemonbiot` (1), `hugoyoung` (2), `jonathanfreedland` (3), `martinkettle` (4).
+- `topic`: a classification label, with possible values including `Politics` (0), `Society` (1), `UK` (2), `World` (3), `Books` (4).
+- `article`: a `string` feature.
+
+#### cross_genre_2
+- `author`: a classification label, with possible values including `catherinebennett` (0), `georgemonbiot` (1), `hugoyoung` (2), `jonathanfreedland` (3), `martinkettle` (4).
+- `topic`: a classification label, with possible values including `Politics` (0), `Society` (1), `UK` (2), `World` (3), `Books` (4).
+- `article`: a `string` feature.
+
+#### cross_genre_3
+- `author`: a classification label, with possible values including `catherinebennett` (0), `georgemonbiot` (1), `hugoyoung` (2), `jonathanfreedland` (3), `martinkettle` (4).
+- `topic`: a classification label, with possible values including `Politics` (0), `Society` (1), `UK` (2), `World` (3), `Books` (4).
+- `article`: a `string` feature.
+
+#### cross_genre_4
+- `author`: a classification label, with possible values including `catherinebennett` (0), `georgemonbiot` (1), `hugoyoung` (2), `jonathanfreedland` (3), `martinkettle` (4).
+- `topic`: a classification label, with possible values including `Politics` (0), `Society` (1), `UK` (2), `World` (3), `Books` (4).
+- `article`: a `string` feature.
+
+#### cross_topic_1
+- `author`: a classification label, with possible values including `catherinebennett` (0), `georgemonbiot` (1), `hugoyoung` (2), `jonathanfreedland` (3), `martinkettle` (4).
+- `topic`: a classification label, with possible values including `Politics` (0), `Society` (1), `UK` (2), `World` (3), `Books` (4).
+- `article`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|    name     |train|validation|test|
+|-------------|----:|---------:|---:|
+|cross_genre_1|   63|       112| 269|
+|cross_genre_2|   63|        62| 319|
+|cross_genre_3|   63|        90| 291|
+|cross_genre_4|   63|       117| 264|
+|cross_topic_1|  112|        62| 207|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{article,
+    author = {Stamatatos, Efstathios},
+    year = {2013},
+    month = {01},
+    pages = {421-439},
+    title = {On the robustness of authorship attribution based on character n-gram features},
+    volume = {21},
+    journal = {Journal of Law and Policy}
+}
+
+@inproceedings{stamatatos2017authorship,
+    title={Authorship attribution using text distortion},
+    author={Stamatatos, Efstathios},
+    booktitle={Proc. of the 15th Conf. of the European Chapter of the Association for Computational Linguistics},
+    volume={1}
+    pages={1138--1149},
+    year={2017}
+}
+
+```
+

--- a/datasets/hans/README.md
+++ b/datasets/hans/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "hans"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/tommccoy1/hans](https://github.com/tommccoy1/hans)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 29.51 MB
+- **Size of the generated dataset:** 30.34 MB
+- **Total amount of disk used:** 59.85 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The HANS dataset is an NLI evaluation set that tests specific hypotheses about invalid heuristics that NLI models are likely to learn.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 29.51 MB
+- **Size of the generated dataset:** 30.34 MB
+- **Total amount of disk used:** 59.85 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `non-entailment` (1).
+- `parse_premise`: a `string` feature.
+- `parse_hypothesis`: a `string` feature.
+- `binary_parse_premise`: a `string` feature.
+- `binary_parse_hypothesis`: a `string` feature.
+- `heuristic`: a `string` feature.
+- `subcase`: a `string` feature.
+- `template`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|validation|
+|----------|----:|---------:|
+|plain_text|30000|     30000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{DBLP:journals/corr/abs-1902-01007,
+  author    = {R. Thomas McCoy and
+               Ellie Pavlick and
+               Tal Linzen},
+  title     = {Right for the Wrong Reasons: Diagnosing Syntactic Heuristics in Natural
+               Language Inference},
+  journal   = {CoRR},
+  volume    = {abs/1902.01007},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1902.01007},
+  archivePrefix = {arXiv},
+  eprint    = {1902.01007},
+  timestamp = {Tue, 21 May 2019 18:03:36 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1902-01007.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+```
+

--- a/datasets/hansards/README.md
+++ b/datasets/hansards/README.md
@@ -1,0 +1,171 @@
+---
+---
+
+# Dataset Card for "hansards"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.isi.edu/natural-language/download/hansard/](https://www.isi.edu/natural-language/download/hansard/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 78.99 MB
+- **Size of the generated dataset:** 248.34 MB
+- **Total amount of disk used:** 327.33 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This release contains 1.3 million pairs of aligned text chunks (sentences or smaller fragments)
+from the official records (Hansards) of the 36th Canadian Parliament.
+
+The complete Hansards of the debates in the House and Senate of the 36th Canadian Parliament,
+as far as available, were aligned. The corpus was then split into 5 sets of sentence pairs:
+training (80% of the sentence pairs), two sets of sentence pairs for testing (5% each), and
+two sets of sentence pairs for final evaluation (5% each). The current release consists of the
+training and testing sets. The evaluation sets are reserved for future MT evaluation purposes
+and currently not available.
+
+Caveats
+1. This release contains only sentence pairs. Even though the order of the sentences is the same
+as in the original, there may be gaps resulting from many-to-one, many-to-many, or one-to-many
+alignments that were filtered out. Therefore, this release may not be suitable for
+discourse-related research.
+2. Neither the sentence splitting nor the alignments are perfect. In particular, watch out for
+pairs that differ considerably in length. You may want to filter these out before you do
+any statistical training.
+
+The alignment of the Hansards was performed as part of the ReWrite project under funding
+from the DARPA TIDES program.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### house
+
+- **Size of downloaded dataset files:** 64.45 MB
+- **Size of the generated dataset:** 204.44 MB
+- **Total amount of disk used:** 268.89 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "en": "Mr. Walt Lastewka (Parliamentary Secretary to Minister of Industry, Lib.):",
+    "fr": "M. Walt Lastewka (secrétaire parlementaire du ministre de l'Industrie, Lib.):"
+}
+```
+
+#### senate
+
+- **Size of downloaded dataset files:** 14.54 MB
+- **Size of the generated dataset:** 43.90 MB
+- **Total amount of disk used:** 58.44 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "en": "Mr. Walt Lastewka (Parliamentary Secretary to Minister of Industry, Lib.):",
+    "fr": "M. Walt Lastewka (secrétaire parlementaire du ministre de l'Industrie, Lib.):"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### house
+- `fr`: a `string` feature.
+- `en`: a `string` feature.
+
+#### senate
+- `fr`: a `string` feature.
+- `en`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name |train | test |
+|------|-----:|-----:|
+|house |947969|122290|
+|senate|182135| 25553|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/hellaswag/README.md
+++ b/datasets/hellaswag/README.md
@@ -1,0 +1,154 @@
+---
+---
+
+# Dataset Card for "hellaswag"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://rowanzellers.com/hellaswag/](https://rowanzellers.com/hellaswag/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 68.18 MB
+- **Size of the generated dataset:** 62.29 MB
+- **Total amount of disk used:** 130.47 MB
+
+### [Dataset Summary](#dataset-summary)
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 68.18 MB
+- **Size of the generated dataset:** 62.29 MB
+- **Total amount of disk used:** 130.47 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "activity_label": "Removing ice from car",
+    "ctx": "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles. then",
+    "ctx_a": "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles.",
+    "ctx_b": "then",
+    "endings": "[\", the man adds wax to the windshield and cuts it.\", \", a person board a ski lift, while two men supporting the head of the per...",
+    "ind": 4,
+    "label": "3",
+    "source_id": "activitynet~v_-1IBHYS3L-Y",
+    "split": "train",
+    "split_type": "indomain"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `ind`: a `int32` feature.
+- `activity_label`: a `string` feature.
+- `ctx_a`: a `string` feature.
+- `ctx_b`: a `string` feature.
+- `ctx`: a `string` feature.
+- `endings`: a `list` of `string` features.
+- `source_id`: a `string` feature.
+- `split`: a `string` feature.
+- `split_type`: a `string` feature.
+- `label`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test |
+|-------|----:|---------:|----:|
+|default|39905|     10042|10003|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{zellers2019hellaswag,
+    title={HellaSwag: Can a Machine Really Finish Your Sentence?},
+    author={Zellers, Rowan and Holtzman, Ari and Bisk, Yonatan and Farhadi, Ali and Choi, Yejin},
+    booktitle ={Proceedings of the 57th Annual Meeting of the Association for Computational Linguistics},
+    year={2019}
+}
+
+```
+

--- a/datasets/hotpot_qa/README.md
+++ b/datasets/hotpot_qa/README.md
@@ -1,0 +1,205 @@
+---
+---
+
+# Dataset Card for "hotpot_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://hotpotqa.github.io/](https://hotpotqa.github.io/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1213.88 MB
+- **Size of the generated dataset:** 1186.81 MB
+- **Total amount of disk used:** 2400.69 MB
+
+### [Dataset Summary](#dataset-summary)
+
+HotpotQA is a new dataset with 113k  Wikipedia-based question-answer  pairs with  four  key  features:  (1)  the  questions  require finding and reasoning over multiple supporting  documents  to  answer;  (2)  the  questions  are  diverse  and  not  constrained  to  any pre-existing  knowledge  bases  or  knowledge schemas;  (3)  we  provide  sentence-level  supporting facts required for reasoning, allowingQA systems to reason with strong supervisionand explain the predictions; (4) we offer a new type  of  factoid  comparison  questions  to  testQA  systems’  ability  to  extract  relevant  facts and perform necessary comparison.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### distractor
+
+- **Size of downloaded dataset files:** 584.36 MB
+- **Size of the generated dataset:** 570.93 MB
+- **Total amount of disk used:** 1155.29 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answer": "This is the answer",
+    "context": {
+        "sentences": [["Sent 1"], ["Sent 21", "Sent 22"]],
+        "title": ["Title1", "Title 2"]
+    },
+    "id": "000001",
+    "level": "medium",
+    "question": "What is the answer?",
+    "supporting_facts": {
+        "sent_id": [0, 1, 3],
+        "title": ["Title of para 1", "Title of para 2", "Title of para 3"]
+    },
+    "type": "comparison"
+}
+```
+
+#### fullwiki
+
+- **Size of downloaded dataset files:** 629.52 MB
+- **Size of the generated dataset:** 615.88 MB
+- **Total amount of disk used:** 1245.40 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answer": "This is the answer",
+    "context": {
+        "sentences": [["Sent 1"], ["Sent 2"]],
+        "title": ["Title1", "Title 2"]
+    },
+    "id": "000001",
+    "level": "hard",
+    "question": "What is the answer?",
+    "supporting_facts": {
+        "sent_id": [0, 1, 3],
+        "title": ["Title of para 1", "Title of para 2", "Title of para 3"]
+    },
+    "type": "bridge"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### distractor
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+- `type`: a `string` feature.
+- `level`: a `string` feature.
+- `supporting_facts`: a dictionary feature containing:
+  - `title`: a `string` feature.
+  - `sent_id`: a `int32` feature.
+- `context`: a dictionary feature containing:
+  - `title`: a `string` feature.
+  - `sentences`: a `list` of `string` features.
+
+#### fullwiki
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+- `type`: a `string` feature.
+- `level`: a `string` feature.
+- `supporting_facts`: a dictionary feature containing:
+  - `title`: a `string` feature.
+  - `sent_id`: a `int32` feature.
+- `context`: a dictionary feature containing:
+  - `title`: a `string` feature.
+  - `sentences`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### distractor
+
+|          |train|validation|
+|----------|----:|---------:|
+|distractor|90447|      7405|
+
+#### fullwiki
+
+|        |train|validation|test|
+|--------|----:|---------:|---:|
+|fullwiki|90447|      7405|7405|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{yang2018hotpotqa,
+  title={{HotpotQA}: A Dataset for Diverse, Explainable Multi-hop Question Answering},
+  author={Yang, Zhilin and Qi, Peng and Zhang, Saizheng and Bengio, Yoshua and Cohen, William W. and Salakhutdinov, Ruslan and Manning, Christopher D.},
+  booktitle={Conference on Empirical Methods in Natural Language Processing ({EMNLP})},
+  year={2018}
+}
+
+```
+

--- a/datasets/hyperpartisan_news_detection/README.md
+++ b/datasets/hyperpartisan_news_detection/README.md
@@ -1,0 +1,186 @@
+---
+---
+
+# Dataset Card for "hyperpartisan_news_detection"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://pan.webis.de/semeval19/semeval19-web/](https://pan.webis.de/semeval19/semeval19-web/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 957.68 MB
+- **Size of the generated dataset:** 5354.14 MB
+- **Total amount of disk used:** 6311.82 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Hyperpartisan News Detection was a dataset created for PAN @ SemEval 2019 Task 4.
+Given a news article text, decide whether it follows a hyperpartisan argumentation, i.e., whether it exhibits blind, prejudiced, or unreasoning allegiance to one party, faction, cause, or person.
+
+There are 2 parts:
+- byarticle: Labeled through crowdsourcing on an article basis. The data contains only articles for which a consensus among the crowdsourcing workers existed.
+- bypublisher: Labeled by the overall bias of the publisher as provided by BuzzFeed journalists or MediaBiasFactCheck.com.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### byarticle
+
+- **Size of downloaded dataset files:** 0.95 MB
+- **Size of the generated dataset:** 2.67 MB
+- **Total amount of disk used:** 3.63 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hyperpartisan": true,
+    "published_at": "2020-01-01",
+    "text": "\"<p>This is a sample article which will contain lots of text</p>\\n    \\n<p>Lorem ipsum dolor sit amet, consectetur adipiscing el...",
+    "title": "Example article 1",
+    "url": "http://www.example.com/example1"
+}
+```
+
+#### bypublisher
+
+- **Size of downloaded dataset files:** 956.72 MB
+- **Size of the generated dataset:** 5351.47 MB
+- **Total amount of disk used:** 6308.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "bias": 3,
+    "hyperpartisan": false,
+    "published_at": "2020-01-01",
+    "text": "\"<p>This is a sample article which will contain lots of text</p>\\n    \\n<p>Phasellus bibendum porta nunc, id venenatis tortor fi...",
+    "title": "Example article 4",
+    "url": "https://example.com/example4"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### byarticle
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `hyperpartisan`: a `bool` feature.
+- `url`: a `string` feature.
+- `published_at`: a `string` feature.
+
+#### bypublisher
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `hyperpartisan`: a `bool` feature.
+- `url`: a `string` feature.
+- `published_at`: a `string` feature.
+- `bias`: a classification label, with possible values including `right` (0), `right-center` (1), `least` (2), `left-center` (3), `left` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### byarticle
+
+|         |train|
+|---------|----:|
+|byarticle|  645|
+
+#### bypublisher
+
+|           |train |validation|
+|-----------|-----:|---------:|
+|bypublisher|600000|    600000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{kiesel2019data,
+  title={Data for pan at semeval 2019 task 4: Hyperpartisan news detection},
+  author={Kiesel, Johannes and Mestre, Maria and Shukla, Rishabh and Vincent, Emmanuel and Corney, David and Adineh, Payam and Stein, Benno and Potthast, Martin},
+  year={2019}
+}
+
+```
+

--- a/datasets/imdb/README.md
+++ b/datasets/imdb/README.md
@@ -1,0 +1,144 @@
+---
+---
+
+# Dataset Card for "imdb"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://ai.stanford.edu/~amaas/data/sentiment/](http://ai.stanford.edu/~amaas/data/sentiment/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 80.23 MB
+- **Size of the generated dataset:** 127.06 MB
+- **Total amount of disk used:** 207.28 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Large Movie Review Dataset.
+This is a dataset for binary sentiment classification containing substantially more data than previous benchmark datasets. We provide a set of 25,000 highly polar movie reviews for training, and 25,000 for testing. There is additional unlabeled data for use as well.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 80.23 MB
+- **Size of the generated dataset:** 127.06 MB
+- **Total amount of disk used:** 207.28 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "label": 0,
+    "text": "Goodbye world2\n"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `neg` (0), `pos` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|unsupervised|test |
+|----------|----:|-----------:|----:|
+|plain_text|25000|       50000|25000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{maas-EtAl:2011:ACL-HLT2011,
+  author    = {Maas, Andrew L.  and  Daly, Raymond E.  and  Pham, Peter T.  and  Huang, Dan  and  Ng, Andrew Y.  and  Potts, Christopher},
+  title     = {Learning Word Vectors for Sentiment Analysis},
+  booktitle = {Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies},
+  month     = {June},
+  year      = {2011},
+  address   = {Portland, Oregon, USA},
+  publisher = {Association for Computational Linguistics},
+  pages     = {142--150},
+  url       = {http://www.aclweb.org/anthology/P11-1015}
+}
+
+```
+

--- a/datasets/indic_glue/README.md
+++ b/datasets/indic_glue/README.md
@@ -1,0 +1,291 @@
+---
+---
+
+# Dataset Card for "indic_glue"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://indicnlp.ai4bharat.org/indic-glue/#natural-language-inference](https://indicnlp.ai4bharat.org/indic-glue/#natural-language-inference)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3351.18 MB
+- **Size of the generated dataset:** 1573.33 MB
+- **Total amount of disk used:** 4924.51 MB
+
+### [Dataset Summary](#dataset-summary)
+
+    IndicGLUE is a natural language understanding benchmark for Indian languages. It contains a wide
+    variety of tasks and covers 11 major Indian languages - as, bn, gu, hi, kn, ml, mr, or, pa, ta, te.
+
+The Winograd Schema Challenge (Levesque et al., 2011) is a reading comprehension task
+in which a system must read a sentence with a pronoun and select the referent of that pronoun from
+a list of choices. The examples are manually constructed to foil simple statistical methods: Each
+one is contingent on contextual information provided by a single word or phrase in the sentence.
+To convert the problem into sentence pair classification, we construct sentence pairs by replacing
+the ambiguous pronoun with each possible referent. The task is to predict if the sentence with the
+pronoun substituted is entailed by the original sentence. We use a small evaluation set consisting of
+new examples derived from fiction books that was shared privately by the authors of the original
+corpus. While the included training set is balanced between two classes, the test set is imbalanced
+between them (65% not entailment). Also, due to a data quirk, the development set is adversarial:
+hypotheses are sometimes shared between training and development examples, so if a model memorizes the
+training examples, they will predict the wrong label on corresponding development set
+example. As with QNLI, each example is evaluated separately, so there is not a systematic correspondence
+between a model's score on this task and its score on the unconverted original task. We
+call converted dataset WNLI (Winograd NLI). This dataset is translated and publicly released for 3
+Indian languages by AI4Bharat.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### actsa-sc.te
+
+- **Size of downloaded dataset files:** 0.36 MB
+- **Size of the generated dataset:** 1.63 MB
+- **Total amount of disk used:** 1.99 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "label": 0,
+    "text": "\"ప్రయాణాల్లో ఉన్నవారికోసం బస్ స్టేషన్లు, రైల్వే స్టేషన్లలో పల్స్పోలియో బూతులను ఏర్పాటు చేసి చిన్నారులకు పోలియో చుక్కలు వేసేలా ఏర..."
+}
+```
+
+#### bbca.hi
+
+- **Size of downloaded dataset files:** 5.50 MB
+- **Size of the generated dataset:** 26.35 MB
+- **Total amount of disk used:** 31.85 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "label": "pakistan",
+    "text": "\"नेटिजन यानि इंटरनेट पर सक्रिय नागरिक अब ट्विटर पर सरकार द्वारा लगाए प्रतिबंधों के समर्थन या विरोध में अपने विचार व्यक्त करते है..."
+}
+```
+
+#### copa.en
+
+- **Size of downloaded dataset files:** 0.72 MB
+- **Size of the generated dataset:** 0.11 MB
+- **Total amount of disk used:** 0.83 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "choice1": "I swept the floor in the unoccupied room.",
+    "choice2": "I shut off the light in the unoccupied room.",
+    "label": 1,
+    "premise": "I wanted to conserve energy.",
+    "question": "effect"
+}
+```
+
+#### copa.gu
+
+- **Size of downloaded dataset files:** 0.72 MB
+- **Size of the generated dataset:** 0.22 MB
+- **Total amount of disk used:** 0.94 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "choice1": "\"સ્ત્રી જાણતી હતી કે તેનો મિત્ર મુશ્કેલ સમયમાંથી પસાર થઈ રહ્યો છે.\"...",
+    "choice2": "\"મહિલાને લાગ્યું કે તેના મિત્રએ તેની દયાળુ લાભ લીધો છે.\"...",
+    "label": 0,
+    "premise": "મહિલાએ તેના મિત્રની મુશ્કેલ વર્તન સહન કરી.",
+    "question": "cause"
+}
+```
+
+#### copa.hi
+
+- **Size of downloaded dataset files:** 0.72 MB
+- **Size of the generated dataset:** 0.22 MB
+- **Total amount of disk used:** 0.94 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "choice1": "मैंने उसका प्रस्ताव ठुकरा दिया।",
+    "choice2": "उन्होंने मुझे उत्पाद खरीदने के लिए राजी किया।",
+    "label": 0,
+    "premise": "मैंने सेल्समैन की पिच पर शक किया।",
+    "question": "effect"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### actsa-sc.te
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `positive` (0), `negative` (1).
+
+#### bbca.hi
+- `label`: a `string` feature.
+- `text`: a `string` feature.
+
+#### copa.en
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+
+#### copa.gu
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+
+#### copa.hi
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### actsa-sc.te
+
+|           |train|validation|test|
+|-----------|----:|---------:|---:|
+|actsa-sc.te| 4328|       541| 541|
+
+#### bbca.hi
+
+|       |train|test|
+|-------|----:|---:|
+|bbca.hi| 3467| 866|
+
+#### copa.en
+
+|       |train|validation|test|
+|-------|----:|---------:|---:|
+|copa.en|  400|       100| 500|
+
+#### copa.gu
+
+|       |train|validation|test|
+|-------|----:|---------:|---:|
+|copa.gu|  362|        88| 448|
+
+#### copa.hi
+
+|       |train|validation|test|
+|-------|----:|---------:|---:|
+|copa.hi|  362|        88| 449|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+    @inproceedings{kakwani2020indicnlpsuite,
+    title={{IndicNLPSuite: Monolingual Corpora, Evaluation Benchmarks and Pre-trained Multilingual Language Models for Indian Languages}},
+    author={Divyanshu Kakwani and Anoop Kunchukuttan and Satish Golla and Gokul N.C. and Avik Bhattacharyya and Mitesh M. Khapra and Pratyush Kumar},
+    year={2020},
+    booktitle={Findings of EMNLP},
+}
+
+@inproceedings{kakwani2020indicnlpsuite,
+title={{IndicNLPSuite: Monolingual Corpora, Evaluation Benchmarks and Pre-trained Multilingual Language Models for Indian Languages}},
+author={Divyanshu Kakwani and Anoop Kunchukuttan and Satish Golla and Gokul N.C. and Avik Bhattacharyya and Mitesh M. Khapra and Pratyush Kumar},
+year={2020},
+booktitle={Findings of EMNLP},
+}
+@inproceedings{Levesque2011TheWS,
+title={The Winograd Schema Challenge},
+author={H. Levesque and E. Davis and L. Morgenstern},
+booktitle={KR},
+year={2011}
+}
+
+```
+

--- a/datasets/iwslt2017/README.md
+++ b/datasets/iwslt2017/README.md
@@ -1,0 +1,224 @@
+---
+---
+
+# Dataset Card for "iwslt2017"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://sites.google.com/site/iwsltevaluation2017/TED-tasks](https://sites.google.com/site/iwsltevaluation2017/TED-tasks)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4046.89 MB
+- **Size of the generated dataset:** 1087.28 MB
+- **Total amount of disk used:** 5134.17 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The IWSLT 2017 Evaluation Campaign includes a multilingual TED Talks MT task. The languages involved are five:
+
+  German, English, Italian, Dutch, Romanian.
+
+For each language pair, training and development sets are available through the entry of the table below: by clicking, an archive will be downloaded which contains the sets and a README file. Numbers in the table refer to millions of units (untokenized words) of the target side of all parallel training sets.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### iwslt2017-ar-en
+
+- **Size of downloaded dataset files:** 26.46 MB
+- **Size of the generated dataset:** 56.02 MB
+- **Total amount of disk used:** 82.48 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"ar\": \"لقد طرت في \\\"القوات الجوية \\\" لمدة ثمان سنوات. والآن أجد نفسي مضطرا لخلع حذائي قبل صعود الطائرة!\", \"en\": \"I flew on Air ..."
+}
+```
+
+#### iwslt2017-de-en
+
+- **Size of downloaded dataset files:** 15.98 MB
+- **Size of the generated dataset:** 42.37 MB
+- **Total amount of disk used:** 58.35 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "translation": {
+        "de": "Es ist mir wirklich eine Ehre, zweimal auf dieser Bühne stehen zu dürfen. Tausend Dank dafür.",
+        "en": "And it's truly a great honor to have the opportunity to come to this stage twice; I'm extremely grateful."
+    }
+}
+```
+
+#### iwslt2017-en-ar
+
+- **Size of downloaded dataset files:** 27.97 MB
+- **Size of the generated dataset:** 56.02 MB
+- **Total amount of disk used:** 83.99 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"ar\": \"لقد طرت في \\\"القوات الجوية \\\" لمدة ثمان سنوات. والآن أجد نفسي مضطرا لخلع حذائي قبل صعود الطائرة!\", \"en\": \"I flew on Air ..."
+}
+```
+
+#### iwslt2017-en-de
+
+- **Size of downloaded dataset files:** 15.98 MB
+- **Size of the generated dataset:** 42.37 MB
+- **Total amount of disk used:** 58.35 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "translation": {
+        "de": "Die nächste Folie, die ich Ihnen zeige, ist eine Zeitrafferaufnahme was in den letzten 25 Jahren passiert ist.",
+        "en": "The next slide I show you will be  a rapid fast-forward of what's happened over the last 25 years."
+    }
+}
+```
+
+#### iwslt2017-en-fr
+
+- **Size of downloaded dataset files:** 26.41 MB
+- **Size of the generated dataset:** 48.87 MB
+- **Total amount of disk used:** 75.28 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "translation": {
+        "en": "But this understates the seriousness of this particular problem  because it doesn't show the thickness of the ice.",
+        "fr": "Mais ceci tend à amoindrir le problème parce qu'on ne voit pas l'épaisseur de la glace."
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### iwslt2017-ar-en
+- `translation`: a multilingual `string` variable, with possible languages including `ar`, `en`.
+
+#### iwslt2017-de-en
+- `translation`: a multilingual `string` variable, with possible languages including `de`, `en`.
+
+#### iwslt2017-en-ar
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `ar`.
+
+#### iwslt2017-en-de
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `de`.
+
+#### iwslt2017-en-fr
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `fr`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|     name      |train |validation|test|
+|---------------|-----:|---------:|---:|
+|iwslt2017-ar-en|231713|       888|8583|
+|iwslt2017-de-en|206112|       888|8079|
+|iwslt2017-en-ar|231713|       888|8583|
+|iwslt2017-en-de|206112|       888|8079|
+|iwslt2017-en-fr|232825|       890|8597|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{cettoloEtAl:EAMT2012,
+Address = {Trento, Italy},
+Author = {Mauro Cettolo and Christian Girardi and Marcello Federico},
+Booktitle = {Proceedings of the 16$^{th}$ Conference of the European Association for Machine Translation (EAMT)},
+Date = {28-30},
+Month = {May},
+Pages = {261--268},
+Title = {WIT$^3$: Web Inventory of Transcribed and Translated Talks},
+Year = {2012}}
+
+```
+

--- a/datasets/jeopardy/README.md
+++ b/datasets/jeopardy/README.md
@@ -1,0 +1,154 @@
+---
+---
+
+# Dataset Card for "jeopardy"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.reddit.com/r/datasets/comments/1uyd0t/200000_jeopardy_questions_in_a_json_file/](https://www.reddit.com/r/datasets/comments/1uyd0t/200000_jeopardy_questions_in_a_json_file/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 12.13 MB
+- **Size of the generated dataset:** 34.46 MB
+- **Total amount of disk used:** 46.59 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Dataset containing 216,930 Jeopardy questions, answers and other data.
+
+The json file is an unordered list of questions where each question has
+'category' : the question category, e.g. "HISTORY"
+'value' : integer $ value of the question as string, e.g. "200"
+Note: This is "None" for Final Jeopardy! and Tiebreaker questions
+'question' : text of question
+Note: This sometimes contains hyperlinks and other things messy text such as when there's a picture or video question
+'answer' : text of answer
+'round' : one of "Jeopardy!","Double Jeopardy!","Final Jeopardy!" or "Tiebreaker"
+Note: Tiebreaker questions do happen but they're very rare (like once every 20 years)
+'show_number' : int of show number, e.g '4680'
+'air_date' : string of the show air date in format YYYY-MM-DD
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 12.13 MB
+- **Size of the generated dataset:** 34.46 MB
+- **Total amount of disk used:** 46.59 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "air_date": "2004-12-31",
+    "answer": "Hattie McDaniel (for her role in Gone with the Wind)",
+    "category": "EPITAPHS & TRIBUTES",
+    "question": "'1939 Oscar winner: \"...you are a credit to your craft, your race and to your family\"'",
+    "round": "Jeopardy!",
+    "show_number": 4680,
+    "value": 2000
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `category`: a `string` feature.
+- `air_date`: a `string` feature.
+- `question`: a `string` feature.
+- `value`: a `int32` feature.
+- `answer`: a `string` feature.
+- `round`: a `string` feature.
+- `show_number`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |
+|-------|-----:|
+|default|216930|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/kilt_wikipedia/README.md
+++ b/datasets/kilt_wikipedia/README.md
@@ -1,0 +1,205 @@
+---
+---
+
+# Dataset Card for "kilt_wikipedia"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/facebookresearch/KILT](https://github.com/facebookresearch/KILT)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 35590.05 MB
+- **Size of the generated dataset:** 28011.83 MB
+- **Total amount of disk used:** 63601.89 MB
+
+### [Dataset Summary](#dataset-summary)
+
+KILT-Wikipedia: Wikipedia pre-processed for KILT.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### 2019-08-01
+
+- **Size of downloaded dataset files:** 35590.05 MB
+- **Size of the generated dataset:** 28011.83 MB
+- **Total amount of disk used:** 63601.89 MB
+
+An example of 'full' looks as follows.
+```
+{
+    "anchors": {
+        "end": [],
+        "href": [],
+        "paragraph_id": [],
+        "start": [],
+        "text": [],
+        "wikipedia_id": [],
+        "wikipedia_title": []
+    },
+    "categories": "",
+    "history": {
+        "pageid": 0,
+        "parentid": 0,
+        "pre_dump": true,
+        "revid": 0,
+        "timestamp": "",
+        "url": ""
+    },
+    "kilt_id": "",
+    "text": {
+        "paragraph": []
+    },
+    "wikidata_info": {
+        "aliases": {
+            "alias": []
+        },
+        "description": "",
+        "enwikiquote_title": "",
+        "wikidata_id": "",
+        "wikidata_label": "",
+        "wikipedia_title": ""
+    },
+    "wikipedia_id": "",
+    "wikipedia_title": ""
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### 2019-08-01
+- `kilt_id`: a `string` feature.
+- `wikipedia_id`: a `string` feature.
+- `wikipedia_title`: a `string` feature.
+- `text`: a dictionary feature containing:
+  - `paragraph`: a `string` feature.
+- `anchors`: a dictionary feature containing:
+  - `paragraph_id`: a `int32` feature.
+  - `start`: a `int32` feature.
+  - `end`: a `int32` feature.
+  - `text`: a `string` feature.
+  - `href`: a `string` feature.
+  - `wikipedia_title`: a `string` feature.
+  - `wikipedia_id`: a `string` feature.
+- `categories`: a `string` feature.
+- `description`: a `string` feature.
+- `enwikiquote_title`: a `string` feature.
+- `wikidata_id`: a `string` feature.
+- `wikidata_label`: a `string` feature.
+- `wikipedia_title`: a `string` feature.
+- `aliases`: a dictionary feature containing:
+  - `alias`: a `string` feature.
+- `pageid`: a `int32` feature.
+- `parentid`: a `int32` feature.
+- `revid`: a `int32` feature.
+- `pre_dump`: a `bool` feature.
+- `timestamp`: a `string` feature.
+- `url`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   | full  |
+|----------|------:|
+|2019-08-01|5903530|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{fb_kilt,
+    author    = {Fabio Petroni and
+                 Aleksandra Piktus and
+                 Angela Fan and
+                 Patrick Lewis and
+                 Majid Yazdani and
+                 Nicola De Cao and
+                 James Thorne and
+                 Yacine Jernite and
+                 Vassilis Plachouras and
+                 Tim Rockt"aschel and
+                 Sebastian Riedel},
+    title     = {{KILT:} a {B}enchmark for {K}nowledge {I}ntensive {L}anguage {T}asks},
+    journal   = {CoRR},
+    archivePrefix = {arXiv},
+    year      = {2020},
+
+```
+

--- a/datasets/kor_nli/README.md
+++ b/datasets/kor_nli/README.md
@@ -1,0 +1,182 @@
+---
+---
+
+# Dataset Card for "kor_nli"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/kakaobrain/KorNLUDatasets](https://github.com/kakaobrain/KorNLUDatasets)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 120.49 MB
+- **Size of the generated dataset:** 158.72 MB
+- **Total amount of disk used:** 279.21 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ Korean Natural  Language Inference datasets
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### multi_nli
+
+- **Size of downloaded dataset files:** 40.16 MB
+- **Size of the generated dataset:** 80.80 MB
+- **Total amount of disk used:** 120.97 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### snli
+
+- **Size of downloaded dataset files:** 40.16 MB
+- **Size of the generated dataset:** 76.42 MB
+- **Total amount of disk used:** 116.59 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### xnli
+
+- **Size of downloaded dataset files:** 40.16 MB
+- **Size of the generated dataset:** 1.49 MB
+- **Total amount of disk used:** 41.66 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### multi_nli
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### snli
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### xnli
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### multi_nli
+
+|         |train |
+|---------|-----:|
+|multi_nli|392702|
+
+#### snli
+
+|    |train |
+|----|-----:|
+|snli|550152|
+
+#### xnli
+
+|    |validation|test|
+|----|---------:|---:|
+|xnli|      2490|5010|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{ham2020kornli,
+  title={KorNLI and KorSTS: New Benchmark Datasets for Korean Natural Language Understanding},
+  author={Ham, Jiyeon and Choe, Yo Joong and Park, Kyubyong and Choi, Ilji and Soh, Hyungjoon},
+  journal={arXiv preprint arXiv:2004.03289},
+  year={2020}
+}
+
+```
+

--- a/datasets/lc_quad/README.md
+++ b/datasets/lc_quad/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "lc_quad"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://lc-quad.sda.tech/](http://lc-quad.sda.tech/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.69 MB
+- **Size of the generated dataset:** 19.77 MB
+- **Total amount of disk used:** 23.46 MB
+
+### [Dataset Summary](#dataset-summary)
+
+LC-QuAD 2.0 is a Large Question Answering dataset with 30,000 pairs of question and its corresponding SPARQL query. The target knowledge base is Wikidata and DBpedia, specifically the 2018 version. Please see our paper for details about the dataset creation process and framework.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 3.69 MB
+- **Size of the generated dataset:** 19.77 MB
+- **Total amount of disk used:** 23.46 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "NNQT_question": "What is the {periodical literature} for {mouthpiece} of {Delta Air Lines}",
+    "paraphrased_question": "What is Delta Air Line's periodical literature mouthpiece?",
+    "question": "What periodical literature does Delta Air Lines use as a moutpiece?",
+    "sparql_dbpedia18": "\"select distinct ?obj where { ?statement <http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <http://wikidata.dbpedia.org/resou...",
+    "sparql_wikidata": " select distinct ?obj where { wd:Q188920 wdt:P2813 ?obj . ?obj wdt:P31 wd:Q1002697 } ",
+    "subgraph": "simple question right",
+    "template": " <S P ?O ; ?O instanceOf Type>",
+    "template_index": 65,
+    "uid": 19719
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `NNQT_question`: a `string` feature.
+- `uid`: a `int32` feature.
+- `subgraph`: a `string` feature.
+- `template_index`: a `int32` feature.
+- `question`: a `string` feature.
+- `sparql_wikidata`: a `string` feature.
+- `sparql_dbpedia18`: a `string` feature.
+- `template`: a `string` feature.
+- `paraphrased_question`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|test|
+|-------|----:|---:|
+|default|19293|4781|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{dubey2017lc2,
+title={LC-QuAD 2.0: A Large Dataset for Complex Question Answering over Wikidata and DBpedia},
+author={Dubey, Mohnish and Banerjee, Debayan and Abdelkawi, Abdelrahman and Lehmann, Jens},
+booktitle={Proceedings of the 18th International Semantic Web Conference (ISWC)},
+year={2019},
+organization={Springer}
+}
+
+```
+

--- a/datasets/librispeech_lm/README.md
+++ b/datasets/librispeech_lm/README.md
@@ -1,0 +1,138 @@
+---
+---
+
+# Dataset Card for "librispeech_lm"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.openslr.org/11](http://www.openslr.org/11)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1437.45 MB
+- **Size of the generated dataset:** 4213.88 MB
+- **Total amount of disk used:** 5651.33 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Language modeling resources to be used in conjunction with the LibriSpeech ASR corpus.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1437.45 MB
+- **Size of the generated dataset:** 4213.88 MB
+- **Total amount of disk used:** 5651.33 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "text": "This is a test file"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train  |
+|-------|-------:|
+|default|40418260|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{panayotov2015librispeech,
+  title={Librispeech: an ASR corpus based on public domain audio books},
+  author={Panayotov, Vassil and Chen, Guoguo and Povey, Daniel and Khudanpur, Sanjeev},
+  booktitle={Acoustics, Speech and Signal Processing (ICASSP), 2015 IEEE International Conference on},
+  pages={5206--5210},
+  year={2015},
+  organization={IEEE}
+}
+
+```
+

--- a/datasets/lince/README.md
+++ b/datasets/lince/README.md
@@ -1,0 +1,261 @@
+---
+---
+
+# Dataset Card for "lince"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://ritual.uh.edu/lince](http://ritual.uh.edu/lince)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 8.67 MB
+- **Size of the generated dataset:** 53.81 MB
+- **Total amount of disk used:** 62.48 MB
+
+### [Dataset Summary](#dataset-summary)
+
+LinCE is a centralized Linguistic Code-switching Evaluation benchmark
+(https://ritual.uh.edu/lince/) that contains data for training and evaluating
+NLP systems on code-switching tasks.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### lid_hineng
+
+- **Size of downloaded dataset files:** 0.41 MB
+- **Size of the generated dataset:** 2.28 MB
+- **Total amount of disk used:** 2.69 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "idx": 0,
+    "lid": ["other", "other", "lang1", "lang1", "lang1", "other", "lang1", "lang1", "lang1", "lang1", "lang1", "lang1", "lang1", "mixed", "lang1", "lang1", "other"],
+    "words": ["@ZahirJ", "@BinyavangaW", "Loved", "the", "ending", "!", "I", "could", "have", "offered", "you", "some", "ironic", "chai-tea", "for", "it", ";)"]
+}
+```
+
+#### lid_msaea
+
+- **Size of downloaded dataset files:** 0.77 MB
+- **Size of the generated dataset:** 4.66 MB
+- **Total amount of disk used:** 5.43 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "idx": 0,
+    "lid": ["ne", "lang2", "other", "lang2", "lang2", "other", "other", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "lang2", "other", "lang2", "lang2", "lang2", "ne", "lang2", "lang2"],
+    "words": "[\"علاء\", \"بخير\", \"،\", \"معنوياته\", \"كويسة\", \".\", \"..\", \"اسخف\", \"حاجة\", \"بس\", \"ان\", \"كل\", \"واحد\", \"منهم\", \"بييقى\", \"مقفول\", \"عليه\"..."
+}
+```
+
+#### lid_nepeng
+
+- **Size of downloaded dataset files:** 0.52 MB
+- **Size of the generated dataset:** 3.06 MB
+- **Total amount of disk used:** 3.58 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "idx": 1,
+    "lid": ["other", "lang2", "lang2", "lang2", "lang2", "lang1", "lang1", "lang1", "lang1", "lang1", "lang2", "lang2", "other", "mixed", "lang2", "lang2", "other", "other", "other", "other"],
+    "words": ["@nirvikdada", "la", "hamlai", "bhetna", "paayeko", "will", "be", "your", "greatest", "gift", "ni", "dada", ";P", "#TreatChaiyo", "j", "hos", ";)", "@zappylily", "@AsthaGhm", "@ayacs_asis"]
+}
+```
+
+#### lid_spaeng
+
+- **Size of downloaded dataset files:** 1.13 MB
+- **Size of the generated dataset:** 6.51 MB
+- **Total amount of disk used:** 7.64 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "idx": 0,
+    "lid": ["other", "other", "lang1", "lang1", "lang1", "other", "lang1", "lang1"],
+    "words": ["11:11", ".....", "make", "a", "wish", ".......", "night", "night"]
+}
+```
+
+#### ner_hineng
+
+- **Size of downloaded dataset files:** 0.13 MB
+- **Size of the generated dataset:** 0.75 MB
+- **Total amount of disk used:** 0.88 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "idx": 1,
+    "lid": ["en", "en", "en", "en", "en", "en", "hi", "hi", "hi", "hi", "hi", "hi", "hi", "en", "en", "en", "en", "rest"],
+    "ner": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "B-PERSON", "I-PERSON", "O", "O", "O", "B-PERSON", "I-PERSON"],
+    "words": ["I", "liked", "a", "@YouTube", "video", "https://t.co/DmVqhZbdaI", "Kabhi", "Palkon", "Pe", "Aasoon", "Hai-", "Kishore", "Kumar", "-Vocal", "Cover", "By", "Stephen", "Qadir"]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### lid_hineng
+- `idx`: a `int32` feature.
+- `words`: a `list` of `string` features.
+- `lid`: a `list` of `string` features.
+
+#### lid_msaea
+- `idx`: a `int32` feature.
+- `words`: a `list` of `string` features.
+- `lid`: a `list` of `string` features.
+
+#### lid_nepeng
+- `idx`: a `int32` feature.
+- `words`: a `list` of `string` features.
+- `lid`: a `list` of `string` features.
+
+#### lid_spaeng
+- `idx`: a `int32` feature.
+- `words`: a `list` of `string` features.
+- `lid`: a `list` of `string` features.
+
+#### ner_hineng
+- `idx`: a `int32` feature.
+- `words`: a `list` of `string` features.
+- `lid`: a `list` of `string` features.
+- `ner`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|validation|test|
+|----------|----:|---------:|---:|
+|lid_hineng| 4823|       744|1854|
+|lid_msaea | 8464|      1116|1663|
+|lid_nepeng| 8451|      1332|3228|
+|lid_spaeng|21030|      3332|8289|
+|ner_hineng| 1243|       314| 522|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{molina-etal-2016-overview,
+   title = "Overview for the Second Shared Task on Language Identification in Code-Switched Data",
+   author = "Molina, Giovanni and
+             AlGhamdi, Fahad and
+             Ghoneim, Mahmoud and
+             Hawwari, Abdelati and
+             Rey-Villamizar, Nicolas and
+             Diab, Mona and
+             Solorio, Thamar",
+   booktitle = "Proceedings of the Second Workshop on Computational Approaches to Code Switching",
+   month = nov,
+   year = "2016",
+   address = "Austin, Texas",
+   publisher = "Association for Computational Linguistics",
+   url = "https://www.aclweb.org/anthology/W16-5805",
+   doi = "10.18653/v1/W16-5805",
+   pages = "40--49",
+}
+
+@inproceedings{aguilar-etal-2020-lince,
+    title = "{L}in{CE}: A Centralized Benchmark for Linguistic Code-switching Evaluation",
+    author = "Aguilar, Gustavo  and
+      Kar, Sudipta  and
+      Solorio, Thamar",
+    booktitle = "Proceedings of The 12th Language Resources and Evaluation Conference",
+    month = may,
+    year = "2020",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://www.aclweb.org/anthology/2020.lrec-1.223",
+    pages = "1803--1813",
+    language = "English",
+    ISBN = "979-10-95546-34-4",
+}
+
+Note that each LinCE dataset has its own citation. Please see the source to see
+the correct citation for each contained dataset.
+```
+

--- a/datasets/math_dataset/README.md
+++ b/datasets/math_dataset/README.md
@@ -1,0 +1,214 @@
+---
+---
+
+# Dataset Card for "math_dataset"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/deepmind/mathematics_dataset](https://github.com/deepmind/mathematics_dataset)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 124600.07 MB
+- **Size of the generated dataset:** 8656.79 MB
+- **Total amount of disk used:** 133256.87 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Mathematics database.
+
+This dataset code generates mathematical question and answer pairs,
+from a range of question types at roughly school-level difficulty.
+This is designed to test the mathematical learning and algebraic
+reasoning skills of learning models.
+
+Original paper: Analysing Mathematical Reasoning Abilities of Neural Models
+(Saxton, Grefenstette, Hill, Kohli).
+
+Example usage:
+train_examples, val_examples = datasets.load_dataset(
+    'math_dataset/arithmetic__mul',
+    split=['train', 'test'],
+    as_supervised=True)
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### algebra__linear_1d
+
+- **Size of downloaded dataset files:** 2225.00 MB
+- **Size of the generated dataset:** 88.31 MB
+- **Total amount of disk used:** 2313.31 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### algebra__linear_1d_composed
+
+- **Size of downloaded dataset files:** 2225.00 MB
+- **Size of the generated dataset:** 191.29 MB
+- **Total amount of disk used:** 2416.29 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### algebra__linear_2d
+
+- **Size of downloaded dataset files:** 2225.00 MB
+- **Size of the generated dataset:** 121.51 MB
+- **Total amount of disk used:** 2346.51 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### algebra__linear_2d_composed
+
+- **Size of downloaded dataset files:** 2225.00 MB
+- **Size of the generated dataset:** 224.68 MB
+- **Total amount of disk used:** 2449.68 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### algebra__polynomial_roots
+
+- **Size of downloaded dataset files:** 2225.00 MB
+- **Size of the generated dataset:** 156.41 MB
+- **Total amount of disk used:** 2381.41 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### algebra__linear_1d
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### algebra__linear_1d_composed
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### algebra__linear_2d
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### algebra__linear_2d_composed
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### algebra__polynomial_roots
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|           name            | train |test |
+|---------------------------|------:|----:|
+|algebra__linear_1d         |1999998|10000|
+|algebra__linear_1d_composed|1999998|10000|
+|algebra__linear_2d         |1999998|10000|
+|algebra__linear_2d_composed|1999998|10000|
+|algebra__polynomial_roots  |1999998|10000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{2019arXiv,
+  author = {Saxton, Grefenstette, Hill, Kohli},
+  title = {Analysing Mathematical Reasoning Abilities of Neural Models},
+  year = {2019},
+  journal = {arXiv:1904.01557}
+}
+
+```
+

--- a/datasets/math_qa/README.md
+++ b/datasets/math_qa/README.md
@@ -1,0 +1,142 @@
+---
+---
+
+# Dataset Card for "math_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://math-qa.github.io/math-QA/](https://math-qa.github.io/math-QA/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 6.96 MB
+- **Size of the generated dataset:** 21.90 MB
+- **Total amount of disk used:** 28.87 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Our dataset is gathered by using a new representation language to annotate over the AQuA-RAT dataset. AQuA-RAT has provided the questions, options, rationale, and the correct options.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 6.96 MB
+- **Size of the generated dataset:** 21.90 MB
+- **Total amount of disk used:** 28.87 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "Problem": "a multiple choice test consists of 4 questions , and each question has 5 answer choices . in how many r ways can the test be completed if every question is unanswered ?",
+    "Rationale": "\"5 choices for each of the 4 questions , thus total r of 5 * 5 * 5 * 5 = 5 ^ 4 = 625 ways to answer all of them . answer : c .\"",
+    "annotated_formula": "power(5, 4)",
+    "category": "general",
+    "correct": "c",
+    "linear_formula": "power(n1,n0)|",
+    "options": "a ) 24 , b ) 120 , c ) 625 , d ) 720 , e ) 1024"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `Problem`: a `string` feature.
+- `Rationale`: a `string` feature.
+- `options`: a `string` feature.
+- `correct`: a `string` feature.
+- `annotated_formula`: a `string` feature.
+- `linear_formula`: a `string` feature.
+- `category`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|29837|      4475|2985|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/matinf/README.md
+++ b/datasets/matinf/README.md
@@ -1,0 +1,227 @@
+---
+---
+
+# Dataset Card for "matinf"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/WHUIR/MATINF](https://github.com/WHUIR/MATINF)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 758.17 MB
+- **Total amount of disk used:** 758.17 MB
+
+### [Dataset Summary](#dataset-summary)
+
+MATINF is the first jointly labeled large-scale dataset for classification, question answering and summarization.
+MATINF contains 1.07 million question-answer pairs with human-labeled categories and user-generated question
+descriptions. Based on such rich information, MATINF is applicable for three major NLP tasks, including classification,
+question answering, and summarization. We benchmark existing methods and a novel multi-task baseline over MATINF to
+inspire further research. Our comprehensive comparison and experiments over MATINF and other datasets demonstrate the
+merits held by MATINF.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### age_classification
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 46.15 MB
+- **Total amount of disk used:** 46.15 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "description": "\"6个月的时候去儿宝检查，医生说宝宝的分胯动作做的不好，说最好去儿童医院看看，但我家宝宝很好，感觉没有什么不正常啊，请教一下，分胯做的不好，有什么不好吗？\"...",
+    "id": 88016,
+    "label": 0,
+    "question": "医生说宝宝的分胯动作不好"
+}
+```
+
+#### qa
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 256.24 MB
+- **Total amount of disk used:** 256.24 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": "\"我一个同学的孩子就是发现了肾积水，治疗了一段时间，结果还是越来越多，没办法就打掉了。虽然舍不得，但是还是要忍痛割爱，不然以后孩子真的有问题，大人和孩子都受罪。不过，这个最后的决定还要你自己做，毕竟是你的宝宝。，、、、、\"...",
+    "id": 536714,
+    "question": "孕5个月检查右侧肾积水孩子能要吗？"
+}
+```
+
+#### summarization
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 246.89 MB
+- **Total amount of disk used:** 246.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "description": "\"宝宝有中度HIE，但原因未查明，这是他出生后脸上红的几道，嘴唇深红近紫，请问这是像缺氧的表现吗？\"...",
+    "id": 173649,
+    "question": "宝宝脸上红的几道嘴唇深红近紫是像缺氧的表现吗？"
+}
+```
+
+#### topic_classification
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 208.89 MB
+- **Total amount of disk used:** 208.89 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "description": "媳妇怀孕五个月了经检查右侧肾积水、过了半月左侧也出现肾积水、她要拿掉孩子、怎么办？",
+    "id": 536714,
+    "label": 8,
+    "question": "孕5个月检查右侧肾积水孩子能要吗？"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### age_classification
+- `question`: a `string` feature.
+- `description`: a `string` feature.
+- `label`: a classification label, with possible values including `0-1岁` (0), `1-2岁` (1), `2-3岁` (2).
+- `id`: a `int32` feature.
+
+#### qa
+- `question`: a `string` feature.
+- `answer`: a `string` feature.
+- `id`: a `int32` feature.
+
+#### summarization
+- `description`: a `string` feature.
+- `question`: a `string` feature.
+- `id`: a `int32` feature.
+
+#### topic_classification
+- `question`: a `string` feature.
+- `description`: a `string` feature.
+- `label`: a classification label, with possible values including `产褥期保健` (0), `儿童过敏` (1), `动作发育` (2), `婴幼保健` (3), `婴幼心理` (4).
+- `id`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|        name        |train |validation| test |
+|--------------------|-----:|---------:|-----:|
+|age_classification  |134852|     19323| 38318|
+|qa                  |747888|    106842|213681|
+|summarization       |747888|    106842|213681|
+|topic_classification|613036|     87519|175363|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{xu-etal-2020-matinf,
+    title = "{MATINF}: A Jointly Labeled Large-Scale Dataset for Classification, Question Answering and Summarization",
+    author = "Xu, Canwen  and
+      Pei, Jiaxin  and
+      Wu, Hongtao  and
+      Liu, Yiyu  and
+      Li, Chenliang",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.acl-main.330",
+    pages = "3586--3596",
+}
+
+```
+

--- a/datasets/mlqa/README.md
+++ b/datasets/mlqa/README.md
@@ -1,0 +1,222 @@
+---
+---
+
+# Dataset Card for "mlqa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/facebookresearch/MLQA](https://github.com/facebookresearch/MLQA)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3958.58 MB
+- **Size of the generated dataset:** 867.85 MB
+- **Total amount of disk used:** 4826.43 MB
+
+### [Dataset Summary](#dataset-summary)
+
+    MLQA (MultiLingual Question Answering) is a benchmark dataset for evaluating cross-lingual question answering performance.
+    MLQA consists of over 5K extractive QA instances (12K in English) in SQuAD format in seven languages - English, Arabic,
+    German, Spanish, Hindi, Vietnamese and Simplified Chinese. MLQA is highly parallel, with QA instances parallel between
+    4 different languages on average.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### mlqa-translate-test.ar
+
+- **Size of downloaded dataset files:** 9.61 MB
+- **Size of the generated dataset:** 5.23 MB
+- **Total amount of disk used:** 14.84 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### mlqa-translate-test.de
+
+- **Size of downloaded dataset files:** 9.61 MB
+- **Size of the generated dataset:** 3.70 MB
+- **Total amount of disk used:** 13.31 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### mlqa-translate-test.es
+
+- **Size of downloaded dataset files:** 9.61 MB
+- **Size of the generated dataset:** 3.74 MB
+- **Total amount of disk used:** 13.34 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### mlqa-translate-test.hi
+
+- **Size of downloaded dataset files:** 9.61 MB
+- **Size of the generated dataset:** 4.40 MB
+- **Total amount of disk used:** 14.00 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### mlqa-translate-test.vi
+
+- **Size of downloaded dataset files:** 9.61 MB
+- **Size of the generated dataset:** 5.72 MB
+- **Total amount of disk used:** 15.33 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### mlqa-translate-test.ar
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+- `id`: a `string` feature.
+
+#### mlqa-translate-test.de
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+- `id`: a `string` feature.
+
+#### mlqa-translate-test.es
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+- `id`: a `string` feature.
+
+#### mlqa-translate-test.hi
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+- `id`: a `string` feature.
+
+#### mlqa-translate-test.vi
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+- `id`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|         name         |test|
+|----------------------|---:|
+|mlqa-translate-test.ar|5335|
+|mlqa-translate-test.de|4517|
+|mlqa-translate-test.es|5253|
+|mlqa-translate-test.hi|4918|
+|mlqa-translate-test.vi|5495|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{lewis2019mlqa,
+  title={MLQA: Evaluating Cross-lingual Extractive Question Answering},
+  author={Lewis, Patrick and Oguz, Barlas and Rinott, Ruty and Riedel, Sebastian and Schwenk, Holger},
+  journal={arXiv preprint arXiv:1910.07475},
+  year={2019}
+}
+
+```
+

--- a/datasets/mlsum/README.md
+++ b/datasets/mlsum/README.md
@@ -1,0 +1,258 @@
+---
+---
+
+# Dataset Card for "mlsum"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** []()
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1748.64 MB
+- **Size of the generated dataset:** 4635.42 MB
+- **Total amount of disk used:** 6384.06 MB
+
+### [Dataset Summary](#dataset-summary)
+
+We present MLSUM, the first large-scale MultiLingual SUMmarization dataset.
+Obtained from online newspapers, it contains 1.5M+ article/summary pairs in five different languages -- namely, French, German, Spanish, Russian, Turkish.
+Together with English newspapers from the popular CNN/Daily mail dataset, the collected data form a large scale multilingual dataset which can enable new research directions for the text summarization community.
+We report cross-lingual comparative analyses based on state-of-the-art systems.
+These highlight existing biases which motivate the use of a multi-lingual dataset.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### de
+
+- **Size of downloaded dataset files:** 330.52 MB
+- **Size of the generated dataset:** 897.34 MB
+- **Total amount of disk used:** 1227.86 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "date": "01/01/2001",
+    "summary": "A text",
+    "text": "This is a text",
+    "title": "A sample",
+    "topic": "football",
+    "url": "https://www.google.com"
+}
+```
+
+#### es
+
+- **Size of downloaded dataset files:** 489.53 MB
+- **Size of the generated dataset:** 1274.55 MB
+- **Total amount of disk used:** 1764.09 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "date": "01/01/2001",
+    "summary": "A text",
+    "text": "This is a text",
+    "title": "A sample",
+    "topic": "football",
+    "url": "https://www.google.com"
+}
+```
+
+#### fr
+
+- **Size of downloaded dataset files:** 591.27 MB
+- **Size of the generated dataset:** 1537.36 MB
+- **Total amount of disk used:** 2128.63 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "date": "01/01/2001",
+    "summary": "A text",
+    "text": "This is a text",
+    "title": "A sample",
+    "topic": "football",
+    "url": "https://www.google.com"
+}
+```
+
+#### ru
+
+- **Size of downloaded dataset files:** 101.30 MB
+- **Size of the generated dataset:** 263.38 MB
+- **Total amount of disk used:** 364.68 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "date": "01/01/2001",
+    "summary": "A text",
+    "text": "This is a text",
+    "title": "A sample",
+    "topic": "football",
+    "url": "https://www.google.com"
+}
+```
+
+#### tu
+
+- **Size of downloaded dataset files:** 236.03 MB
+- **Size of the generated dataset:** 662.79 MB
+- **Total amount of disk used:** 898.82 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "date": "01/01/2001",
+    "summary": "A text",
+    "text": "This is a text",
+    "title": "A sample",
+    "topic": "football",
+    "url": "https://www.google.com"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### de
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `topic`: a `string` feature.
+- `url`: a `string` feature.
+- `title`: a `string` feature.
+- `date`: a `string` feature.
+
+#### es
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `topic`: a `string` feature.
+- `url`: a `string` feature.
+- `title`: a `string` feature.
+- `date`: a `string` feature.
+
+#### fr
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `topic`: a `string` feature.
+- `url`: a `string` feature.
+- `title`: a `string` feature.
+- `date`: a `string` feature.
+
+#### ru
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `topic`: a `string` feature.
+- `url`: a `string` feature.
+- `title`: a `string` feature.
+- `date`: a `string` feature.
+
+#### tu
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `topic`: a `string` feature.
+- `url`: a `string` feature.
+- `title`: a `string` feature.
+- `date`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name|train |validation|test |
+|----|-----:|---------:|----:|
+|de  |220887|     11394|10701|
+|es  |266367|     10358|13920|
+|fr  |392902|     16059|15828|
+|ru  | 25556|       750|  757|
+|tu  |249277|     11565|12775|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{scialom2020mlsum,
+  title={MLSUM: The Multilingual Summarization Corpus},
+  author={Scialom, Thomas and Dray, Paul-Alexis and Lamprier, Sylvain and Piwowarski, Benjamin and Staiano, Jacopo},
+  journal={arXiv preprint arXiv:2004.14900},
+  year={2020}
+}
+
+```
+

--- a/datasets/movie_rationales/README.md
+++ b/datasets/movie_rationales/README.md
@@ -1,0 +1,147 @@
+---
+---
+
+# Dataset Card for "movie_rationales"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.cs.jhu.edu/~ozaidan/rationales/](http://www.cs.jhu.edu/~ozaidan/rationales/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.72 MB
+- **Size of the generated dataset:** 8.33 MB
+- **Total amount of disk used:** 12.04 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The movie rationale dataset contains human annotated rationales for movie
+reviews.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 3.72 MB
+- **Size of the generated dataset:** 8.33 MB
+- **Total amount of disk used:** 12.04 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "evidences": ["Fun movie"],
+    "label": 1,
+    "review": "Fun movie\n"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `review`: a `string` feature.
+- `label`: a classification label, with possible values including `NEG` (0), `POS` (1).
+- `evidences`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 1600|       200| 199|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@unpublished{eraser2019,
+    title = {ERASER: A Benchmark to Evaluate Rationalized NLP Models},
+    author = {Jay DeYoung and Sarthak Jain and Nazneen Fatema Rajani and Eric Lehman and Caiming Xiong and Richard Socher and Byron C. Wallace}
+}
+@InProceedings{zaidan-eisner-piatko-2008:nips,
+  author    =  {Omar F. Zaidan  and  Jason Eisner  and  Christine Piatko},
+  title     =  {Machine Learning with Annotator Rationales to Reduce Annotation Cost},
+  booktitle =  {Proceedings of the NIPS*2008 Workshop on Cost Sensitive Learning},
+  month     =  {December},
+  year      =  {2008}
+}
+
+```
+

--- a/datasets/ms_marco/README.md
+++ b/datasets/ms_marco/README.md
@@ -1,0 +1,197 @@
+---
+---
+
+# Dataset Card for "ms_marco"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://microsoft.github.io/msmarco/](https://microsoft.github.io/msmarco/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1481.03 MB
+- **Size of the generated dataset:** 4503.32 MB
+- **Total amount of disk used:** 5984.34 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Starting with a paper released at NIPS 2016, MS MARCO is a collection of datasets focused on deep learning in search.
+
+The first dataset was a question answering dataset featuring 100,000 real Bing questions and a human generated answer.
+Since then we released a 1,000,000 question dataset, a natural langauge generation dataset, a passage ranking dataset,
+keyphrase extraction dataset, crawling dataset, and a conversational search.
+
+There have been 277 submissions. 20 KeyPhrase Extraction submissions, 87 passage ranking submissions, 0 document ranking
+submissions, 73 QnA V2 submissions, 82 NLGEN submisions, and 15 QnA V1 submissions
+
+This data comes in three tasks/forms: Original QnA dataset(v1.1), Question Answering(v2.1), Natural Language Generation(v2.1).
+
+The original question answering datset featured 100,000 examples and was released in 2016. Leaderboard is now closed but data is availible below.
+
+The current competitive tasks are Question Answering and Natural Language Generation. Question Answering features over 1,000,000 queries and
+is much like the original QnA dataset but bigger and with higher quality. The Natural Language Generation dataset features 180,000 examples and
+builds upon the QnA dataset to deliver answers that could be spoken by a smart speaker.
+
+version v1.1
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### v1.1
+
+- **Size of downloaded dataset files:** 160.88 MB
+- **Size of the generated dataset:** 414.48 MB
+- **Total amount of disk used:** 575.36 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### v2.1
+
+- **Size of downloaded dataset files:** 1320.14 MB
+- **Size of the generated dataset:** 4088.84 MB
+- **Total amount of disk used:** 5408.98 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### v1.1
+- `answers`: a `list` of `string` features.
+- `passages`: a dictionary feature containing:
+  - `is_selected`: a `int32` feature.
+  - `passage_text`: a `string` feature.
+  - `url`: a `string` feature.
+- `query`: a `string` feature.
+- `query_id`: a `int32` feature.
+- `query_type`: a `string` feature.
+- `wellFormedAnswers`: a `list` of `string` features.
+
+#### v2.1
+- `answers`: a `list` of `string` features.
+- `passages`: a dictionary feature containing:
+  - `is_selected`: a `int32` feature.
+  - `passage_text`: a `string` feature.
+  - `url`: a `string` feature.
+- `query`: a `string` feature.
+- `query_id`: a `int32` feature.
+- `query_type`: a `string` feature.
+- `wellFormedAnswers`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name|train |validation| test |
+|----|-----:|---------:|-----:|
+|v1.1| 82326|     10047|  9650|
+|v2.1|808731|    101093|101092|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{DBLP:journals/corr/NguyenRSGTMD16,
+  author    = {Tri Nguyen and
+               Mir Rosenberg and
+               Xia Song and
+               Jianfeng Gao and
+               Saurabh Tiwary and
+               Rangan Majumder and
+               Li Deng},
+  title     = {{MS} {MARCO:} {A} Human Generated MAchine Reading COmprehension Dataset},
+  journal   = {CoRR},
+  volume    = {abs/1611.09268},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1611.09268},
+  archivePrefix = {arXiv},
+  eprint    = {1611.09268},
+  timestamp = {Mon, 13 Aug 2018 16:49:03 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/NguyenRSGTMD16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+}
+
+```
+

--- a/datasets/multi_news/README.md
+++ b/datasets/multi_news/README.md
@@ -1,0 +1,148 @@
+---
+---
+
+# Dataset Card for "multi_news"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/Alex-Fabbri/Multi-News](https://github.com/Alex-Fabbri/Multi-News)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 245.06 MB
+- **Size of the generated dataset:** 667.74 MB
+- **Total amount of disk used:** 912.80 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Multi-News, consists of news articles and human-written summaries
+of these articles from the site newser.com.
+Each summary is professionally written by editors and
+includes links to the original articles cited.
+
+There are two features:
+  - document: text of news articles seperated by special token "|||||".
+  - summary: news summary.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 245.06 MB
+- **Size of the generated dataset:** 667.74 MB
+- **Total amount of disk used:** 912.80 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "document": "some line val \n another line",
+    "summary": "target val line"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `document`: a `string` feature.
+- `summary`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|44972|      5622|5622|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{alex2019multinews,
+    title={Multi-News: a Large-Scale Multi-Document Summarization Dataset and Abstractive Hierarchical Model},
+    author={Alexander R. Fabbri and Irene Li and Tianwei She and Suyi Li and Dragomir R. Radev},
+    year={2019},
+    eprint={1906.01749},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/multi_nli/README.md
+++ b/datasets/multi_nli/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "multi_nli"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.nyu.edu/projects/bowman/multinli/](https://www.nyu.edu/projects/bowman/multinli/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 216.34 MB
+- **Size of the generated dataset:** 73.39 MB
+- **Total amount of disk used:** 289.74 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Multi-Genre Natural Language Inference (MultiNLI) corpus is a
+crowd-sourced collection of 433k sentence pairs annotated with textual
+entailment information. The corpus is modeled on the SNLI corpus, but differs in
+that covers a range of genres of spoken and written text, and supports a
+distinctive cross-genre generalization evaluation. The corpus served as the
+basis for the shared task of the RepEval 2017 Workshop at EMNLP in Copenhagen.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 216.34 MB
+- **Size of the generated dataset:** 73.39 MB
+- **Total amount of disk used:** 289.74 MB
+
+An example of 'validation_matched' looks as follows.
+```
+{
+    "hypothesis": "flammable",
+    "label": 0,
+    "premise": "inflammable"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train |validation_matched|validation_mismatched|
+|----------|-----:|-----------------:|--------------------:|
+|plain_text|392702|              9815|                 9832|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{N18-1101,
+  author = "Williams, Adina
+            and Nangia, Nikita
+            and Bowman, Samuel",
+  title = "A Broad-Coverage Challenge Corpus for
+           Sentence Understanding through Inference",
+  booktitle = "Proceedings of the 2018 Conference of
+               the North American Chapter of the
+               Association for Computational Linguistics:
+               Human Language Technologies, Volume 1 (Long
+               Papers)",
+  year = "2018",
+  publisher = "Association for Computational Linguistics",
+  pages = "1112--1122",
+  location = "New Orleans, Louisiana",
+  url = "http://aclweb.org/anthology/N18-1101"
+}
+
+```
+

--- a/datasets/multi_nli_mismatch/README.md
+++ b/datasets/multi_nli_mismatch/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "multi_nli_mismatch"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.nyu.edu/projects/bowman/multinli/](https://www.nyu.edu/projects/bowman/multinli/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 216.34 MB
+- **Size of the generated dataset:** 74.02 MB
+- **Total amount of disk used:** 290.36 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Multi-Genre Natural Language Inference (MultiNLI) corpus is a
+crowd-sourced collection of 433k sentence pairs annotated with textual
+entailment information. The corpus is modeled on the SNLI corpus, but differs in
+that covers a range of genres of spoken and written text, and supports a
+distinctive cross-genre generalization evaluation. The corpus served as the
+basis for the shared task of the RepEval 2017 Workshop at EMNLP in Copenhagen.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 216.34 MB
+- **Size of the generated dataset:** 74.02 MB
+- **Total amount of disk used:** 290.36 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "hypothesis": "independence",
+    "label": "contradiction",
+    "premise": "correlation"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train |validation|
+|----------|-----:|---------:|
+|plain_text|392702|     10000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{N18-1101,
+  author = "Williams, Adina
+            and Nangia, Nikita
+            and Bowman, Samuel",
+  title = "A Broad-Coverage Challenge Corpus for
+           Sentence Understanding through Inference",
+  booktitle = "Proceedings of the 2018 Conference of
+               the North American Chapter of the
+               Association for Computational Linguistics:
+               Human Language Technologies, Volume 1 (Long
+               Papers)",
+  year = "2018",
+  publisher = "Association for Computational Linguistics",
+  pages = "1112--1122",
+  location = "New Orleans, Louisiana",
+  url = "http://aclweb.org/anthology/N18-1101"
+}
+
+```
+

--- a/datasets/mwsc/README.md
+++ b/datasets/mwsc/README.md
@@ -1,0 +1,143 @@
+---
+---
+
+# Dataset Card for "mwsc"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://decanlp.com](http://decanlp.com)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.04 MB
+- **Total amount of disk used:** 0.06 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Examples taken from the Winograd Schema Challenge modified to ensure that answers are a single word from the context.
+This modified Winograd Schema Challenge (MWSC) ensures that scores are neither inflated nor deflated by oddities in phrasing.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.04 MB
+- **Total amount of disk used:** 0.06 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answer": "example",
+    "options": ["test", "example"],
+    "question": "What is this sentence?",
+    "sentence": "This is a example sentence."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `sentence`: a `string` feature.
+- `question`: a `string` feature.
+- `options`: a `list` of `string` features.
+- `answer`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|   80|        82| 100|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{McCann2018decaNLP,
+  title={The Natural Language Decathlon: Multitask Learning as Question Answering},
+  author={Bryan McCann and Nitish Shirish Keskar and Caiming Xiong and Richard Socher},
+  journal={arXiv preprint arXiv:1806.08730},
+  year={2018}
+}
+
+```
+

--- a/datasets/natural_questions/README.md
+++ b/datasets/natural_questions/README.md
@@ -1,0 +1,160 @@
+---
+---
+
+# Dataset Card for "natural_questions"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://ai.google.com/research/NaturalQuestions/dataset](https://ai.google.com/research/NaturalQuestions/dataset)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 42981.34 MB
+- **Size of the generated dataset:** 95175.86 MB
+- **Total amount of disk used:** 138157.19 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The NQ corpus contains questions from real users, and it requires QA systems to
+read and comprehend an entire Wikipedia article that may or may not contain the
+answer to the question. The inclusion of real user questions, and the
+requirement that solutions should read an entire page to find the answer, cause
+NQ to be a more realistic and challenging task than prior QA datasets.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 42981.34 MB
+- **Size of the generated dataset:** 95175.86 MB
+- **Total amount of disk used:** 138157.19 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `url`: a `string` feature.
+- `html`: a `string` feature.
+- `tokens`: a dictionary feature containing:
+  - `token`: a `string` feature.
+  - `is_html`: a `bool` feature.
+- `text`: a `string` feature.
+- `tokens`: a `list` of `string` features.
+- `annotations`: a dictionary feature containing:
+  - `id`: a `string` feature.
+  - `start_token`: a `int64` feature.
+  - `end_token`: a `int64` feature.
+  - `start_byte`: a `int64` feature.
+  - `end_byte`: a `int64` feature.
+  - `short_answers`: a dictionary feature containing:
+    - `start_token`: a `int64` feature.
+    - `end_token`: a `int64` feature.
+    - `start_byte`: a `int64` feature.
+    - `end_byte`: a `int64` feature.
+    - `text`: a `string` feature.
+  - `yes_no_answer`: a classification label, with possible values including `NO` (0), `YES` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |validation|
+|-------|-----:|---------:|
+|default|307373|      7830|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{47761,
+title	= {Natural Questions: a Benchmark for Question Answering Research},
+author	= {Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov},
+year	= {2019},
+journal	= {Transactions of the Association of Computational Linguistics}
+}
+
+```
+

--- a/datasets/newsgroup/README.md
+++ b/datasets/newsgroup/README.md
@@ -1,0 +1,193 @@
+---
+---
+
+# Dataset Card for "newsgroup"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://qwone.com/~jason/20Newsgroups/](http://qwone.com/~jason/20Newsgroups/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 886.22 MB
+- **Size of the generated dataset:** 118.65 MB
+- **Total amount of disk used:** 1004.87 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The 20 Newsgroups data set is a collection of approximately 20,000 newsgroup documents, partitioned (nearly) evenly across
+20 different newsgroups. To the best of my knowledge, it was originally collected by Ken Lang, probably for his Newsweeder:
+Learning to filter netnews paper, though he does not explicitly mention this collection. The 20 newsgroups collection has become
+a popular data set for experiments in text applications of machine learning techniques, such as text classification and text clustering.
+
+does not include cross-posts and includes only the "From" and "Subject" headers.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### 18828_alt.atheism
+
+- **Size of downloaded dataset files:** 13.99 MB
+- **Size of the generated dataset:** 1.59 MB
+- **Total amount of disk used:** 15.58 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 18828_comp.graphics
+
+- **Size of downloaded dataset files:** 13.99 MB
+- **Size of the generated dataset:** 1.58 MB
+- **Total amount of disk used:** 15.57 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 18828_comp.os.ms-windows.misc
+
+- **Size of downloaded dataset files:** 13.99 MB
+- **Size of the generated dataset:** 2.27 MB
+- **Total amount of disk used:** 16.26 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 18828_comp.sys.ibm.pc.hardware
+
+- **Size of downloaded dataset files:** 13.99 MB
+- **Size of the generated dataset:** 1.13 MB
+- **Total amount of disk used:** 15.12 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 18828_comp.sys.mac.hardware
+
+- **Size of downloaded dataset files:** 13.99 MB
+- **Size of the generated dataset:** 1.01 MB
+- **Total amount of disk used:** 15.00 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### 18828_alt.atheism
+- `text`: a `string` feature.
+
+#### 18828_comp.graphics
+- `text`: a `string` feature.
+
+#### 18828_comp.os.ms-windows.misc
+- `text`: a `string` feature.
+
+#### 18828_comp.sys.ibm.pc.hardware
+- `text`: a `string` feature.
+
+#### 18828_comp.sys.mac.hardware
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|             name             |train|
+|------------------------------|----:|
+|18828_alt.atheism             |  799|
+|18828_comp.graphics           |  973|
+|18828_comp.os.ms-windows.misc |  985|
+|18828_comp.sys.ibm.pc.hardware|  982|
+|18828_comp.sys.mac.hardware   |  961|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/newsroom/README.md
+++ b/datasets/newsroom/README.md
@@ -1,0 +1,179 @@
+---
+---
+
+# Dataset Card for "newsroom"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://summari.es](https://summari.es)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 5057.49 MB
+- **Total amount of disk used:** 5057.49 MB
+
+### [Dataset Summary](#dataset-summary)
+
+NEWSROOM is a large dataset for training and evaluating summarization systems.
+It contains 1.3 million articles and summaries written by authors and
+editors in the newsrooms of 38 major publications.
+
+Dataset features includes:
+  - text: Input news text.
+  - summary: Summary for the news.
+And additional features:
+  - title: news title.
+  - url: url of the news.
+  - date: date of the article.
+  - density: extractive density.
+  - coverage: extractive coverage.
+  - compression: compression ratio.
+  - density_bin: low, medium, high.
+  - coverage_bin: extractive, abstractive.
+  - compression_bin: low, medium, high.
+
+This dataset can be downloaded upon requests. Unzip all the contents
+"train.jsonl, dev.josnl, test.jsonl" to the tfds folder.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 5057.49 MB
+- **Total amount of disk used:** 5057.49 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "compression": 33.880001068115234,
+    "compression_bin": "medium",
+    "coverage": 1.0,
+    "coverage_bin": "high",
+    "date": "200600000",
+    "density": 11.720000267028809,
+    "density_bin": "extractive",
+    "summary": "some summary 1",
+    "text": "some text 1",
+    "title": "news title 1",
+    "url": "url.html"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+- `summary`: a `string` feature.
+- `title`: a `string` feature.
+- `url`: a `string` feature.
+- `date`: a `string` feature.
+- `density_bin`: a `string` feature.
+- `coverage_bin`: a `string` feature.
+- `compression_bin`: a `string` feature.
+- `density`: a `float32` feature.
+- `coverage`: a `float32` feature.
+- `compression`: a `float32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |validation| test |
+|-------|-----:|---------:|-----:|
+|default|995041|    108837|108862|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{N18-1065,
+  author    = {Grusky, Max and Naaman, Mor and Artzi, Yoav},
+  title     = {NEWSROOM: A Dataset of 1.3 Million Summaries
+               with Diverse Extractive Strategies},
+  booktitle = {Proceedings of the 2018 Conference of the
+               North American Chapter of the Association for
+               Computational Linguistics: Human Language Technologies},
+  year      = {2018},
+}
+
+```
+

--- a/datasets/nli_tr/README.md
+++ b/datasets/nli_tr/README.md
@@ -1,0 +1,180 @@
+---
+---
+
+# Dataset Card for "nli_tr"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/boun-tabi/NLI-TR](https://github.com/boun-tabi/NLI-TR)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 110.48 MB
+- **Size of the generated dataset:** 146.26 MB
+- **Total amount of disk used:** 256.74 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Natural Language Inference in Turkish (NLI-TR) is a set of two large scale datasets that were obtained by translating the foundational NLI corpora (SNLI and MNLI) using Amazon Translate.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### multinli_tr
+
+- **Size of downloaded dataset files:** 72.02 MB
+- **Size of the generated dataset:** 75.79 MB
+- **Total amount of disk used:** 147.81 MB
+
+An example of 'validation_matched' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hypothesis": "Mrinal Sen'in çalışmalarının çoğu Avrupa koleksiyonlarında bulunabilir.",
+    "idx": 7,
+    "label": 1,
+    "premise": "\"Kalküta, sanatsal yaratıcılığa dair herhangi bir iddiaya sahip olan tek diğer üretim merkezi gibi görünüyor, ama ironik bir şek..."
+}
+```
+
+#### snli_tr
+
+- **Size of downloaded dataset files:** 38.46 MB
+- **Size of the generated dataset:** 70.47 MB
+- **Total amount of disk used:** 108.93 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "hypothesis": "Yaşlı bir adam, kızının işten çıkmasını bekçiyken suyunu içer.",
+    "idx": 9,
+    "label": 1,
+    "premise": "Parlak renkli gömlek çalışanları arka planda gülümseme iken yaşlı bir adam bir kahve dükkanında küçük bir masada onun portakal suyu ile oturur."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### multinli_tr
+- `idx`: a `int32` feature.
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### snli_tr
+- `idx`: a `int32` feature.
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### multinli_tr
+
+|           |train |validation_matched|validation_mismatched|
+|-----------|-----:|-----------------:|--------------------:|
+|multinli_tr|392702|             10000|                10000|
+
+#### snli_tr
+
+|       |train |validation|test |
+|-------|-----:|---------:|----:|
+|snli_tr|550152|     10000|10000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{budur-etal-2020-data,
+    title = "Data and Representation for Turkish Natural Language Inference",
+    author = "Budur, Emrah and
+      "{O}zçelik, Rıza and
+      G"{u}ng"{o}r, Tunga",
+    booktitle = "Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP)",
+    month = nov,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    abstract = "Large annotated datasets in NLP are overwhelmingly in English. This is an obstacle to progress in other languages. Unfortunately, obtaining new annotated resources for each task in each language would be prohibitively expensive. At the same time, commercial machine translation systems are now robust. Can we leverage these systems to translate English-language datasets automatically? In this paper, we offer a positive response for natural language inference (NLI) in Turkish. We translated two large English NLI datasets into Turkish and had a team of experts validate their translation quality and fidelity to the original labels. Using these datasets, we address core issues of representation for Turkish NLI. We find that in-language embeddings are essential and that morphological parsing can be avoided where the training set is large. Finally, we show that models trained on our machine-translated datasets are successful on human-translated evaluation sets. We share all code, models, and data publicly.",
+}
+
+```
+

--- a/datasets/openbookqa/README.md
+++ b/datasets/openbookqa/README.md
@@ -1,0 +1,164 @@
+---
+---
+
+# Dataset Card for "openbookqa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/open-book-qa](https://allenai.org/data/open-book-qa)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2.76 MB
+- **Size of the generated dataset:** 2.75 MB
+- **Total amount of disk used:** 5.51 MB
+
+### [Dataset Summary](#dataset-summary)
+
+OpenBookQA aims to promote research in advanced question-answering, probing a deeper understanding of both the topic
+(with salient facts summarized as an open book, also provided with the dataset) and the language it is expressed in. In
+particular, it contains questions that require multi-step reasoning, use of additional common and commonsense knowledge,
+and rich text comprehension.
+OpenBookQA is a new kind of question-answering dataset modeled after open book exams for assessing human understanding of
+a subject.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### additional
+
+- **Size of downloaded dataset files:** 1.38 MB
+- **Size of the generated dataset:** 1.38 MB
+- **Total amount of disk used:** 2.75 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### main
+
+- **Size of downloaded dataset files:** 1.38 MB
+- **Size of the generated dataset:** 1.38 MB
+- **Total amount of disk used:** 2.75 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### additional
+- `id`: a `string` feature.
+- `question_stem`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `answerKey`: a `string` feature.
+
+#### main
+- `id`: a `string` feature.
+- `question_stem`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `answerKey`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|validation|test|
+|----------|----:|---------:|---:|
+|additional| 4957|       500| 500|
+|main      | 4957|       500| 500|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{OpenBookQA2018,
+ title={Can a Suit of Armor Conduct Electricity? A New Dataset for Open Book Question Answering},
+ author={Todor Mihaylov and Peter Clark and Tushar Khot and Ashish Sabharwal},
+ booktitle={EMNLP},
+ year={2018}
+}
+
+```
+

--- a/datasets/openwebtext/README.md
+++ b/datasets/openwebtext/README.md
@@ -1,0 +1,138 @@
+---
+---
+
+# Dataset Card for "openwebtext"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://skylion007.github.io/OpenWebTextCorpus/](https://skylion007.github.io/OpenWebTextCorpus/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 12283.35 MB
+- **Size of the generated dataset:** 37927.15 MB
+- **Total amount of disk used:** 50210.50 MB
+
+### [Dataset Summary](#dataset-summary)
+
+An open-source replication of the WebText dataset from OpenAI.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 12283.35 MB
+- **Size of the generated dataset:** 37927.15 MB
+- **Total amount of disk used:** 50210.50 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "text": "\"A magazine supplement with an image of Adolf Hitler and the title 'The Unreadable Book' is pictured in Berlin. No law bans “Mei..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   | train |
+|----------|------:|
+|plain_text|8013769|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc{Gokaslan2019OpenWeb,
+	title={OpenWebText Corpus},
+	author={Aaron Gokaslan*, Vanya Cohen*, Ellie Pavlick, Stefanie Tellex},
+	howpublished{\url{http://Skylion007.github.io/OpenWebTextCorpus}},
+	year={2019}
+}
+
+```
+

--- a/datasets/opinosis/README.md
+++ b/datasets/opinosis/README.md
@@ -1,0 +1,142 @@
+---
+---
+
+# Dataset Card for "opinosis"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://kavita-ganesan.com/opinosis/](http://kavita-ganesan.com/opinosis/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.72 MB
+- **Size of the generated dataset:** 0.71 MB
+- **Total amount of disk used:** 1.43 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Opinosis Opinion Dataset consists of sentences extracted from reviews for 51 topics.
+Topics and opinions are obtained from Tripadvisor, Edmunds.com and Amazon.com.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.72 MB
+- **Size of the generated dataset:** 0.71 MB
+- **Total amount of disk used:** 1.43 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "review_sents": "This is a fake topic. \nThe topics have multiple sentence inputs. \n",
+    "summaries": ["This is a gold summary for topic 1. \nSentences in gold summaries are separated by newlines.", "This is another gold summary for topic 1. \nSentences in gold summaries are separated by newlines."]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `review_sents`: a `string` feature.
+- `summaries`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|
+|-------|----:|
+|default|   51|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{ganesan2010opinosis,
+  title={Opinosis: a graph-based approach to abstractive summarization of highly redundant opinions},
+  author={Ganesan, Kavita and Zhai, ChengXiang and Han, Jiawei},
+  booktitle={Proceedings of the 23rd International Conference on Computational Linguistics},
+  pages={340--348},
+  year={2010},
+  organization={Association for Computational Linguistics}
+}
+
+```
+

--- a/datasets/para_crawl/README.md
+++ b/datasets/para_crawl/README.md
@@ -1,0 +1,213 @@
+---
+---
+
+# Dataset Card for "para_crawl"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://paracrawl.eu/releases.html](https://paracrawl.eu/releases.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 9879.92 MB
+- **Size of the generated dataset:** 31378.09 MB
+- **Total amount of disk used:** 41258.01 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Web-Scale Parallel Corpora for Official European Languages.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### enbg
+
+- **Size of downloaded dataset files:** 98.94 MB
+- **Size of the generated dataset:** 340.02 MB
+- **Total amount of disk used:** 438.95 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"bg\": \". “A felirat faragott karnis a bejárat fölött, templom épült 14 Július 1643, A földesúr és felesége Jeremiás Murguleţ, C..."
+}
+```
+
+#### encs
+
+- **Size of downloaded dataset files:** 187.31 MB
+- **Size of the generated dataset:** 608.51 MB
+- **Total amount of disk used:** 795.82 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"cs\": \". “A felirat faragott karnis a bejárat fölött, templom épült 14 Július 1643, A földesúr és felesége Jeremiás Murguleţ, C..."
+}
+```
+
+#### enda
+
+- **Size of downloaded dataset files:** 174.34 MB
+- **Size of the generated dataset:** 570.89 MB
+- **Total amount of disk used:** 745.23 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"da\": \". “A felirat faragott karnis a bejárat fölött, templom épült 14 Július 1643, A földesúr és felesége Jeremiás Murguleţ, C..."
+}
+```
+
+#### ende
+
+- **Size of downloaded dataset files:** 1247.17 MB
+- **Size of the generated dataset:** 3812.02 MB
+- **Total amount of disk used:** 5059.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"de\": \". “A felirat faragott karnis a bejárat fölött, templom épült 14 Július 1643, A földesúr és felesége Jeremiás Murguleţ, C..."
+}
+```
+
+#### enel
+
+- **Size of downloaded dataset files:** 184.59 MB
+- **Size of the generated dataset:** 656.19 MB
+- **Total amount of disk used:** 840.78 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"el\": \". “A felirat faragott karnis a bejárat fölött, templom épült 14 Július 1643, A földesúr és felesége Jeremiás Murguleţ, C..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### enbg
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `bg`.
+
+#### encs
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `cs`.
+
+#### enda
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `da`.
+
+#### ende
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `de`.
+
+#### enel
+- `translation`: a multilingual `string` variable, with possible languages including `en`, `el`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name| train  |
+|----|-------:|
+|enbg| 1039885|
+|encs| 2981949|
+|enda| 2414895|
+|ende|16264448|
+|enel| 1985233|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc {paracrawl,
+    title  = "ParaCrawl",
+    year   = "2018",
+    url    = "http://paracrawl.eu/download.html."
+}
+
+```
+

--- a/datasets/pg19/README.md
+++ b/datasets/pg19/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "pg19"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/deepmind/pg19](https://github.com/deepmind/pg19)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 11196.60 MB
+- **Size of the generated dataset:** 10978.29 MB
+- **Total amount of disk used:** 22174.89 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This repository contains the PG-19 language modeling benchmark.
+It includes a set of books extracted from the Project Gutenberg books library, that were published before 1919.
+It also contains metadata of book titles and publication dates.
+
+PG-19 is over double the size of the Billion Word benchmark and contains documents that are 20X longer, on average, than the WikiText long-range language modelling benchmark.
+Books are partitioned into a train, validation, and test set. Book metadata is stored in metadata.csv which contains (book_id, short_book_title, publication_date).
+
+Unlike prior benchmarks, we do not constrain the vocabulary size --- i.e. mapping rare words to an UNK token --- but instead release the data as an open-vocabulary benchmark. The only processing of the text that has been applied is the removal of boilerplate license text, and the mapping of offensive discriminatory words as specified by Ofcom to placeholder tokens. Users are free to model the data at the character-level, subword-level, or via any mechanism that can model an arbitrary string of text.
+To compare models we propose to continue measuring the word-level perplexity, by calculating the total likelihood of the dataset (via any chosen subword vocabulary or character-based scheme) divided by the number of tokens --- specified below in the dataset statistics table.
+One could use this dataset for benchmarking long-range language models, or use it to pre-train for other natural language processing tasks which require long-range reasoning, such as LAMBADA or NarrativeQA. We would not recommend using this dataset to train a general-purpose language model, e.g. for applications to a production-system dialogue agent, due to the dated linguistic style of old texts and the inherent biases present in historical writing.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 11196.60 MB
+- **Size of the generated dataset:** 10978.29 MB
+- **Total amount of disk used:** 22174.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "publication_date": 1907,
+    "short_book_title": "La Fiammetta by Giovanni Boccaccio",
+    "text": "\"\\n\\n\\n\\nProduced by Ted Garvin, Dave Morgan and PG Distributed Proofreaders\\n\\n\\n\\n\\nLA FIAMMETTA\\n\\nBY\\n\\nGIOVANNI BOCCACCIO\\n...",
+    "url": "http://www.gutenberg.org/ebooks/10006"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `short_book_title`: a `string` feature.
+- `publication_date`: a `int32` feature.
+- `url`: a `string` feature.
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|28602|        50| 100|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{raecompressive2019,
+  author = {Rae, Jack W and Potapenko, Anna and Jayakumar, Siddhant M and
+            Hillier, Chloe and Lillicrap, Timothy P},
+  title = {Compressive Transformers for Long-Range Sequence Modelling},
+  journal = {arXiv preprint},
+  url = {https://arxiv.org/abs/1911.05507},
+  year = {2019},
+}
+
+```
+

--- a/datasets/piaf/README.md
+++ b/datasets/piaf/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "piaf"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://piaf.etalab.studio](https://piaf.etalab.studio)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.31 MB
+- **Size of the generated dataset:** 3.18 MB
+- **Total amount of disk used:** 4.49 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Piaf is a reading comprehension dataset. This version, published in February 2020, contains 3835 questions on French Wikipedia.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 1.31 MB
+- **Size of the generated dataset:** 3.18 MB
+- **Total amount of disk used:** 4.49 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answers": {
+        "answer_start": [0],
+        "text": ["Voici"]
+    },
+    "context": "Voici le contexte du premier paragraphe du deuxième article.",
+    "id": "p140295460356960",
+    "question": "Suis-je la troisième question ?",
+    "title": "Jakob Böhme"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|
+|----------|----:|
+|plain_text| 3835|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{keraron-EtAl:2020:LREC,
+  author    = {Keraron, Rachel  and  Lancrenon, Guillaume  and  Bras, Mathilde  and  Allary, FrÃ©dÃ©ric  and  Moyse, Gilles  and  Scialom, Thomas  and  Soriano-Morales, Edmundo-Pavel  and  Staiano, Jacopo},
+  title     = {Project PIAF: Building a Native French Question-Answering Dataset},
+  booktitle      = {Proceedings of The 12th Language Resources and Evaluation Conference},
+  month          = {May},
+  year           = {2020},
+  address        = {Marseille, France},
+  publisher      = {European Language Resources Association},
+  pages     = {5483--5492},
+  abstract  = {Motivated by the lack of data for non-English languages, in particular for the evaluation of downstream tasks such as Question Answering, we present a participatory effort to collect a native French Question Answering Dataset. Furthermore, we describe and publicly release the annotation tool developed for our collection effort, along with the data obtained and preliminary baselines.},
+  url       = {https://www.aclweb.org/anthology/2020.lrec-1.673}
+}
+
+```
+

--- a/datasets/polyglot_ner/README.md
+++ b/datasets/polyglot_ner/README.md
@@ -1,0 +1,252 @@
+---
+---
+
+# Dataset Card for "polyglot_ner"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://sites.google.com/site/rmyeid/projects/polylgot-ner](https://sites.google.com/site/rmyeid/projects/polylgot-ner)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 43285.14 MB
+- **Size of the generated dataset:** 11958.61 MB
+- **Total amount of disk used:** 55243.75 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Polyglot-NER
+A training dataset automatically generated from Wikipedia and Freebase the task
+of named entity recognition. The dataset contains the basic Wikipedia based
+training data for 40 languages we have (with coreference resolution) for the task of
+named entity recognition. The details of the procedure of generating them is outlined in
+Section 3 of the paper (https://arxiv.org/abs/1410.3791). Each config contains the data
+corresponding to a different language. For example, "es" includes only spanish examples.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### ar
+
+- **Size of downloaded dataset files:** 1055.74 MB
+- **Size of the generated dataset:** 175.05 MB
+- **Total amount of disk used:** 1230.78 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": "2",
+    "lang": "ar",
+    "ner": ["O", "O", "O", "O", "O", "O", "O", "O", "LOC", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "PER", "PER", "PER", "PER", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"],
+    "words": "[\"وفي\", \"مرحلة\", \"موالية\", \"أنشأت\", \"قبيلة\", \"مكناسة\", \"الزناتية\", \"مكناسة\", \"تازة\", \",\", \"وأقام\", \"بها\", \"المرابطون\", \"قلعة\", \"..."
+}
+```
+
+#### bg
+
+- **Size of downloaded dataset files:** 1055.74 MB
+- **Size of the generated dataset:** 181.68 MB
+- **Total amount of disk used:** 1237.42 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": "1",
+    "lang": "bg",
+    "ner": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"],
+    "words": "[\"Дефиниция\", \"Наименованията\", \"\\\"\", \"книжовен\", \"\\\"/\\\"\", \"литературен\", \"\\\"\", \"език\", \"на\", \"български\", \"за\", \"тази\", \"кодифи..."
+}
+```
+
+#### ca
+
+- **Size of downloaded dataset files:** 1055.74 MB
+- **Size of the generated dataset:** 137.09 MB
+- **Total amount of disk used:** 1192.82 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": "2",
+    "lang": "ca",
+    "ner": "[\"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O\", \"O...",
+    "words": "[\"Com\", \"a\", \"compositor\", \"deixà\", \"un\", \"immens\", \"llegat\", \"que\", \"inclou\", \"8\", \"simfonies\", \"(\", \"1822\", \"),\", \"diverses\", ..."
+}
+```
+
+#### combined
+
+- **Size of downloaded dataset files:** 1055.74 MB
+- **Size of the generated dataset:** 5995.61 MB
+- **Total amount of disk used:** 7051.35 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": "18",
+    "lang": "es",
+    "ner": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"],
+    "words": "[\"Los\", \"cambios\", \"en\", \"la\", \"energía\", \"libre\", \"de\", \"Gibbs\", \"\\\\\", \"Delta\", \"G\", \"nos\", \"dan\", \"una\", \"cuantificación\", \"de..."
+}
+```
+
+#### cs
+
+- **Size of downloaded dataset files:** 1055.74 MB
+- **Size of the generated dataset:** 149.53 MB
+- **Total amount of disk used:** 1205.26 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": "3",
+    "lang": "cs",
+    "ner": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"],
+    "words": "[\"Historie\", \"Symfonická\", \"forma\", \"se\", \"rozvinula\", \"se\", \"především\", \"v\", \"období\", \"klasicismu\", \"a\", \"romantismu\", \",\", \"..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### ar
+- `id`: a `string` feature.
+- `lang`: a `string` feature.
+- `words`: a `list` of `string` features.
+- `ner`: a `list` of `string` features.
+
+#### bg
+- `id`: a `string` feature.
+- `lang`: a `string` feature.
+- `words`: a `list` of `string` features.
+- `ner`: a `list` of `string` features.
+
+#### ca
+- `id`: a `string` feature.
+- `lang`: a `string` feature.
+- `words`: a `list` of `string` features.
+- `ner`: a `list` of `string` features.
+
+#### combined
+- `id`: a `string` feature.
+- `lang`: a `string` feature.
+- `words`: a `list` of `string` features.
+- `ner`: a `list` of `string` features.
+
+#### cs
+- `id`: a `string` feature.
+- `lang`: a `string` feature.
+- `words`: a `list` of `string` features.
+- `ner`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name  | train  |
+|--------|-------:|
+|ar      |  339109|
+|bg      |  559694|
+|ca      |  372665|
+|combined|21070925|
+|cs      |  564462|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{polyglotner,
+         author = {Al-Rfou, Rami and Kulkarni, Vivek and Perozzi, Bryan and Skiena, Steven},
+         title = {{Polyglot-NER}: Massive Multilingual Named Entity Recognition},
+         journal = {{Proceedings of the 2015 {SIAM} International Conference on Data Mining, Vancouver, British Columbia, Canada, April 30- May 2, 2015}},
+         month     = {April},
+         year      = {2015},
+         publisher = {SIAM},
+}
+
+```
+

--- a/datasets/qa4mre/README.md
+++ b/datasets/qa4mre/README.md
@@ -1,0 +1,271 @@
+---
+---
+
+# Dataset Card for "qa4mre"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://nlp.uned.es/clef-qa/repository/pastCampaigns.php](http://nlp.uned.es/clef-qa/repository/pastCampaigns.php)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 5.24 MB
+- **Size of the generated dataset:** 46.11 MB
+- **Total amount of disk used:** 51.35 MB
+
+### [Dataset Summary](#dataset-summary)
+
+QA4MRE dataset was created for the CLEF 2011/2012/2013 shared tasks to promote research in
+question answering and reading comprehension. The dataset contains a supporting
+passage and a set of questions corresponding to the passage. Multiple options
+for answers are provided for each question, of which only one is correct. The
+training and test datasets are available for the main track.
+Additional gold standard documents are available for two pilot studies: one on
+alzheimers data, and the other on entrance exams data.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### 2011.main.DE
+
+- **Size of downloaded dataset files:** 0.21 MB
+- **Size of the generated dataset:** 1.67 MB
+- **Total amount of disk used:** 1.88 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 2011.main.EN
+
+- **Size of downloaded dataset files:** 0.19 MB
+- **Size of the generated dataset:** 1.50 MB
+- **Total amount of disk used:** 1.69 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 2011.main.ES
+
+- **Size of downloaded dataset files:** 0.21 MB
+- **Size of the generated dataset:** 1.62 MB
+- **Total amount of disk used:** 1.82 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 2011.main.IT
+
+- **Size of downloaded dataset files:** 0.20 MB
+- **Size of the generated dataset:** 1.59 MB
+- **Total amount of disk used:** 1.79 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 2011.main.RO
+
+- **Size of downloaded dataset files:** 0.21 MB
+- **Size of the generated dataset:** 1.66 MB
+- **Total amount of disk used:** 1.87 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### 2011.main.DE
+- `topic_id`: a `string` feature.
+- `topic_name`: a `string` feature.
+- `test_id`: a `string` feature.
+- `document_id`: a `string` feature.
+- `document_str`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_str`: a `string` feature.
+- `answer_options`: a dictionary feature containing:
+  - `answer_id`: a `string` feature.
+  - `answer_str`: a `string` feature.
+- `correct_answer_id`: a `string` feature.
+- `correct_answer_str`: a `string` feature.
+
+#### 2011.main.EN
+- `topic_id`: a `string` feature.
+- `topic_name`: a `string` feature.
+- `test_id`: a `string` feature.
+- `document_id`: a `string` feature.
+- `document_str`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_str`: a `string` feature.
+- `answer_options`: a dictionary feature containing:
+  - `answer_id`: a `string` feature.
+  - `answer_str`: a `string` feature.
+- `correct_answer_id`: a `string` feature.
+- `correct_answer_str`: a `string` feature.
+
+#### 2011.main.ES
+- `topic_id`: a `string` feature.
+- `topic_name`: a `string` feature.
+- `test_id`: a `string` feature.
+- `document_id`: a `string` feature.
+- `document_str`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_str`: a `string` feature.
+- `answer_options`: a dictionary feature containing:
+  - `answer_id`: a `string` feature.
+  - `answer_str`: a `string` feature.
+- `correct_answer_id`: a `string` feature.
+- `correct_answer_str`: a `string` feature.
+
+#### 2011.main.IT
+- `topic_id`: a `string` feature.
+- `topic_name`: a `string` feature.
+- `test_id`: a `string` feature.
+- `document_id`: a `string` feature.
+- `document_str`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_str`: a `string` feature.
+- `answer_options`: a dictionary feature containing:
+  - `answer_id`: a `string` feature.
+  - `answer_str`: a `string` feature.
+- `correct_answer_id`: a `string` feature.
+- `correct_answer_str`: a `string` feature.
+
+#### 2011.main.RO
+- `topic_id`: a `string` feature.
+- `topic_name`: a `string` feature.
+- `test_id`: a `string` feature.
+- `document_id`: a `string` feature.
+- `document_str`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_str`: a `string` feature.
+- `answer_options`: a dictionary feature containing:
+  - `answer_id`: a `string` feature.
+  - `answer_str`: a `string` feature.
+- `correct_answer_id`: a `string` feature.
+- `correct_answer_str`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|    name    |train|
+|------------|----:|
+|2011.main.DE|  120|
+|2011.main.EN|  120|
+|2011.main.ES|  120|
+|2011.main.IT|  120|
+|2011.main.RO|  120|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{10.1007/978-3-642-40802-1_29,
+author="Pe{\~{n}}as, Anselmo
+and Hovy, Eduard
+and Forner, Pamela
+and Rodrigo, {\'A}lvaro
+and Sutcliffe, Richard
+and Morante, Roser",
+editor="Forner, Pamela
+and M{\"u}ller, Henning
+and Paredes, Roberto
+and Rosso, Paolo
+and Stein, Benno",
+title="QA4MRE 2011-2013: Overview of Question Answering for Machine Reading Evaluation",
+booktitle="Information Access Evaluation. Multilinguality, Multimodality, and Visualization",
+year="2013",
+publisher="Springer Berlin Heidelberg",
+address="Berlin, Heidelberg",
+pages="303--320",
+abstract="This paper describes the methodology for testing the performance of Machine Reading systems through Question Answering and Reading Comprehension Tests. This was the attempt of the QA4MRE challenge which was run as a Lab at CLEF 2011--2013. The traditional QA task was replaced by a new Machine Reading task, whose intention was to ask questions that required a deep knowledge of individual short texts and in which systems were required to choose one answer, by analysing the corresponding test document in conjunction with background text collections provided by the organization. Four different tasks have been organized during these years: Main Task, Processing Modality and Negation for Machine Reading, Machine Reading of Biomedical Texts about Alzheimer's disease, and Entrance Exams. This paper describes their motivation, their goals, their methodology for preparing the data sets, their background collections, their metrics used for the evaluation, and the lessons learned along these three years.",
+isbn="978-3-642-40802-1"
+}
+
+```
+

--- a/datasets/qa_zre/README.md
+++ b/datasets/qa_zre/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "qa_zre"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://nlp.cs.washington.edu/zeroshot](http://nlp.cs.washington.edu/zeroshot)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 492.15 MB
+- **Size of the generated dataset:** 1989.22 MB
+- **Total amount of disk used:** 2481.37 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A dataset reducing relation extraction to simple reading comprehension questions
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 492.15 MB
+- **Size of the generated dataset:** 1989.22 MB
+- **Total amount of disk used:** 2481.37 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answers": [],
+    "context": "answer",
+    "question": "What is XXX in this question?",
+    "relation": "relation_name",
+    "subject": "Some entity Here is a bit of context which will explain the question in some way"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `relation`: a `string` feature.
+- `question`: a `string` feature.
+- `subject`: a `string` feature.
+- `context`: a `string` feature.
+- `answers`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train |validation| test |
+|-------|------:|---------:|-----:|
+|default|8400000|      6000|120000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{levy-etal-2017-zero,
+    title = "Zero-Shot Relation Extraction via Reading Comprehension",
+    author = "Levy, Omer  and
+      Seo, Minjoon  and
+      Choi, Eunsol  and
+      Zettlemoyer, Luke",
+    booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
+    month = aug,
+    year = "2017",
+    address = "Vancouver, Canada",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/K17-1034",
+    doi = "10.18653/v1/K17-1034",
+    pages = "333--342",
+}
+
+```
+

--- a/datasets/qangaroo/README.md
+++ b/datasets/qangaroo/README.md
@@ -1,0 +1,195 @@
+---
+---
+
+# Dataset Card for "qangaroo"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://qangaroo.cs.ucl.ac.uk/index.html](http://qangaroo.cs.ucl.ac.uk/index.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1296.40 MB
+- **Size of the generated dataset:** 936.40 MB
+- **Total amount of disk used:** 2232.79 MB
+
+### [Dataset Summary](#dataset-summary)
+
+  We have created two new Reading Comprehension datasets focussing on multi-hop (alias multi-step) inference.
+
+Several pieces of information often jointly imply another fact. In multi-hop inference, a new fact is derived by combining facts via a chain of multiple steps.
+
+Our aim is to build Reading Comprehension methods that perform multi-hop inference on text, where individual facts are spread out across different documents.
+
+The two QAngaroo datasets provide a training and evaluation resource for such methods.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### masked_medhop
+
+- **Size of downloaded dataset files:** 324.10 MB
+- **Size of the generated dataset:** 107.41 MB
+- **Total amount of disk used:** 431.51 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### masked_wikihop
+
+- **Size of downloaded dataset files:** 324.10 MB
+- **Size of the generated dataset:** 373.82 MB
+- **Total amount of disk used:** 697.92 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### medhop
+
+- **Size of downloaded dataset files:** 324.10 MB
+- **Size of the generated dataset:** 105.30 MB
+- **Total amount of disk used:** 429.40 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### wikihop
+
+- **Size of downloaded dataset files:** 324.10 MB
+- **Size of the generated dataset:** 349.87 MB
+- **Total amount of disk used:** 673.97 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### masked_medhop
+- `query`: a `string` feature.
+- `supports`: a `list` of `string` features.
+- `candidates`: a `list` of `string` features.
+- `answer`: a `string` feature.
+- `id`: a `string` feature.
+
+#### masked_wikihop
+- `query`: a `string` feature.
+- `supports`: a `list` of `string` features.
+- `candidates`: a `list` of `string` features.
+- `answer`: a `string` feature.
+- `id`: a `string` feature.
+
+#### medhop
+- `query`: a `string` feature.
+- `supports`: a `list` of `string` features.
+- `candidates`: a `list` of `string` features.
+- `answer`: a `string` feature.
+- `id`: a `string` feature.
+
+#### wikihop
+- `query`: a `string` feature.
+- `supports`: a `list` of `string` features.
+- `candidates`: a `list` of `string` features.
+- `answer`: a `string` feature.
+- `id`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|     name     |train|validation|
+|--------------|----:|---------:|
+|masked_medhop | 1620|       342|
+|masked_wikihop|43738|      5129|
+|medhop        | 1620|       342|
+|wikihop       |43738|      5129|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/qanta/README.md
+++ b/datasets/qanta/README.md
@@ -1,0 +1,181 @@
+---
+---
+
+# Dataset Card for "qanta"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.qanta.org/](http://www.qanta.org/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 162.84 MB
+- **Size of the generated dataset:** 140.36 MB
+- **Total amount of disk used:** 303.20 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Qanta dataset is a question answering dataset based on the academic trivia game Quizbowl.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### mode=first,char_skip=25
+
+- **Size of downloaded dataset files:** 162.84 MB
+- **Size of the generated dataset:** 140.36 MB
+- **Total amount of disk used:** 303.20 MB
+
+An example of 'guessdev' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": "Apollo_program",
+    "category": "History",
+    "char_idx": -1,
+    "dataset": "quizdb.org",
+    "difficulty": "easy_college",
+    "first_sentence": "As part of this program, William Anders took a photo that Galen Rowell called \"the most influential environmental photograph ever taken.\"",
+    "fold": "guessdev",
+    "full_question": "\"As part of this program, William Anders took a photo that Galen Rowell called \\\"the most influential environmental photograph e...",
+    "gameplay": false,
+    "id": "127028-first",
+    "page": "Apollo_program",
+    "proto_id": "",
+    "qanta_id": 127028,
+    "qdb_id": 126689,
+    "raw_answer": "Apollo program [or Project Apollo; accept Apollo 8; accept Apollo 1; accept Apollo 11; prompt on landing on the moon]",
+    "sentence_idx": -1,
+    "subcategory": "American",
+    "text": "As part of this program, William Anders took a photo that Galen Rowell called \"the most influential environmental photograph ever taken.\"",
+    "tokenizations": [[0, 137], [138, 281], [282, 412], [413, 592], [593, 675]],
+    "tournament": "ACF Fall",
+    "year": 2016
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### mode=first,char_skip=25
+- `id`: a `string` feature.
+- `qanta_id`: a `int32` feature.
+- `proto_id`: a `string` feature.
+- `qdb_id`: a `int32` feature.
+- `dataset`: a `string` feature.
+- `text`: a `string` feature.
+- `full_question`: a `string` feature.
+- `first_sentence`: a `string` feature.
+- `char_idx`: a `int32` feature.
+- `sentence_idx`: a `int32` feature.
+- `tokenizations`: a dictionary feature containing:
+  - `feature`: a `int32` feature.
+- `answer`: a `string` feature.
+- `page`: a `string` feature.
+- `raw_answer`: a `string` feature.
+- `fold`: a `string` feature.
+- `gameplay`: a `bool` feature.
+- `category`: a `string` feature.
+- `subcategory`: a `string` feature.
+- `tournament`: a `string` feature.
+- `difficulty`: a `string` feature.
+- `year`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|         name          |adversarial|buzzdev|buzztrain|guessdev|guesstrain|buzztest|guesstest|
+|-----------------------|----------:|------:|--------:|-------:|---------:|-------:|--------:|
+|mode=first,char_skip=25|       1145|   1161|    16706|    1055|     96221|    1953|     2151|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{Rodriguez2019QuizbowlTC,
+  title={Quizbowl: The Case for Incremental Question Answering},
+  author={Pedro Rodriguez and Shi Feng and Mohit Iyyer and He He and Jordan L. Boyd-Graber},
+  journal={ArXiv},
+  year={2019},
+  volume={abs/1904.04792}
+}
+
+```
+

--- a/datasets/qasc/README.md
+++ b/datasets/qasc/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "qasc"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/qasc](https://allenai.org/data/qasc)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.54 MB
+- **Size of the generated dataset:** 5.60 MB
+- **Total amount of disk used:** 7.14 MB
+
+### [Dataset Summary](#dataset-summary)
+
+QASC is a question-answering dataset with a focus on sentence composition. It consists of 9,980 8-way multiple-choice
+questions about grade school science (8,134 train, 926 dev, 920 test), and comes with a corpus of 17M sentences.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.54 MB
+- **Size of the generated dataset:** 5.60 MB
+- **Total amount of disk used:** 7.14 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answerKey": "F",
+    "choices": {
+        "label": ["A", "B", "C", "D", "E", "F", "G", "H"],
+        "text": ["sand", "occurs over a wide range", "forests", "Global warming", "rapid changes occur", "local weather conditions", "measure of motion", "city life"]
+    },
+    "combinedfact": "Climate is generally described in terms of local weather conditions",
+    "fact1": "Climate is generally described in terms of temperature and moisture.",
+    "fact2": "Fire behavior is driven by local weather conditions such as winds, temperature and moisture.",
+    "formatted_question": "Climate is generally described in terms of what? (A) sand (B) occurs over a wide range (C) forests (D) Global warming (E) rapid changes occur (F) local weather conditions (G) measure of motion (H) city life",
+    "id": "3NGI5ARFTT4HNGVWXAMLNBMFA0U1PG",
+    "question": "Climate is generally described in terms of what?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `answerKey`: a `string` feature.
+- `fact1`: a `string` feature.
+- `fact2`: a `string` feature.
+- `combinedfact`: a `string` feature.
+- `formatted_question`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 8134|       926| 920|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{allenai:qasc,
+      author    = {Tushar Khot and Peter Clark and Michal Guerquin and Peter Jansen and Ashish Sabharwal},
+      title     = {QASC: A Dataset for Question Answering via Sentence Composition},
+      journal   = {arXiv:1910.11473v2},
+      year      = {2020},
+}
+
+```
+

--- a/datasets/quail/README.md
+++ b/datasets/quail/README.md
@@ -1,0 +1,176 @@
+---
+---
+
+# Dataset Card for "quail"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://text-machine-lab.github.io/blog/2020/quail/](https://text-machine-lab.github.io/blog/2020/quail/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 6.11 MB
+- **Size of the generated dataset:** 28.25 MB
+- **Total amount of disk used:** 34.36 MB
+
+### [Dataset Summary](#dataset-summary)
+
+QuAIL is a  reading comprehension dataset. QuAIL contains 15K multi-choice questions in texts 300-350 tokens long 4 domains (news, user stories, fiction, blogs).QuAIL is balanced and annotated for question types.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### quail
+
+- **Size of downloaded dataset files:** 6.11 MB
+- **Size of the generated dataset:** 28.25 MB
+- **Total amount of disk used:** 34.36 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": ["the cousin is not friendly", "the cousin could have been pretier", "not enough information", "the cousin was too nice"],
+    "context": "\"That fall came and I went back to Michigan and the school year went by and summer came and I never really thought about it. I'm...",
+    "context_id": "f001",
+    "correct_answer_id": 0,
+    "domain": "fiction",
+    "id": "f001_19",
+    "metadata": {
+        "author": "Joseph Devon",
+        "title": "Black Eyed Susan",
+        "url": "http://manybooks.net/pages/devonjother08black_eyed_susan/0.html"
+    },
+    "question": "After the events in the text what does the author think about the cousin?",
+    "question_id": "19",
+    "question_type": "Subsequent_state"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### quail
+- `id`: a `string` feature.
+- `context_id`: a `string` feature.
+- `question_id`: a `string` feature.
+- `domain`: a `string` feature.
+- `author`: a `string` feature.
+- `title`: a `string` feature.
+- `url`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `question_type`: a `string` feature.
+- `answers`: a `list` of `string` features.
+- `correct_answer_id`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train|challenge|validation|
+|-----|----:|--------:|---------:|
+|quail|10246|      556|      2164|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{DBLP:conf/aaai/RogersKDR20,
+  author    = {Anna Rogers and
+               Olga Kovaleva and
+               Matthew Downey and
+               Anna Rumshisky},
+  title     = {Getting Closer to {AI} Complete Question Answering: {A} Set of Prerequisite
+               Real Tasks},
+  booktitle = {The Thirty-Fourth {AAAI} Conference on Artificial Intelligence, {AAAI}
+               2020, The Thirty-Second Innovative Applications of Artificial Intelligence
+               Conference, {IAAI} 2020, The Tenth {AAAI} Symposium on Educational
+               Advances in Artificial Intelligence, {EAAI} 2020, New York, NY, USA,
+               February 7-12, 2020},
+  pages     = {8722--8731},
+  publisher = {{AAAI} Press},
+  year      = {2020},
+  url       = {https://aaai.org/ojs/index.php/AAAI/article/view/6398},
+  timestamp = {Thu, 04 Jun 2020 13:18:48 +0200},
+  biburl    = {https://dblp.org/rec/conf/aaai/RogersKDR20.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+```
+

--- a/datasets/quarel/README.md
+++ b/datasets/quarel/README.md
@@ -1,0 +1,151 @@
+---
+---
+
+# Dataset Card for "quarel"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/quarel](https://allenai.org/data/quarel)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.60 MB
+- **Size of the generated dataset:** 1.46 MB
+- **Total amount of disk used:** 2.07 MB
+
+### [Dataset Summary](#dataset-summary)
+
+QuaRel is a crowdsourced dataset of 2771 multiple-choice story questions, including their logical forms.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.60 MB
+- **Size of the generated dataset:** 1.46 MB
+- **Total amount of disk used:** 2.07 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answer_index": 0,
+    "id": "QuaRel_V1_B5_1403",
+    "logical_form_pretty": "qrel(time, lower, world1) -> qrel(distance, higher, world2) ; qrel(distance, higher, world1)",
+    "logical_forms": ["(infer (time lower world1) (distance higher world2) (distance higher world1))", "(infer (time lower world2) (distance higher world1) (distance higher world2))"],
+    "question": "John and Rita are going for a run.  Rita gets tired and takes a break on the park bench.  After twenty minutes in the park, who has run farther? (A) John (B) Rita",
+    "world_literals": {
+        "world1": ["Rita"],
+        "world2": ["John"]
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `answer_index`: a `int32` feature.
+- `logical_forms`: a `list` of `string` features.
+- `logical_form_pretty`: a `string` feature.
+- `world_literals`: a dictionary feature containing:
+  - `world1`: a `string` feature.
+  - `world2`: a `string` feature.
+- `question`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 1941|       278| 552|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{quarel_v1,
+    title={QuaRel: A Dataset and Models for Answering Questions about Qualitative Relationships},
+    author={Oyvind Tafjord, Peter Clark, Matt Gardner, Wen-tau Yih, Ashish Sabharwal},
+    year={2018},
+    journal={arXiv:1805.05377v1}
+}
+
+```
+

--- a/datasets/quartz/README.md
+++ b/datasets/quartz/README.md
@@ -1,0 +1,185 @@
+---
+---
+
+# Dataset Card for "quartz"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/quartz](https://allenai.org/data/quartz)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.47 MB
+- **Size of the generated dataset:** 1.64 MB
+- **Total amount of disk used:** 2.12 MB
+
+### [Dataset Summary](#dataset-summary)
+
+QuaRTz is a crowdsourced dataset of 3864 multiple-choice questions about open domain qualitative relationships. Each
+question is paired with one of 405 different background sentences (sometimes short paragraphs).
+The QuaRTz dataset V1 contains 3864 questions about open domain qualitative relationships. Each question is paired with
+one of 405 different background sentences (sometimes short paragraphs).
+
+The dataset is split into train (2696), dev (384) and test (784). A background sentence will only appear in a single split.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.47 MB
+- **Size of the generated dataset:** 1.64 MB
+- **Total amount of disk used:** 2.12 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answerKey": "A",
+    "choices": {
+        "label": ["A", "B"],
+        "text": ["higher", "lower"]
+    },
+    "id": "QRQA-10116-3",
+    "para": "Electrons at lower energy levels, which are closer to the nucleus, have less energy.",
+    "para_anno": {
+        "cause_dir_sign": "LESS",
+        "cause_dir_str": "closer",
+        "cause_prop": "distance from a nucleus",
+        "effect_dir_sign": "LESS",
+        "effect_dir_str": "less",
+        "effect_prop": "energy"
+    },
+    "para_id": "QRSent-10116",
+    "question": "Electrons further away from a nucleus have _____ energy levels than close ones.",
+    "question_anno": {
+        "less_cause_dir": "electron energy levels",
+        "less_cause_prop": "nucleus",
+        "less_effect_dir": "lower",
+        "less_effect_prop": "electron energy levels",
+        "more_effect_dir": "higher",
+        "more_effect_prop": "electron energy levels"
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `answerKey`: a `string` feature.
+- `para`: a `string` feature.
+- `para_id`: a `string` feature.
+- `effect_prop`: a `string` feature.
+- `cause_dir_str`: a `string` feature.
+- `effect_dir_str`: a `string` feature.
+- `cause_dir_sign`: a `string` feature.
+- `effect_dir_sign`: a `string` feature.
+- `cause_prop`: a `string` feature.
+- `more_effect_dir`: a `string` feature.
+- `less_effect_dir`: a `string` feature.
+- `less_cause_prop`: a `string` feature.
+- `more_effect_prop`: a `string` feature.
+- `less_effect_prop`: a `string` feature.
+- `less_cause_dir`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 2696|       384| 784|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{quartz,
+  author = {Oyvind Tafjord and Matt Gardner and Kevin Lin and Peter Clark},
+  title = {"QUARTZ: An Open-Domain Dataset of Qualitative Relationship
+Questions"},
+
+  year = {"2019"},
+}
+
+```
+

--- a/datasets/quora/README.md
+++ b/datasets/quora/README.md
@@ -1,0 +1,137 @@
+---
+---
+
+# Dataset Card for "quora"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.kaggle.com/c/quora-question-pairs](https://www.kaggle.com/c/quora-question-pairs)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 55.48 MB
+- **Size of the generated dataset:** 55.46 MB
+- **Total amount of disk used:** 110.94 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Quora dataset is composed of question pairs, and the task is to determine if the questions are paraphrases of each other (have the same meaning).
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 55.48 MB
+- **Size of the generated dataset:** 55.46 MB
+- **Total amount of disk used:** 110.94 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "is_duplicate": true,
+    "questions": {
+        "id": [1, 2],
+        "text": ["Is this a sample question?", "Is this an example question?"]
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `questions`: a dictionary feature containing:
+  - `id`: a `int32` feature.
+  - `text`: a `string` feature.
+- `is_duplicate`: a `bool` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |
+|-------|-----:|
+|default|404290|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/quoref/README.md
+++ b/datasets/quoref/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "quoref"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://leaderboard.allenai.org/quoref/submissions/get-started](https://leaderboard.allenai.org/quoref/submissions/get-started)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 4.84 MB
+- **Size of the generated dataset:** 47.51 MB
+- **Total amount of disk used:** 52.36 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Quoref is a QA dataset which tests the coreferential reasoning capability of reading comprehension systems. In this
+span-selection benchmark containing 24K questions over 4.7K paragraphs from Wikipedia, a system must resolve hard
+coreferences before selecting the appropriate span(s) in the paragraphs for answering questions.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 4.84 MB
+- **Size of the generated dataset:** 47.51 MB
+- **Total amount of disk used:** 52.36 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [1633],
+        "text": ["Frankie"]
+    },
+    "context": "\"Frankie Bono, a mentally disturbed hitman from Cleveland, comes back to his hometown in New York City during Christmas week to ...",
+    "id": "bfc3b34d6b7e73c0bd82a009db12e9ce196b53e6",
+    "question": "What is the first name of the person who has until New Year's Eve to perform a hit?",
+    "title": "Blast of Silence",
+    "url": "https://en.wikipedia.org/wiki/Blast_of_Silence"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `question`: a `string` feature.
+- `context`: a `string` feature.
+- `title`: a `string` feature.
+- `url`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default|19399|      2418|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{allenai:quoref,
+      author    = {Pradeep Dasigi and Nelson F. Liu and Ana Marasovic and Noah A. Smith and  Matt Gardner},
+      title     = {Quoref: A Reading Comprehension Dataset with Questions Requiring Coreferential Reasoning},
+      journal   = {arXiv:1908.05803v2 },
+      year      = {2019},
+}
+
+```
+

--- a/datasets/race/README.md
+++ b/datasets/race/README.md
@@ -1,0 +1,202 @@
+---
+---
+
+# Dataset Card for "race"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.cs.cmu.edu/~glai1/data/race/](http://www.cs.cmu.edu/~glai1/data/race/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 72.79 MB
+- **Size of the generated dataset:** 333.27 MB
+- **Total amount of disk used:** 406.07 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Race is a large-scale reading comprehension dataset with more than 28,000 passages and nearly 100,000 questions. The
+ dataset is collected from English examinations in China, which are designed for middle school and high school students.
+The dataset can be served as the training and test sets for machine comprehension.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### all
+
+- **Size of downloaded dataset files:** 24.26 MB
+- **Size of the generated dataset:** 166.64 MB
+- **Total amount of disk used:** 190.90 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": "A",
+    "article": "\"Schoolgirls have been wearing such short skirts at Paget High School in Branston that they've been ordered to wear trousers ins...",
+    "example_id": "high132.txt",
+    "options": ["short skirts give people the impression of sexualisation", "short skirts are too expensive for parents to afford", "the headmaster doesn't like girls wearing short skirts", "the girls wearing short skirts will be at the risk of being laughed at"],
+    "question": "The girls at Paget High School are not allowed to wear skirts in that    _  ."
+}
+```
+
+#### high
+
+- **Size of downloaded dataset files:** 24.26 MB
+- **Size of the generated dataset:** 133.63 MB
+- **Total amount of disk used:** 157.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": "A",
+    "article": "\"Schoolgirls have been wearing such short skirts at Paget High School in Branston that they've been ordered to wear trousers ins...",
+    "example_id": "high132.txt",
+    "options": ["short skirts give people the impression of sexualisation", "short skirts are too expensive for parents to afford", "the headmaster doesn't like girls wearing short skirts", "the girls wearing short skirts will be at the risk of being laughed at"],
+    "question": "The girls at Paget High School are not allowed to wear skirts in that    _  ."
+}
+```
+
+#### middle
+
+- **Size of downloaded dataset files:** 24.26 MB
+- **Size of the generated dataset:** 33.01 MB
+- **Total amount of disk used:** 57.27 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answer": "B",
+    "article": "\"There is not enough oil in the world now. As time goes by, it becomes less and less, so what are we going to do when it runs ou...",
+    "example_id": "middle3.txt",
+    "options": ["There is more petroleum than we can use now.", "Trees are needed for some other things besides making gas.", "We got electricity from ocean tides in the old days.", "Gas wasn't used to run cars in the Second World War."],
+    "question": "According to the passage, which of the following statements is TRUE?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### all
+- `example_id`: a `string` feature.
+- `article`: a `string` feature.
+- `answer`: a `string` feature.
+- `question`: a `string` feature.
+- `options`: a `list` of `string` features.
+
+#### high
+- `example_id`: a `string` feature.
+- `article`: a `string` feature.
+- `answer`: a `string` feature.
+- `question`: a `string` feature.
+- `options`: a `list` of `string` features.
+
+#### middle
+- `example_id`: a `string` feature.
+- `article`: a `string` feature.
+- `answer`: a `string` feature.
+- `question`: a `string` feature.
+- `options`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name |train|validation|test|
+|------|----:|---------:|---:|
+|all   |87866|      4887|4934|
+|high  |62445|      3451|3498|
+|middle|25421|      1436|1436|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{lai2017large,
+    title={RACE: Large-scale ReAding Comprehension Dataset From Examinations},
+    author={Lai, Guokun and Xie, Qizhe and Liu, Hanxiao and Yang, Yiming and Hovy, Eduard},
+    journal={arXiv preprint arXiv:1704.04683},
+    year={2017}
+}
+
+```
+

--- a/datasets/reddit/README.md
+++ b/datasets/reddit/README.md
@@ -1,0 +1,166 @@
+---
+---
+
+# Dataset Card for "reddit"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/webis-de/webis-tldr-17-corpus](https://github.com/webis-de/webis-tldr-17-corpus)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2996.31 MB
+- **Size of the generated dataset:** 18063.11 MB
+- **Total amount of disk used:** 21059.41 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This corpus contains preprocessed posts from the Reddit dataset.
+The dataset consists of 3,848,330 posts with an average length of 270 words for content,
+and 28 words for the summary.
+
+Features includes strings: author, body, normalizedBody, content, summary, subreddit, subreddit_id.
+Content is used as document and summary is used as summary.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 2996.31 MB
+- **Size of the generated dataset:** 18063.11 MB
+- **Total amount of disk used:** 21059.41 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "author": "me",
+    "body": "<>",
+    "content": "input document.",
+    "id": "1",
+    "normalizedBody": "",
+    "subreddit": "machinelearning",
+    "subreddit_id": "2",
+    "summary": "output summary."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `author`: a `string` feature.
+- `body`: a `string` feature.
+- `normalizedBody`: a `string` feature.
+- `subreddit`: a `string` feature.
+- `subreddit_id`: a `string` feature.
+- `id`: a `string` feature.
+- `content`: a `string` feature.
+- `summary`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  | train |
+|-------|------:|
+|default|3848330|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{volske-etal-2017-tl,
+    title = "{TL};{DR}: Mining {R}eddit to Learn Automatic Summarization",
+    author = {V{"o}lske, Michael  and
+      Potthast, Martin  and
+      Syed, Shahbaz  and
+      Stein, Benno},
+    booktitle = "Proceedings of the Workshop on New Frontiers in Summarization",
+    month = sep,
+    year = "2017",
+    address = "Copenhagen, Denmark",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W17-4508",
+    doi = "10.18653/v1/W17-4508",
+    pages = "59--63",
+    abstract = "Recent advances in automatic text summarization have used deep neural networks to generate high-quality abstractive summaries, but the performance of these models strongly depends on large amounts of suitable training data. We propose a new method for mining social media for author-provided summaries, taking advantage of the common practice of appending a {``}TL;DR{''} to long posts. A case study using a large Reddit crawl yields the Webis-TLDR-17 dataset, complementing existing corpora primarily from the news genre. Our technique is likely applicable to other social media sites and general web crawls.",
+}
+
+```
+

--- a/datasets/reddit_tifu/README.md
+++ b/datasets/reddit_tifu/README.md
@@ -1,0 +1,175 @@
+---
+---
+
+# Dataset Card for "reddit_tifu"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/ctr4si/MMN](https://github.com/ctr4si/MMN)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1279.08 MB
+- **Size of the generated dataset:** 219.12 MB
+- **Total amount of disk used:** 1498.20 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Reddit dataset, where TIFU denotes the name of subbreddit /r/tifu.
+As defined in the publication, styel "short" uses title as summary and
+"long" uses tldr as summary.
+
+Features includes:
+  - document: post text without tldr.
+  - tldr: tldr line.
+  - title: trimmed title without tldr.
+  - ups: upvotes.
+  - score: score.
+  - num_comments: number of comments.
+  - upvote_ratio: upvote ratio.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### long
+
+- **Size of downloaded dataset files:** 639.54 MB
+- **Size of the generated dataset:** 87.74 MB
+- **Total amount of disk used:** 727.29 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### short
+
+- **Size of downloaded dataset files:** 639.54 MB
+- **Size of the generated dataset:** 131.37 MB
+- **Total amount of disk used:** 770.92 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### long
+- `ups`: a `float32` feature.
+- `num_comments`: a `float32` feature.
+- `upvote_ratio`: a `float32` feature.
+- `score`: a `float32` feature.
+- `documents`: a `string` feature.
+- `tldr`: a `string` feature.
+- `title`: a `string` feature.
+
+#### short
+- `ups`: a `float32` feature.
+- `num_comments`: a `float32` feature.
+- `upvote_ratio`: a `float32` feature.
+- `score`: a `float32` feature.
+- `documents`: a `string` feature.
+- `tldr`: a `string` feature.
+- `title`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train|
+|-----|----:|
+|long |42139|
+|short|79740|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{kim2018abstractive,
+    title={Abstractive Summarization of Reddit Posts with Multi-level Memory Networks},
+    author={Byeongchang Kim and Hyunwoo Kim and Gunhee Kim},
+    year={2018},
+    eprint={1811.00783},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/reuters21578/README.md
+++ b/datasets/reuters21578/README.md
@@ -1,0 +1,398 @@
+---
+---
+
+# Dataset Card for "reuters21578"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.html](https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 23.32 MB
+- **Size of the generated dataset:** 49.80 MB
+- **Total amount of disk used:** 73.12 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Reuters-21578 dataset  is one of the most widely used data collections for text
+categorization research. It is collected from the Reuters financial newswire service in 1987.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### ModApte
+
+- **Size of downloaded dataset files:** 7.77 MB
+- **Size of the generated dataset:** 12.45 MB
+- **Total amount of disk used:** 20.23 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "cgis_split": "\"TRAINING-SET\"",
+    "date": "19-MAR-1987 06:17:22.36",
+    "exchanges": [],
+    "lewis_split": "\"TRAIN\"",
+    "new_id": "\"7001\"",
+    "old_id": "\"11914\"",
+    "orgs": [],
+    "people": [],
+    "places": ["australia"],
+    "text": "\"Media group John Fairfax Ltd &lt;FFXA.S>\\nsaid that its flat first half net profit partly reflected the\\nimpact of changes in t...",
+    "title": "FAIRFAX SAYS HIGHER TAX HITS FIRST HALF EARNINGS",
+    "topics": ["earn"]
+}
+```
+
+#### ModHayes
+
+- **Size of downloaded dataset files:** 7.77 MB
+- **Size of the generated dataset:** 18.87 MB
+- **Total amount of disk used:** 26.64 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "cgis_split": "\"TRAINING-SET\"",
+    "date": "19-OCT-1987 23:49:31.45",
+    "exchanges": [],
+    "lewis_split": "\"TEST\"",
+    "new_id": "\"20001\"",
+    "old_id": "\"20596\"",
+    "orgs": [],
+    "people": [],
+    "places": ["japan", "usa"],
+    "text": "\"If the dollar goes the way of Wall Street,\\nJapanese will finally move out of dollar investments in a\\nserious way, Japan inves...",
+    "title": "IF DOLLAR FOLLOWS WALL STREET JAPANESE WILL DIVEST",
+    "topics": ["money-fx"]
+}
+```
+
+#### ModLewis
+
+- **Size of downloaded dataset files:** 7.77 MB
+- **Size of the generated dataset:** 18.48 MB
+- **Total amount of disk used:** 26.26 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "cgis_split": "\"TRAINING-SET\"",
+    "date": "19-MAR-1987 06:17:22.36",
+    "exchanges": [],
+    "lewis_split": "\"TRAIN\"",
+    "new_id": "\"7001\"",
+    "old_id": "\"11914\"",
+    "orgs": [],
+    "people": [],
+    "places": ["australia"],
+    "text": "\"Media group John Fairfax Ltd &lt;FFXA.S>\\nsaid that its flat first half net profit partly reflected the\\nimpact of changes in t...",
+    "title": "FAIRFAX SAYS HIGHER TAX HITS FIRST HALF EARNINGS",
+    "topics": ["earn"]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### ModApte
+- `text`: a `string` feature.
+- `topics`: a `list` of `string` features.
+- `lewis_split`: a `string` feature.
+- `cgis_split`: a `string` feature.
+- `old_id`: a `string` feature.
+- `new_id`: a `string` feature.
+- `places`: a `list` of `string` features.
+- `people`: a `list` of `string` features.
+- `orgs`: a `list` of `string` features.
+- `exchanges`: a `list` of `string` features.
+- `date`: a `string` feature.
+- `title`: a `string` feature.
+
+#### ModHayes
+- `text`: a `string` feature.
+- `topics`: a `list` of `string` features.
+- `lewis_split`: a `string` feature.
+- `cgis_split`: a `string` feature.
+- `old_id`: a `string` feature.
+- `new_id`: a `string` feature.
+- `places`: a `list` of `string` features.
+- `people`: a `list` of `string` features.
+- `orgs`: a `list` of `string` features.
+- `exchanges`: a `list` of `string` features.
+- `date`: a `string` feature.
+- `title`: a `string` feature.
+
+#### ModLewis
+- `text`: a `string` feature.
+- `topics`: a `list` of `string` features.
+- `lewis_split`: a `string` feature.
+- `cgis_split`: a `string` feature.
+- `old_id`: a `string` feature.
+- `new_id`: a `string` feature.
+- `places`: a `list` of `string` features.
+- `people`: a `list` of `string` features.
+- `orgs`: a `list` of `string` features.
+- `exchanges`: a `list` of `string` features.
+- `date`: a `string` feature.
+- `title`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### ModApte
+
+|       |train|unused|test|
+|-------|----:|-----:|---:|
+|ModApte| 8762|   720|3009|
+
+#### ModHayes
+
+|        |train|test|
+|--------|----:|---:|
+|ModHayes|18323| 720|
+
+#### ModLewis
+
+|        |train|unused|test|
+|--------|----:|-----:|---:|
+|ModLewis|12449|   720|5458|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{APTE94,
+author = {Chidanand Apt{'{e}} and Fred Damerau and Sholom M. Weiss},
+title = {Automated Learning of Decision Rules for Text Categorization},
+journal = {ACM Transactions on Information Systems},
+year = {1994},
+note = {To appear.}
+}
+
+@inproceedings{APTE94b,
+author = {Chidanand Apt{'{e}} and Fred Damerau and Sholom M. Weiss},
+title = {Toward Language Independent Automated Learning of Text Categorization Models},
+booktitle = {sigir94},
+year = {1994},
+note = {To appear.}
+}
+
+@inproceedings{HAYES8},
+author = {Philip J. Hayes and Peggy M. Anderson and Irene B. Nirenburg and
+Linda M. Schmandt},
+title = {{TCS}: A Shell for Content-Based Text Categorization},
+booktitle = {IEEE Conference on Artificial Intelligence Applications},
+year = {1990}
+}
+
+@inproceedings{HAYES90b,
+author = {Philip J. Hayes and Steven P. Weinstein},
+title = {{CONSTRUE/TIS:} A System for Content-Based Indexing of a
+Database of News Stories},
+booktitle = {Second Annual Conference on Innovative Applications of
+Artificial Intelligence},
+year = {1990}
+}
+
+@incollection{HAYES92 ,
+author = {Philip J. Hayes},
+title = {Intelligent High-Volume Text Processing using Shallow,
+Domain-Specific Techniques},
+booktitle = {Text-Based Intelligent Systems},
+publisher = {Lawrence Erlbaum},
+address =  {Hillsdale, NJ},
+year = {1992},
+editor = {Paul S. Jacobs}
+}
+
+@inproceedings{LEWIS91c ,
+author = {David D. Lewis},
+title = {Evaluating Text Categorization},
+booktitle = {Proceedings of Speech and Natural Language Workshop},
+year = {1991},
+month = {feb},
+organization = {Defense Advanced Research Projects Agency},
+publisher = {Morgan Kaufmann},
+pages = {312--318}
+
+}
+
+@phdthesis{LEWIS91d,
+author = {David Dolan Lewis},
+title = {Representation and Learning in Information Retrieval},
+school = {Computer Science Dept.; Univ. of Massachusetts; Amherst, MA 01003},
+year = 1992},
+note = {Technical Report 91--93.}
+}
+
+@inproceedings{LEWIS91e,
+author = {David D. Lewis},
+title = {Data Extraction as Text Categorization: An Experiment with
+the {MUC-3} Corpus},
+booktitle = {Proceedings of the Third Message Understanding Evaluation
+and Conference},
+year = {1991},
+month = {may},
+organization = {Defense Advanced Research Projects Agency},
+publisher = {Morgan Kaufmann},
+address = {Los Altos, CA}
+
+}
+
+@inproceedings{LEWIS92b,
+author = {David D. Lewis},
+title = {An Evaluation of Phrasal and Clustered Representations on a Text
+Categorization Task},
+booktitle = {Fifteenth Annual International ACM SIGIR Conference on
+Research and Development in Information Retrieval},
+year = {1992},
+pages = {37--50}
+}
+
+@inproceedings{LEWIS92d ,
+author = {David D. Lewis and Richard M. Tong},
+title = {Text Filtering in {MUC-3} and {MUC-4}},
+booktitle = {Proceedings of the Fourth Message Understanding Conference ({MUC-4})},
+year = {1992},
+month = {jun},
+organization = {Defense Advanced Research Projects Agency},
+publisher = {Morgan Kaufmann},
+address = {Los Altos, CA}
+}
+
+@inproceedings{LEWIS92e,
+author = {David D. Lewis},
+title = {Feature Selection and Feature Extraction for Text Categorization},
+booktitle = {Proceedings of Speech and Natural Language Workshop},
+year = {1992},
+month = {feb} ,
+organization = {Defense Advanced Research Projects Agency},
+publisher = {Morgan Kaufmann},
+pages = {212--217}
+}
+
+@inproceedings{LEWIS94b,
+author = {David D. Lewis and Marc Ringuette},
+title = {A Comparison of Two Learning Algorithms for Text Categorization},
+booktitle = {Symposium on Document Analysis and Information Retrieval},
+year = {1994},
+organization = {ISRI; Univ. of Nevada, Las Vegas},
+address = {Las Vegas, NV},
+month = {apr},
+pages = {81--93}
+}
+
+@article{LEWIS94d,
+author = {David D. Lewis and Philip J. Hayes},
+title = {Guest Editorial},
+journal = {ACM Transactions on Information Systems},
+year = {1994},
+volume  = {12},
+number  = {3},
+pages = {231},
+month = {jul}
+}
+
+@article{SPARCKJONES76,
+author = {K. {Sparck Jones} and  C. J. {van Rijsbergen}},
+title =  {Information Retrieval Test Collections},
+journal = {Journal of Documentation},
+year = {1976},
+volume = {32},
+number = {1},
+pages = {59--75}
+}
+
+@book{WEISS91,
+author = {Sholom M. Weiss and Casimir A. Kulikowski},
+title = {Computer Systems That Learn},
+publisher = {Morgan Kaufmann},
+year = {1991},
+address = {San Mateo, CA}
+}
+
+```
+

--- a/datasets/rotten_tomatoes/README.md
+++ b/datasets/rotten_tomatoes/README.md
@@ -1,0 +1,144 @@
+---
+---
+
+# Dataset Card for "rotten_tomatoes"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.cs.cornell.edu/people/pabo/movie-review-data/](http://www.cs.cornell.edu/people/pabo/movie-review-data/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.47 MB
+- **Size of the generated dataset:** 1.28 MB
+- **Total amount of disk used:** 1.75 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Movie Review Dataset.
+This is a dataset of containing 5,331 positive and 5,331 negative processed
+sentences from Rotten Tomatoes movie reviews. This data was first used in Bo
+Pang and Lillian Lee, ``Seeing stars: Exploiting class relationships for
+sentiment categorization with respect to rating scales.'', Proceedings of the
+ACL, 2005.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.47 MB
+- **Size of the generated dataset:** 1.28 MB
+- **Total amount of disk used:** 1.75 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "label": 1,
+    "text": "Sometimes the days and nights just drag on-- it's the morning that make me feel alive. And I have one thing to thank for that: pancakes."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `neg` (0), `pos` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 8530|      1066|1066|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{Pang+Lee:05a,
+  author =       {Bo Pang and Lillian Lee},
+  title =        {Seeing stars: Exploiting class relationships for sentiment
+                  categorization with respect to rating scales},
+  booktitle =    {Proceedings of the ACL},
+  year =         2005
+}
+
+```
+

--- a/datasets/saudinewsnet/README.md
+++ b/datasets/saudinewsnet/README.md
@@ -1,0 +1,148 @@
+---
+---
+
+# Dataset Card for "saudinewsnet"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/parallelfold/SaudiNewsNet](https://github.com/parallelfold/SaudiNewsNet)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 27.67 MB
+- **Size of the generated dataset:** 98.85 MB
+- **Total amount of disk used:** 126.52 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The dataset contains a set of 31,030 Arabic newspaper articles alongwith metadata, extracted from various online Saudi newspapers and written in MSA.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 27.67 MB
+- **Size of the generated dataset:** 98.85 MB
+- **Total amount of disk used:** 126.52 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "author": "الرياض: محمد الحميدي",
+    "content": "\"في وقت تتهيأ فيه السعودية لإطلاق الإصدار الثاني من العملات المعدنية، لا تزال التداول بمبالغ النقود المصنوعة من المعدن مستقرة عن...",
+    "date_extracted": "2015-07-22 01:18:37",
+    "source": "aawsat",
+    "title": "\"«العملة المعدنية» السعودية تسجل انحسارًا تاريخيًا وسط تهيؤ لإطلاق الإصدار الثاني\"...",
+    "url": "\"http://aawsat.com/home/article/411671/«العملة-المعدنية»-السعودية-تسجل-انحسارًا-تاريخيًا-وسط-تهيؤ-لإطلاق-الإصدار-الثاني\"..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `source`: a `string` feature.
+- `url`: a `string` feature.
+- `date_extracted`: a `string` feature.
+- `title`: a `string` feature.
+- `author`: a `string` feature.
+- `content`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|
+|-------|----:|
+|default|31030|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc{hagrima2015,
+author = "M. Alhagri",
+title = "Saudi Newspapers Arabic Corpus (SaudiNewsNet)",
+year = 2015,
+url = "http://github.com/ParallelMazen/SaudiNewsNet"
+}
+
+```
+

--- a/datasets/scan/README.md
+++ b/datasets/scan/README.md
@@ -1,0 +1,210 @@
+---
+---
+
+# Dataset Card for "scan"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/brendenlake/SCAN](https://github.com/brendenlake/SCAN)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 213.79 MB
+- **Size of the generated dataset:** 42.47 MB
+- **Total amount of disk used:** 256.26 MB
+
+### [Dataset Summary](#dataset-summary)
+
+SCAN tasks with various splits.
+
+SCAN is a set of simple language-driven navigation tasks for studying
+compositional learning and zero-shot generalization.
+
+See https://github.com/brendenlake/SCAN for a description of the splits.
+
+Example usage:
+data = datasets.load_dataset('scan/length')
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### addprim_jump
+
+- **Size of downloaded dataset files:** 17.82 MB
+- **Size of the generated dataset:** 3.86 MB
+- **Total amount of disk used:** 21.68 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### addprim_turn_left
+
+- **Size of downloaded dataset files:** 17.82 MB
+- **Size of the generated dataset:** 3.90 MB
+- **Total amount of disk used:** 21.71 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### filler_num0
+
+- **Size of downloaded dataset files:** 17.82 MB
+- **Size of the generated dataset:** 2.72 MB
+- **Total amount of disk used:** 20.53 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### filler_num1
+
+- **Size of downloaded dataset files:** 17.82 MB
+- **Size of the generated dataset:** 2.99 MB
+- **Total amount of disk used:** 20.81 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### filler_num2
+
+- **Size of downloaded dataset files:** 17.82 MB
+- **Size of the generated dataset:** 3.28 MB
+- **Total amount of disk used:** 21.10 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### addprim_jump
+- `commands`: a `string` feature.
+- `actions`: a `string` feature.
+
+#### addprim_turn_left
+- `commands`: a `string` feature.
+- `actions`: a `string` feature.
+
+#### filler_num0
+- `commands`: a `string` feature.
+- `actions`: a `string` feature.
+
+#### filler_num1
+- `commands`: a `string` feature.
+- `actions`: a `string` feature.
+
+#### filler_num2
+- `commands`: a `string` feature.
+- `actions`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|      name       |train|test|
+|-----------------|----:|---:|
+|addprim_jump     |14670|7706|
+|addprim_turn_left|21890|1208|
+|filler_num0      |15225|1173|
+|filler_num1      |16290|1173|
+|filler_num2      |17391|1173|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{Lake2018GeneralizationWS,
+  title={Generalization without Systematicity: On the Compositional Skills of
+         Sequence-to-Sequence Recurrent Networks},
+  author={Brenden M. Lake and Marco Baroni},
+  booktitle={ICML},
+  year={2018},
+  url={https://arxiv.org/pdf/1711.00350.pdf},
+}
+
+```
+

--- a/datasets/scicite/README.md
+++ b/datasets/scicite/README.md
@@ -1,0 +1,178 @@
+---
+---
+
+# Dataset Card for "scicite"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/allenai/scicite](https://github.com/allenai/scicite)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 22.12 MB
+- **Size of the generated dataset:** 4.91 MB
+- **Total amount of disk used:** 27.02 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This is a dataset for classifying citation intents in academic papers.
+The main citation intent label for each Json object is specified with the label
+key while the citation context is specified in with a context key. Example:
+{
+ 'string': 'In chacma baboons, male-infant relationships can be linked to both
+    formation of friendships and paternity success [30,31].'
+ 'sectionName': 'Introduction',
+ 'label': 'background',
+ 'citingPaperId': '7a6b2d4b405439',
+ 'citedPaperId': '9d1abadc55b5e0',
+ ...
+ }
+You may obtain the full information about the paper using the provided paper ids
+with the Semantic Scholar API (https://api.semanticscholar.org/).
+The labels are:
+Method, Background, Result
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 22.12 MB
+- **Size of the generated dataset:** 4.91 MB
+- **Total amount of disk used:** 27.02 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "citeEnd": 68,
+    "citeStart": 64,
+    "citedPaperId": "5e413c7872f5df231bf4a4f694504384560e98ca",
+    "citingPaperId": "8f1fbe460a901d994e9b81d69f77bfbe32719f4c",
+    "excerpt_index": 0,
+    "id": "8f1fbe460a901d994e9b81d69f77bfbe32719f4c>5e413c7872f5df231bf4a4f694504384560e98ca",
+    "isKeyCitation": false,
+    "label": 2,
+    "label2": 0,
+    "label2_confidence": 0.0,
+    "label_confidence": 0.0,
+    "sectionName": "Discussion",
+    "source": 4,
+    "string": "These results are in contrast with the findings of Santos et al.(16), who reported a significant association between low sedentary time and healthy CVF among Portuguese"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `string`: a `string` feature.
+- `sectionName`: a `string` feature.
+- `label`: a classification label, with possible values including `method` (0), `background` (1), `result` (2).
+- `citingPaperId`: a `string` feature.
+- `citedPaperId`: a `string` feature.
+- `excerpt_index`: a `int32` feature.
+- `isKeyCitation`: a `bool` feature.
+- `label2`: a classification label, with possible values including `supportive` (0), `not_supportive` (1), `cant_determine` (2), `none` (3).
+- `citeEnd`: a `int64` feature.
+- `citeStart`: a `int64` feature.
+- `source`: a classification label, with possible values including `properNoun` (0), `andPhrase` (1), `acronym` (2), `etAlPhrase` (3), `explicit` (4).
+- `label_confidence`: a `float32` feature.
+- `label2_confidence`: a `float32` feature.
+- `id`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default| 8194|       916|1859|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{Cohan2019Structural,
+  author={Arman Cohan and Waleed Ammar and Madeleine Van Zuylen and Field Cady},
+  title={Structural Scaffolds for Citation Intent Classification in Scientific Publications},
+  booktitle="NAACL",
+  year="2019"
+}
+
+```
+

--- a/datasets/scientific_papers/README.md
+++ b/datasets/scientific_papers/README.md
@@ -1,0 +1,178 @@
+---
+---
+
+# Dataset Card for "scientific_papers"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/armancohan/long-summarization](https://github.com/armancohan/long-summarization)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 8591.93 MB
+- **Size of the generated dataset:** 9622.19 MB
+- **Total amount of disk used:** 18214.12 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Scientific papers datasets contains two sets of long and structured documents.
+The datasets are obtained from ArXiv and PubMed OpenAccess repositories.
+
+Both "arxiv" and "pubmed" have two features:
+  - article: the body of the document, pagragraphs seperated by "/n".
+  - abstract: the abstract of the document, pagragraphs seperated by "/n".
+  - section_names: titles of sections, seperated by "/n".
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### arxiv
+
+- **Size of downloaded dataset files:** 4295.97 MB
+- **Size of the generated dataset:** 7231.70 MB
+- **Total amount of disk used:** 11527.66 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\" we have studied the leptonic decay @xmath0 , via the decay channel @xmath1 , using a sample of tagged @xmath2 decays collected...",
+    "article": "\"the leptonic decays of a charged pseudoscalar meson @xmath7 are processes of the type @xmath8 , where @xmath9 , @xmath10 , or @...",
+    "section_names": "[sec:introduction]introduction\n[sec:detector]data and the cleo- detector\n[sec:analysys]analysis method\n[sec:conclusion]summary"
+}
+```
+
+#### pubmed
+
+- **Size of downloaded dataset files:** 4295.97 MB
+- **Size of the generated dataset:** 2390.49 MB
+- **Total amount of disk used:** 6686.46 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "\" background and aim : there is lack of substantial indian data on venous thromboembolism ( vte ) . \\n the aim of this study was...",
+    "article": "\"approximately , one - third of patients with symptomatic vte manifests pe , whereas two - thirds manifest dvt alone .\\nboth dvt...",
+    "section_names": "\"Introduction\\nSubjects and Methods\\nResults\\nDemographics and characteristics of venous thromboembolism patients\\nRisk factors ..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### arxiv
+- `article`: a `string` feature.
+- `abstract`: a `string` feature.
+- `section_names`: a `string` feature.
+
+#### pubmed
+- `article`: a `string` feature.
+- `abstract`: a `string` feature.
+- `section_names`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name |train |validation|test|
+|------|-----:|---------:|---:|
+|arxiv |203037|      6436|6440|
+|pubmed|119924|      6633|6658|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{Cohan_2018,
+   title={A Discourse-Aware Attention Model for Abstractive Summarization of
+            Long Documents},
+   url={http://dx.doi.org/10.18653/v1/n18-2097},
+   DOI={10.18653/v1/n18-2097},
+   journal={Proceedings of the 2018 Conference of the North American Chapter of
+          the Association for Computational Linguistics: Human Language
+          Technologies, Volume 2 (Short Papers)},
+   publisher={Association for Computational Linguistics},
+   author={Cohan, Arman and Dernoncourt, Franck and Kim, Doo Soon and Bui, Trung and Kim, Seokhwan and Chang, Walter and Goharian, Nazli},
+   year={2018}
+}
+
+```
+

--- a/datasets/scifact/README.md
+++ b/datasets/scifact/README.md
@@ -1,0 +1,178 @@
+---
+---
+
+# Dataset Card for "scifact"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://scifact.apps.allenai.org/](https://scifact.apps.allenai.org/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 5.43 MB
+- **Size of the generated dataset:** 7.88 MB
+- **Total amount of disk used:** 13.32 MB
+
+### [Dataset Summary](#dataset-summary)
+
+SciFact, a dataset of 1.4K expert-written scientific claims paired with evidence-containing abstracts, and annotated with labels and rationales
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### claims
+
+- **Size of downloaded dataset files:** 2.72 MB
+- **Size of the generated dataset:** 0.25 MB
+- **Total amount of disk used:** 2.97 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "cited_doc_ids": [14717500],
+    "claim": "1,000 genomes project enables mapping of genetic sequence variation consisting of rare variants with larger penetrance effects than common variants.",
+    "evidence_doc_id": "14717500",
+    "evidence_label": "SUPPORT",
+    "evidence_sentences": [2, 5],
+    "id": 3
+}
+```
+
+#### corpus
+
+- **Size of downloaded dataset files:** 2.72 MB
+- **Size of the generated dataset:** 7.63 MB
+- **Total amount of disk used:** 10.35 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "abstract": "[\"Alterations of the architecture of cerebral white matter in the developing human brain can affect cortical development and res...",
+    "doc_id": 4983,
+    "structured": false,
+    "title": "Microstructural development of human newborn cerebral white matter assessed in vivo by diffusion tensor magnetic resonance imaging."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### claims
+- `id`: a `int32` feature.
+- `claim`: a `string` feature.
+- `evidence_doc_id`: a `string` feature.
+- `evidence_label`: a `string` feature.
+- `evidence_sentences`: a `list` of `int32` features.
+- `cited_doc_ids`: a `list` of `int32` features.
+
+#### corpus
+- `doc_id`: a `int32` feature.
+- `title`: a `string` feature.
+- `abstract`: a `list` of `string` features.
+- `structured`: a `bool` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### claims
+
+|      |train|validation|test|
+|------|----:|---------:|---:|
+|claims| 1261|       450| 300|
+
+#### corpus
+
+|      |train|
+|------|----:|
+|corpus| 5183|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{scifact2020
+  title={ Fact or Fiction: Verifying Scientific Claims},
+  author={David,  Wadden and Kyle, Lo and Lucy Lu, Wang and Shanchuan, Lin and Madeleine van, Zuylen and Arman, Cohan and  Hannaneh, Hajishirzi},
+  booktitle={2011 AAAI Spring Symposium Series},
+  year={2020},
+}
+
+```
+

--- a/datasets/sciq/README.md
+++ b/datasets/sciq/README.md
@@ -1,0 +1,148 @@
+---
+---
+
+# Dataset Card for "sciq"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/sciq](https://allenai.org/data/sciq)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2.69 MB
+- **Size of the generated dataset:** 7.32 MB
+- **Total amount of disk used:** 10.01 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The SciQ dataset contains 13,679 crowdsourced science exam questions about Physics, Chemistry and Biology, among others. The questions are in multiple-choice format with 4 answer options each. For the majority of the questions, an additional paragraph with supporting evidence for the correct answer is provided.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 2.69 MB
+- **Size of the generated dataset:** 7.32 MB
+- **Total amount of disk used:** 10.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "correct_answer": "coriolis effect",
+    "distractor1": "muon effect",
+    "distractor2": "centrifugal effect",
+    "distractor3": "tropical effect",
+    "question": "What phenomenon makes global winds blow northeast to southwest or the reverse in the northern hemisphere and northwest to southeast or the reverse in the southern hemisphere?",
+    "support": "\"Without Coriolis Effect the global winds would blow north to south or south to north. But Coriolis makes them blow northeast to..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `question`: a `string` feature.
+- `distractor3`: a `string` feature.
+- `distractor1`: a `string` feature.
+- `distractor2`: a `string` feature.
+- `correct_answer`: a `string` feature.
+- `support`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|11679|      1000|1000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{SciQ,
+    title={Crowdsourcing Multiple Choice Science Questions},
+    author={Johannes Welbl, Nelson F. Liu, Matt Gardner},
+    year={2017},
+    journal={arXiv:1707.06209v1}
+}
+
+```
+

--- a/datasets/scitail/README.md
+++ b/datasets/scitail/README.md
@@ -1,0 +1,200 @@
+---
+---
+
+# Dataset Card for "scitail"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/scitail](https://allenai.org/data/scitail)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 54.07 MB
+- **Size of the generated dataset:** 46.82 MB
+- **Total amount of disk used:** 100.89 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The SciTail dataset is an entailment dataset created from multiple-choice science exams and web sentences. Each question
+and the correct answer choice are converted into an assertive statement to form the hypothesis. We use information
+retrieval to obtain relevant text from a large text corpus of web sentences, and use these sentences as a premise P. We
+crowdsource the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order to create
+the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with entails label and 16,925 examples
+with neutral label
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### dgem_format
+
+- **Size of downloaded dataset files:** 13.52 MB
+- **Size of the generated dataset:** 7.47 MB
+- **Total amount of disk used:** 20.99 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### predictor_format
+
+- **Size of downloaded dataset files:** 13.52 MB
+- **Size of the generated dataset:** 9.72 MB
+- **Total amount of disk used:** 23.24 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### snli_format
+
+- **Size of downloaded dataset files:** 13.52 MB
+- **Size of the generated dataset:** 24.58 MB
+- **Total amount of disk used:** 38.10 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### tsv_format
+
+- **Size of downloaded dataset files:** 13.52 MB
+- **Size of the generated dataset:** 5.05 MB
+- **Total amount of disk used:** 18.56 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### dgem_format
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a `string` feature.
+- `hypothesis_graph_structure`: a `string` feature.
+
+#### predictor_format
+- `answer`: a `string` feature.
+- `sentence2_structure`: a `string` feature.
+- `sentence1`: a `string` feature.
+- `sentence2`: a `string` feature.
+- `gold_label`: a `string` feature.
+- `question`: a `string` feature.
+
+#### snli_format
+- `sentence1_binary_parse`: a `string` feature.
+- `sentence1_parse`: a `string` feature.
+- `sentence1`: a `string` feature.
+- `sentence2_parse`: a `string` feature.
+- `sentence2`: a `string` feature.
+- `annotator_labels`: a `list` of `string` features.
+- `gold_label`: a `string` feature.
+
+#### tsv_format
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|      name      |train|validation|test|
+|----------------|----:|---------:|---:|
+|dgem_format     |23088|      1304|2126|
+|predictor_format|23587|      1304|2126|
+|snli_format     |23596|      1304|2126|
+|tsv_format      |23097|      1304|2126|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+inproceedings{scitail,
+     Author = {Tushar Khot and Ashish Sabharwal and Peter Clark},
+     Booktitle = {AAAI},
+     Title = {{SciTail}: A Textual Entailment Dataset from Science Question Answering},
+     Year = {2018}
+}
+
+```
+

--- a/datasets/search_qa/README.md
+++ b/datasets/search_qa/README.md
@@ -1,0 +1,199 @@
+---
+---
+
+# Dataset Card for "search_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/nyu-dl/dl4ir-searchQA](https://github.com/nyu-dl/dl4ir-searchQA)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 6163.54 MB
+- **Size of the generated dataset:** 14573.76 MB
+- **Total amount of disk used:** 20737.29 MB
+
+### [Dataset Summary](#dataset-summary)
+
+# pylint: disable=line-too-long
+We publicly release a new large-scale dataset, called SearchQA, for machine comprehension, or question-answering. Unlike recently released datasets, such as DeepMind
+CNN/DailyMail and SQuAD, the proposed SearchQA was constructed to reflect a full pipeline of general question-answering. That is, we start not from an existing article
+and generate a question-answer pair, but start from an existing question-answer pair, crawled from J! Archive, and augment it with text snippets retrieved by Google.
+Following this approach, we built SearchQA, which consists of more than 140k question-answer pairs with each pair having 49.6 snippets on average. Each question-answer-context
+ tuple of the SearchQA comes with additional meta-data such as the snippet's URL, which we believe will be valuable resources for future research. We conduct human evaluation
+ as well as test two baseline methods, one simple word selection and the other deep learning based, on the SearchQA. We show that there is a meaningful gap between the human
+ and machine performances. This suggests that the proposed dataset could well serve as a benchmark for question-answering.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### raw_jeopardy
+
+- **Size of downloaded dataset files:** 3160.84 MB
+- **Size of the generated dataset:** 7410.98 MB
+- **Total amount of disk used:** 10571.82 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### train_test_val
+
+- **Size of downloaded dataset files:** 3002.69 MB
+- **Size of the generated dataset:** 7162.78 MB
+- **Total amount of disk used:** 10165.47 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### raw_jeopardy
+- `category`: a `string` feature.
+- `air_date`: a `string` feature.
+- `question`: a `string` feature.
+- `value`: a `string` feature.
+- `answer`: a `string` feature.
+- `round`: a `string` feature.
+- `show_number`: a `int32` feature.
+- `search_results`: a dictionary feature containing:
+  - `urls`: a `string` feature.
+  - `snippets`: a `string` feature.
+  - `titles`: a `string` feature.
+  - `related_links`: a `string` feature.
+
+#### train_test_val
+- `category`: a `string` feature.
+- `air_date`: a `string` feature.
+- `question`: a `string` feature.
+- `value`: a `string` feature.
+- `answer`: a `string` feature.
+- `round`: a `string` feature.
+- `show_number`: a `int32` feature.
+- `search_results`: a dictionary feature containing:
+  - `urls`: a `string` feature.
+  - `snippets`: a `string` feature.
+  - `titles`: a `string` feature.
+  - `related_links`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### raw_jeopardy
+
+|            |train |
+|------------|-----:|
+|raw_jeopardy|216757|
+
+#### train_test_val
+
+|              |train |validation|test |
+|--------------|-----:|---------:|----:|
+|train_test_val|151295|     21613|43228|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+    @article{DBLP:journals/corr/DunnSHGCC17,
+    author    = {Matthew Dunn and
+                Levent Sagun and
+                Mike Higgins and
+                V. Ugur G{"{u}}ney and
+                Volkan Cirik and
+                Kyunghyun Cho},
+    title     = {SearchQA: {A} New Q{\&}A Dataset Augmented with Context from a
+                Search Engine},
+    journal   = {CoRR},
+    volume    = {abs/1704.05179},
+    year      = {2017},
+    url       = {http://arxiv.org/abs/1704.05179},
+    archivePrefix = {arXiv},
+    eprint    = {1704.05179},
+    timestamp = {Mon, 13 Aug 2018 16:47:09 +0200},
+    biburl    = {https://dblp.org/rec/journals/corr/DunnSHGCC17.bib},
+    bibsource = {dblp computer science bibliography, https://dblp.org}
+    }
+
+```
+

--- a/datasets/sem_eval_2010_task_8/README.md
+++ b/datasets/sem_eval_2010_task_8/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "sem_eval_2010_task_8"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://semeval2.fbk.eu/semeval2.php?location=tasks&taskid=11](https://semeval2.fbk.eu/semeval2.php?location=tasks&taskid=11)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.87 MB
+- **Size of the generated dataset:** 1.35 MB
+- **Total amount of disk used:** 3.22 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The SemEval-2010 Task 8 focuses on Multi-way classification of semantic relations between pairs of nominals.
+The task was designed to compare different approaches to semantic relation classification
+and to provide a standard testbed for future research.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.87 MB
+- **Size of the generated dataset:** 1.35 MB
+- **Total amount of disk used:** 3.22 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "relation": 3,
+    "sentence": "The system as described above has its greatest application in an arrayed <e1>configuration</e1> of antenna <e2>elements</e2>."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `sentence`: a `string` feature.
+- `relation`: a classification label, with possible values including `Cause-Effect(e1,e2)` (0), `Cause-Effect(e2,e1)` (1), `Component-Whole(e1,e2)` (2), `Component-Whole(e2,e1)` (3), `Content-Container(e1,e2)` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|test|
+|-------|----:|---:|
+|default| 8000|2717|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{hendrickx-etal-2010-semeval,
+    title = "{S}em{E}val-2010 Task 8: Multi-Way Classification of Semantic Relations between Pairs of Nominals",
+    author = "Hendrickx, Iris  and
+      Kim, Su Nam  and
+      Kozareva, Zornitsa  and
+      Nakov, Preslav  and
+      {'O} S{'e}aghdha, Diarmuid  and
+      Pad{'o}, Sebastian  and
+      Pennacchiotti, Marco  and
+      Romano, Lorenza  and
+      Szpakowicz, Stan",
+    booktitle = "Proceedings of the 5th International Workshop on Semantic Evaluation",
+    month = jul,
+    year = "2010",
+    address = "Uppsala, Sweden",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/S10-1006",
+    pages = "33--38",
+}
+
+```
+

--- a/datasets/sentiment140/README.md
+++ b/datasets/sentiment140/README.md
@@ -1,0 +1,148 @@
+---
+---
+
+# Dataset Card for "sentiment140"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://help.sentiment140.com/home](http://help.sentiment140.com/home)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 77.59 MB
+- **Size of the generated dataset:** 215.36 MB
+- **Total amount of disk used:** 292.95 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Sentiment140 consists of Twitter messages with emoticons, which are used as noisy labels for
+sentiment classification. For more detailed information please refer to the paper.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### sentiment140
+
+- **Size of downloaded dataset files:** 77.59 MB
+- **Size of the generated dataset:** 215.36 MB
+- **Total amount of disk used:** 292.95 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "date": "23-04-2010",
+    "query": "NO_QUERY",
+    "sentiment": 3,
+    "text": "train message",
+    "user": "train user"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### sentiment140
+- `text`: a `string` feature.
+- `date`: a `string` feature.
+- `user`: a `string` feature.
+- `sentiment`: a `int32` feature.
+- `query`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|    name    | train |test|
+|------------|------:|---:|
+|sentiment140|1600000| 498|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{go2009twitter,
+  title={Twitter sentiment classification using distant supervision},
+  author={Go, Alec and Bhayani, Richa and Huang, Lei},
+  journal={CS224N project report, Stanford},
+  volume={1},
+  number={12},
+  pages={2009},
+  year={2009}
+}
+
+```
+

--- a/datasets/social_bias_frames/README.md
+++ b/datasets/social_bias_frames/README.md
@@ -1,0 +1,174 @@
+---
+---
+
+# Dataset Card for "social_bias_frames"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://homes.cs.washington.edu/~msap/social-bias-frames/](https://homes.cs.washington.edu/~msap/social-bias-frames/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 6.03 MB
+- **Size of the generated dataset:** 42.41 MB
+- **Total amount of disk used:** 48.45 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Social Bias Frames is a new way of representing the biases and offensiveness that are implied in language.
+For example, these frames are meant to distill the implication that "women (candidates) are less qualified"
+behind the statement "we shouldn’t lower our standards to hire more women."
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 6.03 MB
+- **Size of the generated dataset:** 42.41 MB
+- **Total amount of disk used:** 48.45 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "HITId": "3Z8UJEJOCZ74QHXOTFP0JOOGD7039J",
+    "WorkerId": "7162172225567546910",
+    "annotatorAge": "27.0",
+    "annotatorGender": "woman",
+    "annotatorMinority": "women",
+    "annotatorPolitics": "liberal",
+    "annotatorRace": "white",
+    "dataSource": "t/davidson",
+    "intentYN": "1.0",
+    "offensiveYN": "1.0",
+    "post": "Every half-breed cop in America is trying to rape white women.",
+    "sexPhrase": "rape white women",
+    "sexReason": "rape",
+    "sexYN": "1.0",
+    "speakerMinorityYN": "0.0",
+    "targetCategory": "race",
+    "targetMinority": "mixed folks",
+    "targetStereotype": "mixed folks are rapists.",
+    "whoTarget": "1.0"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `whoTarget`: a `string` feature.
+- `intentYN`: a `string` feature.
+- `sexYN`: a `string` feature.
+- `sexReason`: a `string` feature.
+- `offensiveYN`: a `string` feature.
+- `annotatorGender`: a `string` feature.
+- `annotatorMinority`: a `string` feature.
+- `sexPhrase`: a `string` feature.
+- `speakerMinorityYN`: a `string` feature.
+- `WorkerId`: a `string` feature.
+- `HITId`: a `string` feature.
+- `annotatorPolitics`: a `string` feature.
+- `annotatorRace`: a `string` feature.
+- `annotatorAge`: a `string` feature.
+- `post`: a `string` feature.
+- `targetMinority`: a `string` feature.
+- `targetCategory`: a `string` feature.
+- `targetStereotype`: a `string` feature.
+- `dataSource`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |validation|test |
+|-------|-----:|---------:|----:|
+|default|112900|     16738|17501|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{sap2020socialbiasframes,
+   title={Social Bias Frames: Reasoning about Social and Power Implications of Language},
+   author={Sap, Maarten and Gabriel, Saadia and Qin, Lianhui and Jurafsky, Dan and Smith, Noah A and Choi, Yejin},
+   year={2020},
+   booktitle={ACL},
+}
+
+```
+

--- a/datasets/social_i_qa/README.md
+++ b/datasets/social_i_qa/README.md
@@ -1,0 +1,140 @@
+---
+---
+
+# Dataset Card for "social_i_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://leaderboard.allenai.org/socialiqa/submissions/get-started](https://leaderboard.allenai.org/socialiqa/submissions/get-started)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 2.10 MB
+- **Size of the generated dataset:** 6.45 MB
+- **Total amount of disk used:** 8.55 MB
+
+### [Dataset Summary](#dataset-summary)
+
+We introduce Social IQa: Social Interaction QA, a new question-answering benchmark for testing social commonsense intelligence. Contrary to many prior benchmarks that focus on physical or taxonomic knowledge, Social IQa focuses on reasoning about people’s actions and their social implications. For example, given an action like "Jesse saw a concert" and a question like "Why did Jesse do this?", humans can easily infer that Jesse wanted "to see their favorite performer" or "to enjoy the music", and not "to see what's happening inside" or "to see if it works". The actions in Social IQa span a wide variety of social situations, and answer candidates contain both human-curated answers and adversarially-filtered machine-generated candidates. Social IQa contains over 37,000 QA pairs for evaluating models’ abilities to reason about the social implications of everyday events and situations. (Less)
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 2.10 MB
+- **Size of the generated dataset:** 6.45 MB
+- **Total amount of disk used:** 8.55 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answerA": "sympathetic",
+    "answerB": "like a person who was unable to help",
+    "answerC": "incredulous",
+    "context": "Sydney walked past a homeless woman asking for change but did not have any money they could give to her. Sydney felt bad afterwards.",
+    "label": "1",
+    "question": "How would you describe Sydney?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answerA`: a `string` feature.
+- `answerB`: a `string` feature.
+- `answerC`: a `string` feature.
+- `label`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default|33410|      1954|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/sogou_news/README.md
+++ b/datasets/sogou_news/README.md
@@ -1,0 +1,145 @@
+---
+---
+
+# Dataset Card for "sogou_news"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** []()
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 366.47 MB
+- **Size of the generated dataset:** 1360.49 MB
+- **Total amount of disk used:** 1726.96 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Sogou News dataset is a mixture of 2,909,551 news articles from the SogouCA and SogouCS news corpora, in 5 categories.
+The number of training samples selected for each class is 90,000 and testing 12,000. Note that the Chinese characters have been converted to Pinyin.
+classification labels of the news are determined by their domain names in the URL. For example, the news with
+URL http://sports.sohu.com is categorized as a sport class.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 366.47 MB
+- **Size of the generated dataset:** 1360.49 MB
+- **Total amount of disk used:** 1726.96 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "content": "du2 jia1 ti2 go1ng me3i ri4 ba4o jia4 \\n  re4 xia4n :010-64438227\\n  che1 xi2ng ba4o jia4 - cha2 xu2n jie2 guo3 \\n  pi3n pa2i   xi2ng ha4o   jia4 ge2   ji1ng xia1o sha1ng   ri4 qi1   zha1 ka4n ca1n shu4   pi2ng lu4n ",
+    "label": 3,
+    "title": " da3o ha2ng "
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `title`: a `string` feature.
+- `content`: a `string` feature.
+- `label`: a classification label, with possible values including `sports` (0), `finance` (1), `entertainment` (2), `automobile` (3), `technology` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |test |
+|-------|-----:|----:|
+|default|450000|60000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc{zhang2015characterlevel,
+    title={Character-level Convolutional Networks for Text Classification},
+    author={Xiang Zhang and Junbo Zhao and Yann LeCun},
+    year={2015},
+    eprint={1509.01626},
+    archivePrefix={arXiv},
+    primaryClass={cs.LG}
+}
+
+```
+

--- a/datasets/squad/README.md
+++ b/datasets/squad/README.md
@@ -1,0 +1,154 @@
+---
+---
+
+# Dataset Card for "squad"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://rajpurkar.github.io/SQuAD-explorer/](https://rajpurkar.github.io/SQuAD-explorer/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 33.51 MB
+- **Size of the generated dataset:** 85.75 MB
+- **Total amount of disk used:** 119.27 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Stanford Question Answering Dataset (SQuAD) is a reading comprehension dataset, consisting of questions posed by crowdworkers on a set of Wikipedia articles, where the answer to every question is a segment of text, or span, from the corresponding reading passage, or the question might be unanswerable.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 33.51 MB
+- **Size of the generated dataset:** 85.75 MB
+- **Total amount of disk used:** 119.27 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answers": {
+        "answer_start": [1],
+        "text": ["This is a test text"]
+    },
+    "context": "This is a test context.",
+    "id": "1",
+    "question": "Is this a test?",
+    "title": "train test"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train|validation|
+|----------|----:|---------:|
+|plain_text|87599|     10570|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{2016arXiv160605250R,
+       author = {{Rajpurkar}, Pranav and {Zhang}, Jian and {Lopyrev},
+                 Konstantin and {Liang}, Percy},
+        title = "{SQuAD: 100,000+ Questions for Machine Comprehension of Text}",
+      journal = {arXiv e-prints},
+         year = 2016,
+          eid = {arXiv:1606.05250},
+        pages = {arXiv:1606.05250},
+archivePrefix = {arXiv},
+       eprint = {1606.05250},
+}
+
+```
+

--- a/datasets/squad_es/README.md
+++ b/datasets/squad_es/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "squad_es"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/ccasimiro88/TranslateAlignRetrieve](https://github.com/ccasimiro88/TranslateAlignRetrieve)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 37.47 MB
+- **Size of the generated dataset:** 90.25 MB
+- **Total amount of disk used:** 127.72 MB
+
+### [Dataset Summary](#dataset-summary)
+
+automatic translation of the Stanford Question Answering Dataset (SQuAD) v2 into Spanish
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### v1.1.0
+
+- **Size of downloaded dataset files:** 37.47 MB
+- **Size of the generated dataset:** 90.25 MB
+- **Total amount of disk used:** 127.72 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [404, 356, 356],
+        "text": ["Santa Clara, California", "Levi 's Stadium", "Levi 's Stadium en la Bahía de San Francisco en Santa Clara, California."]
+    },
+    "context": "\"El Super Bowl 50 fue un partido de fútbol americano para determinar al campeón de la NFL para la temporada 2015. El campeón de ...",
+    "id": "56be4db0acb8001400a502ee",
+    "question": "¿Dónde tuvo lugar el Super Bowl 50?",
+    "title": "Super Bowl _ 50"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### v1.1.0
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name |train|validation|
+|------|----:|---------:|
+|v1.1.0|87595|     10570|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{2016arXiv160605250R,
+       author = {Casimiro Pio , Carrino and  Marta R. , Costa-jussa and  Jose A. R. , Fonollosa},
+        title = "{Automatic Spanish Translation of the SQuAD Dataset for Multilingual
+Question Answering}",
+      journal = {arXiv e-prints},
+         year = 2019,
+          eid = {arXiv:1912.05200v1},
+        pages = {arXiv:1912.05200v1},
+archivePrefix = {arXiv},
+       eprint = {1912.05200v2},
+}
+
+```
+

--- a/datasets/squad_it/README.md
+++ b/datasets/squad_it/README.md
@@ -1,0 +1,154 @@
+---
+---
+
+# Dataset Card for "squad_it"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/crux82/squad-it](https://github.com/crux82/squad-it)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 8.37 MB
+- **Size of the generated dataset:** 56.07 MB
+- **Total amount of disk used:** 64.44 MB
+
+### [Dataset Summary](#dataset-summary)
+
+SQuAD-it is derived from the SQuAD dataset and it is obtained through semi-automatic translation of the SQuAD dataset
+into Italian. It represents a large-scale dataset for open question answering processes on factoid questions in Italian.
+ The dataset contains more than 60,000 question/answer pairs derived from the original English dataset. The dataset is
+ split into training and test sets to support the replicability of the benchmarking of QA systems:
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 8.37 MB
+- **Size of the generated dataset:** 56.07 MB
+- **Total amount of disk used:** 64.44 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": "{\"answer_start\": [243, 243, 243, 243, 243], \"text\": [\"evitare di essere presi di mira dal boicottaggio\", \"evitare di essere pres...",
+    "context": "\"La crisi ha avuto un forte impatto sulle relazioni internazionali e ha creato una frattura all' interno della NATO. Alcune nazi...",
+    "id": "5725b5a689a1e219009abd28",
+    "question": "Perchè le nazioni europee e il Giappone si sono separati dagli Stati Uniti durante la crisi?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|test|
+|-------|----:|---:|
+|default|54159|7609|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{10.1007/978-3-030-03840-3_29,
+	author="Croce, Danilo and Zelenanska, Alexandra and Basili, Roberto",
+	editor="Ghidini, Chiara and Magnini, Bernardo and Passerini, Andrea and Traverso, Paolo",
+	title="Neural Learning for Question Answering in Italian",
+	booktitle="AI*IA 2018 -- Advances in Artificial Intelligence",
+	year="2018",
+	publisher="Springer International Publishing",
+	address="Cham",
+	pages="389--402",
+	isbn="978-3-030-03840-3"
+}
+
+```
+

--- a/datasets/squad_v1_pt/README.md
+++ b/datasets/squad_v1_pt/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "squad_v1_pt"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/nunorc/squad-v1.1-pt](https://github.com/nunorc/squad-v1.1-pt)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 37.70 MB
+- **Size of the generated dataset:** 92.24 MB
+- **Total amount of disk used:** 129.94 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Portuguese translation of the SQuAD dataset. The translation was performed automatically using the Google Cloud API.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 37.70 MB
+- **Size of the generated dataset:** 92.24 MB
+- **Total amount of disk used:** 129.94 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [0],
+        "text": ["Saint Bernadette Soubirous"]
+    },
+    "context": "\"Arquitetonicamente, a escola tem um caráter católico. No topo da cúpula de ouro do edifício principal é uma estátua de ouro da ...",
+    "id": "5733be284776f41900661182",
+    "question": "A quem a Virgem Maria supostamente apareceu em 1858 em Lourdes, na França?",
+    "title": "University_of_Notre_Dame"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|
+|-------|----:|---------:|
+|default|87599|     10570|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{2016arXiv160605250R,
+       author = {{Rajpurkar}, Pranav and {Zhang}, Jian and {Lopyrev},
+                 Konstantin and {Liang}, Percy},
+        title = "{SQuAD: 100,000+ Questions for Machine Comprehension of Text}",
+      journal = {arXiv e-prints},
+         year = 2016,
+          eid = {arXiv:1606.05250},
+        pages = {arXiv:1606.05250},
+archivePrefix = {arXiv},
+       eprint = {1606.05250},
+}
+
+```
+

--- a/datasets/squad_v2/README.md
+++ b/datasets/squad_v2/README.md
@@ -1,0 +1,158 @@
+---
+---
+
+# Dataset Card for "squad_v2"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://rajpurkar.github.io/SQuAD-explorer/](https://rajpurkar.github.io/SQuAD-explorer/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 44.34 MB
+- **Size of the generated dataset:** 122.57 MB
+- **Total amount of disk used:** 166.91 MB
+
+### [Dataset Summary](#dataset-summary)
+
+combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable questions written adversarially by crowdworkers
+ to look similar to answerable ones. To do well on SQuAD2.0, systems must not only answer questions when possible, but
+ also determine when no answer is supported by the paragraph and abstain from answering.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### squad_v2
+
+- **Size of downloaded dataset files:** 44.34 MB
+- **Size of the generated dataset:** 122.57 MB
+- **Total amount of disk used:** 166.91 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [94, 87, 94, 94],
+        "text": ["10th and 11th centuries", "in the 10th and 11th centuries", "10th and 11th centuries", "10th and 11th centuries"]
+    },
+    "context": "\"The Normans (Norman: Nourmands; French: Normands; Latin: Normanni) were the people who in the 10th and 11th centuries gave thei...",
+    "id": "56ddde6b9a695914005b9629",
+    "question": "When were the Normans in Normandy?",
+    "title": "Normans"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### squad_v2
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name  |train |validation|
+|--------|-----:|---------:|
+|squad_v2|130319|     11873|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{2016arXiv160605250R,
+       author = {{Rajpurkar}, Pranav and {Zhang}, Jian and {Lopyrev},
+                 Konstantin and {Liang}, Percy},
+        title = "{SQuAD: 100,000+ Questions for Machine Comprehension of Text}",
+      journal = {arXiv e-prints},
+         year = 2016,
+          eid = {arXiv:1606.05250},
+        pages = {arXiv:1606.05250},
+archivePrefix = {arXiv},
+       eprint = {1606.05250},
+}
+
+```
+

--- a/datasets/squadshifts/README.md
+++ b/datasets/squadshifts/README.md
@@ -1,0 +1,240 @@
+---
+---
+
+# Dataset Card for "squadshifts"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://modestyachts.github.io/squadshifts-website/index.html](https://modestyachts.github.io/squadshifts-website/index.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 62.96 MB
+- **Size of the generated dataset:** 35.82 MB
+- **Total amount of disk used:** 98.78 MB
+
+### [Dataset Summary](#dataset-summary)
+
+SquadShifts consists of four new test sets for the Stanford Question Answering Dataset (SQuAD) from four different domains: Wikipedia articles, New York \
+Times articles, Reddit comments, and Amazon product reviews. Each dataset was generated using the same data generating pipeline, Amazon Mechanical Turk interface, and data cleaning code as the original SQuAD v1.1 dataset. The "new-wikipedia" dataset measures overfitting on the original SQuAD v1.1 dataset.  The "new-york-times", "reddit", and "amazon" datasets measure robustness to natural distribution shifts. We encourage SQuAD model developers to also evaluate their methods on these new datasets!
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### amazon
+
+- **Size of downloaded dataset files:** 15.74 MB
+- **Size of the generated dataset:** 9.00 MB
+- **Total amount of disk used:** 24.74 MB
+
+An example of 'test' looks as follows.
+```
+{
+    "answers": {
+        "answer_start": [25],
+        "text": ["amazon"]
+    },
+    "context": "This is a paragraph from amazon.",
+    "id": "090909",
+    "question": "Where is this paragraph from?",
+    "title": "amazon dummy data"
+}
+```
+
+#### new_wiki
+
+- **Size of downloaded dataset files:** 15.74 MB
+- **Size of the generated dataset:** 7.50 MB
+- **Total amount of disk used:** 23.24 MB
+
+An example of 'test' looks as follows.
+```
+{
+    "answers": {
+        "answer_start": [25],
+        "text": ["wikipedia"]
+    },
+    "context": "This is a paragraph from wikipedia.",
+    "id": "090909",
+    "question": "Where is this paragraph from?",
+    "title": "new_wiki dummy data"
+}
+```
+
+#### nyt
+
+- **Size of downloaded dataset files:** 15.74 MB
+- **Size of the generated dataset:** 10.29 MB
+- **Total amount of disk used:** 26.03 MB
+
+An example of 'test' looks as follows.
+```
+{
+    "answers": {
+        "answer_start": [25],
+        "text": ["new york times"]
+    },
+    "context": "This is a paragraph from new york times.",
+    "id": "090909",
+    "question": "Where is this paragraph from?",
+    "title": "nyt dummy data"
+}
+```
+
+#### reddit
+
+- **Size of downloaded dataset files:** 15.74 MB
+- **Size of the generated dataset:** 9.03 MB
+- **Total amount of disk used:** 24.77 MB
+
+An example of 'test' looks as follows.
+```
+{
+    "answers": {
+        "answer_start": [25],
+        "text": ["reddit"]
+    },
+    "context": "This is a paragraph from reddit.",
+    "id": "090909",
+    "question": "Where is this paragraph from?",
+    "title": "reddit dummy data"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### amazon
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### new_wiki
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### nyt
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### reddit
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name  |test |
+|--------|----:|
+|amazon  | 9885|
+|new_wiki| 7938|
+|nyt     |10065|
+|reddit  | 9803|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{miller2020effect,
+  author = {J. Miller and K. Krauth and B. Recht and L. Schmidt},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  title = {The Effect of Natural Distribution Shift on Question Answering Models},
+  year = {2020},
+}
+
+```
+

--- a/datasets/style_change_detection/README.md
+++ b/datasets/style_change_detection/README.md
@@ -1,0 +1,181 @@
+---
+---
+
+# Dataset Card for "style_change_detection"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://pan.webis.de/clef20/pan20-web/style-change-detection.html](https://pan.webis.de/clef20/pan20-web/style-change-detection.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 197.60 MB
+- **Total amount of disk used:** 197.60 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The goal of the style change detection task is to identify text positions within a given multi-author document at which the author switches. Detecting these positions is a crucial part of the authorship identification process, and for multi-author document analysis in general.
+
+Access to the dataset needs to be requested from zenodo.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### narrow
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 58.12 MB
+- **Total amount of disk used:** 58.12 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "authors": 2,
+    "changes": [false, false, true, false],
+    "id": "2",
+    "multi-author": true,
+    "site": "exampleSite",
+    "structure": ["A1", "A2"],
+    "text": "This is text from example problem 2.\n"
+}
+```
+
+#### wide
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 139.48 MB
+- **Total amount of disk used:** 139.48 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "authors": 2,
+    "changes": [false, false, true, false],
+    "id": "2",
+    "multi-author": true,
+    "site": "exampleSite",
+    "structure": ["A1", "A2"],
+    "text": "This is text from example problem 2.\n"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### narrow
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `authors`: a `int32` feature.
+- `structure`: a `list` of `string` features.
+- `site`: a `string` feature.
+- `multi-author`: a `bool` feature.
+- `changes`: a `list` of `bool` features.
+
+#### wide
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `authors`: a `int32` feature.
+- `structure`: a `list` of `string` features.
+- `site`: a `string` feature.
+- `multi-author`: a `bool` feature.
+- `changes`: a `list` of `bool` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name |train|validation|
+|------|----:|---------:|
+|narrow| 3418|      1713|
+|wide  | 8030|      4019|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{bevendorff2020shared,
+  title={Shared Tasks on Authorship Analysis at PAN 2020},
+  author={Bevendorff, Janek and Ghanem, Bilal and Giachanou, Anastasia and Kestemont, Mike and Manjavacas, Enrique and Potthast, Martin and Rangel, Francisco and Rosso, Paolo and Specht, G{"u}nther and Stamatatos, Efstathios and others},
+  booktitle={European Conference on Information Retrieval},
+  pages={508--516},
+  year={2020},
+  organization={Springer}
+}
+
+```
+

--- a/datasets/super_glue/README.md
+++ b/datasets/super_glue/README.md
@@ -1,0 +1,249 @@
+---
+---
+
+# Dataset Card for "super_glue"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research-datasets/boolean-questions](https://github.com/google-research-datasets/boolean-questions)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 55.66 MB
+- **Size of the generated dataset:** 238.01 MB
+- **Total amount of disk used:** 293.67 MB
+
+### [Dataset Summary](#dataset-summary)
+
+SuperGLUE (https://super.gluebenchmark.com/) is a new benchmark styled after
+GLUE with a new set of more difficult language understanding tasks, improved
+resources, and a new public leaderboard.
+
+BoolQ (Boolean Questions, Clark et al., 2019a) is a QA task where each example consists of a short
+passage and a yes/no question about the passage. The questions are provided anonymously and
+unsolicited by users of the Google search engine, and afterwards paired with a paragraph from a
+Wikipedia article containing the answer. Following the original work, we evaluate with accuracy.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### axb
+
+- **Size of downloaded dataset files:** 0.03 MB
+- **Size of the generated dataset:** 0.23 MB
+- **Total amount of disk used:** 0.26 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### axg
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.05 MB
+- **Total amount of disk used:** 0.06 MB
+
+An example of 'test' looks as follows.
+```
+
+```
+
+#### boolq
+
+- **Size of downloaded dataset files:** 3.93 MB
+- **Size of the generated dataset:** 9.92 MB
+- **Total amount of disk used:** 13.85 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### cb
+
+- **Size of downloaded dataset files:** 0.07 MB
+- **Size of the generated dataset:** 0.19 MB
+- **Total amount of disk used:** 0.27 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### copa
+
+- **Size of downloaded dataset files:** 0.04 MB
+- **Size of the generated dataset:** 0.12 MB
+- **Total amount of disk used:** 0.16 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### axb
+- `sentence1`: a `string` feature.
+- `sentence2`: a `string` feature.
+- `idx`: a `int32` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `not_entailment` (1).
+
+#### axg
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `idx`: a `int32` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `not_entailment` (1).
+
+#### boolq
+- `question`: a `string` feature.
+- `passage`: a `string` feature.
+- `idx`: a `int32` feature.
+- `label`: a classification label, with possible values including `False` (0), `True` (1).
+
+#### cb
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `idx`: a `int32` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `contradiction` (1), `neutral` (2).
+
+#### copa
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `idx`: a `int32` feature.
+- `label`: a classification label, with possible values including `choice1` (0), `choice2` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+#### axb
+
+|   |test|
+|---|---:|
+|axb|1104|
+
+#### axg
+
+|   |test|
+|---|---:|
+|axg| 356|
+
+#### boolq
+
+|     |train|validation|test|
+|-----|----:|---------:|---:|
+|boolq| 9427|      3270|3245|
+
+#### cb
+
+|   |train|validation|test|
+|---|----:|---------:|---:|
+|cb |  250|        56| 250|
+
+#### copa
+
+|    |train|validation|test|
+|----|----:|---------:|---:|
+|copa|  400|       100| 500|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{clark2019boolq,
+  title={BoolQ: Exploring the Surprising Difficulty of Natural Yes/No Questions},
+  author={Clark, Christopher and Lee, Kenton and Chang, Ming-Wei, and Kwiatkowski, Tom and Collins, Michael, and Toutanova, Kristina},
+  booktitle={NAACL},
+  year={2019}
+}
+@article{wang2019superglue,
+  title={SuperGLUE: A Stickier Benchmark for General-Purpose Language Understanding Systems},
+  author={Wang, Alex and Pruksachatkun, Yada and Nangia, Nikita and Singh, Amanpreet and Michael, Julian and Hill, Felix and Levy, Omer and Bowman, Samuel R},
+  journal={arXiv preprint arXiv:1905.00537},
+  year={2019}
+}
+
+Note that each SuperGLUE dataset has its own citation. Please see the source to
+get the correct citation for each contained dataset.
+
+```
+

--- a/datasets/ted_hrlr/README.md
+++ b/datasets/ted_hrlr/README.md
@@ -1,0 +1,218 @@
+---
+---
+
+# Dataset Card for "ted_hrlr"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/neulab/word-embeddings-for-nmt](https://github.com/neulab/word-embeddings-for-nmt)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1749.12 MB
+- **Size of the generated dataset:** 268.61 MB
+- **Total amount of disk used:** 2017.73 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Data sets derived from TED talk transcripts for comparing similar language pairs
+where one is high resource and the other is low resource.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### az_to_en
+
+- **Size of downloaded dataset files:** 124.94 MB
+- **Size of the generated dataset:** 1.46 MB
+- **Total amount of disk used:** 126.40 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "translation": {
+        "az": "zəhmət olmasa , sizə xitab edən sözlər eşidəndə əlinizi qaldırın .",
+        "en": "please raise your hand if something applies to you ."
+    }
+}
+```
+
+#### aztr_to_en
+
+- **Size of downloaded dataset files:** 124.94 MB
+- **Size of the generated dataset:** 38.28 MB
+- **Total amount of disk used:** 163.22 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "translation": {
+        "az_tr": "zəhmət olmasa , sizə xitab edən sözlər eşidəndə əlinizi qaldırın .",
+        "en": "please raise your hand if something applies to you ."
+    }
+}
+```
+
+#### be_to_en
+
+- **Size of downloaded dataset files:** 124.94 MB
+- **Size of the generated dataset:** 1.36 MB
+- **Total amount of disk used:** 126.29 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "translation": {
+        "be": "zəhmət olmasa , sizə xitab edən sözlər eşidəndə əlinizi qaldırın .",
+        "en": "please raise your hand if something applies to you ."
+    }
+}
+```
+
+#### beru_to_en
+
+- **Size of downloaded dataset files:** 124.94 MB
+- **Size of the generated dataset:** 57.41 MB
+- **Total amount of disk used:** 182.35 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"be_ru\": \"11 yaşımdaydım . səhərin birində , evimizdəki sevinc səslərinə oyandığım indiki kimi yadımdadır .\", \"en\": \"when i was..."
+}
+```
+
+#### es_to_pt
+
+- **Size of downloaded dataset files:** 124.94 MB
+- **Size of the generated dataset:** 8.71 MB
+- **Total amount of disk used:** 133.65 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "translation": "{\"es\": \"11 yaşımdaydım . səhərin birində , evimizdəki sevinc səslərinə oyandığım indiki kimi yadımdadır .\", \"pt\": \"when i was 11..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### az_to_en
+- `translation`: a multilingual `string` variable, with possible languages including `az`, `en`.
+
+#### aztr_to_en
+- `translation`: a multilingual `string` variable, with possible languages including `az_tr`, `en`.
+
+#### be_to_en
+- `translation`: a multilingual `string` variable, with possible languages including `be`, `en`.
+
+#### beru_to_en
+- `translation`: a multilingual `string` variable, with possible languages including `be_ru`, `en`.
+
+#### es_to_pt
+- `translation`: a multilingual `string` variable, with possible languages including `es`, `pt`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train |validation|test|
+|----------|-----:|---------:|---:|
+|az_to_en  |  5947|       672| 904|
+|aztr_to_en|188397|       672| 904|
+|be_to_en  |  4510|       249| 665|
+|beru_to_en|212615|       249| 665|
+|es_to_pt  | 44939|      1017|1764|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{Ye2018WordEmbeddings,
+  author  = {Ye, Qi and Devendra, Sachan and Matthieu, Felix and Sarguna, Padmanabhan and Graham, Neubig},
+  title   = {When and Why are pre-trained word embeddings useful for Neural Machine Translation},
+  booktitle = {HLT-NAACL},
+  year    = {2018},
+  }
+
+```
+

--- a/datasets/ted_multi/README.md
+++ b/datasets/ted_multi/README.md
@@ -1,0 +1,148 @@
+---
+---
+
+# Dataset Card for "ted_multi"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/neulab/word-embeddings-for-nmt](https://github.com/neulab/word-embeddings-for-nmt)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 335.91 MB
+- **Size of the generated dataset:** 754.37 MB
+- **Total amount of disk used:** 1090.27 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Massively multilingual (60 language) data set derived from TED Talk transcripts.
+Each record consists of parallel arrays of language and text. Missing and
+incomplete translations will be filtered out.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 335.91 MB
+- **Size of the generated dataset:** 754.37 MB
+- **Total amount of disk used:** 1090.27 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "talk_name": "shabana_basij_rasikh_dare_to_educate_afghan_girls",
+    "translations": "{\"language\": [\"ar\", \"az\", \"bg\", \"bn\", \"cs\", \"da\", \"de\", \"el\", \"en\", \"es\", \"fa\", \"fr\", \"he\", \"hi\", \"hr\", \"hu\", \"hy\", \"id\", \"it\", ..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `translations`: a multilingual `string` variable, with possible languages including `ar`, `az`, `be`, `bg`, `bn`.
+- `talk_name`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train |validation|test|
+|----------|-----:|---------:|---:|
+|plain_text|258098|      6049|7213|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{qi-EtAl:2018:N18-2,
+  author    = {Qi, Ye  and  Sachan, Devendra  and  Felix, Matthieu  and  Padmanabhan, Sarguna  and  Neubig, Graham},
+  title     = {When and Why Are Pre-Trained Word Embeddings Useful for Neural Machine Translation?},
+  booktitle = {Proceedings of the 2018 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 2 (Short Papers)},
+  month     = {June},
+  year      = {2018},
+  address   = {New Orleans, Louisiana},
+  publisher = {Association for Computational Linguistics},
+  pages     = {529--535},
+  abstract  = {The performance of Neural Machine Translation (NMT) systems often suffers in low-resource scenarios where sufficiently large-scale parallel corpora cannot be obtained. Pre-trained word embeddings have proven to be invaluable for improving performance in natural language analysis tasks, which often suffer from paucity of data. However, their utility for NMT has not been extensively explored. In this work, we perform five sets of experiments that analyze when we can expect pre-trained word embeddings to help in NMT tasks. We show that such embeddings can be surprisingly effective in some cases -- providing gains of up to 20 BLEU points in the most favorable setting.},
+  url       = {http://www.aclweb.org/anthology/N18-2084}
+}
+
+```
+

--- a/datasets/tiny_shakespeare/README.md
+++ b/datasets/tiny_shakespeare/README.md
@@ -1,0 +1,150 @@
+---
+---
+
+# Dataset Card for "tiny_shakespeare"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/karpathy/char-rnn/blob/master/data/tinyshakespeare/input.txt](https://github.com/karpathy/char-rnn/blob/master/data/tinyshakespeare/input.txt)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.06 MB
+- **Size of the generated dataset:** 1.06 MB
+- **Total amount of disk used:** 2.13 MB
+
+### [Dataset Summary](#dataset-summary)
+
+40,000 lines of Shakespeare from a variety of Shakespeare's plays. Featured in Andrej Karpathy's blog post 'The Unreasonable Effectiveness of Recurrent Neural Networks': http://karpathy.github.io/2015/05/21/rnn-effectiveness/.
+
+To use for e.g. character modelling:
+
+```
+d = datasets.load_dataset(name='tiny_shakespeare')['train']
+d = d.map(lambda x: datasets.Value('strings').unicode_split(x['text'], 'UTF-8'))
+# train split includes vocabulary for other splits
+vocabulary = sorted(set(next(iter(d)).numpy()))
+d = d.map(lambda x: {'cur_char': x[:-1], 'next_char': x[1:]})
+d = d.unbatch()
+seq_len = 100
+batch_size = 2
+d = d.batch(seq_len)
+d = d.batch(batch_size)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.06 MB
+- **Size of the generated dataset:** 1.06 MB
+- **Total amount of disk used:** 2.13 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "text": "First Citizen:\nBefore we proceed any further, hear me "
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|    1|         1|   1|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@misc{
+  author={Karpathy, Andrej},
+  title={char-rnn},
+  year={2015},
+  howpublished={\url{https://github.com/karpathy/char-rnn}}
+}
+```
+

--- a/datasets/trec/README.md
+++ b/datasets/trec/README.md
@@ -1,0 +1,155 @@
+---
+---
+
+# Dataset Card for "trec"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://cogcomp.seas.upenn.edu/Data/QA/QC/](https://cogcomp.seas.upenn.edu/Data/QA/QC/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.34 MB
+- **Size of the generated dataset:** 0.39 MB
+- **Total amount of disk used:** 0.74 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Text REtrieval Conference (TREC) Question Classification dataset contains 5500 labeled questions in training set and another 500 for test set. The dataset has 6 labels, 47 level-2 labels. Average length of each sentence is 10, vocabulary size of 8700.
+
+Data are collected from four sources: 4,500 English questions published by USC (Hovy et al., 2001), about 500 manually constructed questions for a few rare classes, 894 TREC 8 and TREC 9 questions, and also 500 questions from TREC 10 which serves as the test set.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 0.34 MB
+- **Size of the generated dataset:** 0.39 MB
+- **Total amount of disk used:** 0.74 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "label-coarse": 1,
+    "label-fine": 2,
+    "text": "What fowl grabs the spotlight after the Chinese Year of the Monkey ?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `label-coarse`: a classification label, with possible values including `DESC` (0), `ENTY` (1), `ABBR` (2), `HUM` (3), `NUM` (4).
+- `label-fine`: a classification label, with possible values including `manner` (0), `cremat` (1), `animal` (2), `exp` (3), `ind` (4).
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|test|
+|-------|----:|---:|
+|default| 5452| 500|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{li-roth-2002-learning,
+    title = "Learning Question Classifiers",
+    author = "Li, Xin  and
+      Roth, Dan",
+    booktitle = "{COLING} 2002: The 19th International Conference on Computational Linguistics",
+    year = "2002",
+    url = "https://www.aclweb.org/anthology/C02-1150",
+}
+@inproceedings{hovy-etal-2001-toward,
+    title = "Toward Semantics-Based Answer Pinpointing",
+    author = "Hovy, Eduard  and
+      Gerber, Laurie  and
+      Hermjakob, Ulf  and
+      Lin, Chin-Yew  and
+      Ravichandran, Deepak",
+    booktitle = "Proceedings of the First International Conference on Human Language Technology Research",
+    year = "2001",
+    url = "https://www.aclweb.org/anthology/H01-1069",
+}
+
+```
+

--- a/datasets/trivia_qa/README.md
+++ b/datasets/trivia_qa/README.md
@@ -1,0 +1,273 @@
+---
+---
+
+# Dataset Card for "trivia_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://nlp.cs.washington.edu/triviaqa/](http://nlp.cs.washington.edu/triviaqa/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 8833.35 MB
+- **Size of the generated dataset:** 43351.32 MB
+- **Total amount of disk used:** 52184.66 MB
+
+### [Dataset Summary](#dataset-summary)
+
+TriviaqQA is a reading comprehension dataset containing over 650K
+question-answer-evidence triples. TriviaqQA includes 95K question-answer
+pairs authored by trivia enthusiasts and independently gathered evidence
+documents, six per question on average, that provide high quality distant
+supervision for answering the questions.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### rc
+
+- **Size of downloaded dataset files:** 2542.29 MB
+- **Size of the generated dataset:** 15275.31 MB
+- **Total amount of disk used:** 17817.60 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### rc.nocontext
+
+- **Size of downloaded dataset files:** 2542.29 MB
+- **Size of the generated dataset:** 120.42 MB
+- **Total amount of disk used:** 2662.71 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### unfiltered
+
+- **Size of downloaded dataset files:** 3145.53 MB
+- **Size of the generated dataset:** 27884.47 MB
+- **Total amount of disk used:** 31030.00 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### unfiltered.nocontext
+
+- **Size of downloaded dataset files:** 603.25 MB
+- **Size of the generated dataset:** 71.11 MB
+- **Total amount of disk used:** 674.35 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### rc
+- `question`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_source`: a `string` feature.
+- `entity_pages`: a dictionary feature containing:
+  - `doc_source`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `title`: a `string` feature.
+  - `wiki_context`: a `string` feature.
+- `search_results`: a dictionary feature containing:
+  - `description`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `rank`: a `int32` feature.
+  - `title`: a `string` feature.
+  - `url`: a `string` feature.
+  - `search_context`: a `string` feature.
+- `aliases`: a `list` of `string` features.
+- `normalized_aliases`: a `list` of `string` features.
+- `matched_wiki_entity_name`: a `string` feature.
+- `normalized_matched_wiki_entity_name`: a `string` feature.
+- `normalized_value`: a `string` feature.
+- `type`: a `string` feature.
+- `value`: a `string` feature.
+
+#### rc.nocontext
+- `question`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_source`: a `string` feature.
+- `entity_pages`: a dictionary feature containing:
+  - `doc_source`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `title`: a `string` feature.
+  - `wiki_context`: a `string` feature.
+- `search_results`: a dictionary feature containing:
+  - `description`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `rank`: a `int32` feature.
+  - `title`: a `string` feature.
+  - `url`: a `string` feature.
+  - `search_context`: a `string` feature.
+- `aliases`: a `list` of `string` features.
+- `normalized_aliases`: a `list` of `string` features.
+- `matched_wiki_entity_name`: a `string` feature.
+- `normalized_matched_wiki_entity_name`: a `string` feature.
+- `normalized_value`: a `string` feature.
+- `type`: a `string` feature.
+- `value`: a `string` feature.
+
+#### unfiltered
+- `question`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_source`: a `string` feature.
+- `entity_pages`: a dictionary feature containing:
+  - `doc_source`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `title`: a `string` feature.
+  - `wiki_context`: a `string` feature.
+- `search_results`: a dictionary feature containing:
+  - `description`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `rank`: a `int32` feature.
+  - `title`: a `string` feature.
+  - `url`: a `string` feature.
+  - `search_context`: a `string` feature.
+- `aliases`: a `list` of `string` features.
+- `normalized_aliases`: a `list` of `string` features.
+- `matched_wiki_entity_name`: a `string` feature.
+- `normalized_matched_wiki_entity_name`: a `string` feature.
+- `normalized_value`: a `string` feature.
+- `type`: a `string` feature.
+- `value`: a `string` feature.
+
+#### unfiltered.nocontext
+- `question`: a `string` feature.
+- `question_id`: a `string` feature.
+- `question_source`: a `string` feature.
+- `entity_pages`: a dictionary feature containing:
+  - `doc_source`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `title`: a `string` feature.
+  - `wiki_context`: a `string` feature.
+- `search_results`: a dictionary feature containing:
+  - `description`: a `string` feature.
+  - `filename`: a `string` feature.
+  - `rank`: a `int32` feature.
+  - `title`: a `string` feature.
+  - `url`: a `string` feature.
+  - `search_context`: a `string` feature.
+- `aliases`: a `list` of `string` features.
+- `normalized_aliases`: a `list` of `string` features.
+- `matched_wiki_entity_name`: a `string` feature.
+- `normalized_matched_wiki_entity_name`: a `string` feature.
+- `normalized_value`: a `string` feature.
+- `type`: a `string` feature.
+- `value`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|        name        |train |validation|test |
+|--------------------|-----:|---------:|----:|
+|rc                  |138384|     18669|17210|
+|rc.nocontext        |138384|     18669|17210|
+|unfiltered          | 87622|     11313|10832|
+|unfiltered.nocontext| 87622|     11313|10832|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{2017arXivtriviaqa,
+       author = {{Joshi}, Mandar and {Choi}, Eunsol and {Weld},
+                 Daniel and {Zettlemoyer}, Luke},
+        title = "{triviaqa: A Large Scale Distantly Supervised Challenge Dataset for Reading Comprehension}",
+      journal = {arXiv e-prints},
+         year = 2017,
+          eid = {arXiv:1705.03551},
+        pages = {arXiv:1705.03551},
+archivePrefix = {arXiv},
+       eprint = {1705.03551},
+}
+
+```
+

--- a/datasets/tydiqa/README.md
+++ b/datasets/tydiqa/README.md
@@ -1,0 +1,199 @@
+---
+---
+
+# Dataset Card for "tydiqa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research-datasets/tydiqa](https://github.com/google-research-datasets/tydiqa)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3726.74 MB
+- **Size of the generated dataset:** 5812.92 MB
+- **Total amount of disk used:** 9539.67 MB
+
+### [Dataset Summary](#dataset-summary)
+
+TyDi QA is a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs.
+The languages of TyDi QA are diverse with regard to their typology -- the set of linguistic features that each language
+expresses -- such that we expect models performing well on this set to generalize across a large number of the languages
+in the world. It contains language phenomena that would not be found in English-only corpora. To provide a realistic
+information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but
+don’t know the answer yet, (unlike SQuAD and its descendents) and the data is collected directly in each language without
+the use of translation (unlike MLQA and XQuAD).
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### primary_task
+
+- **Size of downloaded dataset files:** 1863.37 MB
+- **Size of the generated dataset:** 5757.59 MB
+- **Total amount of disk used:** 7620.96 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "annotations": {
+        "minimal_answers_end_byte": [-1, -1, -1],
+        "minimal_answers_start_byte": [-1, -1, -1],
+        "passage_answer_candidate_index": [-1, -1, -1],
+        "yes_no_answer": ["NONE", "NONE", "NONE"]
+    },
+    "document_plaintext": "\"\\nรองศาสตราจารย์[1] หม่อมราชวงศ์สุขุมพันธุ์ บริพัตร  (22 กันยายน 2495 -) ผู้ว่าราชการกรุงเทพมหานครคนที่ 15 อดีตรองหัวหน้าพรรคปร...",
+    "document_title": "หม่อมราชวงศ์สุขุมพันธุ์ บริพัตร",
+    "document_url": "\"https://th.wikipedia.org/wiki/%E0%B8%AB%E0%B8%A1%E0%B9%88%E0%B8%AD%E0%B8%A1%E0%B8%A3%E0%B8%B2%E0%B8%8A%E0%B8%A7%E0%B8%87%E0%B8%...",
+    "language": "thai",
+    "passage_answer_candidates": "{\"plaintext_end_byte\": [494, 1779, 2931, 3904, 4506, 5588, 6383, 7122, 8224, 9375, 10473, 12563, 15134, 17765, 19863, 21902, 229...",
+    "question_text": "\"หม่อมราชวงศ์สุขุมพันธุ์ บริพัตร เรียนจบจากที่ไหน ?\"..."
+}
+```
+
+#### secondary_task
+
+- **Size of downloaded dataset files:** 1863.37 MB
+- **Size of the generated dataset:** 55.34 MB
+- **Total amount of disk used:** 1918.71 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [394],
+        "text": ["بطولتين"]
+    },
+    "context": "\"أقيمت البطولة 21 مرة، شارك في النهائيات 78 دولة، وعدد الفرق التي فازت بالبطولة حتى الآن 8 فرق، ويعد المنتخب البرازيلي الأكثر تت...",
+    "id": "arabic-2387335860751143628-1",
+    "question": "\"كم عدد مرات فوز الأوروغواي ببطولة كاس العالم لكرو القدم؟\"...",
+    "title": "قائمة نهائيات كأس العالم"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### primary_task
+- `passage_answer_candidates`: a dictionary feature containing:
+  - `plaintext_start_byte`: a `int32` feature.
+  - `plaintext_end_byte`: a `int32` feature.
+- `question_text`: a `string` feature.
+- `document_title`: a `string` feature.
+- `language`: a `string` feature.
+- `annotations`: a dictionary feature containing:
+  - `passage_answer_candidate_index`: a `int32` feature.
+  - `minimal_answers_start_byte`: a `int32` feature.
+  - `minimal_answers_end_byte`: a `int32` feature.
+  - `yes_no_answer`: a `string` feature.
+- `document_plaintext`: a `string` feature.
+- `document_url`: a `string` feature.
+
+#### secondary_task
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|     name     |train |validation|
+|--------------|-----:|---------:|
+|primary_task  |166916|     18670|
+|secondary_task| 49881|      5077|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{tydiqa,
+title   = {TyDi QA: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages},
+author  = {Jonathan H. Clark and Eunsol Choi and Michael Collins and Dan Garrette and Tom Kwiatkowski and Vitaly Nikolaev and Jennimaria Palomaki}
+year    = {2020},
+journal = {Transactions of the Association for Computational Linguistics}
+}
+
+```
+

--- a/datasets/ubuntu_dialogs_corpus/README.md
+++ b/datasets/ubuntu_dialogs_corpus/README.md
@@ -1,0 +1,153 @@
+---
+---
+
+# Dataset Card for "ubuntu_dialogs_corpus"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/rkadlec/ubuntu-ranking-dataset-creator](https://github.com/rkadlec/ubuntu-ranking-dataset-creator)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 62.46 MB
+- **Total amount of disk used:** 62.46 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Ubuntu Dialogue Corpus, a dataset containing almost 1 million multi-turn dialogues, with a total of over 7 million utterances and 100 million words. This provides a unique resource for research into building dialogue managers based on neural language models that can make use of large amounts of unlabeled data. The dataset has both the multi-turn property of conversations in the Dialog State Tracking Challenge datasets, and the unstructured nature of interactions from microblog services such as Twitter.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### train
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 62.46 MB
+- **Total amount of disk used:** 62.46 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "Context": "\"i think we could import the old comment via rsync , but from there we need to go via email . i think it be easier than cach the...",
+    "Label": 1,
+    "Utterance": "basic each xfree86 upload will not forc user to upgrad 100mb of font for noth __eou__ no someth i do in my spare time . __eou__"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### train
+- `Context`: a `string` feature.
+- `Utterance`: a `string` feature.
+- `Label`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train |
+|-----|-----:|
+|train|127422|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{DBLP:journals/corr/LowePSP15,
+  author    = {Ryan Lowe and
+               Nissan Pow and
+               Iulian Serban and
+               Joelle Pineau},
+  title     = {The Ubuntu Dialogue Corpus: {A} Large Dataset for Research in Unstructured
+               Multi-Turn Dialogue Systems},
+  journal   = {CoRR},
+  volume    = {abs/1506.08909},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1506.08909},
+  archivePrefix = {arXiv},
+  eprint    = {1506.08909},
+  timestamp = {Mon, 13 Aug 2018 16:48:23 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/LowePSP15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+
+```
+

--- a/datasets/web_of_science/README.md
+++ b/datasets/web_of_science/README.md
@@ -1,0 +1,198 @@
+---
+---
+
+# Dataset Card for "web_of_science"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://data.mendeley.com/datasets/9rw3vkcfy4/6](https://data.mendeley.com/datasets/9rw3vkcfy4/6)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 172.30 MB
+- **Size of the generated dataset:** 85.65 MB
+- **Total amount of disk used:** 257.95 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Copyright (c) 2017 Kamran Kowsari
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this dataset and associated documentation files (the "Dataset"), to deal
+in the dataset without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Dataset, and to permit persons to whom the dataset is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Dataset.
+
+If you use this dataset please cite: Referenced paper: HDLTex: Hierarchical Deep Learning for Text Classification
+
+Description of Dataset:
+
+Here is three datasets which include WOS-11967 , WOS-46985, and WOS-5736
+Each folder contains:
+-X.txt
+-Y.txt
+-YL1.txt
+-YL2.txt
+
+X is input data that include text sequences
+Y is target value
+YL1 is target value of level one (parent label)
+YL2 is target value of level one (child label)
+Web of Science Dataset WOS-5736
+                        -This dataset contains 5,736 documents with 11 categories which include 3 parents categories.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### WOS11967
+
+- **Size of downloaded dataset files:** 57.43 MB
+- **Size of the generated dataset:** 15.50 MB
+- **Total amount of disk used:** 72.94 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### WOS46985
+
+- **Size of downloaded dataset files:** 57.43 MB
+- **Size of the generated dataset:** 62.47 MB
+- **Total amount of disk used:** 119.90 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### WOS5736
+
+- **Size of downloaded dataset files:** 57.43 MB
+- **Size of the generated dataset:** 7.68 MB
+- **Total amount of disk used:** 65.11 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### WOS11967
+- `input_data`: a `string` feature.
+- `label`: a `int32` feature.
+- `label_level_1`: a `int32` feature.
+- `label_level_2`: a `int32` feature.
+
+#### WOS46985
+- `input_data`: a `string` feature.
+- `label`: a `int32` feature.
+- `label_level_1`: a `int32` feature.
+- `label_level_2`: a `int32` feature.
+
+#### WOS5736
+- `input_data`: a `string` feature.
+- `label`: a `int32` feature.
+- `label_level_1`: a `int32` feature.
+- `label_level_2`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name  |train|
+|--------|----:|
+|WOS11967|11967|
+|WOS46985|46985|
+|WOS5736 | 5736|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{kowsari2017HDLTex,
+title={HDLTex: Hierarchical Deep Learning for Text Classification},
+author={Kowsari, Kamran and Brown, Donald E and Heidarysafa, Mojtaba and Jafari Meimandi, Kiana and and Gerber, Matthew S and Barnes, Laura E},
+booktitle={Machine Learning and Applications (ICMLA), 2017 16th IEEE International Conference on},
+year={2017},
+organization={IEEE}
+}
+
+```
+

--- a/datasets/web_questions/README.md
+++ b/datasets/web_questions/README.md
@@ -1,0 +1,152 @@
+---
+---
+
+# Dataset Card for "web_questions"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://worksheets.codalab.org/worksheets/0xba659fe363cb46e7a505c5b6a774dc8a](https://worksheets.codalab.org/worksheets/0xba659fe363cb46e7a505c5b6a774dc8a)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1.21 MB
+- **Size of the generated dataset:** 0.79 MB
+- **Total amount of disk used:** 2.00 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This dataset consists of 6,642 question/answer pairs.
+The questions are supposed to be answerable by Freebase, a large knowledge graph.
+The questions are mostly centered around a single named entity.
+The questions are popular ones asked on the web (at least in 2013).
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 1.21 MB
+- **Size of the generated dataset:** 0.79 MB
+- **Total amount of disk used:** 2.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answers": ["Jamaican Creole English Language", "Jamaican English"],
+    "question": "what does jamaican people speak?",
+    "url": "http://www.freebase.com/view/en/jamaica"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `url`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a `list` of `string` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|test|
+|-------|----:|---:|
+|default| 3778|2032|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@inproceedings{berant-etal-2013-semantic,
+    title = "Semantic Parsing on {F}reebase from Question-Answer Pairs",
+    author = "Berant, Jonathan  and
+      Chou, Andrew  and
+      Frostig, Roy  and
+      Liang, Percy",
+    booktitle = "Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing",
+    month = oct,
+    year = "2013",
+    address = "Seattle, Washington, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/D13-1160",
+    pages = "1533--1544",
+}
+
+```
+

--- a/datasets/wiki40b/README.md
+++ b/datasets/wiki40b/README.md
@@ -1,0 +1,135 @@
+---
+---
+
+# Dataset Card for "wiki40b"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://research.google/pubs/pub49029/](https://research.google/pubs/pub49029/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 9988.05 MB
+- **Total amount of disk used:** 9988.05 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Clean-up text for 40+ Wikipedia languages editions of pages
+correspond to entities. The datasets have train/dev/test splits per language.
+The dataset is cleaned up by page filtering to remove disambiguation pages,
+redirect pages, deleted pages, and non-entity pages. Each example contains the
+wikidata id of the entity, and the full Wikipedia article after page processing
+that removes non-content sections and structured objects.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### en
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 9988.05 MB
+- **Total amount of disk used:** 9988.05 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### en
+- `wikidata_id`: a `string` feature.
+- `text`: a `string` feature.
+- `version_id`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name| train |validation| test |
+|----|------:|---------:|-----:|
+|en  |2926536|    163597|162274|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+```
+

--- a/datasets/wiki_dpr/README.md
+++ b/datasets/wiki_dpr/README.md
@@ -1,0 +1,249 @@
+---
+---
+
+# Dataset Card for "wiki_dpr"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/facebookresearch/DPR](https://github.com/facebookresearch/DPR)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 406068.98 MB
+- **Size of the generated dataset:** 448718.73 MB
+- **Total amount of disk used:** 932739.13 MB
+
+### [Dataset Summary](#dataset-summary)
+
+This is the wikipedia split used to evaluate the Dense Passage Retrieval (DPR) model.
+It contains 21M passages from wikipedia along with their DPR embeddings.
+The wikipedia articles were split into multiple, disjoint text blocks of 100 words as passages.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### psgs_w100.multiset.compressed
+
+- **Size of downloaded dataset files:** 67678.16 MB
+- **Size of the generated dataset:** 74786.45 MB
+- **Total amount of disk used:** 145204.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "embeddings": "[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1....",
+    "id": "0",
+    "text": "his is the text of a dummy passag",
+    "title": "Title of the article"
+}
+```
+
+#### psgs_w100.multiset.exact
+
+- **Size of downloaded dataset files:** 67678.16 MB
+- **Size of the generated dataset:** 74786.45 MB
+- **Total amount of disk used:** 178700.81 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "embeddings": "[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1....",
+    "id": "0",
+    "text": "his is the text of a dummy passag",
+    "title": "Title of the article"
+}
+```
+
+#### psgs_w100.multiset.no_index
+
+- **Size of downloaded dataset files:** 67678.16 MB
+- **Size of the generated dataset:** 74786.45 MB
+- **Total amount of disk used:** 142464.62 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "embeddings": "[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1....",
+    "id": "0",
+    "text": "his is the text of a dummy passag",
+    "title": "Title of the article"
+}
+```
+
+#### psgs_w100.nq.compressed
+
+- **Size of downloaded dataset files:** 67678.16 MB
+- **Size of the generated dataset:** 74786.45 MB
+- **Total amount of disk used:** 145204.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "embeddings": "[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1....",
+    "id": "0",
+    "text": "his is the text of a dummy passag",
+    "title": "Title of the article"
+}
+```
+
+#### psgs_w100.nq.exact
+
+- **Size of downloaded dataset files:** 67678.16 MB
+- **Size of the generated dataset:** 74786.45 MB
+- **Total amount of disk used:** 178700.81 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "embeddings": "[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1....",
+    "id": "0",
+    "text": "his is the text of a dummy passag",
+    "title": "Title of the article"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### psgs_w100.multiset.compressed
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `embeddings`: a `list` of `float32` features.
+
+#### psgs_w100.multiset.exact
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `embeddings`: a `list` of `float32` features.
+
+#### psgs_w100.multiset.no_index
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `embeddings`: a `list` of `float32` features.
+
+#### psgs_w100.nq.compressed
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `embeddings`: a `list` of `float32` features.
+
+#### psgs_w100.nq.exact
+- `id`: a `string` feature.
+- `text`: a `string` feature.
+- `title`: a `string` feature.
+- `embeddings`: a `list` of `float32` features.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|            name             | train  |
+|-----------------------------|-------:|
+|psgs_w100.multiset.compressed|21015300|
+|psgs_w100.multiset.exact     |21015300|
+|psgs_w100.multiset.no_index  |21015300|
+|psgs_w100.nq.compressed      |21015300|
+|psgs_w100.nq.exact           |21015300|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@misc{karpukhin2020dense,
+    title={Dense Passage Retrieval for Open-Domain Question Answering},
+    author={Vladimir Karpukhin and Barlas Oğuz and Sewon Min and Patrick Lewis and Ledell Wu and Sergey Edunov and Danqi Chen and Wen-tau Yih},
+    year={2020},
+    eprint={2004.04906},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL}
+}
+
+```
+

--- a/datasets/wiki_qa/README.md
+++ b/datasets/wiki_qa/README.md
@@ -1,0 +1,146 @@
+---
+---
+
+# Dataset Card for "wiki_qa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.microsoft.com/en-us/download/details.aspx?id=52419](https://www.microsoft.com/en-us/download/details.aspx?id=52419)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 6.77 MB
+- **Size of the generated dataset:** 6.10 MB
+- **Total amount of disk used:** 12.87 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Wiki Question Answering corpus from Microsoft
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 6.77 MB
+- **Size of the generated dataset:** 6.10 MB
+- **Total amount of disk used:** 12.87 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "answer": "Glacier caves are often called ice caves , but this term is properly used to describe bedrock caves that contain year-round ice.",
+    "document_title": "Glacier cave",
+    "label": 0,
+    "question": "how are glacier caves formed?",
+    "question_id": "Q1"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `question_id`: a `string` feature.
+- `question`: a `string` feature.
+- `document_title`: a `string` feature.
+- `answer`: a `string` feature.
+- `label`: a classification label, with possible values including `0` (0), `1` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|20360|      2733|6165|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{YangYihMeek:EMNLP2015:WikiQA,
+       author = {{Yi}, Yang and {Wen-tau},  Yih and {Christopher} Meek},
+        title = "{WikiQA: A Challenge Dataset for Open-Domain Question Answering}",
+      journal = {Association for Computational Linguistics},
+         year = 2015,
+          doi = {10.18653/v1/D15-1237},
+        pages = {2013–2018},
+}
+
+```
+

--- a/datasets/wiki_snippets/README.md
+++ b/datasets/wiki_snippets/README.md
@@ -1,0 +1,166 @@
+---
+---
+
+# Dataset Card for "wiki_snippets"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://dumps.wikimedia.org](https://dumps.wikimedia.org)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 35001.08 MB
+- **Total amount of disk used:** 35001.08 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Wikipedia version split into plain text snippets for dense semantic indexing.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### wiki40b_en_100_0
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 12268.10 MB
+- **Total amount of disk used:** 12268.10 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### wikipedia_en_100_0
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 22732.97 MB
+- **Total amount of disk used:** 22732.97 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### wiki40b_en_100_0
+- `_id`: a `string` feature.
+- `datasets_id`: a `int32` feature.
+- `wiki_id`: a `string` feature.
+- `start_paragraph`: a `int32` feature.
+- `start_character`: a `int32` feature.
+- `end_paragraph`: a `int32` feature.
+- `end_character`: a `int32` feature.
+- `article_title`: a `string` feature.
+- `section_title`: a `string` feature.
+- `passage_text`: a `string` feature.
+
+#### wikipedia_en_100_0
+- `_id`: a `string` feature.
+- `datasets_id`: a `int32` feature.
+- `wiki_id`: a `string` feature.
+- `start_paragraph`: a `int32` feature.
+- `start_character`: a `int32` feature.
+- `end_paragraph`: a `int32` feature.
+- `end_character`: a `int32` feature.
+- `article_title`: a `string` feature.
+- `section_title`: a `string` feature.
+- `passage_text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|       name       | train  |
+|------------------|-------:|
+|wiki40b_en_100_0  |17553713|
+|wikipedia_en_100_0|30820408|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@ONLINE {wikidump,
+    author = "Wikimedia Foundation",
+    title  = "Wikimedia Downloads",
+    url    = "https://dumps.wikimedia.org"
+}
+
+```
+

--- a/datasets/wiki_split/README.md
+++ b/datasets/wiki_split/README.md
@@ -1,0 +1,144 @@
+---
+---
+
+# Dataset Card for "wiki_split"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://dataset-homepage/](https://dataset-homepage/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 95.63 MB
+- **Size of the generated dataset:** 370.41 MB
+- **Total amount of disk used:** 466.04 MB
+
+### [Dataset Summary](#dataset-summary)
+
+One million English sentences, each split into two sentences that together preserve the original meaning, extracted from Wikipedia
+Google's WikiSplit dataset was constructed automatically from the publicly available Wikipedia revision history. Although
+the dataset contains some inherent noise, it can serve as valuable training data for models that split or merge sentences.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 95.63 MB
+- **Size of the generated dataset:** 370.41 MB
+- **Total amount of disk used:** 466.04 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "complex_sentence": " '' As she translates from one language to another , she tries to find the appropriate wording and context in English that would correspond to the work in Spanish her poems and stories started to have differing meanings in their respective languages .",
+    "simple_sentence_1": "' '' As she translates from one language to another , she tries to find the appropriate wording and context in English that would correspond to the work in Spanish . ",
+    "simple_sentence_2": " Ergo , her poems and stories started to have differing meanings in their respective languages ."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `complex_sentence`: a `string` feature.
+- `simple_sentence_1`: a `string` feature.
+- `simple_sentence_2`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |validation|test|
+|-------|-----:|---------:|---:|
+|default|989944|      5000|5000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{BothaEtAl2018,
+  title = {{Learning To Split and Rephrase From Wikipedia Edit History}},
+  author = {Botha, Jan A and Faruqui, Manaal and Alex, John and Baldridge, Jason and Das, Dipanjan},
+  booktitle = {Proceedings of the 2018 Conference on Empirical Methods in Natural Language Processing},
+  pages = {to appear},
+  note = {arXiv preprint arXiv:1808.09468},
+  year = {2018}
+}
+
+```
+

--- a/datasets/wikipedia/README.md
+++ b/datasets/wikipedia/README.md
@@ -1,0 +1,202 @@
+---
+---
+
+# Dataset Card for "wikipedia"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://dumps.wikimedia.org](https://dumps.wikimedia.org)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 30739.25 MB
+- **Size of the generated dataset:** 35376.35 MB
+- **Total amount of disk used:** 66115.60 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Wikipedia dataset containing cleaned articles of all languages.
+The datasets are built from the Wikipedia dump
+(https://dumps.wikimedia.org/) with one split per language. Each example
+contains the content of one full Wikipedia article with cleaning to strip
+markdown and unwanted sections (references, etc.).
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### 20200501.de
+
+- **Size of downloaded dataset files:** 5531.82 MB
+- **Size of the generated dataset:** 7716.79 MB
+- **Total amount of disk used:** 13248.61 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 20200501.en
+
+- **Size of downloaded dataset files:** 17396.28 MB
+- **Size of the generated dataset:** 17481.07 MB
+- **Total amount of disk used:** 34877.35 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 20200501.fr
+
+- **Size of downloaded dataset files:** 4653.55 MB
+- **Size of the generated dataset:** 6182.24 MB
+- **Total amount of disk used:** 10835.79 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 20200501.frr
+
+- **Size of downloaded dataset files:** 9.05 MB
+- **Size of the generated dataset:** 5.88 MB
+- **Total amount of disk used:** 14.93 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### 20200501.it
+
+- **Size of downloaded dataset files:** 2970.57 MB
+- **Size of the generated dataset:** 3809.89 MB
+- **Total amount of disk used:** 6780.46 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### 20200501.de
+- `title`: a `string` feature.
+- `text`: a `string` feature.
+
+#### 20200501.en
+- `title`: a `string` feature.
+- `text`: a `string` feature.
+
+#### 20200501.fr
+- `title`: a `string` feature.
+- `text`: a `string` feature.
+
+#### 20200501.frr
+- `title`: a `string` feature.
+- `text`: a `string` feature.
+
+#### 20200501.it
+- `title`: a `string` feature.
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|    name    | train |
+|------------|------:|
+|20200501.de |3140341|
+|20200501.en |6078422|
+|20200501.fr |2210508|
+|20200501.frr|  11803|
+|20200501.it |1931197|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@ONLINE {wikidump,
+    author = "Wikimedia Foundation",
+    title  = "Wikimedia Downloads",
+    url    = "https://dumps.wikimedia.org"
+}
+
+```
+

--- a/datasets/wikisql/README.md
+++ b/datasets/wikisql/README.md
@@ -1,0 +1,172 @@
+---
+---
+
+# Dataset Card for "wikisql"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/salesforce/WikiSQL](https://github.com/salesforce/WikiSQL)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 24.95 MB
+- **Size of the generated dataset:** 147.57 MB
+- **Total amount of disk used:** 172.52 MB
+
+### [Dataset Summary](#dataset-summary)
+
+A large crowd-sourced dataset for developing natural language interfaces for relational databases
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 24.95 MB
+- **Size of the generated dataset:** 147.57 MB
+- **Total amount of disk used:** 172.52 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "phase": 1,
+    "question": "How would you answer a second test question?",
+    "sql": {
+        "agg": 0,
+        "conds": {
+            "column_index": [2],
+            "condition": ["Some Entity"],
+            "operator_index": [0]
+        },
+        "human_readable": "SELECT Header1 FROM table WHERE Another Header = Some Entity",
+        "sel": 0
+    },
+    "table": "{\"caption\": \"L\", \"header\": [\"Header1\", \"Header 2\", \"Another Header\"], \"id\": \"1-10015132-9\", \"name\": \"table_10015132_11\", \"page_i..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `phase`: a `int32` feature.
+- `question`: a `string` feature.
+- `header`: a `list` of `string` features.
+- `page_title`: a `string` feature.
+- `page_id`: a `string` feature.
+- `types`: a `list` of `string` features.
+- `id`: a `string` feature.
+- `section_title`: a `string` feature.
+- `caption`: a `string` feature.
+- `rows`: a dictionary feature containing:
+  - `feature`: a `string` feature.
+- `name`: a `string` feature.
+- `human_readable`: a `string` feature.
+- `sel`: a `int32` feature.
+- `agg`: a `int32` feature.
+- `conds`: a dictionary feature containing:
+  - `column_index`: a `int32` feature.
+  - `operator_index`: a `int32` feature.
+  - `condition`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test |
+|-------|----:|---------:|----:|
+|default|56355|      8421|15878|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{zhongSeq2SQL2017,
+  author    = {Victor Zhong and
+               Caiming Xiong and
+               Richard Socher},
+  title     = {Seq2SQL: Generating Structured Queries from Natural Language using
+               Reinforcement Learning},
+  journal   = {CoRR},
+  volume    = {abs/1709.00103},
+  year      = {2017}
+}
+
+```
+

--- a/datasets/wikitext/README.md
+++ b/datasets/wikitext/README.md
@@ -1,0 +1,194 @@
+---
+---
+
+# Dataset Card for "wikitext"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/](https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 373.28 MB
+- **Size of the generated dataset:** 1072.25 MB
+- **Total amount of disk used:** 1445.53 MB
+
+### [Dataset Summary](#dataset-summary)
+
+ The WikiText language modeling dataset is a collection of over 100 million tokens extracted from the set of verified
+ Good and Featured articles on Wikipedia. The dataset is available under the Creative Commons Attribution-ShareAlike License.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### wikitext-103-raw-v1
+
+- **Size of downloaded dataset files:** 183.09 MB
+- **Size of the generated dataset:** 523.97 MB
+- **Total amount of disk used:** 707.06 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "text": "\" The gold dollar or gold one @-@ dollar piece was a coin struck as a regular issue by the United States Bureau of the Mint from..."
+}
+```
+
+#### wikitext-103-v1
+
+- **Size of downloaded dataset files:** 181.42 MB
+- **Size of the generated dataset:** 522.66 MB
+- **Total amount of disk used:** 704.07 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "text": "\" Senjō no Valkyria 3 : <unk> Chronicles ( Japanese : 戦場のヴァルキュリア3 , lit . Valkyria of the Battlefield 3 ) , commonly referred to..."
+}
+```
+
+#### wikitext-2-raw-v1
+
+- **Size of downloaded dataset files:** 4.50 MB
+- **Size of the generated dataset:** 12.91 MB
+- **Total amount of disk used:** 17.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "text": "\" The Sinclair Scientific Programmable was introduced in 1975 , with the same case as the Sinclair Oxford . It was larger than t..."
+}
+```
+
+#### wikitext-2-v1
+
+- **Size of downloaded dataset files:** 4.27 MB
+- **Size of the generated dataset:** 12.72 MB
+- **Total amount of disk used:** 16.99 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "text": "\" Senjō no Valkyria 3 : <unk> Chronicles ( Japanese : 戦場のヴァルキュリア3 , lit . Valkyria of the Battlefield 3 ) , commonly referred to..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### wikitext-103-raw-v1
+- `text`: a `string` feature.
+
+#### wikitext-103-v1
+- `text`: a `string` feature.
+
+#### wikitext-2-raw-v1
+- `text`: a `string` feature.
+
+#### wikitext-2-v1
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|       name        | train |validation|test|
+|-------------------|------:|---------:|---:|
+|wikitext-103-raw-v1|1801350|      3760|4358|
+|wikitext-103-v1    |1801350|      3760|4358|
+|wikitext-2-raw-v1  |  36718|      3760|4358|
+|wikitext-2-v1      |  36718|      3760|4358|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{wikitext,
+    author={Stephen, Merity and Caiming ,Xiong and James, Bradbury and Richard Socher}
+    year=2016
+}
+
+```
+

--- a/datasets/winogrande/README.md
+++ b/datasets/winogrande/README.md
@@ -1,0 +1,212 @@
+---
+---
+
+# Dataset Card for "winogrande"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://leaderboard.allenai.org/winogrande/submissions/get-started](https://leaderboard.allenai.org/winogrande/submissions/get-started)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 19.43 MB
+- **Size of the generated dataset:** 10.01 MB
+- **Total amount of disk used:** 29.44 MB
+
+### [Dataset Summary](#dataset-summary)
+
+WinoGrande is a new collection of 44k problems, inspired by Winograd Schema Challenge (Levesque, Davis, and Morgenstern
+ 2011), but adjusted to improve the scale and robustness against the dataset-specific bias. Formulated as a
+fill-in-a-blank task with binary options, the goal is to choose the right option for a given sentence which requires
+commonsense reasoning.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### winogrande_debiased
+
+- **Size of downloaded dataset files:** 3.24 MB
+- **Size of the generated dataset:** 1.52 MB
+- **Total amount of disk used:** 4.76 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+#### winogrande_l
+
+- **Size of downloaded dataset files:** 3.24 MB
+- **Size of the generated dataset:** 1.63 MB
+- **Total amount of disk used:** 4.87 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### winogrande_m
+
+- **Size of downloaded dataset files:** 3.24 MB
+- **Size of the generated dataset:** 0.69 MB
+- **Total amount of disk used:** 3.93 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### winogrande_s
+
+- **Size of downloaded dataset files:** 3.24 MB
+- **Size of the generated dataset:** 0.45 MB
+- **Total amount of disk used:** 3.69 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### winogrande_xl
+
+- **Size of downloaded dataset files:** 3.24 MB
+- **Size of the generated dataset:** 5.32 MB
+- **Total amount of disk used:** 8.56 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### winogrande_debiased
+- `sentence`: a `string` feature.
+- `option1`: a `string` feature.
+- `option2`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### winogrande_l
+- `sentence`: a `string` feature.
+- `option1`: a `string` feature.
+- `option2`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### winogrande_m
+- `sentence`: a `string` feature.
+- `option1`: a `string` feature.
+- `option2`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### winogrande_s
+- `sentence`: a `string` feature.
+- `option1`: a `string` feature.
+- `option2`: a `string` feature.
+- `answer`: a `string` feature.
+
+#### winogrande_xl
+- `sentence`: a `string` feature.
+- `option1`: a `string` feature.
+- `option2`: a `string` feature.
+- `answer`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|       name        |train|validation|test|
+|-------------------|----:|---------:|---:|
+|winogrande_debiased| 9248|      1267|1767|
+|winogrande_l       |10234|      1267|1767|
+|winogrande_m       | 2558|      1267|1767|
+|winogrande_s       |  640|      1267|1767|
+|winogrande_xl      |40398|      1267|1767|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{ai2:winogrande,
+title = {WinoGrande: An Adversarial Winograd Schema Challenge at Scale},
+authors={Keisuke, Sakaguchi and Ronan, Le Bras and Chandra, Bhagavatula and Yejin, Choi
+},
+year={2019}
+}
+
+```
+

--- a/datasets/wiqa/README.md
+++ b/datasets/wiqa/README.md
@@ -1,0 +1,160 @@
+---
+---
+
+# Dataset Card for "wiqa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://allenai.org/data/wiqa](https://allenai.org/data/wiqa)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 5.00 MB
+- **Size of the generated dataset:** 21.36 MB
+- **Total amount of disk used:** 26.37 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The WIQA dataset V1 has 39705 questions containing a perturbation and a possible effect in the context of a paragraph.
+The dataset is split into 29808 train questions, 6894 dev questions and 3003 test questions.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 5.00 MB
+- **Size of the generated dataset:** 21.36 MB
+- **Total amount of disk used:** 26.37 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "answer_label": "more",
+    "answer_label_as_choice": "A",
+    "choices": {
+        "label": ["A", "B", "C"],
+        "text": ["more", "less", "no effect"]
+    },
+    "metadata_graph_id": "481",
+    "metadata_para_id": "528",
+    "metadata_path_len": 3,
+    "metadata_question_id": "influence_graph:528:481:77#0",
+    "metadata_question_type": "INPARA_EFFECT",
+    "question_para_step": ["A male and female rabbit mate", "The female rabbit becomes pregnant", "Baby rabbits form inside of the mother rabbit", "The female rabbit gives birth to a litter", "The newborn rabbits grow up to become adults", "The adult rabbits find mates."],
+    "question_stem": "suppose the female is sterile happens, how will it affect LESS rabbits."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `question_stem`: a `string` feature.
+- `question_para_step`: a `list` of `string` features.
+- `answer_label`: a `string` feature.
+- `answer_label_as_choice`: a `string` feature.
+- `choices`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `label`: a `string` feature.
+- `metadata_question_id`: a `string` feature.
+- `metadata_graph_id`: a `string` feature.
+- `metadata_para_id`: a `string` feature.
+- `metadata_question_type`: a `string` feature.
+- `metadata_path_len`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|default|29808|      6894|3003|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{wiqa,
+      author    = {Niket Tandon and Bhavana Dalvi Mishra and Keisuke Sakaguchi and Antoine Bosselut and Peter Clark}
+      title     = {WIQA: A dataset for "What if..." reasoning over procedural text},
+      journal   = {arXiv:1909.04739v1},
+      year      = {2019},
+}
+
+```
+

--- a/datasets/wmt14/README.md
+++ b/datasets/wmt14/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "wmt14"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.statmt.org/wmt14/translation-task.html](http://www.statmt.org/wmt14/translation-task.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1616.49 MB
+- **Size of the generated dataset:** 269.84 MB
+- **Total amount of disk used:** 1886.33 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cs-en
+
+- **Size of downloaded dataset files:** 1616.49 MB
+- **Size of the generated dataset:** 269.84 MB
+- **Total amount of disk used:** 1886.33 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cs-en
+- `translation`: a multilingual `string` variable, with possible languages including `cs`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train |validation|test|
+|-----|-----:|---------:|---:|
+|cs-en|953621|      3000|3003|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{bojar-EtAl:2014:W14-33,
+  author    = {Bojar, Ondrej  and  Buck, Christian  and  Federmann, Christian  and  Haddow, Barry  and  Koehn, Philipp  and  Leveling, Johannes  and  Monz, Christof  and  Pecina, Pavel  and  Post, Matt  and  Saint-Amand, Herve  and  Soricut, Radu  and  Specia, Lucia  and  Tamchyna, Ale{s}},
+  title     = {Findings of the 2014 Workshop on Statistical Machine Translation},
+  booktitle = {Proceedings of the Ninth Workshop on Statistical Machine Translation},
+  month     = {June},
+  year      = {2014},
+  address   = {Baltimore, Maryland, USA},
+  publisher = {Association for Computational Linguistics},
+  pages     = {12--58},
+  url       = {http://www.aclweb.org/anthology/W/W14/W14-3302}
+}
+
+```
+

--- a/datasets/wmt15/README.md
+++ b/datasets/wmt15/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "wmt15"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.statmt.org/wmt15/translation-task.html](http://www.statmt.org/wmt15/translation-task.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1659.14 MB
+- **Size of the generated dataset:** 271.17 MB
+- **Total amount of disk used:** 1930.31 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cs-en
+
+- **Size of downloaded dataset files:** 1659.14 MB
+- **Size of the generated dataset:** 271.17 MB
+- **Total amount of disk used:** 1930.31 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cs-en
+- `translation`: a multilingual `string` variable, with possible languages including `cs`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train |validation|test|
+|-----|-----:|---------:|---:|
+|cs-en|959768|      3003|2656|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{bojar-EtAl:2015:WMT,
+  author    = {Bojar, Ond{r}ej  and  Chatterjee, Rajen  and  Federmann, Christian  and  Haddow, Barry  and  Huck, Matthias  and  Hokamp, Chris  and  Koehn, Philipp  and  Logacheva, Varvara  and  Monz, Christof  and  Negri, Matteo  and  Post, Matt  and  Scarton, Carolina  and  Specia, Lucia  and  Turchi, Marco},
+  title     = {Findings of the 2015 Workshop on Statistical Machine Translation},
+  booktitle = {Proceedings of the Tenth Workshop on Statistical Machine Translation},
+  month     = {September},
+  year      = {2015},
+  address   = {Lisbon, Portugal},
+  publisher = {Association for Computational Linguistics},
+  pages     = {1--46},
+  url       = {http://aclweb.org/anthology/W15-3001}
+}
+
+```
+

--- a/datasets/wmt16/README.md
+++ b/datasets/wmt16/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "wmt16"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.statmt.org/wmt16/translation-task.html](http://www.statmt.org/wmt16/translation-task.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1611.50 MB
+- **Size of the generated dataset:** 283.51 MB
+- **Total amount of disk used:** 1895.01 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cs-en
+
+- **Size of downloaded dataset files:** 1611.50 MB
+- **Size of the generated dataset:** 283.51 MB
+- **Total amount of disk used:** 1895.01 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cs-en
+- `translation`: a multilingual `string` variable, with possible languages including `cs`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name |train |validation|test|
+|-----|-----:|---------:|---:|
+|cs-en|997240|      2656|2999|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{bojar-EtAl:2016:WMT1,
+  author    = {Bojar, Ond{r}ej  and  Chatterjee, Rajen  and  Federmann, Christian  and  Graham, Yvette  and  Haddow, Barry  and  Huck, Matthias  and  Jimeno Yepes, Antonio  and  Koehn, Philipp  and  Logacheva, Varvara  and  Monz, Christof  and  Negri, Matteo  and  Neveol, Aurelie  and  Neves, Mariana  and  Popel, Martin  and  Post, Matt  and  Rubino, Raphael  and  Scarton, Carolina  and  Specia, Lucia  and  Turchi, Marco  and  Verspoor, Karin  and  Zampieri, Marcos},
+  title     = {Findings of the 2016 Conference on Machine Translation},
+  booktitle = {Proceedings of the First Conference on Machine Translation},
+  month     = {August},
+  year      = {2016},
+  address   = {Berlin, Germany},
+  publisher = {Association for Computational Linguistics},
+  pages     = {131--198},
+  url       = {http://www.aclweb.org/anthology/W/W16/W16-2301}
+}
+
+```
+

--- a/datasets/wmt17/README.md
+++ b/datasets/wmt17/README.md
@@ -1,0 +1,156 @@
+---
+---
+
+# Dataset Card for "wmt17"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.statmt.org/wmt17/translation-task.html](http://www.statmt.org/wmt17/translation-task.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1700.58 MB
+- **Size of the generated dataset:** 288.10 MB
+- **Total amount of disk used:** 1988.68 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cs-en
+
+- **Size of downloaded dataset files:** 1700.58 MB
+- **Size of the generated dataset:** 288.10 MB
+- **Total amount of disk used:** 1988.68 MB
+
+An example of 'train' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cs-en
+- `translation`: a multilingual `string` variable, with possible languages including `cs`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name | train |validation|test|
+|-----|------:|---------:|---:|
+|cs-en|1018291|      2999|3005|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{bojar-EtAl:2017:WMT1,
+  author    = {Bojar, Ond{r}ej  and  Chatterjee, Rajen  and  Federmann, Christian  and  Graham, Yvette  and  Haddow, Barry  and  Huang, Shujian  and  Huck, Matthias  and  Koehn, Philipp  and  Liu, Qun  and  Logacheva, Varvara  and  Monz, Christof  and  Negri, Matteo  and  Post, Matt  and  Rubino, Raphael  and  Specia, Lucia  and  Turchi, Marco},
+  title     = {Findings of the 2017 Conference on Machine Translation (WMT17)},
+  booktitle = {Proceedings of the Second Conference on Machine Translation, Volume 2: Shared Task Papers},
+  month     = {September},
+  year      = {2017},
+  address   = {Copenhagen, Denmark},
+  publisher = {Association for Computational Linguistics},
+  pages     = {169--214},
+  url       = {http://www.aclweb.org/anthology/W17-4717}
+}
+
+```
+

--- a/datasets/wmt18/README.md
+++ b/datasets/wmt18/README.md
@@ -1,0 +1,158 @@
+---
+---
+
+# Dataset Card for "wmt18"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.statmt.org/wmt18/translation-task.html](http://www.statmt.org/wmt18/translation-task.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1935.34 MB
+- **Size of the generated dataset:** 1394.65 MB
+- **Total amount of disk used:** 3329.99 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cs-en
+
+- **Size of downloaded dataset files:** 1935.34 MB
+- **Size of the generated dataset:** 1394.65 MB
+- **Total amount of disk used:** 3329.99 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cs-en
+- `translation`: a multilingual `string` variable, with possible languages including `cs`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name | train  |validation|test|
+|-----|-------:|---------:|---:|
+|cs-en|11046024|      3005|2983|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{bojar-EtAl:2018:WMT1,
+  author    = {Bojar, Ond{r}ej  and  Federmann, Christian  and  Fishel, Mark
+    and Graham, Yvette  and  Haddow, Barry  and  Huck, Matthias  and
+    Koehn, Philipp  and  Monz, Christof},
+  title     = {Findings of the 2018 Conference on Machine Translation (WMT18)},
+  booktitle = {Proceedings of the Third Conference on Machine Translation,
+    Volume 2: Shared Task Papers},
+  month     = {October},
+  year      = {2018},
+  address   = {Belgium, Brussels},
+  publisher = {Association for Computational Linguistics},
+  pages     = {272--307},
+  url       = {http://www.aclweb.org/anthology/W18-6401}
+}
+
+```
+

--- a/datasets/wmt19/README.md
+++ b/datasets/wmt19/README.md
@@ -1,0 +1,150 @@
+---
+---
+
+# Dataset Card for "wmt19"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://www.statmt.org/wmt19/translation-task.html](http://www.statmt.org/wmt19/translation-task.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1924.57 MB
+- **Size of the generated dataset:** 1254.62 MB
+- **Total amount of disk used:** 3179.19 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### cs-en
+
+- **Size of downloaded dataset files:** 1924.57 MB
+- **Size of the generated dataset:** 1254.62 MB
+- **Total amount of disk used:** 3179.19 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### cs-en
+- `translation`: a multilingual `string` variable, with possible languages including `cs`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name | train |validation|
+|-----|------:|---------:|
+|cs-en|7270695|      2983|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@ONLINE {wmt19translate,
+    author = "Wikimedia Foundation",
+    title  = "ACL 2019 Fourth Conference on Machine Translation (WMT19), Shared Task: Machine Translation of News",
+    url    = "http://www.statmt.org/wmt19/translation-task.html"
+}
+
+```
+

--- a/datasets/wmt_t2t/README.md
+++ b/datasets/wmt_t2t/README.md
@@ -1,0 +1,161 @@
+---
+---
+
+# Dataset Card for "wmt_t2t"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/data_generators/translate_ende.py](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/data_generators/translate_ende.py)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 1647.72 MB
+- **Size of the generated dataset:** 1322.40 MB
+- **Total amount of disk used:** 2970.12 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Translate dataset based on the data from statmt.org.
+
+Versions exists for the different years using a combination of multiple data
+sources. The base `wmt_translate` allows you to create your own config to choose
+your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+
+```
+config = datasets.wmt.WmtConfig(
+    version="0.0.1",
+    language_pair=("fr", "de"),
+    subsets={
+        datasets.Split.TRAIN: ["commoncrawl_frde"],
+        datasets.Split.VALIDATION: ["euelections_dev2019"],
+    },
+)
+builder = datasets.builder("wmt_translate", config=config)
+```
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### de-en
+
+- **Size of downloaded dataset files:** 1647.72 MB
+- **Size of the generated dataset:** 1322.40 MB
+- **Total amount of disk used:** 2970.12 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "translation": {
+        "de": "Just a test sentence.",
+        "en": "Just a test sentence."
+    }
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### de-en
+- `translation`: a multilingual `string` variable, with possible languages including `de`, `en`.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name | train |validation|test|
+|-----|------:|---------:|---:|
+|de-en|4592289|      3000|3003|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@InProceedings{bojar-EtAl:2014:W14-33,
+  author    = {Bojar, Ondrej  and  Buck, Christian  and  Federmann, Christian  and  Haddow, Barry  and  Koehn, Philipp  and  Leveling, Johannes  and  Monz, Christof  and  Pecina, Pavel  and  Post, Matt  and  Saint-Amand, Herve  and  Soricut, Radu  and  Specia, Lucia  and  Tamchyna, Ale{s}},
+  title     = {Findings of the 2014 Workshop on Statistical Machine Translation},
+  booktitle = {Proceedings of the Ninth Workshop on Statistical Machine Translation},
+  month     = {June},
+  year      = {2014},
+  address   = {Baltimore, Maryland, USA},
+  publisher = {Association for Computational Linguistics},
+  pages     = {12--58},
+  url       = {http://www.aclweb.org/anthology/W/W14/W14-3302}
+}
+
+```
+

--- a/datasets/wnut_17/README.md
+++ b/datasets/wnut_17/README.md
@@ -1,0 +1,165 @@
+---
+---
+
+# Dataset Card for "wnut_17"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [http://noisy-text.github.io/2017/emerging-rare-entities.html](http://noisy-text.github.io/2017/emerging-rare-entities.html)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 0.76 MB
+- **Size of the generated dataset:** 1.66 MB
+- **Total amount of disk used:** 2.43 MB
+
+### [Dataset Summary](#dataset-summary)
+
+WNUT 17: Emerging and Rare entity recognition
+
+This shared task focuses on identifying unusual, previously-unseen entities in the context of emerging discussions.
+Named entities form the basis of many modern approaches to other tasks (like event clustering and summarisation),
+but recall on them is a real problem in noisy text - even among annotators. This drop tends to be due to novel entities and surface forms.
+Take for example the tweet “so.. kktny in 30 mins?” - even human experts find entity kktny hard to detect and resolve.
+This task will evaluate the ability to detect and classify novel, emerging, singleton named entities in noisy text.
+
+The goal of this task is to provide a definition of emerging and of rare entities, and based on that, also datasets for detecting these entities.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### wnut_17
+
+- **Size of downloaded dataset files:** 0.76 MB
+- **Size of the generated dataset:** 1.66 MB
+- **Total amount of disk used:** 2.43 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": "0",
+    "ner_tags": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 8, 8, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0],
+    "tokens": ["@paulwalk", "It", "'s", "the", "view", "from", "where", "I", "'m", "living", "for", "two", "weeks", ".", "Empire", "State", "Building", "=", "ESB", ".", "Pretty", "bad", "storm", "here", "last", "evening", "."]
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### wnut_17
+- `id`: a `string` feature.
+- `tokens`: a `list` of `string` features.
+- `ner_tags`: a `list` of classification labels, with possible values including `O` (0), `B-corporation` (1), `I-corporation` (2), `B-creative-work` (3), `I-creative-work` (4).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test|
+|-------|----:|---------:|---:|
+|wnut_17| 3394|      1009|1287|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{derczynski-etal-2017-results,
+    title = "Results of the {WNUT}2017 Shared Task on Novel and Emerging Entity Recognition",
+    author = "Derczynski, Leon  and
+      Nichols, Eric  and
+      van Erp, Marieke  and
+      Limsopatham, Nut",
+    booktitle = "Proceedings of the 3rd Workshop on Noisy User-generated Text",
+    month = sep,
+    year = "2017",
+    address = "Copenhagen, Denmark",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W17-4418",
+    doi = "10.18653/v1/W17-4418",
+    pages = "140--147",
+    abstract = "This shared task focuses on identifying unusual, previously-unseen entities in the context of emerging discussions.
+                Named entities form the basis of many modern approaches to other tasks (like event clustering and summarization),
+                but recall on them is a real problem in noisy text - even among annotators.
+                This drop tends to be due to novel entities and surface forms.
+                Take for example the tweet {``}so.. kktny in 30 mins?!{''} {--} even human experts find the entity {`}kktny{'}
+                hard to detect and resolve. The goal of this task is to provide a definition of emerging and of rare entities,
+                and based on that, also datasets for detecting these entities. The task as described in this paper evaluated the
+                ability of participating entries to detect and classify novel and emerging named entities in noisy text.",
+}
+
+```
+

--- a/datasets/x_stance/README.md
+++ b/datasets/x_stance/README.md
@@ -1,0 +1,157 @@
+---
+---
+
+# Dataset Card for "x_stance"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/ZurichNLP/xstance](https://github.com/ZurichNLP/xstance)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 6.11 MB
+- **Size of the generated dataset:** 24.54 MB
+- **Total amount of disk used:** 30.65 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The x-stance dataset contains more than 150 political questions, and 67k comments written by candidates on those questions.
+
+It can be used to train and evaluate stance detection systems.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 6.11 MB
+- **Size of the generated dataset:** 24.54 MB
+- **Total amount of disk used:** 30.65 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "author": "f27b54a137b4",
+    "comment": "Das Arbeitsgesetz regelt die Arbeitszeiten und schützt den Arbeitnehmer. Es macht doch Sinn, dass wenn eine Nachfrage besteht, die Läden öffnen dürfen und wenn es keine Nachfrage gibt, diese geschlossen bleiben.",
+    "id": 10045,
+    "label": "FAVOR",
+    "language": "de",
+    "numerical_label": 100,
+    "question": "Sind Sie für eine vollständige Liberalisierung der Geschäftsöffnungszeiten (Geschäfte können die Öffnungszeiten nach freiem Ermessen festlegen)?",
+    "question_id": 739,
+    "topic": "Economy"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `question`: a `string` feature.
+- `id`: a `int32` feature.
+- `question_id`: a `int32` feature.
+- `language`: a `string` feature.
+- `comment`: a `string` feature.
+- `label`: a `string` feature.
+- `numerical_label`: a `int32` feature.
+- `author`: a `string` feature.
+- `topic`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train|validation|test |
+|-------|----:|---------:|----:|
+|default|45640|      3926|17705|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{vamvas2020xstance,
+    author    = "Vamvas, Jannis and Sennrich, Rico",
+    title     = "{X-Stance}: A Multilingual Multi-Target Dataset for Stance Detection",
+    booktitle = "Proceedings of the 5th Swiss Text Analytics Conference (SwissText) \& 16th Conference on Natural Language Processing (KONVENS)",
+    address   = "Zurich, Switzerland",
+    year      = "2020",
+    month     = "jun",
+    url       = "http://ceur-ws.org/Vol-2624/paper9.pdf"
+}
+
+```
+

--- a/datasets/xcopa/README.md
+++ b/datasets/xcopa/README.md
@@ -1,0 +1,279 @@
+---
+---
+
+# Dataset Card for "xcopa"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/cambridgeltl/xcopa](https://github.com/cambridgeltl/xcopa)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 3.89 MB
+- **Size of the generated dataset:** 0.97 MB
+- **Total amount of disk used:** 4.86 MB
+
+### [Dataset Summary](#dataset-summary)
+
+  XCOPA: A Multilingual Dataset for Causal Commonsense Reasoning
+The Cross-lingual Choice of Plausible Alternatives dataset is a benchmark to evaluate the ability of machine learning models to transfer commonsense reasoning across
+languages. The dataset is the translation and reannotation of the English COPA (Roemmele et al. 2011) and covers 11 languages from 11 families and several areas around
+the globe. The dataset is challenging as it requires both the command of world knowledge and the ability to generalise to new languages. All the details about the
+creation of XCOPA and the implementation of the baselines are available in the paper.
+
+Xcopa language et
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### et
+
+- **Size of downloaded dataset files:** 0.35 MB
+- **Size of the generated dataset:** 0.07 MB
+- **Total amount of disk used:** 0.42 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "changed": false,
+    "choice1": "Ta kallas piima kaussi.",
+    "choice2": "Ta kaotas oma isu.",
+    "idx": 1,
+    "label": 1,
+    "premise": "Tüdruk leidis oma helveste seest putuka.",
+    "question": "effect"
+}
+```
+
+#### ht
+
+- **Size of downloaded dataset files:** 0.35 MB
+- **Size of the generated dataset:** 0.07 MB
+- **Total amount of disk used:** 0.42 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "changed": false,
+    "choice1": "Ta kallas piima kaussi.",
+    "choice2": "Ta kaotas oma isu.",
+    "idx": 1,
+    "label": 1,
+    "premise": "Tüdruk leidis oma helveste seest putuka.",
+    "question": "effect"
+}
+```
+
+#### id
+
+- **Size of downloaded dataset files:** 0.35 MB
+- **Size of the generated dataset:** 0.07 MB
+- **Total amount of disk used:** 0.43 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "changed": false,
+    "choice1": "Ta kallas piima kaussi.",
+    "choice2": "Ta kaotas oma isu.",
+    "idx": 1,
+    "label": 1,
+    "premise": "Tüdruk leidis oma helveste seest putuka.",
+    "question": "effect"
+}
+```
+
+#### it
+
+- **Size of downloaded dataset files:** 0.35 MB
+- **Size of the generated dataset:** 0.08 MB
+- **Total amount of disk used:** 0.43 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "changed": false,
+    "choice1": "Ta kallas piima kaussi.",
+    "choice2": "Ta kaotas oma isu.",
+    "idx": 1,
+    "label": 1,
+    "premise": "Tüdruk leidis oma helveste seest putuka.",
+    "question": "effect"
+}
+```
+
+#### qu
+
+- **Size of downloaded dataset files:** 0.35 MB
+- **Size of the generated dataset:** 0.08 MB
+- **Total amount of disk used:** 0.43 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "changed": false,
+    "choice1": "Ta kallas piima kaussi.",
+    "choice2": "Ta kaotas oma isu.",
+    "idx": 1,
+    "label": 1,
+    "premise": "Tüdruk leidis oma helveste seest putuka.",
+    "question": "effect"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### et
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+- `idx`: a `int32` feature.
+- `changed`: a `bool` feature.
+
+#### ht
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+- `idx`: a `int32` feature.
+- `changed`: a `bool` feature.
+
+#### id
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+- `idx`: a `int32` feature.
+- `changed`: a `bool` feature.
+
+#### it
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+- `idx`: a `int32` feature.
+- `changed`: a `bool` feature.
+
+#### qu
+- `premise`: a `string` feature.
+- `choice1`: a `string` feature.
+- `choice2`: a `string` feature.
+- `question`: a `string` feature.
+- `label`: a `int32` feature.
+- `idx`: a `int32` feature.
+- `changed`: a `bool` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|name|validation|test|
+|----|---------:|---:|
+|et  |       100| 500|
+|ht  |       100| 500|
+|id  |       100| 500|
+|it  |       100| 500|
+|qu  |       100| 500|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+  @article{ponti2020xcopa,
+  title={{XCOPA: A} Multilingual Dataset for Causal Commonsense Reasoning},
+  author={Edoardo M. Ponti, Goran Glava{s}, Olga Majewska, Qianchu Liu, Ivan Vuli'{c} and Anna Korhonen},
+  journal={arXiv preprint},
+  year={2020},
+  url={https://ducdauge.github.io/files/xcopa.pdf}
+}
+
+@inproceedings{roemmele2011choice,
+  title={Choice of plausible alternatives: An evaluation of commonsense causal reasoning},
+  author={Roemmele, Melissa and Bejan, Cosmin Adrian and Gordon, Andrew S},
+  booktitle={2011 AAAI Spring Symposium Series},
+  year={2011},
+  url={https://people.ict.usc.edu/~gordon/publications/AAAI-SPRING11A.PDF},
+}
+
+```
+

--- a/datasets/xnli/README.md
+++ b/datasets/xnli/README.md
@@ -1,0 +1,244 @@
+---
+---
+
+# Dataset Card for "xnli"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://www.nyu.edu/projects/bowman/xnli/](https://www.nyu.edu/projects/bowman/xnli/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 7384.70 MB
+- **Size of the generated dataset:** 3076.99 MB
+- **Total amount of disk used:** 10461.69 MB
+
+### [Dataset Summary](#dataset-summary)
+
+XNLI is a subset of a few thousand examples from MNLI which has been translated
+into a 14 different languages (some low-ish resource). As with MNLI, the goal is
+to predict textual entailment (does sentence A imply/contradict/neither sentence
+B) and is a classification task (given two sentences, predict one of three
+labels).
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### all_languages
+
+- **Size of downloaded dataset files:** 461.54 MB
+- **Size of the generated dataset:** 1535.82 MB
+- **Total amount of disk used:** 1997.37 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hypothesis": "{\"language\": [\"ar\", \"bg\", \"de\", \"el\", \"en\", \"es\", \"fr\", \"hi\", \"ru\", \"sw\", \"th\", \"tr\", \"ur\", \"vi\", \"zh\"], \"translation\": [\"احد اع...",
+    "label": 0,
+    "premise": "{\"ar\": \"واحدة من رقابنا ستقوم بتنفيذ تعليماتك كلها بكل دقة\", \"bg\": \"един от нашите номера ще ви даде инструкции .\", \"de\": \"Eine ..."
+}
+```
+
+#### ar
+
+- **Size of downloaded dataset files:** 461.54 MB
+- **Size of the generated dataset:** 104.26 MB
+- **Total amount of disk used:** 565.81 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "hypothesis": "اتصل بأمه حالما أوصلته حافلة المدرسية.",
+    "label": 1,
+    "premise": "وقال، ماما، لقد عدت للمنزل."
+}
+```
+
+#### bg
+
+- **Size of downloaded dataset files:** 461.54 MB
+- **Size of the generated dataset:** 122.38 MB
+- **Total amount of disk used:** 583.92 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hypothesis": "\"губиш нещата на следното ниво , ако хората си припомнят .\"...",
+    "label": 0,
+    "premise": "\"по време на сезона и предполагам , че на твоето ниво ще ги загубиш на следващото ниво , ако те решат да си припомнят отбора на ..."
+}
+```
+
+#### de
+
+- **Size of downloaded dataset files:** 461.54 MB
+- **Size of the generated dataset:** 82.18 MB
+- **Total amount of disk used:** 543.73 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hypothesis": "Man verliert die Dinge auf die folgende Ebene , wenn sich die Leute erinnern .",
+    "label": 0,
+    "premise": "\"Du weißt , während der Saison und ich schätze , auf deiner Ebene verlierst du sie auf die nächste Ebene , wenn sie sich entschl..."
+}
+```
+
+#### el
+
+- **Size of downloaded dataset files:** 461.54 MB
+- **Size of the generated dataset:** 135.71 MB
+- **Total amount of disk used:** 597.25 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "hypothesis": "\"Τηλεφώνησε στη μαμά του μόλις το σχολικό λεωφορείο τον άφησε.\"...",
+    "label": 1,
+    "premise": "Και είπε, Μαμά, έφτασα στο σπίτι."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### all_languages
+- `premise`: a multilingual `string` variable, with possible languages including `ar`, `bg`, `de`, `el`, `en`.
+- `hypothesis`: a multilingual `string` variable, with possible languages including `ar`, `bg`, `de`, `el`, `en`.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### ar
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### bg
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### de
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+#### el
+- `premise`: a `string` feature.
+- `hypothesis`: a `string` feature.
+- `label`: a classification label, with possible values including `entailment` (0), `neutral` (1), `contradiction` (2).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|    name     |train |validation|test|
+|-------------|-----:|---------:|---:|
+|all_languages|392702|      2490|5010|
+|ar           |392702|      2490|5010|
+|bg           |392702|      2490|5010|
+|de           |392702|      2490|5010|
+|el           |392702|      2490|5010|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@InProceedings{conneau2018xnli,
+  author = {Conneau, Alexis
+                 and Rinott, Ruty
+                 and Lample, Guillaume
+                 and Williams, Adina
+                 and Bowman, Samuel R.
+                 and Schwenk, Holger
+                 and Stoyanov, Veselin},
+  title = {XNLI: Evaluating Cross-lingual Sentence Representations},
+  booktitle = {Proceedings of the 2018 Conference on Empirical Methods
+               in Natural Language Processing},
+  year = {2018},
+  publisher = {Association for Computational Linguistics},
+  location = {Brussels, Belgium},
+}
+```
+

--- a/datasets/xquad/README.md
+++ b/datasets/xquad/README.md
@@ -1,0 +1,276 @@
+---
+---
+
+# Dataset Card for "xquad"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/deepmind/xquad](https://github.com/deepmind/xquad)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 139.53 MB
+- **Size of the generated dataset:** 18.09 MB
+- **Total amount of disk used:** 157.62 MB
+
+### [Dataset Summary](#dataset-summary)
+
+XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question answering
+performance. The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from the development set
+of SQuAD v1.1 (Rajpurkar et al., 2016) together with their professional translations into ten languages: Spanish, German,
+Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi. Consequently, the dataset is entirely parallel
+across 11 languages.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### xquad.ar
+
+- **Size of downloaded dataset files:** 12.68 MB
+- **Size of the generated dataset:** 1.64 MB
+- **Total amount of disk used:** 14.33 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [527],
+        "text": ["136"]
+    },
+    "context": "\"Die Verteidigung der Panthers gab nur 308 Punkte ab und belegte den sechsten Platz in der Liga, während sie die NFL mit 24 Inte...",
+    "id": "56beb4343aeaaa14008c925c",
+    "question": "Wie viele Sacks erzielte Jared Allen in seiner Karriere?"
+}
+```
+
+#### xquad.de
+
+- **Size of downloaded dataset files:** 12.68 MB
+- **Size of the generated dataset:** 1.23 MB
+- **Total amount of disk used:** 13.91 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [527],
+        "text": ["136"]
+    },
+    "context": "\"Die Verteidigung der Panthers gab nur 308 Punkte ab und belegte den sechsten Platz in der Liga, während sie die NFL mit 24 Inte...",
+    "id": "56beb4343aeaaa14008c925c",
+    "question": "Wie viele Sacks erzielte Jared Allen in seiner Karriere?"
+}
+```
+
+#### xquad.el
+
+- **Size of downloaded dataset files:** 12.68 MB
+- **Size of the generated dataset:** 2.11 MB
+- **Total amount of disk used:** 14.79 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [527],
+        "text": ["136"]
+    },
+    "context": "\"Die Verteidigung der Panthers gab nur 308 Punkte ab und belegte den sechsten Platz in der Liga, während sie die NFL mit 24 Inte...",
+    "id": "56beb4343aeaaa14008c925c",
+    "question": "Wie viele Sacks erzielte Jared Allen in seiner Karriere?"
+}
+```
+
+#### xquad.en
+
+- **Size of downloaded dataset files:** 12.68 MB
+- **Size of the generated dataset:** 1.07 MB
+- **Total amount of disk used:** 13.75 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [527],
+        "text": ["136"]
+    },
+    "context": "\"Die Verteidigung der Panthers gab nur 308 Punkte ab und belegte den sechsten Platz in der Liga, während sie die NFL mit 24 Inte...",
+    "id": "56beb4343aeaaa14008c925c",
+    "question": "Wie viele Sacks erzielte Jared Allen in seiner Karriere?"
+}
+```
+
+#### xquad.es
+
+- **Size of downloaded dataset files:** 12.68 MB
+- **Size of the generated dataset:** 1.22 MB
+- **Total amount of disk used:** 13.90 MB
+
+An example of 'validation' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "answers": {
+        "answer_start": [527],
+        "text": ["136"]
+    },
+    "context": "\"Die Verteidigung der Panthers gab nur 308 Punkte ab und belegte den sechsten Platz in der Liga, während sie die NFL mit 24 Inte...",
+    "id": "56beb4343aeaaa14008c925c",
+    "question": "Wie viele Sacks erzielte Jared Allen in seiner Karriere?"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### xquad.ar
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### xquad.de
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### xquad.el
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### xquad.en
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+#### xquad.es
+- `id`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `text`: a `string` feature.
+  - `answer_start`: a `int32` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|  name  |validation|
+|--------|---------:|
+|xquad.ar|      1190|
+|xquad.de|      1190|
+|xquad.el|      1190|
+|xquad.en|      1190|
+|xquad.es|      1190|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{Artetxe:etal:2019,
+      author    = {Mikel Artetxe and Sebastian Ruder and Dani Yogatama},
+      title     = {On the cross-lingual transferability of monolingual representations},
+      journal   = {CoRR},
+      volume    = {abs/1910.11856},
+      year      = {2019},
+      archivePrefix = {arXiv},
+      eprint    = {1910.11856}
+}
+
+```
+

--- a/datasets/xsum/README.md
+++ b/datasets/xsum/README.md
@@ -1,0 +1,147 @@
+---
+---
+
+# Dataset Card for "xsum"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/EdinburghNLP/XSum/tree/master/XSum-Dataset](https://github.com/EdinburghNLP/XSum/tree/master/XSum-Dataset)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 245.38 MB
+- **Size of the generated dataset:** 507.60 MB
+- **Total amount of disk used:** 752.98 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Extreme Summarization (XSum) Dataset.
+
+There are three features:
+  - document: Input news article.
+  - summary: One sentence summary of the article.
+  - id: BBC ID of the article.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### default
+
+- **Size of downloaded dataset files:** 245.38 MB
+- **Size of the generated dataset:** 507.60 MB
+- **Total amount of disk used:** 752.98 MB
+
+An example of 'validation' looks as follows.
+```
+{
+    "document": "some-body",
+    "id": "29750031",
+    "summary": "some-sentence"
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### default
+- `document`: a `string` feature.
+- `summary`: a `string` feature.
+- `id`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+| name  |train |validation|test |
+|-------|-----:|---------:|----:|
+|default|204045|     11332|11334|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+
+@article{Narayan2018DontGM,
+  title={Don't Give Me the Details, Just the Summary! Topic-Aware Convolutional Neural Networks for Extreme Summarization},
+  author={Shashi Narayan and Shay B. Cohen and Mirella Lapata},
+  journal={ArXiv},
+  year={2018},
+  volume={abs/1808.08745}
+}
+
+```
+

--- a/datasets/xtreme/README.md
+++ b/datasets/xtreme/README.md
@@ -1,0 +1,256 @@
+---
+---
+
+# Dataset Card for "xtreme"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://github.com/google-research/xtreme	https://www.nyu.edu/projects/bowman/xnli/](https://github.com/google-research/xtreme	https://www.nyu.edu/projects/bowman/xnli/)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 15143.21 MB
+- **Size of the generated dataset:** 1027.42 MB
+- **Total amount of disk used:** 16170.64 MB
+
+### [Dataset Summary](#dataset-summary)
+
+The Cross-lingual Natural Language Inference (XNLI) corpus is a crowd-sourced collection of 5,000 test and
+2,500 dev pairs for the MultiNLI corpus. The pairs are annotated with textual entailment and translated into
+14 languages: French, Spanish, German, Greek, Bulgarian, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese,
+Hindi, Swahili and Urdu. This results in 112.5k annotated pairs. Each premise can be associated with the
+corresponding hypothesis in the 15 languages, summing up to more than 1.5M combinations. The corpus is made to
+evaluate how to perform inference in any language (including low-resources ones like Swahili or Urdu) when only
+English NLI data is available at training time. One solution is cross-lingual sentence encoding, for which XNLI
+is an evaluation benchmark.
+The Cross-lingual TRansfer Evaluation of Multilingual Encoders (XTREME) benchmark is a benchmark for the evaluation of
+the cross-lingual generalization ability of pre-trained multilingual models. It covers 40 typologically diverse languages
+(spanning 12 language families) and includes nine tasks that collectively require reasoning about different levels of
+syntax and semantics. The languages in XTREME are selected to maximize language diversity, coverage in existing tasks,
+and availability of training data. Among these are many under-studied languages, such as the Dravidian languages Tamil
+(spoken in southern India, Sri Lanka, and Singapore), Telugu and Malayalam (spoken mainly in southern India), and the
+Niger-Congo languages Swahili and Yoruba, spoken in Africa.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### MLQA.ar.ar
+
+- **Size of downloaded dataset files:** 72.21 MB
+- **Size of the generated dataset:** 8.77 MB
+- **Total amount of disk used:** 80.98 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### MLQA.ar.de
+
+- **Size of downloaded dataset files:** 72.21 MB
+- **Size of the generated dataset:** 2.43 MB
+- **Total amount of disk used:** 74.64 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### MLQA.ar.en
+
+- **Size of downloaded dataset files:** 72.21 MB
+- **Size of the generated dataset:** 8.62 MB
+- **Total amount of disk used:** 80.83 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### MLQA.ar.es
+
+- **Size of downloaded dataset files:** 72.21 MB
+- **Size of the generated dataset:** 3.12 MB
+- **Total amount of disk used:** 75.33 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+#### MLQA.ar.hi
+
+- **Size of downloaded dataset files:** 72.21 MB
+- **Size of the generated dataset:** 3.17 MB
+- **Total amount of disk used:** 75.38 MB
+
+An example of 'validation' looks as follows.
+```
+
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### MLQA.ar.ar
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+
+#### MLQA.ar.de
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+
+#### MLQA.ar.en
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+
+#### MLQA.ar.es
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+
+#### MLQA.ar.hi
+- `id`: a `string` feature.
+- `title`: a `string` feature.
+- `context`: a `string` feature.
+- `question`: a `string` feature.
+- `answers`: a dictionary feature containing:
+  - `answer_start`: a `int32` feature.
+  - `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |validation|test|
+|----------|---------:|---:|
+|MLQA.ar.ar|       517|5335|
+|MLQA.ar.de|       207|1649|
+|MLQA.ar.en|       517|5335|
+|MLQA.ar.es|       161|1978|
+|MLQA.ar.hi|       186|1831|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+  @InProceedings{conneau2018xnli,
+  author = {Conneau, Alexis
+                 and Rinott, Ruty
+                 and Lample, Guillaume
+                 and Williams, Adina
+                 and Bowman, Samuel R.
+                 and Schwenk, Holger
+                 and Stoyanov, Veselin},
+  title = {XNLI: Evaluating Cross-lingual Sentence Representations},
+  booktitle = {Proceedings of the 2018 Conference on Empirical Methods
+               in Natural Language Processing},
+  year = {2018},
+  publisher = {Association for Computational Linguistics},
+  location = {Brussels, Belgium},
+}
+@article{hu2020xtreme,
+      author    = {Junjie Hu and Sebastian Ruder and Aditya Siddhant and Graham Neubig and Orhan Firat and Melvin Johnson},
+      title     = {XTREME: A Massively Multilingual Multi-task Benchmark for Evaluating Cross-lingual Generalization},
+      journal   = {CoRR},
+      volume    = {abs/2003.11080},
+      year      = {2020},
+      archivePrefix = {arXiv},
+      eprint    = {2003.11080}
+}
+
+```
+

--- a/datasets/yelp_polarity/README.md
+++ b/datasets/yelp_polarity/README.md
@@ -1,0 +1,174 @@
+---
+---
+
+# Dataset Card for "yelp_polarity"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://course.fast.ai/datasets](https://course.fast.ai/datasets)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Size of downloaded dataset files:** 158.67 MB
+- **Size of the generated dataset:** 421.28 MB
+- **Total amount of disk used:** 579.95 MB
+
+### [Dataset Summary](#dataset-summary)
+
+Large Yelp Review Dataset.
+This is a dataset for binary sentiment classification. We provide a set of 560,000 highly polar yelp reviews for training, and 38,000 for testing.
+ORIGIN
+The Yelp reviews dataset consists of reviews from Yelp. It is extracted
+from the Yelp Dataset Challenge 2015 data. For more information, please
+refer to http://www.yelp.com/dataset_challenge
+
+The Yelp reviews polarity dataset is constructed by
+Xiang Zhang (xiang.zhang@nyu.edu) from the above dataset.
+It is first used as a text classification benchmark in the following paper:
+Xiang Zhang, Junbo Zhao, Yann LeCun. Character-level Convolutional Networks
+for Text Classification. Advances in Neural Information Processing Systems 28
+(NIPS 2015).
+
+DESCRIPTION
+
+The Yelp reviews polarity dataset is constructed by considering stars 1 and 2
+negative, and 3 and 4 positive. For each polarity 280,000 training samples and
+19,000 testing samples are take randomly. In total there are 560,000 trainig
+samples and 38,000 testing samples. Negative polarity is class 1,
+and positive class 2.
+
+The files train.csv and test.csv contain all the training samples as
+comma-sparated values. There are 2 columns in them, corresponding to class
+index (1 and 2) and review text. The review texts are escaped using double
+quotes ("), and any internal double quote is escaped by 2 double quotes ("").
+New lines are escaped by a backslash followed with an "n" character,
+that is "
+".
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for up to 5 configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+#### plain_text
+
+- **Size of downloaded dataset files:** 158.67 MB
+- **Size of the generated dataset:** 421.28 MB
+- **Total amount of disk used:** 579.95 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "label": 0,
+    "text": "\"Unfortunately, the frustration of being Dr. Goldberg's patient is a repeat of the experience I've had with so many other doctor..."
+}
+```
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all splits.
+
+#### plain_text
+- `text`: a `string` feature.
+- `label`: a classification label, with possible values including `1` (0), `2` (1).
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|   name   |train |test |
+|----------|-----:|----:|
+|plain_text|560000|38000|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Citation Information](#citation-information)
+
+```
+@article{zhangCharacterlevelConvolutionalNetworks2015,
+  archivePrefix = {arXiv},
+  eprinttype = {arxiv},
+  eprint = {1509.01626},
+  primaryClass = {cs},
+  title = {Character-Level {{Convolutional Networks}} for {{Text Classification}}},
+  abstract = {This article offers an empirical exploration on the use of character-level convolutional networks (ConvNets) for text classification. We constructed several large-scale datasets to show that character-level convolutional networks could achieve state-of-the-art or competitive results. Comparisons are offered against traditional models such as bag of words, n-grams and their TFIDF variants, and deep learning models such as word-based ConvNets and recurrent neural networks.},
+  journal = {arXiv:1509.01626 [cs]},
+  author = {Zhang, Xiang and Zhao, Junbo and LeCun, Yann},
+  month = sep,
+  year = {2015},
+}
+
+```
+


### PR DESCRIPTION
This is it: we worked on a generator with Yacine @yjernite , and we generated dataset cards for all missing ones (161), with all the information we could gather from datasets repository, and using dummy_data to generate examples when possible.

Code is available here for the moment: https://github.com/madlag/datasets_readme_generator .
We will move it to a Hugging Face repository and to https://huggingface.co/datasets/card-creator/ later.
