### PR TITLE
Fix various typos/grammer in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ from datasets import list_datasets, load_dataset, list_metrics, load_metric
 # Print all the available datasets
 print(list_datasets())
 
-# Load a dataset and print the first examples in the training set
+# Load a dataset and print the first example in the training set
 squad_dataset = load_dataset('squad')
 print(squad_dataset['train'][0])
 
@@ -98,20 +98,20 @@ squad_metric = load_metric('squad')
 # Process the dataset - add a column with the length of the context texts
 dataset_with_length = squad_dataset.map(lambda x: {"length": len(x["context"])})
 
-# Process the dataset - tokenize the context texts (using a tokenizer from the 🤗 transformers library)
+# Process the dataset - tokenize the context texts (using a tokenizer from the 🤗Transformers library)
 from transformers import AutoTokenizer
 tokenizer = AutoTokenizer.from_pretrained('bert-base-cased')
 
 tokenized_dataset = squad_dataset.map(lambda x: tokenizer(x['context']), batched=True)
 ```
 
-For more details on using the library, check the quick tour page in the documentation: https://huggingface.co/docs/datasets/quicktour.html and the specific pages on
+For more details on using the library, check the quick tour page in the documentation: https://huggingface.co/docs/datasets/quicktour.html and the specific pages on:
 
 - Loading a dataset https://huggingface.co/docs/datasets/loading_datasets.html
 - What's in a Dataset: https://huggingface.co/docs/datasets/exploring.html
 - Processing data with `🤗Datasets`: https://huggingface.co/docs/datasets/processing.html
 - Writing your own dataset loading script: https://huggingface.co/docs/datasets/add_dataset.html
-- etc
+- etc.
 
 Another introduction to `🤗Datasets` is the tutorial on Google Colab here:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/datasets/blob/master/notebooks/Overview.ipynb)

--- a/README.md
+++ b/README.md
@@ -42,11 +42,23 @@
 
 # Installation
 
+## With pip
+
 `🤗Datasets` can be installed from PyPi and has to be installed in a virtual environment (venv or conda for instance)
 
 ```bash
 pip install datasets
 ```
+
+## With conda
+
+`🤗Datasets` can be installed using conda as follows:
+
+```bash
+conda install -c huggingface -c conda-forge datasets
+```
+
+Follow the installation pages of TensorFlow and PyTorch to see how to install them with conda.
 
 For more details on installation, check the installation page in the documentation: https://huggingface.co/docs/datasets/installation.html
 

--- a/docs/source/add_dataset.rst
+++ b/docs/source/add_dataset.rst
@@ -12,13 +12,13 @@ This chapter will explain how datasets are loaded and how you can write from scr
 
     You can start from the `template for a dataset loading script <https://github.com/huggingface/datasets/blob/master/templates/new_dataset_script.py>`__ when writing a new dataset loading script. You can find this template in the ``templates`` folder on the github repository.
 
-Here a quick general overview of the classes  and method involved when generating a dataset:
+Here is a quick general overview of the classes and method involved when generating a dataset:
 
 .. image:: /imgs/datasets_doc.jpg
 
 On the left is the general organization inside the library to create a :class:`datasets.Dataset` instance and on the right, the elements which are specific to each dataset loading script. To create a new dataset loading script one mostly needs to specify three methods in a :class:`datasets.DatasetBuilder` class:
 
-- :func:`datasets.DatasetBuilder._info` which is in charge of specifying the dataset metadata as a :obj:`datasets.DatasetInfo` dataclass and in particular the :class:`datasets.Features` which defined the names and types of each column in the dataset,
+- :func:`datasets.DatasetBuilder._info` which is in charge of specifying the dataset metadata as a :obj:`datasets.DatasetInfo` dataclass and in particular the :class:`datasets.Features` which define the names and types of each column in the dataset,
 - :func:`datasets.DatasetBuilder._split_generator` which is in charge of downloading or retrieving the data files, organizing them by splits and defining specific arguments for the generation process if needed,
 - :func:`datasets.DatasetBuilder._generate_examples` which is in charge of loading the files for a split and yielding examples with the format specified in the ``features``.
 
@@ -41,7 +41,7 @@ The most important attributes to specify are:
 - :attr:`datasets.DatasetInfo.citation`: a :obj:`str` containing the citation for the dataset in a BibTex format for inclusion in communications citing the dataset,
 - :attr:`datasets.DatasetInfo.homepage`: a :obj:`str` containing an URL to an original homepage of the dataset.
 
-Here is for instance the :func:`datasets.Dataset._info` for the SQuAD dataset for instance, which is taken from the `squad dataset loading script <https://github.com/huggingface/datasets/tree/master/datasets/squad/squad.py>`__
+Here is for instance the :func:`datasets.Dataset._info` for the SQuAD dataset for instance, which is taken from the `squad dataset loading script <https://github.com/huggingface/datasets/tree/master/datasets/squad/squad.py>`__:
 
 .. code-block::
 
@@ -80,8 +80,9 @@ Here are the features of the SQuAD dataset for instance, which is taken from the
             "context": datasets.Value("string"),
             "question": datasets.Value("string"),
             "answers": datasets.Sequence(
-                {"text": datasets.Value("string"),
-                "answer_start": datasets.Value("int32"),
+                {
+                    "text": datasets.Value("string"),
+                    "answer_start": datasets.Value("int32"),
                 }
             ),
         }
@@ -113,7 +114,7 @@ Let's take another example of features from the `large-scale reading comprehensi
             "article": datasets.Value("string"),
             "answer": datasets.Value("string"),
             "question": datasets.Value("string"),
-            "options": datasets.features.Sequence({"option": datasets.Value("string")})
+            "options": datasets.features.Sequence(datasets.Value("string"))
         }
     )
 
@@ -122,20 +123,19 @@ Here is the corresponding first examples in the dataset:
 .. code-block::
 
     >>> from datasets import load_dataset
-    >>> dataset = load_dataset('race', split='train')
+    >>> dataset = load_dataset('race', 'high', split='train')
     >>> dataset[0]
     {'article': 'My husband is a born shopper. He loves to look at things and to touch them. He likes to compare prices between the same items in different shops. He would never think of buying anything without looking around in several
      ...
      sadder. When he saw me he said, "I\'m sorry, Mum. I have forgotten to buy oranges and the meat. I only remembered to buy six eggs, but I\'ve dropped three of them."',
      'answer': 'C',
      'question': 'The husband likes shopping because   _  .',
-     'options': {
-        'option':['he has much money.',
-                  'he likes the shops.',
-                  'he likes to compare the prices between the same items.',
-                  'he has nothing to do but shopping.'
-                ]
-        }
+     'options':
+        ['he has much money.',
+         'he likes the shops.',
+         'he likes to compare the prices between the same items.',
+         'he has nothing to do but shopping.'
+        ]
     }
 
 
@@ -172,7 +172,7 @@ Let's have a look at a simple example of a :func:`datasets.DatasetBuilder._split
                 datasets.SplitGenerator(name=datasets.Split.VALIDATION, gen_kwargs={"filepath": downloaded_files["dev"]}),
             ]
 
-As you can see this method first prepares a dict of URL to the original data files for SQuAD. This dict is then provided to the :func:`datasets.DownloadManager.download_and_extract` method which will take care of downloading or retrieving these files from the local file system and returning a object of the same type and organization (here a dictionary) with the path to the local version of the requested files. :func:`datasets.DownloadManager.download_and_extract` can take as input a single URL/path or a list or dictionary of URLs/paths and will return an object of the same structure (single URL/path, list or dictionary of URLs/paths) with the path to the local files. This method also takes care of extracting compressed tar, gzip and zip archives.
+As you can see, this method first prepares a dict of URLs to the original data files for SQuAD. This dict is then provided to the :func:`datasets.DownloadManager.download_and_extract` method which will take care of downloading or retrieving these files from the local file system and returning a object of the same type and organization (here a dictionary) with the path to the local version of the requested files. :func:`datasets.DownloadManager.download_and_extract` can take as input a single URL/path or a list or dictionary of URLs/paths and will return an object of the same structure (single URL/path, list or dictionary of URLs/paths) with the path to the local files. This method also takes care of extracting compressed tar, gzip and zip archives.
 
 :func:`datasets.DownloadManager.download_and_extract` can download files from a large set of origins but if your data files are hosted on a special access server, it's also possible to provide a callable which will take care of the downloading process to the ``DownloadManager`` using :func:`datasets.DownloadManager.download_custom`.
 
@@ -245,7 +245,7 @@ The base :class:`datasets.BuilderConfig` class is very simple and only comprises
 - :obj:`name` (``str``) is the name of the dataset configuration, for instance the language name if the various configurations are specific to various languages
 - :obj:`version` an optional version identifier
 - :obj:`data_dir` (``str``) can be used to store the path to a local folder containing data files
-- :obj:`data_files` (``Union[Dict, List]`` can be used to store paths to local data files
+- :obj:`data_files` (``Union[Dict, List]``) can be used to store paths to local data files
 - :obj:`description` (``str``) can be used to give a long description of the configuration
 
 :class:`datasets.BuilderConfig` is only used as a container of informations which can be used in the :class:`datasets.DatasetBuilder` to build the dataset by being accessed in the ``self.config`` attribute of the :class:`datasets.DatasetBuilder` instance.
@@ -285,7 +285,7 @@ And then define several predefined configurations in the DatasetBuilder:
 
         ...
 
-        def self._generate_examples(file):
+        def _generate_examples(file):
             with open(file) as csvfile:
                 data = csv.reader(csvfile, delimiter = self.config.delimiter)
                 for i, row in enumerate(data):

--- a/docs/source/add_dataset.rst
+++ b/docs/source/add_dataset.rst
@@ -18,7 +18,7 @@ Here is a quick general overview of the classes and method involved when generat
 
 On the left is the general organization inside the library to create a :class:`datasets.Dataset` instance and on the right, the elements which are specific to each dataset loading script. To create a new dataset loading script one mostly needs to specify three methods in a :class:`datasets.DatasetBuilder` class:
 
-- :func:`datasets.DatasetBuilder._info` which is in charge of specifying the dataset metadata as a :obj:`datasets.DatasetInfo` dataclass and in particular the :class:`datasets.Features` which define the names and types of each column in the dataset,
+- :func:`datasets.DatasetBuilder._info` which is in charge of specifying the dataset metadata as a :obj:`datasets.DatasetInfo` dataclass and in particular the :class:`datasets.Features` which defines the names and types of each column in the dataset,
 - :func:`datasets.DatasetBuilder._split_generator` which is in charge of downloading or retrieving the data files, organizing them by splits and defining specific arguments for the generation process if needed,
 - :func:`datasets.DatasetBuilder._generate_examples` which is in charge of loading the files for a split and yielding examples with the format specified in the ``features``.
 

--- a/docs/source/add_metric.rst
+++ b/docs/source/add_metric.rst
@@ -12,7 +12,7 @@ This chapter will explain how metrics are loaded and how you can write from scra
 
 To create a new metric loading script one mostly needs to specify three methods in a :class:`datasets.Metric` class:
 
-- :func:`datasets.Metric._info` which is in charge of specifying the metric metadata as a :obj:`datasets.MetricInfo` dataclass and in particular the :class:`datasets.Features` which defined the types of the predictions and the references,
+- :func:`datasets.Metric._info` which is in charge of specifying the metric metadata as a :obj:`datasets.MetricInfo` dataclass and in particular the :class:`datasets.Features` which defines the types of the predictions and the references,
 - :func:`datasets.Metric._compute` which is in charge of computing the actual score(s), given some predictions and references.
 
 .. note::
@@ -23,7 +23,7 @@ To create a new metric loading script one mostly needs to specify three methods 
 Adding metric metadata
 ----------------------------------
 
-The :func:`datasets.Metric._info` method is in charge of specifying the metric metadata as a :obj:`datasets.MetricInfo` dataclass and in particular the :class:`datasets.Features` which defined the types of the predictions and the references. :class:`datasets.MetricInfo` has a predefined set of attributes and cannot be extended. The full list of attributes can be found in the package reference.
+The :func:`datasets.Metric._info` method is in charge of specifying the metric metadata as a :obj:`datasets.MetricInfo` dataclass and in particular the :class:`datasets.Features` which defines the types of the predictions and the references. :class:`datasets.MetricInfo` has a predefined set of attributes and cannot be extended. The full list of attributes can be found in the package reference.
 
 The most important attributes to specify are:
 
@@ -31,9 +31,9 @@ The most important attributes to specify are:
 - :attr:`datasets.MetricInfo.description`: a :obj:`str` describing the metric,
 - :attr:`datasets.MetricInfo.citation`: a :obj:`str` containing the citation for the metric in a BibTex format for inclusion in communications citing the metric,
 - :attr:`datasets.MetricInfo.homepage`: a :obj:`str` containing an URL to an original homepage of the metric.
-- :attr:`datasets.MetricInfo.format`: an optional :obj:`str` to tell what is the format of the predictions and the references passed to _compute. It can be set to "numpy", "torch", "tensorflow" or "pandas".
+- :attr:`datasets.MetricInfo.format`: an optional :obj:`str` to tell what is the format of the predictions and the references passed to the :func:`datasets.DatasetBuilder._compute` method. It can be set to "numpy", "torch", "tensorflow" or "pandas".
 
-Here is for instance the :func:`datasets.Metric._info` for the Sacrebleu metric for instance, which is taken from the `sacrebleu metric loading script <https://github.com/huggingface/datasets/tree/master/metrics/sacrebleu/sacrebleu.py>`__
+Here is for instance the :func:`datasets.Metric._info` for the Sacrebleu metric, which is taken from the `sacrebleu metric loading script <https://github.com/huggingface/datasets/tree/master/metrics/sacrebleu/sacrebleu.py>`__:
 
 .. code-block::
 
@@ -77,8 +77,9 @@ Indeed we can use the metric the following way:
     ...                    ['It was not unexpected.', 'No one was surprised.'],
     ...                    ['The man bit him first.', 'The man had bitten the dog.']]
     >>> sys_batch = ['The dog bit the man.', "It wasn't surprising.", 'The man had just bitten him.']
