### PR TITLE
Standardizing datasets.dtypes

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -1,12 +1,37 @@
 Dataset features
 ===========================
 
-:class:`datasets.Features` define the internal structure and typings for each example in the dataset. Features are used to specify the underlying serailization format but also contain high-level informations regarding the fields, e.g. conversion methods from names to integer values for a class label field.
+:class:`datasets.Features` defines the internal structure of a dataset. Features are used to specify the underlying serialization format but also contain high-level information regarding the fields, e.g. column names, types, and conversion methods from names to integer values for a class label field.
 
-Here is a brief presentation of the various types of features which can be used to define the dataset fields (aka columns):
+A brief summary of how to use this class:
 
-- :class:`datasets.Features` is the base class and should be only called once and instantiated with a dictionary of field names and field sub-features as detailed in the rest of this list,
+- :class:`datasets.Features` should be only called once and instantiated with a ``dict[str, FieldType]``, where keys are your desired column names, and values are the type of that column.
+
+`FieldType` can be one of a few possibilities:
+
+- a :class:`datasets.Value` feature specifies a single typed value, e.g. ``int64`` or ``string``. The dtypes supported are as follows:
+    - null
+    - bool
+    - int8
+    - int16
+    - int32
+    - int64
+    - uint8
+    - uint16
+    - uint32
+    - uint64
+    - float16
+    - float32 (alias float)
+    - float64 (alias double)
+    - timestamp[(s|ms|us|ns)]
+    - timestamp[(s|ms|us|ns), tz=(tzstring)]
+    - binary
+    - large_binary
+    - string
+    - large_string
+
 - a python :obj:`dict` specifies that the field is a nested field containing a mapping of sub-fields to sub-fields features. It's possible to have nested fields of nested fields in an arbitrary manner.
+
 - a python :obj:`list` or a :class:`datasets.Sequence` specifies that the field contains a list of objects. The python :obj:`list` or :class:`datasets.Sequence` should be provided with a single sub-feature as an example of the feature type hosted in this list. Python :obj:`list` are simplest to define and write while :class:`datasets.Sequence` provide a few more specific behaviors like the possibility to specify a fixed length for the list (slightly more efficient).
 
 .. note::
@@ -14,8 +39,6 @@ Here is a brief presentation of the various types of features which can be used 
     A :class:`datasets.Sequence` with a internal dictionary feature will be automatically converted into a dictionary of lists. This behavior is implemented to have a compatilbity layer with the TensorFlow Datasets library but may be un-wanted in some cases. If you don't want this behavior, you can use a python :obj:`list` instead of the :class:`datasets.Sequence`.
 
 - a :class:`datasets.ClassLabel` feature specifies a field with a predefined set of classes which can have labels associated to them and will be stored as integers in the dataset. This field will be stored and retrieved as an integer value and two conversion methods, :func:`datasets.ClassLabel.str2int` and :func:`datasets.ClassLabel.int2str` can be used to convert from the label names to the associate integer value and vice-versa.
-
-- a :class:`datasets.Value` feature specifies a single typed value, e.g. ``int64`` or ``string``. The types supported are all the `non-nested types of Apache Arrow <https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions>`__ among which the most commonly used ones are ``int64``, ``float32`` and ``string``.
 
 - finally, two features are specific to Machine Translation: :class:`datasets.Translation` and :class:`datasets.TranslationVariableLanguages`. We refer to the package reference for more details on these features.
 

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -47,7 +47,7 @@ def string_to_arrow(type_str: str) -> pa.DataType:
         which means that each Value() must resolve into its corresponding pyarrow.DataType, which is the purpose
         of this function.
     """
-    timestamp_regex = re.compile("^timestamp\[(.*)\]$")
+    timestamp_regex = re.compile(r"^timestamp\[(.*)\]$")
     timestamp_matches = timestamp_regex.search(type_str)
     if timestamp_matches:
         """
