### PR TITLE
`list_datasets()` returns a list of strings, not objects

### DIFF
--- a/docs/source/loading_datasets.rst
+++ b/docs/source/loading_datasets.rst
@@ -26,7 +26,7 @@ All the datasets currently available on the `Hub <https://huggingface.co/dataset
     >>> datasets_list = list_datasets()
     >>> len(datasets_list)
     136
-    >>> print(', '.join(dataset.id for dataset in datasets_list))
+    >>> print(', '.join(dataset for dataset in datasets_list))
     aeslc, ag_news, ai2_arc, allocine, anli, arcd, art, billsum, blended_skill_talk, blimp, blog_authorship_corpus, bookcorpus, boolq, break_data,
     c4, cfq, civil_comments, cmrc2018, cnn_dailymail, coarse_discourse, com_qa, commonsense_qa, compguesswhat, coqa, cornell_movie_dialog, cos_e, 
     cosmos_qa, crime_and_punish, csv, definite_pronoun_resolution, discofuse, docred, drop, eli5, empathetic_dialogues, eraser_multi_rc, esnli, 

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -15,7 +15,7 @@ Let's have a quick look at the 🤗datasets library. This library has three main
     >>> datasets_list = list_datasets()
     >>> len(datasets_list)
     136
-    >>> print(', '.join(dataset.id for dataset in datasets_list))
+    >>> print(', '.join(dataset for dataset in datasets_list))
     aeslc, ag_news, ai2_arc, allocine, anli, arcd, art, billsum, blended_skill_talk, blimp, blog_authorship_corpus, bookcorpus, boolq, break_data,
     c4, cfq, civil_comments, cmrc2018, cnn_dailymail, coarse_discourse, com_qa, commonsense_qa, compguesswhat, coqa, cornell_movie_dialog, cos_e, 
     cosmos_qa, crime_and_punish, csv, definite_pronoun_resolution, discofuse, docred, drop, eli5, empathetic_dialogues, eraser_multi_rc, esnli, 


### PR DESCRIPTION
Here and there in the docs there is still stuff like this:

```python
>>> datasets_list = list_datasets()
>>> print(', '.join(dataset.id for dataset in datasets_list))
```

However, my understanding is that `list_datasets()` returns a list of strings rather than a list of objects.