-    >>> score = metric.add_batch(predictions=sys_batch, references=reference_batch)
-    >>> print(metric)
+    >>> score = metric.compute(predictions=sys_batch, references=reference_batch)
+    >>> print(score)
+    {'score': 48.530827009929865, 'counts': [14, 7, 5, 3], 'totals': [17, 14, 11, 8], 'precisions': [82.3529411764706, 50.0, 45.45454545454545, 37.5], 'bp': 0.9428731438548749, 'sys_len': 17, 'ref_len': 18}
 
 
 Downloading data files
@@ -116,7 +117,7 @@ Computing the scores
 
 The :func:`datasets.DatasetBuilder._compute` is in charge of computing the metric scores given predictions and references that are in the format specified in the ``features`` set in :func:`datasets.DatasetBuilder._info`.
 
-Here again, let's take the simple example of the `xnli metric loading script <https://github.com/huggingface/datasets/tree/master/metrics/squad/squad.py>`__:
+Here again, let's take the simple example of the `xnli metric loading script <https://github.com/huggingface/datasets/tree/master/metrics/xnli/xnli.py>`__:
 
 .. code-block::
 
@@ -150,7 +151,7 @@ Specifying several metric configurations
 
 Sometimes you want to provide several ways of computing the scores.
 
-It is possible to gave different configurations for a metric. The configuration name is stored in :obj:`datasets.Metric.config_name` attribute. The configuration name can be specified by the user when instantiating a metric:
+It is possible to gave different configurations for a metric. The configuration name is stored in the :obj:`datasets.Metric.config_name` attribute. The configuration name can be specified by the user when instantiating a metric:
 
 .. code-block::
 

--- a/docs/source/beam_dataset.rst
+++ b/docs/source/beam_dataset.rst
@@ -13,7 +13,7 @@ More infos about the different runners `here <https://beam.apache.org/documentat
 Already processed datasets are provided
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-At Hugging Face we have already run the Beam pipelines for datasets like wikipedia and wiki40b to provide already processed datasets. Therefore users can simply do run `load_dataset('wikipedia', '20200501.en')` and the already processed dataset will be downloaded.
+At Hugging Face we have already run the Beam pipelines for datasets like wikipedia and wiki40b to provide already processed datasets. Therefore users can simply run ``load_dataset('wikipedia', '20200501.en')`` and the already processed dataset will be downloaded.
 
 How to run a Beam dataset processing pipeline
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,12 +58,12 @@ If you want to run the Beam pipeline of a dataset anyway, here are the different
 
 .. note::
 
-    you can also use the flags `num_workers` or `machine_type` to fit your needs.
+    You can also use the flags `num_workers` or `machine_type` to fit your needs.
 
 Note that it also works if you change the runner to Spark, Flink, etc. instead of Dataflow or if you change the output location to S3 or HDFS instead of GCS.
 
 How to create your own Beam dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is highly recommended to be familiar with Beam pipelines first.
+It is highly recommended to be familiar with the Beam pipelines first.
 Then, you can start looking at the `wikipedia.py <https://github.com/huggingface/datasets/blob/master/datasets/wikipedia/wikipedia.py>`_ script for an example.

--- a/docs/source/exploring.rst
+++ b/docs/source/exploring.rst
@@ -20,15 +20,15 @@ An :class:`datasets.Dataset` is a python container with a length coresponding to
     >>> len(dataset)
     3668
     >>> dataset[0]
-    {'sentence1': 'Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .',
-     'sentence2': 'Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .',
+    {'idx': 0,
      'label': 1,
-     'idx': 0}
+     'sentence1': 'Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .',
+     'sentence2': 'Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .'}
 
 Features and columns
 ------------------------------------------------------
 
-A :class:`datasets.Dataset` instance is more precisely a table with **rows** and **columns** in which the columns are typed. Querying an example (a single row) will thus return a python dictionary with keys corresponding to columns names, and values corresponding to the example's value for each column.
+A :class:`datasets.Dataset` instance is more precisely a table with **rows** and **columns** in which the columns are typed. Querying an example (a single row) will thus return a python dictionary with keys corresponding to column names, and values corresponding to the example's value for each column.
 
 You can get the number of rows and columns of the dataset with various standard attributes:
 
@@ -48,12 +48,12 @@ You can list the column names with :func:`datasets.Dataset.column_names` and get
 .. code-block::
 
     >>> dataset.column_names
-    ['sentence1', 'sentence2', 'label', 'idx']
+    ['idx', 'label', 'sentence1', 'sentence2']
     >>> dataset.features
