### PR TITLE
Fix ipython function creation in tests

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,6 +1,6 @@
 import pickle
 from hashlib import md5
-from types import CodeType, FunctionType
+from types import FunctionType
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -145,11 +145,14 @@ class RecurseDumpTest(TestCase):
         )
 
         def create_ipython_func(co_filename, returned_obj):
+            from dill._dill import _create_code
+
             def func():
                 return returned_obj
 
             code = func.__code__
-            code = CodeType(*[getattr(code, k) if k != "co_filename" else co_filename for k in code_args])
+            # Use _create_code from dill in order to make it work for different python versions
+            code = _create_code(*[getattr(code, k) if k != "co_filename" else co_filename for k in code_args])
             return FunctionType(code, func.__globals__, func.__name__, func.__defaults__, func.__closure__)
 
         co_filename, returned_obj = "<ipython-input-2-e0383a102aae>", [0]


### PR DESCRIPTION
The test at `tests/test_caching.py::RecurseDumpTest::test_dump_ipython_function` was failing in python 3.8 because the ipython function was not properly created.

Fix #2010 