### PR TITLE
Use a config id in the cache directory names for custom configs

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -18,6 +18,7 @@
 
 import abc
 import contextlib
+import copy
 import inspect
 import os
 import shutil
@@ -26,6 +27,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Dict, List, Optional, Union
 
+from datasets.features import Features
 from datasets.utils.mock_download_manager import MockDownloadManager
 
 from . import utils
@@ -91,6 +93,85 @@ class BuilderConfig:
                     ).format(invalid_windows_characters, self.name)
                 )
 
+    def __eq__(self, o):
+        # we need to override the default dataclass __eq__ since it doesn't check for
+        # other attributes that the ones of the signature.
+        if set(self.__dict__.keys()) != set(o.__dict__.keys()):
+            return False
+        return all((k, getattr(self, k)) == (k, getattr(o, k)) for k in self.__dict__.keys())
+
+    def get_config_id(self, config_kwargs: dict, custom_features: Optional[Features] = None) -> str:
+        """
+        The config id is used to build the cache directory.
+        By default it is equal to the config name.
+        However the name of a config is not sufficent to have a unique identifier for the dataset being generated since
+        it doesn't take into account:
+        - the config kwargs that can be used to overwrite attributes
+        - the custom features used to write the dataset
+        - the data_files for json/text/csv/pandas datasets
+        Therefore the config id is just the config name with an optional suffix based on these.
+        """
+        # Possibly add a suffix to the name to handle custom features/data_files/config_kwargs
+        suffix: Optional[str] = None
+        config_kwargs_to_add_to_suffix = dict(config_kwargs)
+        # name and version are already used to build the cache directory
+        config_kwargs_to_add_to_suffix.pop("name", None)
+        config_kwargs_to_add_to_suffix.pop("version", None)
+        # data files are handled differently
+        config_kwargs_to_add_to_suffix.pop("data_files", None)
+        # data dir is ignored (when specified it points to the manually downloaded data)
+        config_kwargs_to_add_to_suffix.pop("data_dir", None)
+        if config_kwargs_to_add_to_suffix:
+            # we don't care about the order of the kwargs
+            config_kwargs_to_add_to_suffix = {
+                k: config_kwargs_to_add_to_suffix[k] for k in sorted(config_kwargs_to_add_to_suffix)
+            }
+            if all(isinstance(v, (str, bool, int, float)) for v in config_kwargs_to_add_to_suffix.values()):
+                suffix = ",".join(
+                    str(k) + "=" + urllib.parse.quote_plus(str(v)) for k, v in config_kwargs_to_add_to_suffix.items()
+                )
+                if len(suffix) > 32:  # hash if too long
+                    suffix = Hasher.hash(config_kwargs_to_add_to_suffix)
+            else:
+                suffix = Hasher.hash(config_kwargs_to_add_to_suffix)
+
+        if self.data_files is not None:
+            m = Hasher()
+            if suffix:
+                m.update(suffix)
+            if isinstance(self.data_files, str):
+                data_files = {"train": [self.data_files]}
+            elif isinstance(self.data_files, (tuple, list)):
+                data_files = {"train": self.data_files}
+            elif isinstance(self.data_files, dict):
+                data_files = {
+                    str(key): files if isinstance(files, (tuple, list)) else [files]
+                    for key, files in self.data_files.items()
+                }
+            else:
+                raise ValueError("Please provide a valid `data_files` in `DatasetBuilder`")
+            for key in sorted(data_files.keys()):
+                m.update(key)
+                for data_file in data_files[key]:
+                    m.update(os.path.abspath(data_file))
+                    m.update(str(os.path.getmtime(data_file)))
+            suffix = m.hexdigest()
+
+        if custom_features is not None:
+            m = Hasher()
+            if suffix:
+                m.update(suffix)
+            m.update(custom_features)
+            suffix = m.hexdigest()
+
+        if suffix:
+            config_id = self.name + "-" + suffix
+            if len(config_id) > MAX_DIRECTORY_NAME_LENGTH:
+                config_id = self.name + "-" + Hasher.hash(suffix)
+            return config_id
+        else:
+            return self.name
+
 
 class DatasetBuilder:
     """Abstract base class for all datasets.
@@ -154,7 +235,7 @@ class DatasetBuilder:
         config_kwargs = dict((key, value) for key, value in config_kwargs.items() if value is not None)
         if "features" in inspect.signature(self.BUILDER_CONFIG_CLASS.__init__).parameters and features is not None:
             config_kwargs["features"] = features
-        self.config = self._create_builder_config(
+        self.config, self.config_config_id = self._create_builder_config(
             name,
             custom_features=features,
             **config_kwargs,
@@ -214,11 +295,13 @@ class DatasetBuilder:
         return self.get_all_exported_dataset_infos().get(self.config.name, DatasetInfo())
 
     def _create_builder_config(self, name=None, custom_features=None, **config_kwargs):
-        """Create and validate BuilderConfig object.
+        """Create and validate BuilderConfig object as well as a unique config id for this config.
         Raises ValueError if there are multiple builder configs and name and DEFAULT_CONFIG_NAME are None.
         config_kwargs override the defaults kwargs in config
         """
         builder_config = None
