### PR TITLE
Handle timeouts

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -281,9 +281,10 @@ class PackagedDatasetTest(parameterized.TestCase):
         self.dataset_tester = DatasetTester(self)
 
     def test_load_dataset_offline(self, dataset_name):
-        with offline():
-            configs = self.dataset_tester.load_all_configs(dataset_name)[:1]
-            self.dataset_tester.check_load_dataset(dataset_name, configs, use_local_dummy_data=True)
+        for connection_times_out in (False, True):
+            with offline(connection_times_out=connection_times_out):
+                configs = self.dataset_tester.load_all_configs(dataset_name)[:1]
+                self.dataset_tester.check_load_dataset(dataset_name, configs, use_local_dummy_data=True)
 
     def test_builder_class(self, dataset_name):
         builder_cls = self.dataset_tester.load_builder_class(dataset_name)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -113,11 +113,12 @@ class LoadTest(TestCase):
             self.assertEqual(dummy_module.MY_DUMMY_VARIABLE, "general kenobi")
             self.assertEqual(module_hash, sha256(dummy_code.encode("utf-8")).hexdigest())
             # missing module
-            with offline():
-                with self.assertRaises((FileNotFoundError, ConnectionError, requests.exceptions.ConnectionError)):
-                    datasets.load.prepare_module(
-                        "__missing_dummy_module_name__", dynamic_modules_path=self.dynamic_modules_path
-                    )
+            for connection_times_out in (False, True):
+                with offline(connection_times_out=connection_times_out):
+                    with self.assertRaises((FileNotFoundError, ConnectionError, requests.exceptions.ConnectionError)):
+                        datasets.load.prepare_module(
+                            "__missing_dummy_module_name__", dynamic_modules_path=self.dynamic_modules_path
+                        )
 
     def test_offline_prepare_module(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -132,16 +133,17 @@ class LoadTest(TestCase):
             importable_module_path2, _ = datasets.load.prepare_module(
                 module_dir, dynamic_modules_path=self.dynamic_modules_path
             )
-        with offline():
-            self._caplog.clear()
-            # allow provide the module name without an explicit path to remote or local actual file
-            importable_module_path3, _ = datasets.load.prepare_module(
-                "__dummy_module_name2__", dynamic_modules_path=self.dynamic_modules_path
-            )
-            # it loads the most recent version of the module
-            self.assertEqual(importable_module_path2, importable_module_path3)
-            self.assertNotEqual(importable_module_path1, importable_module_path3)
-            self.assertIn("Using the latest cached version of the module", self._caplog.text)
+        for connection_times_out in (False, True):
+            with offline(connection_times_out=connection_times_out):
+                self._caplog.clear()
+                # allow provide the module name without an explicit path to remote or local actual file
+                importable_module_path3, _ = datasets.load.prepare_module(
+                    "__dummy_module_name2__", dynamic_modules_path=self.dynamic_modules_path
+                )
+                # it loads the most recent version of the module
+                self.assertEqual(importable_module_path2, importable_module_path3)
+                self.assertNotEqual(importable_module_path1, importable_module_path3)
+                self.assertIn("Using the latest cached version of the module", self._caplog.text)
 
     def test_load_dataset_canonical(self):
         with self.assertRaises(FileNotFoundError) as context:
@@ -156,13 +158,14 @@ class LoadTest(TestCase):
             "https://raw.githubusercontent.com/huggingface/datasets/0.0.0/datasets/_dummy/_dummy.py",
             str(context.exception),
         )
-        with offline():
-            with self.assertRaises(ConnectionError) as context:
-                datasets.load_dataset("_dummy")
-            self.assertIn(
-                "https://raw.githubusercontent.com/huggingface/datasets/master/datasets/_dummy/_dummy.py",
-                str(context.exception),
-            )
+        for connection_times_out in (False, True):
+            with offline(connection_times_out=connection_times_out):
+                with self.assertRaises(ConnectionError) as context:
+                    datasets.load_dataset("_dummy")
+                self.assertIn(
+                    "https://raw.githubusercontent.com/huggingface/datasets/master/datasets/_dummy/_dummy.py",
+                    str(context.exception),
+                )
 
     def test_load_dataset_users(self):
         with self.assertRaises(FileNotFoundError) as context:
@@ -171,13 +174,14 @@ class LoadTest(TestCase):
             "https://huggingface.co/datasets/lhoestq/_dummy/resolve/main/_dummy.py",
             str(context.exception),
         )
-        with offline():
-            with self.assertRaises(ConnectionError) as context:
-                datasets.load_dataset("lhoestq/_dummy")
-            self.assertIn(
-                "https://huggingface.co/datasets/lhoestq/_dummy/resolve/main/_dummy.py",
-                str(context.exception),
-            )
+        for connection_times_out in (False, True):
+            with offline(connection_times_out=connection_times_out):
+                with self.assertRaises(ConnectionError) as context:
+                    datasets.load_dataset("lhoestq/_dummy")
+                self.assertIn(
+                    "https://huggingface.co/datasets/lhoestq/_dummy/resolve/main/_dummy.py",
+                    str(context.exception),
+                )
 
 
 @pytest.mark.parametrize("keep_in_memory", [False, True])
