### PR TITLE
Update documentation with not in place transforms and update DatasetDict

### DIFF
--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -16,8 +16,9 @@ The base class :class:`datasets.Dataset` implements a Dataset backed by an Apach
 .. autoclass:: datasets.Dataset
     :members: from_file, from_buffer, from_pandas, from_dict,
         data, cache_files, num_columns, num_rows, column_names, shape,
-        unique, flatten_,
-        cast_, remove_columns_, rename_column_,
+        unique,
+        flatten_, cast_, remove_columns_, rename_column_,
+        flatten, cast, remove_columns, rename_column,
         __len__, __iter__, formatted_as, set_format, set_transform, reset_format, with_format, with_transform,
         __getitem__, cleanup_cache_files,
         map, filter, select, sort, shuffle, train_test_split, shard, export,
@@ -43,10 +44,11 @@ It also has dataset transform methods like map or filter, to process all the spl
 
 .. autoclass:: datasets.DatasetDict
     :members: data, cache_files, num_columns, num_rows, column_names, shape,
-        unique, flatten_,
+        unique,
         cleanup_cache_files,
         map, filter, sort, shuffle, set_format, reset_format, formatted_as, with_format, with_transform,
-        cast_, remove_columns_, rename_column_,
+        flatten_, cast_, remove_columns_, rename_column_,
+        flatten, cast, remove_columns, rename_column,
         save_to_disk, load_from_disk,
 
 

--- a/docs/source/processing.rst
+++ b/docs/source/processing.rst
@@ -134,6 +134,111 @@ The :func:`datasets.Dataset.shard` takes as arguments the total number of shards
 
 This method can be used to slice a very large dataset in a predefined number of chunks.
 