+
+        # try default config
         if name is None and self.BUILDER_CONFIGS and not config_kwargs:
             if self.DEFAULT_CONFIG_NAME is not None:
                 builder_config = self.builder_configs.get(self.DEFAULT_CONFIG_NAME)
@@ -233,12 +316,16 @@ class DatasetBuilder:
                     )
                 builder_config = self.BUILDER_CONFIGS[0]
                 logger.info("No config specified, defaulting to first: %s/%s", self.name, builder_config.name)
+
+        # try get config by name
         if isinstance(name, str):
             builder_config = self.builder_configs.get(name)
             if builder_config is None and self.BUILDER_CONFIGS:
                 raise ValueError(
                     "BuilderConfig %s not found. Available: %s" % (name, list(self.builder_configs.keys()))
                 )
+
+        # if not using an existing config, then create a new config on the fly with config_kwargs
         if not builder_config:
             if name is not None:
                 config_kwargs["name"] = name
@@ -246,88 +333,36 @@ class DatasetBuilder:
                 config_kwargs["version"] = self.VERSION
             builder_config = self.BUILDER_CONFIG_CLASS(**config_kwargs)
 
-        for key, value in config_kwargs.items():
-            if value is not None:
-                setattr(builder_config, key, value)
-
-        name = builder_config.name
-        is_custom = name not in self.builder_configs
-        if is_custom:
-            logger.warning("Using custom data configuration %s", name)
+        # otherwise use the config_kwargs to overwrite the attributes
         else:
-            if builder_config != self.builder_configs[name]:
+            builder_config = copy.deepcopy(builder_config)
+            for key, value in config_kwargs.items():
+                if value is not None:
+                    if not hasattr(builder_config, key):
+                        raise ValueError(f"BuilderConfig {builder_config} doesn't have a '{key}' key.")
+                    setattr(builder_config, key, value)
+
+        if not builder_config.name:
+            raise ValueError("BuilderConfig must have a name, got %s" % builder_config.name)
+
+        # compute the config id that is going to be used for caching
+        config_id = builder_config.get_config_id(config_kwargs, custom_features=custom_features)
+        is_custom = config_id not in self.builder_configs
+        if is_custom:
+            logger.warning("Using custom data configuration %s", config_id)
+        else:
+            if builder_config != self.builder_configs[builder_config.name]:
                 raise ValueError(
                     "Cannot name a custom BuilderConfig the same as an available "
                     "BuilderConfig. Change the name. Available BuilderConfigs: %s"
                     % (list(self.builder_configs.keys()))
                 )
             if not builder_config.version:
