### PR TITLE
Fix: Wiki_dpr - add missing scalar quantizer

### DIFF
--- a/datasets/wiki_dpr/wiki_dpr.py
+++ b/datasets/wiki_dpr/wiki_dpr.py
@@ -196,7 +196,7 @@ class WikiDpr(datasets.GeneratorBasedBuilder):
                 train_size = self.config.index_train_size
                 logger.info("Building wiki_dpr faiss index")
                 if self.config.index_name == "exact":
-                    index = faiss.IndexHNSWFlat(d, 128, faiss.METRIC_INNER_PRODUCT)
+                    index = faiss.IndexHNSWSQ(d, faiss.ScalarQuantizer.QT_8bit, 128, faiss.METRIC_INNER_PRODUCT)
                     index.hnsw.efConstruction = 200
                     index.hnsw.efSearch = 128
                     dataset.add_faiss_index("embeddings", custom_index=index)


### PR DESCRIPTION
All the prebuilt wiki_dpr indexes already use SQ8, I forgot to update the wiki_dpr script after building them. Now it's finally done.

The scalar quantizer SQ8 doesn't reduce the performance of the index as shown in retrieval experiments on RAG.
The quantizer reduces the size of the index a lot but increases index building time.