### PR TITLE
Don't gitignore dvc.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Locked files
 *.lock
+!dvc.lock
 
 # Extracted dummy data
 datasets/**/dummy_data-zip-extracted/


### PR DESCRIPTION
The benchmarks runs are [failing](https://github.com/huggingface/datasets/runs/2055534629?check_suite_focus=true) because of 
```
ERROR: 'dvc.lock' is git-ignored.
```

I removed the dvc.lock file from the gitignore to fix that