### PR TITLE
Standardizing datasets dtypes

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -1,12 +1,37 @@
 Dataset features
-===========================
+================
 
-:class:`datasets.Features` define the internal structure and typings for each example in the dataset. Features are used to specify the underlying serailization format but also contain high-level informations regarding the fields, e.g. conversion methods from names to integer values for a class label field.
+:class:`datasets.Features` defines the internal structure of a dataset. Features are used to specify the underlying serialization format but also contain high-level information regarding the fields, e.g. column names, types, and conversion methods from names to integer values for a class label field.
 
-Here is a brief presentation of the various types of features which can be used to define the dataset fields (aka columns):
+A brief summary of how to use this class:
 
-- :class:`datasets.Features` is the base class and should be only called once and instantiated with a dictionary of field names and field sub-features as detailed in the rest of this list,
+- :class:`datasets.Features` should be only called once and instantiated with a ``dict[str, FieldType]``, where keys are your desired column names, and values are the type of that column.
+
+`FieldType` can be one of a few possibilities:
+
+- a :class:`datasets.Value` feature specifies a single typed value, e.g. ``int64`` or ``string``. The dtypes supported are as follows:
+    - null
+    - bool
+    - int8
+    - int16
+    - int32
+    - int64
+    - uint8
+    - uint16
+    - uint32
+    - uint64
+    - float16
+    - float32 (alias float)
+    - float64 (alias double)
+    - timestamp[(s|ms|us|ns)]
+    - timestamp[(s|ms|us|ns), tz=(tzstring)]
+    - binary
+    - large_binary
+    - string
+    - large_string
+
 - a python :obj:`dict` specifies that the field is a nested field containing a mapping of sub-fields to sub-fields features. It's possible to have nested fields of nested fields in an arbitrary manner.
+
 - a python :obj:`list` or a :class:`datasets.Sequence` specifies that the field contains a list of objects. The python :obj:`list` or :class:`datasets.Sequence` should be provided with a single sub-feature as an example of the feature type hosted in this list. Python :obj:`list` are simplest to define and write while :class:`datasets.Sequence` provide a few more specific behaviors like the possibility to specify a fixed length for the list (slightly more efficient).
 
 .. note::
@@ -14,8 +39,6 @@ Here is a brief presentation of the various types of features which can be used 
     A :class:`datasets.Sequence` with a internal dictionary feature will be automatically converted into a dictionary of lists. This behavior is implemented to have a compatilbity layer with the TensorFlow Datasets library but may be un-wanted in some cases. If you don't want this behavior, you can use a python :obj:`list` instead of the :class:`datasets.Sequence`.
 
 - a :class:`datasets.ClassLabel` feature specifies a field with a predefined set of classes which can have labels associated to them and will be stored as integers in the dataset. This field will be stored and retrieved as an integer value and two conversion methods, :func:`datasets.ClassLabel.str2int` and :func:`datasets.ClassLabel.int2str` can be used to convert from the label names to the associate integer value and vice-versa.
-
-- a :class:`datasets.Value` feature specifies a single typed value, e.g. ``int64`` or ``string``. The types supported are all the `non-nested types of Apache Arrow <https://arrow.apache.org/docs/python/api/datatypes.html#factory-functions>`__ among which the most commonly used ones are ``int64``, ``float32`` and ``string``.
 
 - finally, two features are specific to Machine Translation: :class:`datasets.Translation` and :class:`datasets.TranslationVariableLanguages`. We refer to the package reference for more details on these features.
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -10,6 +10,7 @@ from datasets.features import (
     Features,
     Sequence,
     Value,
+    _arrow_to_datasets_dtype,
     _cast_to_python_objects,
     cast_to_python_objects,
     string_to_arrow,
@@ -45,21 +46,22 @@ class FeaturesTest(TestCase):
             pa.timestamp("ns", tz="America/New_York"),
             pa.string(),
             pa.int32(),
+            pa.float64(),
         ]
         for dt in supported_pyarrow_datatypes:
-            self.assertEqual(dt, string_to_arrow(str(dt)))
+            self.assertEqual(dt, string_to_arrow(_arrow_to_datasets_dtype(dt)))
 
         unsupported_pyarrow_datatypes = [pa.list_(pa.float64())]
         for dt in unsupported_pyarrow_datatypes:
             with self.assertRaises(ValueError):
-                string_to_arrow(str(dt))
+                string_to_arrow(_arrow_to_datasets_dtype(dt))
 
-        supported_pyarrow_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "int32"]
-        for sdt in supported_pyarrow_dtypes:
-            self.assertEqual(sdt, str(string_to_arrow(sdt)))
+        supported_datasets_dtypes = ["timestamp[ns]", "timestamp[ns, tz=+07:30]", "int32", "float64"]
+        for sdt in supported_datasets_dtypes:
+            self.assertEqual(sdt, _arrow_to_datasets_dtype(string_to_arrow(sdt)))
 
-        unsupported_pyarrow_dtypes = ["timestamp[blob]", "timestamp[[ns]]", "timestamp[ns, tz=[ns]]", "int"]
-        for sdt in unsupported_pyarrow_dtypes:
+        unsupported_datasets_dtypes = ["timestamp[blob]", "timestamp[[ns]]", "timestamp[ns, tz=[ns]]", "int"]
+        for sdt in unsupported_datasets_dtypes:
             with self.assertRaises(ValueError):
                 string_to_arrow(sdt)
 


### PR DESCRIPTION
This PR follows up on discussion in #1900 to have an explicit set of basic dtypes for datasets.

This moves away from str(pyarrow.DataType) as the method of choice for creating dtypes, favoring an explicit mapping to a list of supported Value dtypes.

I believe in practice this should be backward compatible, since anyone previously using Value() would only have been able to use dtypes that had an identically named pyarrow factory function, which are all explicitly supported here, with `float32` and `float64` acting as the official datasets dtypes, which resolves the tension between `double` being the pyarrow dtype and `float64` being the pyarrow type factory function.