### PR TITLE
[Metrics] Add word error metric metric

### DIFF
--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -62,12 +62,14 @@ Returns:
 
 Examples:
 
-    >>> predictions = ["hello this is the prediction", "there is an other sample"]
-    >>> references = ["hello this is the reference", "there is another one"]
+    >>> from datasets import load_metric
+
+    >>> predictions = ["this is the prediction", "there is an other sample"]
+    >>> references = ["this is the reference", "there is another one"]
     >>> wer = datasets.load_metric("wer")
     >>> wer_score = wer.compute(predictions=predictions, references=references)
     >>> print(wer_score)
-    5/9 are correct => 0.44 WER
+    0.5
 """
 
 

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -62,8 +62,6 @@ Returns:
 
 Examples:
 
-    >>> from datasets import load_metric
-
     >>> predictions = ["this is the prediction", "there is an other sample"]
     >>> references = ["this is the reference", "there is another one"]
     >>> wer = datasets.load_metric("wer")

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+# Copyright 2021 The HuggingFace Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Word Error Ratio (WER) metric. """
+
+from jiwer import wer  # From: https://github.com/jitsi/jiwer
+
+import datasets
+
+
+_CITATION = """\
+@inproceedings{inproceedings,
+    author = {Morris, Andrew and Maier, Viktoria and Green, Phil},
+    year = {2004},
+    month = {01},
+    pages = {},
+    title = {From WER and RIL to MER and WIL: improved evaluation measures for connected speech recognition.}
+}
+"""
+
+_DESCRIPTION = """\
+Word error rate (WER) is a common metric of the performance of an automatic speech recognition system.
+
+The general difficulty of measuring performance lies in the fact that the recognized word sequence can have a different length from the reference word sequence (supposedly the correct one). The WER is derived from the Levenshtein distance, working at the word level instead of the phoneme level. The WER is a valuable tool for comparing different systems as well as for evaluating improvements within one system. This kind of measurement, however, provides no details on the nature of translation errors and further work is therefore required to identify the main source(s) of error and to focus any research effort.
+
+This problem is solved by first aligning the recognized word sequence with the reference (spoken) word sequence using dynamic string alignment. Examination of this issue is seen through a theory called the power law that states the correlation between perplexity and word error rate.
+
+Word error rate can then be computed as:
+
+WER = (S + D + I) / N = (S + D + I) / (S + D + C)
+
+where
+
+S is the number of substitutions,
+D is the number of deletions,
+I is the number of insertions,
+C is the number of correct words,
+N is the number of words in the reference (N=S+D+C).
+
+WER's output is always a number between 0 and 1. This value indicates the percentage of words that were incorrectly predicted. The lower the value, the better the
+performance of the ASR system with a WER of 0 being a perfect score.
+"""
+
+_KWARGS_DESCRIPTION = """
+Computes WER score of transcribed segments against references.
+Args:
+    references: list of references for each speech input.
+    predictions: list of transcribtions to score.
+Returns:
+    (float): the word error rate
+
+Examples:
+
+    >>> predictions = ["hello this is the prediction", "there is an other sample"]
+    >>> references = ["hello this is the reference", "there is another one"]
+    >>> wer = datasets.load_metric("wer")
+    >>> wer_score = wer.compute(predictions=predictions, references=references)
+    >>> print(wer_score)
+    5/9 are correct => 0.44 WER
+"""
+
+
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class WER(datasets.Metric):
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("string", id="sequence"),
+                    "references": datasets.Value("string", id="sequence"),
+                }
+            ),
+            codebase_urls=["https://github.com/jitsi/jiwer/"],
+            reference_urls=[
+                "https://en.wikipedia.org/wiki/Word_error_rate",
+            ],
+        )
+
+    def _compute(self, predictions, references):
+        return wer(references, predictions)

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """ Word Error Ratio (WER) metric. """
 
-from jiwer import wer  # From: https://github.com/jitsi/jiwer
+from jiwer import wer
 
 import datasets
 

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ TESTS_REQUIRE = [
     "scipy",
     "seqeval",
     "sklearn",
+    "jiwer",
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",


### PR DESCRIPTION
This PR adds the word error rate metric to datasets. 
WER: https://en.wikipedia.org/wiki/Word_error_rate
for speech recognition. WER is the main metric used in ASR. 

`jiwer` seems to be a solid library (see https://github.com/asteroid-team/asteroid/pull/329#discussion_r525158939)