### PR TITLE
Fix: Wikipedia - save memory by replacing root.clear with elem.clear

### DIFF
--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -473,10 +473,7 @@ class Wikipedia(datasets.BeamBasedBuilder):
                 else:
                     utf_f = f
 
-                # To clear root, to free-up more memory than just `elem.clear()`.
                 context = etree.iterparse(utf_f, events=("end",))
-                context = iter(context)
-                unused_event, root = next(context)
                 for unused_event, elem in context:
                     if not elem.tag.endswith("page"):
                         continue
@@ -487,11 +484,11 @@ class Wikipedia(datasets.BeamBasedBuilder):
 
                     # Filter pages that are not in the "main" namespace.
                     if ns != "0":
-                        root.clear()
+                        elem.clear()
                         continue
 
                     raw_content = elem.find("./{0}revision/{0}text".format(namespace)).text
-                    root.clear()
+                    elem.clear()
 
                     # Filter redirects.
                     if raw_content is None or raw_content.lower().startswith("#redirect"):


### PR DESCRIPTION
see: https://github.com/huggingface/datasets/issues/2031

What I did:
- replace root.clear with elem.clear
- remove lines to get root element
- $ make style
- $ make test
  - some tests required some pip packages, I installed them.

test results on origin/master and my branch are same. I think it's not related on my modification, isn't it?
```
==================================================================================== short test summary info ====================================================================================
FAILED tests/test_arrow_writer.py::TypedSequenceTest::test_catch_overflow - AssertionError: OverflowError not raised
============================================================= 1 failed, 2332 passed, 5138 skipped, 70 warnings in 91.75s (0:01:31) ==============================================================
make: *** [Makefile:19: test] Error 1

```

Is there anything else I should do?