### PR TITLE
Fix writing GPU Faiss index

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -323,6 +323,10 @@ class FaissIndex(BaseIndex):
             hasattr(self.faiss_index, "device")
             and self.faiss_index.device is not None
             and self.faiss_index.device > -1
+        ) or (
+            hasattr(self.faiss_index, "getDevice")
+            and self.faiss_index.getDevice() is not None
+            and self.faiss_index.getDevice() > -1
         ):
             index = faiss.index_gpu_to_cpu(self.faiss_index)
         else:


### PR DESCRIPTION
As reported in by @corticalstack there is currently an error when we try to save a faiss index on GPU.

I fixed that by checking the index `getDevice()` method before calling `index_gpu_to_cpu`

Close #1859 