### PR TITLE
Remove unnecessary docstart check in conll-like datasets

### DIFF
--- a/datasets/bc2gm_corpus/bc2gm_corpus.py
+++ b/datasets/bc2gm_corpus/bc2gm_corpus.py
@@ -119,7 +119,7 @@ class Bc2gmCorpus(datasets.GeneratorBasedBuilder):
             tokens = []
             ner_tags = []
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/conll2002/README.md
+++ b/datasets/conll2002/README.md
@@ -91,6 +91,10 @@ The examples look like this :
 }
 ```
 
+The original data files within the Dutch sub-dataset have `-DOCSTART-` lines used to separate documents, but these lines are removed here.
+Indeed `-DOCSTART-` is a special line that acts as a boundary between two different documents, and it is filtered out in this implementation.
+
+
 ### Data Fields
 
 - `id`: id of the sample

--- a/datasets/hausa_voa_ner/hausa_voa_ner.py
+++ b/datasets/hausa_voa_ner/hausa_voa_ner.py
@@ -140,7 +140,7 @@ class HausaVoaNer(datasets.GeneratorBasedBuilder):
             ner_tags = []
             for line in f:
                 line = line.strip()
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/jnlpba/jnlpba.py
+++ b/datasets/jnlpba/jnlpba.py
@@ -117,7 +117,7 @@ class JNLPBA(datasets.GeneratorBasedBuilder):
             tokens = []
             ner_tags = []
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/lener_br/lener_br.py
+++ b/datasets/lener_br/lener_br.py
@@ -138,7 +138,7 @@ class LenerBr(datasets.GeneratorBasedBuilder):
             ner_tags = []
 
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/linnaeus/linnaeus.py
+++ b/datasets/linnaeus/linnaeus.py
@@ -116,7 +116,7 @@ class Linnaeus(datasets.GeneratorBasedBuilder):
             tokens = []
             ner_tags = []
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/ncbi_disease/ncbi_disease.py
+++ b/datasets/ncbi_disease/ncbi_disease.py
@@ -121,7 +121,7 @@ class NCBIDisease(datasets.GeneratorBasedBuilder):
             tokens = []
             ner_tags = []
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/species_800/species_800.py
+++ b/datasets/species_800/species_800.py
@@ -123,7 +123,7 @@ class Species800(datasets.GeneratorBasedBuilder):
             tokens = []
             ner_tags = []
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),

--- a/datasets/wikiann/wikiann.py
+++ b/datasets/wikiann/wikiann.py
@@ -296,7 +296,7 @@ class Wikiann(datasets.GeneratorBasedBuilder):
             ner_tags = []
             langs = []
             for line in f:
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid_index, {"tokens": tokens, "ner_tags": ner_tags, "langs": langs}
                         guid_index += 1

--- a/datasets/xtreme/xtreme.py
+++ b/datasets/xtreme/xtreme.py
@@ -933,7 +933,7 @@ class Xtreme(datasets.GeneratorBasedBuilder):
                 ner_tags = []
                 langs = []
                 for line in f:
-                    if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                    if line == "" or line == "\n":
                         if tokens:
                             yield guid_index, {"tokens": tokens, "ner_tags": ner_tags, "langs": langs}
                             guid_index += 1

--- a/datasets/yoruba_gv_ner/yoruba_gv_ner.py
+++ b/datasets/yoruba_gv_ner/yoruba_gv_ner.py
@@ -139,7 +139,7 @@ class YorubaGvNer(datasets.GeneratorBasedBuilder):
             ner_tags = []
             for line in f:
                 line = line.strip()
-                if line.startswith("-DOCSTART-") or line == "" or line == "\n":
+                if line == "" or line == "\n":
                     if tokens:
                         yield guid, {
                             "id": str(guid),


### PR DESCRIPTION
Related to this PR: #1998

Additionally, this PR adds the docstart note to the conll2002 dataset card ([link](https://raw.githubusercontent.com/teropa/nlp/master/resources/corpora/conll2002/ned.train) to the raw data with `DOCSTART` lines).
