### PR TITLE
Small fix with corrected logging of train vectors

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -267,8 +267,8 @@ class FaissIndex(BaseIndex):
 
         # Train
         if train_size is not None:
-            logger.info("Training the index with the first {} vectors".format(train_size))
             train_vecs = vectors[:train_size] if column is None else vectors[:train_size][column]
+            logger.info("Training the index with the first {} vectors".format(len(train_vecs)))
             self.faiss_index.train(train_vecs)
         else:
             logger.info("Ignored the training step of the faiss index as `train_size` is None.")


### PR DESCRIPTION
Now you can set `train_size` to the whole dataset size via `train_size = -1` and login writes not `Training the index with the first -1 vectors` but (for example) `Training the index with the first 16123 vectors`. And maybe more than dataset length. Logging will be correct