### PR TITLE
Pin fsspec lower than 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ REQUIRED_PKGS = [
     # to get metadata of optional dependencies such as torch or tensorflow for Python versions that don't have it
     "importlib_metadata;python_version<'3.8'",
     # for saving datsets to local
-    "fsspec",
+    "fsspec<0.9.0",  # 0.9.0 requires s3fs 0.6.0 which is not compatible with the pinned versions of moto/boto3/botocore
     # To get datasets from the Datasets Hub on huggingface.co
     "huggingface_hub<0.1.0",
 ]
@@ -109,10 +109,10 @@ TESTS_REQUIRE = [
     "boto3==1.16.43",
     "botocore==1.19.43",
     "faiss-cpu",
-    "fsspec[s3]<0.9.0",
+    "fsspec[s3]",
     "moto[s3]==1.3.16",
     "rarfile>=4.0",
-    "s3fs>=0.4.2,<0.6.0"
+    "s3fs>=0.4.2,<0.6.0"  # don't use 0.6.0 which is not compatible with the pinned versions of moto/boto3/botocore
     "tensorflow>=2.3",
     "torch",
     "transformers",

--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,10 @@ TESTS_REQUIRE = [
     "boto3==1.16.43",
     "botocore==1.19.43",
     "faiss-cpu",
-    "fsspec[s3]",
+    "fsspec[s3]<0.9.0",
     "moto[s3]==1.3.16",
     "rarfile>=4.0",
+    "s3fs>=0.4.2,<0.6.0"
     "tensorflow>=2.3",
     "torch",
     "transformers",
@@ -139,7 +140,6 @@ TESTS_REQUIRE = [
     "requests_file>=1.5.1",
     "tldextract>=3.1.0",
     "texttable>=1.6.3",
-    "s3fs>=0.4.2",
     "Werkzeug>=1.0.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ TESTS_REQUIRE = [
     "fsspec[s3]",
     "moto[s3]==1.3.16",
     "rarfile>=4.0",
-    "s3fs>=0.4.2,<0.6.0"  # don't use 0.6.0 which is not compatible with the pinned versions of moto/boto3/botocore
+    "s3fs>=0.4.2,<0.6.0",  # don't use 0.6.0 which is not compatible with the pinned versions of moto/boto3/botocore
     "tensorflow>=2.3",
     "torch",
     "transformers",


### PR DESCRIPTION
Today's release of `fsspec` 0.9.0 implied a new release of `s3fs` 0.6.0 but this version breaks the CI (see [here](https://app.circleci.com/pipelines/github/huggingface/datasets/5312/workflows/490f3240-cd1c-4dd1-bb60-b416771c5584/jobs/32734) for example)

I'm pinning `fsspec` until this has been resolved