### PR TITLE
Support future datasets

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -91,7 +91,7 @@ class LoadTest(TestCase):
             finally:
                 datasets.utils.logging.disable_propagation()
 
-    def test_load_dataset(self):
+    def test_load_dataset_local(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dummy_code = """
 import os
@@ -121,12 +121,53 @@ class __DummyDataset1__(datasets.GeneratorBasedBuilder):
             with open(os.path.join(tmp_dir, "test.txt"), "w") as f:
                 f.write("bar\n" * 10)
             module_dir = self._dummy_module_dir(tmp_dir, "__dummy_dataset1__", dummy_code)
+            # load dataset from local path
             self.assertTrue(len(datasets.load_dataset(module_dir, data_dir=tmp_dir)), 2)
         with offline():
             self._caplog.clear()
             try:
                 datasets.utils.logging.enable_propagation()
+                # load dataset from cache
                 self.assertTrue(len(datasets.load_dataset("__dummy_dataset1__", data_dir=tmp_dir)), 2)
                 self.assertIn("Using the latest cached version of the module", self._caplog.text)
             finally:
                 datasets.utils.logging.disable_propagation()
+        with self.assertRaises(FileNotFoundError) as context:
+            datasets.load_dataset("_dummy")
+        self.assertIn("at _dummy/_dummy.py", str(context.exception))
+
+    def test_load_dataset_canonical(self):
+        with self.assertRaises(FileNotFoundError) as context:
+            datasets.load_dataset("_dummy")
+        self.assertIn(
+            "https://raw.githubusercontent.com/huggingface/datasets/master/datasets/_dummy/_dummy.py",
+            str(context.exception),
+        )
+        with self.assertRaises(FileNotFoundError) as context:
+            datasets.load_dataset("_dummy", script_version="0.0.0")
+        self.assertIn(
+            "https://raw.githubusercontent.com/huggingface/datasets/0.0.0/datasets/_dummy/_dummy.py",
+            str(context.exception),
+        )
+        with offline():
+            with self.assertRaises(ConnectionError) as context:
+                datasets.load_dataset("_dummy")
+            self.assertIn(
+                "https://raw.githubusercontent.com/huggingface/datasets/master/datasets/_dummy/_dummy.py",
+                str(context.exception),
+            )
+
+    def test_load_dataset_users(self):
+        with self.assertRaises(FileNotFoundError) as context:
+            datasets.load_dataset("dummy_user/_dummy")
+        self.assertIn(
+            "https://s3.amazonaws.com/datasets.huggingface.co/datasets/datasets/dummy_user/_dummy/_dummy.py",
+            str(context.exception),
+        )
+        with offline():
+            with self.assertRaises(ConnectionError) as context:
+                datasets.load_dataset("dummy_user/_dummy")
+            self.assertIn(
+                "https://s3.amazonaws.com/datasets.huggingface.co/datasets/datasets/dummy_user/_dummy/_dummy.py",
+                str(context.exception),
+            )

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -134,7 +134,7 @@ class __DummyDataset1__(datasets.GeneratorBasedBuilder):
                 datasets.utils.logging.disable_propagation()
         with self.assertRaises(FileNotFoundError) as context:
             datasets.load_dataset("_dummy")
-        self.assertIn("at _dummy/_dummy.py", str(context.exception))
+        self.assertIn("at " + os.path.join("_dummy", "_dummy.py"), str(context.exception))
 
     def test_load_dataset_canonical(self):
         with self.assertRaises(FileNotFoundError) as context:


### PR DESCRIPTION
If a dataset is available at the version of the local installation of `datasets` (e.g. 1.2.0), then loading this dataset means loading the script at this version.

However when trying to load a dataset that is only available on master, currently users have to specify `script_version="master"` in `load_dataset` to make it work.

However we could automatically get the dataset from master instead in this case.

I added this feature in this PR.
I also added a warning if a dataset is not available at the version of the local installation of `datasets` but is loaded from master:
```python
>>> load_dataset("silicone", "dyda_da")
Couldn't find file locally at silicone/silicone.py, or remotely at https://raw.githubusercontent.com/huggingface/datasets/1.2.0/datasets/silicone/silicone.py.
The file was picked from the master branch on github instead at https://raw.githubusercontent.com/huggingface/datasets/master/datasets/silicone/silicone.py.
Downloading and preparing dataset silicone/dyda_da (download: 8.46 MiB, generated: 9.39 MiB, post-processed: Unknown size, total: 17.86 MiB) to /Users/quentinlhoest/.cache/huggingface/datasets/silicone/dyda_da/1.0.0/d41d8c0b73c6df035b1369c45774418f0051163ea689b5502b8bda783adf6342...
...
```