-                raise ValueError("BuilderConfig %s must have a version" % name)
+                raise ValueError("BuilderConfig %s must have a version" % builder_config.name)
             # if not builder_config.description:
-            #     raise ValueError("BuilderConfig %s must have a description" % name)
-            return builder_config  # found existing configuration
-        if not name:
-            raise ValueError("BuilderConfig must have a name, got %s" % name)
+            #     raise ValueError("BuilderConfig %s must have a description" % builder_config.name)
 
-        # Possibly add a suffix to the name to handle custom features/data_files/config_kwargs
-        suffix: Optional[str] = None
-        config_kwargs_to_add_to_suffix = dict(config_kwargs)
-        # name and version are already used to build the cache directory
-        config_kwargs_to_add_to_suffix.pop("name", None)
-        config_kwargs_to_add_to_suffix.pop("version", None)
-        # data files are handled differently
-        config_kwargs_to_add_to_suffix.pop("data_files", None)
-        # data dir is ignored (when specified it points to the manually downloaded data)
-        config_kwargs_to_add_to_suffix.pop("data_dir", None)
-        if config_kwargs_to_add_to_suffix:
-            # we don't care about the order of the kwargs
-            config_kwargs_to_add_to_suffix = {
-                k: config_kwargs_to_add_to_suffix[k] for k in sorted(config_kwargs_to_add_to_suffix)
-            }
-            if all(isinstance(v, (str, bool, int, float)) for v in config_kwargs_to_add_to_suffix.values()):
-                suffix = ",".join(
-                    str(k) + "=" + urllib.parse.quote_plus(str(v)) for k, v in config_kwargs_to_add_to_suffix.items()
-                )
-                if len(suffix) > 32:  # hash if too long
-                    suffix = Hasher.hash(config_kwargs_to_add_to_suffix)
-            else:
-                suffix = Hasher.hash(config_kwargs_to_add_to_suffix)
-
-        if builder_config.data_files is not None:
-            m = Hasher()
-            if suffix:
-                m.update(suffix)
-            if isinstance(builder_config.data_files, str):
-                data_files = {"train": [builder_config.data_files]}
-            elif isinstance(builder_config.data_files, (tuple, list)):
-                data_files = {"train": builder_config.data_files}
-            elif isinstance(builder_config.data_files, dict):
-                data_files = {
-                    str(key): files if isinstance(files, (tuple, list)) else [files]
-                    for key, files in builder_config.data_files.items()
-                }
-            else:
-                raise ValueError("Please provide a valid `data_files` in `DatasetBuilder`")
-            for key in sorted(data_files.keys()):
-                m.update(key)
-                for data_file in data_files[key]:
-                    m.update(os.path.abspath(data_file))
-                    m.update(str(os.path.getmtime(data_file)))
-            suffix = m.hexdigest()
-
-        if custom_features is not None:
-            m = Hasher()
-            if suffix:
-                m.update(suffix)
-            m.update(custom_features)
-            suffix = m.hexdigest()
-
-        if suffix:
-            new_name = builder_config.name + "-" + suffix
-            if len(new_name) > MAX_DIRECTORY_NAME_LENGTH:
-                new_name = builder_config.name + "-" + Hasher.hash(suffix)
-            builder_config.name = new_name
-        return builder_config
+        return builder_config, config_id
 
     @utils.classproperty
     @classmethod
@@ -354,7 +389,8 @@ class DatasetBuilder:
         builder_config = self.config
         hash = self.hash
         if builder_config:
-            builder_data_dir = os.path.join(builder_data_dir, builder_config.name)
+            # use the enriched name instead of the name to make it unique
+            builder_data_dir = os.path.join(builder_data_dir, self.config_config_id)
         if with_version:
             builder_data_dir = os.path.join(builder_data_dir, str(self.config.version))
         if with_hash and hash and isinstance(hash, str):

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -100,7 +100,7 @@ class BuilderConfig:
             return False
         return all((k, getattr(self, k)) == (k, getattr(o, k)) for k in self.__dict__.keys())
 
