### PR TITLE
Fix metrics collision in separate multiprocessed experiments

### DIFF
--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -285,13 +285,16 @@ class Metric(MetricInfoMixin):
         # Let's acquire a lock on each process files to be sure they are finished writing
         filelocks = []
         for process_id, file_path in enumerate(file_paths):
-            filelock = FileLock(file_path + ".lock")
-            try:
-                filelock.acquire(timeout=self.timeout)
-            except Timeout:
-                raise ValueError(f"Cannot acquire lock on cached file {file_path} for process {process_id}.")
+            if process_id == 0:  # process 0 already has its lock file
+                filelocks.append(self.filelock)
             else:
-                filelocks.append(filelock)
+                filelock = FileLock(file_path + ".lock")
+                try:
+                    filelock.acquire(timeout=self.timeout)
+                except Timeout:
+                    raise ValueError(f"Cannot acquire lock on cached file {file_path} for process {process_id}.")
+                else:
+                    filelocks.append(filelock)
 
         return file_paths, filelocks
 
@@ -338,7 +341,8 @@ class Metric(MetricInfoMixin):
         if self.writer is not None:
             self.writer.finalize()
         self.writer = None
-        if self.filelock is not None:
+        # release the locks of the processes > 0 so that process 0 can lock them to read + delete the data
+        if self.filelock is not None and self.process_id > 0:
             self.filelock.release()
 
         if self.keep_in_memory:
@@ -403,8 +407,8 @@ class Metric(MetricInfoMixin):
                 del self.data
                 self.data = None
             else:
-                # Release locks and delete all the cache files
-                for filelock, file_path in zip(self.filelocks, self.file_paths):
+                # Release locks and delete all the cache files. Process 0 is released last.
+                for filelock, file_path in reversed(list(zip(self.filelocks, self.file_paths))):
                     logger.info(f"Removing {file_path}")
                     del self.data
                     self.data = None


### PR DESCRIPTION
As noticed in #1942 , there's a issue with locks if you run multiple separate evaluation experiments in a multiprocessed setup.

Indeed there is a time span in Metric._finalize() where the process 0 loses its lock before re-acquiring it. This is bad since the lock of the process 0 tells the other process that the corresponding cache file is available for writing/reading/deleting: we end up having one metric cache that collides with another one. This can raise FileNotFound errors when a metric tries to read the cache file and if the second conflicting metric deleted it.

To fix that I made sure that the lock file of the process 0 stays acquired from the cache file creation to the end of the metric computation. This way the other metrics can simply sample a new hashing name in order to avoid the collision.

Finally I added missing tests for separate experiments in distributed setup.