### PR TITLE
Fixes check of TF_AVAILABLE and TORCH_AVAILABLE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="datasets",
-    version="1.4.1",
+    version="1.4.1.dev0",
     description=DOCLINES[0],
     long_description="\n".join(DOCLINES[2:]),
     author="HuggingFace Inc.",

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -79,7 +79,7 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
                                 pass
     if TF_AVAILABLE:
         if version.parse(TF_VERSION) < version.parse("2"):
-            logger.info(f"TensorFlow found but with version {TF_VERSION}. Transformers requires version 2 minimum.")
+            logger.info(f"TensorFlow found but with version {TF_VERSION}. `datasets` requires version 2 minimum.")
             TF_AVAILABLE = False
         else:
             logger.info(f"TensorFlow version {TF_VERSION} available.")

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -30,26 +30,30 @@ if int(PY_VERSION.split(".")[0]) == 3 and int(PY_VERSION.split(".")[1]) < 8:
 else:
     import importlib.metadata as importlib_metadata
 
+ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
+ENV_VARS_TRUE_AND_AUTO_VALUES = ENV_VARS_TRUE_VALUES.union({"AUTO"})
 
 USE_TF = os.environ.get("USE_TF", "AUTO").upper()
 USE_TORCH = os.environ.get("USE_TORCH", "AUTO").upper()
 
 TORCH_VERSION = "N/A"
 TORCH_AVAILABLE = False
-if USE_TORCH in ("1", "ON", "YES", "AUTO") and USE_TF not in ("1", "ON", "YES"):
-    try:
-        TORCH_VERSION = importlib_metadata.version("torch")
-        TORCH_AVAILABLE = True
-        logger.info("PyTorch version {} available.".format(TORCH_VERSION))
-    except importlib_metadata.PackageNotFoundError:
-        pass
+
+if USE_TORCH in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TF not in ENV_VARS_TRUE_VALUES:
+    TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
+    if TORCH_AVAILABLE:
+        try:
+            TORCH_VERSION = importlib_metadata.version("torch")
+            logger.info(f"PyTorch version {TORCH_VERSION} available.")
+        except importlib_metadata.PackageNotFoundError:
+            pass
 else:
     logger.info("Disabling PyTorch because USE_TF is set")
 
 TF_VERSION = "N/A"
 TF_AVAILABLE = False
 
-if USE_TF in ("1", "ON", "YES", "AUTO") and USE_TORCH not in ("1", "ON", "YES"):
+if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VALUES:
     TF_AVAILABLE = importlib.util.find_spec("tensorflow") is not None
     if TF_AVAILABLE:
         # For the metadata, we have to look for both tensorflow and tensorflow-cpu
@@ -71,8 +75,7 @@ if USE_TF in ("1", "ON", "YES", "AUTO") and USE_TORCH not in ("1", "ON", "YES"):
                             try:
                                 TF_VERSION = importlib_metadata.version("tf-nightly-gpu")
                             except importlib_metadata.PackageNotFoundError:
-                                TF_VERSION = None
-                                TF_AVAILABLE = False
+                                pass
     if TF_AVAILABLE:
         if version.parse(TF_VERSION) < version.parse("2"):
             logger.info(f"TensorFlow found but with version {TF_VERSION}. Transformers requires version 2 minimum.")
@@ -81,7 +84,6 @@ if USE_TF in ("1", "ON", "YES", "AUTO") and USE_TORCH not in ("1", "ON", "YES"):
             logger.info(f"TensorFlow version {TF_VERSION} available.")
 else:
     logger.info("Disabling Tensorflow because USE_TORCH is set")
-    TF_AVAILABLE = False
 
 
 

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -1,7 +1,8 @@
+import importlib
 import os
 import sys
-import importlib
 from pathlib import Path
+
 from packaging import version
 
 from .utils.logging import get_logger
@@ -84,13 +85,6 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
             logger.info(f"TensorFlow version {TF_VERSION} available.")
 else:
     logger.info("Disabling Tensorflow because USE_TORCH is set")
-
-
-
-
-
-
-
 
 
 USE_BEAM = os.environ.get("USE_BEAM", "AUTO").upper()


### PR DESCRIPTION
# What is this PR doing

This PR implements the checks if `Tensorflow` and `Pytorch` are available the same way as `transformers` does it. I added the additional checks for the different `Tensorflow` and `torch` versions.  #2068 