-    def get_config_id(self, config_kwargs: dict, custom_features: Optional[Features] = None) -> str:
+    def create_config_id(self, config_kwargs: dict, custom_features: Optional[Features] = None) -> str:
         """
         The config id is used to build the cache directory.
         By default it is equal to the config name.
@@ -235,7 +235,7 @@ class DatasetBuilder:
         config_kwargs = dict((key, value) for key, value in config_kwargs.items() if value is not None)
         if "features" in inspect.signature(self.BUILDER_CONFIG_CLASS.__init__).parameters and features is not None:
             config_kwargs["features"] = features
-        self.config, self.config_config_id = self._create_builder_config(
+        self.config, self.config_id = self._create_builder_config(
             name,
             custom_features=features,
             **config_kwargs,
@@ -346,7 +346,7 @@ class DatasetBuilder:
             raise ValueError("BuilderConfig must have a name, got %s" % builder_config.name)
 
         # compute the config id that is going to be used for caching
-        config_id = builder_config.get_config_id(config_kwargs, custom_features=custom_features)
+        config_id = builder_config.create_config_id(config_kwargs, custom_features=custom_features)
         is_custom = config_id not in self.builder_configs
         if is_custom:
             logger.warning("Using custom data configuration %s", config_id)
@@ -390,7 +390,7 @@ class DatasetBuilder:
         hash = self.hash
         if builder_config:
             # use the enriched name instead of the name to make it unique
-            builder_data_dir = os.path.join(builder_data_dir, self.config_config_id)
+            builder_data_dir = os.path.join(builder_data_dir, self.config_id)
         if with_version:
             builder_data_dir = os.path.join(builder_data_dir, str(self.config.version))
         if with_hash and hash and isinstance(hash, str):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -60,6 +60,7 @@ class DummyGeneratorBasedBuilderWithConfigConfig(BuilderConfig):
     def __init__(self, content="foo", times=2, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.content = content
+        self.times = times
 
 
 class DummyGeneratorBasedBuilderWithConfig(GeneratorBasedBuilder):
@@ -545,6 +546,7 @@ class BuilderTest(TestCase):
 
     def test_cache_dir_for_config_kwargs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
+            # create config on the fly
             dummy_builder = DummyGeneratorBasedBuilderWithConfig(
                 cache_dir=tmp_dir, name="dummy", content="foo", times=2
             )
@@ -559,6 +561,18 @@ class BuilderTest(TestCase):
             )
             self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, name="dummy", content="foo")
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # overwrite an existing config
+            dummy_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="foo", times=2)
+            other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", times=2, content="foo")
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertIn("content=foo", dummy_builder.cache_dir)
+            self.assertIn("times=2", dummy_builder.cache_dir)
+            other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="bar", times=2)
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="foo")
             self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
 
     def test_custom_writer_batch_size(self):


### PR DESCRIPTION
As noticed by @JetRunner there was some issues when trying to generate a dataset using a custom config that is based on an existing config.

For example in the following code the `mnli_custom` would reuse the cache used to create `mnli` instead of generating a new dataset with the new label classes:
```python
from datasets import load_dataset

mnli = load_dataset("glue", "mnli")
mnli_custom = load_dataset("glue", "mnli", label_classes=["contradiction", "entailment", "neutral"])
```

I fixed that by extending the cache directory definition of a dataset that is being generated.
Instead of using the config name in the cache directory name, I switched to using a `config_id`.

By default it is equal to the config name.
However the name of a config is not sufficent to have a unique identifier for the dataset being generated since it doesn't take into account:
- the config kwargs that can be used to overwrite attributes
- the custom features used to write the dataset
- the data_files for json/text/csv/pandas datasets

Therefore the config id is just the config name with an optional suffix based on these.

In particular taking into account the config kwargs fixes the issue with the `label_classes` above.

I completed the current test cases by adding the case that was missing: overwriting an already existing config.