### PR TITLE
Conda support

### DIFF
--- a/.github/conda/build.sh
+++ b/.github/conda/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install     # Python command to install the script.

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "datasets" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ DATASETS_VERSION }}"
+
+source:
+  path: ../../
+
+build:
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy >=1.17
+    - pyarrow >=0.17.1
+    - python-xxhash
+    - dill
+    - pandas
+    - requests >=2.19.0
+    - tqdm >=4.27,<4.50.0
+    - dataclasses
+    - multiprocess
+  run:
+    - python
+    - pip
+    - numpy >=1.17
+    - pyarrow >=0.17.1
+    - python-xxhash
+    - dill
+    - pandas
+    - requests >=2.19.0
+    - tqdm >=4.27,<4.50.0
+    - dataclasses
+    - multiprocess
+
+test:
+  imports:
+    - datasets
+
+about:
+  home: https://huggingface.co
+  license: Apache License 2.0
+  license_file: LICENSE
+  summary: "🤗 The largest hub of ready-to-use NLP datasets for ML models with fast, easy-to-use and efficient data manipulation tools"

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -3,7 +3,7 @@ name: Release - Conda
 on:
   push:
     tags:
-      - '*'
+      - [0-9]+.[0-9]+.[0-9]+*
 
 env:
   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -3,7 +3,7 @@ name: Release - Conda
 on:
   push:
     tags:
-      - v*
+      - '*'
 
 env:
   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -1,0 +1,44 @@
+name: Release - Conda
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+
+jobs:
+  build_and_package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Install miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          activate-environment: "build-datasets"
+          channels: huggingface,conda-forge
+
+      - name: Setup conda env
+        run: |
+          conda install -c defaults anaconda-client conda-build
+
+      - name: Extract version
+        run: echo "DATASETS_VERSION=`python setup.py --version`" >> $GITHUB_ENV
+
+      - name: Build conda packages
+        run: |
+          conda info
+          conda-build .github/conda
+
+      - name: Upload to Anaconda
+        run: |
+          anaconda upload `conda-build .github/conda --output -c conda-forge` --force


### PR DESCRIPTION
Will push a new version on anaconda cloud every time a tag starting with `v` is pushed (like `v1.2.2`).

Will appear here: https://anaconda.org/huggingface/datasets

Depends on `conda-forge` for now, so the following is required for installation:

```
conda install -c huggingface -c conda-forge datasets
```