-    {'sentence1': Value(dtype='string', id=None),
-     'sentence2': Value(dtype='string', id=None),
+    {'idx': Value(dtype='int32', id=None),
      'label': ClassLabel(num_classes=2, names=['not_equivalent', 'equivalent'], names_file=None, id=None),
-     'idx': Value(dtype='int32', id=None)
+     'sentence1': Value(dtype='string', id=None),
+     'sentence2': Value(dtype='string', id=None),
     }
 
 Here we can see that the column ``label`` is a :class:`datasets.ClassLabel` feature.
@@ -71,14 +71,14 @@ We can access this feature to get more information on the values in the ``label`
     >>> dataset.features['label'].str2int('not_equivalent')
     0
 
-More details on the ``features`` can be found in the guide on features :doc:`features` and in the package reference on :class:`datasets.Features`.
+More details on the ``features`` can be found in the guide on :doc:`features` and in the package reference on :class:`datasets.Features`.
 
 Metadata
 ------------------------------------------------------
 
 The :class:`datasets.Dataset` object also host many important metadata on the dataset which are all stored in ``dataset.info``. Many of these metadata are also accessible on the lower level, i.e. directly as attributes of the Dataset for shorter access (e.g. ``dataset.info.features`` is also available as ``dataset.features``).
 
-All these attributes are listed in the package refefence on :class:`datasets.DatasetInfo`. The most important metadata are ``split``, ``description``, ``citation``, ``homepage`` (and ``licence`` when this one is available).
+All these attributes are listed in the package reference on :class:`datasets.DatasetInfo`. The most important metadata are ``split``, ``description``, ``citation``, ``homepage`` (and ``licence`` when this one is available).
 
 .. code-block::
 
@@ -118,8 +118,8 @@ Let's see how big is our dataset and how much RAM loading it requires:
 .. code-block::
 
     >>> from datasets import total_allocated_bytes
-    >>> print("The number of bytes allocated on the drive is", dataset.nbytes)
-    The number of bytes allocated on the drive is 943864
+    >>> print("The number of bytes allocated on the drive is", dataset.dataset_size)
+    The number of bytes allocated on the drive is 1492156
     >>> print("For comparison, here is the number of bytes allocated in memory:", total_allocated_bytes())
     For comparison, here is the number of bytes allocated in memory: 0
 
@@ -145,20 +145,20 @@ While you can access a single row with the ``dataset[i]`` pattern, you can also 
 .. code-block::
 
     >>> dataset[:3]
-    {'sentence1': ['Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .', "Yucaipa owned Dominick 's before selling the chain to Safeway in 1998 for $ 2.5 billion .", 'They had published an advertisement on the Internet on June 10 , offering the cargo for sale , he added .'],
-     'sentence2': ['Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .', "Yucaipa bought Dominick 's in 1995 for $ 693 million and sold it to Safeway for $ 1.8 billion in 1998 .", "On June 10 , the ship 's owners had published an advertisement on the Internet , offering the explosives for sale ."],
+    {'idx': [0, 1, 2],
      'label': [1, 0, 1],
-     'idx': [0, 1, 2]
+     'sentence1': ['Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .', "Yucaipa owned Dominick 's before selling the chain to Safeway in 1998 for $ 2.5 billion .", 'They had published an advertisement on the Internet on June 10 , offering the cargo for sale , he added .'],
+     'sentence2': ['Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .', "Yucaipa bought Dominick 's in 1995 for $ 693 million and sold it to Safeway for $ 1.8 billion in 1998 .", "On June 10 , the ship 's owners had published an advertisement on the Internet , offering the explosives for sale ."]
     }
     >>> dataset[[1, 3, 5]]
-    {'sentence1': ["Yucaipa owned Dominick 's before selling the chain to Safeway in 1998 for $ 2.5 billion .", 'Around 0335 GMT , Tab shares were up 19 cents , or 4.4 % , at A $ 4.56 , having earlier set a record high of A $ 4.57 .', 'Revenue in the first quarter of the year dropped 15 percent from the same period a year earlier .'],
-     'sentence2': ["Yucaipa bought Dominick 's in 1995 for $ 693 million and sold it to Safeway for $ 1.8 billion in 1998 .", 'Tab shares jumped 20 cents , or 4.6 % , to set a record closing high at A $ 4.57 .', "With the scandal hanging over Stewart 's company , revenue the first quarter of the year dropped 15 percent from the same period a year earlier ."],
+    {'idx': [1, 3, 5],
      'label': [0, 0, 1], 
-     'idx': [1, 3, 5]
+     'sentence1': ["Yucaipa owned Dominick 's before selling the chain to Safeway in 1998 for $ 2.5 billion .", 'Around 0335 GMT , Tab shares were up 19 cents , or 4.4 % , at A $ 4.56 , having earlier set a record high of A $ 4.57 .', 'Revenue in the first quarter of the year dropped 15 percent from the same period a year earlier .'],
+     'sentence2': ["Yucaipa bought Dominick 's in 1995 for $ 693 million and sold it to Safeway for $ 1.8 billion in 1998 .", 'Tab shares jumped 20 cents , or 4.6 % , to set a record closing high at A $ 4.57 .', "With the scandal hanging over Stewart 's company , revenue the first quarter of the year dropped 15 percent from the same period a year earlier ."]
     }
 
 
-You can also get a full columns by querying its name as a string. This will return a list of elements:
+You can also get a full column by querying its name as a string. This will return a list of elements:
 
 .. code-block::
 
@@ -190,7 +190,7 @@ Up to now, the rows/batches/columns returned when querying the elements of the d
 
 Sometimes we would like to have more sophisticated objects returned by our dataset, for instance NumPy arrays or PyTorch tensors instead of python lists.
 
-🤗datasets provides a way to do that through what is called a ``format``.
+🤗Datasets provides a way to do that through what is called a ``format``.
 
 While the internal storage of the dataset is always the Apache Arrow format, by setting a specific format on a dataset, you can filter some columns and cast the output of :func:`datasets.Dataset.__getitem__` in NumPy/pandas/PyTorch/TensorFlow, on-the-fly.
 
@@ -198,14 +198,14 @@ A specific format can be activated with :func:`datasets.Dataset.set_format`.
 
 :func:`datasets.Dataset.set_format` accepts those inputs to control the format of the dataset:
 
-- :obj:`type` (``Union[None, str]``, default to ``None``) defines the return type for the dataset :obj`__getitem__` method and is one of ``[None, 'numpy', 'pandas', 'torch', 'tensorflow']`` (``None`` means return python objects),
+- :obj:`type` (``Union[None, str]``, default to ``None``) defines the return type for the dataset :obj:`__getitem__` method and is one of ``[None, 'numpy', 'pandas', 'torch', 'tensorflow']`` (``None`` means return python objects),
 - :obj:`columns` (``Union[None, str, List[str]]``, default to ``None``) defines the columns returned by :obj:`__getitem__` and takes the name of a column in the dataset or a list of columns to return (``None`` means return all columns),
 - :obj:`output_all_columns` (``bool``, default to ``False``) controls whether the columns which cannot be formatted (e.g. a column with ``string`` cannot be cast in a PyTorch Tensor) are still outputted as python objects.
 - :obj:`format_kwargs` can be used to provide additional keywords arguments that will be forwarded to the convertiong function like ``np.array``, ``torch.tensor`` or ``tensorflow.ragged.constant``. For instance, to create ``torch.Tensor`` directly on the GPU you can specify ``device='cuda'``.
 
 .. note::
 
-    The format is only applied to single row or batches of rows (i.e. when querying :obj:`dataset[0]` or :obj:`dataset[10:20]`). Querying a column (e.g. :obj:`dataset['sentence1']`) will return the column even if it's filtered by the format. In this case the un-formatted column is returned.
+    The format is only applied to a single row or batches of rows (i.e. when querying :obj:`dataset[0]` or :obj:`dataset[10:20]`). Querying a column (e.g. :obj:`dataset['sentence1']`) will return the column even if it's filtered by the format. In this case the un-formatted column is returned.
     This design choice was made because it's quite rare to use column-only access when working with deep-learning frameworks and it's quite usefull to be able to access column even when they are masked by the format.
 
 Here is an example:
@@ -226,7 +226,7 @@ The current format of the dataset can be queried with ``datasets.Dataset.format`
     {'type': 'torch', 'format_kwargs': {}, 'columns': ['label'], 'output_all_columns': False}
     >>> dataset.reset_format()
     >>> dataset.format
-    {'type': 'python', 'format_kwargs': {}, 'columns': ['sentence1', 'sentence2', 'label', 'idx'], 'output_all_columns': False}
+    {'type': 'python', 'format_kwargs': {}, 'columns': ['idx', 'label', 'sentence1', 'sentence2'], 'output_all_columns': False}
 
 You can also define your own formatting transform that is applied on-the-fly. To do so you can use :func:`datasets.Dataset.set_transform`. It replaces any format that may have been defined beforehand.
 A formatting transform is a callable that takes a batch (as a dict) as input and returns a batch.

--- a/docs/source/faiss_and_ea.rst
+++ b/docs/source/faiss_and_ea.rst
@@ -1,7 +1,7 @@
 Adding a FAISS or Elastic Search index to a Dataset
 ====================================================================
 
-It is possible to do documents retrieval in a dataset.
+It is possible to do document retrieval in a dataset.
 
 For example, one way to do Open Domain Question Answering, one way to do that is to first retrieve documents that may be relevant to answer a question, and then we can use a model to generate an answer given the retrieved documents.
 

--- a/docs/source/filesystems.rst
+++ b/docs/source/filesystems.rst
@@ -6,7 +6,7 @@ Supported Filesystems
 
 Currenlty ``datasets`` offers an s3 filesystem implementation with :class:`datasets.filesystems.S3FileSystem`. ``S3FileSystem`` is a subclass of `s3fs.S3FileSystem <https://s3fs.readthedocs.io/en/latest/api.html>`_, which is a known implementation of ``fsspec``.
 
-Furthermore ``datasets`` supports all ``fsspec`` implementations. Currently Known Implementations these are: 
+Furthermore ``datasets`` supports all ``fsspec`` implementations. Currently known implementations are: 
 
 - `s3fs <https://s3fs.readthedocs.io/en/latest/>`_  for Amazon S3 and other compatible stores
 - `gcsfs <https://gcsfs.readthedocs.io/en/latest/>`_ for Google Cloud Storage
@@ -15,7 +15,7 @@ Furthermore ``datasets`` supports all ``fsspec`` implementations. Currently Know
 - `dropbox <https://github.com/MarineChap/dropboxdrivefs>`_ for access to dropbox shares
 - `gdrive <https://github.com/intake/gdrivefs>`_ to access Google Drive and shares (experimental)
 
-These know implementations are going to be natively added in the near future within ``datasets``.
+These known implementations are going to be natively added in the near future within ``datasets``.
 
 **Examples:**	
 
@@ -26,7 +26,7 @@ Example using :class:`datasets.filesystems.S3FileSystem` within ``datasets``.
 
     >>> pip install datasets[s3]
 
-Listing files from public s3 bucket.
+Listing files from a public s3 bucket.
 
 .. code-block::
 
@@ -35,7 +35,7 @@ Listing files from public s3 bucket.
       >>> s3.ls('public-datasets/imdb/train')  # doctest: +SKIP
       ['dataset_info.json.json','dataset.arrow','state.json']
 
-Listing files from private s3 bucket using ``aws_access_key_id`` and ``aws_secret_access_key``.
+Listing files from a private s3 bucket using ``aws_access_key_id`` and ``aws_secret_access_key``.
 
 .. code-block::
 
@@ -51,7 +51,6 @@ Using ``S3Filesystem`` with ``botocore.session.Session`` and custom ``aws_profil
       >>> import botocore 
       >>> from datasets.filesystems import S3FileSystem
       >>> s3_session = botocore.session.Session(profile_name='my_profile_name')
-      >>>
       >>> s3 = S3FileSystem(session=s3_session)  # doctest: +SKIP
 
 
@@ -62,7 +61,7 @@ Saving a processed dataset to s3
 Once you have your final dataset you can save it to s3 and reuse it later using :obj:`datasets.load_from_disk`.
 Saving a dataset to s3 will upload various files to your bucket:
 
-- ``arrow files.arrow``: they contain your dataset's data
+- ``arrow files``: they contain your dataset's data
 - ``dataset_info.json``: contains the description, citations, etc. of the dataset
 - ``state.json``: contains the list of the arrow files and other informations like the dataset format type, if any (torch or tensorflow for example)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Datasets and evaluation metrics for natural language processing
 
 Compatible with NumPy, Pandas, PyTorch and TensorFlow
 
-🤗datasets is a lightweight and extensible library to easily share and access datasets and evaluation metrics for Natural Language Processing (NLP).
+🤗Datasets is a lightweight and extensible library to easily share and access datasets and evaluation metrics for Natural Language Processing (NLP).
 
 🤗Datasets has many interesting features (beside easy sharing and accessing datasets/metrics):
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,23 +1,21 @@
 # Installation
 
-🤗datasets is tested on Python 3.6+.
+🤗Datasets is tested on Python 3.6+.
 
-You should install 🤗datasets in a [virtual environment](https://docs.python.org/3/library/venv.html). If you're
-unfamiliar with Python virtual environments, check out the [user guide](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/). Create a virtual environment with the version of Python you're going 
-to use and activate it.
+You should install 🤗Datasets in a [virtual environment](https://docs.python.org/3/library/venv.html). If you're
+unfamiliar with Python virtual environments, check out the [user guide](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/). Create a virtual environment with the version of Python you're going to use and activate it.
 
-Now, if you want to use 🤗datasets, you can install it with pip. If you'd like to play with the examples, you
-must install it from source.
+Now, if you want to use 🤗Datasets, you can install it with pip. If you'd like to play with the examples, you must install it from source.
 
 ## Installation with pip
 
-🤗datasets can be installed using pip as follows:
+🤗Datasets can be installed using pip as follows:
 
 ```bash
 pip install datasets
 ```
 
-To check 🤗 Transformers is properly installed, run the following command:
+To check 🤗Datasets is properly installed, run the following command:
 
 ```bash
 python -c "from datasets import load_dataset; print(load_dataset('squad', split='train')[0])"
@@ -26,32 +24,41 @@ python -c "from datasets import load_dataset; print(load_dataset('squad', split=
 It should download version 1 of the [Stanford Question Answering Dataset](https://rajpurkar.github.io/SQuAD-explorer/), load its training split and print the first training example:
 
 ```python
-{'id': '5733be284776f41900661182', 'title': 'University_of_Notre_Dame', 'context': 'Architecturally, the school has a Catholic character. Atop the Main Building\'s gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend "Venite Ad Me Omnes". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive (and in a direct line that connects through 3 statues and the Gold Dome), is a simple, modern stone statue of Mary.', 'question': 'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?', 'answers': {'text': array(['Saint Bernadette Soubirous'], dtype=object), 'answer_start': array([515], dtype=int32)}}
+{'answers': {'answer_start': [515], 'text': ['Saint Bernadette Soubirous']}, 'context': 'Architecturally, the school has a Catholic character. Atop the Main Building\'s gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend "Venite Ad Me Omnes". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive (and in a direct line that connects through 3 statues and the Gold Dome), is a simple, modern stone statue of Mary.', 'id': '5733be284776f41900661182', 'question': 'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?', 'title': 'University_of_Notre_Dame'}
 ```
 
-If you want to use the 🤗datasets library with TensorFlow 2.0 or PyTorch, you will need to install these seperately.
+If you want to use the 🤗Datasets library with TensorFlow 2.0 or PyTorch, you will need to install these seperately.
 Please refer to [TensorFlow installation page](https://www.tensorflow.org/install/pip#tensorflow-2.0-rc-is-available) 
-and/or [PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) regarding the specific 
-install command for your platform.
+and/or [PyTorch installation page](https://pytorch.org/get-started/locally/#start-locally) regarding the specific install command for your platform.
 
 
 ## Installing from source
 
 To install from source, clone the repository and install with the following commands:
 
-``` bash
+```bash
 git clone https://github.com/huggingface/datasets.git
 cd datasets
 pip install -e .
 ```
 
-Again, you can run 
+Again, you can run:
 
 ```bash
 python -c "from datasets import load_dataset; print(load_dataset('squad', split='train')[0])"
 ```
 
-to check 🤗datasets is properly installed.
+to check 🤗Datasets is properly installed.
+
+## With conda
+
+🤗Datasets can be installed using conda as follows:
+
+```bash
+conda install -c huggingface -c conda-forge datasets
+```
+
+Follow the installation pages of TensorFlow and PyTorch to see how to install them with conda.
 
 ## Caching datasets and metrics
 
@@ -65,4 +72,4 @@ The HuggingFace cache home is (by order of priority):
   * shell environment variable ``ENV_XDG_CACHE_HOME`` + ``/huggingface/``
   * default: ``~/.cache/huggingface/``
 
-So if you don't have any specific environment variable set, the cache directory for datasets scripts and data will be at ``~/.cache/huggingface/datasets/``.
+So if you don't have any specific environment variable set, the cache directory for dataset scripts and data will be at ``~/.cache/huggingface/datasets/``.

--- a/docs/source/loading_datasets.rst
+++ b/docs/source/loading_datasets.rst
@@ -12,7 +12,7 @@ In this section we study each option.
 From the HuggingFace Hub
 -------------------------------------------------
 
-Over 135 datasets for many NLP tasks like text classification, question answering, language modeling, etc, are provided on the `HuggingFace Hub <https://huggingface.co/datasets>`__ and can be viewed and explored online with the `🤗datasets viewer <https://huggingface.co/datasets/viewer>`__.
+Over 135 datasets for many NLP tasks like text classification, question answering, language modeling, etc, are provided on the `HuggingFace Hub <https://huggingface.co/datasets>`__ and can be viewed and explored online with the `🤗Datasets viewer <https://huggingface.co/datasets/viewer>`__.
 
 .. note::
 
@@ -61,7 +61,7 @@ This call to :func:`datasets.load_dataset` does the following steps under the ho
 
 .. note::
 
-    An Apache Arrow Table is the internal storing format for 🤗datasets. It allows to store arbitrarily long dataframe, typed with potentially complex nested types that can be mapped to numpy/pandas/python types. Apache Arrow allows you to map blobs of data on-drive without doing any deserialization. So caching the dataset directly on disk can use memory-mapping and pay effectively zero cost with O(1) random access. The default in 🤗datasets is thus to always memory-map dataset on drive.
+    An Apache Arrow Table is the internal storing format for 🤗Datasets. It allows to store arbitrarily long dataframe, typed with potentially complex nested types that can be mapped to numpy/pandas/python types. Apache Arrow allows you to map blobs of data on-drive without doing any deserialization. So caching the dataset directly on disk can use memory-mapping and pay effectively zero cost with O(1) random access. The default in 🤗Datasets is thus to always memory-map dataset on drive.
 
 3. Return a **dataset built from the splits** asked by the user (default: all); in the above example we create a dataset with the train split.
 
@@ -123,7 +123,7 @@ Some dataset require you to download manually some files, usually because of lic
 
 In this case specific instruction for dowloading the missing files will be provided when running the script with :func:`datasets.load_dataset` for the first time to explain where and how you can get the files.
 
-After you've downloaded the files, you can point to the folder hosting them locally with the :obj:`data_dir` argument as follow
+After you've downloaded the files, you can point to the folder hosting them locally with the :obj:`data_dir` argument as follows:
 
 .. code-block::
 
@@ -178,7 +178,7 @@ Let's see an example of all the various ways you can provide files to :func:`dat
 CSV files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-🤗datasets can read a dataset made of on or several CSV files.
+🤗Datasets can read a dataset made of on or several CSV files.
 
 All the CSV files in the dataset should have the same organization and in particular the same datatypes for the columns.
 
@@ -199,7 +199,7 @@ Here is an example loading two CSV file to create a ``train`` split (default spl
 
 The ``csv`` loading script provides a few simple access options to control parsing and reading the CSV files:
 
-    - :obj:`skip_rows` (int) - Number of first rows in the file to skip (default is 0)
+    - :obj:`skiprows` (int) - Number of first rows in the file to skip (default is 0)
     - :obj:`column_names` (list, optional) – The column names of the target table. If empty, fall back on autogenerate_column_names (default: empty).
     - :obj:`delimiter` (1-character string) – The character delimiting individual cells in the CSV data (default ``','``).
     - :obj:`quotechar` (1-character string) – The character used optionally for quoting CSV values (default '"').
@@ -207,7 +207,7 @@ The ``csv`` loading script provides a few simple access options to control parsi
 
 If you want more control, the ``csv`` script provide full control on reading, parsong and convertion through the Apache Arrow `pyarrow.csv.ReadOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ReadOptions.html>`__, `pyarrow.csv.ParseOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html>`__ and `pyarrow.csv.ConvertOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ConvertOptions.html>`__
 
-    - :obj:`read_options` — Can be provided with a `pyarrow.csv.ReadOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ReadOptions.html>`__ to control all the reading options. If :obj:`skip_rows`, :obj:`column_names` or :obj:`autogenerate_column_names` are also provided (see above), they will take priority over the attributes in :obj:`read_options`.
+    - :obj:`read_options` — Can be provided with a `pyarrow.csv.ReadOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ReadOptions.html>`__ to control all the reading options. If :obj:`skiprows`, :obj:`column_names` or :obj:`autogenerate_column_names` are also provided (see above), they will take priority over the attributes in :obj:`read_options`.
     - :obj:`parse_options` — Can be provided with a `pyarrow.csv.ParseOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html>`__ to control all the parsing options. If :obj:`delimiter` or :obj:`quote_char` are also provided (see above), they will take priority over the attributes in :obj:`parse_options`.
     - :obj:`convert_options` — Can be provided with a `pyarrow.csv.ConvertOptions <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ConvertOptions.html>`__ to control all the conversion options.
 
@@ -215,7 +215,7 @@ If you want more control, the ``csv`` script provide full control on reading, pa
 JSON files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-🤗datasets supports building a dataset from JSON files in various format.
+🤗Datasets supports building a dataset from JSON files in various format.
 
 The most efficient format is to have JSON files consisting of multiple JSON objects, one per line, representing individual data rows:
 
@@ -248,7 +248,7 @@ One common occurence is to have a JSON file with a single root dictionary where 
               {"a": 4, "b": -5.5, "c": null, "d": true}]
     }
 
-In this case you will need to specify which field contains the dataset using the :obj:`field` argument as follow:
+In this case you will need to specify which field contains the dataset using the :obj:`field` argument as follows:
 
 .. code-block::
 
@@ -259,7 +259,7 @@ In this case you will need to specify which field contains the dataset using the
 Text files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-🤗datasets also supports building a dataset from text files read line by line (each line will be a row in the dataset).
+🤗Datasets also supports building a dataset from text files read line by line (each line will be a row in the dataset).
 
 This is simply done using the ``text`` loading script which will generate a dataset with a single column called ``text`` containing all the text lines of the input files as strings.
 

--- a/docs/source/loading_metrics.rst
+++ b/docs/source/loading_metrics.rst
@@ -71,7 +71,7 @@ This call to :func:`datasets.load_metric` does the following steps under the hoo
 
 .. note::
 
-    The :class:`datasets.Metric` object use Apache Arrow Tables as the internal storing format for predictions and references. It allows to store predictions and references directly on disk with memory-mapping and thus do lazy computation of the metrics, in particular to easily gather the predictions in a distributed setup. The default in 🤗datasets is to always memory-map metrics data on drive.
+    The :class:`datasets.Metric` object use Apache Arrow Tables as the internal storing format for predictions and references. It allows to store predictions and references directly on disk with memory-mapping and thus do lazy computation of the metrics, in particular to easily gather the predictions in a distributed setup. The default in 🤗Datasets is to always memory-map metrics data on drive.
 
 Using a custom metric script
 -----------------------------------------------------------
@@ -151,7 +151,7 @@ The synchronization is performed with the help of file locks on the filesystem.
 Multiple and independent distributed setups
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In some cases, several **independent and not related** distributed evaluations might be running on the same server and the same file system at the same time (e.g. two independent multi-processing trainings running on the same server) and it is then important to distinguish these experiemnts and allow them to operate in independently.
+In some cases, several **independent and not related** distributed evaluations might be running on the same server and the same file system at the same time (e.g. two independent multiprocessing trainings running on the same server) and it is then important to distinguish these experiemnts and allow them to operate in independently.
 
 In this situation you should provide an ``experiment_id`` to :func:`datasets.load_metric` which has to be a unique identifier of the current distributed experiment.
 

--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -1,7 +1,7 @@
 Logging methods
 ----------------------------------------------------
 
-`datasets` tries to be very transparent and explicit about its inner working, but this can be quite verbose at times.
+🤗datasets tries to be very transparent and explicit about its inner working, but this can be quite verbose at times.
 
 A series of logging methods let you easily adjust the level of verbosity of the whole library.
 

--- a/docs/source/package_reference/logging_methods.rst
+++ b/docs/source/package_reference/logging_methods.rst
@@ -1,7 +1,7 @@
 Logging methods
 ----------------------------------------------------
 
-🤗datasets tries to be very transparent and explicit about its inner working, but this can be quite verbose at times.
+🤗Datasets tries to be very transparent and explicit about its inner working, but this can be quite verbose at times.
 
 A series of logging methods let you easily adjust the level of verbosity of the whole library.
 

--- a/docs/source/processing.rst
+++ b/docs/source/processing.rst
@@ -1,7 +1,7 @@
 Processing data in a Dataset
 ==============================================================
 
-🤗datasets provides many methods to modify a Dataset, be it to reorder, split or shuffle the dataset or to apply data processing functions or evaluation functions to its elements.
+🤗Datasets provides many methods to modify a Dataset, be it to reorder, split or shuffle the dataset or to apply data processing functions or evaluation functions to its elements.
 
 We'll start by presenting the methods which change the order or number of elements before presenting methods which access and can change the content of the elements themselves.
 
@@ -22,7 +22,7 @@ As always, let's start by loading a small dataset for our demonstrations:
 
     A subsequent call to any of the methods detailed here (like :func:`datasets.Dataset.sort`, :func:`datasets.Dataset.map`, etc) will thus **reuse the cached file instead of recomputing the operation** (even in another python session).
 
-    This usually makes it very efficient to process data with 🤗datasets.
+    This usually makes it very efficient to process data with 🤗Datasets.
 
     If the disk space is critical, these methods can be called with arguments to avoid this behavior (see the last section), or the cache files can be cleaned using the method :func:`datasets.Dataset.cleanup_cache_files`.
 
@@ -46,7 +46,7 @@ Let's see them in action:
 Sorting the dataset according to a column: ``sort``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The provided column has to be of a NumPy compatible column (typically a column containing numerical values).
+The provided column has to be NumPy compatible (typically a column containing numerical values).
 
 .. code-block::
 
@@ -92,7 +92,7 @@ You can filter rows according to a list of indices (:func:`datasets.Dataset.sele
      'Artists are worried the plan would harm those who need help most - performers who have a difficult time lining up shows .'
     ]
 
-:func:`datasets.Dataset.filter` expect a function which can accept a single example of the dataset, i.e. the python dictionary returned by :obj:`dataset[i]` and return a boolean value. It's also possible to use the indice of each example in the function by setting :obj:`with_indices=True` in :func:`datasets.Dataset.filter`. In this case, the signature of the function given to :func:`datasets.Dataset.filter` should be :obj:`function(example: dict, indice: int) -> bool`:
+:func:`datasets.Dataset.filter` expects a function which can accept a single example of the dataset, i.e. the python dictionary returned by :obj:`dataset[i]` and returns a boolean value. It's also possible to use the indice of each example in the function by setting :obj:`with_indices=True` in :func:`datasets.Dataset.filter`. In this case, the signature of the function given to :func:`datasets.Dataset.filter` should be :obj:`function(example: dict, indice: int) -> bool`:
 
 .. code-block::
 
@@ -141,7 +141,7 @@ Renaming, removing, casting and flattening columns
 Renaming a column: ``rename_column``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This method renames a column in the dataset, and move the features associated to the original column under the new column name. This operation will fail if the new column name already exists.
+This method renames a column in the dataset, and moves the features associated to the original column under the new column name. This operation will fail if the new column name already exists.
 
 :func:`datasets.Dataset.rename_column` takes the name of the original column and the new name as arguments.
 
@@ -165,7 +165,7 @@ You can also remove a column using :func:`Dataset.map` with `remove_columns` but
 doesn't copy the data to a new dataset object and is thus faster.
 
 :func:`datasets.Dataset.remove_columns` takes the names of the column to remove as argument.
-You can provide one single column names or a list of column names.
+You can provide one single column name or a list of column names.
 
 .. code-block::
 
@@ -242,11 +242,11 @@ In this case if you want each of the two subfields to be actual columns, you can
 Processing data with ``map``
 --------------------------------
 
-All the methods we seen up to now operate on examples taken as a whole and don't inspect (excepted for the ``filter`` method) or modify the content of the samples.
+All the methods we've seen up to now operate on examples taken as a whole and don't inspect (excepted for the ``filter`` method) or modify the content of the samples.
 
-We now turn to the :func:`datasets.Dataset.map` method which is a powerful method inspired by ``tf.data.Dataset`` map method and which you can use to apply a processing function to each examples in a dataset, independently or in batch and even generate new rows or columns.
+We now turn to the :func:`datasets.Dataset.map` method which is a powerful method inspired by ``tf.data.Dataset`` map method and which you can use to apply a processing function to each example in a dataset, independently or in batch and even generate new rows or columns.
 
-:func:`datasets.Dataset.map` takes a callable accepting a dict as argument (same dict as returned by :obj:`dataset[i]`) and iterate over the dataset by calling the function with each example.
+:func:`datasets.Dataset.map` takes a callable accepting a dict as argument (same dict as returned by :obj:`dataset[i]`) and iterates over the dataset by calling the function with each example.
 
 Let's print the length of the ``sentence1`` value for each sample in our dataset:
 
@@ -279,7 +279,7 @@ The above example had no effect on the dataset because the method we supplied to
 
 In such a case, :func:`datasets.Dataset.map` will return the original dataset (:obj:`self`) and the user is usually only interested in side effects of the provided method.
 
-Now let's see how we can use a method that actually modify the dataset with :func:`datasets.Dataset.map`.
+Now let's see how we can use a method that actually modifies the dataset with :func:`datasets.Dataset.map`.
 
 Processing data row by row
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -288,7 +288,7 @@ The main interest of :func:`datasets.Dataset.map` is to update and modify the co
 
 To use :func:`datasets.Dataset.map` to update elements in the table you need to provide a function with the following signature: :obj:`function(example: dict) -> dict`.
 
-Let's add a prefix ``'My sentence: '`` to each ``sentence1`` values in our small dataset:
+Let's add a prefix ``'My sentence: '`` to each ``sentence1`` value in our small dataset:
 
 .. code-block::
 
@@ -310,13 +310,13 @@ This call to :func:`datasets.Dataset.map` computed and returned an updated table
 
     Calling :func:`datasets.Dataset.map` also stored the updated table in a cache file indexed by the current state and the mapped function.
     A subsequent call to :func:`datasets.Dataset.map` (even in another python session) will reuse the cached file instead of recomputing the operation.
-    You can test this by running again the previous cell, you will see that the result are directly loaded from the cache and not re-computed again.
+    You can test this by running again the previous cell, you will see that the result is directly loaded from the cache and not re-computed again.
 
 The function you provide to :func:`datasets.Dataset.map` should accept an input with the format of an item of the dataset: :obj:`function(dataset[0])` and return a python dict.
 
 The columns and type of the outputs **can be different** from columns and type of the input dict. In this case the new keys will be **added** as additional columns in the dataset.
 
-Each dataset example dict is updated with the dictionary returned by the function. Under the hood :obj:`map` operate like this:
+Each dataset example dict is updated with the dictionary returned by the function. Under the hood :obj:`map` operates like this:
 
 .. code-block::
 
@@ -341,7 +341,7 @@ Since the input example dict is **updated** with output dict generated by our :o
 If a dataset was formatted using :func:`datasets.Dataset.set_format`, then:
 
 - if a format type was set, then the format type doesn't change
-- if a list of columns that __getitem__ should return was set, then the new columns added by map are added to this list
+- if a list of columns that :func:`datasets.Dataset.__getitem__` should return was set, then the new columns added by map are added to this list
 
 Removing columns
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -351,7 +351,7 @@ This process of **updating** the original example with the output of the mapped 
 
 To this aim, the :obj:`remove_columns=List[str]` argument can be used and provided with a single name or a list of names of columns which should be removed during the :func:`datasets.Dataset.map` operation.
 
-Column to remove are removed **after** the example has been provided to the mapped function so that the mapped function can use the content of these columns before they are removed.
+Columns to remove are removed **after** the example has been provided to the mapped function so that the mapped function can use the content of these columns before they are removed.
 
 Here is an example removing the ``sentence1`` column while adding a ``new_sentence`` column with the content of the ``new_sentence``. Said more simply, we are renaming the ``sentence1`` column as ``new_sentence``:
 
@@ -367,7 +367,7 @@ Using row indices
 
 When the argument :obj:`with_indices` is set to :obj:`True`, the indices of the rows (from ``0`` to ``len(dataset)``) will be provided to the mapped function. This function must then have the following signature: :obj:`function(example: dict, indice: int) -> Union[None, dict]`.
 
-In the following example, we add the index of the example as a prefix to the 'sentence2' field of each example:
+In the following example, we add the index of the example as a prefix to the ``sentence2`` field of each example:
 
 .. code-block::
 
@@ -391,7 +391,7 @@ To operate on batch of example, just set :obj:`batched=True` when calling :func:
 
 In other words, the mapped function should accept an input with the format of a slice of the dataset: :obj:`function(dataset[:10])`.
 
-Let's take an example with a fast tokenizer of the 🤗transformers library.
+Let's take an example with a fast tokenizer of the 🤗Transformers library.
 
 First install this library if you haven't already done it:
 
@@ -406,11 +406,11 @@ Then we will import a fast tokenizer, for instance the tokenizer of the Bert mod
     >>> from transformers import BertTokenizerFast
     >>> tokenizer = BertTokenizerFast.from_pretrained('bert-base-cased')
 
-Now let's batch tokenize the 'sentence1' fields of our dataset. The tokenizers of the 🤗transformers library can accept lists of texts as inputs and tokenize them efficiently in batch (for the fast tokenizers in particular).
+Now let's batch tokenize the ``sentence1`` fields of our dataset. The tokenizers of the 🤗Transformers library can accept lists of texts as inputs and tokenize them efficiently in batch (for the fast tokenizers in particular).
 
-For more details on the tokenizers of the 🤗transformers library Please refer to its `guide on processing data <https://huggingface.co/transformers/preprocessing.html>`__.
+For more details on the tokenizers of the 🤗Transformers library please refer to its `guide on processing data <https://huggingface.co/transformers/preprocessing.html>`__.
 
-This tokenizer will output a dictionary-like object with three fields: ``input_ids``, ``token_type_ids``, ``attention_mask`` corresponding to Bert model's required inputs. Each field contain a list (batch) of samples.
+This tokenizer will output a dictionary-like object with three fields: ``input_ids``, ``token_type_ids``, ``attention_mask`` corresponding to Bert model's required inputs. Each field contains a list (batch) of samples.
 
 The output of the tokenizer is thus compatible with the :func:`datasets.Dataset.map` method which is also expected to return a dictionary. We can thus directly return the dictionary generated by the tokenizer as the output of our mapped function:
 
@@ -429,16 +429,16 @@ The output of the tokenizer is thus compatible with the :func:`datasets.Dataset.
      'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     }
 
-We have indeed the added columns for ``input_ids``, ``token_type_ids``, ``attention_mask`` which contains the encoded version of the ``sentence1`` field.
+We have indeed added the columns for ``input_ids``, ``token_type_ids``, ``attention_mask`` which contain the encoded version of the ``sentence1`` field.
 
 The batch size provided to the mapped function can be controlled by the :obj:`batch_size` argument. The default value is ``1000``, i.e. batches of 1000 samples will be provided to the mapped function by default.
 
 Augmenting the dataset
 ---------------------------
 
-Using :func:`datasets.Dataset.map` in batched mode (i.e. with :obj:`batched=True`) actually let you control the size of the generate dataset freely.
+Using :func:`datasets.Dataset.map` in batched mode (i.e. with :obj:`batched=True`) actually let you control the size of the generated dataset freely.
 
-More precisely, in batched mode :func:`datasets.Dataset.map` will provide batch of examples (as a dict of lists) to the mapped function and expect the mapped function to return back a batch of examples (as a dict of lists) but **the input and output batch are not required to be of the same size**.
+More precisely, in batched mode :func:`datasets.Dataset.map` will provide a batch of examples (as a dict of lists) to the mapped function and expect the mapped function to return back a batch of examples (as a dict of lists) but **the input and output batch are not required to be of the same size**.
 
 In other words, a batch mapped function can take as input a batch of size ``N`` and return a batch of size ``M`` where ``M`` can be greater or less than ``N`` and can even be zero.
 
@@ -452,11 +452,11 @@ This can be taken advantage of for several use-cases:
 
 .. note::
 
-    **One important condition on the output of the mapped function** Each field in the output dictionary returned by the mapped function must contain the **same number of elements** as the other field in this output dictionary otherwise it's not possible to define the number of examples in the output returned the mapped function. This number can vary between the successive batches processed by the mapped function but in a single batch, all fields of the output dictionary should have the same number of elements.
+    **One important condition on the output of the mapped function.** Each field in the output dictionary returned by the mapped function must contain the **same number of elements** as the other field in this output dictionary otherwise it's not possible to define the number of examples in the output returned the mapped function. This number can vary between the successive batches processed by the mapped function but in a single batch, all fields of the output dictionary should have the same number of elements.
 
 Let's show how we can implemented the two simple examples we mentioned: "cutting examples which are too long in several snippets" and do some "data augmentation".
 
-We'll start by chunking the ``sentence1`` field of our dataset in chunk of 50 characters and stack all these chunks to make our new dataset.
+We'll start by chunking the ``sentence1`` field of our dataset in chunks of 50 characters and stack all these chunks to make our new dataset.
 
 We will also remove all the columns of the dataset and only keep the chunks in order to avoid the issue of uneven field lengths mentioned in the above note (we could also duplicate the other fields to compensated but let's make it as simple as possible here):
 
@@ -487,7 +487,7 @@ As we can see, our dataset is now much longer (10470 row) and contains a single 
 
 Now let's finish with the other example and try to do some data augmentation. We will use a Roberta model to sample some masked tokens.
 
-Here we can use the `FillMaskPipeline of transformers <https://huggingface.co/transformers/main_classes/pipelines.html?#transformers.pipeline>`__ to generate options for a masked token in a sentence.
+Here we can use the `FillMaskPipeline of 🤗Transformers <https://huggingface.co/transformers/main_classes/pipelines.html?#transformers.FillMaskPipeline>`__ to generate options for a masked token in a sentence.
 
 We will randomly select a word to mask in the sentence and return the original sentence plus the two top replacements by Roberta.
 
@@ -509,7 +509,7 @@ Since the Roberta model is quite large to run on a small laptop CPU, we will res
     ...         K = randint(1, len(words)-1)
     ...         masked_sentence = " ".join(words[:K]  + [mask_token] + words[K+1:])
     ...         predictions = fillmask(masked_sentence)
-    ...         augmented_sequences = [predictions[i]['sequence']for i in range(3)]
+    ...         augmented_sequences = [predictions[i]['sequence'] for i in range(3)]
     ...         outputs += [sentence] + augmented_sequences
     ...     
     ...     return {'data': outputs}
@@ -527,9 +527,9 @@ Since the Roberta model is quite large to run on a small laptop CPU, we will res
      "Yucaipa owned Dominick's before selling the chain to Safeway in 1998 for $ 2.5 billion.", 
      'Yucaipa owned Dominick Pizza before selling the chain to Safeway in 1998 for $ 2.5 billion.']
 
-Here we have now multiply the size of our dataset by ``4`` by adding three alternatives generated with Roberta to each example.  We can see that the word ``distorting`` in the first example was augmented with other possibilities by the Roberta model: ``withholding``, ``suppressing``, ``destroying``, while in the second sentence, it was the ``'s`` token which was randomly sampled and replaced by ``Stores`` and ``Pizza``.
+Here we have now multiplied the size of our dataset by ``4`` by adding three alternatives generated with Roberta to each example. We can see that the word ``distorting`` in the first example was augmented with other possibilities by the Roberta model: ``withholding``, ``suppressing``, ``destroying``, while in the second sentence, it was the ``'s`` token which was randomly sampled and replaced by ``Stores`` and ``Pizza``.
 
-Obviously this is a very simple example for data augmentation and it could be improved in several ways, the most interesting take-aways is probably how this can be written in roughtly ten lines of code without any loss in flexibility.
+Obviously this is a very simple example for data augmentation and it could be improved in several ways, the most interesting take-away is probably how this can be written in roughtly ten lines of code without any loss in flexibility.
 
 Processing several splits at once
 -----------------------------------
@@ -555,7 +555,7 @@ You can directly call map, filter, shuffle, and sort directly on a :obj:`dataset
      'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     }
 
-This concludes our chapter on data processing with 🤗datasets (and 🤗transformers).
+This concludes our chapter on data processing with 🤗Datasets (and 🤗Transformers).
 
 Concatenate several datasets
 ----------------------------
@@ -594,7 +594,7 @@ Saving a dataset creates a directory with various files:
 Both :obj:`datasets.Dataset` and :obj:`datasets.DatasetDict` objects can be saved on disk, by using respectively :func:`datasets.Dataset.save_to_disk` and :func:`datasets.DatasetDict.save_to_disk`.
 
 Furthermore it is also possible to save :obj:`datasets.Dataset` and :obj:`datasets.DatasetDict` to other filesystems and cloud storages such as S3 by using respectively :func:`datasets.Dataset.save_to_disk` 
-and :func:`datasets.DatasetDict.save_to_disk` and providing a ``Filesystem`` as input ``fs``. To learn more about saving your ``datasets`` to other filesystem take a look at :doc:`filesystems`
+and :func:`datasets.DatasetDict.save_to_disk` and providing a ``Filesystem`` as input ``fs``. To learn more about saving your ``datasets`` to other filesystem take a look at :doc:`filesystems`.
 
 Exporting a dataset to csv, or to python objects
 ------------------------------------------------
@@ -611,14 +611,14 @@ The caching mechanism allows to reload an existing cache file if it's already be
 
 Reloading a dataset is possible since the cache files are named using the dataset fingerprint, which is updated after each transform.
 
-Note that the caching extend beyond sessions. Re-running the very same dataset processing methods (in the same order and on the same data files) in a different session will load from the same cache files.
+Note that the caching extends beyond sessions. Re-running the very same dataset processing methods (in the same order and on the same data files) in a different session will load from the same cache files.
 This is possible thanks to a custom hashing function that works with most python objects (see fingerprinting section below).
 
 
 Fingerprinting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The fingerprint of a dataset in a given state is an internal value computed by combining the fingerprint of the previous state and a hash of the latest transform that was applied. (Transform are all the processing method for transforming a dataset that we listed in this chapter (:func:`datasets.Dataset.map`, :func:`datasets.Dataset.shuffle`, etc)
+The fingerprint of a dataset in a given state is an internal value computed by combining the fingerprint of the previous state and a hash of the latest transform that was applied. (Transforms are all the processing method for transforming a dataset that we listed in this chapter (:func:`datasets.Dataset.map`, :func:`datasets.Dataset.shuffle`, etc)
 The initial fingerprint is computed using a hash of the arrow table, or a hash of the arrow files if the dataset lives on disk.
 
 For example:
@@ -644,7 +644,7 @@ You can also specify the name of path where the cache file will be written using
 
 It is also possible to disable caching globally with :func:`datasets.set_caching_enabled`.
 
-If the caching is disabled, the library will no longer reload cached datasets files when applying transforms to the datasets.
+If the caching is disabled, the library will no longer reload cached dataset files when applying transforms to the datasets.
 More precisely, if the caching is disabled:
 - cache files are always recreated
 - cache files are written to a temporary directory that is deleted when session closes

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -1,13 +1,13 @@
 Quick tour
 ==========
 
-Let's have a quick look at the 🤗datasets library. This library has three main features:
+Let's have a quick look at the 🤗Datasets library. This library has three main features:
 
 - It provides a very **efficient way to load and process data** from raw files (CSV/JSON/text) or in-memory data (python dict, pandas dataframe) with a special focus on memory efficiency and speed. As a matter of example, loading a 18GB dataset like English Wikipedia allocate 9 MB in RAM and you can iterate over the dataset at 1-2 GBit/s in python.
 - It provides a very **simple way to access and share datasets** with the research and practitioner communities (over 130 NLP datasets are already accessible in one line with the library as we'll see below).
 - It was designed with a particular focus on interoperabilty with frameworks like **pandas, NumPy, PyTorch and TensorFlow**.
 
-🤗datasets provides datasets for many NLP tasks like text classification, question answering, language modeling, etc and obviously these datasets can always be used to other tasks than their originally assigned task. Let's list all the currently provided datasets using :func:`datasets.list_datasets`:
+🤗Datasets provides datasets for many NLP tasks like text classification, question answering, language modeling, etc., and obviously these datasets can always be used for other tasks than their originally assigned task. Let's list all the currently provided datasets using :func:`datasets.list_datasets`:
 
 .. code-block::
 
@@ -28,7 +28,7 @@ Let's have a quick look at the 🤗datasets library. This library has three main
     wikihow, wikipedia, wikisql, wikitext, winogrande, wiqa, wmt14, wmt15, wmt16, wmt17, wmt18, wmt19, wmt_t2t, wnut_17, x_stance, xcopa, xnli, 
     xquad, xsum, xtreme, yelp_polarity
 
-All these datasets can also be browsed on the `HuggingFace Hub <https://huggingface.co/datasets>`__ and can be viewed and explored online with the `🤗datasets viewer <https://huggingface.co/datasets/viewer/>`__.
+All these datasets can also be browsed on the `HuggingFace Hub <https://huggingface.co/datasets>`__ and can be viewed and explored online with the `🤗Datasets viewer <https://huggingface.co/datasets/viewer/>`__.
 
 Loading a dataset
 --------------------
@@ -54,7 +54,7 @@ If you want to create a :class:`datasets.Dataset` from local CSV, JSON, text or 
 
 .. note::
 
-    If you don't provide a :obj:`split` argument to :func:`datasets.load_dataset`, this method will return a dictionary containing a datasets for each split in the dataset. This dictionary is a :obj:`datasets.DatasetDict` object that lets you process all the splits at once using :func:`datasets.DatasetDict.map`, :func:`datasets.DatasetDict.filter`, etc.
+    If you don't provide a :obj:`split` argument to :func:`datasets.load_dataset`, this method will return a dictionary containing a dataset for each split in the dataset. This dictionary is a :obj:`datasets.DatasetDict` object that lets you process all the splits at once using :func:`datasets.DatasetDict.map`, :func:`datasets.DatasetDict.filter`, etc.
 
 Now let's have a look at our newly created :class:`datasets.Dataset` object. It basically behaves like a normal python container. You can query its length, get a single row but also get multiple rows and even index along columns (see all the details in :doc:`exploring </exploring>`):
 
@@ -69,9 +69,9 @@ Now let's have a look at our newly created :class:`datasets.Dataset` object. It 
      'idx': 0}
 
 A lot of metadata are available in the dataset attributes (description, citation, split sizes, etc) and we'll dive in this in the :doc:`exploring </exploring>` page.
-We'll just say here that :class:`datasets.Dataset` have columns which are typed with types which can be arbitrarily nested complex types (e.g. list of strings or list of lists of int64 values).
+We'll just say here that :class:`datasets.Dataset` has columns which are typed with types which can be arbitrarily nested complex types (e.g. list of strings or list of lists of int64 values).
 
-Let's take a look at the column in our dataset by printing its :func:`datasets.Dataset.features`:
+Let's take a look at the column in our dataset by printing its :attr:`datasets.Dataset.features`:
 
 .. code-block::
 
@@ -88,7 +88,7 @@ In the rest of this quick-tour we will use this dataset to fine-tune a Bert mode
 
 As you can see from the above features, the labels are a :class:`datasets.ClassLabel` instance with two classes: ``not_equivalent`` and ``equivalent``. 
 
-We can print one example of each class using :func:`datasets.Dataset.filter` and a name-to-integer conversion method of the feature :class:`datasets.ClassLabel` called :func:`datasets.ClassLabel.str2int` (that we detail these methods in :doc:`processing </processing>` and :doc:`exploring </exploring>`):
+We can print one example of each class using :func:`datasets.Dataset.filter` and a name-to-integer conversion method of the feature :class:`datasets.ClassLabel` called :func:`datasets.ClassLabel.str2int` (we explain these methods in more detail in :doc:`processing </processing>` and :doc:`exploring </exploring>`):
 
 .. code-block::
 
@@ -105,9 +105,9 @@ We can print one example of each class using :func:`datasets.Dataset.filter` and
      'sentence2': "Yucaipa bought Dominick 's in 1995 for $ 693 million and sold it to Safeway for $ 1.8 billion in 1998 ."
     }
 
