### PR TITLE
Ignore definition line number of functions for caching

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -447,13 +447,18 @@ def _save_code(pickler, obj):
     of functions created in notebooks or shells for example.
     """
     dill._dill.log.info("Co: %s" % obj)
+    # The filename of a function is the .py file where it is defined.
     # Filenames of functions created in notebooks or shells start with '<'
     # ex: <ipython-input-13-9ed2afe61d25> for ipython, and <stdin> for shell
     # Moreover lambda functions have a special name: '<lambda>'
     # ex: (lambda x: x).__code__.co_name == "<lambda>"  # True
+    # For the hashing mechanism we ignore where the function has been defined
+    # More specifically:
+    # - we ignore the filename of special functions (filename starts with '<')
+    # - we always ignore the line number
     # Only those two lines are different from the original implementation:
     co_filename = "" if obj.co_filename.startswith("<") or obj.co_name == "<lambda>" else obj.co_filename
-    co_firstlineno = 1 if obj.co_filename.startswith("<") or obj.co_name == "<lambda>" else obj.co_firstlineno
+    co_firstlineno = 1
     # The rest is the same as in the original dill implementation
     if dill._dill.PY3:
         if hasattr(obj, "co_posonlyargcount"):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -96,6 +96,18 @@ class RecurseDumpTest(TestCase):
         self.assertEqual(hash1, hash3)
         self.assertNotEqual(hash1, hash2)
 
+    def test_dump_ignores_line_definition_of_function(self):
+        def func():
+            pass
+
+        hash1 = md5(datasets.utils.dumps(func)).hexdigest()
+
+        def func():
+            pass
+
+        hash2 = md5(datasets.utils.dumps(func)).hexdigest()
+        self.assertEqual(hash1, hash2)
+
     def test_recurse_dump_for_class(self):
 
         hash1 = md5(datasets.utils.dumps(Foo([0]))).hexdigest()


### PR DESCRIPTION
As noticed in #1718 , when a function used for processing with `map` is moved inside its python file, then the change of line number causes the caching mechanism to consider it as a different function. Therefore in this case, it recomputes everything.

This is because we were not ignoring the line number definition for such functions (even though we're doing it for lambda functions).

For example this code currently prints False:
```python
from datasets.fingerprint import Hasher

# define once
def foo(x):
    return x

h = Hasher.hash(foo)

# define a second time elsewhere
def foo(x):
    return x

print(h == Hasher.hash(foo))
```

I changed this by ignoring the line number for all functions.