### PR TITLE
set bert_score version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ TESTS_REQUIRE = [
     "tldextract",
     "zstandard",
     # metrics dependencies
-    "bert_score",
+    "bert_score>=0.3.6",
     "rouge_score",
     "sacrebleu",
     "scipy",


### PR DESCRIPTION
Set the bert_score version in requirements since previous versions of bert_score will fail with datasets (closes #843)