### PR TITLE
more explicit method parameters

### DIFF
--- a/templates/new_dataset_script.py
+++ b/templates/new_dataset_script.py
@@ -153,24 +153,25 @@ class NewDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, **gen_kwargs):
-        """ Yields examples. """
-        # TODO: This method will receive as arguments the `gen_kwargs` defined in the previous `_split_generators` method.
-        # It is in charge of opening the given file and yielding (key, example) tuples from the dataset
-        # The key is not important, it's more here for legacy reason (legacy from tfds)
+    def _generate_examples(
+        self, filepath, split  # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+    ):
+        """ Yields examples as (key, example) tuples. """
+        # This method handles input defined in _split_generators to yield (key, example) tuples from the dataset.
+        # The `key` is here for legacy reason (tfds) and is not important in itself.
 
-        with open(gen_kwargs["filepath"], encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             for id_, row in enumerate(f):
                 data = json.loads(row)
                 if self.config.name == "first_domain":
                     yield id_, {
                         "sentence": data["sentence"],
                         "option1": data["option1"],
-                        "answer": "" if gen_kwargs["split"] == "test" else data["answer"],
+                        "answer": "" if split == "test" else data["answer"],
                     }
                 else:
                     yield id_, {
                         "sentence": data["sentence"],
                         "option2": data["option2"],
-                        "second_domain_answer": "" if gen_kwargs["split"] == "test" else data["second_domain_answer"],
+                        "second_domain_answer": "" if split == "test" else data["second_domain_answer"],
                     }

--- a/templates/new_dataset_script.py
+++ b/templates/new_dataset_script.py
@@ -153,24 +153,24 @@ class NewDataset(datasets.GeneratorBasedBuilder):
             ),
         ]
 
-    def _generate_examples(self, filepath, split):
+    def _generate_examples(self, **gen_kwargs):
         """ Yields examples. """
         # TODO: This method will receive as arguments the `gen_kwargs` defined in the previous `_split_generators` method.
         # It is in charge of opening the given file and yielding (key, example) tuples from the dataset
         # The key is not important, it's more here for legacy reason (legacy from tfds)
 
-        with open(filepath, encoding="utf-8") as f:
+        with open(gen_kwargs["filepath"], encoding="utf-8") as f:
             for id_, row in enumerate(f):
                 data = json.loads(row)
                 if self.config.name == "first_domain":
                     yield id_, {
                         "sentence": data["sentence"],
                         "option1": data["option1"],
-                        "answer": "" if split == "test" else data["answer"],
+                        "answer": "" if gen_kwargs["split"] == "test" else data["answer"],
                     }
                 else:
                     yield id_, {
                         "sentence": data["sentence"],
                         "option2": data["option2"],
-                        "second_domain_answer": "" if split == "test" else data["second_domain_answer"],
+                        "second_domain_answer": "" if gen_kwargs["split"] == "test" else data["second_domain_answer"],
                     }


### PR DESCRIPTION
re: #2009

not super convinced this is better, and while I usually fight against kwargs here it seems to me that it better conveys the relationship to the `_split_generator` method.