-Now our goal will be to train a model which can predict the correct label (``not_equivalent`` or ``equivalent``) from a pair of sentence.
+Now our goal will be to train a model which can predict the correct label (``not_equivalent`` or ``equivalent``) from a pair of sentences.
 
-Let's import a pretrained Bert model and its tokenizer using 🤗transformers.
+Let's import a pretrained Bert model and its tokenizer using 🤗Transformers.
 
 .. code-block::
 
@@ -130,8 +130,8 @@ Let's import a pretrained Bert model and its tokenizer using 🤗transformers.
     You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
     >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-cased')
 
-🤗transformers warns us that we should probably train this model on a downstream task before using it which is exactly what we are going to do.
-If you want more details on the models and tokenizers of 🤗transformers, you should refer to the documentation and tutorials of this library `which are available here <https://huggingface.co/transformers/>`__.
+🤗Transformers warns us that we should probably train this model on a downstream task before using it which is exactly what we are going to do.
+If you want more details on the models and tokenizers of 🤗Transformers, you should refer to the documentation and tutorials of this library `which are available here <https://huggingface.co/transformers/>`__.
 
 Tokenizing the dataset
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -148,10 +148,10 @@ The first step is to tokenize our sentences in order to build sequences of integ
     >>> tokenizer.decode(tokenizer(dataset[0]['sentence1'], dataset[0]['sentence2'])['input_ids'])
     '[CLS] Amrozi accused his brother, whom he called " the witness ", of deliberately distorting his evidence. [SEP] Referring to him as only " the witness ", Amrozi accused his brother of deliberately distorting his evidence. [SEP]'
 
