### PR TITLE
Render docstring return type as inline

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,3 +193,4 @@ def setup(app):
 # -- Extension configuration -------------------------------------------------
 # Napoleon settings
 napoleon_use_ivar = True
+napoleon_use_rtype = False


### PR DESCRIPTION
This documentation setting will avoid having the return type in a separate line under `Return type`. 

See e.g. current docs for `Dataset.to_csv`.