### PR TITLE
Fix: Allows a feature to be named "_type"

### DIFF
--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -887,7 +887,7 @@ def generate_from_dict(obj: Any):
     if isinstance(obj, list):
         return [generate_from_dict(value) for value in obj]
     # Otherwise we have a dict or a dataclass
-    if "_type" not in obj:
+    if "_type" not in obj or isinstance(obj["_type"], dict):
         return {key: generate_from_dict(value) for key, value in obj.items()}
     class_type = globals()[obj.pop("_type")]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -6,6 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
+from datasets import DatasetInfo
 from datasets.arrow_dataset import Dataset
 from datasets.features import (
     ClassLabel,
@@ -66,6 +68,13 @@ class FeaturesTest(TestCase):
         for sdt in unsupported_datasets_dtypes:
             with self.assertRaises(ValueError):
                 string_to_arrow(sdt)
+
+    def test_feature_named_type(self):
+        """reference: issue #1110"""
+        features = Features({"_type": Value("string")})
+        ds_info = DatasetInfo(features=features)
+        reloaded_features = Features.from_dict(asdict(ds_info)["features"])
+        assert features == reloaded_features
 
 
 def test_classlabel_init(tmp_path_factory):


### PR DESCRIPTION
This PR tries to fix issue #1110. Sorry for taking so long to come back to this.

It's a simple fix, but i am not sure if it works for all possible types of `obj`. Let me know what you think @lhoestq 