### PR TITLE
Allow stateful function in dataset.map

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1483,7 +1483,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 info.features = features
                 return Dataset.from_file(cache_file_name, info=info, split=self.split)
 
-        # We set this variable to True After processing the first example/batch in
+        # We set this variable to True after processing the first example/batch in
         # `apply_function_on_filtered_inputs` if the map function returns a dict.
         # If set to False, no new arrow table will be created
         update_data = None

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1223,7 +1223,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         new_fingerprint: Optional[str] = None,
     ) -> "Dataset":
         """Apply a function to all the elements in the table (individually or in batches)
-        and update the table (if function does updated examples).
+        and update the table (if function does update examples).
 
         Args:
             function (`callable`): with one of the following signature:
@@ -1288,43 +1288,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if fn_kwargs is None:
             fn_kwargs = {}
 
-        # Check if the function returns updated examples
-        def does_function_return_dict(inputs, indices):
-            """ Does the function returns a dict. """
-            fn_args = [inputs] if input_columns is None else [inputs[col] for col in input_columns]
-            processed_inputs = (
-                function(*fn_args, indices, **fn_kwargs) if with_indices else function(*fn_args, **fn_kwargs)
-            )
-            does_return_dict = isinstance(processed_inputs, Mapping)
-
-            if does_return_dict is False and processed_inputs is not None:
-                raise TypeError(
-                    "Provided `function` which is applied to all elements of table returns a variable of type {}. Make sure provided `function` returns a variable of type `dict` to update the dataset or `None` if you are only interested in side effects.".format(
-                        type(processed_inputs)
-                    )
-                )
-            elif isinstance(test_indices, list) and does_return_dict is True:
-                allowed_batch_return_types = (list, np.ndarray)
-                all_dict_values_are_lists = all(
-                    isinstance(value, allowed_batch_return_types) for value in processed_inputs.values()
-                )
-                if all_dict_values_are_lists is False:
-                    raise TypeError(
-                        "Provided `function` which is applied to all elements of table returns a `dict` of types {}. When using `batched=True`, make sure provided `function` returns a `dict` of types like `{}`.".format(
-                            [type(x) for x in processed_inputs.values()], allowed_batch_return_types
-                        )
-                    )
-
-            return does_return_dict
-
-        # We only update the data table (and use the cache) if the function returns a dict.
-        # Test it on the first element or a small batch (0, 1) for batched inputs
-        logger.info("Testing the mapped function outputs")
-        test_inputs = self[:2] if batched else self[0]
-        test_indices = [0, 1] if batched else 0
-        update_data = does_function_return_dict(test_inputs, test_indices)
-        logger.info("Testing finished, running the mapping function on the dataset")
-
         if num_proc is None or num_proc == 1:
             return self._map_single(
                 function=function,
@@ -1342,7 +1305,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 disable_nullable=disable_nullable,
                 fn_kwargs=fn_kwargs,
                 new_fingerprint=new_fingerprint,
-                update_data=update_data,
             )
         else:
 
@@ -1394,7 +1356,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                         fn_kwargs=fn_kwargs,
                         rank=rank,
                         offset=sum(len(s) for s in shards[:rank]),
-                        update_data=update_data,
                     )
                     for rank in range(num_proc)
                 ]
@@ -1428,10 +1389,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         new_fingerprint: Optional[str] = None,
         rank: Optional[int] = None,
         offset: int = 0,
-        update_data=True,
     ) -> "Dataset":
         """Apply a function to all the elements in the table (individually or in batches)
-        and update the table (if function does updated examples).
+        and update the table (if function does update examples).
 
         Args:
             function (`callable`): with one of the following signature:
@@ -1466,7 +1426,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
             rank: (`Optional[int]`, defaults to `None`): If specified, this is the process rank when doing multiprocessing
             offset: (`int`, defaults to 0): If specified, this is an offset applied to the indices passed to `function` if `with_indices=True`
