### PR TITLE
Allow pickling of big in-memory tables

### DIFF
--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -137,6 +137,10 @@ HF_MODULES_CACHE = Path(os.getenv("HF_MODULES_CACHE", DEFAULT_HF_MODULES_CACHE))
 # https://github.com/apache/arrow/blob/master/docs/source/cpp/arrays.rst#size-limitations-and-recommendations)
 DEFAULT_MAX_BATCH_SIZE = 10_000
 
+# Pickling tables works only for small tables (<4GiB)
+# For big tables, we write them on disk instead
+MAX_TABLE_NBYTES_FOR_PICKLING = 4 << 30
+
 # Offline mode
 HF_DATASETS_OFFLINE = os.environ.get("HF_DATASETS_OFFLINE", "AUTO").upper()
 if HF_DATASETS_OFFLINE in ("1", "ON", "YES"):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -17,7 +17,7 @@ from datasets.table import (
     inject_arrow_table_documentation,
 )
 
-from .utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases
+from .utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases, slow
 
 
 @pytest.fixture(scope="session")
@@ -223,6 +223,15 @@ def test_in_memory_table_from_batches(in_memory_pa_table):
     table = InMemoryTable.from_batches(batches)
     assert table.table == in_memory_pa_table
     assert isinstance(table, InMemoryTable)
+
+
+@slow
+def test_in_memory_table_pickle_big_table():
+    big_table_4GB = InMemoryTable.from_pydict({"col": [0] * ((4 * 8 << 30) // 64)})
+    length = len(big_table_4GB)
+    big_table_4GB = pickle.dumps(big_table_4GB)
+    big_table_4GB = pickle.loads(big_table_4GB)
+    assert len(big_table_4GB) == length
 
 
 def test_in_memory_table_slice(in_memory_pa_table):


### PR DESCRIPTION
This should fix issue #2134 

Pickling is limited to <4GiB objects, it's not possible to pickle a big arrow table (for multiprocessing for example).
For big tables, we have to write them on disk and only pickle the path to the table.