### PR TITLE
[WIP] Adding Support for Reading Pandas Category

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -354,11 +354,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         """
 
         # Step 1: Pre-process pandas dataframe.  a. Convert Category to int.
-        postprocessed_df = df
+        postprocessed_df = df.copy()
         category_values = {}
         for colname in df.select_dtypes(include=["category"]):
             category_values[str(colname)] = postprocessed_df[colname].cat.categories.to_list()
-            postprocessed_df[colname] = postprocessed_df[colname].cat.codes.astype('int64')
+            postprocessed_df[colname] = postprocessed_df[colname].cat.codes.astype("int64")
 
         # Step 2: Generate the pyarrow table, providing features if they were provided by caller.
         if info is not None and features is not None and info.features != features:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -41,7 +41,7 @@ from tqdm.auto import tqdm
 from . import config
 from .arrow_reader import ArrowReader
 from .arrow_writer import ArrowWriter, TypedSequence
-from .features import Features, Value, cast_to_python_objects, ClassLabel
+from .features import ClassLabel, Features, Value, cast_to_python_objects
 from .filesystems import extract_path_from_uri, is_remote_filesystem
 from .fingerprint import (
     fingerprint_transform,
@@ -376,6 +376,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             features = Features.from_arrow_schema(pa_table.schema)
             for colname, labels in category_values.items():
                 features[colname] = ClassLabel(names=labels)
+            pa_table = pa_table.cast(pa.schema(features.type))
         if info is None:
             info = DatasetInfo()
         info.features = features

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -358,7 +358,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         category_values = {}
         for colname in df.select_dtypes(include=["category"]):
             category_values[str(colname)] = postprocessed_df[colname].cat.categories.to_list()
-            postprocessed_df[colname] = postprocessed_df[colname].cat.codes
+            postprocessed_df[colname] = postprocessed_df[colname].cat.codes.astype('int64')
 
         # Step 2: Generate the pyarrow table, providing features if they were provided by caller.
         if info is not None and features is not None and info.features != features:
@@ -376,7 +376,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             features = Features.from_arrow_schema(pa_table.schema)
             for colname, labels in category_values.items():
                 features[colname] = ClassLabel(names=labels)
-            pa_table = pa_table.cast(pa.schema(features.type))
         if info is None:
             info = DatasetInfo()
         info.features = features

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -929,10 +929,7 @@ def generate_from_arrow_type(pa_type: pa.DataType) -> FeatureType:
         array_feature = [None, None, Array2D, Array3D, Array4D, Array5D][pa_type.ndims]
         return array_feature(shape=pa_type.shape, dtype=pa_type.value_type)
     elif isinstance(pa_type, pa.DictionaryType):
-        if pyarrow.types.is_integer(pa_type.index_type) and pyarrow.types.is_string(pa_type.value_type):
-            return ClassLabel()
-        else:
-            raise NotImplementedError  # ClassLabel requires the dictionary data values, not just the pyarrow type.
+        raise NotImplementedError  # ClassLabel requires label names, which aren't present on pa.DictionaryType
     elif isinstance(pa_type, pa.DataType):
         return Value(dtype=_arrow_to_datasets_dtype(pa_type))
     else:

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -929,7 +929,10 @@ def generate_from_arrow_type(pa_type: pa.DataType) -> FeatureType:
         array_feature = [None, None, Array2D, Array3D, Array4D, Array5D][pa_type.ndims]
         return array_feature(shape=pa_type.shape, dtype=pa_type.value_type)
     elif isinstance(pa_type, pa.DictionaryType):
-        raise NotImplementedError  # TODO(thom) this will need access to the dictionary as well (for labels). I.e. to the py_table
+        if pyarrow.types.is_integer(pa_type.index_type) and pyarrow.types.is_string(pa_type.value_type):
+            return ClassLabel()
+        else:
+            raise NotImplementedError  # ClassLabel requires the dictionary data values, not just the pyarrow type.
     elif isinstance(pa_type, pa.DataType):
         return Value(dtype=_arrow_to_datasets_dtype(pa_type))
     else:


### PR DESCRIPTION
@lhoestq - continuing our conversation from https://github.com/huggingface/datasets/issues/1906#issuecomment-784247014

The goal of this PR is to support `Dataset.from_pandas(df)` where the dataframe contains a Category.

Just the 4 line change below actually does seem to work:

```
>>> from datasets import Dataset
>>> import pandas as pd
>>> df = pd.DataFrame(pd.Series(["a", "b", "c", "a"], dtype="category"))
>>> ds = Dataset.from_pandas(df)
>>> ds.to_pandas()
   0
0  a
1  b
2  c
3  a
>>> ds.to_pandas().dtypes
0    category
dtype: object
```

save_to_disk, etc. all seem to work as well.  The main things that are theoretically "incorrect" if we leave this are:

```
>>> ds.features.type
StructType(struct<0: int64>)
```
there are a decent number of references to this property in the library, but I can't find anything that seems to actually break as a result of this being int64 vs. dictionary?  I think the gist of my question is: a) do we *need* to change the dtype of Classlabel and have get_nested_type return a pyarrow.DictionaryType instead of int64? and b) do you *want* it to change?  The biggest challenge I see to implementing this correctly is that the data will need to be passed in along with the pyarrow schema when instantiating the Classlabel (I *think* this is unavoidable, since the type itself doesn't contain the actual label values) which could be a fairly intrusive change - e.g. `from_arrow_schema`'s interface would need to change to include optional arrow data?  Once we start going down this path of modifying the public interfaces I am admittedly feeling a little bit outside of my comfort zone

Additionally I think `int2str`, `str2int`, and `encode_example` probably won't work - but I can't find any usages of them in the library itself.