### PR TITLE
Add OSCAR dataset card

### DIFF
--- a/datasets/oscar/README.md
+++ b/datasets/oscar/README.md
@@ -2670,7 +2670,7 @@ This example was too long and was cropped:
 
 
 <details>
-  <summary>Click to expand the Data/size information for each language (deduplicated)</summary>
+  <summary>Click to expand the Data/size information for each language (original)</summary>
 
 #### unshuffled_original_af
 

--- a/datasets/oscar/README.md
+++ b/datasets/oscar/README.md
@@ -1,4 +1,5721 @@
+---
+---
+
+# Dataset Card for "oscar"
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-fields)
+  - [Data Splits Sample Size](#data-splits-sample-size)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+  - [Contributions](#contributions)
+
+## [Dataset Description](#dataset-description)
+
+- **Homepage:** [https://oscar-corpus.com](https://oscar-corpus.com)
+- **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Dataset Summary](#dataset-summary)
+
+The Open Super-large Crawled ALMAnaCH coRpus is a huge multilingual corpus obtained by language classification and filtering of the Common Crawl corpus using the goclassy architecture.
+
+### [Supported Tasks](#supported-tasks)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Languages](#languages)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Dataset Structure](#dataset-structure)
+
+We show detailed information for all the configurations of the dataset.
+
+### [Data Instances](#data-instances)
+
+
+<details>
+  <summary>Click to expand the Data/size information for each language (deduplicated)</summary>
+
+#### unshuffled_deduplicated_af
+
+- **Size of downloaded dataset files:** 62.93 MB
+- **Size of the generated dataset:** 164.32 MB
+- **Total amount of disk used:** 227.25 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "aanlyn markte as gevolg van ons voortgesette 'n begrip opsie handel sakeplan pdf terwyl ons steeds die gereelde ons binêre opsies handel"
+}
+```
+
+#### unshuffled_deduplicated_als
+
+- **Size of downloaded dataset files:** 1.20 MB
+- **Size of the generated dataset:** 2.82 MB
+- **Total amount of disk used:** 4.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"De Nazionalpark hät e Flächi vo 170,3 km² und isch dodemit s grösti Naturschutzgebiet vo de Schwiz. Er ligt uf em Gebiet vo de ..."
+}
+```
+
+#### unshuffled_deduplicated_am
+
+- **Size of downloaded dataset files:** 58.51 MB
+- **Size of the generated dataset:** 206.14 MB
+- **Total amount of disk used:** 264.64 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"አየር መንገዱ ከአዲስ አበባ ወደ ሮም ጣሊያን በማምራት ላይ በነበረበት ጊዜ ረዳት አብራሪው የጉዞውን አቅጣጫ በመቀየር ጄኔቭ አውሮፓላን ማረፊያ በማሳረፍ እጁን ለፖሊስ ሰጥቷል።\\nየኢትዮጵያ መንግስት የ..."
+}
+```
+
+#### unshuffled_deduplicated_an
+
+- **Size of downloaded dataset files:** 0.13 MB
+- **Size of the generated dataset:** 0.81 MB
+- **Total amount of disk used:** 0.94 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"واااااااأسفاه الأمم تفتخر ب 0 أمي ووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووو..."
+}
+```
+
+#### unshuffled_deduplicated_ar
+
+- **Size of downloaded dataset files:** 9219.35 MB
+- **Size of the generated dataset:** 32010.73 MB
+- **Total amount of disk used:** 41230.07 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"مرحبا بك عزيز الزائر نتمنى لك أوقاتاً سعيدة معنا وأن نزداد شرفا بخدمتك ولا تنسى التسجيل معنا لتستفيد بكل جديد\\nأهلا وسهلا بك زا..."
+}
+```
+
+#### unshuffled_deduplicated_arz
+
+- **Size of downloaded dataset files:** 9.56 MB
+- **Size of the generated dataset:** 34.25 MB
+- **Total amount of disk used:** 43.81 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"بنى عجل : قبيلة من عجل بن لجيم بن صعب بن على بن بكر بن وائل انتقل اغلبهم الى البصرة فى العراق و اصفهان و خراسان فى ايران و اذرب..."
+}
+```
+
+#### unshuffled_deduplicated_as
+
+- **Size of downloaded dataset files:** 14.79 MB
+- **Size of the generated dataset:** 70.64 MB
+- **Total amount of disk used:** 85.43 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"আমি, এই সংগঠনৰ সদস্য সকলে একেলগ হৈ অসমকে ধৰি ভাৰতৰ উত্তৰ পূৰ্বাঞ্চলৰ অমূল্য কলা-সাংস্কৃতিক সম্পদৰাজি বৃহত্তৰ অষ্ট্ৰেলিয়াৰ সন্মু..."
+}
+```
+
+#### unshuffled_deduplicated_ast
+
+- **Size of downloaded dataset files:** 0.82 MB
+- **Size of the generated dataset:** 2.07 MB
+- **Total amount of disk used:** 2.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"The Killers llanzaron el so álbum debú, Hot Fuss, en xunu de 2004 nel Reinu Xuníu, al traviés de la discográfica Lizard King, y..."
+}
+```
+
+#### unshuffled_deduplicated_av
+
+- **Size of downloaded dataset files:** 0.07 MB
+- **Size of the generated dataset:** 0.32 MB
+- **Total amount of disk used:** 0.39 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Жинда малъараб ва божизе бегьулеб рагІудаса кьуризе бегьуларо гьев. Гьес насихІат гьабизе кколелъул бацІцІадаб диналъул рахъалъ..."
+}
+```
+
+#### unshuffled_deduplicated_az
+
+- **Size of downloaded dataset files:** 497.57 MB
+- **Size of the generated dataset:** 1460.07 MB
+- **Total amount of disk used:** 1957.65 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"AZTV-Artıq 7 ildir ki, Abşeron rayonu dotasiya almadan bütün xərclərini yerli daxilolmalar hesabına maliyyələşdirir.\\nDünən, 10..."
+}
+```
+
+#### unshuffled_deduplicated_azb
+
+- **Size of downloaded dataset files:** 4.95 MB
+- **Size of the generated dataset:** 19.15 MB
+- **Total amount of disk used:** 24.10 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"لعلی ١٣-جو عصرده یاشاییب یاراتمیش گؤرکملی آذربایجان شاعرلریندندیر. ١٢٢٤-جی ایلده تبریزده آنادان اولموشدور، گنج یاشلاریندا تیجار..."
+}
+```
+
+#### unshuffled_deduplicated_ba
+
+- **Size of downloaded dataset files:** 24.78 MB
+- **Size of the generated dataset:** 89.49 MB
+- **Total amount of disk used:** 114.27 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Күҙәтеү ҡуласаһы моделен хәҙер Мифтахетдин Аҡмулла исемендәге Башҡорт дәүләт педагогия университетында ла эшләргә мөмкин\\t\\nКүҙ..."
+}
+```
+
+#### unshuffled_deduplicated_bar
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "                                                                                                                                          vo"
+}
+```
+
+#### unshuffled_deduplicated_bcl
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"& ÿ ó / í 0 - ø û ù ö ú ð ï ú \\u0014 ù þ ô ö í ÷ ò \\u0014 ÷ í ù û ö í \\u0001 û ñ ç þ \\u0001 ð \\u0007 þ ò ñ ñ ò ô \\u0017 û ö ô ÷..."
+}
+```
+
+#### unshuffled_deduplicated_be
+
+- **Size of downloaded dataset files:** 292.49 MB
+- **Size of the generated dataset:** 1030.74 MB
+- **Total amount of disk used:** 1323.24 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Брэсцкія ўлады не дазволілі прафсаюзу РЭП правесці пікетаванне ў парку Воінаў-інтэрнацыяналістаў 30 мая 2018 года.\\nСітуацыю пр..."
+}
+```
+
+#### unshuffled_deduplicated_bg
+
+- **Size of downloaded dataset files:** 3670.37 MB
+- **Size of the generated dataset:** 13784.23 MB
+- **Total amount of disk used:** 17454.60 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ЖАЛБОПОДАТЕЛЯТ директор на Дирекция „ Обжалване и данъчно-осигурителна практика“- Бургас, редовно призован, се представлява от ..."
+}
+```
+
+#### unshuffled_deduplicated_bh
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.04 MB
+- **Total amount of disk used:** 0.04 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"सुकमा जिला भारत के छत्तीसगढ़ राज्य में एगो जिला बाटे। एकर मुख्यालय सुकमा शहर बाटे। एकर कुल रकबा 5636 वर्ग कि॰मी॰ बाटे।\"..."
+}
+```
+
+#### unshuffled_deduplicated_bn
+
+- **Size of downloaded dataset files:** 1198.98 MB
+- **Size of the generated dataset:** 5951.79 MB
+- **Total amount of disk used:** 7150.77 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ভড়ং সর্বস্ব বাংলা আর্ট অ্যান্ড কালচারের হিসাব গুলিয়ে দেওয়ার ম্যাজিকের নাম ব্রাত্য রাইসু November 23, 2017\\nTagged with ডায়োজিনি..."
+}
+```
+
+#### unshuffled_deduplicated_bo
+
+- **Size of downloaded dataset files:** 21.33 MB
+- **Size of the generated dataset:** 137.95 MB
+- **Total amount of disk used:** 159.28 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"བོད་མི་འདི་དག་ནི་རང་རྒྱུད་སྒོ་རུ་ཕུད་དེ་གཞན་རྒྱུད་པང་དུ་ཉར་ནས་གསོ་སྐྱོང་བྱེད་དགོས་ཟེར་བ་དང་གཅིག་མཚུངས་རེད།\\nཚན་རིག་ནི་དང་ཐོག་རང..."
+}
+```
+
+#### unshuffled_deduplicated_bpy
+
+- **Size of downloaded dataset files:** 0.18 MB
+- **Size of the generated dataset:** 1.70 MB
+- **Total amount of disk used:** 1.88 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"পৌরসভা এহার আয়তন (লয়াহান) ২,৭৩০,.৬৩ বর্গ কিলোমিটার। পৌরসভা এহার মাপাহানর অক্ষাংশ বারো দ্রাঘিমাংশ ইলতাই 18.63° S 48.18° W ।[১]..."
+}
+```
+
+#### unshuffled_deduplicated_br
+
+- **Size of downloaded dataset files:** 6.17 MB
+- **Size of the generated dataset:** 16.21 MB
+- **Total amount of disk used:** 22.38 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Ar mank Magalhães(Daveoù a vank) a zo ur spesad evned, Spheniscus magellanicus an anv skiantel anezhañ.\\nGallout a reer implijo..."
+}
+```
+
+#### unshuffled_deduplicated_bs
+
+- **Size of downloaded dataset files:** 0.04 MB
+- **Size of the generated dataset:** 0.14 MB
+- **Total amount of disk used:** 0.17 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ž šř é ú šř šř ě šř ž é č ě ž ů ě ď éé ýš ě ě Ž č š ý ě ď é ýš ě ď ě éé ýš ě č ž ě š ý ď ě ýš é ú č ž č š ý ď ý ž é éě ď é č ýš..."
+}
+```
+
+#### unshuffled_deduplicated_bxr
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"2002 оной хабар буряад хэлэ бэшэгэй һалбари Үндэһэтэнэй хүмүүнлиг ухаанай дээдэ һургуули болгогдожо өөршэлэгдөө.\\nХарин мүнөө б..."
+}
+```
+
+#### unshuffled_deduplicated_ca
+
+- **Size of downloaded dataset files:** 1654.19 MB
+- **Size of the generated dataset:** 4358.12 MB
+- **Total amount of disk used:** 6012.31 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Daniel Vendrell, conegut com Vandrell, ha sigut un dels il•lustradors contemporanis més influents, representant a la nova onada..."
+}
+```
+
+#### unshuffled_deduplicated_cbk
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano..."
+}
+```
+
+#### unshuffled_deduplicated_ce
+
+- **Size of downloaded dataset files:** 1.78 MB
+- **Size of the generated dataset:** 6.71 MB
+- **Total amount of disk used:** 8.49 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Шаьш анархисташ ду бохучу жигархойн дIахьедарехь дуьйцу, оьрсийн ницкъаллийн структурийн а, федералан каналан а Iалашонаш \\\"мар..."
+}
+```
+
+#### unshuffled_deduplicated_ceb
+
+- **Size of downloaded dataset files:** 6.79 MB
+- **Size of the generated dataset:** 23.68 MB
+- **Total amount of disk used:** 30.47 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Si Isko walay pupamilok nga nagtan-aw sa unahan, natugaw. “Naunsa ka gud diha Isko nga layo man kaayo ang imong panan-aw?” ni I..."
+}
+```
+
+#### unshuffled_deduplicated_ckb
+
+- **Size of downloaded dataset files:** 57.53 MB
+- **Size of the generated dataset:** 226.71 MB
+- **Total amount of disk used:** 284.24 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"رسی رۆژ - ساڵێک دوای بومەلەرزەی کرماشان میوانی بەرنامە : کاک سیاوەش حەیاتی چالاکی مەدەنی -قەسری شیرین\\nپارچە موزیک 30 / 10 / 20..."
+}
+```
+
+#### unshuffled_deduplicated_cs
+
+- **Size of downloaded dataset files:** 10008.10 MB
+- **Size of the generated dataset:** 24516.08 MB
+- **Total amount of disk used:** 34524.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Akce anarchistů proti připravovanému novému služební řádu a nízkým mzdám 1903 – Historie českého anarchismu (1880 – 1939)\\nRost..."
+}
+```
+
+#### unshuffled_deduplicated_cv
+
+- **Size of downloaded dataset files:** 7.12 MB
+- **Size of the generated dataset:** 26.22 MB
+- **Total amount of disk used:** 33.33 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Шыранӑ чухне ӑнсӑртран латин кирилл саспаллисем вырӑнне латин саспаллисене ҫырсан, сайт эсир ҫырнине юсама тӑрӑшӗ.\\nКу сайтра ч..."
+}
+```
+
+#### unshuffled_deduplicated_cy
+
+- **Size of downloaded dataset files:** 51.15 MB
+- **Size of the generated dataset:** 134.68 MB
+- **Total amount of disk used:** 185.83 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Mae capeli Cymreig yr Andes ym Mhatagonia wedi cyhoeddi na fydd gwasanaethau yno weddill y mis, oherwydd yr eira trwm sydd wedi..."
+}
+```
+
+#### unshuffled_deduplicated_da
+
+- **Size of downloaded dataset files:** 3639.58 MB
+- **Size of the generated dataset:** 9769.17 MB
+- **Total amount of disk used:** 13408.75 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Den 2.-5. februar 2016 løb det tredje kursus i uddannelsen af 4kommunesamarbejdets Local Impact Coaches, af stablen i Gentofte ..."
+}
+```
+
+#### unshuffled_deduplicated_de
+
+- **Size of downloaded dataset files:** 57981.35 MB
+- **Size of the generated dataset:** 149056.82 MB
+- **Total amount of disk used:** 207038.17 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Auf dieser Seite gibt es mind. ein YouTube Video. Cookies für diese Website wurden abgelehnt. Dadurch können keine YouTube Vide..."
+}
+```
+
+#### unshuffled_deduplicated_diq
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Zıwanê Slawki, zıwano merdumanê Slawano. Zıwanê Slawki yew lızgeyê Zıwananê Hind u Ewropao. Keyeyê Zıwananê Slawki beno hirê letey:"
+}
+```
+
+#### unshuffled_deduplicated_dsb
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Pśiklaskaju južo pśed pśedstajenim... 1500 źiśi njamóžo wěcej docakaś, měsćańska hala w Chóśebuzu - wupśedana."
+}
+```
+
+#### unshuffled_deduplicated_dv
+
+- **Size of downloaded dataset files:** 16.06 MB
+- **Size of the generated dataset:** 78.38 MB
+- **Total amount of disk used:** 94.44 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ބ. އަތޮޅުގައި ހުޅުވަން ތައްޔާރުވަމުން އަންނަ ވައްކަރު ރިސޯޓުގައި ވަޒީފާ އަދާކުރަން ޝައުގުވެރިވާ ފަރާތްތަކަށް ކުރިމަތިލުމުގެ ފުރ..."
+}
+```
+
+#### unshuffled_deduplicated_el
+
+- **Size of downloaded dataset files:** 7541.61 MB
+- **Size of the generated dataset:** 27411.37 MB
+- **Total amount of disk used:** 34952.98 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Νεκρός εντοπίστηκε μέσα στο σπίτι του στην οδό Ηρώδου Αττικού στον αριθμό 7 ο επικεφαλής του προξενικού τμήματος της Ρωσικής πρ..."
+}
+```
+
+#### unshuffled_deduplicated_eml
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"A séguit dal prucès ad rubutiśasiòṅ di abitànt dal pòpul ad Mikenes, Angoras 'l è finî dènt'r a 'n robot cun la tèsta dna rana ..."
+}
+```
+
+#### unshuffled_deduplicated_en
+
+- **Size of downloaded dataset files:** 473495.62 MB
+- **Size of the generated dataset:** 1239536.47 MB
+- **Total amount of disk used:** 1713032.09 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Mtendere Village was inspired by the vision of Chief Napoleon Dzombe, which he shared with John Blanchard during his first visi..."
+}
+```
+
+#### unshuffled_deduplicated_eo
+
+- **Size of downloaded dataset files:** 88.56 MB
+- **Size of the generated dataset:** 229.00 MB
+- **Total amount of disk used:** 317.56 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Ĉu ... preĝi | mediti | ricevi instigojn || kanti | muziki || informiĝi | legi | studi || prepari Diservon\\nTemas pri kolekto d..."
+}
+```
+
+#### unshuffled_deduplicated_es
+
+- **Size of downloaded dataset files:** 57663.89 MB
+- **Size of the generated dataset:** 153406.00 MB
+- **Total amount of disk used:** 211069.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Como se librará de la celulitis en el gimnasio La piel superflua en las manos después del adelgazamiento, Los bailes fáciles pa..."
+}
+```
+
+#### unshuffled_deduplicated_et
+
+- **Size of downloaded dataset files:** 922.00 MB
+- **Size of the generated dataset:** 2333.07 MB
+- **Total amount of disk used:** 3255.07 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"MTÜ AB Video järgib oma tegevuses kodanikuühenduste eetilise tegevuse üldtunnustatud põhimõtteid, mis on lühidalt kokkuvõetud 7..."
+}
+```
+
+#### unshuffled_deduplicated_eu
+
+- **Size of downloaded dataset files:** 128.44 MB
+- **Size of the generated dataset:** 347.07 MB
+- **Total amount of disk used:** 475.51 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Gure jarduerek eraikuntzarekin, elkarbizitzarekin, hirigintzarekin eta ekologiarekin dute harremana, baita ideia eta konponbideak irudikatu eta garatzearekin ere, eraikuntza sektorea hobetuz, pertsonen erosotasuna eta bizi-kalitatea hobetzeko."
+}
+```
+
+#### unshuffled_deduplicated_fa
+
+- **Size of downloaded dataset files:** 9974.78 MB
+- **Size of the generated dataset:** 38205.13 MB
+- **Total amount of disk used:** 48179.91 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"قـــــــــــــــــرار بود با هم کنـــــــــــــار بیایم نه اینکه از کنــــــــــــار هم رد بشیم...!!!\\nاگر روزی دلت لبریز غم بو..."
+}
+```
+
+#### unshuffled_deduplicated_fi
+
+- **Size of downloaded dataset files:** 5130.81 MB
+- **Size of the generated dataset:** 13341.18 MB
+- **Total amount of disk used:** 18472.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Kiitos Deelle kaikesta - 1,5 viikkoa kulunut, kun Dee ei ole enää ollut omani. Reilu viikko sitten sunnuntaina vein Deen uuteen kotiinsa. Itselläni on ollut niin ristiriitaiset t..."
+}
+```
+
+#### unshuffled_deduplicated_fr
+
+- **Size of downloaded dataset files:** 52893.42 MB
+- **Size of the generated dataset:** 141412.98 MB
+- **Total amount of disk used:** 194306.40 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Média de débat d'idées, de culture et de littérature. Récits, décryptages, analyses, portraits et critiques autour de la vie des idées. Magazine engagé, ouvert aux autres et au monde.. Bring up to date in french"
+}
+```
+
+#### unshuffled_deduplicated_frr
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Hiragana’ Practice’Sheet’1’(A -O)’ ’ Name:’________ __________________________’Section:’_______________ _’ ’ ’ ’ ’ ’ ’ ’ ’ ’ ’ ..."
+}
+```
+
+#### unshuffled_deduplicated_fy
+
+- **Size of downloaded dataset files:** 9.79 MB
+- **Size of the generated dataset:** 25.49 MB
+- **Total amount of disk used:** 35.29 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Nim in sêfte ride op Holmsjön, yn ien fan 'e lytse marren yn de omkriten, of nim se op avontueren lykas nonresidential. lâns Indalsälven wetter. Holm Sportklubb hawwe kano 's te huur, yn gearwurking mei de Baltyske Power konferinsje."
+}
+```
+
+#### unshuffled_deduplicated_ga
+
+- **Size of downloaded dataset files:** 21.19 MB
+- **Size of the generated dataset:** 60.90 MB
+- **Total amount of disk used:** 82.09 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Is fóram é seo chun plé a dhéanamh ar an leabhar atá roghnaithe do mhí na Samhna 2013 amháin. Ní féidir ach le baill chláraithe..."
+}
+```
+
+#### unshuffled_deduplicated_gd
+
+- **Size of downloaded dataset files:** 0.40 MB
+- **Size of the generated dataset:** 1.30 MB
+- **Total amount of disk used:** 1.70 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Zhou Yujun, a 'phàrtaidh Rùnaire Comataidh Sgìre Yanfeng ann Hengyang bhaile agus a Sgìre pàrtaidh agus an riaghaltas a' bhuidheann-riochdachaidh a 'tighinn a chèilidh air ar companaidh air Apr. 14, 2017."
+}
+```
+
+#### unshuffled_deduplicated_gl
+
+- **Size of downloaded dataset files:** 148.63 MB
+- **Size of the generated dataset:** 389.42 MB
+- **Total amount of disk used:** 538.05 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"O persoal de Inditex da provincia de Pontevedra segue a reclamar iguais condicións laborais no conxunto do país - CIG: Confeder..."
+}
+```
+
+#### unshuffled_deduplicated_gn
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"º ÑÆÚÓ À Ã Ð É Æ ¾ ÄÂ Î À ¼ Æ É ÄÛ = Ü Ý\\\"Þ ßà á â ã ä å æçè ã é ê â å àë ì æê íî é á ë ï í çì àð í Ü à ñ ê é ò ä ì\"..."
+}
+```
+
+#### unshuffled_deduplicated_gom
+
+- **Size of downloaded dataset files:** 0.36 MB
+- **Size of the generated dataset:** 1.78 MB
+- **Total amount of disk used:** 2.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"दुष्ट शीळ हें कौरवांचें । रामें सविस्तर देखूनि साचें । बोलिले वचनें जें दुर्वाचे । करी तयांचें अनुस्मरण ॥२२०॥\"..."
+}
+```
+
+#### unshuffled_deduplicated_gu
+
+- **Size of downloaded dataset files:** 155.42 MB
+- **Size of the generated dataset:** 724.16 MB
+- **Total amount of disk used:** 879.59 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"અધિક માસ ચાલે છે. સમગ્ર ભારતમાં અને તેમાંય ખાસ કરીને પવિત્ર કે ધાર્મિક કહેવાય છે તેવા સ્થાનક પર કથાનો દોર ચાલે છે. ઉનાળાની કાળઝ..."
+}
+```
+
+#### unshuffled_deduplicated_he
+
+- **Size of downloaded dataset files:** 2902.40 MB
+- **Size of the generated dataset:** 9985.95 MB
+- **Total amount of disk used:** 12888.35 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"זקוקים לרשתות נגד יתושים? מחפשים רשת מתאימה לחלון צר וקטן? רשתות נגד יתושים אקורדיון של חברת קליר-מש הן הפתרון.\\nרשתות לחלונות ..."
+}
+```
+
+#### unshuffled_deduplicated_hi
+
+- **Size of downloaded dataset files:** 1914.45 MB
+- **Size of the generated dataset:** 9125.27 MB
+- **Total amount of disk used:** 11039.71 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"'आइटम गर्ल' बनकर हिट हुई थीं राखी सावंत, आज करीना-कटरीना तक फॉलो कर रही हैं ट्रेंड नक्‍सलियों का दम निकालेगा बाइक ग्रेनेड लॉन्च..."
+}
+```
+
+#### unshuffled_deduplicated_hr
+
+- **Size of downloaded dataset files:** 44.57 MB
+- **Size of the generated dataset:** 115.87 MB
+- **Total amount of disk used:** 160.44 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"U raspravi je sudjelovao i HSS-ov saborski zastupnik rekavši kako poljoprivrednici ne osjete mjere o kojima ministar govori jer..."
+}
+```
+
+#### unshuffled_deduplicated_hsb
+
+- **Size of downloaded dataset files:** 0.69 MB
+- **Size of the generated dataset:** 1.80 MB
+- **Total amount of disk used:** 2.49 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Budyšin (SN/BŠe). Elektronikarjo mějachu lětsa cyle hinaši zazběh do swojeho wukubłanja. Wokrjesne rjemjeslnistwo bě mjenujcy w..."
+}
+```
+
+#### unshuffled_deduplicated_ht
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan..."
+}
+```
+
+#### unshuffled_deduplicated_hu
+
+- **Size of downloaded dataset files:** 7026.77 MB
+- **Size of the generated dataset:** 18205.29 MB
+- **Total amount of disk used:** 25232.06 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"monster - Amatőr, házi szex videók és kezdő csjaok pornó filmjei. - Free amateur, home made sex videos and online porn movies. ..."
+}
+```
+
+#### unshuffled_deduplicated_hy
+
+- **Size of downloaded dataset files:** 375.39 MB
+- **Size of the generated dataset:** 1490.29 MB
+- **Total amount of disk used:** 1865.67 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Արցախի Հանրապետության հռչակման 26-րդ տարեդարձի կապակցությամբ Շուշիի Արվեստի կենտրոնում կազմակերպվել է մոսկվաբնակ նկարիչներ՝ հայ..."
+}
+```
+
+#### unshuffled_deduplicated_ia
+
+- **Size of downloaded dataset files:** 0.05 MB
+- **Size of the generated dataset:** 0.36 MB
+- **Total amount of disk used:** 0.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha h..."
+}
+```
+
+#### unshuffled_deduplicated_id
+
+- **Size of downloaded dataset files:** 5717.76 MB
+- **Size of the generated dataset:** 16260.55 MB
+- **Total amount of disk used:** 21978.31 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Perihal dari itu, kalau kunci hal yang demikian hilang, pemilik wajib melapor ke bengkel sah untuk dibuatkan kunci baru dengan ..."
+}
+```
+
+#### unshuffled_deduplicated_ie
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Plastic Yo Yo Metal Yo Yos Wooden Yo Yo Keychain Yo Yo Translucent Yo Yo Light Up Yo Yo Globe Yo Yo Stress Reliever Yo Yo Jellyfish Yo Yo Sports Ball Yo Yo Sound Yo Yo Miniature Yo Yo Promotional Yo Yo Novelty Yo Yo Video Game Yo Yo ECO Recycled Yo Yo"
+}
+```
+
+#### unshuffled_deduplicated_ilo
+
+- **Size of downloaded dataset files:** 0.22 MB
+- **Size of the generated dataset:** 0.65 MB
+- **Total amount of disk used:** 0.87 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Segun ken ni Ping-ay, ti yellow corn ti maysa kadagiti nadakamat a liberalized agricultural commodity iti daytoy a free trade k..."
+}
+```
+
+#### unshuffled_deduplicated_io
+
+- **Size of downloaded dataset files:** 0.04 MB
+- **Size of the generated dataset:** 0.13 MB
+- **Total amount of disk used:** 0.18 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Chekia esas parlamentala republiko. La chefo di stato esas la prezidanto. Til 2013 lu elektesis dal parlamento. Pos ta yaro, ol..."
+}
+```
+
+#### unshuffled_deduplicated_is
+
+- **Size of downloaded dataset files:** 317.45 MB
+- **Size of the generated dataset:** 852.85 MB
+- **Total amount of disk used:** 1170.30 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Eyjar.net - upplýsinga- og fréttamiðill um Vestmannaeyjar - Fréttir - Nái núverandi stefna stjórnvalda fram að ganga mun það va..."
+}
+```
+
+#### unshuffled_deduplicated_it
+
+- **Size of downloaded dataset files:** 26637.62 MB
+- **Size of the generated dataset:** 70661.48 MB
+- **Total amount of disk used:** 97299.10 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Jaundice - causes, treatment & pathology massaggio a osteochondrosis dellindizio di una controindicazione\\nTrattamento su un co..."
+}
+```
+
+#### unshuffled_deduplicated_ja
+
+- **Size of downloaded dataset files:** 38911.07 MB
+- **Size of the generated dataset:** 108369.76 MB
+- **Total amount of disk used:** 147280.83 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"神社などへ一緒に同行して、様々な角度のショットで家族写真やお子様の写真を撮影致します！お好みに合わせて様々な写真を取ることができますので、その場でカメラマンへのリクエストも可能です！お子様の晴れ姿を、緊張していない自然な笑顔で残しませんか？\\n※七五三の..."
+}
+```
+
+#### unshuffled_deduplicated_jbo
+
+- **Size of downloaded dataset files:** 0.19 MB
+- **Size of the generated dataset:** 0.67 MB
+- **Total amount of disk used:** 0.87 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "ni'o 23 la cimast. cu 23moi djedi fi'o masti la cimast. noi ke'a cu cimoi masti .i 22 la cimast. cu purlamdei .ije 24 la cimast. cu bavlamdei"
+}
+```
+
+#### unshuffled_deduplicated_jv
+
+- **Size of downloaded dataset files:** 0.20 MB
+- **Size of the generated dataset:** 0.59 MB
+- **Total amount of disk used:** 0.78 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"José Mourinho (diwaca: [ʒuˈzɛ moˈɾiɲu]; lair ing Setubal, Portugal, 26 Januari 1963; umur 55 taun) iku salah siji pelatih bal k..."
+}
+```
+
+#### unshuffled_deduplicated_ka
+
+- **Size of downloaded dataset files:** 359.75 MB
+- **Size of the generated dataset:** 1893.55 MB
+- **Total amount of disk used:** 2253.29 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"წამიყვანე შენთან ერთად (ქართულად) / Возьми меня с собой (картулад) / (რუსული სერიალები ქართულად) (რუსების პორნო ონლაინში) (ruse..."
+}
+```
+
+#### unshuffled_deduplicated_kk
+
+- **Size of downloaded dataset files:** 371.09 MB
+- **Size of the generated dataset:** 1512.19 MB
+- **Total amount of disk used:** 1883.28 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Түлкібас ауданында «Латын негізді әліпби мен емле ережесі туралы насихат» жобасының тобы семинар өткізді\\nЕлорданың «Қазақстан»..."
+}
+```
+
+#### unshuffled_deduplicated_km
+
+- **Size of downloaded dataset files:** 109.18 MB
+- **Size of the generated dataset:** 582.32 MB
+- **Total amount of disk used:** 691.50 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ខ្សឹបដាក់ត្រចៀក៖ លោក សួស សុផានិត នាយផ្នែករដ្ឋបាលព្រៃឈើ ស្រុកភ្នំក្រវាញ់ ដែលទើបឡើងកាន់តំណែងថ្មី បើកដៃឲ្យឈ្នួញ ប្រព្រឹត្តបទល្មើស ..."
+}
+```
+
+#### unshuffled_deduplicated_kn
+
+- **Size of downloaded dataset files:** 205.54 MB
+- **Size of the generated dataset:** 1032.29 MB
+- **Total amount of disk used:** 1237.83 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ರಾಷ್ಟ್ರಪತಿ ಪ್ರಣಬ್ ಮುಖರ್ಜಿಯಿಂದ ಪದ್ಮ ಪ್ರಶಸ್ತಿ ಪ್ರದಾನ | President Pranab Mukherjee Confers Padma Awards | Photo Gallery on Kannada..."
+}
+```
+
+#### unshuffled_deduplicated_ko
+
+- **Size of downloaded dataset files:** 4256.05 MB
+- **Size of the generated dataset:** 11447.72 MB
+- **Total amount of disk used:** 15703.77 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"CIA 프로젝트에서는 데이터베이스로 들어오는 요청을 중간에 수집(Sniffing)하고 수집한 데이터를 분석(Parsing)하여 그로 인한 결과를 판단하여 알릴 수 있는 시스템(Push Service)이 필요하다. 그리고 연구를 ..."
+}
+```
+
+#### unshuffled_deduplicated_krc
+
+- **Size of downloaded dataset files:** 0.59 MB
+- **Size of the generated dataset:** 2.30 MB
+- **Total amount of disk used:** 2.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Шамханланы, Бийлени къаршысына ябушуп, Батыр уланларыбызны къоллары булан «ортакъ ожакъ» къургъанбыз. Шо иш уллу зараллы иш бол..."
+}
+```
+
+#### unshuffled_deduplicated_ku
+
+- **Size of downloaded dataset files:** 22.26 MB
+- **Size of the generated dataset:** 60.17 MB
+- **Total amount of disk used:** 82.43 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Me di 114 bernameyên xwe yên berê da perçeyên ji berhemên zanyarî yên kurdzanên mezin bi wergera kurdî da ...\\nMe di 114 bernam..."
+}
+```
+
+#### unshuffled_deduplicated_kv
+
+- **Size of downloaded dataset files:** 0.31 MB
+- **Size of the generated dataset:** 1.15 MB
+- **Total amount of disk used:** 1.47 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Коми кытшыслӧн ыджытжык тор вӧр увтын куйлӧ, сійӧн и фаунасӧ татӧн аркмӧтӧны вӧрын олісь подаэз. Ассямаӧн лоӧ сія, мый кытшас с..."
+}
+```
+
+#### unshuffled_deduplicated_kw
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼Pray without ceasing🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏..."
+}
+```
+
+#### unshuffled_deduplicated_ky
+
+- **Size of downloaded dataset files:** 101.30 MB
+- **Size of the generated dataset:** 389.48 MB
+- **Total amount of disk used:** 490.77 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Turmush: Бишкек шаардык кеңешинин кезексиз отурумунда мэрге ишенбөөчүлүк көрсөтүү маселеси каралат, - депутат Т.Сагынов\\nБишкек..."
+}
+```
+
+#### unshuffled_deduplicated_la
+
+- **Size of downloaded dataset files:** 3.26 MB
+- **Size of the generated dataset:** 9.34 MB
+- **Total amount of disk used:** 12.61 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Hæ sunt generationes Noë: Noë vir justus atque perfectus fuit in generationibus suis; cum Deo ambulavit.\\nEcce ego adducam aqua..."
+}
+```
+
+#### unshuffled_deduplicated_lb
+
+- **Size of downloaded dataset files:** 7.92 MB
+- **Size of the generated dataset:** 20.43 MB
+- **Total amount of disk used:** 28.34 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Während dem Gaardefestival \\\"Ambiance Jardins\\\" vum 15. bis de 17. Mee huet den SNJ nees zesumme mam Groupe Animateur en Inform..."
+}
+```
+
+#### unshuffled_deduplicated_lez
+
+- **Size of downloaded dataset files:** 0.73 MB
+- **Size of the generated dataset:** 2.94 MB
+- **Total amount of disk used:** 3.66 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Ахцегь хуьр, виридалай ч1ехи лезги хуьрерикая я. Ам Урусатдин виридалай къиблепатавай хуьрерикай я. Ин хуьр...\"..."
+}
+```
+
+#### unshuffled_deduplicated_li
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.03 MB
+- **Total amount of disk used:** 0.04 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"'t Good Goedenraad aan de Ezerbaek besjteit oet 'n kesjtièl mèt gesjlote haof en 'n park van 26 hectare. Hie in sjtoon väól beu..."
+}
+```
+
+#### unshuffled_deduplicated_lmo
+
+- **Size of downloaded dataset files:** 0.10 MB
+- **Size of the generated dataset:** 0.44 MB
+- **Total amount of disk used:** 0.54 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Serét (en tortonés: Sregh; en piemontés: Srèj) l'è 'n cümü italià, de la regiù del Piemónt, en Pruvìncia de Alessandria. El g'h..."
+}
+```
+
+#### unshuffled_deduplicated_lo
+
+- **Size of downloaded dataset files:** 22.54 MB
+- **Size of the generated dataset:** 113.76 MB
+- **Total amount of disk used:** 136.30 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"ຜູ້ພິພາກສາ ປະຈຳເຂດ ສຫລ ທ່ານນຶ່ງ ຕັດສິນວ່າ ໂຄງການເກັບກຳຂໍ້ມູນ ທາງໂທລະສັບ ຂອງອົງການ ຄວາມໝັ້ນຄົງແຫ່ງຊາດ ແມ່ນຖືກຕ້ອງ ຕາມກົດໝາຍ.\\nກະ..."
+}
+```
+
+#### unshuffled_deduplicated_lrc
+
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.06 MB
+- **Total amount of disk used:** 0.08 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"آرلینگتون یئ گئل د شأریا ڤولاتچە ڤیرجینیا و یئ گئل د شأریا ڤولات ڤولاتچە یا یأکاگئرئتە ئمریکاە. ئی شأر دویومی کألوٙن شأر د راسا..."
+}
+```
+
+#### unshuffled_deduplicated_lt
+
+- **Size of downloaded dataset files:** 1576.45 MB
+- **Size of the generated dataset:** 4007.37 MB
+- **Total amount of disk used:** 5583.82 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Čir vir vir pavasaris! Čia čia čia… dalinamės labai simpatiška video pamokėle, kurią pristato ab888art galerija.\\nBe galo papra..."
+}
+```
+
+#### unshuffled_deduplicated_lv
+
+- **Size of downloaded dataset files:** 677.54 MB
+- **Size of the generated dataset:** 1817.28 MB
+- **Total amount of disk used:** 2494.82 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Dekoratīvi sliekšņi MITSUBISHI OUTLANDER 2007, izgatavoti no ovālas formas, pulētas nerūsējošā tērauda caurules...\\ndažādas tūn..."
+}
+```
+
+#### unshuffled_deduplicated_mai
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"१ · २ · ३ · ४ · ५ · ६ · ७ · ८ · ९ · १० · ११ · १२ · १३ · १४ · १५ · १६ · १७ · १८ · १९ · २० · २१ · २२ · २३ · २४ · २५ · २६ · २७ · २..."
+}
+```
+
+#### unshuffled_deduplicated_mg
+
+- **Size of downloaded dataset files:** 4.10 MB
+- **Size of the generated dataset:** 12.96 MB
+- **Total amount of disk used:** 17.06 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Nanamboatra taratasy apetaka sy soso-kevitra ho an'ny olona te-hanatevin-daharana ity fihetsiketsehana ity i Anocrena.\\nNosorat..."
+}
+```
+
+#### unshuffled_deduplicated_mhr
+
+- **Size of downloaded dataset files:** 1.55 MB
+- **Size of the generated dataset:** 5.97 MB
+- **Total amount of disk used:** 7.52 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Акрет жап годым Уганда кундемым Пигмей племена- влак айлен шогеныт. мемнан эран 1 курым гыч Банту племена влакат тиде кундемышк..."
+}
+```
+
+#### unshuffled_deduplicated_min
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.30 MB
+- **Total amount of disk used:** 0.31 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ..."
+}
+```
+
+#### unshuffled_deduplicated_mk
+
+- **Size of downloaded dataset files:** 289.08 MB
+- **Size of the generated dataset:** 1133.51 MB
+- **Total amount of disk used:** 1422.58 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"„Филм плус“ е насловен првиот филмски месечник во Македонија, чиј прв број ќе биде промовиран вечер во „Менада“. Новото македон..."
+}
+```
+
+#### unshuffled_deduplicated_ml
+
+- **Size of downloaded dataset files:** 473.79 MB
+- **Size of the generated dataset:** 2563.38 MB
+- **Total amount of disk used:** 3037.17 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"സ്ത്രീ പ്രവേശനം സര്‍ക്കാര്‍ പൂര്‍ണമായും അംഗീകരിക്കുന്നുവെന്നും ശബരിമലയുടെ സുരക്ഷയില്‍ ഇടപെടുമെന്നും സര്‍ക്കാര്‍ ഹൈക്കോടതിയില്‍\\..."
+}
+```
+
+#### unshuffled_deduplicated_mn
+
+- **Size of downloaded dataset files:** 209.35 MB
+- **Size of the generated dataset:** 842.53 MB
+- **Total amount of disk used:** 1051.88 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"МУБИС-ын багш мэргэжлийн хөрвөх сургалтыг төгссөн багшид багшлах эрх олгох тухай ~ БМДИ-ийн захирлын тушаал - Багшийн мэргэжил ..."
+}
+```
+
+#### unshuffled_deduplicated_mr
+
+- **Size of downloaded dataset files:** 285.80 MB
+- **Size of the generated dataset:** 1420.53 MB
+- **Total amount of disk used:** 1706.32 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Home / motivational marathi story / उद्योजकता (Entrepreneurship) / यांना हे जमलय, तर आपल्याला का नाही जमणार ?\\nयापैकी कोणाचीही ..."
+}
+```
+
+#### unshuffled_deduplicated_mrj
+
+- **Size of downloaded dataset files:** 0.28 MB
+- **Size of the generated dataset:** 1.05 MB
+- **Total amount of disk used:** 1.32 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Лӹпӹвлӓ (латинлӓ Lepidoptera ; алыкмарла лыве-влак) — капшангывлӓ йыхыш пырышы сӱмӓн нӹл шылдыран капшангывлӓ. Цилӓжӹ 180000 тӹ..."
+}
+```
+
+#### unshuffled_deduplicated_ms
+
+- **Size of downloaded dataset files:** 15.63 MB
+- **Size of the generated dataset:** 47.16 MB
+- **Total amount of disk used:** 62.80 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Sanad pertama daripada Zuhair bin Harb daripada ‘Affan daripada Hammad daripada Thabit daripada Anas.\\nSanad kedua daripada ‘Ab..."
+}
+```
+
+#### unshuffled_deduplicated_mt
+
+- **Size of downloaded dataset files:** 5.63 MB
+- **Size of the generated dataset:** 16.86 MB
+- **Total amount of disk used:** 22.49 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "tibgħat il-kawża lura lill-Qorti Ġenerali għall-annullament jew għat-tnaqqis tal-penalità imposta mill-Kummissjoni bid-deċiżjoni inizjali kif emendata bid-deċiżjoni ta’ rettifika;"
+}
+```
+
+#### unshuffled_deduplicated_mwl
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Deciplina social i outónoma que angloba atebidades de ouserbaçon, de análeze, de çcriçon, cumparaçon, de sistematizaçon i de sp..."
+}
+```
+
+#### unshuffled_deduplicated_my
+
+- **Size of downloaded dataset files:** 197.54 MB
+- **Size of the generated dataset:** 1061.72 MB
+- **Total amount of disk used:** 1259.26 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ျမ၀တီ - ရန္ကုန္တိုင္းေဒသႀကီး ေျမာက္ဥကၠလာပႏွင္႕ ဗဟန္းၿမိဳ႔နယ္ မေကြးတိုင္း ေဒသႀကီး ပခုကၠဴၿမိဳ႔နယ္တို႔၌ ျမန္မာ႕တပ္မေတာ္အား ေထာက္ခံ..."
+}
+```
+
+#### unshuffled_deduplicated_myv
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"2018 иень умарьковонь 6-це чистэ сась паро куля! Россиянь культурань Министерствась макссь невтемань конёв (прокатной удостовер..."
+}
+```
+
+#### unshuffled_deduplicated_mzn
+
+- **Size of downloaded dataset files:** 0.15 MB
+- **Size of the generated dataset:** 0.60 MB
+- **Total amount of disk used:** 0.75 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"قرآن یا قوران اسلام ِآسمونی کتاب هسته. مسلمونون گانّّه قرآن ره خدا، وحی جه برسنی‌یه، «محمد معجزه» هسته و ثقلین حدیث دله ونه خَو..."
+}
+```
+
+#### unshuffled_deduplicated_nah
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "In mācuīlpōhualxihuitl VI (inic chicuacē) in mācuīlpōhualli xiuhitl cāhuitl īhuīcpa 501 xihuitl oc 600 xihuitl."
+}
+```
+
+#### unshuffled_deduplicated_nap
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ò AUDIT í Ç è î ÿ å å 30 ò ÿ ÿ é, õ ñ ì ÿ, ê ã- ò à ì. å â å í ç â à à é ñ è å é ó ó ë. å å å û è å î é è à. à è à AUDIT 1-7 â ..."
+}
+```
+
+#### unshuffled_deduplicated_nds
+
+- **Size of downloaded dataset files:** 5.03 MB
+- **Size of the generated dataset:** 12.86 MB
+- **Total amount of disk used:** 17.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Dor kann sik vun nu af an de hele plattdüütsche Welt – vun Niebüll bit New York, vun Helgoland bit Honolulu – drapen. Allens, w..."
+}
+```
+
+#### unshuffled_deduplicated_ne
+
+- **Size of downloaded dataset files:** 229.48 MB
+- **Size of the generated dataset:** 1182.90 MB
+- **Total amount of disk used:** 1412.38 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"बर्दिबास नगरपालिकाको तेस्रो नगर परिषदबाट पारित आ.व.२०७३।७४ को संशोधित र २०७४।७५ को प्रस्तावित नीति, कार्यक्रम तथा बजेट\\nअार्थिक..."
+}
+```
+
+#### unshuffled_deduplicated_new
+
+- **Size of downloaded dataset files:** 0.79 MB
+- **Size of the generated dataset:** 4.06 MB
+- **Total amount of disk used:** 4.85 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"थ्व शहरयागु अक्षांश ३४.७००१६४ उत्तर व देशान्तर ८६.३७६४६९ पश्चिम खः (34.700164° N 86.376469° W)। थ्व थासे ७२२६७३२ वर्ग मिटर (२.७..."
+}
+```
+
+#### unshuffled_deduplicated_nl
+
+- **Size of downloaded dataset files:** 15005.27 MB
+- **Size of the generated dataset:** 39971.93 MB
+- **Total amount of disk used:** 54977.20 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Op vrijdag 31 augustus wordt het nieuwe studiejaar van de masteropleiding architectuur geopend met een dagexcursie naar Venlo.\\..."
+}
+```
+
+#### unshuffled_deduplicated_nn
+
+- **Size of downloaded dataset files:** 22.49 MB
+- **Size of the generated dataset:** 55.62 MB
+- **Total amount of disk used:** 78.11 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Planomtale krav til innhald Bakgrunn: Spørsmål frå fleire kommunar om kva ein planomtale/planbeskrivelse bør innehalde Fylkeskommunen og fylkesmannen har i ein del saker reist motsegn på formelt grunnlag"
+}
+```
+
+#### unshuffled_deduplicated_no
+
+- **Size of downloaded dataset files:** 1869.99 MB
+- **Size of the generated dataset:** 4872.30 MB
+- **Total amount of disk used:** 6742.29 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Ytterligere aktører i primærhelsetjenesten og andre NHS-virksomheter ble infisert, inkludert legekontor.Læreren vår er så attra..."
+}
+```
+
+#### unshuffled_deduplicated_oc
+
+- **Size of downloaded dataset files:** 1.28 MB
+- **Size of the generated dataset:** 3.81 MB
+- **Total amount of disk used:** 5.09 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": ".рф (rf, còdi punycode: .xn--p1ai)[1] es lo nom de domeni en rus per Russia. Foguèt activat lo 12 de mai de 2010. Lo còdi latin es .ru."
+}
+```
+
+#### unshuffled_deduplicated_or
+
+- **Size of downloaded dataset files:** 36.93 MB
+- **Size of the generated dataset:** 188.47 MB
+- **Total amount of disk used:** 225.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ଭୁବନେଶ୍ୱର, ୨୭/୧– (ଓଡ଼ିଆ ପୁଅ) ସିପିଆଇ ଜାତୀୟ ପରିଷଦର ଆହ୍ୱାନକ୍ରମେ ଗତକାଲି ଜାନୁୟାରୀ ୨୬ ସାଧାରଣତନ୍ତ୍ର ଦିବସକୁ ଦେଶ ବ୍ୟାପୀ ସମ୍ବିଧାନ ସୁରକ୍ଷା ..."
+}
+```
+
+#### unshuffled_deduplicated_os
+
+- **Size of downloaded dataset files:** 2.70 MB
+- **Size of the generated dataset:** 10.49 MB
+- **Total amount of disk used:** 13.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"1. Лæппу æмæ чызг казрæдзийы зæрдæмæ куы фæцæуынц æмæ, куы сфæнд кæнынц сæ цард баиу кæнын, уæд лæппу бар ракуры чызгæй, цæмæй ..."
+}
+```
+
+#### unshuffled_deduplicated_pa
+
+- **Size of downloaded dataset files:** 97.65 MB
+- **Size of the generated dataset:** 460.66 MB
+- **Total amount of disk used:** 558.30 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ਰਜਿ: ਨੰ: PB/JL-138/2018-20 ਜਿਲਦ 63, ਬਾਨੀ ਸੰਪਾਦਕ (ਸਵ:) ਡਾ: ਸਾਧੂ ਸਿੰਘ ਹਮਦਰਦ ਫ਼ੋਨ : 0181-2455961-62-63, 5032400, ਫੈਕਸ : 2455960, 2..."
+}
+```
+
+#### unshuffled_deduplicated_pam
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Áku pu i Anak ning Aláya at ngeni ipákit kó kékayu ngan nûng makanánu lang susúlat détinang kulit a mágkas. Lauan ya ing tarátu..."
+}
+```
+
+#### unshuffled_deduplicated_pl
+
+- **Size of downloaded dataset files:** 19253.88 MB
+- **Size of the generated dataset:** 48242.44 MB
+- **Total amount of disk used:** 67496.33 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"System informatyczny - Załącznik nr 1 do zarządzenia Wójta Gminy Podegrodzie Nr 530/2013 z dnia 27 maja 2013 r\\nSystem informat..."
+}
+```
+
+#### unshuffled_deduplicated_pms
+
+- **Size of downloaded dataset files:** 0.68 MB
+- **Size of the generated dataset:** 1.91 MB
+- **Total amount of disk used:** 2.59 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Louvigné-du-Désert a l'é na comun-a fransèisa ant la region aministrativa dla Brëtagna, ant ël dipartiment d'Ille-et-Vilaine. A..."
+}
+```
+
+#### unshuffled_deduplicated_pnb
+
+- **Size of downloaded dataset files:** 2.46 MB
+- **Size of the generated dataset:** 9.00 MB
+- **Total amount of disk used:** 11.46 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"ایہ فائل Wikimedia Commons توں اے تے دوجیاں ویونتاں تے وی ورتی جاےکدی اے۔ گل بات اس دے فائل گل بات صفہ تے تھلے دتی گئی۔\"..."
+}
+```
+
+#### unshuffled_deduplicated_ps
+
+- **Size of downloaded dataset files:** 68.50 MB
+- **Size of the generated dataset:** 242.99 MB
+- **Total amount of disk used:** 311.48 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Many people usually use the time period ‘business to business (B2B) advertising,’ however most of them do not know precisely wh..."
+}
+```
+
+#### unshuffled_deduplicated_pt
+
+- **Size of downloaded dataset files:** 24793.43 MB
+- **Size of the generated dataset:** 65204.78 MB
+- **Total amount of disk used:** 89998.21 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Você pode estar lendo este texto no sofá, levantar pra pegar uma breja na geladeira, dar uma cagada e sentar novamente, sem int..."
+}
+```
+
+#### unshuffled_deduplicated_qu
+
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.07 MB
+- **Total amount of disk used:** 0.09 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Warayu wichay (kastilla simipi: Ascensión de Guarayos) nisqaqa Buliwya mama llaqtapi, Santa Krus suyupi, huk llaqtam, Warayu pruwinsyap uma llaqtanmi."
+}
+```
+
+#### unshuffled_deduplicated_rm
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"practicists agrars / practicistas agraras AFP pon far ina furmaziun da basa scursanida per cuntanscher in attestat federal da q..."
+}
+```
+
+#### unshuffled_deduplicated_ro
+
+- **Size of downloaded dataset files:** 4270.96 MB
+- **Size of the generated dataset:** 11118.45 MB
+- **Total amount of disk used:** 15389.40 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"“În viață, oportunitatea nu este totul. Cine atrage Lumina, cineva bun în umbră. Timpul ne creează.” maestru\\nLyn.Evans: Ce mar..."
+}
+```
+
+#### unshuffled_deduplicated_ru
+
+- **Size of downloaded dataset files:** 158955.70 MB
+- **Size of the generated dataset:** 583362.25 MB
+- **Total amount of disk used:** 742317.96 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Доступ к данному профилю для публичного просмотра закрыт администрацией сайта - профиль находится на модерации.\\nРазработчикам ..."
+}
+```
+
+#### unshuffled_deduplicated_sa
+
+- **Size of downloaded dataset files:** 6.93 MB
+- **Size of the generated dataset:** 36.55 MB
+- **Total amount of disk used:** 43.49 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"अनिरुद्धनगरे क्रीडिता रामलीला सम्‍प्रति समाप्‍ता अस्ति । तस्‍य कानिचन् चित्राणि पूर्वमेव प्रकाशितानि सन्ति । द्वौ चलचित्रौ अपि ..."
+}
+```
+
+#### unshuffled_deduplicated_sah
+
+- **Size of downloaded dataset files:** 6.69 MB
+- **Size of the generated dataset:** 26.19 MB
+- **Total amount of disk used:** 32.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████..."
+}
+```
+
+#### unshuffled_deduplicated_scn
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "La gilusìa è nu sintimentu dulurusu ca nasci d'un disideriu di pussessu sclusivu ntê cunfrunti dâ pirsuna amata e dû timuri, dû suspettu o dâ cirtizza dâ sò nfidiltati."
+}
+```
+
+#### unshuffled_deduplicated_sd
+
+- **Size of downloaded dataset files:** 70.73 MB
+- **Size of the generated dataset:** 262.72 MB
+- **Total amount of disk used:** 333.46 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"هر ڪو ڄاڻي ٿو ته جڏهن توهان هڪ وڏي خريد ڪرڻ چاهيون ٿا, توهان پڄي ضروري حڪم ۾ ان جي ڪم ڪرڻ جي هٿ ۾ لاڳاپو ڪيو آهي. جي شيء آهي ته..."
+}
+```
+
+#### unshuffled_deduplicated_sh
+
+- **Size of downloaded dataset files:** 1.38 MB
+- **Size of the generated dataset:** 6.14 MB
+- **Total amount of disk used:** 7.51 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Opština Gornja Radgona se nalazi u sjeveroistočnoj Sloveniji i graniči s susjednom Austriji duž rijeke Mure. Sa tridesetim nase..."
+}
+```
+
+#### unshuffled_deduplicated_si
+
+- **Size of downloaded dataset files:** 167.48 MB
+- **Size of the generated dataset:** 803.54 MB
+- **Total amount of disk used:** 971.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"ලාංකීය සිතිවිලි සිංහල බ්ලොග් කියවනය කොත්තු සින්ඩිය ලංකා Blogger හත්මාළුව ලංකා බ්ලොග් කියවනය මාතලන්ගේ සින්ඩිය මොබයිල්lk\\nඅවකාශය ..."
+}
+```
+
+#### unshuffled_deduplicated_sk
+
+- **Size of downloaded dataset files:** 1869.59 MB
+- **Size of the generated dataset:** 4580.82 MB
+- **Total amount of disk used:** 6450.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Aktivity | Agentúra podporovaného zamestnávania | vzdelávanie pre klientov, vzdelávanie pre odborníkov, kurzy\\nŠpecializované k..."
+}
+```
+
+#### unshuffled_deduplicated_sl
+
+- **Size of downloaded dataset files:** 498.98 MB
+- **Size of the generated dataset:** 1261.18 MB
+- **Total amount of disk used:** 1760.16 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Če Creatures, ki je želel, da pridejo na čas, predvsem je povedlo – razlikuje od ljubosumja začel grizenja kolen (ali zadnjica)..."
+}
+```
+
+#### unshuffled_deduplicated_so
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"тттттттттттттттттттттттттттттттт тттттттттттттттттттттттттттттттт тттттттттттттттттттттттттттттттт ттттттттттттттттуууууууууууу..."
+}
+```
+
+#### unshuffled_deduplicated_sq
+
+- **Size of downloaded dataset files:** 424.73 MB
+- **Size of the generated dataset:** 1155.30 MB
+- **Total amount of disk used:** 1580.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Çfarë do të më pëlqente tek një femër ose çfarë do të më shndërronte në një shpërthim drite? – Albert Vataj\\nTë gjithëve një zo..."
+}
+```
+
+#### unshuffled_deduplicated_sr
+
+- **Size of downloaded dataset files:** 634.22 MB
+- **Size of the generated dataset:** 2253.84 MB
+- **Total amount of disk used:** 2888.06 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Корисни савети за сваки дан. На сајту су разне категорије, као што су љепота, мода, кување и поправка властитим рукама.\\nШколск..."
+}
+```
+
+#### unshuffled_deduplicated_su
+
+- **Size of downloaded dataset files:** 0.05 MB
+- **Size of the generated dataset:** 0.15 MB
+- **Total amount of disk used:** 0.20 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Kartu krédit nyaéta \"duit plastik\" anu dikaluarkeun ku bank pikeun alat pambayaran di tempat-tempat nu tangtu samisal jiga di hotél, réstoran, tempat rékréasi jeung sajabana.[1]"
+}
+```
+
+#### unshuffled_deduplicated_sv
+
+- **Size of downloaded dataset files:** 9713.55 MB
+- **Size of the generated dataset:** 25107.51 MB
+- **Total amount of disk used:** 34821.06 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"1783 är ett viktigt årtal i den nya tidens historia. Det året slöts en fred i Paris och därmed blev de 13 brittiska kolonierna ..."
+}
+```
+
+#### unshuffled_deduplicated_sw
+
+- **Size of downloaded dataset files:** 2.81 MB
+- **Size of the generated dataset:** 8.56 MB
+- **Total amount of disk used:** 11.37 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Miripuko hiyo inakuja mwanzoni mwa Wiki Takatifu kuelekea Pasaka na ikiwa ni wiki chache tu kabla ya Papa Francis kuanza ziara yake katika nchi hiyo yenye idadi kubwa kabisa ya watu katika ulimwengu wa nchi za Kiarabu."
+}
+```
+
+#### unshuffled_deduplicated_ta
+
+- **Size of downloaded dataset files:** 926.13 MB
+- **Size of the generated dataset:** 5229.02 MB
+- **Total amount of disk used:** 6155.15 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"பொழுது சாய்ந்து வெகு நேரமாகிவிட்டது. கூலி வேலைக்குப் போயிருந்த 'சித்தாள் ' பெண்கள் எல்லோரும் வீடு திரும்பி விட்டார்கள். இன்னும்..."
+}
+```
+
+#### unshuffled_deduplicated_te
+
+- **Size of downloaded dataset files:** 326.57 MB
+- **Size of the generated dataset:** 1617.70 MB
+- **Total amount of disk used:** 1944.26 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"హర్యానాలో టోల్ దగ్గర సిబ్బంది.. స్థానిక ప్రజలు కొట్టుకున్నారు. కర్నాల్ అనే గ్రామానికి సమీపంలో టోల్ గేట్ ఉంది. అయితే సాధారణంగా స..."
+}
+```
+
+#### unshuffled_deduplicated_tg
+
+- **Size of downloaded dataset files:** 59.99 MB
+- **Size of the generated dataset:** 249.56 MB
+- **Total amount of disk used:** 309.56 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Ҳумайро гуфтааст, мухолифи низом аст, низоме, ки дар Тоҷикистон вуҷуд дорад. Ба ин маънӣ, худро мухолифи давлату ҳукумати Тоҷик..."
+}
+```
+
+#### unshuffled_deduplicated_th
+
+- **Size of downloaded dataset files:** 3372.64 MB
+- **Size of the generated dataset:** 16320.84 MB
+- **Total amount of disk used:** 19693.48 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ฟันที่แลดูขาวสะอาดไม่มีเศษอาหารติดอยู่ เหงือกสีชมพู ไม่เจ็บ หรือมีเลือดออกเวลาแปรงฟันหรือขัดฟัน ไม่มีปัญหาเรื่องกลิ่นปาก ทำให้ก..."
+}
+```
+
+#### unshuffled_deduplicated_tk
+
+- **Size of downloaded dataset files:** 2.12 MB
+- **Size of the generated dataset:** 6.79 MB
+- **Total amount of disk used:** 8.91 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Türkmenistanyň Prezidenti agyr atletika boýunça dünýä çempionatyna taýýarlyk işleriniň barşy bilen tanyşdy\\nHalallykdan kemal t..."
+}
+```
+
+#### unshuffled_deduplicated_tl
+
+- **Size of downloaded dataset files:** 144.33 MB
+- **Size of the generated dataset:** 411.69 MB
+- **Total amount of disk used:** 556.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"“Gusto ko manawagan sa mga Unit Head ng Chanel 2 Salve. Kasi napapansin ko iyon mga alaga ko ang taping halos once a week lang,..."
+}
+```
+
+#### unshuffled_deduplicated_tr
+
+- **Size of downloaded dataset files:** 9909.40 MB
+- **Size of the generated dataset:** 27151.22 MB
+- **Total amount of disk used:** 37060.62 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Son yıllarda görülen ay tutulmalarına göre daha etkili olacağı söylenen Kanlı veya Kırmızı Ay Tutulmasına saatler kaldı. Bu akş..."
+}
+```
+
+#### unshuffled_deduplicated_tt
+
+- **Size of downloaded dataset files:** 81.91 MB
+- **Size of the generated dataset:** 306.48 MB
+- **Total amount of disk used:** 388.39 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"\\\"Иремнең вафатына 40 көн узгач, Алмаз да безнең өйгә кереп үлде\\\". Арчада 35 яшьлек ир өстенә кондызлар ега башлаган агач төшк..."
+}
+```
+
+#### unshuffled_deduplicated_tyv
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Экии, хүндүлуг аалчылар болгаш тыва дылдың деткикчилери! Тыва дылдың болгаш чогаалдың ховар бир башкызынга, Менги Ооржакка, ажы..."
+}
+```
+
+#### unshuffled_deduplicated_ug
+
+- **Size of downloaded dataset files:** 19.58 MB
+- **Size of the generated dataset:** 82.44 MB
+- **Total amount of disk used:** 102.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"زاڭ-ءتۇزىم | عىلىم-تەحنيكا | ءتىل-ادەبيەت | تۇرمىس | دەنە تاربيە | ساياحات-ورتا | سۋرەتتى حابار | سىر سۇحبات | ارناۋلى تاقىرىپ ..."
+}
+```
+
+#### unshuffled_deduplicated_uk
+
+- **Size of downloaded dataset files:** 7665.38 MB
+- **Size of the generated dataset:** 28478.19 MB
+- **Total amount of disk used:** 36143.57 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Про надання роз'яснення (щодо форми письмового зобов'язання громадян про зворотне ввезення/вивезення товарів), Державна митна с..."
+}
+```
+
+#### unshuffled_deduplicated_ur
+
+- **Size of downloaded dataset files:** 461.19 MB
+- **Size of the generated dataset:** 1737.79 MB
+- **Total amount of disk used:** 2198.98 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"آئیے اہم اسلامی کتب کو یونیکوڈ میں انٹرنیٹ پر پیش کرنے کے لئے مل جل کر آن لائن ٹائپنگ کریں۔ محدث ٹائپنگ پراجیکٹ کے ذریعے آپ روز..."
+}
+```
+
+#### unshuffled_deduplicated_uz
+
+- **Size of downloaded dataset files:** 4.10 MB
+- **Size of the generated dataset:** 11.44 MB
+- **Total amount of disk used:** 15.54 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Qurama tog'lari tizmasining Toshkentdan 154 km uzoqlikdagi Toshkent-Ush yo'li yeqasidaxushmanzara tabiat qo'ynida joylashgan maydoni 30 ga.\nBolalarni sog'lomlashtirish oromgohi Bo'stonliq tumani Oqtosh muntaqasining soy-salqin gushasida joylashgan."
+}
+```
+
+#### unshuffled_deduplicated_vec
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Par ogni pónto, ła derivada ła xe ła pendensa de ła reta tangente a ła curva de ła funsion f. Ła reta de cołor róso l'è senpre ..."
+}
+```
+
+#### unshuffled_deduplicated_vi
+
+- **Size of downloaded dataset files:** 10215.29 MB
+- **Size of the generated dataset:** 32041.91 MB
+- **Total amount of disk used:** 42257.20 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Canh chua cá bông lau không chỉ là món ăn giải nhiệt, thanh mát ngày hè mà còn là món siêu bổ dưỡng, rất tốt cho người gầy ốm. ..."
+}
+```
+
+#### unshuffled_deduplicated_vo
+
+- **Size of downloaded dataset files:** 0.29 MB
+- **Size of the generated dataset:** 2.00 MB
+- **Total amount of disk used:** 2.29 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Sarniguet binon zif in ziläk: Hautes-Pyrénées, in topäd: Midi-Pyrénées, in Fransän. Sarniguet topon videtü 43°19’ 7’’ N e lunetü 0°5’ 19’’ L."
+}
+```
+
+#### unshuffled_deduplicated_wa
+
+- **Size of downloaded dataset files:** 0.08 MB
+- **Size of the generated dataset:** 0.21 MB
+- **Total amount of disk used:** 0.28 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Cisse pådje ci n' est co k' on djermon, dj' ô bén k' el pådje est djusse sibåtcheye, eyet co trop tene; et s' divreut ele ecråxhî ene miete."
+}
+```
+
+#### unshuffled_deduplicated_war
+
+- **Size of downloaded dataset files:** 0.52 MB
+- **Size of the generated dataset:** 2.25 MB
+- **Total amount of disk used:** 2.77 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "An Honce amo in usa ka baryo ngan munisipalidad ha distrito han Rožňava ha rehiyon han Košice ha nasod han Slovakia.\nAn Rumegies amo in usa ka komyun ha departamento han Nord ngan ha rehiyon han Nord-Pas-de-Calais ha nasod han Fransya."
+}
+```
+
+#### unshuffled_deduplicated_wuu
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.03 MB
+- **Total amount of disk used:** 0.04 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"伊春元旦天气 伊春腊八天气 伊春春节天气 伊春情人节天气 伊春元宵节天气 伊春愚人节天气 伊春清明节天气 伊春劳动节天气 伊春母亲节天气 伊春端午节天气 伊春七夕节天气 伊春教师节天气 伊春中秋节天气 伊春国庆节天气 伊春重阳节天气 伊春万圣节天气 伊春..."
+}
+```
+
+#### unshuffled_deduplicated_xal
+
+- **Size of downloaded dataset files:** 0.03 MB
+- **Size of the generated dataset:** 0.11 MB
+- **Total amount of disk used:** 0.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Арнгудин Орн гисн Европд бәәдг һазр. 2007 җилин тooһaр эн орн нутгт 3,600,523 әмтн бәәдг билә. Арнгудин Орнин хотл балһсна нерн..."
+}
+```
+
+#### unshuffled_deduplicated_xmf
+
+- **Size of downloaded dataset files:** 0.90 MB
+- **Size of the generated dataset:** 4.42 MB
+- **Total amount of disk used:** 5.32 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"მოჩამილი ტექსტი წჷმორინელი რე Creative Commons Attribution-ShareAlike ლიცენზიათ; შილებე გეძინელი პირობეფიშ არსებუა. კილიშკილიშა..."
+}
+```
+
+#### unshuffled_deduplicated_yi
+
+- **Size of downloaded dataset files:** 21.17 MB
+- **Size of the generated dataset:** 84.20 MB
+- **Total amount of disk used:** 105.37 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ממשותדיק - חבֿרה, איך אַרבעט איצט אױף אַ זשורנאַל. טאָמער איר האָט עפּעס צוצוגעבן זאָלט איר שיקן מיר אַן אָנזאָג. ס'װעט הײסן \\\"..."
+}
+```
+
+#### unshuffled_deduplicated_yo
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.03 MB
+- **Total amount of disk used:** 0.04 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Copyright © 2018 BBC. BBC kò mọ̀ nípa àwọn ohun tí ó wà ní àwọn ojú òpó tí ó wà ní ìta. Ọwọ́ tí a fi mú ìbáṣepọ̀ ti ìta.\"..."
+}
+```
+
+#### unshuffled_deduplicated_yue
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 你還不爆 我累了 投降輸一半可以嗎\"..."
+}
+```
+
+#### unshuffled_deduplicated_zh
+
+- **Size of downloaded dataset files:** 95351.01 MB
+- **Size of the generated dataset:** 255468.07 MB
+- **Total amount of disk used:** 350819.08 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"中国铝灰网 中国有色金属矿产网 中国黄莲网 中国水轮发电机网 中国抽油泵网 中国数控雕刻机网 中国不锈钢抛光网 中国磨具加工网 中国压铸铝网 中国耐水腻子网 中国手机摄像头网 中国粗粮网 中国车门锁网 中国钛粉网 中国轮圈网\\n天天中奖彩票图 天天中彩票..."
+}
+```
+
+</details>
+
+
+<details>
+  <summary>Click to expand the Data/size information for each language (deduplicated)</summary>
+
+#### unshuffled_original_af
+
+- **Size of downloaded dataset files:** 81.82 MB
+- **Size of the generated dataset:** 242.31 MB
+- **Total amount of disk used:** 324.13 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "aanlyn markte as gevolg van ons voortgesette 'n begrip opsie handel sakeplan pdf terwyl ons steeds die gereelde ons binêre opsies handel"
+}
+```
+
+#### unshuffled_original_als
+
+- **Size of downloaded dataset files:** 1.42 MB
+- **Size of the generated dataset:** 5.05 MB
+- **Total amount of disk used:** 6.47 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"De Nazionalpark hät e Flächi vo 170,3 km² und isch dodemit s grösti Naturschutzgebiet vo de Schwiz. Er ligt uf em Gebiet vo de ..."
+}
+```
+
+#### unshuffled_original_am
+
+- **Size of downloaded dataset files:** 98.03 MB
+- **Size of the generated dataset:** 360.55 MB
+- **Total amount of disk used:** 458.57 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"አየር መንገዱ ከአዲስ አበባ ወደ ሮም ጣሊያን በማምራት ላይ በነበረበት ጊዜ ረዳት አብራሪው የጉዞውን አቅጣጫ በመቀየር ጄኔቭ አውሮፓላን ማረፊያ በማሳረፍ እጁን ለፖሊስ ሰጥቷል።\\nየኢትዮጵያ መንግስት የ..."
+}
+```
+
+#### unshuffled_original_an
+
+- **Size of downloaded dataset files:** 0.14 MB
+- **Size of the generated dataset:** 1.27 MB
+- **Total amount of disk used:** 1.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"واااااااأسفاه الأمم تفتخر ب 0 أمي ووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووووو..."
+}
+```
+
+#### unshuffled_original_ar
+
+- **Size of downloaded dataset files:** 21202.61 MB
+- **Size of the generated dataset:** 83862.08 MB
+- **Total amount of disk used:** 105064.69 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"مرحبا بك عزيز الزائر نتمنى لك أوقاتاً سعيدة معنا وأن نزداد شرفا بخدمتك ولا تنسى التسجيل معنا لتستفيد بكل جديد\\nأهلا وسهلا بك زا..."
+}
+```
+
+#### unshuffled_original_arz
+
+- **Size of downloaded dataset files:** 15.16 MB
+- **Size of the generated dataset:** 66.88 MB
+- **Total amount of disk used:** 82.04 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"بنى عجل : قبيلة من عجل بن لجيم بن صعب بن على بن بكر بن وائل انتقل اغلبهم الى البصرة فى العراق و اصفهان و خراسان فى ايران و اذرب..."
+}
+```
+
+#### unshuffled_original_as
+
+- **Size of downloaded dataset files:** 20.44 MB
+- **Size of the generated dataset:** 112.28 MB
+- **Total amount of disk used:** 132.72 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"আমি, এই সংগঠনৰ সদস্য সকলে একেলগ হৈ অসমকে ধৰি ভাৰতৰ উত্তৰ পূৰ্বাঞ্চলৰ অমূল্য কলা-সাংস্কৃতিক সম্পদৰাজি বৃহত্তৰ অষ্ট্ৰেলিয়াৰ সন্মু..."
+}
+```
+
+#### unshuffled_original_ast
+
+- **Size of downloaded dataset files:** 0.88 MB
+- **Size of the generated dataset:** 2.42 MB
+- **Total amount of disk used:** 3.30 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"The Killers llanzaron el so álbum debú, Hot Fuss, en xunu de 2004 nel Reinu Xuníu, al traviés de la discográfica Lizard King, y..."
+}
+```
+
+#### unshuffled_original_av
+
+- **Size of downloaded dataset files:** 0.08 MB
+- **Size of the generated dataset:** 0.40 MB
+- **Total amount of disk used:** 0.48 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Жинда малъараб ва божизе бегьулеб рагІудаса кьуризе бегьуларо гьев. Гьес насихІат гьабизе кколелъул бацІцІадаб диналъул рахъалъ..."
+}
+```
+
+#### unshuffled_original_az
+
+- **Size of downloaded dataset files:** 884.78 MB
+- **Size of the generated dataset:** 2827.44 MB
+- **Total amount of disk used:** 3712.22 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"AZTV-Artıq 7 ildir ki, Abşeron rayonu dotasiya almadan bütün xərclərini yerli daxilolmalar hesabına maliyyələşdirir.\\nDünən, 10..."
+}
+```
+
+#### unshuffled_original_azb
+
+- **Size of downloaded dataset files:** 6.33 MB
+- **Size of the generated dataset:** 27.15 MB
+- **Total amount of disk used:** 33.48 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"لعلی ١٣-جو عصرده یاشاییب یاراتمیش گؤرکملی آذربایجان شاعرلریندندیر. ١٢٢٤-جی ایلده تبریزده آنادان اولموشدور، گنج یاشلاریندا تیجار..."
+}
+```
+
+#### unshuffled_original_ba
+
+- **Size of downloaded dataset files:** 31.68 MB
+- **Size of the generated dataset:** 127.51 MB
+- **Total amount of disk used:** 159.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Күҙәтеү ҡуласаһы моделен хәҙер Мифтахетдин Аҡмулла исемендәге Башҡорт дәүләт педагогия университетында ла эшләргә мөмкин\\t\\nКүҙ..."
+}
+```
+
+#### unshuffled_original_bar
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "                                                                                                                                          vo"
+}
+```
+
+#### unshuffled_original_bcl
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"& ÿ ó / í 0 - ø û ù ö ú ð ï ú \\u0014 ù þ ô ö í ÷ ò \\u0014 ÷ í ù û ö í \\u0001 û ñ ç þ \\u0001 ð \\u0007 þ ò ñ ñ ò ô \\u0017 û ö ô ÷..."
+}
+```
+
+#### unshuffled_original_be
+
+- **Size of downloaded dataset files:** 475.21 MB
+- **Size of the generated dataset:** 1790.97 MB
+- **Total amount of disk used:** 2266.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Брэсцкія ўлады не дазволілі прафсаюзу РЭП правесці пікетаванне ў парку Воінаў-інтэрнацыяналістаў 30 мая 2018 года.\\nСітуацыю пр..."
+}
+```
+
+#### unshuffled_original_bg
+
+- **Size of downloaded dataset files:** 7950.75 MB
+- **Size of the generated dataset:** 32190.14 MB
+- **Total amount of disk used:** 40140.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ЖАЛБОПОДАТЕЛЯТ директор на Дирекция „ Обжалване и данъчно-осигурителна практика“- Бургас, редовно призован, се представлява от ..."
+}
+```
+
+#### unshuffled_original_bh
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.11 MB
+- **Total amount of disk used:** 0.12 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"सुकमा जिला भारत के छत्तीसगढ़ राज्य में एगो जिला बाटे। एकर मुख्यालय सुकमा शहर बाटे। एकर कुल रकबा 5636 वर्ग कि॰मी॰ बाटे।\"..."
+}
+```
+
+#### unshuffled_original_bn
+
+- **Size of downloaded dataset files:** 2040.81 MB
+- **Size of the generated dataset:** 10272.93 MB
+- **Total amount of disk used:** 12313.74 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ভড়ং সর্বস্ব বাংলা আর্ট অ্যান্ড কালচারের হিসাব গুলিয়ে দেওয়ার ম্যাজিকের নাম ব্রাত্য রাইসু November 23, 2017\\nভড়ং সর্বস্ব বাংলা আর..."
+}
+```
+
+#### unshuffled_original_bo
+
+- **Size of downloaded dataset files:** 27.60 MB
+- **Size of the generated dataset:** 186.35 MB
+- **Total amount of disk used:** 213.95 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"བོད་མི་འདི་དག་ནི་རང་རྒྱུད་སྒོ་རུ་ཕུད་དེ་གཞན་རྒྱུད་པང་དུ་ཉར་ནས་གསོ་སྐྱོང་བྱེད་དགོས་ཟེར་བ་དང་གཅིག་མཚུངས་རེད།\\nཚན་རིག་ནི་དང་ཐོག་རང..."
+}
+```
+
+#### unshuffled_original_bpy
+
+- **Size of downloaded dataset files:** 0.32 MB
+- **Size of the generated dataset:** 4.15 MB
+- **Total amount of disk used:** 4.47 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"পৌরসভা এহার আয়তন (লয়াহান) ২,৭৩০,.৬৩ বর্গ কিলোমিটার। পৌরসভা এহার মাপাহানর অক্ষাংশ বারো দ্রাঘিমাংশ ইলতাই 18.63° S 48.18° W ।[১]..."
+}
+```
+
+#### unshuffled_original_br
+
+- **Size of downloaded dataset files:** 8.75 MB
+- **Size of the generated dataset:** 28.80 MB
+- **Total amount of disk used:** 37.56 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Ar mank Magalhães(Daveoù a vank) a zo ur spesad evned, Spheniscus magellanicus an anv skiantel anezhañ.\\nGallout a reer implijo..."
+}
+```
+
+#### unshuffled_original_bs
+
+- **Size of downloaded dataset files:** 0.05 MB
+- **Size of the generated dataset:** 0.46 MB
+- **Total amount of disk used:** 0.51 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ž šř é ú šř šř ě šř ž é č ě ž ů ě ď éé ýš ě ě Ž č š ý ě ď é ýš ě ď ě éé ýš ě č ž ě š ý ď ě ýš é ú č ž č š ý ď ý ž é éě ď é č ýš..."
+}
+```
+
+#### unshuffled_original_bxr
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"2002 оной хабар буряад хэлэ бэшэгэй һалбари Үндэһэтэнэй хүмүүнлиг ухаанай дээдэ һургуули болгогдожо өөршэлэгдөө.\\nХарин мүнөө б..."
+}
+```
+
+#### unshuffled_original_ca
+
+- **Size of downloaded dataset files:** 2958.25 MB
+- **Size of the generated dataset:** 8223.77 MB
+- **Total amount of disk used:** 11182.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Daniel Vendrell, conegut com Vandrell, ha sigut un dels il•lustradors contemporanis més influents, representant a la nova onada..."
+}
+```
+
+#### unshuffled_original_cbk
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano yo gano..."
+}
+```
+
+#### unshuffled_original_ce
+
+- **Size of downloaded dataset files:** 1.99 MB
+- **Size of the generated dataset:** 8.33 MB
+- **Total amount of disk used:** 10.32 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Шаьш анархисташ ду бохучу жигархойн дIахьедарехь дуьйцу, оьрсийн ницкъаллийн структурийн а, федералан каналан а Iалашонаш \\\"мар..."
+}
+```
+
+#### unshuffled_original_ceb
+
+- **Size of downloaded dataset files:** 10.56 MB
+- **Size of the generated dataset:** 39.07 MB
+- **Total amount of disk used:** 49.62 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Si Isko walay pupamilok nga nagtan-aw sa unahan, natugaw. “Naunsa ka gud diha Isko nga layo man kaayo ang imong panan-aw?” ni I..."
+}
+```
+
+#### unshuffled_original_ckb
+
+- **Size of downloaded dataset files:** 106.70 MB
+- **Size of the generated dataset:** 487.30 MB
+- **Total amount of disk used:** 594.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"رسی رۆژ - ساڵێک دوای بومەلەرزەی کرماشان میوانی بەرنامە : کاک سیاوەش حەیاتی چالاکی مەدەنی -قەسری شیرین\\nپارچە موزیک 30 / 10 / 20..."
+}
+```
+
+#### unshuffled_original_cs
+
+- **Size of downloaded dataset files:** 20710.66 MB
+- **Size of the generated dataset:** 54435.87 MB
+- **Total amount of disk used:** 75146.52 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Akce anarchistů proti připravovanému novému služební řádu a nízkým mzdám 1903 – Historie českého anarchismu (1880 – 1939)\\nRost..."
+}
+```
+
+#### unshuffled_original_cv
+
+- **Size of downloaded dataset files:** 8.96 MB
+- **Size of the generated dataset:** 39.15 MB
+- **Total amount of disk used:** 48.11 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Шыранӑ чухне ӑнсӑртран латин кирилл саспаллисем вырӑнне латин саспаллисене ҫырсан, сайт эсир ҫырнине юсама тӑрӑшӗ.\\nКу сайтра ч..."
+}
+```
+
+#### unshuffled_original_cy
+
+- **Size of downloaded dataset files:** 77.95 MB
+- **Size of the generated dataset:** 214.51 MB
+- **Total amount of disk used:** 292.46 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Mae capeli Cymreig yr Andes ym Mhatagonia wedi cyhoeddi na fydd gwasanaethau yno weddill y mis, oherwydd yr eira trwm sydd wedi..."
+}
+```
+
+#### unshuffled_original_da
+
+- **Size of downloaded dataset files:** 5722.60 MB
+- **Size of the generated dataset:** 15980.20 MB
+- **Total amount of disk used:** 21702.80 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Den 2.-5. februar 2016 løb det tredje kursus i uddannelsen af 4kommunesamarbejdets Local Impact Coaches, af stablen i Gentofte ..."
+}
+```
+
+#### unshuffled_original_de
+
+- **Size of downloaded dataset files:** 113970.06 MB
+- **Size of the generated dataset:** 315880.28 MB
+- **Total amount of disk used:** 429850.34 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Auf dieser Seite gibt es mind. ein YouTube Video. Cookies für diese Website wurden abgelehnt. Dadurch können keine YouTube Vide..."
+}
+```
+
+#### unshuffled_original_diq
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Zıwanê Slawki, zıwano merdumanê Slawano. Zıwanê Slawki yew lızgeyê Zıwananê Hind u Ewropao. Keyeyê Zıwananê Slawki beno hirê letey:"
+}
+```
+
+#### unshuffled_original_dsb
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Pśiklaskaju južo pśed pśedstajenim... 1500 źiśi njamóžo wěcej docakaś, měsćańska hala w Chóśebuzu - wupśedana."
+}
+```
+
+#### unshuffled_original_dv
+
+- **Size of downloaded dataset files:** 23.76 MB
+- **Size of the generated dataset:** 125.53 MB
+- **Total amount of disk used:** 149.29 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ބ. އަތޮޅުގައި ހުޅުވަން ތައްޔާރުވަމުން އަންނަ ވައްކަރު ރިސޯޓުގައި ވަޒީފާ އަދާކުރަން ޝައުގުވެރިވާ ފަރާތްތަކަށް ކުރިމަތިލުމުގެ ފުރ..."
+}
+```
+
+#### unshuffled_original_el
+
+- **Size of downloaded dataset files:** 16507.72 MB
+- **Size of the generated dataset:** 63203.08 MB
+- **Total amount of disk used:** 79710.80 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Νεκρός εντοπίστηκε μέσα στο σπίτι του στην οδό Ηρώδου Αττικού στον αριθμό 7 ο επικεφαλής του προξενικού τμήματος της Ρωσικής πρ..."
+}
+```
+
+#### unshuffled_original_eml
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"A séguit dal prucès ad rubutiśasiòṅ di abitànt dal pòpul ad Mikenes, Angoras 'l è finî dènt'r a 'n robot cun la tèsta dna rana ..."
+}
+```
+
+#### unshuffled_original_en
+
+- **Size of downloaded dataset files:** 861960.11 MB
+- **Size of the generated dataset:** 2408445.27 MB
+- **Total amount of disk used:** 3270405.39 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Mtendere Village was inspired by the vision of Chief Napoleon Dzombe, which he shared with John Blanchard during his first visi..."
+}
+```
+
+#### unshuffled_original_eo
+
+- **Size of downloaded dataset files:** 111.65 MB
+- **Size of the generated dataset:** 299.63 MB
+- **Total amount of disk used:** 411.29 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Ĉu ... preĝi | mediti | ricevi instigojn || kanti | muziki || informiĝi | legi | studi || prepari Diservon\\nTemas pri kolekto d..."
+}
+```
+
+#### unshuffled_original_es
+
+- **Size of downloaded dataset files:** 101126.80 MB
+- **Size of the generated dataset:** 284664.41 MB
+- **Total amount of disk used:** 385791.21 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Como se librará de la celulitis en el gimnasio La piel superflua en las manos después del adelgazamiento, Los bailes fáciles pa..."
+}
+```
+
+#### unshuffled_original_et
+
+- **Size of downloaded dataset files:** 1794.17 MB
+- **Size of the generated dataset:** 4935.07 MB
+- **Total amount of disk used:** 6729.25 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"MTÜ AB Video järgib oma tegevuses kodanikuühenduste eetilise tegevuse üldtunnustatud põhimõtteid, mis on lühidalt kokkuvõetud 7..."
+}
+```
+
+#### unshuffled_original_eu
+
+- **Size of downloaded dataset files:** 236.69 MB
+- **Size of the generated dataset:** 853.38 MB
+- **Total amount of disk used:** 1090.07 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Gure jarduerek eraikuntzarekin, elkarbizitzarekin, hirigintzarekin eta ekologiarekin dute harremana, baita ideia eta konponbideak irudikatu eta garatzearekin ere, eraikuntza sektorea hobetuz, pertsonen erosotasuna eta bizi-kalitatea hobetzeko."
+}
+```
+
+#### unshuffled_original_fa
+
+- **Size of downloaded dataset files:** 19985.59 MB
+- **Size of the generated dataset:** 80308.39 MB
+- **Total amount of disk used:** 100293.98 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"قـــــــــــــــــرار بود با هم کنـــــــــــــار بیایم نه اینکه از کنــــــــــــار هم رد بشیم...!!!\\nاگر روزی دلت لبریز غم بو..."
+}
+```
+
+#### unshuffled_original_fi
+
+- **Size of downloaded dataset files:** 9508.93 MB
+- **Size of the generated dataset:** 27247.83 MB
+- **Total amount of disk used:** 36756.76 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Kiitos Deelle kaikesta - 1,5 viikkoa kulunut, kun Dee ei ole enää ollut omani. Reilu viikko sitten sunnuntaina vein Deen uuteen kotiinsa. Itselläni on ollut niin ristiriitaiset t..."
+}
+```
+
+#### unshuffled_original_fr
+
+- **Size of downloaded dataset files:** 100445.11 MB
+- **Size of the generated dataset:** 289144.84 MB
+- **Total amount of disk used:** 389589.95 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Média de débat d'idées, de culture et de littérature. Récits, décryptages, analyses, portraits et critiques autour de la vie des idées. Magazine engagé, ouvert aux autres et au monde.. Bring up to date in french"
+}
+```
+
+#### unshuffled_original_frr
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Hiragana’ Practice’Sheet’1’(A -O)’ ’ Name:’________ __________________________’Section:’_______________ _’ ’ ’ ’ ’ ’ ’ ’ ’ ’ ’ ..."
+}
+```
+
+#### unshuffled_original_fy
+
+- **Size of downloaded dataset files:** 11.83 MB
+- **Size of the generated dataset:** 34.56 MB
+- **Total amount of disk used:** 46.39 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Nim in sêfte ride op Holmsjön, yn ien fan 'e lytse marren yn de omkriten, of nim se op avontueren lykas nonresidential. lâns Indalsälven wetter. Holm Sportklubb hawwe kano 's te huur, yn gearwurking mei de Baltyske Power konferinsje."
+}
+```
+
+#### unshuffled_original_ga
+
+- **Size of downloaded dataset files:** 27.91 MB
+- **Size of the generated dataset:** 88.09 MB
+- **Total amount of disk used:** 116.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Is fóram é seo chun plé a dhéanamh ar an leabhar atá roghnaithe do mhí na Samhna 2013 amháin. Ní féidir ach le baill chláraithe..."
+}
+```
+
+#### unshuffled_original_gd
+
+- **Size of downloaded dataset files:** 0.50 MB
+- **Size of the generated dataset:** 1.93 MB
+- **Total amount of disk used:** 2.43 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Zhou Yujun, a 'phàrtaidh Rùnaire Comataidh Sgìre Yanfeng ann Hengyang bhaile agus a Sgìre pàrtaidh agus an riaghaltas a' bhuidheann-riochdachaidh a 'tighinn a chèilidh air ar companaidh air Apr. 14, 2017."
+}
+```
+
+#### unshuffled_original_gl
+
+- **Size of downloaded dataset files:** 224.48 MB
+- **Size of the generated dataset:** 626.07 MB
+- **Total amount of disk used:** 850.55 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"O persoal de Inditex da provincia de Pontevedra segue a reclamar iguais condicións laborais no conxunto do país - CIG: Confeder..."
+}
+```
+
+#### unshuffled_original_gn
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.04 MB
+- **Total amount of disk used:** 0.05 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"º ÑÆÚÓ À Ã Ð É Æ ¾ ÄÂ Î À ¼ Æ É ÄÛ = Ü Ý\\\"Þ ßà á â ã ä å æçè ã é ê â å àë ì æê íî é á ë ï í çì àð í Ü à ñ ê é ò ä ì\"..."
+}
+```
+
+#### unshuffled_original_gom
+
+- **Size of downloaded dataset files:** 0.42 MB
+- **Size of the generated dataset:** 2.15 MB
+- **Total amount of disk used:** 2.58 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"दुष्ट शीळ हें कौरवांचें । रामें सविस्तर देखूनि साचें । बोलिले वचनें जें दुर्वाचे । करी तयांचें अनुस्मरण ॥२२०॥\"..."
+}
+```
+
+#### unshuffled_original_gu
+
+- **Size of downloaded dataset files:** 221.27 MB
+- **Size of the generated dataset:** 1044.10 MB
+- **Total amount of disk used:** 1265.37 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"અધિક માસ ચાલે છે. સમગ્ર ભારતમાં અને તેમાંય ખાસ કરીને પવિત્ર કે ધાર્મિક કહેવાય છે તેવા સ્થાનક પર કથાનો દોર ચાલે છે. ઉનાળાની કાળઝ..."
+}
+```
+
+#### unshuffled_original_he
+
+- **Size of downloaded dataset files:** 5397.82 MB
+- **Size of the generated dataset:** 20135.60 MB
+- **Total amount of disk used:** 25533.42 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"זקוקים לרשתות נגד יתושים? מחפשים רשת מתאימה לחלון צר וקטן? רשתות נגד יתושים אקורדיון של חברת קליר-מש הן הפתרון.\\nרשתות לחלונות ..."
+}
+```
+
+#### unshuffled_original_hi
+
+- **Size of downloaded dataset files:** 3487.24 MB
+- **Size of the generated dataset:** 17098.70 MB
+- **Total amount of disk used:** 20585.94 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"'आइटम गर्ल' बनकर हिट हुई थीं राखी सावंत, आज करीना-कटरीना तक फॉलो कर रही हैं ट्रेंड नक्‍सलियों का दम निकालेगा बाइक ग्रेनेड लॉन्च..."
+}
+```
+
+#### unshuffled_original_hr
+
+- **Size of downloaded dataset files:** 75.74 MB
+- **Size of the generated dataset:** 232.53 MB
+- **Total amount of disk used:** 308.27 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"U raspravi je sudjelovao i HSS-ov saborski zastupnik rekavši kako poljoprivrednici ne osjete mjere o kojima ministar govori jer..."
+}
+```
+
+#### unshuffled_original_hsb
+
+- **Size of downloaded dataset files:** 1.33 MB
+- **Size of the generated dataset:** 4.28 MB
+- **Total amount of disk used:** 5.60 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Budyšin (SN/BŠe). Elektronikarjo mějachu lětsa cyle hinaši zazběh do swojeho wukubłanja. Wokrjesne rjemjeslnistwo bě mjenujcy w..."
+}
+```
+
+#### unshuffled_original_ht
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan..."
+}
+```
+
+#### unshuffled_original_hu
+
+- **Size of downloaded dataset files:** 14966.82 MB
+- **Size of the generated dataset:** 41079.42 MB
+- **Total amount of disk used:** 56046.24 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"monster - Amatőr, házi szex videók és kezdő csjaok pornó filmjei. - Free amateur, home made sex videos and online porn movies. ..."
+}
+```
+
+#### unshuffled_original_hy
+
+- **Size of downloaded dataset files:** 855.79 MB
+- **Size of the generated dataset:** 3757.16 MB
+- **Total amount of disk used:** 4612.96 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Արցախի Հանրապետության հռչակման 26-րդ տարեդարձի կապակցությամբ Շուշիի Արվեստի կենտրոնում կազմակերպվել է մոսկվաբնակ նկարիչներ՝ հայ..."
+}
+```
+
+#### unshuffled_original_ia
+
+- **Size of downloaded dataset files:** 0.08 MB
+- **Size of the generated dataset:** 0.66 MB
+- **Total amount of disk used:** 0.74 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha h..."
+}
+```
+
+#### unshuffled_original_id
+
+- **Size of downloaded dataset files:** 10106.08 MB
+- **Size of the generated dataset:** 30820.54 MB
+- **Total amount of disk used:** 40926.62 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Perihal dari itu, kalau kunci hal yang demikian hilang, pemilik wajib melapor ke bengkel sah untuk dibuatkan kunci baru dengan ..."
+}
+```
+
+#### unshuffled_original_ie
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Plastic Yo Yo Metal Yo Yos Wooden Yo Yo Keychain Yo Yo Translucent Yo Yo Light Up Yo Yo Globe Yo Yo Stress Reliever Yo Yo Jellyfish Yo Yo Sports Ball Yo Yo Sound Yo Yo Miniature Yo Yo Promotional Yo Yo Novelty Yo Yo Video Game Yo Yo ECO Recycled Yo Yo"
+}
+```
+
+#### unshuffled_original_ilo
+
+- **Size of downloaded dataset files:** 0.26 MB
+- **Size of the generated dataset:** 0.88 MB
+- **Total amount of disk used:** 1.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Segun ken ni Ping-ay, ti yellow corn ti maysa kadagiti nadakamat a liberalized agricultural commodity iti daytoy a free trade k..."
+}
+```
+
+#### unshuffled_original_io
+
+- **Size of downloaded dataset files:** 0.04 MB
+- **Size of the generated dataset:** 0.15 MB
+- **Total amount of disk used:** 0.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Chekia esas parlamentala republiko. La chefo di stato esas la prezidanto. Til 2013 lu elektesis dal parlamento. Pos ta yaro, ol..."
+}
+```
+
+#### unshuffled_original_is
+
+- **Size of downloaded dataset files:** 508.34 MB
+- **Size of the generated dataset:** 1454.29 MB
+- **Total amount of disk used:** 1962.63 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Eyjar.net - upplýsinga- og fréttamiðill um Vestmannaeyjar - Fréttir - Nái núverandi stefna stjórnvalda fram að ganga mun það va..."
+}
+```
+
+#### unshuffled_original_it
+
+- **Size of downloaded dataset files:** 49741.45 MB
+- **Size of the generated dataset:** 140550.72 MB
+- **Total amount of disk used:** 190292.18 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Jaundice - causes, treatment & pathology massaggio a osteochondrosis dellindizio di una controindicazione\\nTrattamento su un co..."
+}
+```
+
+#### unshuffled_original_ja
+
+- **Size of downloaded dataset files:** 75878.76 MB
+- **Size of the generated dataset:** 221459.12 MB
+- **Total amount of disk used:** 297337.88 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"神社などへ一緒に同行して、様々な角度のショットで家族写真やお子様の写真を撮影致します！お好みに合わせて様々な写真を取ることができますので、その場でカメラマンへのリクエストも可能です！お子様の晴れ姿を、緊張していない自然な笑顔で残しませんか？\\n※七五三の..."
+}
+```
+
+#### unshuffled_original_jbo
+
+- **Size of downloaded dataset files:** 0.20 MB
+- **Size of the generated dataset:** 0.73 MB
+- **Total amount of disk used:** 0.93 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "ni'o 23 la cimast. cu 23moi djedi fi'o masti la cimast. noi ke'a cu cimoi masti .i 22 la cimast. cu purlamdei .ije 24 la cimast. cu bavlamdei"
+}
+```
+
+#### unshuffled_original_jv
+
+- **Size of downloaded dataset files:** 0.21 MB
+- **Size of the generated dataset:** 0.66 MB
+- **Total amount of disk used:** 0.87 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"José Mourinho (diwaca: [ʒuˈzɛ moˈɾiɲu]; lair ing Setubal, Portugal, 26 Januari 1963; umur 55 taun) iku salah siji pelatih bal k..."
+}
+```
+
+#### unshuffled_original_ka
+
+- **Size of downloaded dataset files:** 649.20 MB
+- **Size of the generated dataset:** 3594.24 MB
+- **Total amount of disk used:** 4243.44 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"წამიყვანე შენთან ერთად (ქართულად) / Возьми меня с собой (картулад) / (რუსული სერიალები ქართულად) (რუსების პორნო ონლაინში) (ruse..."
+}
+```
+
+#### unshuffled_original_kk
+
+- **Size of downloaded dataset files:** 586.57 MB
+- **Size of the generated dataset:** 2702.50 MB
+- **Total amount of disk used:** 3289.08 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Түлкібас ауданында «Латын негізді әліпби мен емле ережесі туралы насихат» жобасының тобы семинар өткізді\\nЕлорданың «Қазақстан»..."
+}
+```
+
+#### unshuffled_original_km
+
+- **Size of downloaded dataset files:** 184.33 MB
+- **Size of the generated dataset:** 1051.54 MB
+- **Total amount of disk used:** 1235.87 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ខ្សឹបដាក់ត្រចៀក៖ លោក សួស សុផានិត នាយផ្នែករដ្ឋបាលព្រៃឈើ ស្រុកភ្នំក្រវាញ់ ដែលទើបឡើងកាន់តំណែងថ្មី បើកដៃឲ្យឈ្នួញ ប្រព្រឹត្តបទល្មើស ..."
+}
+```
+
+#### unshuffled_original_kn
+
+- **Size of downloaded dataset files:** 326.30 MB
+- **Size of the generated dataset:** 1681.92 MB
+- **Total amount of disk used:** 2008.23 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ರಾಷ್ಟ್ರಪತಿ ಪ್ರಣಬ್ ಮುಖರ್ಜಿಯಿಂದ ಪದ್ಮ ಪ್ರಶಸ್ತಿ ಪ್ರದಾನ | President Pranab Mukherjee Confers Padma Awards | Photo Gallery on Kannada..."
+}
+```
+
+#### unshuffled_original_ko
+
+- **Size of downloaded dataset files:** 8399.90 MB
+- **Size of the generated dataset:** 24120.43 MB
+- **Total amount of disk used:** 32520.33 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"CIA 프로젝트에서는 데이터베이스로 들어오는 요청을 중간에 수집(Sniffing)하고 수집한 데이터를 분석(Parsing)하여 그로 인한 결과를 판단하여 알릴 수 있는 시스템(Push Service)이 필요하다. 그리고 연구를 ..."
+}
+```
+
+#### unshuffled_original_krc
+
+- **Size of downloaded dataset files:** 0.63 MB
+- **Size of the generated dataset:** 2.56 MB
+- **Total amount of disk used:** 3.19 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Шамханланы, Бийлени къаршысына ябушуп, Батыр уланларыбызны къоллары булан «ортакъ ожакъ» къургъанбыз. Шо иш уллу зараллы иш бол..."
+}
+```
+
+#### unshuffled_original_ku
+
+- **Size of downloaded dataset files:** 31.83 MB
+- **Size of the generated dataset:** 94.47 MB
+- **Total amount of disk used:** 126.30 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Me di 114 bernameyên xwe yên berê da perçeyên ji berhemên zanyarî yên kurdzanên mezin bi wergera kurdî da ...\\nMe di 114 bernam..."
+}
+```
+
+#### unshuffled_original_kv
+
+- **Size of downloaded dataset files:** 0.38 MB
+- **Size of the generated dataset:** 2.27 MB
+- **Total amount of disk used:** 2.65 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Коми кытшыслӧн ыджытжык тор вӧр увтын куйлӧ, сійӧн и фаунасӧ татӧн аркмӧтӧны вӧрын олісь подаэз. Ассямаӧн лоӧ сія, мый кытшас с..."
+}
+```
+
+#### unshuffled_original_kw
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.04 MB
+- **Total amount of disk used:** 0.05 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼Pray without ceasing🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏🏼🙏..."
+}
+```
+
+#### unshuffled_original_ky
+
+- **Size of downloaded dataset files:** 145.57 MB
+- **Size of the generated dataset:** 601.57 MB
+- **Total amount of disk used:** 747.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Turmush: Бишкек шаардык кеңешинин кезексиз отурумунда мэрге ишенбөөчүлүк көрсөтүү маселеси каралат, - депутат Т.Сагынов\\nБишкек..."
+}
+```
+
+#### unshuffled_original_la
+
+- **Size of downloaded dataset files:** 5.21 MB
+- **Size of the generated dataset:** 26.51 MB
+- **Total amount of disk used:** 31.72 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Hæ sunt generationes Noë: Noë vir justus atque perfectus fuit in generationibus suis; cum Deo ambulavit.\\nEcce ego adducam aqua..."
+}
+```
+
+#### unshuffled_original_lb
+
+- **Size of downloaded dataset files:** 10.23 MB
+- **Size of the generated dataset:** 29.18 MB
+- **Total amount of disk used:** 39.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Während dem Gaardefestival \\\"Ambiance Jardins\\\" vum 15. bis de 17. Mee huet den SNJ nees zesumme mam Groupe Animateur en Inform..."
+}
+```
+
+#### unshuffled_original_lez
+
+- **Size of downloaded dataset files:** 0.79 MB
+- **Size of the generated dataset:** 3.22 MB
+- **Total amount of disk used:** 4.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Ахцегь хуьр, виридалай ч1ехи лезги хуьрерикая я. Ам Урусатдин виридалай къиблепатавай хуьрерикай я. Ин хуьр...\"..."
+}
+```
+
+#### unshuffled_original_li
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.03 MB
+- **Total amount of disk used:** 0.04 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"'t Good Goedenraad aan de Ezerbaek besjteit oet 'n kesjtièl mèt gesjlote haof en 'n park van 26 hectare. Hie in sjtoon väól beu..."
+}
+```
+
+#### unshuffled_original_lmo
+
+- **Size of downloaded dataset files:** 0.10 MB
+- **Size of the generated dataset:** 0.45 MB
+- **Total amount of disk used:** 0.55 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Serét (en tortonés: Sregh; en piemontés: Srèj) l'è 'n cümü italià, de la regiù del Piemónt, en Pruvìncia de Alessandria. El g'h..."
+}
+```
+
+#### unshuffled_original_lo
+
+- **Size of downloaded dataset files:** 32.35 MB
+- **Size of the generated dataset:** 173.91 MB
+- **Total amount of disk used:** 206.26 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"ຜູ້ພິພາກສາ ປະຈຳເຂດ ສຫລ ທ່ານນຶ່ງ ຕັດສິນວ່າ ໂຄງການເກັບກຳຂໍ້ມູນ ທາງໂທລະສັບ ຂອງອົງການ ຄວາມໝັ້ນຄົງແຫ່ງຊາດ ແມ່ນຖືກຕ້ອງ ຕາມກົດໝາຍ.\\nກະ..."
+}
+```
+
+#### unshuffled_original_lrc
+
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.07 MB
+- **Total amount of disk used:** 0.09 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"آرلینگتون یئ گئل د شأریا ڤولاتچە ڤیرجینیا و یئ گئل د شأریا ڤولات ڤولاتچە یا یأکاگئرئتە ئمریکاە. ئی شأر دویومی کألوٙن شأر د راسا..."
+}
+```
+
+#### unshuffled_original_lt
+
+- **Size of downloaded dataset files:** 3280.44 MB
+- **Size of the generated dataset:** 9007.72 MB
+- **Total amount of disk used:** 12288.16 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Čir vir vir pavasaris! Čia čia čia… dalinamės labai simpatiška video pamokėle, kurią pristato ab888art galerija.\\nBe galo papra..."
+}
+```
+
+#### unshuffled_original_lv
+
+- **Size of downloaded dataset files:** 1417.80 MB
+- **Size of the generated dataset:** 4069.15 MB
+- **Total amount of disk used:** 5486.95 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Dekoratīvi sliekšņi MITSUBISHI OUTLANDER 2007, izgatavoti no ovālas formas, pulētas nerūsējošā tērauda caurules...\\ndažādas tūn..."
+}
+```
+
+#### unshuffled_original_mai
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.31 MB
+- **Total amount of disk used:** 0.32 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"१ · २ · ३ · ४ · ५ · ६ · ७ · ८ · ९ · १० · ११ · १२ · १३ · १४ · १५ · १६ · १७ · १८ · १९ · २० · २१ · २२ · २३ · २४ · २५ · २६ · २७ · २..."
+}
+```
+
+#### unshuffled_original_mg
+
+- **Size of downloaded dataset files:** 5.93 MB
+- **Size of the generated dataset:** 20.78 MB
+- **Total amount of disk used:** 26.71 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Nanamboatra taratasy apetaka sy soso-kevitra ho an'ny olona te-hanatevin-daharana ity fihetsiketsehana ity i Anocrena.\\nNosorat..."
+}
+```
+
+#### unshuffled_original_mhr
+
+- **Size of downloaded dataset files:** 1.75 MB
+- **Size of the generated dataset:** 7.20 MB
+- **Total amount of disk used:** 8.95 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Акрет жап годым Уганда кундемым Пигмей племена- влак айлен шогеныт. мемнан эран 1 курым гыч Банту племена влакат тиде кундемышк..."
+}
+```
+
+#### unshuffled_original_min
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.60 MB
+- **Total amount of disk used:** 0.61 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ‏‏‎ ..."
+}
+```
+
+#### unshuffled_original_mk
+
+- **Size of downloaded dataset files:** 484.70 MB
+- **Size of the generated dataset:** 2100.45 MB
+- **Total amount of disk used:** 2585.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"„Филм плус“ е насловен првиот филмски месечник во Македонија, чиј прв број ќе биде промовиран вечер во „Менада“. Новото македон..."
+}
+```
+
+#### unshuffled_original_ml
+
+- **Size of downloaded dataset files:** 895.20 MB
+- **Size of the generated dataset:** 5001.33 MB
+- **Total amount of disk used:** 5896.53 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"സ്ത്രീ പ്രവേശനം സര്‍ക്കാര്‍ പൂര്‍ണമായും അംഗീകരിക്കുന്നുവെന്നും ശബരിമലയുടെ സുരക്ഷയില്‍ ഇടപെടുമെന്നും സര്‍ക്കാര്‍ ഹൈക്കോടതിയില്‍\\..."
+}
+```
+
+#### unshuffled_original_mn
+
+- **Size of downloaded dataset files:** 450.48 MB
+- **Size of the generated dataset:** 2224.82 MB
+- **Total amount of disk used:** 2675.30 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Монгол улс, Улаанбаатар хот - 14191 Энхтайваны өргөн чөлөө - 10, Багш хөгжлийн ордон, Багшийн мэргэжил дээшлүүлэх институт\\nБаг..."
+}
+```
+
+#### unshuffled_original_mr
+
+- **Size of downloaded dataset files:** 500.97 MB
+- **Size of the generated dataset:** 2685.98 MB
+- **Total amount of disk used:** 3186.95 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Home / motivational marathi story / उद्योजकता (Entrepreneurship) / यांना हे जमलय, तर आपल्याला का नाही जमणार ?\\nयापैकी कोणाचीही ..."
+}
+```
+
+#### unshuffled_original_mrj
+
+- **Size of downloaded dataset files:** 0.29 MB
+- **Size of the generated dataset:** 1.11 MB
+- **Total amount of disk used:** 1.40 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Лӹпӹвлӓ (латинлӓ Lepidoptera ; алыкмарла лыве-влак) — капшангывлӓ йыхыш пырышы сӱмӓн нӹл шылдыран капшангывлӓ. Цилӓжӹ 180000 тӹ..."
+}
+```
+
+#### unshuffled_original_ms
+
+- **Size of downloaded dataset files:** 27.14 MB
+- **Size of the generated dataset:** 116.66 MB
+- **Total amount of disk used:** 143.80 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Sanad pertama daripada Zuhair bin Harb daripada ‘Affan daripada Hammad daripada Thabit daripada Anas.\\nSanad kedua daripada ‘Ab..."
+}
+```
+
+#### unshuffled_original_mt
+
+- **Size of downloaded dataset files:** 7.18 MB
+- **Size of the generated dataset:** 23.34 MB
+- **Total amount of disk used:** 30.52 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "tibgħat il-kawża lura lill-Qorti Ġenerali għall-annullament jew għat-tnaqqis tal-penalità imposta mill-Kummissjoni bid-deċiżjoni inizjali kif emendata bid-deċiżjoni ta’ rettifika;"
+}
+```
+
+#### unshuffled_original_mwl
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Deciplina social i outónoma que angloba atebidades de ouserbaçon, de análeze, de çcriçon, cumparaçon, de sistematizaçon i de sp..."
+}
+```
+
+#### unshuffled_original_my
+
+- **Size of downloaded dataset files:** 352.72 MB
+- **Size of the generated dataset:** 1928.21 MB
+- **Total amount of disk used:** 2280.92 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ျမ၀တီ - ရန္ကုန္တိုင္းေဒသႀကီး ေျမာက္ဥကၠလာပႏွင္႕ ဗဟန္းၿမိဳ႔နယ္ မေကြးတိုင္း ေဒသႀကီး ပခုကၠဴၿမိဳ႔နယ္တို႔၌ ျမန္မာ႕တပ္မေတာ္အား ေထာက္ခံ..."
+}
+```
+
+#### unshuffled_original_myv
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"2018 иень умарьковонь 6-це чистэ сась паро куля! Россиянь культурань Министерствась макссь невтемань конёв (прокатной удостовер..."
+}
+```
+
+#### unshuffled_original_mzn
+
+- **Size of downloaded dataset files:** 0.17 MB
+- **Size of the generated dataset:** 0.69 MB
+- **Total amount of disk used:** 0.86 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"قرآن یا قوران اسلام ِآسمونی کتاب هسته. مسلمونون گانّّه قرآن ره خدا، وحی جه برسنی‌یه، «محمد معجزه» هسته و ثقلین حدیث دله ونه خَو..."
+}
+```
+
+#### unshuffled_original_nah
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "In mācuīlpōhualxihuitl VI (inic chicuacē) in mācuīlpōhualli xiuhitl cāhuitl īhuīcpa 501 xihuitl oc 600 xihuitl."
+}
+```
+
+#### unshuffled_original_nap
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.02 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ò AUDIT í Ç è î ÿ å å 30 ò ÿ ÿ é, õ ñ ì ÿ, ê ã- ò à ì. å â å í ç â à à é ñ è å é ó ó ë. å å å û è å î é è à. à è à AUDIT 1-7 â ..."
+}
+```
+
+#### unshuffled_original_nds
+
+- **Size of downloaded dataset files:** 6.43 MB
+- **Size of the generated dataset:** 17.39 MB
+- **Total amount of disk used:** 23.83 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Dor kann sik vun nu af an de hele plattdüütsche Welt – vun Niebüll bit New York, vun Helgoland bit Honolulu – drapen. Allens, w..."
+}
+```
+
+#### unshuffled_original_ne
+
+- **Size of downloaded dataset files:** 338.83 MB
+- **Size of the generated dataset:** 1780.37 MB
+- **Total amount of disk used:** 2119.20 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"बर्दिबास नगरपालिकाको तेस्रो नगर परिषदबाट पारित आ.व.२०७३।७४ को संशोधित र २०७४।७५ को प्रस्तावित नीति, कार्यक्रम तथा बजेट\\nअार्थिक..."
+}
+```
+
+#### unshuffled_original_new
+
+- **Size of downloaded dataset files:** 0.98 MB
+- **Size of the generated dataset:** 5.50 MB
+- **Total amount of disk used:** 6.48 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"थ्व शहरयागु अक्षांश ३४.७००१६४ उत्तर व देशान्तर ८६.३७६४६९ पश्चिम खः (34.700164° N 86.376469° W)। थ्व थासे ७२२६७३२ वर्ग मिटर (२.७..."
+}
+```
+
+#### unshuffled_original_nl
+
+- **Size of downloaded dataset files:** 27993.02 MB
+- **Size of the generated dataset:** 79375.23 MB
+- **Total amount of disk used:** 107368.26 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Op vrijdag 31 augustus wordt het nieuwe studiejaar van de masteropleiding architectuur geopend met een dagexcursie naar Venlo.\\..."
+}
+```
+
+#### unshuffled_original_nn
+
+- **Size of downloaded dataset files:** 31.34 MB
+- **Size of the generated dataset:** 86.63 MB
+- **Total amount of disk used:** 117.97 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "Planomtale krav til innhald Bakgrunn: Spørsmål frå fleire kommunar om kva ein planomtale/planbeskrivelse bør innehalde Fylkeskommunen og fylkesmannen har i ein del saker reist motsegn på formelt grunnlag"
+}
+```
+
+#### unshuffled_original_no
+
+- **Size of downloaded dataset files:** 2962.26 MB
+- **Size of the generated dataset:** 8251.24 MB
+- **Total amount of disk used:** 11213.50 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Ytterligere aktører i primærhelsetjenesten og andre NHS-virksomheter ble infisert, inkludert legekontor.Læreren vår er så attra..."
+}
+```
+
+#### unshuffled_original_oc
+
+- **Size of downloaded dataset files:** 1.50 MB
+- **Size of the generated dataset:** 5.84 MB
+- **Total amount of disk used:** 7.35 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": ".рф (rf, còdi punycode: .xn--p1ai)[1] es lo nom de domeni en rus per Russia. Foguèt activat lo 12 de mai de 2010. Lo còdi latin es .ru."
+}
+```
+
+#### unshuffled_original_or
+
+- **Size of downloaded dataset files:** 47.53 MB
+- **Size of the generated dataset:** 248.10 MB
+- **Total amount of disk used:** 295.63 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ଭୁବନେଶ୍ୱର, ୨୭/୧– (ଓଡ଼ିଆ ପୁଅ) ସିପିଆଇ ଜାତୀୟ ପରିଷଦର ଆହ୍ୱାନକ୍ରମେ ଗତକାଲି ଜାନୁୟାରୀ ୨୬ ସାଧାରଣତନ୍ତ୍ର ଦିବସକୁ ଦେଶ ବ୍ୟାପୀ ସମ୍ବିଧାନ ସୁରକ୍ଷା ..."
+}
+```
+
+#### unshuffled_original_os
+
+- **Size of downloaded dataset files:** 2.95 MB
+- **Size of the generated dataset:** 12.30 MB
+- **Total amount of disk used:** 15.25 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"1. Лæппу æмæ чызг казрæдзийы зæрдæмæ куы фæцæуынц æмæ, куы сфæнд кæнынц сæ цард баиу кæнын, уæд лæппу бар ракуры чызгæй, цæмæй ..."
+}
+```
+
+#### unshuffled_original_pa
+
+- **Size of downloaded dataset files:** 156.60 MB
+- **Size of the generated dataset:** 764.05 MB
+- **Total amount of disk used:** 920.65 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ਰਜਿ: ਨੰ: PB/JL-138/2018-20 ਜਿਲਦ 63, ਬਾਨੀ ਸੰਪਾਦਕ (ਸਵ:) ਡਾ: ਸਾਧੂ ਸਿੰਘ ਹਮਦਰਦ ਫ਼ੋਨ : 0181-2455961-62-63, 5032400, ਫੈਕਸ : 2455960, 2..."
+}
+```
+
+#### unshuffled_original_pam
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Áku pu i Anak ning Aláya at ngeni ipákit kó kékayu ngan nûng makanánu lang susúlat détinang kulit a mágkas. Lauan ya ing tarátu..."
+}
+```
+
+#### unshuffled_original_pl
+
+- **Size of downloaded dataset files:** 40898.23 MB
+- **Size of the generated dataset:** 111695.64 MB
+- **Total amount of disk used:** 152593.87 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"System informatyczny - Załącznik nr 1 do zarządzenia Wójta Gminy Podegrodzie Nr 530/2013 z dnia 27 maja 2013 r\\nSystem informat..."
+}
+```
+
+#### unshuffled_original_pms
+
+- **Size of downloaded dataset files:** 0.72 MB
+- **Size of the generated dataset:** 2.05 MB
+- **Total amount of disk used:** 2.78 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Louvigné-du-Désert a l'é na comun-a fransèisa ant la region aministrativa dla Brëtagna, ant ël dipartiment d'Ille-et-Vilaine. A..."
+}
+```
+
+#### unshuffled_original_pnb
+
+- **Size of downloaded dataset files:** 3.07 MB
+- **Size of the generated dataset:** 11.48 MB
+- **Total amount of disk used:** 14.55 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"ایہ فائل Wikimedia Commons توں اے تے دوجیاں ویونتاں تے وی ورتی جاےکدی اے۔ گل بات اس دے فائل گل بات صفہ تے تھلے دتی گئی۔\"..."
+}
+```
+
+#### unshuffled_original_ps
+
+- **Size of downloaded dataset files:** 98.86 MB
+- **Size of the generated dataset:** 361.93 MB
+- **Total amount of disk used:** 460.79 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Many people usually use the time period ‘business to business (B2B) advertising,’ however most of them do not know precisely wh..."
+}
+```
+
+#### unshuffled_original_pt
+
+- **Size of downloaded dataset files:** 45068.69 MB
+- **Size of the generated dataset:** 126491.06 MB
+- **Total amount of disk used:** 171559.75 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Você pode estar lendo este texto no sofá, levantar pra pegar uma breja na geladeira, dar uma cagada e sentar novamente, sem int..."
+}
+```
+
+#### unshuffled_original_qu
+
+- **Size of downloaded dataset files:** 0.02 MB
+- **Size of the generated dataset:** 0.08 MB
+- **Total amount of disk used:** 0.10 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Warayu wichay (kastilla simipi: Ascensión de Guarayos) nisqaqa Buliwya mama llaqtapi, Santa Krus suyupi, huk llaqtam, Warayu pruwinsyap uma llaqtanmi."
+}
+```
+
+#### unshuffled_original_rm
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"practicists agrars / practicistas agraras AFP pon far ina furmaziun da basa scursanida per cuntanscher in attestat federal da q..."
+}
+```
+
+#### unshuffled_original_ro
+
+- **Size of downloaded dataset files:** 9092.83 MB
+- **Size of the generated dataset:** 25624.51 MB
+- **Total amount of disk used:** 34717.34 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"“În viață, oportunitatea nu este totul. Cine atrage Lumina, cineva bun în umbră. Timpul ne creează.” maestru\\nLyn.Evans: Ce mar..."
+}
+```
+
+#### unshuffled_original_ru
+
+- **Size of downloaded dataset files:** 304942.49 MB
+- **Size of the generated dataset:** 1184107.94 MB
+- **Total amount of disk used:** 1489050.43 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Доступ к данному профилю для публичного просмотра закрыт администрацией сайта - профиль находится на модерации.\\nРазработчикам ..."
+}
+```
+
+#### unshuffled_original_sa
+
+- **Size of downloaded dataset files:** 16.71 MB
+- **Size of the generated dataset:** 92.56 MB
+- **Total amount of disk used:** 109.27 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"अनिरुद्धनगरे क्रीडिता रामलीला सम्‍प्रति समाप्‍ता अस्ति । तस्‍य कानिचन् चित्राणि पूर्वमेव प्रकाशितानि सन्ति । द्वौ चलचित्रौ अपि ..."
+}
+```
+
+#### unshuffled_original_sah
+
+- **Size of downloaded dataset files:** 8.66 MB
+- **Size of the generated dataset:** 41.79 MB
+- **Total amount of disk used:** 50.45 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████..."
+}
+```
+
+#### unshuffled_original_scn
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 0,
+    "text": "La gilusìa è nu sintimentu dulurusu ca nasci d'un disideriu di pussessu sclusivu ntê cunfrunti dâ pirsuna amata e dû timuri, dû suspettu o dâ cirtizza dâ sò nfidiltati."
+}
+```
+
+#### unshuffled_original_sd
+
+- **Size of downloaded dataset files:** 86.42 MB
+- **Size of the generated dataset:** 347.38 MB
+- **Total amount of disk used:** 433.81 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"هر ڪو ڄاڻي ٿو ته جڏهن توهان هڪ وڏي خريد ڪرڻ چاهيون ٿا, توهان پڄي ضروري حڪم ۾ ان جي ڪم ڪرڻ جي هٿ ۾ لاڳاپو ڪيو آهي. جي شيء آهي ته..."
+}
+```
+
+#### unshuffled_original_sh
+
+- **Size of downloaded dataset files:** 3.30 MB
+- **Size of the generated dataset:** 24.64 MB
+- **Total amount of disk used:** 27.94 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Opština Gornja Radgona se nalazi u sjeveroistočnoj Sloveniji i graniči s susjednom Austriji duž rijeke Mure. Sa tridesetim nase..."
+}
+```
+
+#### unshuffled_original_si
+
+- **Size of downloaded dataset files:** 296.53 MB
+- **Size of the generated dataset:** 1401.31 MB
+- **Total amount of disk used:** 1697.84 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"ලාංකීය සිතිවිලි සිංහල බ්ලොග් කියවනය කොත්තු සින්ඩිය ලංකා Blogger හත්මාළුව ලංකා බ්ලොග් කියවනය මාතලන්ගේ සින්ඩිය මොබයිල්lk\\nඅවකාශය ..."
+}
+```
+
+#### unshuffled_original_sk
+
+- **Size of downloaded dataset files:** 3536.52 MB
+- **Size of the generated dataset:** 9353.81 MB
+- **Total amount of disk used:** 12890.33 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Aktivity | Agentúra podporovaného zamestnávania | vzdelávanie pre klientov, vzdelávanie pre odborníkov, kurzy\\nŠpecializované k..."
+}
+```
+
+#### unshuffled_original_sl
+
+- **Size of downloaded dataset files:** 911.90 MB
+- **Size of the generated dataset:** 2551.71 MB
+- **Total amount of disk used:** 3463.61 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Če Creatures, ki je želel, da pridejo na čas, predvsem je povedlo – razlikuje od ljubosumja začel grizenja kolen (ali zadnjica)..."
+}
+```
+
+#### unshuffled_original_so
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.06 MB
+- **Total amount of disk used:** 0.06 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"тттттттттттттттттттттттттттттттт тттттттттттттттттттттттттттттттт тттттттттттттттттттттттттттттттт ттттттттттттттттуууууууууууу..."
+}
+```
+
+#### unshuffled_original_sq
+
+- **Size of downloaded dataset files:** 821.91 MB
+- **Size of the generated dataset:** 2327.76 MB
+- **Total amount of disk used:** 3149.67 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Çfarë do të më pëlqente tek një femër ose çfarë do të më shndërronte në një shpërthim drite? – Albert Vataj\\nTë gjithëve një zo..."
+}
+```
+
+#### unshuffled_original_sr
+
+- **Size of downloaded dataset files:** 1031.05 MB
+- **Size of the generated dataset:** 3940.51 MB
+- **Total amount of disk used:** 4971.55 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Корисни савети за сваки дан. На сајту су разне категорије, као што су љепота, мода, кување и поправка властитим рукама.\\nШколск..."
+}
+```
+
+#### unshuffled_original_su
+
+- **Size of downloaded dataset files:** 0.06 MB
+- **Size of the generated dataset:** 0.22 MB
+- **Total amount of disk used:** 0.27 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Kartu krédit nyaéta \"duit plastik\" anu dikaluarkeun ku bank pikeun alat pambayaran di tempat-tempat nu tangtu samisal jiga di hotél, réstoran, tempat rékréasi jeung sajabana.[1]"
+}
+```
+
+#### unshuffled_original_sv
+
+- **Size of downloaded dataset files:** 16386.70 MB
+- **Size of the generated dataset:** 44823.58 MB
+- **Total amount of disk used:** 61210.28 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"1783 är ett viktigt årtal i den nya tidens historia. Det året slöts en fred i Paris och därmed blev de 13 brittiska kolonierna ..."
+}
+```
+
+#### unshuffled_original_sw
+
+- **Size of downloaded dataset files:** 3.54 MB
+- **Size of the generated dataset:** 13.42 MB
+- **Total amount of disk used:** 16.96 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Miripuko hiyo inakuja mwanzoni mwa Wiki Takatifu kuelekea Pasaka na ikiwa ni wiki chache tu kabla ya Papa Francis kuanza ziara yake katika nchi hiyo yenye idadi kubwa kabisa ya watu katika ulimwengu wa nchi za Kiarabu."
+}
+```
+
+#### unshuffled_original_ta
+
+- **Size of downloaded dataset files:** 1656.77 MB
+- **Size of the generated dataset:** 9474.64 MB
+- **Total amount of disk used:** 11131.41 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"பொழுது சாய்ந்து வெகு நேரமாகிவிட்டது. கூலி வேலைக்குப் போயிருந்த 'சித்தாள் ' பெண்கள் எல்லோரும் வீடு திரும்பி விட்டார்கள். இன்னும்..."
+}
+```
+
+#### unshuffled_original_te
+
+- **Size of downloaded dataset files:** 498.27 MB
+- **Size of the generated dataset:** 2490.57 MB
+- **Total amount of disk used:** 2988.83 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"హర్యానాలో టోల్ దగ్గర సిబ్బంది.. స్థానిక ప్రజలు కొట్టుకున్నారు. కర్నాల్ అనే గ్రామానికి సమీపంలో టోల్ గేట్ ఉంది. అయితే సాధారణంగా స..."
+}
+```
+
+#### unshuffled_original_tg
+
+- **Size of downloaded dataset files:** 86.76 MB
+- **Size of the generated dataset:** 379.02 MB
+- **Total amount of disk used:** 465.78 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Ҳумайро гуфтааст, мухолифи низом аст, низоме, ки дар Тоҷикистон вуҷуд дорад. Ба ин маънӣ, худро мухолифи давлату ҳукумати Тоҷик..."
+}
+```
+
+#### unshuffled_original_th
+
+- **Size of downloaded dataset files:** 7035.70 MB
+- **Size of the generated dataset:** 36515.45 MB
+- **Total amount of disk used:** 43551.16 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ฟันที่แลดูขาวสะอาดไม่มีเศษอาหารติดอยู่ เหงือกสีชมพู ไม่เจ็บ หรือมีเลือดออกเวลาแปรงฟันหรือขัดฟัน ไม่มีปัญหาเรื่องกลิ่นปาก ทำให้ก..."
+}
+```
+
+#### unshuffled_original_tk
+
+- **Size of downloaded dataset files:** 2.82 MB
+- **Size of the generated dataset:** 10.17 MB
+- **Total amount of disk used:** 12.99 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"Türkmenistanyň Prezidenti agyr atletika boýunça dünýä çempionatyna taýýarlyk işleriniň barşy bilen tanyşdy\\nHalallykdan kemal t..."
+}
+```
+
+#### unshuffled_original_tl
+
+- **Size of downloaded dataset files:** 195.40 MB
+- **Size of the generated dataset:** 578.21 MB
+- **Total amount of disk used:** 773.61 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"“Gusto ko manawagan sa mga Unit Head ng Chanel 2 Salve. Kasi napapansin ko iyon mga alaga ko ang taping halos once a week lang,..."
+}
+```
+
+#### unshuffled_original_tr
+
+- **Size of downloaded dataset files:** 20944.18 MB
+- **Size of the generated dataset:** 60635.71 MB
+- **Total amount of disk used:** 81579.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Son yıllarda görülen ay tutulmalarına göre daha etkili olacağı söylenen Kanlı veya Kırmızı Ay Tutulmasına saatler kaldı. Bu akş..."
+}
+```
+
+#### unshuffled_original_tt
+
+- **Size of downloaded dataset files:** 144.06 MB
+- **Size of the generated dataset:** 670.83 MB
+- **Total amount of disk used:** 814.89 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"\\\"Иремнең вафатына 40 көн узгач, Алмаз да безнең өйгә кереп үлде\\\". Арчада 35 яшьлек ир өстенә кондызлар ега башлаган агач төшк..."
+}
+```
+
+#### unshuffled_original_tyv
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.01 MB
+- **Total amount of disk used:** 0.01 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Экии, хүндүлуг аалчылар болгаш тыва дылдың деткикчилери! Тыва дылдың болгаш чогаалдың ховар бир башкызынга, Менги Ооржакка, ажы..."
+}
+```
+
+#### unshuffled_original_ug
+
+- **Size of downloaded dataset files:** 26.63 MB
+- **Size of the generated dataset:** 121.52 MB
+- **Total amount of disk used:** 148.15 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"زاڭ-ءتۇزىم | عىلىم-تەحنيكا | ءتىل-ادەبيەت | تۇرمىس | دەنە تاربيە | ساياحات-ورتا | سۋرەتتى حابار | سىر سۇحبات | ارناۋلى تاقىرىپ ..."
+}
+```
+
+#### unshuffled_original_uk
+
+- **Size of downloaded dataset files:** 13751.22 MB
+- **Size of the generated dataset:** 53824.90 MB
+- **Total amount of disk used:** 67576.12 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Про надання роз'яснення (щодо форми письмового зобов'язання громадян про зворотне ввезення/вивезення товарів), Державна митна с..."
+}
+```
+
+#### unshuffled_original_ur
+
+- **Size of downloaded dataset files:** 679.60 MB
+- **Size of the generated dataset:** 2672.45 MB
+- **Total amount of disk used:** 3352.05 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"آئیے اہم اسلامی کتب کو یونیکوڈ میں انٹرنیٹ پر پیش کرنے کے لئے مل جل کر آن لائن ٹائپنگ کریں۔ محدث ٹائپنگ پراجیکٹ کے ذریعے آپ روز..."
+}
+```
+
+#### unshuffled_original_uz
+
+- **Size of downloaded dataset files:** 5.51 MB
+- **Size of the generated dataset:** 20.47 MB
+- **Total amount of disk used:** 25.98 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Qurama tog'lari tizmasining Toshkentdan 154 km uzoqlikdagi Toshkent-Ush yo'li yeqasidaxushmanzara tabiat qo'ynida joylashgan maydoni 30 ga.\nBolalarni sog'lomlashtirish oromgohi Bo'stonliq tumani Oqtosh muntaqasining soy-salqin gushasida joylashgan."
+}
+```
+
+#### unshuffled_original_vec
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.02 MB
+- **Total amount of disk used:** 0.03 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Par ogni pónto, ła derivada ła xe ła pendensa de ła reta tangente a ła curva de ła funsion f. Ła reta de cołor róso l'è senpre ..."
+}
+```
+
+#### unshuffled_original_vi
+
+- **Size of downloaded dataset files:** 20507.43 MB
+- **Size of the generated dataset:** 68880.45 MB
+- **Total amount of disk used:** 89387.88 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Canh chua cá bông lau không chỉ là món ăn giải nhiệt, thanh mát ngày hè mà còn là món siêu bổ dưỡng, rất tốt cho người gầy ốm. ..."
+}
+```
+
+#### unshuffled_original_vo
+
+- **Size of downloaded dataset files:** 0.29 MB
+- **Size of the generated dataset:** 2.02 MB
+- **Total amount of disk used:** 2.31 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Sarniguet binon zif in ziläk: Hautes-Pyrénées, in topäd: Midi-Pyrénées, in Fransän. Sarniguet topon videtü 43°19’ 7’’ N e lunetü 0°5’ 19’’ L."
+}
+```
+
+#### unshuffled_original_wa
+
+- **Size of downloaded dataset files:** 0.09 MB
+- **Size of the generated dataset:** 0.28 MB
+- **Total amount of disk used:** 0.36 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "Cisse pådje ci n' est co k' on djermon, dj' ô bén k' el pådje est djusse sibåtcheye, eyet co trop tene; et s' divreut ele ecråxhî ene miete."
+}
+```
+
+#### unshuffled_original_war
+
+- **Size of downloaded dataset files:** 0.61 MB
+- **Size of the generated dataset:** 2.56 MB
+- **Total amount of disk used:** 3.17 MB
+
+An example of 'train' looks as follows.
+```
+{
+    "id": 1,
+    "text": "An Honce amo in usa ka baryo ngan munisipalidad ha distrito han Rožňava ha rehiyon han Košice ha nasod han Slovakia.\nAn Rumegies amo in usa ka komyun ha departamento han Nord ngan ha rehiyon han Nord-Pas-de-Calais ha nasod han Fransya."
+}
+```
+
+#### unshuffled_original_wuu
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.11 MB
+- **Total amount of disk used:** 0.12 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"伊春元旦天气 伊春腊八天气 伊春春节天气 伊春情人节天气 伊春元宵节天气 伊春愚人节天气 伊春清明节天气 伊春劳动节天气 伊春母亲节天气 伊春端午节天气 伊春七夕节天气 伊春教师节天气 伊春中秋节天气 伊春国庆节天气 伊春重阳节天气 伊春万圣节天气 伊春..."
+}
+```
+
+#### unshuffled_original_xal
+
+- **Size of downloaded dataset files:** 0.03 MB
+- **Size of the generated dataset:** 0.11 MB
+- **Total amount of disk used:** 0.14 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Арнгудин Орн гисн Европд бәәдг һазр. 2007 җилин тooһaр эн орн нутгт 3,600,523 әмтн бәәдг билә. Арнгудин Орнин хотл балһсна нерн..."
+}
+```
+
+#### unshuffled_original_xmf
+
+- **Size of downloaded dataset files:** 1.00 MB
+- **Size of the generated dataset:** 5.84 MB
+- **Total amount of disk used:** 6.84 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"მოჩამილი ტექსტი წჷმორინელი რე Creative Commons Attribution-ShareAlike ლიცენზიათ; შილებე გეძინელი პირობეფიშ არსებუა. კილიშკილიშა..."
+}
+```
+
+#### unshuffled_original_yi
+
+- **Size of downloaded dataset files:** 31.79 MB
+- **Size of the generated dataset:** 140.76 MB
+- **Total amount of disk used:** 172.56 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"ממשותדיק - חבֿרה, איך אַרבעט איצט אױף אַ זשורנאַל. טאָמער איר האָט עפּעס צוצוגעבן זאָלט איר שיקן מיר אַן אָנזאָג. ס'װעט הײסן \\\"..."
+}
+```
+
+#### unshuffled_original_yo
+
+- **Size of downloaded dataset files:** 0.01 MB
+- **Size of the generated dataset:** 0.06 MB
+- **Total amount of disk used:** 0.06 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 0,
+    "text": "\"Copyright © 2018 BBC. BBC kò mọ̀ nípa àwọn ohun tí ó wà ní àwọn ojú òpó tí ó wà ní ìta. Ọwọ́ tí a fi mú ìbáṣepọ̀ ti ìta.\"..."
+}
+```
+
+#### unshuffled_original_yue
+
+- **Size of downloaded dataset files:** 0.00 MB
+- **Size of the generated dataset:** 0.00 MB
+- **Total amount of disk used:** 0.00 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 我 灌 我 灌 我 灌 灌 灌 你還不爆 我累了 投降輸一半可以嗎\"..."
+}
+```
+
+#### unshuffled_original_zh
+
+- **Size of downloaded dataset files:** 196460.72 MB
+- **Size of the generated dataset:** 520331.90 MB
+- **Total amount of disk used:** 716792.61 MB
+
+An example of 'train' looks as follows.
+```
+This example was too long and was cropped:
+
+{
+    "id": 1,
+    "text": "\"中国铝灰网 中国有色金属矿产网 中国黄莲网 中国水轮发电机网 中国抽油泵网 中国数控雕刻机网 中国不锈钢抛光网 中国磨具加工网 中国压铸铝网 中国耐水腻子网 中国手机摄像头网 中国粗粮网 中国车门锁网 中国钛粉网 中国轮圈网\\n天天中奖彩票图 天天中彩票..."
+}
+```
+
+</details>
+
+### [Data Fields](#data-fields)
+
+The data fields are the same among all configs.
+
+- `id`: a `int64` feature.
+- `text`: a `string` feature.
+
+### [Data Splits Sample Size](#data-splits-sample-size)
+
+|           name            |  train  |
+|---------------------------|--------:|
+|unshuffled_deduplicated_af |   201117|
+|unshuffled_deduplicated_als|     7324|
+|unshuffled_deduplicated_am |    83663|
+|unshuffled_deduplicated_an |     2449|
+|unshuffled_deduplicated_ar | 16365590|
+|unshuffled_deduplicated_arz|   158113|
+|unshuffled_deduplicated_as |    14985|
+|unshuffled_deduplicated_ast|     6999|
+|unshuffled_deduplicated_av |      456|
+|unshuffled_deduplicated_az |   912330|
+|unshuffled_deduplicated_azb|    15446|
+|unshuffled_deduplicated_ba |    42551|
+|unshuffled_deduplicated_bar|        4|
+|unshuffled_deduplicated_bcl|        1|
+|unshuffled_deduplicated_be |   585903|
+|unshuffled_deduplicated_bg |  5869683|
+|unshuffled_deduplicated_bh |      336|
+|unshuffled_deduplicated_bn |  1675514|
+|unshuffled_deduplicated_bo |    26795|
+|unshuffled_deduplicated_bpy|     6046|
+|unshuffled_deduplicated_br |    37085|
+|unshuffled_deduplicated_bs |     2143|
+|unshuffled_deduplicated_bxr|       42|
+|unshuffled_deduplicated_ca |  4390754|
+|unshuffled_deduplicated_cbk|        1|
+|unshuffled_deduplicated_ce |     4042|
+|unshuffled_deduplicated_ceb|    56248|
+|unshuffled_deduplicated_ckb|   103639|
+|unshuffled_deduplicated_cs | 21001382|
+|unshuffled_deduplicated_cv |    20281|
+|unshuffled_deduplicated_cy |   157698|
+|unshuffled_deduplicated_da |  7663999|
+|unshuffled_deduplicated_de |104913007|
+|unshuffled_deduplicated_diq|        1|
+|unshuffled_deduplicated_dsb|       65|
+|unshuffled_deduplicated_dv |    21018|
+|unshuffled_deduplicated_el | 10425591|
+|unshuffled_deduplicated_eml|       84|
+|unshuffled_deduplicated_en |455970823|
+|unshuffled_deduplicated_eo |   121166|
+|unshuffled_deduplicated_es | 88198940|
+|unshuffled_deduplicated_et |  2093620|
+|unshuffled_deduplicated_eu |   505548|
+|unshuffled_deduplicated_fa | 13704697|
+|unshuffled_deduplicated_fi |  8557449|
+|unshuffled_deduplicated_fr | 96742305|
+|unshuffled_deduplicated_frr|        7|
+|unshuffled_deduplicated_fy |    33053|
+|unshuffled_deduplicated_ga |    83223|
+|unshuffled_deduplicated_gd |     5799|
+|unshuffled_deduplicated_gl |   544388|
+|unshuffled_deduplicated_gn |      106|
+|unshuffled_deduplicated_gom|      640|
+|unshuffled_deduplicated_gu |   240691|
+|unshuffled_deduplicated_he |  3808394|
+|unshuffled_deduplicated_hi |  3264659|
+|unshuffled_deduplicated_hr |   582219|
+|unshuffled_deduplicated_hsb|     7959|
+|unshuffled_deduplicated_ht |       13|
+|unshuffled_deduplicated_hu | 11197766|
+|unshuffled_deduplicated_hy |   659430|
+|unshuffled_deduplicated_ia |     1040|
+|unshuffled_deduplicated_id | 16236105|
+|unshuffled_deduplicated_ie |      101|
+|unshuffled_deduplicated_ilo|     2638|
+|unshuffled_deduplicated_io |      694|
+|unshuffled_deduplicated_is |   625673|
+|unshuffled_deduplicated_it | 46981719|
+|unshuffled_deduplicated_ja | 62691967|
+|unshuffled_deduplicated_jbo|      832|
+|unshuffled_deduplicated_jv |     1445|
+|unshuffled_deduplicated_ka |   563915|
+|unshuffled_deduplicated_kk |   524591|
+|unshuffled_deduplicated_km |   159363|
+|unshuffled_deduplicated_kn |   350363|
+|unshuffled_deduplicated_ko |  7344864|
+|unshuffled_deduplicated_krc|     1581|
+|unshuffled_deduplicated_ku |    46535|
+|unshuffled_deduplicated_kv |     1549|
+|unshuffled_deduplicated_kw |      203|
+|unshuffled_deduplicated_ky |   146993|
+|unshuffled_deduplicated_la |    94588|
+|unshuffled_deduplicated_lb |    34807|
+|unshuffled_deduplicated_lez|     1485|
+|unshuffled_deduplicated_li |      137|
+|unshuffled_deduplicated_lmo|     1401|
+|unshuffled_deduplicated_lo |    52910|
+|unshuffled_deduplicated_lrc|       88|
+|unshuffled_deduplicated_lt |  2977755|
+|unshuffled_deduplicated_lv |  1593820|
+|unshuffled_deduplicated_mai|      123|
+|unshuffled_deduplicated_mg |    17957|
+|unshuffled_deduplicated_mhr|     3212|
+|unshuffled_deduplicated_min|      220|
+|unshuffled_deduplicated_mk |   437871|
+|unshuffled_deduplicated_ml |   603936|
+|unshuffled_deduplicated_mn |   395605|
+|unshuffled_deduplicated_mr |   326804|
+|unshuffled_deduplicated_mrj|      757|
+|unshuffled_deduplicated_ms |   534016|
+|unshuffled_deduplicated_mt |    26598|
+|unshuffled_deduplicated_mwl|        8|
+|unshuffled_deduplicated_my |   232329|
+|unshuffled_deduplicated_myv|        6|
+|unshuffled_deduplicated_mzn|     1055|
+|unshuffled_deduplicated_nah|       61|
+|unshuffled_deduplicated_nap|       73|
+|unshuffled_deduplicated_nds|    18174|
+|unshuffled_deduplicated_ne |   299938|
+|unshuffled_deduplicated_new|     4696|
+|unshuffled_deduplicated_nl | 34682128|
+|unshuffled_deduplicated_nn |   185884|
+|unshuffled_deduplicated_no |  5546197|
+|unshuffled_deduplicated_oc |    10709|
+|unshuffled_deduplicated_or |    59463|
+|unshuffled_deduplicated_os |     5213|
+|unshuffled_deduplicated_pa |   127467|
+|unshuffled_deduplicated_pam|        3|
+|unshuffled_deduplicated_pl | 35440957|
+|unshuffled_deduplicated_pms|     3225|
+|unshuffled_deduplicated_pnb|     4599|
+|unshuffled_deduplicated_ps |    98216|
+|unshuffled_deduplicated_pt | 42114504|
+|unshuffled_deduplicated_qu |      452|
+|unshuffled_deduplicated_rm |       41|
+|unshuffled_deduplicated_ro |  9387263|
+|unshuffled_deduplicated_ru |161823473|
+|unshuffled_deduplicated_sa |    14291|
+|unshuffled_deduplicated_sah|    22301|
+|unshuffled_deduplicated_scn|       21|
+|unshuffled_deduplicated_sd |    44280|
+|unshuffled_deduplicated_sh |    36700|
+|unshuffled_deduplicated_si |   203082|
+|unshuffled_deduplicated_sk |  5492193|
+|unshuffled_deduplicated_sl |  1746604|
+|unshuffled_deduplicated_so |      156|
+|unshuffled_deduplicated_sq |   672077|
+|unshuffled_deduplicated_sr |  1013619|
+|unshuffled_deduplicated_su |      805|
+|unshuffled_deduplicated_sv | 17395619|
+|unshuffled_deduplicated_sw |    41986|
+|unshuffled_deduplicated_ta |  1262993|
+|unshuffled_deduplicated_te |   475703|
+|unshuffled_deduplicated_tg |    89002|
+|unshuffled_deduplicated_th |  6064105|
+|unshuffled_deduplicated_tk |     6456|
+|unshuffled_deduplicated_tl |   458206|
+|unshuffled_deduplicated_tr | 18535232|
+|unshuffled_deduplicated_tt |   135923|
+|unshuffled_deduplicated_tyv|       34|
+|unshuffled_deduplicated_ug |    22255|
+|unshuffled_deduplicated_uk | 12973344|
+|unshuffled_deduplicated_ur |   638596|
+|unshuffled_deduplicated_uz |    27537|
+|unshuffled_deduplicated_vec|       73|
+|unshuffled_deduplicated_vi | 14897520|
+|unshuffled_deduplicated_vo |     3366|
+|unshuffled_deduplicated_wa |     1001|
+|unshuffled_deduplicated_war|     9760|
+|unshuffled_deduplicated_wuu|      214|
+|unshuffled_deduplicated_xal|       39|
+|unshuffled_deduplicated_xmf|     3783|
+|unshuffled_deduplicated_yi |    59364|
+|unshuffled_deduplicated_yo |      214|
+|unshuffled_deduplicated_yue|       11|
+|unshuffled_deduplicated_zh | 60137577|
+|unshuffled_original_af     |   201117|
+|unshuffled_original_als    |     7324|
+|unshuffled_original_am     |    83663|
+|unshuffled_original_an     |     2449|
+|unshuffled_original_ar     | 16365602|
+|unshuffled_original_arz    |   158113|
+|unshuffled_original_as     |    14985|
+|unshuffled_original_ast    |     6999|
+|unshuffled_original_av     |      456|
+|unshuffled_original_az     |   912330|
+|unshuffled_original_azb    |    15446|
+|unshuffled_original_ba     |    42551|
+|unshuffled_original_bar    |        4|
+|unshuffled_original_bcl    |        1|
+|unshuffled_original_be     |   586031|
+|unshuffled_original_bg     |  5869686|
+|unshuffled_original_bh     |      336|
+|unshuffled_original_bn     |  1675515|
+|unshuffled_original_bo     |    26795|
+|unshuffled_original_bpy    |     6046|
+|unshuffled_original_br     |    37085|
+|unshuffled_original_bs     |     2143|
+|unshuffled_original_bxr    |       42|
+|unshuffled_original_ca     |  4390754|
+|unshuffled_original_cbk    |        1|
+|unshuffled_original_ce     |     4042|
+|unshuffled_original_ceb    |    56248|
+|unshuffled_original_ckb    |   103639|
+|unshuffled_original_cs     | 21001388|
+|unshuffled_original_cv     |    20281|
+|unshuffled_original_cy     |   157698|
+|unshuffled_original_da     |  7664010|
+|unshuffled_original_de     |104913504|
+|unshuffled_original_diq    |        1|
+|unshuffled_original_dsb    |       65|
+|unshuffled_original_dv     |    21018|
+|unshuffled_original_el     | 10425596|
+|unshuffled_original_eml    |       84|
+|unshuffled_original_en     |455994980|
+|unshuffled_original_eo     |   121171|
+|unshuffled_original_es     | 88199221|
+|unshuffled_original_et     |  2093621|
+|unshuffled_original_eu     |   506883|
+|unshuffled_original_fa     | 13704702|
+|unshuffled_original_fi     |  8557453|
+|unshuffled_original_fr     | 96742378|
+|unshuffled_original_frr    |        7|
+|unshuffled_original_fy     |    33053|
+|unshuffled_original_ga     |    83223|
+|unshuffled_original_gd     |     5799|
+|unshuffled_original_gl     |   544388|
+|unshuffled_original_gn     |      106|
+|unshuffled_original_gom    |      640|
+|unshuffled_original_gu     |   240691|
+|unshuffled_original_he     |  3808397|
+|unshuffled_original_hi     |  3264660|
+|unshuffled_original_hr     |   582219|
+|unshuffled_original_hsb    |     7959|
+|unshuffled_original_ht     |       13|
+|unshuffled_original_hu     | 11197780|
+|unshuffled_original_hy     |   659430|
+|unshuffled_original_ia     |     1040|
+|unshuffled_original_id     | 16236463|
+|unshuffled_original_ie     |      101|
+|unshuffled_original_ilo    |     2638|
+|unshuffled_original_io     |      694|
+|unshuffled_original_is     |   625673|
+|unshuffled_original_it     | 46981781|
+|unshuffled_original_ja     | 62721527|
+|unshuffled_original_jbo    |      832|
+|unshuffled_original_jv     |     1445|
+|unshuffled_original_ka     |   563916|
+|unshuffled_original_kk     |   524591|
+|unshuffled_original_km     |   159363|
+|unshuffled_original_kn     |   350363|
+|unshuffled_original_ko     |  7345075|
+|unshuffled_original_krc    |     1581|
+|unshuffled_original_ku     |    46535|
+|unshuffled_original_kv     |     1549|
+|unshuffled_original_kw     |      203|
+|unshuffled_original_ky     |   146993|
+|unshuffled_original_la     |    94588|
+|unshuffled_original_lb     |    34807|
+|unshuffled_original_lez    |     1485|
+|unshuffled_original_li     |      137|
+|unshuffled_original_lmo    |     1401|
+|unshuffled_original_lo     |    52910|
+|unshuffled_original_lrc    |       88|
+|unshuffled_original_lt     |  2977757|
+|unshuffled_original_lv     |  1593820|
+|unshuffled_original_mai    |      123|
+|unshuffled_original_mg     |    17957|
+|unshuffled_original_mhr    |     3212|
+|unshuffled_original_min    |      220|
+|unshuffled_original_mk     |   437871|
+|unshuffled_original_ml     |   603937|
+|unshuffled_original_mn     |   395605|
+|unshuffled_original_mr     |   326804|
+|unshuffled_original_mrj    |      757|
+|unshuffled_original_ms     |   534016|
+|unshuffled_original_mt     |    26598|
+|unshuffled_original_mwl    |        8|
+|unshuffled_original_my     |   232329|
+|unshuffled_original_myv    |        6|
+|unshuffled_original_mzn    |     1055|
+|unshuffled_original_nah    |       61|
+|unshuffled_original_nap    |       73|
+|unshuffled_original_nds    |    18174|
+|unshuffled_original_ne     |   299938|
+|unshuffled_original_new    |     4696|
+|unshuffled_original_nl     | 34682142|
+|unshuffled_original_nn     |   185884|
+|unshuffled_original_no     |  5546211|
+|unshuffled_original_oc     |    10709|
+|unshuffled_original_or     |    59463|
+|unshuffled_original_os     |     5213|
+|unshuffled_original_pa     |   127467|
+|unshuffled_original_pam    |        3|
+|unshuffled_original_pl     | 35440972|
+|unshuffled_original_pms    |     3225|
+|unshuffled_original_pnb    |     4599|
+|unshuffled_original_ps     |    98216|
+|unshuffled_original_pt     | 42114520|
+|unshuffled_original_qu     |      452|
+|unshuffled_original_rm     |       41|
+|unshuffled_original_ro     |  9387265|
+|unshuffled_original_ru     |161836003|
+|unshuffled_original_sa     |    14291|
+|unshuffled_original_sah    |    22301|
+|unshuffled_original_scn    |       21|
+|unshuffled_original_sd     |    44280|
+|unshuffled_original_sh     |    36700|
+|unshuffled_original_si     |   203082|
+|unshuffled_original_sk     |  5492194|
+|unshuffled_original_sl     |  1746604|
+|unshuffled_original_so     |      156|
+|unshuffled_original_sq     |   672077|
+|unshuffled_original_sr     |  1013619|
+|unshuffled_original_su     |      805|
+|unshuffled_original_sv     | 17395625|
+|unshuffled_original_sw     |    41986|
+|unshuffled_original_ta     |  1263280|
+|unshuffled_original_te     |   475703|
+|unshuffled_original_tg     |    89002|
+|unshuffled_original_th     |  6064129|
+|unshuffled_original_tk     |     6456|
+|unshuffled_original_tl     |   458206|
+|unshuffled_original_tr     | 18535253|
+|unshuffled_original_tt     |   135923|
+|unshuffled_original_tyv    |       34|
+|unshuffled_original_ug     |    22255|
+|unshuffled_original_uk     | 12973467|
+|unshuffled_original_ur     |   638596|
+|unshuffled_original_uz     |    27537|
+|unshuffled_original_vec    |       73|
+|unshuffled_original_vi     | 14898250|
+|unshuffled_original_vo     |     3366|
+|unshuffled_original_wa     |     1001|
+|unshuffled_original_war    |     9760|
+|unshuffled_original_wuu    |      214|
+|unshuffled_original_xal    |       39|
+|unshuffled_original_xmf    |     3783|
+|unshuffled_original_yi     |    59364|
+|unshuffled_original_yo     |      214|
+|unshuffled_original_yue    |       11|
+|unshuffled_original_zh     | 60137667|
+
+## [Dataset Creation](#dataset-creation)
+
+### [Curation Rationale](#curation-rationale)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Source Data](#source-data)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Annotations](#annotations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Personal and Sensitive Information](#personal-and-sensitive-information)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Considerations for Using the Data](#considerations-for-using-the-data)
+
+### [Social Impact of Dataset](#social-impact-of-dataset)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Discussion of Biases](#discussion-of-biases)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Other Known Limitations](#other-known-limitations)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+## [Additional Information](#additional-information)
+
+### [Dataset Curators](#dataset-curators)
+
+[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+
+### [Licensing Information](#licensing-information)
+
+    These data are released under this licensing scheme
+    We do not own any of the text from which these data has been extracted.
+    We license the actual packaging of these data under the Creative Commons CC0 license     ("no rights reserved") http://creativecommons.org/publicdomain/zero/1.0/
+    To the extent possible under law, Inria has waived all copyright     and related or neighboring rights to OSCAR
+    This work is published from: France.
+
+    Should you consider that our data contains material that is owned by you     and should therefore not be reproduced here, please:
+    * Clearly identify yourself, with detailed contact data such as an address,     telephone number or email address at which you can be contacted.
+    * Clearly identify the copyrighted work claimed to be infringed.
+    * Clearly identify the material that is claimed to be infringing and     information reasonably sufficient to allow us to locate the material.
+
+    We will comply to legitimate requests by removing the affected sources     from the next release of the corpus.
+
+### [Citation Information](#citation-information)
+
+```
+@inproceedings{ortiz-suarez-etal-2020-monolingual,
+    title = "A Monolingual Approach to Contextualized Word Embeddings for Mid-Resource Languages",
+    author = "Ortiz Su{'a}rez, Pedro Javier  and
+      Romary, Laurent  and
+      Sagot, Benoit",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.acl-main.156",
+    pages = "1703--1714",
+    abstract = "We use the multilingual OSCAR corpus, extracted from Common Crawl via language classification, filtering and cleaning, to train monolingual contextualized word embeddings (ELMo) for five mid-resource languages. We then compare the performance of OSCAR-based and Wikipedia-based ELMo embeddings for these languages on the part-of-speech tagging and parsing tasks. We show that, despite the noise in the Common-Crawl-based OSCAR data, embeddings trained on OSCAR perform much better than monolingual embeddings trained on Wikipedia. They actually equal or improve the current state of the art in tagging and parsing for all five languages. In particular, they also improve over multilingual Wikipedia-based contextual embeddings (multilingual BERT), which almost always constitutes the previous state of the art, thereby showing that the benefit of a larger, more diverse corpus surpasses the cross-lingual benefit of multilingual embedding architectures.",
+}
+
+@inproceedings{OrtizSuarezSagotRomary2019,
+  author    = {Pedro Javier {Ortiz Su{'a}rez} and Benoit Sagot and Laurent Romary},
+  title     = {Asynchronous pipelines for processing huge corpora on medium to low resource infrastructures},
+  series = {Proceedings of the Workshop on Challenges in the Management of Large Corpora (CMLC-7) 2019. Cardiff, 22nd July 2019},
+  editor    = {Piotr Bański and Adrien Barbaresi and Hanno Biber and Evelyn Breiteneder and Simon Clematide and Marc Kupietz and Harald L{"u}ngen and Caroline Iliadi},
+  publisher = {Leibniz-Institut f{"u}r Deutsche Sprache},
+  address   = {Mannheim},
+  doi       = {10.14618/ids-pub-9021},
+  url       = {http://nbn-resolving.de/urn:nbn:de:bsz:mh39-90215},
+  pages     = {9 -- 16},
+  year      = {2019},
+  abstract  = {Common Crawl is a considerably large, heterogeneous multilingual corpus comprised of crawled documents from the internet, surpassing 20TB of data and distributed as a set of more than 50 thousand plain text files where each contains many documents written in a wide variety of languages. Even though each document has a metadata block associated to it, this data lacks any information about the language in which each document is written, making it extremely difficult to use Common Crawl for monolingual applications. We propose a general, highly parallel, multithreaded pipeline to clean and classify Common Crawl by language; we specifically design it so that it runs efficiently on medium to low resource infrastructures where I/O speeds are the main constraint. We develop the pipeline so that it can be easily reapplied to any kind of heterogeneous corpus and so that it can be parameterised to a wide range of infrastructures. We also distribute a 6.3TB version of Common Crawl, filtered, classified by language, shuffled at line level in order to avoid copyright issues, and ready to be used for NLP applications.},
+  language  = {en}
+}
+
+```
 
 ### Contributions
 
-Thanks to [@lhoestq](https://github.com/lhoestq) for adding this dataset.
+Thanks to [@pjox](https://github.com/pjox) and [@lhoestq](https://github.com/lhoestq) for adding this dataset.


### PR DESCRIPTION
I started adding the dataset card for OSCAR !

For now it's just basic info for all the different configurations in `Dataset Structure`.
In particular the Data Splits section tells how may samples there are for each config. The Data Instances section show an example for each config, and it also shows the size in MB. Since the Data Instances section is very long the user has to click to expand the info. I was able to generate it thanks to the tools made by  @madlag and @yjernite :D

Cc @pjox could you help me with the other sections ? (Dataset Description, Dataset Creation, Considerations for Using the Data, Additional Information)
