### PR TITLE
Replace legacy torch.Tensor constructor with torch.tensor

### DIFF
--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -934,7 +934,7 @@ class BaseDatasetTest(TestCase):
         import torch
 
         def func(example):
-            return {"tensor": torch.Tensor([1.0, 2, 3])}
+            return {"tensor": torch.tensor([1.0, 2, 3])}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             dset = self._create_dummy_dataset(in_memory, tmp_dir)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -155,8 +155,8 @@ class CastToPythonObjectsTest(TestCase):
         import torch
 
         obj = {
-            "col_1": [{"vec": torch.Tensor(np.arange(1, 4)), "txt": "foo"}] * 3,
-            "col_2": torch.Tensor(np.arange(1, 7).reshape(3, 2)),
+            "col_1": [{"vec": torch.tensor(np.arange(1, 4)), "txt": "foo"}] * 3,
+            "col_2": torch.tensor(np.arange(1, 7).reshape(3, 2)),
         }
         expected_obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}
         casted_obj = cast_to_python_objects(obj)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -430,7 +430,7 @@ class TestMetric(TestCase):
 
         preds, refs = DummyMetric.predictions_and_references()
         expected_results = DummyMetric.expected_results()
-        preds, refs = torch.Tensor(preds), torch.Tensor(refs)
+        preds, refs = torch.tensor(preds), torch.tensor(refs)
 
         metric = DummyMetric(experiment_id="test_input_torch")
         self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))


### PR DESCRIPTION
The title says it all (motivated by [this issue](https://github.com/pytorch/pytorch/issues/53146) in the pytorch repo).