### PR TITLE
Preserve column ordering in Dataset.rename_column

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -888,8 +888,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if self._format_columns is not None:
             self._format_columns = rename(self._format_columns)
 
-        self._info.features[new_column_name] = self._info.features[original_column_name]
-        del self._info.features[original_column_name]
+        self._info.features = Features(
+            {
+                new_column_name if col == original_column_name else col: feature
+                for col, feature in self._info.features.items()
+            }
+        )
 
         self._data = self._data.rename_columns(new_column_names)
 
@@ -928,8 +932,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if self._format_columns is not None:
             dataset._format_columns = rename(self._format_columns)
 
-        dataset._info.features[new_column_name] = dataset._info.features[original_column_name]
-        del dataset._info.features[original_column_name]
+        dataset._info.features = Features(
+            {
+                new_column_name if col == original_column_name else col: feature
+                for col, feature in self._info.features.items()
+            }
+        )
 
         dataset._data = dataset._data.rename_columns(new_column_names)
         dataset._fingerprint = new_fingerprint


### PR DESCRIPTION
Currently `Dataset.rename_column` doesn't necessarily preserve the order of the columns:
```python
>>> from datasets import Dataset
>>> d = Dataset.from_dict({'sentences': ["s1", "s2"], 'label': [0, 1]})
>>> d
Dataset({
    features: ['sentences', 'label'],
    num_rows: 2
})
>>> d.rename_column('sentences', 'text')
Dataset({
    features: ['label', 'text'],
    num_rows: 2
})
```
This PR fixes this.