### PR TITLE
Fix save_to_disk with relative path

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -465,9 +465,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             fs = fsspec.filesystem("file")
 
         # create temporary directory for saving
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            temp_dataset_path = Path(tmp_dir).joinpath(dataset_path)
-            os.makedirs(temp_dataset_path, exist_ok=True)
+        with tempfile.TemporaryDirectory() as temp_dataset_path:
+            fs.makedirs(dataset_path, exist_ok=True)
 
             # Write indices if needed
             if self._indices is not None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -208,4 +208,4 @@ def set_current_working_directory_to_temp_dir(*args, **kwargs):
     with tempfile.TemporaryDirectory(*args, **kwargs) as tmp_dir:
         os.chdir(tmp_dir)
         yield
-    os.chdir(original_working_dir)
+        os.chdir(original_working_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
 import os
+import tempfile
 import unittest
 from contextlib import contextmanager
 from distutils.util import strtobool
+from pathlib import Path
 
 from datasets import config
 
@@ -198,3 +200,12 @@ def offline(exception_cls=None):
         yield
     finally:
         socket.socket = online_socket
+
+
+@contextmanager
+def set_current_working_directory_to_temp_dir(*args, **kwargs):
+    original_working_dir = str(Path().resolve())
+    with tempfile.TemporaryDirectory(*args, **kwargs) as tmp_dir:
+        os.chdir(tmp_dir)
+        yield
+    os.chdir(original_working_dir)


### PR DESCRIPTION
As noticed in #1919 and #1920 the target directory was not created using `makedirs` so saving to it raises `FileNotFoundError`. For absolute paths it works but not for the good reason. This is because the target path was the same as the temporary path where in-memory data are written as an intermediary step.

I added the `makedirs` call using `fs.makedirs` in order to support remote filesystems.
I also fixed the issue with the target path being the temporary path.

I added a test case for relative paths as well for save_to_disk.

Thanks to @M-Salti for reporting and investigating