-            update_data (`bool`, defaults to `True`): If False, no new arrow table will be created
         """
         assert (
             not keep_in_memory or cache_file_name is None
@@ -1512,11 +1471,44 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if batched and (batch_size is None or batch_size <= 0):
             batch_size = self.num_rows
 
+        # We set this variable in `apply_function_on_filtered_inputs` to True if
+        # function returns a dict. If set to False, no new arrow table will be created
+        update_data = None
+        # This variable is set in `check_if_cached` that gets called in 
+        # `apply_function_on_filtered_inputs` once we know the value of `update_data`
+        is_cached = None
+
         class NumExamplesMismatch(Exception):
             pass
 
+        # Check if the function returns updated examples
+        def does_function_return_dict(processed_inputs, indices):
+            """ Does the function returns a dict. """
+            does_return_dict = isinstance(processed_inputs, Mapping)
+
+            if does_return_dict is False and processed_inputs is not None:
+                raise TypeError(
+                    "Provided `function` which is applied to all elements of table returns a variable of type {}. Make sure provided `function` returns a variable of type `dict` to update the dataset or `None` if you are only interested in side effects.".format(
+                        type(processed_inputs)
+                    )
+                )
+            elif isinstance(indices, list) and does_return_dict is True:
+                allowed_batch_return_types = (list, np.ndarray)
+                all_dict_values_are_lists = all(
+                    isinstance(value, allowed_batch_return_types) for value in processed_inputs.values()
+                )
+                if all_dict_values_are_lists is False:
+                    raise TypeError(
+                        "Provided `function` which is applied to all elements of table returns a `dict` of types {}. When using `batched=True`, make sure provided `function` returns a `dict` of types like `{}`.".format(
+                            [type(x) for x in processed_inputs.values()], allowed_batch_return_types
+                        )
+                    )
+
+            return does_return_dict
+
         def apply_function_on_filtered_inputs(inputs, indices, check_same_num_examples=False, offset=0):
             """ Utility to apply the function on a selection of columns. """
+            nonlocal update_data
             fn_args = [inputs] if input_columns is None else [inputs[col] for col in input_columns]
             if offset == 0:
                 effective_indices = indices
@@ -1525,6 +1517,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             processed_inputs = (
                 function(*fn_args, effective_indices, **fn_kwargs) if with_indices else function(*fn_args, **fn_kwargs)
             )
+            if update_data is None:
+                update_data = does_function_return_dict(processed_inputs, indices)
+                check_if_cached()
             if not update_data:
                 return None  # Nothing to update, let's move on
             if remove_columns is not None:
@@ -1546,20 +1541,23 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             return inputs
 
         # Check if we've already cached this computation (indexed by a hash)
-        if update_data and self._data_files:
-            if cache_file_name is None:
-                # we create a unique hash from the function, current dataset file and the mapping args
-                cache_file_name = self._get_cache_file_path(new_fingerprint)
-            if os.path.exists(cache_file_name) and load_from_cache_file:
-                logger.warning("Loading cached processed dataset at %s", cache_file_name)
-                info = self.info.copy()
-                info.features = features
-                return Dataset.from_file(cache_file_name, info=info, split=self.split)
+        def check_if_cached():
+            nonlocal is_cached
+            nonlocal cache_file_name
+            if self._data_files:
+                if cache_file_name is None:
+                    # we create a unique hash from the function,
+                    # current dataset file and the mapping args
+                    cache_file_name = self._get_cache_file_path(new_fingerprint)
+                is_cached = os.path.exists(cache_file_name) and load_from_cache_file
+            else:
+                is_cached = False
 
         # Prepare output buffer and batched writer in memory or on file if we update the table
-        if update_data:
-            if features is None:
-                features = self.features
+        def init_buffer_and_writer():
+            writer_features = features
+            if writer_features is None:
+                writer_features = self.features
                 update_features = True
             else:
                 update_features = False
@@ -1567,7 +1565,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 buf_writer = pa.BufferOutputStream()
                 tmp_file = None
                 writer = ArrowWriter(
-                    features=features,
+                    features=writer_features,
                     stream=buf_writer,
                     writer_batch_size=writer_batch_size,
                     update_features=update_features,
@@ -1579,57 +1577,73 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 logger.info("Caching processed dataset at %s", cache_file_name)
                 tmp_file = tempfile.NamedTemporaryFile("wb", dir=os.path.dirname(cache_file_name), delete=False)
                 writer = ArrowWriter(
-                    features=features,
+                    features=writer_features,
                     path=tmp_file.name,
                     writer_batch_size=writer_batch_size,
                     update_features=update_features,
                     fingerprint=new_fingerprint,
                     disable_nullable=disable_nullable,
                 )
-        else:
-            # we don't need a writer so we use an empty context
-            writer = contextlib.ExitStack()
+            return buf_writer, writer, tmp_file
 
-        with writer:
-            try:
-                # Loop over single examples or batches and write to buffer/file if examples are to be updated
-                pbar_iterable = self if not batched else range(0, len(self), batch_size)
-                pbar_unit = "ex" if not batched else "ba"
-                pbar_desc = "#" + str(rank) if rank is not None else None
-                pbar = tqdm(pbar_iterable, disable=not_verbose, position=rank, unit=pbar_unit, desc=pbar_desc)
-                if not batched:
-                    for i, example in enumerate(pbar):
-                        example = apply_function_on_filtered_inputs(example, i, offset=offset)
-                        if update_data:
-                            example = cast_to_python_objects(example)
-                            writer.write(example)
-                else:
-                    for i in pbar:
-                        if drop_last_batch and i + batch_size > self.num_rows:
-                            continue
-                        batch = self[i : i + batch_size]
-                        indices = list(range(*(slice(i, i + batch_size).indices(self.num_rows))))  # Something simpler?
-                        try:
-                            batch = apply_function_on_filtered_inputs(
-                                batch, indices, check_same_num_examples=len(self.list_indexes()) > 0, offset=offset
-                            )
-                        except NumExamplesMismatch:
-                            raise DatasetTransformationNotAllowedError(
-                                "Using `.map` in batched mode on a dataset with attached indexes is allowed only if it doesn't create or remove existing examples. You can first run `.drop_index() to remove your index and then re-add it."
-                            )
-                        if update_data:
-                            batch = cast_to_python_objects(batch)
-                            writer.write_batch(batch)
-                if update_data:
-                    writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
-            except (Exception, KeyboardInterrupt):
-                if update_data:
-                    writer.finalize()
-                if update_data and tmp_file is not None:
-                    tmp_file.close()
-                    if os.path.exists(tmp_file.name):
-                        os.remove(tmp_file.name)
-                raise
+        try:
+            # Loop over single examples or batches and write to buffer/file if examples are to be updated
+            pbar_iterable = self if not batched else range(0, len(self), batch_size)
+            pbar_unit = "ex" if not batched else "ba"
+            pbar_desc = "#" + str(rank) if rank is not None else None
+            pbar = tqdm(pbar_iterable, disable=not_verbose, position=rank, unit=pbar_unit, desc=pbar_desc)
+            if not batched:
+                for i, example in enumerate(pbar):
+                    example = apply_function_on_filtered_inputs(example, i, offset=offset)
+                    # If cached, break and return, otherwise prepare resources
+                    if i == 0 and update_data:
+                        if is_cached:
+                            break
+                        else:
+                            buf_writer, writer, tmp_file = init_buffer_and_writer()
+                    if update_data:
+                        example = cast_to_python_objects(example)
+
+                        writer.write(example)
+            else:
+                for i in pbar:
+                    if drop_last_batch and i + batch_size > self.num_rows:
+                        continue
+                    batch = self[i : i + batch_size]
+                    indices = list(range(*(slice(i, i + batch_size).indices(self.num_rows))))  # Something simpler?
+                    try:
+                        batch = apply_function_on_filtered_inputs(
+                            batch, indices, check_same_num_examples=len(self.list_indexes()) > 0, offset=offset
+                        )
+                    except NumExamplesMismatch:
+                        raise DatasetTransformationNotAllowedError(
+                            "Using `.map` in batched mode on a dataset with attached indexes is allowed only if it doesn't create or remove existing examples. You can first run `.drop_index() to remove your index and then re-add it."
+                        )
+                    # If cached, break and return, otherwise prepare resources
+                    if i == 0 and update_data:
+                        if is_cached:
+                            break
+                        else:
+                            buf_writer, writer, tmp_file = init_buffer_and_writer()
+                    if update_data:
+                        batch = cast_to_python_objects(batch)
+                        writer.write_batch(batch)
+            if update_data and not is_cached:
+                writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
+        except (Exception, KeyboardInterrupt) as e:
+            if update_data and not is_cached:
+                writer.finalize()
+            if update_data and not is_cached and tmp_file is not None:
+                tmp_file.close()
+                if os.path.exists(tmp_file.name):
+                    os.remove(tmp_file.name)
+            raise
+
+        if is_cached:
+            logger.warning("Loading cached processed dataset at %s", cache_file_name)
+            info = self.info.copy()
+            info.features = features
+            return Dataset.from_file(cache_file_name, info=info, split=self.split)
 
         if update_data and tmp_file is not None:
             tmp_file.close()

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1595,7 +1595,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             if not batched:
                 for i, example in enumerate(pbar):
                     example = apply_function_on_filtered_inputs(example, i, offset=offset)
-                    # If cached, break and return, otherwise prepare resources
+                    # If cached, break and return a cached dataset, otherwise prepare resources
                     if i == 0 and update_data:
                         if is_cached:
                             break
@@ -1603,7 +1603,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                             buf_writer, writer, tmp_file = init_buffer_and_writer()
                     if update_data:
                         example = cast_to_python_objects(example)
-
                         writer.write(example)
             else:
                 for i in pbar:
@@ -1619,7 +1618,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                         raise DatasetTransformationNotAllowedError(
                             "Using `.map` in batched mode on a dataset with attached indexes is allowed only if it doesn't create or remove existing examples. You can first run `.drop_index() to remove your index and then re-add it."
                         )
-                    # If cached, break and return, otherwise prepare resources
+                    # If cached, break and return a cached dataset, otherwise prepare resources
                     if i == 0 and update_data:
                         if is_cached:
                             break

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1474,7 +1474,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         # We set this variable in `apply_function_on_filtered_inputs` to True if
         # function returns a dict. If set to False, no new arrow table will be created
         update_data = None
-        # This variable is set in `check_if_cached` that gets called in 
+        # This variable is set in `check_if_cached` that gets called in
         # `apply_function_on_filtered_inputs` once we know the value of `update_data`
         is_cached = None
 
@@ -1629,7 +1629,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                         writer.write_batch(batch)
             if update_data and not is_cached:
                 writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
-        except (Exception, KeyboardInterrupt) as e:
+        except (Exception, KeyboardInterrupt):
             if update_data and not is_cached:
                 writer.finalize()
             if update_data and not is_cached and tmp_file is not None:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1593,9 +1593,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     if update_data:
                         if i == 0:
                             cache_file_name = determine_cache_file_name(cache_file_name)
-                            is_cached = check_if_cached(cache_file_name)
-                            if is_cached:
-                                break
+                            if check_if_cached(cache_file_name):
+                                logger.warning("Loading cached processed dataset at %s", cache_file_name)
+                                info = self.info.copy()
+                                info.features = features
+                                return Dataset.from_file(cache_file_name, info=info, split=self.split)
                             else:
                                 buf_writer, writer, tmp_file = init_buffer_and_writer(cache_file_name)
                         example = cast_to_python_objects(example)
@@ -1617,9 +1619,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     if update_data:
                         if i == 0:
                             cache_file_name = determine_cache_file_name(cache_file_name)
-                            is_cached = check_if_cached(cache_file_name)
-                            if is_cached:
-                                break
+                            if check_if_cached(cache_file_name):
+                                logger.warning("Loading cached processed dataset at %s", cache_file_name)
+                                info = self.info.copy()
+                                info.features = features
+                                return Dataset.from_file(cache_file_name, info=info, split=self.split)
                             else:
                                 buf_writer, writer, tmp_file = init_buffer_and_writer(cache_file_name)
                         batch = cast_to_python_objects(batch)
@@ -1635,12 +1639,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     if os.path.exists(tmp_file.name):
                         os.remove(tmp_file.name)
             raise
-
-        if update_data and is_cached:
-            logger.warning("Loading cached processed dataset at %s", cache_file_name)
-            info = self.info.copy()
-            info.features = features
-            return Dataset.from_file(cache_file_name, info=info, split=self.split)
 
         if update_data and tmp_file is not None:
             tmp_file.close()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -981,6 +981,34 @@ class BaseDatasetTest(TestCase):
             self.assertDictEqual(dset.features, Features({"filename": Value("string"), "name": Value("string")}))
             del dset
 
+    def test_map_stateful_callable(self, in_memory):
+        # be sure that the state of the map callable is unaffected
+        # before processing the dataset examples
+
+        class ExampleCounter:
+            def __init__(self, batched=False):
+                self.batched = batched
+                # state
+                self.cnt = 0
+
+            def __call__(self, example):
+                if self.batched:
+                    self.cnt += len(example)
+                else:
+                    self.cnt += 1
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dset = self._create_dummy_dataset(in_memory, tmp_dir)
+
+            ex_cnt = ExampleCounter()
+            dset.map(ex_cnt)
+            self.assertEqual(ex_cnt.cnt, len(dset))
+
+            ex_cnt = ExampleCounter(batched=True)
+            dset.map(ex_cnt)
+            self.assertEqual(ex_cnt.cnt, len(dset))
+            del dset
+
     def test_filter(self, in_memory):
         # keep only first five examples
 


### PR DESCRIPTION
Removes the "test type" section in Dataset.map which would modify the state of the stateful function. Now, the return type of the map function is inferred after processing the first example.

Fixes #1940 

@lhoestq Not very happy with the usage of `nonlocal`. Would like to hear your opinion on this.