-As you can see, the tokenizer has merged the pair of sequences in a single input separating them by some special tokens ``[CLS]`` and ``[SEP]`` expected by Bert. For more details on this, you can refer to `🤗transformers's documentation on data processing <https://huggingface.co/transformers/preprocessing.html#preprocessing-pairs-of-sentences>`__.
+As you can see, the tokenizer has merged the pair of sequences in a single input separating them by some special tokens ``[CLS]`` and ``[SEP]`` expected by Bert. For more details on this, you can refer to `🤗Transformers's documentation on data processing <https://huggingface.co/transformers/preprocessing.html#preprocessing-pairs-of-sentences>`__.
 
-In our case, we want to tokenize our full dataset, so we will use a method called :func:`datasets.Dataset.map` to apply the encoding process to their whole dataset.
-To be sure we can easily build tensors batches for our model, we will truncate and pad the inputs to the max length of our model.
+In our case, we want to tokenize our full dataset, so we will use a method called :func:`datasets.Dataset.map` to apply the encoding process to the whole dataset.
+To be sure we can easily build tensor batches for our model, we will truncate and pad the inputs to the max length of our model.
 
 .. code-block::
 
@@ -169,7 +169,7 @@ To be sure we can easily build tensors batches for our model, we will truncate a
      'token_type_ids': array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
      'attention_mask': array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])}
 
