### PR TITLE
Fix text-classification tags

### DIFF
--- a/datasets/ajgt_twitter_ar/README.md
+++ b/datasets/ajgt_twitter_ar/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - sentiment-classification
 ---

--- a/datasets/ar_res_reviews/README.md
+++ b/datasets/ar_res_reviews/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - sentiment-classification
 ---

--- a/datasets/emotone_ar/README.md
+++ b/datasets/emotone_ar/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - emotion-classification
 ---

--- a/datasets/interpress_news_category_tr/README.md
+++ b/datasets/interpress_news_category_tr/README.md
@@ -14,9 +14,9 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
-- text_classification-other-news-category-classification
+- text-classification-other-news-category-classification
 ---
 
 # Dataset Card for Interpress Turkish News Category Dataset (270K)

--- a/datasets/interpress_news_category_tr_lite/README.md
+++ b/datasets/interpress_news_category_tr_lite/README.md
@@ -14,9 +14,9 @@ size_categories:
 source_datasets:
 - extended|interpress_news_category_tr
 task_categories:
-- text_classification
+- text-classification
 task_ids:
-- text_classification-other-news-category-classification
+- text-classification-other-news-category-classification
 ---
 
 # Dataset Card for Interpress Turkish News Category Dataset (270K - Lite Version)

--- a/datasets/labr/README.md
+++ b/datasets/labr/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - multi-class-classification
 ---

--- a/datasets/offenseval2020_tr/README.md
+++ b/datasets/offenseval2020_tr/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - text-classification-other-offensive-language-classification
 ---

--- a/datasets/ttc4900/README.md
+++ b/datasets/ttc4900/README.md
@@ -14,9 +14,9 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
-- text_classification-other-news-category-classification
+- text-classification-other-news-category-classification
 ---
 
 # Dataset Card for TTC4900: A Benchmark Data for Turkish Text Categorization

--- a/datasets/turkish_movie_sentiment/README.md
+++ b/datasets/turkish_movie_sentiment/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - sentiment-classification
 - sentiment-scoring

--- a/datasets/turkish_product_reviews/README.md
+++ b/datasets/turkish_product_reviews/README.md
@@ -14,7 +14,7 @@ size_categories:
 source_datasets:
 - original
 task_categories:
-- text_classification
+- text-classification
 task_ids:
 - sentiment-classification
 ---


### PR DESCRIPTION
There are different tags for text classification right now: `text-classification` and `text_classification`:
![image](https://user-images.githubusercontent.com/29076344/111042457-856bdf00-8463-11eb-93c9-50a30106a1a1.png).

This PR fixes it.
