### PR TITLE
Fix windows path scheme in cached path

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -345,8 +345,10 @@ def cached_path(
     elif os.path.exists(url_or_filename):
         # File, and it exists.
         output_path = url_or_filename
-    elif urlparse(url_or_filename).scheme == "":
+    elif urlparse(url_or_filename).scheme == "" or os.path.ismount(urlparse(url_or_filename).scheme + ":/"):
         # File, but it doesn't exist.
+        # On unix the scheme of a local path is empty, while on windows the scheme is the drive name (ex: "c")
+        # for details on the windows behavior, see https://bugs.python.org/issue42215
         raise FileNotFoundError("Local file {} doesn't exist".format(url_or_filename))
     else:
         # Something unknown

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,6 +1,9 @@
+import os
+from pathlib import Path
 from unittest import TestCase
 
 import numpy as np
+import pytest
 
 from datasets.utils.file_utils import DownloadConfig, cached_path, temp_seed
 
@@ -69,3 +72,23 @@ def test_cached_path_extract(xz_file, tmp_path, text_file):
     with open(text_file) as f:
         expected_file_content = f.read()
     assert extracted_file_content == expected_file_content
+
+
+def test_cached_path_local(text_file):
+    # absolute path
+    text_file = str(Path(text_file).resolve())
+    assert cached_path(text_file) == text_file
+    # relative path
+    text_file = str(Path(__file__).resolve().relative_to(Path(os.getcwd())))
+    assert cached_path(text_file) == text_file
+
+
+def test_cached_path_missing_local(tmp_path):
+    # absolute path
+    missing_file = str(tmp_path.resolve() / "__missing_file__.txt")
+    with pytest.raises(FileNotFoundError):
+        cached_path(missing_file)
+    # relative path
+    missing_file = "./__missing_file__.txt"
+    with pytest.raises(FileNotFoundError):
+        cached_path(missing_file)


### PR DESCRIPTION
As noticed in #807 there's currently an issue with `cached_path` not raising `FileNotFoundError` on windows for absolute paths. This is due to the way we check for a path to be local or not. The check on the scheme using urlparse was incomplete.

I fixed this and added tests