@@ -187,12 +191,13 @@ def test_load_dataset_local(dataset_loading_script_dir, data_dir, keep_in_memory
     increased_allocated_memory = (pa.total_allocated_bytes() - previous_allocated_memory) > 0
     assert len(dataset) == 2
     assert increased_allocated_memory == keep_in_memory
-    with offline():
-        caplog.clear()
-        # Load dataset from cache
-        dataset = datasets.load_dataset(DATASET_LOADING_SCRIPT_NAME, data_dir=data_dir)
-        assert len(dataset) == 2
-        assert "Using the latest cached version of the module" in caplog.text
+    for connection_times_out in (False, True):
+        with offline(connection_times_out=connection_times_out):
+            caplog.clear()
+            # Load dataset from cache
+            dataset = datasets.load_dataset(DATASET_LOADING_SCRIPT_NAME, data_dir=data_dir)
+            assert len(dataset) == 2
+            assert "Using the latest cached version of the module" in caplog.text
     with pytest.raises(FileNotFoundError) as exc_info:
         datasets.load_dataset("_dummy")
     assert "at " + os.path.join("_dummy", "_dummy.py") in str(exc_info.value)

--- a/tests/test_offline_util.py
+++ b/tests/test_offline_util.py
@@ -1,0 +1,18 @@
+import pytest
+import requests
+
+from .utils import RequestWouldHangIndefinitlyError, offline
+
+
+def test_offline_with_timeout():
+    with offline(connection_times_out=True):
+        with pytest.raises(RequestWouldHangIndefinitlyError):
+            requests.request("GET", "https://huggingface.co")
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            requests.request("GET", "https://huggingface.co", timeout=1.0)
+
+
+def test_offline_with_connection_error():
+    with offline(connection_times_out=False):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            requests.request("GET", "https://huggingface.co")

--- a/tests/test_offline_util.py
+++ b/tests/test_offline_util.py
@@ -1,12 +1,12 @@
 import pytest
 import requests
 
-from .utils import RequestWouldHangIndefinitlyError, offline
+from .utils import RequestWouldHangIndefinitelyError, offline
 
 
 def test_offline_with_timeout():
     with offline(connection_times_out=True):
-        with pytest.raises(RequestWouldHangIndefinitlyError):
+        with pytest.raises(RequestWouldHangIndefinitelyError):
             requests.request("GET", "https://huggingface.co")
         with pytest.raises(requests.exceptions.ConnectTimeout):
             requests.request("GET", "https://huggingface.co", timeout=1.0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import unittest
 from contextlib import contextmanager
 from distutils.util import strtobool
 from pathlib import Path
+from unittest.mock import patch
 
 from datasets import config
 
@@ -184,22 +185,55 @@ def for_all_test_methods(*decorators):
     return decorate
 
 
+class RequestWouldHangIndefinitlyError(Exception):
+    pass
+
+
 @contextmanager
-def offline(exception_cls=None):
-    """inspired from https://stackoverflow.com/a/18601897"""
+def offline(connection_times_out=False, timeout=1e-16):
+    """
+    Simulate offline mode.
+
+    By default a ConnectionError is raised for each network call.
+    With connection_times_out=True on the other hand, the connection hangs until it times out.
+    The default timeout value is low (1e-16) to speed up the tests.
+
+    Connection errors are created by mocking socket.socket,
+    while the timeout errors are created by mocking requests.request.
+    """
     import socket
 
-    online_socket = socket.socket
+    from requests import request as online_request
 
-    def guard(*args, **kwargs):
-        error = exception_cls if exception_cls is not None else socket.error
-        raise error("Offline mode is enabled.")
+    def timeout_request(method, url, **kwargs):
+        # Change the url to an invalid url so that the connection hangs
+        invalid_url = "https://10.255.255.1"
+        if kwargs.get("timeout") is None:
+            raise RequestWouldHangIndefinitlyError(
+                f"Tried a call to {url} in offline mode with no timeout set. Please set a timeout."
+            )
+        kwargs["timeout"] = timeout
+        try:
+            return online_request(method, invalid_url, **kwargs)
+        except Exception as e:
+            # The following changes in the error are just here to make the offline timeout error prettier
+            e.request.url = url
+            max_retry_error = e.args[0]
+            max_retry_error.args = (max_retry_error.args[0].replace("10.255.255.1", f"OfflineMock[{url}]"),)
+            e.args = (max_retry_error,)
+            raise
 
-    try:
-        socket.socket = guard
-        yield
-    finally:
-        socket.socket = online_socket
+    def offline_socket(*args, **kwargs):
+        raise socket.error("Offline mode is enabled.")
+
+    if connection_times_out:
+        # inspired from https://stackoverflow.com/a/904609
+        with patch("requests.request", timeout_request):
+            yield
+    else:
+        # inspired from https://stackoverflow.com/a/18601897
+        with patch("socket.socket", offline_socket):
+            yield
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -185,7 +185,7 @@ def for_all_test_methods(*decorators):
     return decorate
 
 
-class RequestWouldHangIndefinitlyError(Exception):
+class RequestWouldHangIndefinitelyError(Exception):
     pass
 
 
@@ -209,7 +209,7 @@ def offline(connection_times_out=False, timeout=1e-16):
         # Change the url to an invalid url so that the connection hangs
         invalid_url = "https://10.255.255.1"
         if kwargs.get("timeout") is None:
-            raise RequestWouldHangIndefinitlyError(
+            raise RequestWouldHangIndefinitelyError(
                 f"Tried a call to {url} in offline mode with no timeout set. Please set a timeout."
             )
         kwargs["timeout"] = timeout


### PR DESCRIPTION
As noticed in https://github.com/huggingface/datasets/issues/1939, timeouts were not properly handled when loading a dataset.
This caused the connection to hang indefinitely when working in a firewalled environment cc @stas00 

I added a default timeout, and included an option to our offline environment for tests to be able to simulate both connection errors and timeout errors (previously it was simulating connection errors only).

Now networks calls don't hang indefinitely.
The default timeout is set to 10sec (we might reduce it).