### PR TITLE
Add keep_linebreaks parameter to text loader

### DIFF
--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -21,6 +21,7 @@ class TextConfig(datasets.BuilderConfig):
 
     encoding: str = "utf-8"
     chunksize: int = 10 << 20  # 10MB
+    keep_linebreaks: bool = False
 
 
 class Text(datasets.ArrowBasedBuilder):
@@ -59,7 +60,7 @@ class Text(datasets.ArrowBasedBuilder):
                     if not batch:
                         break
                     batch += f.readline()  # finish current line
-                    batch = batch.splitlines()
+                    batch = batch.splitlines(keepends=self.config.keep_linebreaks)
                     pa_table = pa.Table.from_arrays([pa.array(batch)], schema=pa.schema({"text": pa.string()}))
                     # Uncomment for debugging (will print the Arrow table size and elements)
                     # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")

--- a/tests/test_packaged_modules.py
+++ b/tests/test_packaged_modules.py
@@ -1,8 +1,10 @@
 import textwrap
 
+import pyarrow as pa
 import pytest
 
 from datasets.packaged_modules.csv.csv import Csv
+from datasets.packaged_modules.text.text import Text
 
 
 @pytest.fixture
@@ -35,6 +37,22 @@ def malformed_csv_file(tmp_path):
     return str(filename)
 
 
+@pytest.fixture
+def text_file(tmp_path):
+    filename = tmp_path / "text.txt"
+    data = textwrap.dedent(
+        """\
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
+
+
 def test_csv_generate_tables_raises_error_with_malformed_csv(csv_file, malformed_csv_file, caplog):
     csv = Csv()
     generator = csv._generate_tables([csv_file, malformed_csv_file])
@@ -45,3 +63,13 @@ def test_csv_generate_tables_raises_error_with_malformed_csv(csv_file, malformed
         record.levelname == "ERROR" and f"Failed to read file '{malformed_csv_file}'" in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.parametrize("keep_linebreaks", [True, False])
+def test_text_linebreaks(text_file, keep_linebreaks):
+    with open(text_file) as f:
+        expected_content = f.read().splitlines(keepends=keep_linebreaks)
+    text = Text(keep_linebreaks=keep_linebreaks)
+    generator = text._generate_tables([text_file])
+    generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()["text"]
+    assert generated_content == expected_content


### PR DESCRIPTION
As asked in #870 and https://github.com/huggingface/transformers/issues/10269 there should be a parameter to keep the linebreaks when loading a text dataset.
cc @sgugger @jncasey