### PR TITLE
dtype fix when using numpy arrays

### DIFF
--- a/datasets/alt/README.md
+++ b/datasets/alt/README.md
@@ -64,7 +64,7 @@ task_ids:
 
 - **Homepage:** https://www2.nict.go.jp/astrec-att/member/mutiyama/ALT/
 - **Leaderboard:** 
-- **Paper:** [Introduction of the Asian Language Treebank]https://ieeexplore.ieee.org/abstract/document/7918974)
+- **Paper:** [Introduction of the Asian Language Treebank](https://ieeexplore.ieee.org/abstract/document/7918974)
 - **Point of Contact:** [ALT info](alt-info@khn.nict.go.jp)
 
 ### Dataset Summary

--- a/datasets/aqua_rat/README.md
+++ b/datasets/aqua_rat/README.md
@@ -26,7 +26,6 @@ task_ids:
 ## Table of Contents
 - [Dataset Description](#dataset-description)
   - [Dataset Summary](#dataset-summary)
-  
   - [Supported Tasks](#supported-tasks-and-leaderboards)
   - [Languages](#languages)
 - [Dataset Structure](#dataset-structure)
@@ -50,11 +49,9 @@ task_ids:
 
 ## Dataset Description
 
-- **Homepage:** https://github.com/deepmind/AQuA
-- **Repository:** https://github.com/deepmind/AQuA
-- **Paper:** https://arxiv.org/pdf/1705.04146.pdf
-- **Leaderboard:**
-- **Point of Contact:**
+- **Homepage:** [https://github.com/deepmind/AQuA](https://github.com/deepmind/AQuA)
+- **Repository:** [https://github.com/deepmind/AQuA](https://github.com/deepmind/AQuA)
+- **Paper:** [https://arxiv.org/pdf/1705.04146.pdf](https://arxiv.org/pdf/1705.04146.pdf)
 
 ### Dataset Summary
 

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -17,7 +17,6 @@ import errno
 import json
 import os
 import socket
-
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -20,6 +20,7 @@ import socket
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
+import numpy as np
 import pyarrow as pa
 from tqdm.auto import tqdm
 
@@ -88,11 +89,15 @@ class TypedSequence:
         """This function is called when calling pa.array(typed_sequence)"""
         assert type is None, "TypedSequence is supposed to be used with pa.array(typed_sequence, type=None)"
         trying_type = False
-        if type is None and self.try_type:
+
+        if type is not None:  # user explicitly passed the feature
+            pass
+        elif isinstance(self.data, np.ndarray):  # maintain dtype of numpy array passed by user
+            type = pa.from_numpy_dtype(self.data.dtype)
+        else:
             type = self.try_type
             trying_type = True
-        else:
-            type = self.type
+
         try:
             if isinstance(type, _ArrayXDExtensionType):
                 out = pa.ExtensionArray.from_storage(type, pa.array(self.data, type.storage_dtype))

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -92,17 +92,17 @@ class TypedSequence:
 
         if type is not None:  # user explicitly passed the feature
             pass
-        elif isinstance(self.data, np.ndarray):
-            value = numpy_to_pyarrow_listarray(self.data)
         elif type is None and self.try_type:
             type = self.try_type
             trying_type = True
+        else:
+            type = self.type
 
         try:
             if isinstance(type, _ArrayXDExtensionType):
                 out = pa.ExtensionArray.from_storage(type, pa.array(self.data, type.storage_dtype))
             elif isinstance(self.data, np.ndarray):
-                out = value
+                out = numpy_to_pyarrow_listarray(self.data)
             else:
                 out = pa.array(self.data, type=type)
             if trying_type and out[0].as_py() != self.data[0]:

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -17,6 +17,7 @@ import errno
 import json
 import os
 import socket
+
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
@@ -25,7 +26,7 @@ import pyarrow as pa
 from tqdm.auto import tqdm
 
 from . import config
-from .features import Features, _ArrayXDExtensionType
+from .features import Features, _ArrayXDExtensionType, numpy_to_pyarrow_listarray
 from .info import DatasetInfo
 from .utils.file_utils import hash_url_to_filename
 from .utils.logging import WARNING, get_logger
@@ -92,15 +93,17 @@ class TypedSequence:
 
         if type is not None:  # user explicitly passed the feature
             pass
-        elif isinstance(self.data, np.ndarray):  # maintain dtype of numpy array passed by user
-            type = pa.from_numpy_dtype(self.data.dtype)
-        else:
+        elif isinstance(self.data, np.ndarray):
+            value = numpy_to_pyarrow_listarray(self.data)
+        elif type is None and self.try_type:
             type = self.try_type
             trying_type = True
 
         try:
             if isinstance(type, _ArrayXDExtensionType):
                 out = pa.ExtensionArray.from_storage(type, pa.array(self.data, type.storage_dtype))
+            elif isinstance(self.data, np.ndarray):
+                out = value
             else:
                 out = pa.array(self.data, type=type)
             if trying_type and out[0].as_py() != self.data[0]:

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -779,16 +779,17 @@ def generate_from_arrow_type(pa_type: pa.DataType):
     else:
         raise ValueError(f"Cannot convert {pa_type} to a Feature type.")
 
+
 def numpy_to_pyarrow_listarray(arr: np.ndarray):
-    """Build a PyArrow ListArray from a multidimensional NumPy array.
-    """
+    """Build a PyArrow ListArray from a multidimensional NumPy array."""
     values = pa.array(arr.flatten())
     for i in range(arr.ndim - 1):
-        n_offsets = reduce(mul, arr.shape[:arr.ndim - i - 1], 1)
+        n_offsets = reduce(mul, arr.shape[: arr.ndim - i - 1], 1)
         step_offsets = arr.shape[arr.ndim - i - 1]
         offsets = pa.array(np.arange(n_offsets + 1) * step_offsets, type=pa.int32())
         values = pa.ListArray.from_arrays(offsets, values)
     return values
+
 
 class Features(dict):
     @property


### PR DESCRIPTION
As discussed in #625 this fix lets the user preserve the dtype of numpy array to pyarrow array which was getting lost due to conversion of numpy array -> list -> pyarrow array