### PR TITLE
Issue #1895: Bugfix for string_to_arrow timestamp[ns] support

### DIFF
--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -47,7 +47,7 @@ def string_to_arrow(type_str: str) -> pa.DataType:
         which means that each Value() must resolve into its corresponding pyarrow.DataType, which is the purpose
         of this function.
     """
-    timestamp_regex = re.compile("^timestamp\[(.*)\]$")
+    timestamp_regex = re.compile(r"^timestamp\[(.*)\]$")
     timestamp_matches = timestamp_regex.search(type_str)
     if timestamp_matches:
         """
@@ -58,7 +58,7 @@ def string_to_arrow(type_str: str) -> pa.DataType:
         'timestamp[us, tz=America/New_York]'
         """
         timestamp_internals = timestamp_matches.group(1)
-        internals_regex = re.compile("^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+:]*)$")
+        internals_regex = re.compile(r"^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+:]*)$")
         internals_matches = internals_regex.search(timestamp_internals)
         if timestamp_internals in ["s", "ms", "us", "ns"]:
             return pa.timestamp(timestamp_internals)

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -37,7 +37,7 @@ def string_to_arrow(type_str: str) -> pa.DataType:
     """
     string_to_arrow takes a datasets string dtype and converts it to a pyarrow.DataType.
 
-    In effect, `dt == string_to_arrow(arrow_to_datasets_dtype(dt))`
+    In effect, `dt == string_to_arrow(str(dt))`
 
     This is necessary because the datasets.Value() primitive type is constructed using a string dtype
 

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -809,7 +809,8 @@ def generate_from_dict(obj: Any):
     We use the '_type' fields to get the dataclass name to load.
 
     generate_from_dict is the recursive helper for Features.from_dict, and allows for a convenient constructor syntax
-        for users to define new datasets and provide their own Features.  This acts as an analogue to
+        to define features from json dictionaries. This function is used in particular when deserializing
+        a DatasetInfo that was dumped to a json dictionary. This acts as an analogue to
         Features.from_arrow_schema and handles the recursive field-by-field instantiation, but doesn't require any
         mapping to/from pyarrow, except for the fact that it takes advantage of the mapping of pyarrow primitive dtypes
         that Value() automatically performs.

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -39,7 +39,7 @@ class FeaturesTest(TestCase):
         self.assertDictEqual(dset[0], new_dset[0])
         self.assertDictEqual(dset[:], new_dset[:])
 
-    def test_string_to_arrow_bijection(self):
+    def test_string_to_arrow_bijection_for_primitive_types(self):
         supported_pyarrow_datatypes = [
             pa.timestamp("s"),
             pa.timestamp("ns", tz="America/New_York"),

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,9 +3,17 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 
 from datasets.arrow_dataset import Dataset
-from datasets.features import Features, Sequence, Value, _cast_to_python_objects, cast_to_python_objects
+from datasets.features import (
+    Features,
+    Sequence,
+    Value,
+    _cast_to_python_objects,
+    cast_to_python_objects,
+    string_to_arrow,
+)
 
 from .utils import require_tf, require_torch
 
@@ -30,6 +38,31 @@ class FeaturesTest(TestCase):
         self.assertEqual(original_features.type, new_features.type)
         self.assertDictEqual(dset[0], new_dset[0])
         self.assertDictEqual(dset[:], new_dset[:])
+
+    def test_string_to_arrow_bijection(self):
+        supported_pyarrow_datatypes = [
+            pa.timestamp("s"),
+            pa.timestamp("ns", tz="America/New_York"),
+            pa.string(),
+            pa.int32(),
+            pa.float64(),
+        ]
+        for dt in supported_pyarrow_datatypes:
+            self.assertEqual(dt, string_to_arrow(str(dt)))
+
+        unsupported_pyarrow_datatypes = [pa.list_(pa.float64())]
+        for dt in unsupported_pyarrow_datatypes:
+            with self.assertRaises(ValueError):
+                string_to_arrow(str(dt))
+
+        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "double", "int32"]
+        for sdt in supported_pyarrow_dtypes:
+            self.assertEqual(sdt, str(string_to_arrow(sdt)))
+
+        unsupported_pyarrow_dtypes = ["timestamp[blob]", "timestamp[[ns]]", "timestamp[ns, tz=[ns]]", "int"]
+        for sdt in unsupported_pyarrow_dtypes:
+            with self.assertRaises(ValueError):
+                string_to_arrow(sdt)
 
     def test_cast_to_python_objects_list(self):
         obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -45,7 +45,6 @@ class FeaturesTest(TestCase):
             pa.timestamp("ns", tz="America/New_York"),
             pa.string(),
             pa.int32(),
-            pa.float64(),
         ]
         for dt in supported_pyarrow_datatypes:
             self.assertEqual(dt, string_to_arrow(str(dt)))
@@ -55,7 +54,7 @@ class FeaturesTest(TestCase):
             with self.assertRaises(ValueError):
                 string_to_arrow(str(dt))
 
-        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "double", "int32"]
+        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "int32"]
         for sdt in supported_pyarrow_dtypes:
             self.assertEqual(sdt, str(string_to_arrow(sdt)))
 


### PR DESCRIPTION
Should resolve https://github.com/huggingface/datasets/issues/1895

The main part of this PR adds additional parsing in `string_to_arrow` to convert the timestamp dtypes that result from `str(pa_type)` back into the pa.DataType TimestampType.

While adding unit-testing, I noticed that support for the double/float types also don't invert correctly, so I added them, which I believe would hypothetically make this section of `Value` redundant:

```
    def __post_init__(self):
        if self.dtype == "double":  # fix inferred type
            self.dtype = "float64"
        if self.dtype == "float":  # fix inferred type
            self.dtype = "float32"
```

However, since I think Value.dtype is part of the public interface, removing that would result in a backward-incompatible change, so I didn't muck with that.

The rest of the PR consists of docstrings that I added while developing locally so I could keep track of which functions were supposed to be inverses of each other, and thought I'd include them initially in case you want to keep them around, but I'm happy to delete or remove any of them at your request!