@@ -58,7 +58,7 @@ def string_to_arrow(type_str: str) -> pa.DataType:
         'timestamp[us, tz=America/New_York]'
         """
         timestamp_internals = timestamp_matches.group(1)
-        internals_regex = re.compile("^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+:]*)$")
+        internals_regex = re.compile(r"^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+:]*)$")
         internals_matches = internals_regex.search(timestamp_internals)
         if timestamp_internals in ["s", "ms", "us", "ns"]:
             return pa.timestamp(timestamp_internals)

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -23,8 +23,10 @@ from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.types
 from pandas.api.extensions import ExtensionArray as PandasExtensionArray
 from pandas.api.extensions import ExtensionDtype as PandasExtensionDtype
+from pyarrow.lib import TimestampType
 
 from . import config, utils
 from .utils.logging import get_logger
@@ -33,11 +35,64 @@ from .utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def string_to_arrow(type_str: str) -> pa.DataType:
+def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
+    """
+    _arrow_to_datasets_dtype takes a pyarrow.DataType and converts it to a datasets string dtype.
+
+    In effect, `dt == string_to_arrow(_arrow_to_datasets_dtype(dt))`
+    """
+
+    if pyarrow.types.is_null(arrow_type):
+        return "null"
+    elif pyarrow.types.is_boolean(arrow_type):
+        return "bool"
+    elif pyarrow.types.is_int8(arrow_type):
+        return "int8"
+    elif pyarrow.types.is_int16(arrow_type):
+        return "int16"
+    elif pyarrow.types.is_int32(arrow_type):
+        return "int32"
+    elif pyarrow.types.is_int64(arrow_type):
+        return "int64"
+    elif pyarrow.types.is_uint8(arrow_type):
+        return "uint8"
+    elif pyarrow.types.is_uint16(arrow_type):
+        return "uint16"
+    elif pyarrow.types.is_uint32(arrow_type):
+        return "uint32"
+    elif pyarrow.types.is_uint64(arrow_type):
+        return "uint64"
+    elif pyarrow.types.is_float16(arrow_type):
+        return "float16"  # pyarrow dtype is "halffloat"
+    elif pyarrow.types.is_float32(arrow_type):
+        return "float32"  # pyarrow dtype is "float"
+    elif pyarrow.types.is_float64(arrow_type):
+        return "float64"  # pyarrow dtype is "double"
+    elif pyarrow.types.is_timestamp(arrow_type):
+        assert isinstance(arrow_type, TimestampType)
+        if arrow_type.tz is None:
+            return f"timestamp[{arrow_type.unit}]"
+        elif arrow_type.tz:
+            return f"timestamp[{arrow_type.unit}, tz={arrow_type.tz}]"
+        else:
+            raise ValueError(f"Unexpected timestamp object {arrow_type}.")
+    elif pyarrow.types.is_binary(arrow_type):
+        return "binary"
+    elif pyarrow.types.is_large_binary(arrow_type):
+        return "large_binary"
+    elif pyarrow.types.is_string(arrow_type):
+        return "string"
+    elif pyarrow.types.is_large_string(arrow_type):
+        return "large_string"
+    else:
+        raise ValueError(f"Arrow type {arrow_type} does not have a datasets dtype equivalent.")
+
+
+def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     """
     string_to_arrow takes a datasets string dtype and converts it to a pyarrow.DataType.
 
-    In effect, `dt == string_to_arrow(arrow_to_datasets_dtype(dt))`
+    In effect, `dt == string_to_arrow(_arrow_to_datasets_dtype(dt))`
 
     This is necessary because the datasets.Value() primitive type is constructed using a string dtype
 
@@ -48,14 +103,8 @@ def string_to_arrow(type_str: str) -> pa.DataType:
         purpose of this function.
     """
     timestamp_regex = re.compile(r"^timestamp\[(.*)\]$")
-    timestamp_matches = timestamp_regex.search(type_str)
+    timestamp_matches = timestamp_regex.search(datasets_dtype)
     if timestamp_matches:
-        """
-        Example timestamp dtypes:
-
-        timestamp[us]
-        timestamp[us, tz=America/New_York]
-        """
         timestamp_internals = timestamp_matches.group(1)
         internals_regex = re.compile(r"^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+:]*)$")
         internals_matches = internals_regex.search(timestamp_internals)
@@ -65,22 +114,75 @@ def string_to_arrow(type_str: str) -> pa.DataType:
             return pa.timestamp(internals_matches.group(1), internals_matches.group(2))
         else:
             raise ValueError(
-                f"{type_str} is not a validly formatted string representation of a pyarrow timestamp."
+                f"{datasets_dtype} is not a validly formatted string representation of a pyarrow timestamp."
                 f"Examples include timestamp[us] or timestamp[us, tz=America/New_York]"
                 f"See: https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html#pyarrow.timestamp"
             )
-    elif type_str not in pa.__dict__:
-        if str(type_str + "_") not in pa.__dict__:
+    elif datasets_dtype not in pa.__dict__:
+        if str(datasets_dtype + "_") not in pa.__dict__:
             raise ValueError(
-                f"Neither {type_str} nor {type_str + '_'} seems to be a pyarrow data type. "
+                f"Neither {datasets_dtype} nor {datasets_dtype + '_'} seems to be a pyarrow data type. "
                 f"Please make sure to use a correct data type, see: "
                 f"https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions"
             )
-        arrow_data_factory_function_name = str(type_str + "_")
+        arrow_data_factory_function_name = str(datasets_dtype + "_")
     else:
-        arrow_data_factory_function_name = type_str
+        arrow_data_factory_function_name = datasets_dtype
 
     return pa.__dict__[arrow_data_factory_function_name]()
+
+
+@dataclass
+class Value:
+    """
+    The Value dtypes are as follows:
+
+    null
+    bool
+    int8
+    int16
+    int32
+    int64
+    uint8
+    uint16
+    uint32
+    uint64
+    float16
+    float32 (alias float)
+    float64 (alias double)
+    timestamp[(s|ms|us|ns)]
+    timestamp[(s|ms|us|ns), tz=(tzstring)]
+    binary
+    large_binary
+    string
+    large_string
+    """
+
+    dtype: str
+    id: Optional[str] = None
+    # Automatically constructed
+    pa_type: ClassVar[Any] = None
+    _type: str = field(default="Value", init=False, repr=False)
+
+    def __post_init__(self):
+        if self.dtype == "double":  # fix inferred type
+            self.dtype = "float64"
+        if self.dtype == "float":  # fix inferred type
+            self.dtype = "float32"
+        self.pa_type = string_to_arrow(self.dtype)
+
+    def __call__(self):
+        return self.pa_type
+
+    def encode_example(self, value):
+        if pa.types.is_boolean(self.pa_type):
+            return bool(value)
+        elif pa.types.is_integer(self.pa_type):
+            return int(value)
+        elif pa.types.is_floating(self.pa_type):
+            return float(value)
+        else:
+            return value
 
 
 def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
@@ -159,37 +261,6 @@ def cast_to_python_objects(obj: Any) -> Any:
         casted_obj: the casted object
     """
     return _cast_to_python_objects(obj)[0]
