### PR TITLE
Filtering refactor

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1720,15 +1720,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             fn_kwargs = {}
         fn_kwargs["input_columns"] = input_columns
 
-        # return map function
-        return self.map(
+        mask = self.map(
             partial(map_function, function=function, with_indices=with_indices),
             batched=True,
             with_indices=with_indices,
             features=self.features,
             batch_size=batch_size,
             remove_columns=remove_columns,
-            keep_in_memory=keep_in_memory,
+            keep_in_memory=True,
             load_from_cache_file=load_from_cache_file,
             cache_file_name=cache_file_name,
             writer_batch_size=writer_batch_size,
@@ -1737,6 +1736,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             suffix_template=suffix_template,
             new_fingerprint=new_fingerprint,
         )
+        filtered = self._data.filter(mask)
+        return Dataset(filtered)
 
     @transmit_format
     @fingerprint_transform(inplace=False, ignore_kwargs=["cache_file_name"])


### PR DESCRIPTION
fix https://github.com/huggingface/datasets/issues/2032

benchmarking is somewhat inconclusive, currently running on `book_corpus` to get a better sense of the improvement

```diff
3,11c3,11
<   "map identity": 16.943350610003108,
<   "map identity batched": 0.9310493359953398,
<   "map no-op batched": 0.632951049003168,
<   "map no-op batched numpy": 0.6800740210019285,
<   "map no-op batched pandas": 0.4896433609974338,
<   "map no-op batched pytorch": 0.5659142479998991,
<   "map no-op batched tensorflow": 1.3155841589905322,
<   "map fast-tokenizer batched": 14.161769978993107,
<   "filter": 9.384816927995416
---
>   "map identity": 16.720537469998817,
>   "map identity batched": 0.909121311007766,
>   "map no-op batched": 0.5962835579994135,
>   "map no-op batched numpy": 0.6866216960042948,
>   "map no-op batched pandas": 0.4974203809979372,
>   "map no-op batched pytorch": 0.5545022570004221,
>   "map no-op batched tensorflow": 1.3693314480042318,
>   "map fast-tokenizer batched": 13.003258584998548,
>   "filter": 9.322257651001564
```