### PR TITLE
Enable logging propagation and remove logging handler

### DIFF
--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -49,10 +49,6 @@ Functions
 
 .. autofunction:: datasets.logging.set_verbosity_error
 
-.. autofunction:: datasets.logging.disable_default_handler
-
-.. autofunction:: datasets.logging.enable_default_handler
-
 .. autofunction:: datasets.logging.disable_propagation
 
 .. autofunction:: datasets.logging.enable_propagation

--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -175,24 +175,6 @@ def set_verbosity_error():
     return set_verbosity(ERROR)
 
 
-def disable_default_handler() -> None:
-    """Disable the default handler of the HuggingFace datasets library's root logger."""
-
-    _configure_library_root_logger()
-
-    assert _default_handler is not None
-    _get_library_root_logger().removeHandler(_default_handler)
-
-
-def enable_default_handler() -> None:
-    """Enable the default handler of the HuggingFace datasets library's root logger."""
-
-    _configure_library_root_logger()
-
-    assert _default_handler is not None
-    _get_library_root_logger().addHandler(_default_handler)
-
-
 def disable_propagation() -> None:
     """Disable propagation of the library log outputs.
     Note that log propagation is disabled by default.

--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -29,7 +29,7 @@ from typing import Optional
 
 
 _lock = threading.Lock()
-_default_handler: Optional[logging.Handler] = None
+_library_root_logger_configured = False
 
 log_levels = {
     "debug": logging.DEBUG,
@@ -71,33 +71,28 @@ def _get_library_root_logger() -> logging.Logger:
 
 def _configure_library_root_logger() -> None:
 
-    global _default_handler
+    global _library_root_logger_configured
 
     with _lock:
-        if _default_handler:
+        if _library_root_logger_configured:
             # This library has already configured the library root logger.
             return
-        _default_handler = logging.StreamHandler()  # Set sys.stderr as stream.
+        _library_root_logger_configured = True
 
         # Apply our default configuration to the library root logger.
         library_root_logger = _get_library_root_logger()
-        library_root_logger.addHandler(_default_handler)
         library_root_logger.setLevel(_get_default_logging_level())
-        library_root_logger.propagate = False
 
 
 def _reset_library_root_logger() -> None:
 
-    global _default_handler
+    global _library_root_logger_configured
 
     with _lock:
-        if not _default_handler:
-            return
 
         library_root_logger = _get_library_root_logger()
-        library_root_logger.removeHandler(_default_handler)
         library_root_logger.setLevel(logging.NOTSET)
-        _default_handler = None
+        _library_root_logger_configured = False
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -767,55 +767,51 @@ class BaseDatasetTest(TestCase):
             del dset
 
     def test_map_caching(self, in_memory):
-        datasets.utils.logging.enable_propagation()
-        try:
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                self._caplog.clear()
-                with self._caplog.at_level(logging.WARNING):
-                    dset = self._create_dummy_dataset(in_memory, tmp_dir)
-                    dset_test1 = dset.map(lambda x: {"foo": "bar"})
-                    dset_test1_data_files = list(dset_test1._data_files)
-                    del dset_test1
-                    dset_test2 = dset.map(lambda x: {"foo": "bar"})
-                    self.assertEqual(dset_test1_data_files, dset_test2._data_files)
-                    self.assertEqual(len(dset_test2._data_files), 1 - int(in_memory))
-                    self.assertTrue(("Loading cached processed dataset" in self._caplog.text) ^ in_memory)
-                    del dset, dset_test2
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._caplog.clear()
+            with self._caplog.at_level(logging.WARNING):
+                dset = self._create_dummy_dataset(in_memory, tmp_dir)
+                dset_test1 = dset.map(lambda x: {"foo": "bar"})
+                dset_test1_data_files = list(dset_test1._data_files)
+                del dset_test1
+                dset_test2 = dset.map(lambda x: {"foo": "bar"})
+                self.assertEqual(dset_test1_data_files, dset_test2._data_files)
+                self.assertEqual(len(dset_test2._data_files), 1 - int(in_memory))
+                self.assertTrue(("Loading cached processed dataset" in self._caplog.text) ^ in_memory)
+                del dset, dset_test2
 
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                self._caplog.clear()
-                with self._caplog.at_level(logging.WARNING):
-                    dset = self._create_dummy_dataset(in_memory, tmp_dir)
-                    dset_test1 = dset.map(lambda x: {"foo": "bar"})
-                    dset_test1_data_files = list(dset_test1._data_files)
-                    del dset_test1
-                    dset_test2 = dset.map(lambda x: {"foo": "bar"}, load_from_cache_file=False)
-                    self.assertEqual(dset_test1_data_files, dset_test2._data_files)
-                    self.assertEqual(len(dset_test2._data_files), 1 - int(in_memory))
-                    self.assertNotIn("Loading cached processed dataset", self._caplog.text)
-                    del dset, dset_test2
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._caplog.clear()
+            with self._caplog.at_level(logging.WARNING):
+                dset = self._create_dummy_dataset(in_memory, tmp_dir)
+                dset_test1 = dset.map(lambda x: {"foo": "bar"})
+                dset_test1_data_files = list(dset_test1._data_files)
+                del dset_test1
+                dset_test2 = dset.map(lambda x: {"foo": "bar"}, load_from_cache_file=False)
+                self.assertEqual(dset_test1_data_files, dset_test2._data_files)
+                self.assertEqual(len(dset_test2._data_files), 1 - int(in_memory))
+                self.assertNotIn("Loading cached processed dataset", self._caplog.text)
+                del dset, dset_test2
 
-            if not in_memory:
-                try:
-                    self._caplog.clear()
-                    with tempfile.TemporaryDirectory() as tmp_dir:
-                        with self._caplog.at_level(logging.WARNING):
-                            dset = self._create_dummy_dataset(in_memory, tmp_dir)
-                            datasets.set_caching_enabled(False)
-                            dset_test1 = dset.map(lambda x: {"foo": "bar"})
-                            dset_test2 = dset.map(lambda x: {"foo": "bar"})
-                            self.assertNotEqual(dset_test1._data_files, dset_test2._data_files)
-                            self.assertEqual(len(dset_test1._data_files), 1)
-                            self.assertEqual(len(dset_test2._data_files), 1)
-                            self.assertNotIn("Loading cached processed dataset", self._caplog.text)
-                            # make sure the arrow files are going to be removed
-                            self.assertIn("tmp", dset_test1._data_files[0]["filename"])
-                            self.assertIn("tmp", dset_test2._data_files[0]["filename"])
-                            del dset, dset_test2
-                finally:
-                    datasets.set_caching_enabled(True)
-        finally:
-            datasets.utils.logging.disable_propagation()
+        if not in_memory:
+            try:
+                self._caplog.clear()
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    with self._caplog.at_level(logging.WARNING):
+                        dset = self._create_dummy_dataset(in_memory, tmp_dir)
+                        datasets.set_caching_enabled(False)
+                        dset_test1 = dset.map(lambda x: {"foo": "bar"})
+                        dset_test2 = dset.map(lambda x: {"foo": "bar"})
+                        self.assertNotEqual(dset_test1._data_files, dset_test2._data_files)
+                        self.assertEqual(len(dset_test1._data_files), 1)
+                        self.assertEqual(len(dset_test2._data_files), 1)
+                        self.assertNotIn("Loading cached processed dataset", self._caplog.text)
+                        # make sure the arrow files are going to be removed
+                        self.assertIn("tmp", dset_test1._data_files[0]["filename"])
+                        self.assertIn("tmp", dset_test2._data_files[0]["filename"])
+                        del dset, dset_test2
+            finally:
+                datasets.set_caching_enabled(True)
 
     @require_torch
     def test_map_torch(self, in_memory):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -78,18 +78,14 @@ class LoadTest(TestCase):
             )
         with offline():
             self._caplog.clear()
-            try:
-                datasets.utils.logging.enable_propagation()
-                # allow provide the module name without an explicit path to remote or local actual file
-                importable_module_path3, _ = datasets.load.prepare_module(
-                    "__dummy_module_name2__", dynamic_modules_path=self.dynamic_modules_path
-                )
-                # it loads the most recent version of the module
-                self.assertEqual(importable_module_path2, importable_module_path3)
-                self.assertNotEqual(importable_module_path1, importable_module_path3)
-                self.assertIn("Using the latest cached version of the module", self._caplog.text)
-            finally:
-                datasets.utils.logging.disable_propagation()
+            # allow provide the module name without an explicit path to remote or local actual file
+            importable_module_path3, _ = datasets.load.prepare_module(
+                "__dummy_module_name2__", dynamic_modules_path=self.dynamic_modules_path
+            )
+            # it loads the most recent version of the module
+            self.assertEqual(importable_module_path2, importable_module_path3)
+            self.assertNotEqual(importable_module_path1, importable_module_path3)
+            self.assertIn("Using the latest cached version of the module", self._caplog.text)
 
     def test_load_dataset_local(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -125,13 +121,9 @@ class __DummyDataset1__(datasets.GeneratorBasedBuilder):
             self.assertTrue(len(datasets.load_dataset(module_dir, data_dir=tmp_dir)), 2)
         with offline():
             self._caplog.clear()
-            try:
-                datasets.utils.logging.enable_propagation()
-                # load dataset from cache
-                self.assertTrue(len(datasets.load_dataset("__dummy_dataset1__", data_dir=tmp_dir)), 2)
-                self.assertIn("Using the latest cached version of the module", self._caplog.text)
-            finally:
-                datasets.utils.logging.disable_propagation()
+            # load dataset from cache
+            self.assertTrue(len(datasets.load_dataset("__dummy_dataset1__", data_dir=tmp_dir)), 2)
+            self.assertIn("Using the latest cached version of the module", self._caplog.text)
         with self.assertRaises(FileNotFoundError) as context:
             datasets.load_dataset("_dummy")
         self.assertIn("at " + os.path.join("_dummy", "_dummy.py"), str(context.exception))


### PR DESCRIPTION
We used to have logging propagation disabled because of this issue: https://github.com/tensorflow/tensorflow/issues/26691
But since it's now fixed we should re-enable it. This is important to keep the default logging behavior for users, and propagation is also needed for pytest fixtures as asked in #1826 

I also removed the handler that was added since, according to the logging [documentation](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):
> It is strongly advised that you do not add any handlers other than NullHandler to your library’s loggers. This is because the configuration of handlers is the prerogative of the application developer who uses your library. The application developer knows their target audience and what handlers are most appropriate for their application: if you add handlers ‘under the hood’, you might well interfere with their ability to carry out unit tests and deliver logs which suit their requirements.

It could have been useful if we wanted to have a custom formatter for the logging but I think it's more important to keep the logging as default to not interfere with the users' logging management.

Therefore I also removed the two methods `datasets.logging.enable_default_handler` and `datasets.logging.disable_default_handler`.

cc @albertvillanova this should let you use capsys/caplog in pytest
cc @LysandreJik @sgugger if you want to do the same in `transformers`