-
-
-@dataclass
-class Value:
-    """Encapsulate an Arrow datatype for easy serialization."""
-
-    dtype: str
-    id: Optional[str] = None
-    # Automatically constructed
-    pa_type: ClassVar[Any] = None
-    _type: str = field(default="Value", init=False, repr=False)
-
-    def __post_init__(self):
-        if self.dtype == "double":  # fix inferred type
-            self.dtype = "float64"
-        if self.dtype == "float":  # fix inferred type
-            self.dtype = "float32"
-        self.pa_type = string_to_arrow(self.dtype)
-
-    def __call__(self):
-        return self.pa_type
-
-    def encode_example(self, value):
-        if pa.types.is_boolean(self.pa_type):
-            return bool(value)
-        elif pa.types.is_integer(self.pa_type):
-            return int(value)
-        elif pa.types.is_floating(self.pa_type):
-            return float(value)
-        else:
-            return value
 
 
 class _ArrayXD:
@@ -848,7 +919,7 @@ def generate_from_arrow_type(pa_type: pa.DataType) -> FeatureType:
     elif isinstance(pa_type, pa.DictionaryType):
         raise NotImplementedError  # TODO(thom) this will need access to the dictionary as well (for labels). I.e. to the py_table
     elif isinstance(pa_type, pa.DataType):
-        return Value(dtype=str(pa_type))
+        return Value(dtype=_arrow_to_datasets_dtype(pa_type))
     else:
         raise ValueError(f"Cannot convert {pa_type} to a Feature type.")
 

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -809,7 +809,8 @@ def generate_from_dict(obj: Any):
     We use the '_type' fields to get the dataclass name to load.
 
     generate_from_dict is the recursive helper for Features.from_dict, and allows for a convenient constructor syntax
-        for users to define new datasets and provide their own Features.  This acts as an analogue to
+        to define features from json dictionaries. This function is used in particular when deserializing
+        a DatasetInfo that was dumped to a json dictionary. This acts as an analogue to
         Features.from_arrow_schema and handles the recursive field-by-field instantiation, but doesn't require any
         mapping to/from pyarrow, except for the fact that it takes advantage of the mapping of pyarrow primitive dtypes
         that Value() automatically performs.

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -39,7 +39,7 @@ class FeaturesTest(TestCase):
         self.assertDictEqual(dset[0], new_dset[0])
         self.assertDictEqual(dset[:], new_dset[:])
 
