### PR TITLE
Fix typo in README.md of cnn_dailymail

### DIFF
--- a/datasets/cnn_dailymail/README.md
+++ b/datasets/cnn_dailymail/README.md
@@ -33,7 +33,7 @@ task_ids:
 ## Tasks supported:
 ### Task categorization / tags
 
-[Versions 2.0.0 and 3.0.0 of the CCN / DailyMail Dataset](https://www.aclweb.org/anthology/K16-1028.pdf) were developed for abstractive and extractive summarization. [Version 1.0.0](https://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend.pdf) was developed for machine reading and comprehension and abstractive question answering. 
+[Versions 2.0.0 and 3.0.0 of the CNN / DailyMail Dataset](https://www.aclweb.org/anthology/K16-1028.pdf) were developed for abstractive and extractive summarization. [Version 1.0.0](https://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend.pdf) was developed for machine reading and comprehension and abstractive question answering. 
 
 ## Purpose
 


### PR DESCRIPTION
When I read the README.md of `CNN/DailyMail Dataset`, there seems to be a typo `CCN`.

I am afraid this is a trivial matter, but I would like to make a suggestion for revision.