### PR TITLE
Updating old cards

### DIFF
--- a/datasets/allocine/README.md
+++ b/datasets/allocine/README.md
@@ -10,7 +10,7 @@ licenses:
 multilinguality:
 - monolingual
 size_categories:
-- 100K < n <1M
+- 100K<n<1M
 source_datasets:
 - original
 task_categories:
@@ -61,15 +61,15 @@ task_ids:
 
 ### Dataset Summary
 
-The Allociné dataset was developed for large-scale sentiment analysis in French. The texts are movie reviews written by members of the [Allociné.fr](https://www.allocine.fr/) community for various films. The reviews were written between 2006 and 2020. Further information on the kinds of films included in the dataset has not been documented.
+The Allociné dataset is a French-language dataset for sentiment analysis. The texts are movie reviews written between 2006 and 2020 by members of the [Allociné.fr](https://www.allocine.fr/) community for various films. It contains 100k positive and 100k negative reviews divied into train (160k), validation (20k), and test (20k). 
 
 ### Supported Tasks and Leaderboards
 
-[tf-allociné](https://huggingface.co/tblard/tf-allocine) achieves 97.44% accuracy on the test set. 
+- `text-classification`, `sentiment-classification`: The dataset can be used to train a model for sentiment classification. The model performance is evaluated based on the accuracy of the predicted labels as compared to the given labels in the dataset. A BERT-based model, [tf-allociné](https://huggingface.co/tblard/tf-allocine), achieves 97.44% accuracy on the test set. 
 
 ### Languages
 
-The BCP-47 code for French is fr.
+The text is in French, as spoken by users of the [Allociné.fr](https://www.allocine.fr/) website. The BCP-47 code for French is fr.
 
 ## Dataset Structure
 
@@ -86,23 +86,24 @@ An example from the Allociné train set looks like the following:
 
 ### Data Fields
 
-- 'review'
-- 'label'
+- 'review': a string containing the review text
+- 'label': an integer, either _0_ or _1_, indicating a _negative_ or _positive_ review, respectively
 
 ### Data Splits
 
 The Allociné dataset has 3 splits: _train_, _validation_, and _test_. The splits contain disjoint sets of movies. The following table contains the number of reviews in each split and the percentage of positive and negative reviews. 
-Dataset Split | Number of Instances in Split | Percent Negative Reviews | Percent Positive Reviews
---------------|------------------------------|--------------------------|-------------------------
-Train | 160,000 | 49.6% | 50.4%
-Validation | 20,000 | 51.0% | 49.0%
-Test | 20,000 | 52.0% | 48.0%
+
+| Dataset Split | Number of Instances in Split | Percent Negative Reviews | Percent Positive Reviews |
+| ------------- | ---------------------------- | ------------------------ | ------------------------ |
+| Train         | 160,000                      | 49.6%                    | 50.4%                    |
+| Validation    | 20,000                       | 51.0%                    | 49.0%                    |
+| Test          | 20,000                       | 52.0%                    | 48.0%                    |
 
 ## Dataset Creation
 
 ### Curation Rationale
 
-[More Information Needed]
+The Allociné dataset was developed to support large-scale sentiment analysis in French. It was released alongside the [tf-allociné](https://huggingface.co/tblard/tf-allocine) model and used to compare the performance of several language models on this task. 
 
 ### Source Data
 
@@ -114,7 +115,7 @@ The reviews were originally labeled with a rating from 0.5 to 5.0 with a step of
 
 #### Who are the source language producers?
 
-The dataset contains movie reviews collected from [Allociné.fr](https://www.allocine.fr/). The content of each review may include information and opinions about the film's actors, film crew, and plot.
+The dataset contains movie reviews produced by the online community of the [Allociné.fr](https://www.allocine.fr/) website. 
 
 ### Annotations
 
@@ -130,17 +131,19 @@ The dataset does not contain any additional annotations.
 
 ### Personal and Sensitive Information
 
-[More Information Needed]
+Reviewer usernames or personal information were not collected with the reviews, but could potentially be recovered. The content of each review may include information and opinions about the film's actors, film crew, and plot.
 
 ## Considerations for Using the Data
 
 ### Social Impact of Dataset
 
-[More Information Needed]
+Sentiment classification is a complex task which requires sophisticated language understanding skills. Successful models can support decision-making based on the outcome of the sentiment analysis, though such models currently require a high degree of domain specificity. 
+
+It should be noted that the community represented in the dataset may not represent any downstream application's potential users, and the observed behavior of a model trained on this dataset may vary based on the domain and use case. 
 
 ### Discussion of Biases
 
-[More Information Needed]
+The Allociné website lists a number of topics which violate their [terms of service](https://www.allocine.fr/service/conditions.html#charte). Further analysis is needed to determine the extent to which moderators have successfully removed such content. 
 
 ### Other Known Limitations
 

--- a/datasets/allocine/README.md
+++ b/datasets/allocine/README.md
@@ -10,7 +10,7 @@ licenses:
 multilinguality:
 - monolingual
 size_categories:
-- 100K<n<1M
+- 100K < n <1M
 source_datasets:
 - original
 task_categories:
@@ -22,60 +22,74 @@ task_ids:
 # Dataset Card for Allociné
 
 ## Table of Contents
-- [Tasks Supported](#tasks-supported)
-- [Purpose](#purpose)
-- [Languages](#languages)
-- [People Involved](#who-iswas-involved-in-the-dataset-use-and-creation)
-- [Data Characteristics](#data-characteristics)
-- [Dataset Structure](#dataset-structure)
-- [Known Limitations](#known-limitations)
-- [Licensing information](#licensing-information)
+- [Dataset Card for Allociné](#dataset-card-for-allociné)
+  - [Table of Contents](#table-of-contents)
+  - [Dataset Description](#dataset-description)
+    - [Dataset Summary](#dataset-summary)
+    - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
+    - [Languages](#languages)
+  - [Dataset Structure](#dataset-structure)
+    - [Data Instances](#data-instances)
+    - [Data Fields](#data-fields)
+    - [Data Splits](#data-splits)
+  - [Dataset Creation](#dataset-creation)
+    - [Curation Rationale](#curation-rationale)
+    - [Source Data](#source-data)
+      - [Initial Data Collection and Normalization](#initial-data-collection-and-normalization)
+      - [Who are the source language producers?](#who-are-the-source-language-producers)
+    - [Annotations](#annotations)
+      - [Annotation process](#annotation-process)
+      - [Who are the annotators?](#who-are-the-annotators)
+    - [Personal and Sensitive Information](#personal-and-sensitive-information)
+  - [Considerations for Using the Data](#considerations-for-using-the-data)
+    - [Social Impact of Dataset](#social-impact-of-dataset)
+    - [Discussion of Biases](#discussion-of-biases)
+    - [Other Known Limitations](#other-known-limitations)
+  - [Additional Information](#additional-information)
+    - [Dataset Curators](#dataset-curators)
+    - [Licensing Information](#licensing-information)
+    - [Citation Information](#citation-information)
+    - [Contributions](#contributions)
 
-## Tasks supported:
-### Task categorization / tags
+## Dataset Description
 
-Text to binary text classification
+- **Homepage:** 
+- **Repository:** [Allociné dataset repository](https://github.com/TheophileBlard/french-sentiment-analysis-with-bert/tree/master/allocine_dataset)
+- **Paper:**
+- **Leaderboard:**
+- **Point of Contact:** [Théophile Blard](mailto:theophile.blard@gmail.com)
 
-## Purpose
+### Dataset Summary
 
-The Allociné dataset was developed for large-scale sentiment analysis in French. 
+The Allociné dataset was developed for large-scale sentiment analysis in French. The texts are movie reviews written by members of the [Allociné.fr](https://www.allocine.fr/) community for various films. The reviews were written between 2006 and 2020. Further information on the kinds of films included in the dataset has not been documented.
 
-## Languages 
-### Per language:
+### Supported Tasks and Leaderboards
 
-The BCP-47 code for French is fr. Dialect information is unknown (see Speaker section for further details).
+[tf-allociné](https://huggingface.co/tblard/tf-allocine) achieves 97.44% accuracy on the test set. 
 
-## Who is/was involved in the dataset use and creation?
-### Who are the dataset curators?
+### Languages
 
-The Allociné dataset was collected by Théophile Blard. 
-
-### Who are the language producers (who wrote the text / created the base content)?
-
-The dataset contains movie reviews collected from [Allociné.fr](https://www.allocine.fr/). The content of each review may include information and opinions about the film's actors, film crew, and plot.
-
-### Who are the annotators?
-
-No annotations were included in this dataset. 
-
-## Data characteristics
-
-The texts are movie reviews written by members of the [Allociné.fr](https://www.allocine.fr/) community for various films. The reviews were written between 2006 and 2020. Further information on the kinds of films included in the dataset has not been documented.
-
-### How was the data collected?
-
-The reviews and ratings were collected using a list of [film page urls](https://github.com/TheophileBlard/french-sentiment-analysis-with-bert/blob/master/allocine_dataset/allocine_films_urls.txt) and the [allocine_scraper.py](https://github.com/TheophileBlard/french-sentiment-analysis-with-bert/blob/master/allocine_dataset/allocine_scraper.py) tool. Up to 30 reviews were collected for each film. 
-
-### Normalization information
-
-The reviews were originally labeled with a rating from 0.5 to 5.0 with a step of 0.5 between each rating. Ratings less than or equal to 2 are labeled as negative and ratings greater than or equal to 4 are labeled as positive. Only reviews with less than 2000 characters are included in the dataset. 
-
-### Annotation process
-
-No annotations were included in this dataset. 
+The BCP-47 code for French is fr.
 
 ## Dataset Structure
-### Splits, features, and labels
+
+### Data Instances
+
+Each data instance contains the following features: _review_ and _label_. In the Hugging Face distribution of the dataset, the _label_ has 2 possible values, _0_ and _1_, which correspond to _negative_ and _positive_ respectively. See the [Allociné corpus viewer](https://huggingface.co/datasets/viewer/?dataset=allocine) to explore more examples.
+
+An example from the Allociné train set looks like the following:
+```
+{'review': 'Premier film de la saga Kozure Okami, "Le Sabre de la vengeance" est un très bon film qui mêle drame et action, et qui, en 40 ans, n'a pas pris une ride.',
+ 'label': 1}
+
+```
+
+### Data Fields
+
+- 'review'
+- 'label'
+
+### Data Splits
 
 The Allociné dataset has 3 splits: _train_, _validation_, and _test_. The splits contain disjoint sets of movies. The following table contains the number of reviews in each split and the percentage of positive and negative reviews. 
 Dataset Split | Number of Instances in Split | Percent Negative Reviews | Percent Positive Reviews
@@ -84,43 +98,67 @@ Train | 160,000 | 49.6% | 50.4%
 Validation | 20,000 | 51.0% | 49.0%
 Test | 20,000 | 52.0% | 48.0%
 
-Each data instance contains the following features: _review_ and _label_. In the Hugging Face distribution of the dataset, the _label_ has 2 possible values, _0_ and _1_, which correspond to _negative_ and _positive_ respectively. 
+## Dataset Creation
 
-### Span indices
+### Curation Rationale
 
-No span indices are included in this dataset.
+[More Information Needed]
 
-### Example ID
+### Source Data
 
-The ID is an integer starting from 0. It has no inherent meaning. 
+#### Initial Data Collection and Normalization
 
-### Free text description for context (e.g. describe difference between title / selftext / body in Reddit data) and example
+The reviews and ratings were collected using a list of [film page urls](https://github.com/TheophileBlard/french-sentiment-analysis-with-bert/blob/master/allocine_dataset/allocine_films_urls.txt) and the [allocine_scraper.py](https://github.com/TheophileBlard/french-sentiment-analysis-with-bert/blob/master/allocine_dataset/allocine_scraper.py) tool. Up to 30 reviews were collected for each film. 
 
-For each ID, there is a string for the review and an integer for the label. See the [Allociné corpus viewer](https://huggingface.co/datasets/viewer/?dataset=allocine) to explore more examples.
+The reviews were originally labeled with a rating from 0.5 to 5.0 with a step of 0.5 between each rating. Ratings less than or equal to 2 are labeled as negative and ratings greater than or equal to 4 are labeled as positive. Only reviews with less than 2000 characters are included in the dataset. 
 
-ID | Review | Label
----|--------|-------
-4	| Premier film de la saga Kozure Okami, "Le Sabre de la vengeance" est un très bon film qui mêle drame et action, et qui, en 40 ans, n'a pas pris une ride.	| 1
-5	| L'amnésie est un thème en or pour susciter le mystère. Encore faut-il être capable de construire un scénario qui se tienne. Celui-ci est boursouflé et accumule incohérences et invraisemblances. Notons aussi la stupidité du titre français, sans lien avec l'histoire.	| 0
+#### Who are the source language producers?
 
+The dataset contains movie reviews collected from [Allociné.fr](https://www.allocine.fr/). The content of each review may include information and opinions about the film's actors, film crew, and plot.
 
-### Suggested metrics / models:
+### Annotations
 
-[tf-allociné](https://huggingface.co/tblard/tf-allocine) achieves 97.44% accuracy on the test set. 
+The dataset does not contain any additional annotations. 
 
-## Known Limitations
-### Known social biases
+#### Annotation process
 
-The social biases of this dataset have not yet been investigated.
+[N/A]
 
-### Other known limitations
+#### Who are the annotators?
+
+[N/A]
+
+### Personal and Sensitive Information
+
+[More Information Needed]
+
+## Considerations for Using the Data
+
+### Social Impact of Dataset
+
+[More Information Needed]
+
+### Discussion of Biases
+
+[More Information Needed]
+
+### Other Known Limitations
 
 The limitations of the Allociné dataset have not yet been investigated, however [Staliūnaitė and Bonfil (2017)](https://www.aclweb.org/anthology/W17-5410.pdf) detail linguistic phenomena that are generally present in sentiment analysis but difficult for models to accurately label, such as negation, adverbial modifiers, and reviewer pragmatics. 
 
-## Licensing information
+## Additional Information
+
+### Dataset Curators
+
+The Allociné dataset was collected by Théophile Blard. 
+
+### Licensing Information
 
 The Allociné dataset is licensed under the [MIT License](https://opensource.org/licenses/MIT).
 
+### Citation Information
+
+> Théophile Blard, French sentiment analysis with BERT, (2020), GitHub repository, <https://github.com/TheophileBlard/french-sentiment-analysis-with-bert>
 
 ### Contributions
 

--- a/datasets/allocine/README.md
+++ b/datasets/allocine/README.md
@@ -61,7 +61,7 @@ task_ids:
 
 ### Dataset Summary
 
-The Allociné dataset is a French-language dataset for sentiment analysis. The texts are movie reviews written between 2006 and 2020 by members of the [Allociné.fr](https://www.allocine.fr/) community for various films. It contains 100k positive and 100k negative reviews divied into train (160k), validation (20k), and test (20k). 
+The Allociné dataset is a French-language dataset for sentiment analysis. The texts are movie reviews written between 2006 and 2020 by members of the [Allociné.fr](https://www.allocine.fr/) community for various films. It contains 100k positive and 100k negative reviews divided into train (160k), validation (20k), and test (20k). 
 
 ### Supported Tasks and Leaderboards
 

--- a/datasets/allocine/README.md
+++ b/datasets/allocine/README.md
@@ -165,4 +165,4 @@ The Allociné dataset is licensed under the [MIT License](https://opensource.org
 
 ### Contributions
 
-Thanks to [@thomwolf](https://github.com/thomwolf), [@TheophileBlard](https://github.com/TheophileBlard), [@lewtun](https://github.com/lewtun) for adding this dataset.
+Thanks to [@thomwolf](https://github.com/thomwolf), [@TheophileBlard](https://github.com/TheophileBlard), [@lewtun](https://github.com/lewtun) and [@mcmillanmajora](https://github.com/mcmillanmajora) for adding this dataset.

--- a/datasets/cnn_dailymail/README.md
+++ b/datasets/cnn_dailymail/README.md
@@ -21,31 +21,149 @@ task_ids:
 # Dataset Card for CNN Dailymail Dataset
 
 ## Table of Contents
-- [Tasks Supported](#tasks-supported)
-- [Purpose](#purpose)
-- [Languages](#languages)
-- [People Involved](#who-iswas-involved-in-the-dataset-use-and-creation)
-- [Data Characteristics](#data-characteristics)
-- [Dataset Structure](#dataset-structure)
-- [Known Limitations](#known-limitations)
-- [Licensing information](#licensing-information)
+- [Dataset Card for CNN Dailymail Dataset](#dataset-card-for-cnn-dailymail-dataset)
+  - [Table of Contents](#table-of-contents)
+  - [Dataset Description](#dataset-description)
+    - [Dataset Summary](#dataset-summary)
+    - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
+    - [Languages](#languages)
+  - [Dataset Structure](#dataset-structure)
+    - [Data Instances](#data-instances)
+    - [Data Fields](#data-fields)
+    - [Data Splits](#data-splits)
+  - [Dataset Creation](#dataset-creation)
+    - [Curation Rationale](#curation-rationale)
+    - [Source Data](#source-data)
+      - [Initial Data Collection and Normalization](#initial-data-collection-and-normalization)
+      - [Who are the source language producers?](#who-are-the-source-language-producers)
+    - [Annotations](#annotations)
+      - [Annotation process](#annotation-process)
+      - [Who are the annotators?](#who-are-the-annotators)
+    - [Personal and Sensitive Information](#personal-and-sensitive-information)
+  - [Considerations for Using the Data](#considerations-for-using-the-data)
+    - [Social Impact of Dataset](#social-impact-of-dataset)
+    - [Discussion of Biases](#discussion-of-biases)
+    - [Other Known Limitations](#other-known-limitations)
+  - [Additional Information](#additional-information)
+    - [Dataset Curators](#dataset-curators)
+    - [Licensing Information](#licensing-information)
+    - [Citation Information](#citation-information)
+    - [Contributions](#contributions)
 
-## Tasks supported:
-### Task categorization / tags
+## Dataset Description
 
-[Versions 2.0.0 and 3.0.0 of the CNN / DailyMail Dataset](https://www.aclweb.org/anthology/K16-1028.pdf) were developed for abstractive and extractive summarization. [Version 1.0.0](https://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend.pdf) was developed for machine reading and comprehension and abstractive question answering. 
+- **Homepage:**
+- **Repository:** [CNN / DailyMail Dataset repository](https://github.com/abisee/cnn-dailymail)
+- **Paper:** [Abstractive Text Summarization Using Sequence-to-Sequence RNNs and Beyond](https://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend.pdf), [Get To The Point: Summarization with Pointer-Generator Networks](https://www.aclweb.org/anthology/K16-1028.pdf)
+- **Leaderboard:** [Papers with Code leaderboard for CNN / Dailymail Dataset](https://paperswithcode.com/sota/document-summarization-on-cnn-daily-mail)
+- **Point of Contact:** [Abigail See](mailto:abisee@stanford.edu)
 
-## Purpose
+### Dataset Summary
 
-Version 1.0.0 aimed to support supervised neural methodologies for machine reading and question answering with a large amount of real natural language training data and released about 313k unique articles and nearly 1M Cloze style questions to go with the articles. Versions 2.0.0 and 3.0.0 changed the structure of the dataset to support summarization rather than question answering. Version 3.0.0 provided a non-anonymized version of the data, whereas both the previous versions were preprocessed to replace named entities with unique identifier labels. 
+The CNN / DailyMail Dataset is an English-language dataset containing just over 300k unique news aticles as written by journalists at CNN and the Daily Mail. The current version supports both extractive and abstractive summarization, though the original version was created for machine reading and comprehension and abstractive question answering. 
 
-## Languages 
-### Per language:
+### Supported Tasks and Leaderboards
+
+- 'summarization': [Versions 2.0.0 and 3.0.0 of the CNN / DailyMail Dataset](https://www.aclweb.org/anthology/K16-1028.pdf) can be used to train a model for abstractive and extractive summarization ([Version 1.0.0](https://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend.pdf) was developed for machine reading and comprehension and abstractive question answering). The model performance is measured by how high the output summary's [ROUGE](https://huggingface.co/metrics/rouge) score for a given article is when compared to the highlight as written by the original article author. [Zhong et al (2020)](https://www.aclweb.org/anthology/2020.acl-main.552.pdf) report a ROUGE-1 score of 44.41 when testing a model trained for extractive summarization. See the [Papers With Code leaderboard](https://paperswithcode.com/sota/document-summarization-on-cnn-daily-mail) for more models. 
+
+### Languages
 
 The BCP-47 code for English as generally spoken in the United States is en-US and the BCP-47 code for English as generally spoken in the United Kingdom is en-GB. It is unknown if other varieties of English are represented in the data.
 
-## Who is/was involved in the dataset use and creation? 
-### Who are the dataset curators? 
+## Dataset Structure
+
+### Data Instances
+
+For each instance, there is a string for the article, a string for the highlights, and a string for the id. See the [CNN / Daily Mail dataset viewer](https://huggingface.co/datasets/viewer/?dataset=cnn_dailymail&config=3.0.0) to explore more examples.
+
+```
+{'id': '0054d6d30dbcad772e20b22771153a2a9cbeaf62',
+ 'article': '(CNN) -- An American woman died aboard a cruise ship that docked at Rio de Janeiro on Tuesday, the same ship on which 86 passengers previously fell ill, according to the state-run Brazilian news agency, Agencia Brasil. The American tourist died aboard the MS Veendam, owned by cruise operator Holland America. Federal Police told Agencia Brasil that forensic doctors were investigating her death. The ship's doctors told police that the woman was elderly and suffered from diabetes and hypertension, according the agency. The other passengers came down with diarrhea prior to her death during an earlier part of the trip, the ship's doctors said. The Veendam left New York 36 days ago for a South America tour.'
+ 'highlights': 'The elderly woman suffered from diabetes and hypertension, ship's doctors say .\nPreviously, 86 passengers had fallen ill on the ship, Agencia Brasil says .'}
+```
+
+The average token count for the articles and the highlights are provided below:
+
+| Feature    | Mean Token Count |
+| ---------- | ---------------- |
+| Article    | 781              |
+| Highlights | 56               |
+
+### Data Fields
+
+- `id`: a string containing the heximal formated SHA1 hash of the url where the story was retrieved from
+- `article`: a string containing the body of the news article 
+- `highlights`: a string containing the highlight of the article as written by the article author
+
+### Data Splits
+
+The CNN/DailyMail dataset has 3 splits: _train_, _validation_, and _test_. Below are the statistics for Version 3.0.0 of the dataset.
+
+| Dataset Split | Number of Instances in Split                |
+| ------------- | ------------------------------------------- |
+| Train         | 287,113                                     |
+| Validation    | 13,368                                      |
+| Test          | 11,490                                      |
+
+## Dataset Creation
+
+### Curation Rationale
+
+Version 1.0.0 aimed to support supervised neural methodologies for machine reading and question answering with a large amount of real natural language training data and released about 313k unique articles and nearly 1M Cloze style questions to go with the articles. Versions 2.0.0 and 3.0.0 changed the structure of the dataset to support summarization rather than question answering. Version 3.0.0 provided a non-anonymized version of the data, whereas both the previous versions were preprocessed to replace named entities with unique identifier labels. 
+
+### Source Data
+
+#### Initial Data Collection and Normalization
+
+The data consists of news articles and highlight sentences. In the question answering setting of the data, the articles are used as the context and entities are hidden one at a time in the highlight sentences, producing Cloze style questions where the goal of the model is to correctly guess which entity in the context has been hidden in the highlight. In the summarization setting, the highlight sentences are concatenated to form a summary of the article. The CNN articles were written between April 2007 and April 2015. The Daily Mail articles were written between June 2010 and April 2015. 
+
+The code for the original data collection is available at <https://github.com/deepmind/rc-data>. The articles were downloaded using archives of <www.cnn.com> and <www.dailymail.co.uk> on the Wayback Machine. Articles were not included in the Version 1.0.0 collection if they exceeded 2000 tokens. Due to accessibility issues with the Wayback Machine, Kyunghyun Cho has made the datasets available at <https://cs.nyu.edu/~kcho/DMQA/>. An updated version of the code that does not anonymize the data is available at <https://github.com/abisee/cnn-dailymail>. 
+
+Hermann et al provided their own tokenization script. The script provided by See uses the PTBTokenizer. It also lowercases the text and adds periods to lines missing them.
+
+#### Who are the source language producers?
+
+The text was written by journalists at CNN and the Daily Mail. 
+
+### Annotations
+
+The dataset does not contain any additional annotations.
+
+#### Annotation process
+
+[N/A]
+
+#### Who are the annotators?
+
+[N/A]
+
+### Personal and Sensitive Information
+
+Version 3.0 is not anonymized, so individuals' names can be found in the dataset. Information about the original author is not included in the dataset.
+
+## Considerations for Using the Data
+
+### Social Impact of Dataset
+
+The purpose of this dataset is to help develop models that can summarize long paragraphs of text in one or two sentences.
+
+This task is useful for efficiently presenting information given a large quantity of text. It should be made clear that any summarizations produced by models trained on this dataset are reflective of the language used in the articles, but are in fact automatically generated.
+
+### Discussion of Biases
+
+[Bordia and Bowman (2019)](https://www.aclweb.org/anthology/N19-3002.pdf) explore measuring gender bias and debiasing techniques in the CNN / Dailymail dataset, the Penn Treebank, and WikiText-2. They find the CNN / Dailymail dataset to have a slightly lower gender bias based on their metric compared to the other datasets, but still show evidence of gender bias when looking at words such as 'fragile'.
+
+Because the articles were written by and for people in the US and the UK, they will likely present specifically US and UK perspectives and feature events that are considered relevant to those populations during the time that the articles were published. 
+
+### Other Known Limitations
+
+News articles have been shown to conform to writing conventions in which important information is primarily presented in the first third of the article [(Kryściński et al, 2019)](https://www.aclweb.org/anthology/D19-1051.pdf). [Chen et al (2016)](https://www.aclweb.org/anthology/P16-1223.pdf) conducted a manual study of 100 random instances of the first version of the dataset and found 25% of the samples to be difficult even for humans to answer correctly due to ambiguity and coreference errors. 
+
+It should also be noted that machine-generated summarizations, even when extractive, may differ in truth values when compared to the original articles. 
+
+## Additional Information
+
+### Dataset Curators
 
 The data was originally collected by Karl Moritz Hermann, Tomáš Kočiský, Edward Grefenstette, Lasse Espeholt, Will Kay, Mustafa Suleyman, and Phil Blunsom of Google DeepMind. Tomáš Kočiský and Phil Blunsom are also affiliated with the University of Oxford. They released scripts to collect and process the data into the question answering format. 
 
@@ -53,83 +171,45 @@ Ramesh Nallapati, Bowen Zhou, Cicero dos Santos, and Bing Xiang of IMB Watson an
 
 The code for the non-anonymized version is made publicly available by Abigail See of Stanford University, Peter J. Liu of Google Brain and Christopher D. Manning of Stanford University at <https://github.com/abisee/cnn-dailymail>. The work at Stanford University was supported by the DARPA DEFT ProgramAFRL contract no. FA8750-13-2-0040.
 
-
-### Who are the language producers (who wrote the text / created the base content)?
-
-The text was written by journalists at CNN and the Daily Mail. 
-
-### Who are the annotators?
-
-No annotation was provided with the dataset.
-
-## Data characteristics
-
-The data consists of news articles and highlight sentences. In the question answering setting of the data, the articles are used as the context and entities are hidden one at a time in the highlight sentences, producing Cloze style questions where the goal of the model is to correctly guess which entity in the context has been hidden in the highlight. In the summarization setting, the highlight sentences are concatenated to form a summary of the article. The CNN articles were written between April 2007 and April 2015. The Daily Mail articles were written between June 2010 and April 2015. 
-
-### How was the data collected?
-
-The code for the original data collection is available at <https://github.com/deepmind/rc-data>. The articles were downloaded using archives of <www.cnn.com> and <www.dailymail.co.uk> on the Wayback Machine. Articles were not included in the Version 1.0.0 collection if they exceeded 2000 tokens. Due to accessibility issues with the Wayback Machine, Kyunghyun Cho has made the datasets available at <https://cs.nyu.edu/~kcho/DMQA/>. An updated version of the code that does not anonymize the data is available at <https://github.com/abisee/cnn-dailymail>. 
-
-
-### Normalization information
-
-Hermann et al provided their own tokenization script. The script provided by See uses the PTBTokenizer. It also lowercases the text and adds periods to lines missing them.
-
-### Annotation process
-
-No annotation was provided with the dataset.
-
-## Dataset Structure
-### Splits, features, and labels
-
-The CNN/DailyMail dataset has 3 splits: _train_, _validation_, and _test_. Below are the statistics for Version 3.0.0 of the dataset.
-
-Dataset Split | Number of Instances in Split
---------------|--------------------------------------------
-Train | 287,113
-Validation | 13,368
-Test | 11,490
-
-Each data instance contains the following features: _article_, _highlights_, _id_.
-
-Feature | Mean Token Count
---------|-----------------
-Article | 781 
-Highlights | 56
-
-### Span indices
-
-No span indices are included in this dataset.
-
-### Example ID
-
-An example ID is '0001d1afc246a7964130f43ae940af6bc6c57f01'. These are heximal formated SHA1 hashes of the urls where the stories were retrieved from.
-
-### Free text description for context (e.g. describe difference between title / selftext / body in Reddit data) and example
-
-For each ID, there is a string for the article, a string for the highlights, and a string for the id. See the [CNN / Daily Mail dataset viewer](https://huggingface.co/datasets/viewer/?dataset=cnn_dailymail&config=3.0.0) to explore more examples.
-
-ID | Article | Hightlights 
----|---------|------------
-0054d6d30dbcad772e20b22771153a2a9cbeaf62 | (CNN) -- An American woman died aboard a cruise ship that docked at Rio de Janeiro on Tuesday, the same ship on which 86 passengers previously fell ill, according to the state-run Brazilian news agency, Agencia Brasil. The American tourist died aboard the MS Veendam, owned by cruise operator Holland America. Federal Police told Agencia Brasil that forensic doctors were investigating her death. The ship's doctors told police that the woman was elderly and suffered from diabetes and hypertension, according the agency. The other passengers came down with diarrhea prior to her death during an earlier part of the trip, the ship's doctors said. The Veendam left New York 36 days ago for a South America tour.	| The elderly woman suffered from diabetes and hypertension, ship's doctors say .\nPreviously, 86 passengers had fallen ill on the ship, Agencia Brasil says .
-
-### Suggested metrics / models:
-
-[Zhong et al (2020)](https://www.aclweb.org/anthology/2020.acl-main.552.pdf) report a ROUGE-1 score of 44.41. See the [Papers With Code leaderboard](https://paperswithcode.com/sota/document-summarization-on-cnn-daily-mail) for more models. 
-
-## Known Limitations
-### Known social biases
-
-[Bordia and Bowman (2019)](https://www.aclweb.org/anthology/N19-3002.pdf) explore measuring gender bias and debiasing techniques in the CNN / Dailymail dataset, the Penn Treebank, and WikiText-2. They find the CNN / Dailymail dataset to have a slightly lower gender bias based on their metric compared to the other datasets, but still show evidence of gender bias when looking at words such as 'fragile'.
-
-### Other known limitations
-
-News articles have been shown to conform to writing conventions in which important information is primarily presented in the first third of the article [(Kryściński et al, 2019)](https://www.aclweb.org/anthology/D19-1051.pdf). [Chen et al (2016)](https://www.aclweb.org/anthology/P16-1223.pdf) conducted a manual study of 100 random instances of the first version of the dataset and found 25% of the samples to be difficult even for humans to answer correctly due to ambiguity and coreference errors. 
-
-## Licensing information
+### Licensing Information
 
 The CNN / Daily Mail dataset version 1.0.0 is released under the [Apache-2.0 License](http://www.apache.org/licenses/LICENSE-2.0). 
+
+### Citation Information
+
+```
+@inproceedings{see-etal-2017-get,
+    title = "Get To The Point: Summarization with Pointer-Generator Networks",
+    author = "See, Abigail  and
+      Liu, Peter J.  and
+      Manning, Christopher D.",
+    booktitle = "Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2017",
+    address = "Vancouver, Canada",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/P17-1099",
+    doi = "10.18653/v1/P17-1099",
+    pages = "1073--1083",
+    abstract = "Neural sequence-to-sequence models have provided a viable new approach for abstractive text summarization (meaning they are not restricted to simply selecting and rearranging passages from the original text). However, these models have two shortcomings: they are liable to reproduce factual details inaccurately, and they tend to repeat themselves. In this work we propose a novel architecture that augments the standard sequence-to-sequence attentional model in two orthogonal ways. First, we use a hybrid pointer-generator network that can copy words from the source text via pointing, which aids accurate reproduction of information, while retaining the ability to produce novel words through the generator. Second, we use coverage to keep track of what has been summarized, which discourages repetition. We apply our model to the CNN / Daily Mail summarization task, outperforming the current abstractive state-of-the-art by at least 2 ROUGE points.",
+}
+```
+
+```
+@inproceedings{DBLP:conf/nips/HermannKGEKSB15,
+  author={Karl Moritz Hermann and Tomás Kociský and Edward Grefenstette and Lasse Espeholt and Will Kay and Mustafa Suleyman and Phil Blunsom},
+  title={Teaching Machines to Read and Comprehend},
+  year={2015},
+  cdate={1420070400000},
+  pages={1693-1701},
+  url={http://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend},
+  booktitle={NIPS},
+  crossref={conf/nips/2015}
+}
+
+```
 
 ### Contributions
 
 Thanks to [@thomwolf](https://github.com/thomwolf), [@lewtun](https://github.com/lewtun), [@jplu](https://github.com/jplu), [@jbragg](https://github.com/jbragg), [@patrickvonplaten](https://github.com/patrickvonplaten) for adding this dataset.
+

--- a/datasets/cnn_dailymail/README.md
+++ b/datasets/cnn_dailymail/README.md
@@ -211,5 +211,5 @@ The CNN / Daily Mail dataset version 1.0.0 is released under the [Apache-2.0 Lic
 
 ### Contributions
 
-Thanks to [@thomwolf](https://github.com/thomwolf), [@lewtun](https://github.com/lewtun), [@jplu](https://github.com/jplu), [@jbragg](https://github.com/jbragg), [@patrickvonplaten](https://github.com/patrickvonplaten) for adding this dataset.
+Thanks to [@thomwolf](https://github.com/thomwolf), [@lewtun](https://github.com/lewtun), [@jplu](https://github.com/jplu), [@jbragg](https://github.com/jbragg), [@patrickvonplaten](https://github.com/patrickvonplaten) and [@mcmillanmajora](https://github.com/mcmillanmajora) for adding this dataset.
 

--- a/datasets/snli/README.md
+++ b/datasets/snli/README.md
@@ -22,37 +22,110 @@ task_ids:
 # Dataset Card for SNLI
 
 ## Table of Contents
-- [Tasks Supported](#tasks-supported)
-- [Purpose](#purpose)
-- [Languages](#languages)
-- [People Involved](#who-iswas-involved-in-the-dataset-use-and-creation)
-- [Data Characteristics](#data-characteristics)
-- [Dataset Structure](#dataset-structure)
-- [Known Limitations](#known-limitations)
-- [Licensing information](#licensing-information)
+- [Dataset Card for SNLI](#dataset-card-for-snli)
+  - [Table of Contents](#table-of-contents)
+  - [Dataset Description](#dataset-description)
+    - [Dataset Summary](#dataset-summary)
+    - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
+    - [Languages](#languages)
+  - [Dataset Structure](#dataset-structure)
+    - [Data Instances](#data-instances)
+    - [Data Fields](#data-fields)
+    - [Data Splits](#data-splits)
+  - [Dataset Creation](#dataset-creation)
+    - [Curation Rationale](#curation-rationale)
+    - [Source Data](#source-data)
+      - [Initial Data Collection and Normalization](#initial-data-collection-and-normalization)
+      - [Who are the source language producers?](#who-are-the-source-language-producers)
+    - [Annotations](#annotations)
+      - [Annotation process](#annotation-process)
+      - [Who are the annotators?](#who-are-the-annotators)
+    - [Personal and Sensitive Information](#personal-and-sensitive-information)
+  - [Considerations for Using the Data](#considerations-for-using-the-data)
+    - [Social Impact of Dataset](#social-impact-of-dataset)
+    - [Discussion of Biases](#discussion-of-biases)
+    - [Other Known Limitations](#other-known-limitations)
+  - [Additional Information](#additional-information)
+    - [Dataset Curators](#dataset-curators)
+    - [Licensing Information](#licensing-information)
+    - [Citation Information](#citation-information)
+    - [Contributions](#contributions)
 
-## Tasks supported:
-### Task categorization / tags
+## Dataset Description
 
-Text to three-way text classification
+- **Homepage:** [SNLI homepage](https://nlp.stanford.edu/projects/snli/)
+- **Repository:**
+- **Paper:** [A large annotated corpus for learning natural langauge inference](https://nlp.stanford.edu/pubs/snli_paper.pdf)
+- **Leaderboard:** [SNLI leaderboard](https://nlp.stanford.edu/projects/snli/) (located on the homepage)
+- **Point of Contact:** [Samuel Bowman](mailto:bowman@nyu.edu) and [Gabor Angeli](mailto:angeli@stanford.edu)
 
-## Purpose
+### Dataset Summary
 
-The [SNLI corpus (version 1.0)](https://nlp.stanford.edu/projects/snli/) was developed as a benchmark for natural langauge inference (NLI), also known as recognizing textual entailment (RTE), with the goal of producing a dataset large enough to train models using neural methodologies. It contains 570k English sentence pairs, which include a premise, a hypothesis, and a label indicating whether the hypothesis entails the premise, contradicts it, or neither. 
+The SNLI corpus (version 1.0) is a collection of 570k human-written English sentence pairs manually labeled for balanced classification with the labels entailment, contradiction, and neutral, supporting the task of natural language inference (NLI), also known as recognizing textual entailment (RTE). 
 
-## Languages 
-### Per language:
+### Supported Tasks and Leaderboards
 
-The BCP-47 code for English is en. Dialect information is unknown (see Speaker and Annotator sections for further details).
+[SemBERT](https://arxiv.org/pdf/1909.02209.pdf) (Zhousheng Zhang et al, 2019b) is currently listed as SOTA, achieving 91.9% accuracy on the test set. See the [corpus webpage](https://nlp.stanford.edu/projects/snli/) for a list of published results.
 
-## Who is/was involved in the dataset use and creation?
-### Who are the dataset curators?
+### Languages
 
-The SNLI corpus was developed by Samuel R. Bowman, Gabor Angeli, Christopher Potts, and Christopher D. Manning as part of the [Stanford NLP group](https://nlp.stanford.edu/).
+The language in the dataset is English as spoken by users of the website Flickr and as spoken by crowdworkers from Amazon Mechanical Turk. The BCP-47 code for English is en. 
 
-It was supported by a Google Faculty Research Award, a gift from Bloomberg L.P., the Defense Advanced Research Projects Agency (DARPA) Deep Exploration and Filtering of Text (DEFT) Program under Air Force Research Laboratory (AFRL) contract no. FA8750-13-2-0040, the National Science Foundation under grant no. IIS 1159679, and the Department of the Navy, Office of Naval Research, under grant no. N00014-10-1-0109.
+## Dataset Structure
 
-### Who are the language producers (who wrote the text / created the base content)?
+### Data Instances
+
+For each instance, there is a string for the premise, a string for the hypothesis, and an integer for the label. Note that each premise may appear three times with a different hypothesis and label. See the [SNLI corpus viewer](https://huggingface.co/datasets/viewer/?dataset=snli) to explore more examples.
+
+```
+{'premise': 'Two women are embracing while holding to go packages.'
+ 'hypothesis': 'The sisters are hugging goodbye while holding to go packages after just eating lunch.'
+ 'label': 1}
+```
+
+The average token count for the premises and hypotheses are given below:
+
+| Feature    | Mean Token Count |
+| ---------- | ---------------- |
+| Premise    | 14.1             |
+| Hypothesis | 8.3              |
+
+### Data Fields
+
+- `premise`: a string used to determine the truthfulness of the hypothesis
+- `hypothesis`: a string that may be true, false, or whose truth conditions may not be knowable when compared to the premise
+- `label`: an integer whose value may be either _0_, indicating that the hypothesis entails the premise, _1_, indicating that the premise and hypothesis neither entail nor contradict each other, or _2_, indicating that the hypothesis contradicts the premise.
+
+
+### Data Splits
+
+The SNLI dataset has 3 splits: _train_, _validation_, and _test_. All of the examples in the _validation_ and _test_ sets come from the set that was annotated in the validation task with no-consensus examples removed. The remaining multiply-annotated examples are in the training set with no-consensus examples removed. Each unique premise/caption shows up in only one split, even though they usually appear in at least three different examples.
+
+| Dataset Split | Number of Instances in Split |
+| ------------- |----------------------------- |
+| Train         | 550,152                      |
+| Validation    | 10,000                       |
+| Test          | 10,000                       |
+
+## Dataset Creation
+
+### Curation Rationale
+
+The [SNLI corpus (version 1.0)](https://nlp.stanford.edu/projects/snli/) was developed as a benchmark for natural langauge inference (NLI), also known as recognizing textual entailment (RTE), with the goal of producing a dataset large enough to train models using neural methodologies. 
+
+### Source Data
+
+#### Initial Data Collection and Normalization
+
+The hypotheses were elicited by presenting crowdworkers with captions from preexisting datasets without the associated photos, but the vocabulary of the hypotheses still reflects the content of the photos as well as the caption style of writing (e.g. mostly present tense). The dataset developers report 37,026 distinct words in the corpus, ignoring case. They allowed bare NPs as well as full sentences. Using the Stanford PCFG Parser 3.5.2 (Klein and Manning, 2003) trained on the standard training set as well as on the Brown Corpus (Francis and Kucera 1979), the authors report that 74% of the premises and 88.9% of the hypotheses result in a parse rooted with an 'S'. The corpus was developed between 2014 and 2015. 
+
+Crowdworkers were presented with a caption without the associated photo and asked to produce three alternate captions, one that is definitely true, one that might be true, and one that is definitely false. See Section 2.1 and Figure 1 for details (Bowman et al., 2015).
+
+The corpus includes content from the [Flickr 30k corpus](http://shannon.cs.illinois.edu/DenotationGraph/) and the [VisualGenome corpus](https://visualgenome.org/). The photo captions used to prompt the data creation were collected on Flickr by [Young et al. (2014)](https://www.aclweb.org/anthology/Q14-1006.pdf), who extended the Flickr 8K dataset developed by [Hodosh et al. (2013)](https://www.jair.org/index.php/jair/article/view/10833). Hodosh et al. collected photos from the following Flickr groups: strangers!, Wild-Child (Kids in Action), Dogs in Action (Read the Rules), Outdoor Activities, Action Photography, Flickr-Social (two or more people in the photo). Young et al. do not list the specific groups they collected photos from. The VisualGenome corpus also contains images from Flickr, originally collected in [MS-COCO](https://cocodataset.org/#home) and [YFCC100M](http://projects.dfki.uni-kl.de/yfcc100m/).
+
+The premises from the Flickr 30k corpus corrected for spelling using the Linux spell checker and ungrammatical sentences were removed. Bowman et al. do not report any normalization, though they note that punctuation and capitalization are often omitted. 
+
+#### Who are the source language producers?
 
 A large portion of the premises (160k) were produced in the [Flickr 30k corpus](http://shannon.cs.illinois.edu/DenotationGraph/) by an unknown number of crowdworkers. About 2,500 crowdworkers from Amazon Mechanical Turk produced the associated hypotheses. The premises from the Flickr 30k project describe people and animals whose photos were collected and presented to the Flickr 30k crowdworkers, but the SNLI corpus did not present the photos to the hypotheses creators. 
 
@@ -60,91 +133,68 @@ The Flickr 30k corpus did not report crowdworker or photo subject demographic in
 
 An additional 4,000 premises come from the pilot study of the [VisualGenome corpus](https://visualgenome.org/static/paper/Visual_Genome.pdf). Though the pilot study itself is not described, the location information of the 33,000 AMT crowdworkers that participated over the course of the 6 months of data collection are aggregated. Most of the workers were located in the United States (93%), with others from the Philippines, Kenya, India, Russia, and Canada. Workers were paid $6-$8 per hour.
 
-### Who are the annotators?
+### Annotations
 
-The annotators of the validation task were a closed set of about 30 trusted crowdworkers on Amazon Mechanical Turk. No demographic information was collected. Annotators were compensated per HIT between $.1 and $.5 with $1 bonuses in cases where annotator labels agreed with the curators' labels for 250 randomly distributed examples.
-
-## Data characteristics
-
-The hypotheses were elicited by presenting crowdworkers with captions from preexisting datasets without the associated photos, but the vocabulary of the hypotheses still reflects the content of the photos as well as the caption style of writing (e.g. mostly present tense). The dataset developers report 37,026 distinct words in the corpus, ignoring case. They allowed bare NPs as well as full sentences. Using the Stanford PCFG Parser 3.5.2 (Klein and Manning, 2003) trained on the standard training set as well as on the Brown Corpus (Francis and Kucera 1979), the authors report that 74% of the premises and 88.9% of the hypotheses result in a parse rooted with an 'S'. The corpus was developed between 2014 and 2015. 
-
-### How was the data collected?
-
-Crowdworkers were presented with a caption without the associated photo and asked to produce three alternate captions, one that is definitely true, one that might be true, and one that is definitely false. See Section 2.1 and Figure 1 for details (Bowman et al., 2015).
-
-The corpus includes content from the [Flickr 30k corpus](http://shannon.cs.illinois.edu/DenotationGraph/) and the [VisualGenome corpus](https://visualgenome.org/). The photo captions used to prompt the data creation were collected on Flickr by [Young et al. (2014)](https://www.aclweb.org/anthology/Q14-1006.pdf), who extended the Flickr 8K dataset developed by [Hodosh et al. (2013)](https://www.jair.org/index.php/jair/article/view/10833). Hodosh et al. collected photos from the following Flickr groups: strangers!, Wild-Child (Kids in Action), Dogs in Action (Read the Rules), Outdoor Activities, Action Photography, Flickr-Social (two or more people in the photo). Young et al. do not list the specific groups they collected photos from. The VisualGenome corpus also contains images from Flickr, originally collected in [MS-COCO](https://cocodataset.org/#home) and [YFCC100M](http://projects.dfki.uni-kl.de/yfcc100m/).
-
-### Normalization information
-
-The premises from the Flickr 30k corpus corrected for spelling using the Linux spell checker and ungrammatical sentences were removed. Bowman et al. do not report any normalization, though they note that punctuation and capitalization are often omitted. 
-
-### Annotation process
+#### Annotation process
 
 56,941 of the total sentence pairs were further annotated in a validation task. Four annotators each labeled a premise-hypothesis pair as entailment, contradiction, or neither, resulting in 5 total judgements including the original hypothesis author judgement. See Section 2.2 for more details (Bowman et al., 2015). 
 
 The authors report 3/5 annotator agreement on 98% of the validation set and unanimous annotator agreement on 58.3% of the validation set. If a label was chosen by three annotators, that label was made the gold label. Following from this, 2% of the data did not have a consensus label and was labeled '-' by the authors. 
 
-Label | Fleiss κ
-------|---------
-_contradiction_ | 0.77
-_entailment_ | 0.72
-_neutral_ | 0.60
-overall | 0.70
+| Label           | Fleiss κ |
+| --------------- |--------- |
+| _contradiction_ | 0.77     |
+| _entailment_    | 0.72     |
+| _neutral_       | 0.60     |
+| overall         | 0.70     |
 
-## Dataset Structure
+#### Who are the annotators?
 
-### Splits, features, and labels
+The annotators of the validation task were a closed set of about 30 trusted crowdworkers on Amazon Mechanical Turk. No demographic information was collected. Annotators were compensated per HIT between $.1 and $.5 with $1 bonuses in cases where annotator labels agreed with the curators' labels for 250 randomly distributed examples.
 
-The SNLI dataset has 3 splits: _train_, _validation_, and _test_. All of the examples in the _validation_ and _test_ sets come from the set that was annotated in the validation task with no-consensus examples removed. The remaining multiply-annotated examples are in the training set with no-consensus examples removed. Each unique premise/caption shows up in only one split, even though they usually appear in at least three different examples.
-Dataset Split | Number of Instances in Split
---------------|--------------------------------------------
-Train | 550,152
-Validation | 10,000
-Test | 10,000
+### Personal and Sensitive Information
 
-Each data instance contains the following features: _premise_, _hypothesis_, _label_.
+The dataset does not contain any personal information about the authors or the crowdworkers, but may contain descriptions of the people in the original Flickr photos. 
 
-Feature | Mean Token Count
---------|-----------------
-Premise | 14.1
-Hypothesis | 8.3
+## Considerations for Using the Data
 
-In the Hugging Face distribution of the dataset, the _label_ has 4 possible values, _0_, _1_, _2_, _-1_.  which correspond to _entailment_, _neutral_, _contradiction_, and _no label_ respectively. The dataset was developed so that the first three values would be evenly distributed across the splits. See the Annotation Process section for details on _no label_.
+### Social Impact of Dataset
 
-### Span indices
+This dataset was developed as a benchmark for evaluating representational systems for text, especially including those induced by representation learning methods, in the task of predicting truth conditions in a given context. (It should be noted that the truth conditions of a hypothesis given a premise does not necessarily match the truth conditions of the hypothesis in the real world.) Systems that are successful at such a task may be more successful in modeling semantic representations. 
 
-No span indices are included in this dataset.
+### Discussion of Biases
 
-### Example ID
+The language reflects the content of the photos collected from Flickr, as described in the [Data Collection](#initial-data-collection-and-normalization) section. [Rudinger et al (2017)](https://www.aclweb.org/anthology/W17-1609.pdf) use pointwise mutual information to calculate a measure of association between a manually selected list of tokens corresponding to identity categories and the other words in the corpus, showing strong evidence of stereotypes across gender categories. They also provide examples in which crowdworkers reproduced harmful stereotypes or pejorative language in the hypotheses. 
 
-The IDs in the original dataset correspond to identifiers from Flickr30k or (the draft version of) VisualGenome, suffixed with an internal identifier, though these IDs are not included in the Hugging Face version of the corpus.
-
-### Free text description for context (e.g. describe difference between title / selftext / body in Reddit data) and example
-
-For each ID, there is a string for the premise, a string for the hypothesis, and an integer for the label. Note that each premise may appear three times with a different hypothesis and label. See the [SNLI corpus viewer](https://huggingface.co/datasets/viewer/?dataset=snli) to explore more examples.
-
-ID | Premise | Hypothesis | Label
----|---------|------------|-------
-0	| Two women are embracing while holding to go packages.	| The sisters are hugging goodbye while holding to go packages after just eating lunch.	| 1
-1	| Two women are embracing while holding to go packages.	| Two woman are holding packages.	| 0
-2	| Two women are embracing while holding to go packages.	| The men are fighting outside a deli. | 2
-
-### Suggested metrics / models:
-
-[SemBERT](https://arxiv.org/pdf/1909.02209.pdf) (Zhousheng Zhang et al, 2019b) is currently listed as SOTA, achieving 91.9% accuracy on the test set. See the [corpus webpage](https://nlp.stanford.edu/projects/snli/) for a list of published results.
-
-## Known Limitations
-### Known social biases
-
-The language reflects the content of the photos collected from Flickr, as described in the Data Collection section. [Rudinger et al (2017)](https://www.aclweb.org/anthology/W17-1609.pdf) use pointwise mutual information to calculate a measure of association between a manually selected list of tokens corresponding to identity categories and the other words in the corpus, showing strong evidence of stereotypes across gender categories. They also provide examples in which crowdworkers reproduced harmful stereotypes or pejorative language in the hypotheses. 
-
-### Other known limitations
+### Other Known Limitations
 
 [Gururangan et al (2018)](https://www.aclweb.org/anthology/N18-2017.pdf), [Poliak et al (2018)](https://www.aclweb.org/anthology/S18-2023.pdf), and [Tsuchiya (2018)](https://www.aclweb.org/anthology/L18-1239.pdf) show that the SNLI corpus has a number of annotation artifacts. Using various classifiers, Poliak et al correctly predicted the label of the hypothesis 69% of the time without using the premise, Gururangan et al 67% of the time, and Tsuchiya 63% of the time.
 
-## Licensing information
+## Additional Information
+
+### Dataset Curators
+
+The SNLI corpus was developed by Samuel R. Bowman, Gabor Angeli, Christopher Potts, and Christopher D. Manning as part of the [Stanford NLP group](https://nlp.stanford.edu/).
+
+It was supported by a Google Faculty Research Award, a gift from Bloomberg L.P., the Defense Advanced Research Projects Agency (DARPA) Deep Exploration and Filtering of Text (DEFT) Program under Air Force Research Laboratory (AFRL) contract no. FA8750-13-2-0040, the National Science Foundation under grant no. IIS 1159679, and the Department of the Navy, Office of Naval Research, under grant no. N00014-10-1-0109.
+
+### Licensing Information
+
 The Stanford Natural Language Inference Corpus is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+
+### Citation Information
+
+```
+@inproceedings{snli:emnlp2015,
+	Author = {Bowman, Samuel R. and Angeli, Gabor and Potts, Christopher, and Manning, Christopher D.},
+	Booktitle = {Proceedings of the 2015 Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+	Publisher = {Association for Computational Linguistics},
+	Title = {A large annotated corpus for learning natural language inference},
+	Year = {2015}
+}
+```
 
 ### Contributions
 
 Thanks to [@mariamabarham](https://github.com/mariamabarham), [@thomwolf](https://github.com/thomwolf), [@lewtun](https://github.com/lewtun), [@patrickvonplaten](https://github.com/patrickvonplaten) for adding this dataset.
+

--- a/datasets/snli/README.md
+++ b/datasets/snli/README.md
@@ -196,5 +196,4 @@ The Stanford Natural Language Inference Corpus is licensed under a [Creative Com
 
 ### Contributions
 
-Thanks to [@mariamabarham](https://github.com/mariamabarham), [@thomwolf](https://github.com/thomwolf), [@lewtun](https://github.com/lewtun), [@patrickvonplaten](https://github.com/patrickvonplaten) for adding this dataset.
-
+Thanks to [@mariamabarham](https://github.com/mariamabarham), [@thomwolf](https://github.com/thomwolf), [@lewtun](https://github.com/lewtun), [@patrickvonplaten](https://github.com/patrickvonplaten) and [@mcmillanmajora](https://github.com/mcmillanmajora) for adding this dataset.


### PR DESCRIPTION
Updated the cards for [Allocine](https://github.com/mcmillanmajora/datasets/tree/updating-old-cards/datasets/allocine), [CNN/DailyMail](https://github.com/mcmillanmajora/datasets/tree/updating-old-cards/datasets/cnn_dailymail), and [SNLI](https://github.com/mcmillanmajora/datasets/tree/updating-old-cards/datasets/snli). For the most part, the information was just rearranged or rephrased, but the social impact statements are new. 