-    def test_string_to_arrow_bijection(self):
+    def test_string_to_arrow_bijection_for_primitive_types(self):
         supported_pyarrow_datatypes = [
             pa.timestamp("s"),
             pa.timestamp("ns", tz="America/New_York"),

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -10,6 +10,7 @@ from datasets.features import (
     Features,
     Sequence,
     Value,
+    _arrow_to_datasets_dtype,
     _cast_to_python_objects,
     cast_to_python_objects,
     string_to_arrow,
@@ -45,21 +46,22 @@ class FeaturesTest(TestCase):
             pa.timestamp("ns", tz="America/New_York"),
             pa.string(),
             pa.int32(),
+            pa.float64(),
         ]
         for dt in supported_pyarrow_datatypes:
-            self.assertEqual(dt, string_to_arrow(str(dt)))
+            self.assertEqual(dt, string_to_arrow(_arrow_to_datasets_dtype(dt)))
 
         unsupported_pyarrow_datatypes = [pa.list_(pa.float64())]
         for dt in unsupported_pyarrow_datatypes:
             with self.assertRaises(ValueError):
-                string_to_arrow(str(dt))
+                string_to_arrow(_arrow_to_datasets_dtype(dt))
 
-        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "int32"]
-        for sdt in supported_pyarrow_dtypes:
-            self.assertEqual(sdt, str(string_to_arrow(sdt)))
+        supported_datasets_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "int32", "float64"]
+        for sdt in supported_datasets_dtypes:
+            self.assertEqual(sdt, _arrow_to_datasets_dtype(string_to_arrow(sdt)))
 
-        unsupported_pyarrow_dtypes = ["timestamp[blob]", "timestamp[[ns]]", "timestamp[ns, tz=[ns]]", "int"]
-        for sdt in unsupported_pyarrow_dtypes:
+        unsupported_datasets_dtypes = ["timestamp[blob]", "timestamp[[ns]]", "timestamp[ns, tz=[ns]]", "int"]
+        for sdt in unsupported_datasets_dtypes:
             with self.assertRaises(ValueError):
                 string_to_arrow(sdt)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,9 +3,17 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 
 from datasets.arrow_dataset import Dataset
-from datasets.features import Features, Sequence, Value, _cast_to_python_objects, cast_to_python_objects
+from datasets.features import (
+    Features,
+    Sequence,
+    Value,
+    _cast_to_python_objects,
+    cast_to_python_objects,
+    string_to_arrow,
+)
 
 from .utils import require_tf, require_torch
 
@@ -30,6 +38,31 @@ class FeaturesTest(TestCase):
         self.assertEqual(original_features.type, new_features.type)
         self.assertDictEqual(dset[0], new_dset[0])
         self.assertDictEqual(dset[:], new_dset[:])
+
+    def test_string_to_arrow_bijection(self):
+        supported_pyarrow_datatypes = [
+            pa.timestamp("s"),
+            pa.timestamp("ns", tz="America/New_York"),
+            pa.string(),
+            pa.int32(),
+            pa.float64(),
+        ]
+        for dt in supported_pyarrow_datatypes:
+            self.assertEqual(dt, string_to_arrow(str(dt)))
+
+        unsupported_pyarrow_datatypes = [pa.list_(pa.float64())]
+        for dt in unsupported_pyarrow_datatypes:
+            with self.assertRaises(ValueError):
+                string_to_arrow(str(dt))
+
+        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "double", "int32"]
+        for sdt in supported_pyarrow_dtypes:
+            self.assertEqual(sdt, str(string_to_arrow(sdt)))
+
+        unsupported_pyarrow_dtypes = ["timestamp[blob]", "timestamp[[ns]]", "timestamp[ns, tz=[ns]]", "int"]
+        for sdt in unsupported_pyarrow_dtypes:
+            with self.assertRaises(ValueError):
+                string_to_arrow(sdt)
 
     def test_cast_to_python_objects_list(self):
         obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -45,7 +45,6 @@ class FeaturesTest(TestCase):
             pa.timestamp("ns", tz="America/New_York"),
             pa.string(),
             pa.int32(),
-            pa.float64(),
         ]
         for dt in supported_pyarrow_datatypes:
             self.assertEqual(dt, string_to_arrow(str(dt)))
@@ -55,7 +54,7 @@ class FeaturesTest(TestCase):
             with self.assertRaises(ValueError):
                 string_to_arrow(str(dt))
 
-        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "double", "int32"]
+        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "int32"]
         for sdt in supported_pyarrow_dtypes:
             self.assertEqual(sdt, str(string_to_arrow(sdt)))
 


### PR DESCRIPTION
This PR was further branched off of jdy-str-to-pyarrow-parsing, so it depends on https://github.com/huggingface/datasets/pull/1900 going first for the diff to be up-to-date (I'm not sure if there's a way for me to use jdy-str-to-pyarrow-parsing as a base branch while having it appear in the pull requests here).

This moves away from `str(pyarrow.DataType)` as the method of choice for creating dtypes, favoring an explicit mapping to a list of supported Value dtypes.

I believe in practice this should be backward compatible, since anyone previously using Value() would only have been able to use dtypes that had an identically named pyarrow factory function, which are all explicitly supported here.