-This operation has added three new columns to our dataset: ``input_ids``, ``token_type_ids`` and ``attention_mask``. These are the inputs our model need for training.
+This operation has added three new columns to our dataset: ``input_ids``, ``token_type_ids`` and ``attention_mask``. These are the inputs our model needs for training.
 
 .. note::
 
@@ -188,9 +188,9 @@ To be able to train our model with this dataset and PyTorch, we will need to do 
 
 .. note::
 
-    We don't want the columns `sentence1` or `sentence2` as inputs to train our model, but we could still want to keep them in the dataset, for instance for the evaluation of the model. 🤗datasets let you control the output format of :func:`datasets.Dataset.__getitem__` to just mask them as detailed in :doc:`exploring <./exploring>`.
+    We don't want the columns `sentence1` or `sentence2` as inputs to train our model, but we could still want to keep them in the dataset, for instance for the evaluation of the model. 🤗Datasets let you control the output format of :func:`datasets.Dataset.__getitem__` to just mask them as detailed in :doc:`exploring <./exploring>`.
 
-The first modification is just a matter of renaming the column as follow (we could have done it during the tokenization process as well:
+The first modification is just a matter of renaming the column as follows (we could have done it during the tokenization process as well):
 
 .. code-block::
 
@@ -261,7 +261,7 @@ Here is how we can apply the right format to our dataset using :func:`datasets.D
            0, 1, 1, 1, 0, 0, 1, 1, 1, 0])>)
 
 
-We are now ready to train our model. Let's write a simple training loop and a start the training
+We are now ready to train our model. Let's write a simple training loop and start the training:
 
 .. code-block::
 
@@ -287,7 +287,7 @@ We are now ready to train our model. Let's write a simple training loop and a st
     >>> model.fit(tfdataset, epochs=3)
 
 
-Now this was a very simple tour, you should continue with either the detailled notebook which is `here <https://colab.research.google.com/github/huggingface/datasets/blob/master/notebooks/Overview.ipynb#scrollTo=my95uHbLyjwR>`__ or the in-depth guides on
+Now this was a very simple tour, you should continue with either the detailed notebook which is `here <https://colab.research.google.com/github/huggingface/datasets/blob/master/notebooks/Overview.ipynb#scrollTo=my95uHbLyjwR>`__ or the in-depth guides on
 
 - :doc:`loading datasets <./loading_datasets>`
 - :doc:`exploring the dataset object attributes <./exploring>`

--- a/docs/source/share_dataset.rst
+++ b/docs/source/share_dataset.rst
@@ -394,9 +394,9 @@ This command will output instructions specifically tailored to your dataset and 
 
     - If the method `_generate_examples(...)` includes multiple `open()` statements, you might have to create other files in addition to 'dummy_data/TREC_10.label, dummy_data/train_5500.label'. In this case please refer to the `_generate_examples(...)` method
 
-    -After all dummy data files are created, they should be zipped recursively to 'dummy_data.zip' with the command `zip -r dummy_data.zip dummy_data/`
+    - After all dummy data files are created, they should be zipped recursively to 'dummy_data.zip' with the command `zip -r dummy_data.zip dummy_data/`
 
-    -You can now delete the folder 'dummy_data' with the command `rm -r dummy_data`
+    - You can now delete the folder 'dummy_data' with the command `rm -r dummy_data`
 
     - To get the folder 'dummy_data' back for further changes to the dummy data, simply unzip dummy_data.zip with the command `unzip dummy_data.zip`
 

--- a/docs/source/share_dataset.rst
+++ b/docs/source/share_dataset.rst
@@ -3,7 +3,7 @@ Sharing your dataset
 
 Once you've written a new dataset loading script as detailed on the :doc:`add_dataset` page, you may want to share it with the community for instance on the `HuggingFace Hub <https://huggingface.co/datasets>`__. There are two options to do that:
 
-- add it as a canonical dataset by opening a pull-request on the `GitHub repository for 🤗datasets <https://github.com/huggingface/datasets>`__,
+- add it as a canonical dataset by opening a pull-request on the `GitHub repository for 🤗Datasets <https://github.com/huggingface/datasets>`__,
 - directly upload it on the Hub as a community provided dataset.
 
 Here are the main differences between these two options.
@@ -31,7 +31,7 @@ Sharing a "canonical" dataset
 
 To add a "canonical" dataset to the library, you need to go through the following steps:
 
-**1. Fork the** `🤗datasets repository <https://github.com/huggingface/datasets>`__ by clicking on the 'Fork' button on the repository's home page. This creates a copy of the code under your GitHub user account.
+**1. Fork the** `🤗Datasets repository <https://github.com/huggingface/datasets>`__ by clicking on the 'Fork' button on the repository's home page. This creates a copy of the code under your GitHub user account.
 
 **2. Clone your fork** to your local disk, and add the base repository as a remote:
 
@@ -50,7 +50,7 @@ To add a "canonical" dataset to the library, you need to go through the followin
 
 .. note::
 
-    **do not** work on the ``master`` branch.
+    **Do not** work on the ``master`` branch.
 
 **4. Set up a development environment** by running the following command **in a virtual environment**:
 
@@ -60,7 +60,7 @@ To add a "canonical" dataset to the library, you need to go through the followin
 
 .. note::
 
-   If 🤗datasets was already installed in the virtual environment, remove
+   If 🤗Datasets was already installed in the virtual environment, remove
    it with ``pip uninstall datasets`` before reinstalling it in editable
    mode with the ``-e`` flag.
 
@@ -147,7 +147,7 @@ Basic steps
 In order to upload a dataset, you'll need to first create a git repo. This repo will live on the datasets hub, allowing
 users to clone it and you (and your organization members) to push to it.
 
-You can create a dataset repo directly from `the /new page on the website <https://huggingface.co/new-dataset>`__.
+You can create a dataset repo directly from `the /new-dataset page on the website <https://huggingface.co/new-dataset>`__.
 
 Alternatively, you can use the ``huggingface-cli``. The next steps describe that process:
 
@@ -238,7 +238,7 @@ It's crucial that ``git lfs track`` gets run on the large data files before ``gi
   remote: Your push was rejected because it contains files larger than 10M.
   remote: Please use https://git-lfs.github.com/ to store larger files.
 
-it means you ``git add``ed the data files before telling ``lfs`` to track those.
+it means you ``git add``\ed the data files before telling ``lfs`` to track those.
 
 Now you can add the dataset script and `dataset_infos.json` file:
 
@@ -276,7 +276,7 @@ Anyone can load it from code:
     >>> dataset = load_dataset("namespace/your_dataset_name")
 
 
-You may specify a version by using the ``script-version`` flag in the ``load_dataset`` function:
+You may specify a version by using the ``script_version`` flag in the ``load_dataset`` function:
 
 .. code-block::
 
@@ -485,7 +485,7 @@ And *for the dummy data*:
 
 If all tests pass, your dataset works correctly. Awesome! You can now follow the last steps of the :ref:`canonical-dataset` or :ref:`community-dataset` sections to share the dataset with the community. If you experienced problems with the dummy data tests, here are some additional tips:
 
-- Verify that all filenames are spelled correctly. Rerun the command
+- Verify that all filenames are spelled correctly. Rerun the command:
 
 .. code-block::
 
@@ -493,6 +493,6 @@ If all tests pass, your dataset works correctly. Awesome! You can now follow the
 
 and make sure you follow the exact instructions provided by the command.
 
-- Your datascript might require a difficult dummy data structure. In this case make sure you fully understand the data folder logit created by the function ``_split_generations(...)`` and expected by the function ``_generate_examples(...)`` of your dataset script. Also take a look at `tests/README.md` which lists different possible cases of how the dummy data should be created.
+- Your datascript might require a difficult dummy data structure. In this case make sure you fully understand the data folder logit created by the function ``_split_generators(...)`` and expected by the function ``_generate_examples(...)`` of your dataset script. Also take a look at `tests/README.md` which lists different possible cases of how the dummy data should be created.
 
 - If the dummy data tests still fail, open a PR in the main repository on github and make a remark in the description that you need help creating the dummy data and we will be happy to help you.

--- a/docs/source/torch_tensorflow.rst
+++ b/docs/source/torch_tensorflow.rst
@@ -3,7 +3,7 @@ Using a Dataset with PyTorch/Tensorflow
 
 Once your dataset is processed, you often want to use it with a framework such as PyTorch, Tensorflow, Numpy or Pandas. For instance we may want to use our dataset in a ``torch.Dataloader`` or a ``tf.data.Dataset`` and train a model with it.
 
-🤗datasets provides a simple way to do this through what is called the format of a dataset.
+🤗Datasets provides a simple way to do this through what is called the format of a dataset.
 
 The format of a :class:`datasets.Dataset` instance defines which columns of the dataset are returned by the :func:`datasets.Dataset.__getitem__` method and cast them in PyTorch, Tensorflow, Numpy or Pandas types.
 

--- a/docs/source/using_metrics.rst
+++ b/docs/source/using_metrics.rst
@@ -4,9 +4,9 @@ Using a Metric
 Evaluating a model's predictions with :class:`datasets.Metric` involves just a couple of methods:
 
 - :func:`datasets.Metric.add` and :func:`datasets.Metric.add_batch` are used to add pairs of predictions/reference (or just predictions if a metric doesn't make use of references) to a temporary and memory efficient cache table,
-- :func:`datasets.Metric.compute` then gather all the cached predictions and reference to compute the metric score.
+- :func:`datasets.Metric.compute` then gathers all the cached predictions and references to compute the metric score.
 
-A typical **two-steps workflow** to compute the metric is thus as follow:
+A typical **two-step workflow** to compute the metric is thus as follows:
 
 .. code-block::
 
@@ -20,7 +20,7 @@ A typical **two-steps workflow** to compute the metric is thus as follow:
 
     final_score = metric.compute()
 
-Alternatively, when the model predictions over the whole evaluation dataset can be computed in one step, a **single-step workflow** can be used by directly feeding the predictions/references to the :func:`datasets.Metric.compute` method as follow:
+Alternatively, when the model predictions over the whole evaluation dataset can be computed in one step, a **single-step workflow** can be used by directly feeding the predictions/references to the :func:`datasets.Metric.compute` method as follows:
 
 .. code-block::
 
@@ -28,14 +28,14 @@ Alternatively, when the model predictions over the whole evaluation dataset can 
 
     metric = datasets.load_metric('my_metric')
 
-    model_prediction = model(model_inputs)
+    model_predictions = model(model_inputs)
 
-    final_score = metric.compute(predictions=model_prediction, references=gold_references)
+    final_score = metric.compute(predictions=model_predictions, references=gold_references)
 
 
 .. note::
 
-    Uner the hood, both the two-steps workflow and the single-step workflow use memory-mapped temporary cache tables to store predictions/references before computing the scores (similarly to a :class:`datasets.Dataset`). This is convenient for several reasons:
+    Under the hood, both the two-steps workflow and the single-step workflow use memory-mapped temporary cache tables to store predictions/references before computing the scores (similarly to a :class:`datasets.Dataset`). This is convenient for several reasons:
 
     -  let us easily handle metrics whose scores depends on the evaluation set in non-additive ways, i.e. when f(A∪B) ≠ f(A) + f(B),
     - very efficient in terms of CPU/GPU memory (effectively requiring no CPU/GPU memory to use the metrics),
@@ -67,6 +67,7 @@ Here is an example for the sacrebleu metric:
     Metric(name: "sacrebleu", features: {'predictions': Value(dtype='string', id='sequence'), 'references': Sequence(feature=Value(dtype='string', id='sequence'), length=-1, id='references')}, usage: """
     Produces BLEU scores along with its sufficient statistics
     from a source against one or more references.
+
     Args:
         predictions: The system stream (a sequence of segments)
         references: A list of one or more reference streams (each a sequence of segments)
@@ -83,13 +84,24 @@ Here is an example for the sacrebleu metric:
         'bp': Brevity penalty,
         'sys_len': predictions length,
         'ref_len': reference length,
-    """)
+    Examples:
+
+        >>> predictions = ["hello there general kenobi", "foo bar foobar"]
+        >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
+        >>> sacrebleu = datasets.load_metric("sacrebleu")
+        >>> results = sacrebleu.compute(predictions=predictions, references=references)
+        >>> print(list(results.keys()))
+        ['score', 'counts', 'totals', 'precisions', 'bp', 'sys_len', 'ref_len']
+        >>> print(round(results["score"], 1))
+        100.0
+    """, stored examples: 0)
     >>> print(metric.features)
     {'predictions': Value(dtype='string', id='sequence'),
      'references': Sequence(feature=Value(dtype='string', id='sequence'), length=-1, id='references')}
     >>> print(metric.inputs_description)
     Produces BLEU scores along with its sufficient statistics
     from a source against one or more references.
+    
     Args:
         predictions: The system stream (a sequence of segments)
         references: A list of one or more reference streams (each a sequence of segments)
@@ -106,10 +118,19 @@ Here is an example for the sacrebleu metric:
         'bp': Brevity penalty,
         'sys_len': predictions length,
         'ref_len': reference length,
+    Examples:
+        >>> predictions = ["hello there general kenobi", "foo bar foobar"]
+        >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
+        >>> sacrebleu = datasets.load_metric("sacrebleu")
+        >>> results = sacrebleu.compute(predictions=predictions, references=references)
+        >>> print(list(results.keys()))
+        ['score', 'counts', 'totals', 'precisions', 'bp', 'sys_len', 'ref_len']
+        >>> print(round(results["score"], 1))
+        100.0
 
-Here we can see that the ``sacrebleu`` metric expect a sequence of segments as predictions and a list of one or several sequences of segments as references.
+Here we can see that the ``sacrebleu`` metric expects a sequence of segments as predictions and a list of one or several sequences of segments as references.
 
-You can find more information on the segments in the description, homepage and publication of ``sacrebleu`` which can be access with the respective attributes on the metric:
+You can find more information on the segments in the description, homepage and publication of ``sacrebleu`` which can be accessed with the respective attributes on the metric:
 
 .. code-block::
 
@@ -142,12 +163,12 @@ Let's use ``sacrebleu`` with the official quick-start example on its homepage at
     ...                    ['The man bit him first.', 'The man had bitten the dog.']]
     >>> sys_batch = ['The dog bit the man.', "It wasn't surprising.", 'The man had just bitten him.']
     >>> metric.add_batch(predictions=sys_batch, references=reference_batch)
-    >>> print(len(metric)
+    >>> print(len(metric))
     3
 
 Note that the format of the inputs is a bit different than the official sacrebleu format: we provide the references for each prediction in a list inside the list associated to the prediction while the official example is nested the other way around (list for the reference numbers and inside list for the examples).
 
-Querying the length of a Metric object will return the number of  we can see on the last line, we have stored three evaluation examples in our metric. 
+Querying the length of a Metric object will return the number of examples (predictions or predictions/references pair) currently stored in the metric's cache. As we can see on the last line, we have stored three evaluation examples in our metric. 
 
 Now let's compute the sacrebleu score from these 3 evaluation datapoints.
 
@@ -161,13 +182,11 @@ This method can accept several arguments:
 - predictions and references: you can add predictions and references (to be added at the end of the cache if you have used :func:`datasets.Metric.add` or :func:`datasets.Metric.add_batch` before)
 - specific arguments that can be required or can modify the behavior of some metrics (print the metric input description to see the details with ``print(metric)`` or ``print(metric.inputs_description)``).
 
-In the simplest case (when the predictions and references have already been added with ``add`` or ``add_batch`` and no specific argument need to be set to modify the default behavior of the metric, we can just call :func:`datasets.Metric.compute`:
+In the simplest case when the predictions and references have already been added with ``add`` or ``add_batch`` and no specific arguments need to be set to modify the default behavior of the metric, we can just call :func:`datasets.Metric.compute`:
 
 .. code-block::
 
     >>> score = metric.compute()
-    Done writing 3 examples in 265 bytes /Users/thomwolf/.cache/huggingface/metrics/sacrebleu/default/default_experiment-0430a7c7-31cb-48bf-9fb0-2a0b6c03ad81-1-0.arrow.
-    Set __getitem__(key) output type to python objects for no columns  (when key is int or slice) and don't output other (un-formatted) columns.
     >>> print(score)
     {'score': 48.530827009929865, 'counts': [14, 7, 5, 3], 'totals': [17, 14, 11, 8], 'precisions': [82.3529411764706, 50.0, 45.45454545454545, 37.5], 'bp': 0.9428731438548749, 'sys_len': 17, 'ref_len': 18}
 
@@ -176,11 +195,11 @@ These additional arguments are detailed in the metric information.
 
 For example ``sacrebleu`` accepts the following additional arguments:
 
-- smooth: The smoothing method to use
-- smooth_value: For 'floor' smoothing, the floor to use
-- force: Ignore data that looks already tokenized
-- lowercase: Lowercase the data
-- tokenize: The tokenizer to use
+- ``smooth``: The smoothing method to use
+- ``smooth_value``: For 'floor' smoothing, the floor to use
+- ``force``: Ignore data that looks already tokenized
+- ``lowercase``: Lowercase the data
+- ``tokenize``: The tokenizer to use
 
 You can list these arguments with ``print(metric)`` or ``print(metric.inputs_description)`` as we saw in the previous section and have more details on the official ``sacrebleu`` homepage and publication (accessible with ``print(metric.homepage)`` and ``print(metric.citation)``):
 
@@ -189,6 +208,7 @@ You can list these arguments with ``print(metric)`` or ``print(metric.inputs_des
     >>> print(metric.inputs_description)
     Produces BLEU scores along with its sufficient statistics
     from a source against one or more references.
+
     Args:
         predictions: The system stream (a sequence of segments)
         references: A list of one or more reference streams (each a sequence of segments)
@@ -205,6 +225,15 @@ You can list these arguments with ``print(metric)`` or ``print(metric.inputs_des
         'bp': Brevity penalty,
         'sys_len': predictions length,
         'ref_len': reference length,
+    Examples:
+        >>> predictions = ["hello there general kenobi", "foo bar foobar"]
+        >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
+        >>> sacrebleu = datasets.load_metric("sacrebleu")
+        >>> results = sacrebleu.compute(predictions=predictions, references=references)
+        >>> print(list(results.keys()))
+        ['score', 'counts', 'totals', 'precisions', 'bp', 'sys_len', 'ref_len']
+        >>> print(round(results["score"], 1))
+        100.0
 
 Distributed usage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +242,7 @@ Using the metric in a distributed or multiprocessing setting is exactly identica
 
 We detailed on the :doc:`loading_metrics` page how to load a metric in a distributed setup.
 
-Here is now a sample script showing how to instantiate and run a metric computation in a distributed/multi-processing setup:
+Here is now a sample script showing how to instantiate and run a metric computation in a distributed/multiprocessing setup:
 
 Here is how we can instantiate the metric in such a distributed script:
 

--- a/src/datasets/commands/dummy_data.py
+++ b/src/datasets/commands/dummy_data.py
@@ -441,18 +441,18 @@ class DummyDataCommand(BaseTransformersCLICommand):
             dummy_data_guidance_print += f"- If the method `_generate_examples(...)` includes multiple `open()` statements, you might have to create other files in addition to '{files_string}'. In this case please refer to the `_generate_examples(...)` method \n\n"
 
         if len(files_to_create) == 1 and next(iter(files_to_create)) == dummy_file_name:
-            dummy_data_guidance_print += f"-After the dummy data file is created, it should be zipped to '{dummy_file_name}.zip' with the command `zip {dummy_file_name}.zip {dummy_file_name}` \n\n"
+            dummy_data_guidance_print += f"- After the dummy data file is created, it should be zipped to '{dummy_file_name}.zip' with the command `zip {dummy_file_name}.zip {dummy_file_name}` \n\n"
 
             dummy_data_guidance_print += (
-                f"-You can now delete the file '{dummy_file_name}' with the command `rm {dummy_file_name}` \n\n"
+                f"- You can now delete the file '{dummy_file_name}' with the command `rm {dummy_file_name}` \n\n"
             )
 
             dummy_data_guidance_print += f"- To get the file '{dummy_file_name}' back for further changes to the dummy data, simply unzip {dummy_file_name}.zip with the command `unzip {dummy_file_name}.zip` \n\n"
         else:
-            dummy_data_guidance_print += f"-After all dummy data files are created, they should be zipped recursively to '{dummy_file_name}.zip' with the command `zip -r {dummy_file_name}.zip {dummy_file_name}/` \n\n"
+            dummy_data_guidance_print += f"- After all dummy data files are created, they should be zipped recursively to '{dummy_file_name}.zip' with the command `zip -r {dummy_file_name}.zip {dummy_file_name}/` \n\n"
 
             dummy_data_guidance_print += (
-                f"-You can now delete the folder '{dummy_file_name}' with the command `rm -r {dummy_file_name}` \n\n"
+                f"- You can now delete the folder '{dummy_file_name}' with the command `rm -r {dummy_file_name}` \n\n"
             )
 
             dummy_data_guidance_print += f"- To get the folder '{dummy_file_name}' back for further changes to the dummy data, simply unzip {dummy_file_name}.zip with the command `unzip {dummy_file_name}.zip` \n\n"

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -125,7 +125,7 @@ class MetricInfoMixin(object):
 
 
 class Metric(MetricInfoMixin):
-    """A Metrics is the base class and common API for all metrics.
+    """A Metric is the base class and common API for all metrics.
 
     Args:
         config_name (``str``): This is used to define a hash specific to a metrics computation script and prevents the metric's data


### PR DESCRIPTION
This PR:
* fixes various typos/grammer I came across while reading the docs
* adds the "Install with conda" installation instructions

Closes #1959 