+
+Renaming, removing, casting and flattening columns
+--------------------------------------------------
+
+Renaming a column: ``rename_column``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This method renames a column in the dataset, and move the features associated to the original column under the new column name.
+
+:func:`datasets.Dataset.rename_column` takes the name of the original column and the new name as arguments.
+
+.. code-block::
+
+    >>> dataset = dataset.rename_column("sentence1", "sentenceA")
+    >>> dataset = dataset.rename_column("sentence2", "sentenceB")
+    >>> dataset
+    Dataset({
+        features: ['sentenceA', 'sentenceB', 'label', 'idx'],
+        num_rows: 3668
+    })
+
+
+Removing one or several columns: ``remove_columns``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It allows to remove one or several column(s) in the dataset and the features associated to them.
+
+You can also remove a column using :func:`Dataset.map` with `remove_columns` but the present method
+is in-place (doesn't copy the data to a new dataset) and is thus faster.
+
+:func:`datasets.Dataset.remove_columns` takes the names of the column to remove as argument.
+You can provide one single column names or a list of column names.
+
+.. code-block::
+
+    >>> dataset = dataset.remove_columns("label")
+    >>> dataset
+    Dataset({
+        features: ['sentence1', 'sentence2', 'idx'],
+        num_rows: 3668
+    })
+    >>> dataset = dataset.remove_columns(['sentence1', 'sentence2'])
+    >>> dataset
+    Dataset({
+        features: ['idx'],
+        num_rows: 3668
+    })
+
+Casting the dataset to a new set of features types: ``cast``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This method is used to cast the dataset to a new set of features.
+You can change the feature type of one or several columns.
+
+For the dataset casting to work, the original features type and the new feature types must be compatible for casting one to the other.
+For example you can cast a column with the feature type ``Value("int32")`` to ``Value("bool")`` only if it only contains ones and zeros.
+In general, you can only cast a column to a new type if pyarrow allows to cast between the underlying pyarrow data types.
+
+:func:`datasets.Dataset.cast` takes the new :obj:`datasets.Features` definition as argument.
+
+In this example, we change the :obj:`datasets.ClassLabel` label names, and we also change the ``idx`` from ``int32`` to ``int64``:
+
+.. code-block::
+
+    >>> dataset.features
+    {'sentence1': Value(dtype='string', id=None),
+    'sentence2': Value(dtype='string', id=None),
+    'label': ClassLabel(num_classes=2, names=['not_equivalent', 'equivalent'], names_file=None, id=None),
+    'idx': Value(dtype='int32', id=None)}
+    >>> from datasets import ClassLabel, Value
+    >>> new_features = dataset.features.copy()
+    >>> new_features["label"] = ClassLabel(names=['negative', 'positive'])
+    >>> new_features["idx"] = Value('int64')
+    >>> dataset = dataset.cast(new_features)
+    >>> dataset.features
+    {'sentence1': Value(dtype='string', id=None),
+    'sentence2': Value(dtype='string', id=None),
+    'label': ClassLabel(num_classes=2, names=['negative', 'positive'], names_file=None, id=None),
+    'idx': Value(dtype='int64', id=None)}
+
+
+Flattening columns: ``flatten``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A column type can be a nested struct of several types.
+For example a column "answers" may have two subfields "answer_start" and "text".
+In this case if you want each of the two subfields to be actual columns, you can use :func:`datasets.Dataset.flatten`:
+
+.. code-block::
+
+    >>> squad = load_dataset("squad", split="train")
+    >>> squad
+    Dataset({
+        features: ['id', 'title', 'context', 'question', 'answers'],
+        num_rows: 87599
+    })
+    >>> flattened_squad = squad.flatten()
+    >>> flattened_squad
+    Dataset({
+        features: ['answers.answer_start', 'answers.text', 'context', 'id', 'question', 'title'],
+        num_rows: 87599
+    })
+
+
+
 Processing data with ``map``
 --------------------------------
 
@@ -463,7 +568,7 @@ When you have several :obj:`datasets.Dataset` objects that share the same column
     >>>
     >>> bookcorpus = load_dataset("bookcorpus", split="train")
     >>> wiki = load_dataset("wikipedia", "20200501.en", split="train")
-    >>> wiki.remove_columns_("title")  # only keep the text
+    >>> wiki = wiki.remove_columns("title")  # only keep the text
     >>>
     >>> assert bookcorpus.features.type == wiki.features.type
     >>> bert_dataset = concatenate_datasets([bookcorpus, wiki])

--- a/docs/source/processing.rst
+++ b/docs/source/processing.rst
@@ -141,7 +141,7 @@ Renaming, removing, casting and flattening columns
 Renaming a column: ``rename_column``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This method renames a column in the dataset, and move the features associated to the original column under the new column name.
+This method renames a column in the dataset, and move the features associated to the original column under the new column name. This operation will fail if the new column name already exists.
 
 :func:`datasets.Dataset.rename_column` takes the name of the original column and the new name as arguments.
 
@@ -162,7 +162,7 @@ Removing one or several columns: ``remove_columns``
 It allows to remove one or several column(s) in the dataset and the features associated to them.
 
 You can also remove a column using :func:`Dataset.map` with `remove_columns` but the present method
-is in-place (doesn't copy the data to a new dataset) and is thus faster.
+doesn't copy the data to a new dataset object and is thus faster.
 
 :func:`datasets.Dataset.remove_columns` takes the names of the column to remove as argument.
 You can provide one single column names or a list of column names.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -85,7 +85,7 @@ class DatasetInfoMixin(object):
     @property
     def info(self):
         """ :class:`datasets.DatasetInfo` object containing all the metadata in the dataset."""
-        return self._info.copy()
+        return self._info
 
     @property
     def split(self):
@@ -122,7 +122,7 @@ class DatasetInfoMixin(object):
 
     @property
     def features(self) -> Features:
-        return self._info.features.copy()
+        return self._info.features
 
     @property
     def homepage(self) -> Optional[str]:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -85,7 +85,7 @@ class DatasetInfoMixin(object):
     @property
     def info(self):
         """ :class:`datasets.DatasetInfo` object containing all the metadata in the dataset."""
-        return self._info
+        return self._info.copy()
 
     @property
     def split(self):
@@ -122,7 +122,7 @@ class DatasetInfoMixin(object):
 
     @property
     def features(self) -> Features:
-        return self._info.features
+        return self._info.features.copy()
 
     @property
     def homepage(self) -> Optional[str]:
@@ -676,7 +676,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
     @replayable_table_alteration
     @fingerprint_transform(inplace=True)
     def flatten_(self, max_depth=16):
-        """In-place version of :func:`Dataset.flatten`"""
+        """
+        In-place version of :func:`Dataset.flatten`
+        This method is deprecated, please use :func:`Dataset.flatten` instead.
+        """
         for depth in range(1, max_depth):
             if any(isinstance(field.type, pa.StructType) for field in self._data.schema):
                 self._data = self._data.flatten()
@@ -718,6 +721,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
     def cast_(self, features: Features):
         """
         In-place version of :func:`Dataset.cast`
+        This method is deprecated, please use :func:`Dataset.cast` instead.
 
         Args:
             features (:class:`datasets.Features`): New features to cast the dataset to.
@@ -741,9 +745,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
     def cast(self, features: Features, new_fingerprint) -> "Dataset":
         """
         Cast the dataset to a new set of features.
-
-        You can also remove a column using :func:`Dataset.map` with `feature` but :func:`cast_`
-        is in-place (doesn't copy the data to a new dataset) and is thus faster.
 
         Args:
             features (:class:`datasets.Features`): New features to cast the dataset to.
@@ -774,6 +775,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
     def remove_columns_(self, column_names: Union[str, List[str]]):
         """
         In-place version of :func:`Dataset.remove_columns`
+        This method is deprecated, please use :func:`Dataset.remove_columns` instead.
 
         Args:
             column_names (:obj:`Union[str, List[str]]`): Name of the column(s) to remove.
@@ -833,6 +835,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
     def rename_column_(self, original_column_name: str, new_column_name: str):
         """
         In-place version of :func:`Dataset.rename_column`
+        This method is deprecated, please use :func:`Dataset.rename_column` instead.
 
         Args:
             original_column_name (:obj:`str`): Name of the column to rename.
@@ -864,10 +867,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
     def rename_column(self, original_column_name: str, new_column_name: str, new_fingerprint) -> "Dataset":
         """
         Rename a column in the dataset, and move the features associated to the original column under the new column name.
-
-        You can also rename a column using :func:`Dataset.map` with `remove_columns` but the present method:
-            - takes care of moving the original features under the new column name.
-            - doesn't copy the data to a new dataset and is thus much faster.
 
         Args:
             original_column_name (:obj:`str`): Name of the column to rename.

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -76,13 +76,21 @@ class DatasetDict(dict):
             dataset.dictionary_encode_column_(column=column)
 
     def flatten_(self, max_depth=16):
+        """
+        In-place version of :func:`Dataset.flatten`
+        This method is deprecated, please use :func:`DatasetDict.flatten` instead.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.flatten_(max_depth=max_depth)
+
+    def flatten(self, max_depth=16):
         """Flatten the Apache Arrow Table of each split (nested features are flatten).
         Each column with a struct type is flattened into one column per struct field.
         Other columns are left unchanged.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.flatten_(max_depth=max_depth)
+        return DatasetDict({k: dataset.flatten(max_depth=max_depth) for k, dataset in self.items()})
 
     def unique(self, column: str) -> Dict[str, List[Any]]:
         """Return a list of the unique elements in a column for each split.
@@ -116,6 +124,21 @@ class DatasetDict(dict):
 
     def cast_(self, features: Features):
         """
+        In-place version of :func:`DatasetDict.cast`
+        This method is deprecated, please use :func:`DatasetDict.cast` instead.
+
+        Args:
+            features (:class:`datasets.Features`): New features to cast the dataset to.
+                The name and order of the fields in the features must match the current column names.
+                The type of the data must also be convertible from one type to the other.
+                For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.cast_(features=features)
+
+    def cast(self, features: Features):
+        """
         Cast the dataset to a new set of features.
         The transformation is applied to all the datasets of the dataset dictionary.
 
@@ -129,10 +152,21 @@ class DatasetDict(dict):
                 For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.cast_(features=features)
+        return DatasetDict({k: dataset.cast(features=features) for k, dataset in self.items()})
 
     def remove_columns_(self, column_names: Union[str, List[str]]):
+        """
+        In-place version of :func:`DatasetDict.remove_columns`
+        This method is deprecated, please use :func:`DatasetDict.remove_columns` instead.
+
+        Args:
+            column_names (:obj:`Union[str, List[str]]`): Name of the column(s) to remove.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.remove_columns_(column_names=column_names)
+
+    def remove_columns(self, column_names: Union[str, List[str]]):
         """
         Remove one or several column(s) from each split in the dataset
         and the features associated to the column(s).
@@ -146,10 +180,22 @@ class DatasetDict(dict):
             column_names (:obj:`Union[str, List[str]]`): Name of the column(s) to remove.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.remove_columns_(column_names=column_names)
+        return DatasetDict({k: dataset.remove_columns(column_names=column_names) for k, dataset in self.items()})
 
     def rename_column_(self, original_column_name: str, new_column_name: str):
+        """
+        In-place version of :func:`DatasetDict.rename_column_`
+        This method is deprecated, please use :func:`DatasetDict.rename_column` instead.
+
+        Args:
+            original_column_name (:obj:`str`): Name of the column to rename.
+            new_column_name (:obj:`str`): New name for the column.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.rename_column_(original_column_name=original_column_name, new_column_name=new_column_name)
+
+    def rename_column(self, original_column_name: str, new_column_name: str):
         """
         Rename a column in the dataset and move the features associated to the original column under the new column name.
         The transformation is applied to all the datasets of the dataset dictionary.
@@ -163,8 +209,12 @@ class DatasetDict(dict):
             new_column_name (:obj:`str`): New name for the column.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.rename_column_(original_column_name=original_column_name, new_column_name=new_column_name)
+        return DatasetDict(
+            {
+                k: dataset.rename_column(original_column_name=original_column_name, new_column_name=new_column_name)
+                for k, dataset in self.items()
+            }
+        )
 
     @contextlib.contextmanager
     def formatted_as(

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 from .arrow_dataset import Dataset
 from .features import Features
 from .filesystems import extract_path_from_uri, is_remote_filesystem
+from .utils.deprecation_utils import deprecated
 
 
 class DatasetDict(dict):
@@ -136,8 +137,8 @@ class DatasetDict(dict):
                 For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.cast_(features=features)
+        new_dataset_dict = {k: dataset.cast(features=features) for k, dataset in self.items()}
+        self.update(new_dataset_dict)
 
     def cast(self, features: Features):
         """
@@ -166,8 +167,8 @@ class DatasetDict(dict):
             column_names (:obj:`Union[str, List[str]]`): Name of the column(s) to remove.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.remove_columns_(column_names=column_names)
+        new_dataset_dict = {k: dataset.remove_columns(column_names=column_names) for k, dataset in self.items()}
+        self.update(new_dataset_dict)
 
     def remove_columns(self, column_names: Union[str, List[str]]):
         """
@@ -196,8 +197,11 @@ class DatasetDict(dict):
             new_column_name (:obj:`str`): New name for the column.
         """
         self._check_values_type()
-        for dataset in self.values():
-            dataset.rename_column_(original_column_name=original_column_name, new_column_name=new_column_name)
+        new_dataset_dict = {
+            k: dataset.rename_column(original_column_name=original_column_name, new_column_name=new_column_name)
+            for k, dataset in self.items()
+        }
+        self.update(new_dataset_dict)
 
     def rename_column(self, original_column_name: str, new_column_name: str):
         """

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -75,9 +75,10 @@ class DatasetDict(dict):
         for dataset in self.values():
             dataset.dictionary_encode_column_(column=column)
 
+    @deprecated(help_message="Please use :func:`DatasetDict.flatten` instead.")
     def flatten_(self, max_depth=16):
         """
-        In-place version of :func:`Dataset.flatten`
+        In-place version of :func:`DatasetDict.flatten`
         This method is deprecated, please use :func:`DatasetDict.flatten` instead.
         """
         self._check_values_type()
@@ -122,6 +123,7 @@ class DatasetDict(dict):
         repr = re.sub(r"^", " " * 4, repr, 0, re.M)
         return f"DatasetDict({{\n{repr}\n}})"
 
+    @deprecated(help_message="Please use :func:`DatasetDict.cast` instead.")
     def cast_(self, features: Features):
         """
         In-place version of :func:`DatasetDict.cast`
@@ -154,6 +156,7 @@ class DatasetDict(dict):
         self._check_values_type()
         return DatasetDict({k: dataset.cast(features=features) for k, dataset in self.items()})
 
+    @deprecated(help_message="Please use :func:`DatasetDict.remove_columns` instead.")
     def remove_columns_(self, column_names: Union[str, List[str]]):
         """
         In-place version of :func:`DatasetDict.remove_columns`
@@ -182,6 +185,7 @@ class DatasetDict(dict):
         self._check_values_type()
         return DatasetDict({k: dataset.remove_columns(column_names=column_names) for k, dataset in self.items()})
 
+    @deprecated(help_message="Please use :func:`DatasetDict.rename_column` instead.")
     def rename_column_(self, original_column_name: str, new_column_name: str):
         """
         In-place version of :func:`DatasetDict.rename_column_`

--- a/src/datasets/utils/deprecation_utils.py
+++ b/src/datasets/utils/deprecation_utils.py
@@ -21,7 +21,7 @@ def deprecated(help_message: Optional[str] = None):
         warning_msg = (
             (
                 f"{deprecated_function.__name__} is deprecated and will be removed "
-                "in the next major version of datasets."
+                "in the next major version of datasets. "
             )
             + help_message
             if help_message

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -34,13 +34,27 @@ class DatasetDictTest(TestCase):
             }
         )
 
-    def test_flatten(self):
+    def test_flatten_in_place(self):
         dset_split = Dataset.from_dict(
             {"a": [{"b": {"c": ["text"]}}] * 10, "foo": [1] * 10},
             features=Features({"a": {"b": Sequence({"c": Value("string")})}, "foo": Value("int64")}),
         )
         dset = DatasetDict({"train": dset_split, "test": dset_split})
         dset.flatten_()
+        self.assertDictEqual(dset.column_names, {"train": ["a.b.c", "foo"], "test": ["a.b.c", "foo"]})
+        self.assertListEqual(list(dset["train"].features.keys()), ["a.b.c", "foo"])
+        self.assertDictEqual(
+            dset["train"].features, Features({"a.b.c": Sequence(Value("string")), "foo": Value("int64")})
+        )
+        del dset
+
+    def test_flatten(self):
+        dset_split = Dataset.from_dict(
+            {"a": [{"b": {"c": ["text"]}}] * 10, "foo": [1] * 10},
+            features=Features({"a": {"b": Sequence({"c": Value("string")})}, "foo": Value("int64")}),
+        )
+        dset = DatasetDict({"train": dset_split, "test": dset_split})
+        dset = dset.flatten()
         self.assertDictEqual(dset.column_names, {"train": ["a.b.c", "foo"], "test": ["a.b.c", "foo"]})
         self.assertListEqual(list(dset["train"].features.keys()), ["a.b.c", "foo"])
         self.assertDictEqual(
@@ -188,7 +202,7 @@ class DatasetDictTest(TestCase):
             self.assertDictEqual(dset_split.format, dset_split2.format)
         del dset, dset2
 
-    def test_cast_(self):
+    def test_cast_in_place(self):
         dset = self._create_dummy_dataset_dict(multiple_columns=True)
         features = dset["train"].features
         features["col_1"] = Value("float64")
@@ -199,7 +213,18 @@ class DatasetDictTest(TestCase):
             self.assertIsInstance(dset_split[0]["col_1"], float)
         del dset
 
-    def test_remove_columns_(self):
+    def test_cast(self):
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        features = dset["train"].features
+        features["col_1"] = Value("float64")
+        dset = dset.cast(features)
+        for dset_split in dset.values():
+            self.assertEqual(dset_split.num_columns, 2)
+            self.assertEqual(dset_split.features["col_1"], Value("float64"))
+            self.assertIsInstance(dset_split[0]["col_1"], float)
+        del dset
+
+    def test_remove_columns_in_place(self):
         dset = self._create_dummy_dataset_dict(multiple_columns=True)
         dset.remove_columns_(column_names="col_1")
         for dset_split in dset.values():
@@ -212,9 +237,30 @@ class DatasetDictTest(TestCase):
             self.assertEqual(dset_split.num_columns, 0)
         del dset
 
-    def test_rename_column_(self):
+    def test_remove_columns(self):
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset = dset.remove_columns(column_names="col_1")
+        for dset_split in dset.values():
+            self.assertEqual(dset_split.num_columns, 1)
+            self.assertListEqual(list(dset_split.column_names), ["col_2"])
+
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset = dset.remove_columns(column_names=["col_1", "col_2"])
+        for dset_split in dset.values():
+            self.assertEqual(dset_split.num_columns, 0)
+        del dset
+
+    def test_rename_column_in_place(self):
         dset = self._create_dummy_dataset_dict(multiple_columns=True)
         dset.rename_column_(original_column_name="col_1", new_column_name="new_name")
+        for dset_split in dset.values():
+            self.assertEqual(dset_split.num_columns, 2)
+            self.assertListEqual(list(dset_split.column_names), ["new_name", "col_2"])
+        del dset
+
+    def test_rename_column(self):
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset = dset.rename_column(original_column_name="col_1", new_column_name="new_name")
         for dset_split in dset.values():
             self.assertEqual(dset_split.num_columns, 2)
             self.assertListEqual(list(dset_split.column_names), ["new_name", "col_2"])


### PR DESCRIPTION
In #1883 were added the not in-place transforms `flatten`, `remove_columns`, `rename_column` and `cast`.

I added them to the documentation and added a paragraph on how to use them

You can preview the documentation [here](https://28862-250213286-gh.circle-artifacts.com/0/docs/_build/html/processing.html#renaming-removing-casting-and-flattening-columns)

I also added these methods to the DatasetDict class.