### PR TITLE
Fix PandasArrayExtensionArray conversion to native type

### DIFF
--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -321,7 +321,7 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         """
         Convert to NumPy Array.
         Note that Pandas expects a 1D array when dtype is set to object.
-        But for other dtypes, the returned shape is same as the one of ``data``.
+        But for other dtypes, the returned shape is the same as the one of ``data``.
 
         More info about pandas 1D requirement for PandasExtensionArray here:
         https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.extensions.ExtensionArray.html#pandas.api.extensions.ExtensionArray

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -317,6 +317,26 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         self._data = data if not copy else np.array(data)
         self._dtype = PandasArrayExtensionDtype(data.dtype)
 
+    def __array__(self, dtype=None):
+        """
+        Convert to NumPy Array.
+        Note that Pandas expects a 1D array when dtype is set to object.
+        But for other dtypes, the returned shape is same as the one of ``data``.
+
+        More info about pandas 1D requirement for PandasExtensionArray here:
+        https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.extensions.ExtensionArray.html#pandas.api.extensions.ExtensionArray
+
+        """
+        if dtype == object:
+            out = np.empty(len(self._data), dtype=object)
+            for i in range(len(self._data)):
+                out[i] = self._data[i]
+            return out
+        if dtype is None:
+            return self._data
+        else:
+            return self._data.astype(dtype)
+
     def copy(self, deep: bool = False) -> "PandasArrayExtensionArray":
         return PandasArrayExtensionArray(self._data, copy=True)
 
@@ -341,9 +361,7 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         return self._data.nbytes
 
     def isna(self) -> np.ndarray:
-        if np.issubdtype(self.dtype.value_type, np.floating):
-            return np.array(np.isnan(arr).any() for arr in self._data)
-        return np.array((arr < 0).any() for arr in self._data)
+        return np.array([np.isnan(arr).any() for arr in self._data])
 
     def __setitem__(self, key: Union[int, slice, np.ndarray], value: Any) -> None:
         raise NotImplementedError()


### PR DESCRIPTION
To make the conversion to csv work in #1887 , we need  PandasArrayExtensionArray used for multidimensional numpy arrays to be converted to pandas native types.
However previously pandas.core.internals.ExtensionBlock.to_native_types would fail with an PandasExtensionArray because
1. the PandasExtensionArray.isna method was wrong
2. the conversion of a PandasExtensionArray to a numpy array with dtype=object was returning a multidimensional array while pandas excepts a 1D array in this case (more info [here](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.extensions.ExtensionArray.html#pandas.api.extensions.ExtensionArray))

I fixed these two issues and now the conversion to native types works, and so is the export to csv.
cc @SBrandeis 