### PR TITLE
Fix arrow memory checks issue in tests

### DIFF
--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -19,6 +19,8 @@ from datasets.io.csv import CsvDatasetReader
 @pytest.mark.parametrize("split", [None, NamedSplit("train"), "train", "test"])
 @pytest.mark.parametrize("path_type", [str, list])
 def test_csv_dataset_reader(path_type, split, features, keep_in_memory, csv_path, tmp_path):
+    import gc
+    gc.collect()
     if issubclass(path_type, str):
         path = csv_path
     elif issubclass(path_type, list):

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -1,8 +1,9 @@
-import pyarrow as pa
 import pytest
 
 from datasets import Dataset, DatasetDict, Features, NamedSplit, Value
 from datasets.io.csv import CsvDatasetReader
+
+from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases
 
 
 @pytest.mark.parametrize("keep_in_memory", [False, True])
@@ -19,8 +20,6 @@ from datasets.io.csv import CsvDatasetReader
 @pytest.mark.parametrize("split", [None, NamedSplit("train"), "train", "test"])
 @pytest.mark.parametrize("path_type", [str, list])
 def test_csv_dataset_reader(path_type, split, features, keep_in_memory, csv_path, tmp_path):
-    import gc
-    gc.collect()
     if issubclass(path_type, str):
         path = csv_path
     elif issubclass(path_type, list):
@@ -33,11 +32,10 @@ def test_csv_dataset_reader(path_type, split, features, keep_in_memory, csv_path
     default_expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     expected_features = features.copy() if features else default_expected_features
     features = Features({feature: Value(dtype) for feature, dtype in features.items()}) if features else None
-    previous_allocated_memory = pa.total_allocated_bytes()
-    dataset = CsvDatasetReader(
-        path, split=split, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory
-    ).read()
-    increased_allocated_memory = (pa.total_allocated_bytes() - previous_allocated_memory) > 0
+    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
+        dataset = CsvDatasetReader(
+            path, split=split, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     assert isinstance(dataset, Dataset)
     assert dataset.num_rows == 4
     assert dataset.num_columns == 3
@@ -45,7 +43,6 @@ def test_csv_dataset_reader(path_type, split, features, keep_in_memory, csv_path
     assert dataset.split == expected_split
     for feature, expected_dtype in expected_features.items():
         assert dataset.features[feature].dtype == expected_dtype
-    assert increased_allocated_memory == keep_in_memory
 
 
 @pytest.mark.parametrize("keep_in_memory", [False, True])
@@ -72,9 +69,8 @@ def test_csv_datasetdict_reader(split, features, keep_in_memory, csv_path, tmp_p
     default_expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     expected_features = features.copy() if features else default_expected_features
     features = Features({feature: Value(dtype) for feature, dtype in features.items()}) if features else None
-    previous_allocated_memory = pa.total_allocated_bytes()
-    dataset = CsvDatasetReader(path, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
-    increased_allocated_memory = (pa.total_allocated_bytes() - previous_allocated_memory) > 0
+    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
+        dataset = CsvDatasetReader(path, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
     assert isinstance(dataset, DatasetDict)
     dataset = dataset[split]
     assert dataset.num_rows == 4
@@ -83,4 +79,3 @@ def test_csv_datasetdict_reader(split, features, keep_in_memory, csv_path, tmp_p
     assert dataset.split == split
     for feature, expected_dtype in expected_features.items():
         assert dataset.features[feature].dtype == expected_dtype
-    assert increased_allocated_memory == keep_in_memory

--- a/tests/test_arrow_reader.py
+++ b/tests/test_arrow_reader.py
@@ -11,6 +11,8 @@ from datasets.arrow_reader import ArrowReader, BaseReader
 from datasets.info import DatasetInfo
 from datasets.splits import SplitDict, SplitInfo
 
+from .utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases
+
 
 class ReaderTest(BaseReader):
     """
@@ -88,25 +90,21 @@ class BaseReaderTest(TestCase):
 @pytest.mark.parametrize("in_memory", [False, True])
 def test_read_table(in_memory, dataset, arrow_file):
     filename = arrow_file
-    previous_allocated_memory = pa.total_allocated_bytes()
-    table = ArrowReader.read_table(filename, in_memory=in_memory)
-    increased_allocated_memory = (pa.total_allocated_bytes() - previous_allocated_memory) > 0
+    with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
+        table = ArrowReader.read_table(filename, in_memory=in_memory)
     assert table.shape == dataset.data.shape
     assert set(table.column_names) == set(dataset.data.column_names)
     assert dict(table.to_pydict()) == dict(dataset.data.to_pydict())  # to_pydict returns OrderedDict
-    assert increased_allocated_memory == in_memory
 
 
 @pytest.mark.parametrize("in_memory", [False, True])
 def test_read_files(in_memory, dataset, arrow_file):
     filename = arrow_file
     reader = ArrowReader("", None)
-    previous_allocated_memory = pa.total_allocated_bytes()
-    dataset_kwargs = reader.read_files([{"filename": filename}], in_memory=in_memory)
-    increased_allocated_memory = (pa.total_allocated_bytes() - previous_allocated_memory) > 0
+    with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
+        dataset_kwargs = reader.read_files([{"filename": filename}], in_memory=in_memory)
     assert dataset_kwargs.keys() == set(["arrow_table", "data_files", "info", "split"])
     table = dataset_kwargs["arrow_table"]
     assert table.shape == dataset.data.shape
     assert set(table.column_names) == set(dataset.data.column_names)
     assert dict(table.to_pydict()) == dict(dataset.data.to_pydict())  # to_pydict returns OrderedDict
-    assert increased_allocated_memory == in_memory

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,8 @@ from enum import Enum
 from pathlib import Path
 from unittest.mock import patch
 
+import pyarrow as pa
+
 from datasets import config
 
 
@@ -258,3 +260,23 @@ def set_current_working_directory_to_temp_dir(*args, **kwargs):
         os.chdir(tmp_dir)
         yield
         os.chdir(original_working_dir)
+
+
+@contextmanager
+def assert_arrow_memory_increases():
+    import gc
+
+    gc.collect()
+    previous_allocated_memory = pa.total_allocated_bytes()
+    yield
+    assert pa.total_allocated_bytes() - previous_allocated_memory > 0
+
+
+@contextmanager
+def assert_arrow_memory_doesnt_increase():
+    import gc
+
+    gc.collect()
+    previous_allocated_memory = pa.total_allocated_bytes()
+    yield
+    assert pa.total_allocated_bytes() - previous_allocated_memory <= 0


### PR DESCRIPTION
The tests currently fail on `master` because the arrow memory verification doesn't return the expected memory evolution when loading an arrow table in memory.
From my experiments, the tests fail only when the full test suite is ran.
This made me think that maybe some arrow objects from other tests were not freeing their memory until they do and cause the memory verifications to fail in other tests.

Collecting the garbage collector before checking the arrow memory usage seems to fix this issue.
I added a context manager `assert_arrow_memory_increases` that we can use in tests and that deals with the gc.