### PR TITLE
Add metrics usage examples and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - run: python -m venv venv
             - run: source venv/bin/activate
             - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt
+            - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==0.17.1
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
@@ -28,7 +28,7 @@ jobs:
             - run: python -m venv venv
             - run: source venv/bin/activate
             - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt
+            - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
@@ -46,7 +46,7 @@ jobs:
             - run: python -m virtualenv venv --system-site-packages
             - run: "& venv/Scripts/activate.ps1"
             - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt
+            - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==0.17.1
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -sv ./tests/
@@ -64,7 +64,7 @@ jobs:
             - run: python -m virtualenv venv --system-site-packages
             - run: "& venv/Scripts/activate.ps1"
             - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt
+            - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -sv ./tests/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
             - run: python -m venv venv
             - run: source venv/bin/activate
             - run: pip install .[tests]
+            - run: pip install -r additional-tests-requirements.txt
             - run: pip install pyarrow==0.17.1
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
@@ -27,6 +28,7 @@ jobs:
             - run: python -m venv venv
             - run: source venv/bin/activate
             - run: pip install .[tests]
+            - run: pip install -r additional-tests-requirements.txt
             - run: pip install pyarrow==1.0.0
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
@@ -44,6 +46,7 @@ jobs:
             - run: python -m virtualenv venv --system-site-packages
             - run: "& venv/Scripts/activate.ps1"
             - run: pip install .[tests]
+            - run: pip install -r additional-tests-requirements.txt
             - run: pip install pyarrow==0.17.1
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -sv ./tests/
@@ -61,6 +64,7 @@ jobs:
             - run: python -m virtualenv venv --system-site-packages
             - run: "& venv/Scripts/activate.ps1"
             - run: pip install .[tests]
+            - run: pip install -r additional-tests-requirements.txt
             - run: pip install pyarrow==1.0.0
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -sv ./tests/

--- a/additional-tests-requirements.txt
+++ b/additional-tests-requirements.txt
@@ -1,3 +1,7 @@
+pytorch-nlp==0.5.0  # for unbabel-comet
+pytorch_lightning  # for unbabel-comet
+fastBPE==0.1.0  # for unbabel-comet
+fairseq  # for unbabel-comet
 unbabel-comet>=0.0.6
 git+https://github.com/google-research/bleurt.git
 git+https://github.com/ns-moosavi/coval.git

--- a/additional-tests-requirements.txt
+++ b/additional-tests-requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/google-research/bleurt.git
+git+https://github.com/ns-moosavi/coval.git

--- a/additional-tests-requirements.txt
+++ b/additional-tests-requirements.txt
@@ -1,3 +1,3 @@
-unbabel-comet>=0.0.6
+unbabel-comet>=0.0.6; platform_system != "Windows"
 git+https://github.com/google-research/bleurt.git
 git+https://github.com/ns-moosavi/coval.git

--- a/additional-tests-requirements.txt
+++ b/additional-tests-requirements.txt
@@ -1,7 +1,3 @@
-pytorch-nlp==0.5.0  # for unbabel-comet
-pytorch_lightning  # for unbabel-comet
-fastBPE==0.1.0  # for unbabel-comet
-fairseq  # for unbabel-comet
 unbabel-comet>=0.0.6
 git+https://github.com/google-research/bleurt.git
 git+https://github.com/ns-moosavi/coval.git

--- a/additional-tests-requirements.txt
+++ b/additional-tests-requirements.txt
@@ -1,2 +1,3 @@
+unbabel-comet>=0.0.6
 git+https://github.com/google-research/bleurt.git
 git+https://github.com/ns-moosavi/coval.git

--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -37,6 +37,14 @@ Args:
     sample_weight: Sample weights.
 Returns:
     accuracy: Accuracy score.
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> accuracy_metric = datasets.load_metric("accuracy")
+    >>> results = accuracy_metric.compute(references=[0, 1], predictions=[0, 1])
+    >>> print(results)
+    {'accuracy': 1.0}
 """
 
 _CITATION = """\
@@ -54,6 +62,7 @@ _CITATION = """\
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Accuracy(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -38,8 +38,6 @@ Args:
 Returns:
     accuracy: Accuracy score.
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> accuracy_metric = datasets.load_metric("accuracy")
     >>> results = accuracy_metric.compute(references=[0, 1], predictions=[0, 1])

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -65,8 +65,6 @@ Returns:
     'f1', F1 score,
     'hashcode': Hashcode of the library,
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = ["hello there", "general kenobi"]
     >>> references = ["hello there", "general kenobi"]

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -64,9 +64,20 @@ Returns:
     'recall': Recall,
     'f1', F1 score,
     'hashcode': Hashcode of the library,
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = ["hello there", "general kenobi"]
+    >>> references = ["hello there", "general kenobi"]
+    >>> bertscore = datasets.load_metric("bertscore")
+    >>> results = bertscore.compute(predictions=predictions, references=references, lang="en")
+    >>> print([round(v, 2) for v in results["f1"]])
+    [1.0, 1.0]
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class BERTScore(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
@@ -139,9 +150,9 @@ class BERTScore(datasets.Metric):
             batch_size=batch_size,
         )
         output_dict = {
-            "precision": P,
-            "recall": R,
-            "f1": F,
+            "precision": P.tolist(),
+            "recall": R.tolist(),
+            "f1": F.tolist(),
             "hashcode": hashcode,
         }
         return output_dict

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -74,8 +74,6 @@ Returns:
     'translation_length': translation_length,
     'reference_length': reference_length
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = [
     ...     ["hello", "there", "general", "kenobi"],                             # tokenized prediction of the first sample

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -73,9 +73,26 @@ Returns:
     'length_ratio': ratio of lengths,
     'translation_length': translation_length,
     'reference_length': reference_length
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = [
+    ...     ["hello", "there", "general", "kenobi"],                             # tokenized prediction of the first sample
+    ...     ["foo", "bar", "foobar"]                                             # tokenized prediction of the second sample
+    ... ]
+    >>> references = [
+    ...     [["hello", "there", "general", "kenobi"], ["hello", "there", "!"]],  # tokenized references for the first sample (2 references)
+    ...     [["foo", "bar", "foobar"]]                                           # tokenized references for the second sample (1 reference)
+    ... ]
+    >>> bleu = datasets.load_metric("bleu")
+    >>> results = bleu.compute(predictions=predictions, references=references)
+    >>> print(results["bleu"])
+    1.0
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Bleu(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -53,8 +53,6 @@ Args:
 Returns:
     'scores': List of scores.
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = ["hello there", "general kenobi"]
     >>> references = ["hello there", "general kenobi"]

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -46,13 +46,22 @@ _KWARGS_DESCRIPTION = """
 BLEURT score.
 
 Args:
