### PR TITLE
Fix to_pandas for boolean ArrayXD

### DIFF
--- a/tests/test_array_xd.py
+++ b/tests/test_array_xd.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
 from absl.testing import parameterized
 
 import datasets
@@ -228,3 +229,13 @@ class ArrayXDTest(unittest.TestCase):
         )
         self._check_getitem_output_type(dataset, shape_1, shape_2, dict_examples["matrix"][0])
         del dataset
+
+
+@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+def test_table_to_pandas(dtype, dummy_value):
+    features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    df = dataset._data.to_pandas()
+    assert type(df.foo.dtype) == datasets.features.PandasArrayExtensionDtype
+    arr = df.foo.to_numpy()
+    np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))


### PR DESCRIPTION
As noticed in #1887 the conversion of a dataset with a boolean ArrayXD feature types fails because of the underlying ListArray conversion to numpy requires `zero_copy_only=False`.

zero copy is available for all primitive types except booleans
see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy
and https://issues.apache.org/jira/browse/ARROW-2871?jql=text%20~%20%22boolean%20to_numpy%22

cc @SBrandeis 