### PR TITLE
Pin docutils for better doc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ EXTRAS_REQUIRE = {
     "quality": QUALITY_REQUIRE,
     "benchmarks": BENCHMARKS_REQUIRE,
     "docs": [
+        "docutils==0.16.0",
         "recommonmark",
         "sphinx==3.1.2",
         "sphinx-markdown-tables",


### PR DESCRIPTION
The latest release of docutils make the navbar in the documentation weird and the Markdown wrongly interpreted:

![image](https://user-images.githubusercontent.com/35901082/113711773-5be55280-96b3-11eb-9b3b-9794f17709aa.png)

We had the same problem in Transformers and solved it by pinning docutils (a dep of sphinx).

You can see the version after the change [here](https://32769-250213286-gh.circle-artifacts.com/0/docs/_build/html/index.html).