-
-predictions` (list of str): prediction/candidate sentences
-`references` (list of str): reference sentences
- checkpoint: BLEURT checkpoint. Will default to BLEURT-tiny if None.
+    `predictions` (list of str): prediction/candidate sentences
+    `references` (list of str): reference sentences
+    `checkpoint` BLEURT checkpoint. Will default to BLEURT-tiny if None.
 
 Returns:
     'scores': List of scores.
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = ["hello there", "general kenobi"]
+    >>> references = ["hello there", "general kenobi"]
+    >>> bleurt = datasets.load_metric("bleurt")
+    >>> results = bleurt.compute(predictions=predictions, references=references)
+    >>> print([round(v, 2) for v in results["scores"]])
+    [1.03, 1.04]
 """
 
 CHECKPOINT_URLS = {
@@ -65,6 +74,7 @@ CHECKPOINT_URLS = {
 }
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class BLEURT(datasets.Metric):
     def _info(self):
 

--- a/metrics/comet/comet.py
+++ b/metrics/comet/comet.py
@@ -99,8 +99,7 @@ Examples:
 
     >>> comet_metric = datasets.load_metric('comet') # doctest:+ELLIPSIS
     [...]Download succeeded. Loading model[...]
-    >>> # comet_metric = load_metric('comet')
-    >>> # comet_metric = load_metric('comet', 'wmt-large-hter-estimator')
+    >>> # comet_metric = load_metric('comet', 'wmt-large-hter-estimator')  # you can also choose which model to use
     >>> source = ["Dem Feuer konnte Einhalt geboten werden", "Schulen und Kindergärten wurden eröffnet."]
     >>> hypothesis = ["The fire could be stopped", "Schools and kindergartens were open"]
     >>> reference = ["They were able to control the fire.", "Schools and kindergartens opened"]

--- a/metrics/comet/comet.py
+++ b/metrics/comet/comet.py
@@ -38,7 +38,7 @@ predictions['scores']
 import os
 from logging import getLogger
 
-from comet.models import download_model, load_checkpoint  # From: unbabel-comet
+from comet.models import download_model  # From: unbabel-comet
 
 import datasets
 
@@ -95,25 +95,24 @@ Returns:
     `samples`: List of dictionaries with `src`, `mt`, `ref` and `score`.
     `scores`: List of scores.
 
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
 
-Usage:
-```python
-from datasets import load_metric
-comet_metric = load_metric('metrics/comet/comet.py')
-#comet_metric = load_metric('comet')
-#comet_metric = load_metric('comet', 'wmt-large-hter-estimator')
-
-
-source = ["Dem Feuer konnte Einhalt geboten werden", "Schulen und Kindergärten wurden eröffnet."]
-hypothesis = ["The fire could be stopped", "Schools and kindergartens were open"]
-reference = ["They were able to control the fire.", "Schools and kindergartens opened"]
-
-predictions = comet_metric.compute(predictions=hypothesis, references=reference, sources=source)
-predictions['scores']
-```
+    >>> comet_metric = datasets.load_metric('comet') # doctest:+ELLIPSIS
+    [...]Download succeeded. Loading model[...]
+    >>> # comet_metric = load_metric('comet')
+    >>> # comet_metric = load_metric('comet', 'wmt-large-hter-estimator')
+    >>> source = ["Dem Feuer konnte Einhalt geboten werden", "Schulen und Kindergärten wurden eröffnet."]
+    >>> hypothesis = ["The fire could be stopped", "Schools and kindergartens were open"]
+    >>> reference = ["They were able to control the fire.", "Schools and kindergartens opened"]
+    >>> results = comet_metric.compute(predictions=hypothesis, references=reference, sources=source)
+    >>> print([round(v, 2) for v in results["scores"]])
+    [0.19, 0.92]
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class COMET(datasets.Metric):
     def _info(self):
 

--- a/metrics/comet/comet.py
+++ b/metrics/comet/comet.py
@@ -96,8 +96,6 @@ Returns:
     `scores`: List of scores.
 
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> comet_metric = datasets.load_metric('comet') # doctest:+ELLIPSIS
     [...]Download succeeded. Loading model[...]

--- a/metrics/coval/coval.py
+++ b/metrics/coval/coval.py
@@ -13,12 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ CoVal metric. """
+import logging
 
 import coval  # From: git+https://github.com/ns-moosavi/coval.git noqa: F401
 from coval.conll import reader, util
 from coval.eval import evaluator
 
 import datasets
+
+
+logger = logging.getLogger(__name__)
 
 
 _CITATION = """\
@@ -119,11 +123,11 @@ Parsing CoNLL files is developed by Leo Born.
 _KWARGS_DESCRIPTION = """
 Calculates coreference evaluation metrics.
 Args:
-    predictions: list of predictions to score in the CoNLL format.
+    predictions: list of sentences. Each sentence is a list of word predictions to score in the CoNLL format.
         Each prediction is a word with its annotations as a string made of columns joined with spaces.
         Only columns 4, 5, 6 and the last column are used (word, POS, Pars and coreference annotation)
         See the details on the format in the description of the metric.
-    references: list of references for scoring in the CoNLL format.
+    references: list of sentences. Each sentence is a list of word reference to score in the CoNLL format.
         Each reference is a word with its annotations as a string made of columns joined with spaces.
         Only columns 4, 5, 6 and the last column are used (word, POS, Pars and coreference annotation)
         See the details on the format in the description of the metric.
@@ -135,7 +139,7 @@ Args:
         will be excluded from the evaluation.
     NP_only: Most of the recent coreference resolvers only resolve NP mentions and
         leave out the resolution of VPs. By setting the 'NP_only' option, the scorer will only evaluate the resolution of NPs.
-    min_spans: By setting 'min_spans', the scorer reports the results based on automatically detected minimum spans.
+    min_span: By setting 'min_span', the scorer reports the results based on automatically detected minimum spans.
         Minimum spans are determined using the MINA algorithm.
 
 Returns:
@@ -145,6 +149,23 @@ Returns:
     'ceafe': CEAFe [Luo et al., 2005]
     'lea': LEA [Moosavi and Strube, 2016]
     'conll_score': averaged CoNLL score (the average of the F1 values of MUC, B-cubed and CEAFe)
+
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> coval = datasets.load_metric('coval')
+    >>> words = ['bc/cctv/00/cctv_0005   0   0       Thank   VBP  (TOP(S(VP*    thank  01   1    Xu_li  *           (V*)        *       -',
+    ... 'bc/cctv/00/cctv_0005   0   1         you   PRP        (NP*)      -    -   -    Xu_li  *        (ARG1*)   (ARG0*)   (116)',
+    ... 'bc/cctv/00/cctv_0005   0   2    everyone    NN        (NP*)      -    -   -    Xu_li  *    (ARGM-DIS*)        *    (116)',
+    ... 'bc/cctv/00/cctv_0005   0   3         for    IN        (PP*       -    -   -    Xu_li  *        (ARG2*         *       -',
+    ... 'bc/cctv/00/cctv_0005   0   4    watching   VBG   (S(VP*))))   watch  01   1    Xu_li  *             *)      (V*)      -',
+    ... 'bc/cctv/00/cctv_0005   0   5           .     .          *))      -    -   -    Xu_li  *             *         *       -']
+    >>> references = [words]
+    >>> predictions = [words]
+    >>> results = coval.compute(predictions=predictions, references=references)
+    >>> print(results) # doctest:+ELLIPSIS
+    {'mentions/recall': 1.0,[...] 'conll_score': 100.0}
 """
 
 
@@ -191,17 +212,17 @@ def get_coref_infos(
     doc_coref_infos[doc] = (key_clusters, sys_clusters, key_mention_sys_cluster, sys_mention_key_cluster)
 
     if remove_nested:
-        print(
+        logger.info(
             "Number of removed nested coreferring mentions in the key "
             "annotation: %s; and system annotation: %s" % (key_nested_coref_num, sys_nested_coref_num)
         )
-        print(
+        logger.info(
             "Number of resulting singleton clusters in the key "
             "annotation: %s; and system annotation: %s" % (key_removed_nested_clusters, sys_removed_nested_clusters)
         )
 
     if not keep_singletons:
-        print(
+        logger.info(
             "%d and %d singletons are removed from the key and system "
             "files, respectively" % (key_singletons_num, sys_singletons_num)
         )
@@ -223,7 +244,7 @@ def evaluate(key_lines, sys_lines, metrics, NP_only, remove_nested, keep_singlet
             conll_subparts_num += 1
         output_scores.update({f"{name}/recall": recall, f"{name}/precision": precision, f"{name}/f1": f1})
 
-        print(
+        logger.info(
             name.ljust(10),
             "Recall: %.2f" % (recall * 100),
             " Precision: %.2f" % (precision * 100),
@@ -232,7 +253,7 @@ def evaluate(key_lines, sys_lines, metrics, NP_only, remove_nested, keep_singlet
 
     if conll_subparts_num == 3:
         conll = (conll / 3) * 100
-        print("CoNLL score: %.2f" % conll)
+        logger.info("CoNLL score: %.2f" % conll)
         output_scores.update({f"conll_score": conll})
 
     return output_scores
@@ -252,6 +273,7 @@ def check_gold_parse_annotation(key_lines):
     return has_gold_parse
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Coval(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
@@ -260,8 +282,8 @@ class Coval(datasets.Metric):
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Value("string", id="sequence"),
+                    "predictions": datasets.Sequence(datasets.Value("string")),
+                    "references": datasets.Sequence(datasets.Value("string")),
                 }
             ),
             codebase_urls=["https://github.com/ns-moosavi/coval"],
@@ -273,7 +295,7 @@ class Coval(datasets.Metric):
         )
 
     def _compute(
-        self, predictions, references, keep_singletons=True, NP_only=False, min_spans=False, remove_nested=False
+        self, predictions, references, keep_singletons=True, NP_only=False, min_span=False, remove_nested=False
     ):
         allmetrics = [
             ("mentions", evaluator.mentions),
@@ -283,10 +305,10 @@ class Coval(datasets.Metric):
             ("lea", evaluator.lea),
         ]
 
-        if min_spans:
+        if min_span:
             has_gold_parse = util.check_gold_parse_annotation(references)
             if not has_gold_parse:
-                raise NotImplementedError("References should have gold parse annotation to use 'min_spans'.")
+                raise NotImplementedError("References should have gold parse annotation to use 'min_span'.")
                 # util.parse_key_file(key_file)
                 # key_file = key_file + ".parsed"
 
@@ -297,7 +319,7 @@ class Coval(datasets.Metric):
             NP_only=NP_only,
             remove_nested=remove_nested,
             keep_singletons=keep_singletons,
-            min_spans=min_spans,
+            min_span=min_span,
         )
 
         return score

--- a/metrics/coval/coval.py
+++ b/metrics/coval/coval.py
@@ -151,8 +151,6 @@ Returns:
     'conll_score': averaged CoNLL score (the average of the F1 values of MUC, B-cubed and CEAFe)
 
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> coval = datasets.load_metric('coval')
     >>> words = ['bc/cctv/00/cctv_0005   0   0       Thank   VBP  (TOP(S(VP*    thank  01   1    Xu_li  *           (V*)        *       -',

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -54,8 +54,6 @@ Args:
 Returns:
     f1: F1 score.
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> f1_metric = datasets.load_metric("f1")
     >>> results = f1_metric.compute(references=[0, 1], predictions=[0, 1])

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -53,6 +53,14 @@ Args:
     sample_weight: Sample weights.
 Returns:
     f1: F1 score.
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> f1_metric = datasets.load_metric("f1")
+    >>> results = f1_metric.compute(references=[0, 1], predictions=[0, 1])
+    >>> print(results)
+    {'f1': 1.0}
 """
 
 _CITATION = """\
@@ -70,6 +78,7 @@ _CITATION = """\
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class F1(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -48,6 +48,37 @@ Returns: depending on the GLUE subset, one or several of:
     "pearson": Pearson Correlation
     "spearmanr": Spearman Correlation
     "matthews_correlation": Matthew Correlation
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> glue_metric = datasets.load_metric('glue', 'sst2')  # 'sst2' or any of ["mnli", "mnli_mismatched", "mnli_matched", "qnli", "rte", "wnli", "hans"]
+    >>> references = [0, 1]
+    >>> predictions = [0, 1]
+    >>> results = glue_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'accuracy': 1.0}
+
+    >>> glue_metric = datasets.load_metric('glue', 'mrpc')  # 'mrpc' or 'qqp'
+    >>> references = [0, 1]
+    >>> predictions = [0, 1]
+    >>> results = glue_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'accuracy': 1.0, 'f1': 1.0}
+
+    >>> glue_metric = datasets.load_metric('glue', 'stsb')
+    >>> references = [0., 1., 2., 3., 4., 5.]
+    >>> predictions = [0., 1., 2., 3., 4., 5.]
+    >>> results = glue_metric.compute(predictions=predictions, references=references)
+    >>> print({"pearson": round(results["pearson"], 2), "spearmanr": round(results["spearmanr"], 2)})
+    {'pearson': 1.0, 'spearmanr': 1.0}
+
+    >>> glue_metric = datasets.load_metric('glue', 'cola')
+    >>> references = [0, 1]
+    >>> predictions = [0, 1]
+    >>> results = glue_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'matthews_correlation': 1.0}
 """
 
 
@@ -73,6 +104,7 @@ def pearson_and_spearman(preds, labels):
     }
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Glue(datasets.Metric):
     def _info(self):
         if self.config_name not in [

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -49,8 +49,6 @@ Returns: depending on the GLUE subset, one or several of:
     "spearmanr": Spearman Correlation
     "matthews_correlation": Matthew Correlation
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> glue_metric = datasets.load_metric('glue', 'sst2')  # 'sst2' or any of ["mnli", "mnli_mismatched", "mnli_matched", "qnli", "rte", "wnli", "hans"]
     >>> references = [0, 1]

--- a/metrics/indic_glue/indic_glue.py
+++ b/metrics/indic_glue/indic_glue.py
@@ -48,8 +48,6 @@ Returns: depending on the IndicGLUE subset, one or several of:
     "f1": F1 score
     "precision": Precision@10
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> indic_glue_metric = datasets.load_metric('indic_glue', 'wnli')  # 'wnli' or any of ["copa", "sna", "csqa", "wstp", "inltkh", "bbca", "iitp-mr", "iitp-pr", "actsa-sc", "md"]
     >>> references = [0, 1]

--- a/metrics/indic_glue/indic_glue.py
+++ b/metrics/indic_glue/indic_glue.py
@@ -39,12 +39,39 @@ _DESCRIPTION = """\
 _KWARGS_DESCRIPTION = """
 Compute IndicGLUE evaluation metric associated to each IndicGLUE dataset.
 Args:
-    predictions: list of predictions to score (as int64).
-    references: list of ground truth labels corresponding to the predictions (as int64).
+    predictions: list of predictions to score (as int64),
+        except for 'cvit-mkb-clsr' where each prediction is a vector (of float32).
+    references: list of ground truth labels corresponding to the predictions (as int64),
+        except for 'cvit-mkb-clsr' where each reference is a vector (of float32).
 Returns: depending on the IndicGLUE subset, one or several of:
     "accuracy": Accuracy
     "f1": F1 score
     "precision": Precision@10
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> indic_glue_metric = datasets.load_metric('indic_glue', 'wnli')  # 'wnli' or any of ["copa", "sna", "csqa", "wstp", "inltkh", "bbca", "iitp-mr", "iitp-pr", "actsa-sc", "md"]
+    >>> references = [0, 1]
+    >>> predictions = [0, 1]
+    >>> results = indic_glue_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'accuracy': 1.0}
+
+    >>> indic_glue_metric = datasets.load_metric('indic_glue', 'wiki-ner')
+    >>> references = [0, 1]
+    >>> predictions = [0, 1]
+    >>> results = indic_glue_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'accuracy': 1.0, 'f1': 1.0}
+
+    >>> indic_glue_metric = datasets.load_metric('indic_glue', 'cvit-mkb-clsr')
+    >>> references = [[0.5, 0.5, 0.5], [0.1, 0.2, 0.3]]
+    >>> predictions = [[0.5, 0.5, 0.5], [0.1, 0.2, 0.3]]
+    >>> results = indic_glue_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'precision@10': 1.0}
+
 """
 
 
@@ -77,6 +104,7 @@ def precision_at_10(en_sentvecs, in_sentvecs):
     return matches.mean()
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class IndicGlue(datasets.Metric):
     def _info(self):
         if self.config_name not in [

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -66,8 +66,6 @@ Args:
 Returns:
     'meteor': meteor score.
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> meteor = datasets.load_metric('meteor')
     >>> predictions = ["It is a guide to action which ensures that the military always obeys the commands of the party"]

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -96,6 +96,11 @@ class Meteor(datasets.Metric):
             ],
         )
 
+    def _download_and_prepare(self, dl_manager):
+        import nltk
+
+        nltk.download('wordnet')
+
     def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
         scores = [
             meteor_score.single_meteor_score(ref, pred, alpha=alpha, beta=beta, gamma=gamma)

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -99,7 +99,7 @@ class Meteor(datasets.Metric):
     def _download_and_prepare(self, dl_manager):
         import nltk
 
-        nltk.download('wordnet')
+        nltk.download("wordnet")
 
     def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
         scores = [

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -65,9 +65,20 @@ Args:
     gamma: Relative weight assigned to fragmentation penalty. default: 0.5
 Returns:
     'meteor': meteor score.
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> meteor = datasets.load_metric('meteor')
+    >>> predictions = ["It is a guide to action which ensures that the military always obeys the commands of the party"]
+    >>> references = ["It is a guide to action that ensures that the military will forever heed Party commands"]
+    >>> results = meteor.compute(predictions=predictions, references=references)
+    >>> print(round(results["meteor"], 4))
+    0.7398
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Meteor(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -55,6 +55,14 @@ Args:
     sample_weight: Sample weights.
 Returns:
     precision: Precision score.
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> precision_metric = datasets.load_metric("precision")
+    >>> results = precision_metric.compute(references=[0, 1], predictions=[0, 1])
+    >>> print(results)
+    {'precision': 1.0}
 """
 
 _CITATION = """\
@@ -72,6 +80,7 @@ _CITATION = """\
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Precision(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -56,8 +56,6 @@ Args:
 Returns:
     precision: Precision score.
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> precision_metric = datasets.load_metric("precision")
     >>> results = precision_metric.compute(references=[0, 1], predictions=[0, 1])

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -55,6 +55,14 @@ Args:
     sample_weight: Sample weights.
 Returns:
     recall: Recall score.
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> recall_metric = datasets.load_metric("recall")
+    >>> results = recall_metric.compute(references=[0, 1], predictions=[0, 1])
+    >>> print(results)
+    {'recall': 1.0}
 """
 
 _CITATION = """\
@@ -72,6 +80,7 @@ _CITATION = """\
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Recall(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -56,8 +56,6 @@ Args:
 Returns:
     recall: Recall score.
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> recall_metric = datasets.load_metric("recall")
     >>> results = recall_metric.compute(references=[0, 1], predictions=[0, 1])

--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -69,9 +69,24 @@ Returns:
     rouge2: rouge_2 (precision, recall, f1),
     rougeL: rouge_l (precision, recall, f1),
     rougeLsum: rouge_lsum (precision, recall, f1)
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> rouge = datasets.load_metric('rouge')
+    >>> predictions = ["hello there", "general kenobi"]
+    >>> references = ["hello there", "general kenobi"]
+    >>> results = rouge.compute(predictions=predictions, references=references)
+    >>> print(list(results.keys()))
+    ['rouge1', 'rouge2', 'rougeL', 'rougeLsum']
+    >>> print(results["rouge1"])
+    AggregateScore(low=Score(precision=1.0, recall=1.0, fmeasure=1.0), mid=Score(precision=1.0, recall=1.0, fmeasure=1.0), high=Score(precision=1.0, recall=1.0, fmeasure=1.0))
+    >>> print(results["rouge1"].mid.fmeasure)
+    1.0
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Rouge(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -70,8 +70,6 @@ Returns:
     rougeL: rouge_l (precision, recall, f1),
     rougeLsum: rouge_lsum (precision, recall, f1)
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> rouge = datasets.load_metric('rouge')
     >>> predictions = ["hello there", "general kenobi"]

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -61,9 +61,22 @@ Returns:
     'bp': Brevity penalty,
     'sys_len': predictions length,
     'ref_len': reference length,
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = ["hello there general kenobi", "foo bar foobar"]
+    >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
+    >>> sacrebleu = datasets.load_metric("sacrebleu")
+    >>> results = sacrebleu.compute(predictions=predictions, references=references)
+    >>> print(list(results.keys()))
+    ['score', 'counts', 'totals', 'precisions', 'bp', 'sys_len', 'ref_len']
+    >>> print(round(results["score"], 1))
+    100.0
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Sacrebleu(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -62,8 +62,6 @@ Returns:
     'sys_len': predictions length,
     'ref_len': reference length,
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = ["hello there general kenobi", "foo bar foobar"]
     >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -73,9 +73,24 @@ Returns:
             'precision': precision,
             'recall': recall,
             'f1': F1 score, also known as balanced F-score or F-measure
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
+    >>> references = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
+    >>> seqeval = datasets.load_metric("seqeval")
+    >>> results = seqeval.compute(predictions=predictions, references=references)
+    >>> print(list(results.keys()))
+    ['MISC', 'PER', 'overall_precision', 'overall_recall', 'overall_f1', 'overall_accuracy']
+    >>> print(results["overall_f1"])
+    0.5
+    >>> print(results["PER"]["f1"])
+    1.0
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Seqeval(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -74,8 +74,6 @@ Returns:
             'recall': recall,
             'f1': F1 score, also known as balanced F-score or F-measure
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
     >>> references = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]

--- a/metrics/squad/squad.py
+++ b/metrics/squad/squad.py
@@ -53,9 +53,20 @@ Args:
 Returns:
     'exact_match': Exact match (the normalized answer exactly match the gold answer)
     'f1': The F-score of predicted tokens versus the gold answer
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = [{'prediction_text': '1976', 'id': '56e10a3be3433e1400422b22'}]
+    >>> references = [{'answers': {'answer_start': [97], 'text': ['1976']}, 'id': '56e10a3be3433e1400422b22'}]
+    >>> squad_metric = datasets.load_metric("squad")
+    >>> results = squad_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'exact_match': 100.0, 'f1': 100.0}
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Squad(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/metrics/squad/squad.py
+++ b/metrics/squad/squad.py
@@ -54,8 +54,6 @@ Returns:
     'exact_match': Exact match (the normalized answer exactly match the gold answer)
     'f1': The F-score of predicted tokens versus the gold answer
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = [{'prediction_text': '1976', 'id': '56e10a3be3433e1400422b22'}]
     >>> references = [{'answers': {'answer_start': [97], 'text': ['1976']}, 'id': '56e10a3be3433e1400422b22'}]

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -75,9 +75,20 @@ Returns:
     'best_exact_thresh': No-answer probability threshold associated to the best exact match
     'best_f1': Best F1 (with varying threshold)
     'best_f1_thresh': No-answer probability threshold associated to the best F1
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = [{'prediction_text': '1976', 'id': '56e10a3be3433e1400422b22', 'no_answer_probability': 0.}]
+    >>> references = [{'answers': {'answer_start': [97], 'text': ['1976']}, 'id': '56e10a3be3433e1400422b22'}]
+    >>> squad_v2_metric = datasets.load_metric("squad_v2")
+    >>> results = squad_v2_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'exact': 100.0, 'f1': 100.0, 'total': 1, 'HasAns_exact': 100.0, 'HasAns_f1': 100.0, 'HasAns_total': 1, 'best_exact': 100.0, 'best_exact_thresh': 0.0, 'best_f1': 100.0, 'best_f1_thresh': 0.0}
 """
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class SquadV2(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(
@@ -124,4 +135,4 @@ class SquadV2(datasets.Metric):
             no_ans_eval = make_eval_dict(exact_thresh, f1_thresh, qid_list=no_ans_qids)
             merge_eval(out_eval, no_ans_eval, "NoAns")
         find_all_best_thresh(out_eval, predictions, exact_raw, f1_raw, no_answer_probabilities, qid_to_has_ans)
-        return out_eval
+        return dict(out_eval)

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -76,8 +76,6 @@ Returns:
     'best_f1': Best F1 (with varying threshold)
     'best_f1_thresh': No-answer probability threshold associated to the best F1
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = [{'prediction_text': '1976', 'id': '56e10a3be3433e1400422b22', 'no_answer_probability': 0.}]
     >>> references = [{'answers': {'answer_start': [97], 'text': ['1976']}, 'id': '56e10a3be3433e1400422b22'}]

--- a/metrics/xnli/xnli.py
+++ b/metrics/xnli/xnli.py
@@ -51,8 +51,6 @@ Args:
 Returns:
     'accuracy': accuracy
 Examples:
-    Examples should be written in doctest format, and should illustrate how
-    to use the function.
 
     >>> predictions = [0, 1]
     >>> references = [0, 1]

--- a/metrics/xnli/xnli.py
+++ b/metrics/xnli/xnli.py
@@ -50,6 +50,16 @@ Args:
     references: Ground truth labels.
 Returns:
     'accuracy': accuracy
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> predictions = [0, 1]
+    >>> references = [0, 1]
+    >>> xnli_metric = datasets.load_metric("xnli")
+    >>> results = xnli_metric.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'accuracy': 1.0}
 """
 
 
@@ -57,6 +67,7 @@ def simple_accuracy(preds, labels):
     return (preds == labels).mean()
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Xnli(datasets.Metric):
     def _info(self):
         return datasets.MetricInfo(

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ TESTS_REQUIRE = [
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1"
-    "tldextract>=3.0.2",
+    "tldextract>=2.2.2",
     "texttable>=1.6.3"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,11 @@ TESTS_REQUIRE = [
     "seqeval",
     "sklearn",
     "unbabel-comet",
+    # to speed up pip backtracking
+    "toml>=0.10.1",
+    "requests_file>=1.5.1"
+    "tldextract>=3.0.2",
+    "texttable>=1.6.3"
 ]
 
 if os.name == "nt":  # windows

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ TESTS_REQUIRE = [
     "moto[s3]==1.3.16",
     "rarfile>=4.0",
     "tensorflow>=2.3",
-    "torch>=1.0",
+    "torch",
     "transformers",
     # datasets dependencies
     "bs4",

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,6 @@ TESTS_REQUIRE = [
     "scipy",
     "seqeval",
     "sklearn",
-    "unbabel-comet>=0.0.6",
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",

--- a/setup.py
+++ b/setup.py
@@ -101,16 +101,16 @@ TESTS_REQUIRE = [
     "pytest",
     "pytest-xdist",
     # optional dependencies
-    "apache-beam",
+    "apache-beam>=2.24.0",
     "elasticsearch",
     "boto3==1.16.43",
     "botocore==1.19.43",
     "faiss-cpu",
     "fsspec[s3]",
     "moto[s3]==1.3.16",
-    "rarfile",
-    "tensorflow",
-    "torch",
+    "rarfile>=4.0",
+    "tensorflow>=2.3",
+    "torch>=1.0",
     "transformers",
     # datasets dependencies
     "bs4",
@@ -130,12 +130,14 @@ TESTS_REQUIRE = [
     "scipy",
     "seqeval",
     "sklearn",
-    "unbabel-comet",
+    "unbabel-comet>=0.0.6",
     # to speed up pip backtracking
     "toml>=0.10.1",
-    "requests_file>=1.5.1"
-    "tldextract>=2.2.2",
-    "texttable>=1.6.3"
+    "requests_file>=1.5.1",
+    "tldextract>=3.1.0",
+    "texttable>=1.6.3",
+    "s3fs>=0.4.2",
+    "Werkzeug>=1.0.1",
 ]
 
 if os.name == "nt":  # windows

--- a/setup.py
+++ b/setup.py
@@ -130,11 +130,6 @@ TESTS_REQUIRE = [
     "scipy",
     "seqeval",
     "sklearn",
-    "wget>=3.2",  # for unbabel-comet
-    "pytorch-nlp==0.5.0",  # for unbabel-comet
-    "pytorch_lightning",  # for unbabel-comet
-    "fastBPE==0.1.0",  # for unbabel-comet
-    "fairseq",  # for unbabel-comet
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",
@@ -146,6 +141,16 @@ TESTS_REQUIRE = [
 
 if os.name == "nt":  # windows
     TESTS_REQUIRE.remove("faiss-cpu")  # faiss doesn't exist on windows
+else:
+    # dependencies of unbabel-comet
+    # only test if not on windows since there're issues installing fairseq on windows
+    TESTS_REQUIRE.extend([
+        "wget>=3.2",
+        "pytorch-nlp==0.5.0",
+        "pytorch_lightning",
+        "fastBPE==0.1.0",
+        "fairseq",
+    ])
 
 
 QUALITY_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ TESTS_REQUIRE = [
     "scipy",
     "seqeval",
     "sklearn",
+    "wget>=3.2",  # for unbabel-comet
     "pytorch-nlp==0.5.0",  # for unbabel-comet
     "pytorch_lightning",  # for unbabel-comet
     "fastBPE==0.1.0",  # for unbabel-comet

--- a/setup.py
+++ b/setup.py
@@ -96,30 +96,41 @@ BENCHMARKS_REQUIRE = [
 ]
 
 TESTS_REQUIRE = [
-    "apache-beam",
+    # test dependencies
     "absl-py",
+    "pytest",
+    "pytest-xdist",
+    # optional dependencies
+    "apache-beam",
+    "elasticsearch",
+    "boto3==1.16.43",
+    "botocore==1.19.43",
+    "faiss-cpu",
+    "fsspec[s3]",
+    "moto[s3]==1.3.16",
+    "rarfile",
+    "tensorflow",
+    "torch",
+    "transformers",
+    # datasets dependencies
     "bs4",
     "conllu",
-    "elasticsearch",
-    "faiss-cpu",
     "langdetect",
     "lxml",
     "mwparserfromhell",
     "nltk",
     "openpyxl",
     "py7zr",
-    "pytest",
-    "pytest-xdist",
-    "tensorflow",
-    "torch",
     "tldextract",
-    "transformers",
     "zstandard",
-    "rarfile",
-    "moto[s3]==1.3.16",
-    "fsspec[s3]",
-    "boto3==1.16.43",
-    "botocore==1.19.43",
+    # metrics dependencies
+    "bert_score",
+    "rouge_score",
+    "sacrebleu",
+    "scipy",
+    "seqeval",
+    "sklearn",
+    "unbabel-comet",
 ]
 
 if os.name == "nt":  # windows

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,10 @@ TESTS_REQUIRE = [
     "scipy",
     "seqeval",
     "sklearn",
+    "pytorch-nlp==0.5.0",  # for unbabel-comet
+    "pytorch_lightning",  # for unbabel-comet
+    "fastBPE==0.1.0",  # for unbabel-comet
+    "fairseq",  # for unbabel-comet
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -541,9 +541,9 @@ class Metric(MetricInfoMixin):
         raise NotImplementedError
 
     def __del__(self):
-        if self.filelock is not None:
+        if hasattr(self, "filelock") and self.filelock is not None:
             self.filelock.release()
-        if self.rendez_vous_lock is not None:
+        if hasattr(self, "rendez_vous_lock") and self.rendez_vous_lock is not None:
             self.rendez_vous_lock.release()
         if hasattr(self, "writer"):  # in case it was already deleted
             del self.writer

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -733,3 +733,19 @@ def is_rarfile(path: str) -> bool:
         return True
     else:
         return False
+
+
+def add_start_docstrings(*docstr):
+    def docstring_decorator(fn):
+        fn.__doc__ = "".join(docstr) + (fn.__doc__ if fn.__doc__ is not None else "")
+        return fn
+
+    return docstring_decorator
+
+
+def add_end_docstrings(*docstr):
+    def docstring_decorator(fn):
+        fn.__doc__ = (fn.__doc__ if fn.__doc__ is not None else "") + "".join(docstr)
+        return fn
+
+    return docstring_decorator

--- a/templates/new_metric_script.py
+++ b/templates/new_metric_script.py
@@ -43,12 +43,21 @@ Args:
 Returns:
     accuracy: description of the first score,
     another_score: description of the second score,
+Examples:
+    Examples should be written in doctest format, and should illustrate how
+    to use the function.
+
+    >>> my_new_metric = datasets.load_metric("my_new_metric")
+    >>> results = my_new_metric.compute(references=[0, 1], predictions=[0, 1])
+    >>> print(results)
+    {'accuracy': 1.0}
 """
 
 # TODO: Define external resources urls if needed
 BAD_WORDS_URL = "http://url/to/external/resource/bad_words.txt"
 
 
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class NewMetric(datasets.Metric):
     """TODO: Short description of my metric."""
 

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -19,8 +19,8 @@ import importlib
 import inspect
 import os
 from contextlib import contextmanager
-from unittest.mock import patch
 from functools import wraps
+from unittest.mock import patch
 
 import numpy as np
 from absl.testing import parameterized
@@ -28,7 +28,8 @@ from absl.testing import parameterized
 import datasets
 from datasets import load_metric
 
-from .utils import local, slow, for_all_test_methods
+from .utils import for_all_test_methods, local, slow
+
 
 REQUIRE_FAIRSEQ = {"comet"}
 _has_fairseq = importlib.util.find_spec("fairseq") is not None

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -13,72 +13,138 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import doctest
 import glob
+import importlib
 import inspect
 import os
-import tempfile
+from contextlib import contextmanager
+from unittest.mock import patch
 
+import numpy as np
 from absl.testing import parameterized
 
-from datasets import DownloadConfig, hf_api, load_metric
+import datasets
+from datasets import load_metric
 
-from .utils import local, remote, slow
+from .utils import local, slow
 
 
 def get_local_metric_names():
     metrics = [metric_dir.split(os.sep)[-2] for metric_dir in glob.glob("./metrics/*/")]
-    return [{"testcase_name": x, "metric_name": x} for x in metrics]
-
-
-def get_remote_metric_names():
-    api = hf_api.HfApi()
-    # fetch all metric names
-    metrics = [x.id for x in api.metric_list()]
-    return [{"testcase_name": x, "metric_name": x} for x in metrics]
-
-
-@parameterized.named_parameters(get_remote_metric_names())
-@remote
-class RemoteMetricTest(parameterized.TestCase):
-    metric_name = None
-
-    @slow
-    def test_load_real_metric(self, metric_name):
-        with tempfile.TemporaryDirectory() as temp_data_dir:
-            download_config = DownloadConfig()
-            download_config.force_download = True
-            config_name = None
-            if metric_name == "glue":
-                config_name = "sst2"
-            metric = load_metric(
-                metric_name, config_name=config_name, data_dir=temp_data_dir, download_config=download_config
-            )
-
-            parameters = inspect.signature(metric._compute).parameters
-            self.assertTrue("predictions" in parameters)
-            self.assertTrue("references" in parameters)
-            self.assertTrue(all([p.kind != p.VAR_KEYWORD for p in parameters.values()]))  # no **kwargs
+    return [{"testcase_name": x, "metric_name": x} for x in metrics if x != "gleu"]  # gleu is unfinished
 
 
 @parameterized.named_parameters(get_local_metric_names())
 @local
 class LocalMetricTest(parameterized.TestCase):
+    INTENSIVE_CALLS_PATCHER = {}
     metric_name = None
+
+    def test_load_metric(self, metric_name):
+        doctest.ELLIPSIS_MARKER = "[...]"
+        metric_module = importlib.import_module(datasets.load.prepare_module(os.path.join("metrics", metric_name))[0])
+        metric = datasets.load.import_main_class(metric_module.__name__, dataset=False)
+        # check parameters
+        parameters = inspect.signature(metric._compute).parameters
+        self.assertTrue("predictions" in parameters)
+        self.assertTrue("references" in parameters)
+        self.assertTrue(all([p.kind != p.VAR_KEYWORD for p in parameters.values()]))  # no **kwargs
+        # run doctest
+        with self.patch_intensive_calls(metric_name, metric_module.__name__):
+            with self.use_local_metrics():
+                results = doctest.testmod(metric_module, verbose=True, raise_on_error=True)
+        self.assertEqual(results.failed, 0)
+        self.assertGreater(results.attempted, 1)
 
     @slow
     def test_load_real_metric(self, metric_name):
-        with tempfile.TemporaryDirectory() as temp_data_dir:
-            download_config = DownloadConfig()
-            download_config.force_download = True
-            config_name = None
-            if metric_name == "glue":
-                config_name = "sst2"
-            metric = load_metric(
-                metric_name, config_name=config_name, data_dir=temp_data_dir, download_config=download_config
-            )
+        doctest.ELLIPSIS_MARKER = "[...]"
+        metric_module = importlib.import_module(datasets.load.prepare_module(os.path.join("metrics", metric_name))[0])
+        # run doctest
+        with self.use_local_metrics():
+            results = doctest.testmod(metric_module, verbose=True, raise_on_error=True)
+        self.assertEqual(results.failed, 0)
+        self.assertGreater(results.attempted, 1)
 
-            parameters = inspect.signature(metric._compute).parameters
-            self.assertTrue("predictions" in parameters)
-            self.assertTrue("references" in parameters)
-            self.assertTrue(all([p.kind != p.VAR_KEYWORD for p in parameters.values()]))  # no **kwargs
-            del metric
+    @contextmanager
+    def patch_intensive_calls(self, metric_name, module_name):
+        if metric_name in self.INTENSIVE_CALLS_PATCHER:
+            with self.INTENSIVE_CALLS_PATCHER[metric_name](module_name):
+                yield
+        else:
+            yield
+
+    @contextmanager
+    def use_local_metrics(self):
+        def load_local_metric(metric_name, *args, **kwargs):
+            return load_metric(os.path.join("metrics", metric_name), *args, **kwargs)
+
+        with patch("datasets.load_metric") as mock_load_metric:
+            mock_load_metric.side_effect = load_local_metric
+            yield
+
+    @classmethod
+    def register_intensive_calls_patcher(cls, metric_name):
+        def wrapper(patcher):
+            patcher = contextmanager(patcher)
+            cls.INTENSIVE_CALLS_PATCHER[metric_name] = patcher
+            return patcher
+
+        return wrapper
+
+
+# Metrics intensive calls patchers
+# --------------------------------
+
+
+@LocalMetricTest.register_intensive_calls_patcher("bleurt")
+def patch_bleurt(module_name):
+    import tensorflow.compat.v1 as tf
+
+    tf.flags.DEFINE_string("sv", "", "")  # handle pytest cli flags
+
+    def prefict_fn(tf_input):
+        assert len(tf_input["input_ids"]) == 2
+        return np.array([1.03, 1.04])
+
+    # mock predict_fn which is supposed to do a forward pass with a bleurt model
+    with patch("bleurt.score._make_predict_fn_from_checkpoint") as mock_make_predict_fn_from_checkpoint:
+        mock_make_predict_fn_from_checkpoint.return_value = prefict_fn
+        yield
+
+
+@LocalMetricTest.register_intensive_calls_patcher("bertscore")
+def patch_bertscore(module_name):
+    import torch
+
+    def bert_cos_score_idf(model, refs, *args, **kwargs):
+        return torch.tensor([[1.0, 1.0, 1.0]] * len(refs))
+
+    # mock get_model which is supposed to do download a bert model
+    # mock bert_cos_score_idf which is supposed to do a forward pass with a bert model
+    with patch("bert_score.scorer.get_model"), patch(
+        "bert_score.scorer.bert_cos_score_idf"
+    ) as mock_bert_cos_score_idf:
+        mock_bert_cos_score_idf.side_effect = bert_cos_score_idf
+        yield
+
+
+@LocalMetricTest.register_intensive_calls_patcher("comet")
+def patch_comet(module_name):
+    def download_model(model):
+        class Model:
+            def predict(self, data, *args, **kwargs):
+                assert len(data) == 2
+                scores = [0.19, 0.92]
+                data[0]["predicted_score"] = scores[0]
+                data[1]["predicted_score"] = scores[1]
+                return data, scores
+
+        print("Download succeeded. Loading model...")
+        return Model()
+
+    # mock download_model which is supposed to do download a bert model
+    with patch("comet.models.download_model") as mock_download_model:
+        mock_download_model.side_effect = download_model
+        yield


### PR DESCRIPTION
All metrics finally have usage examples and proper fast + slow tests :)

I added examples of usage for every metric, and I use doctest to make sure they all work as expected.

For "slow" metrics such as bert_score or bleurt which require to download + run a transformer model, the download + forward pass are only done in the slow test.
In the fast test on the other hand, the download + forward pass are monkey patched.

Metrics that need to be installed from github are not added to setup.py because it prevents uploading the `datasets` package to pypi.
An additional-test-requirements.txt file is used instead. This file also include `comet` in order to not have to resolve its *impossible* dependencies.

Also `comet` is not tested on windows because one of its dependencies (fairseq) can't be installed in the CI for some reason.