### PR TITLE
Fix typo in huggingface hub

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - multiprocess
     - importlib_metadata
     - fsspec
-    - huggingface-hub
+    - huggingface_hub
   run:
     - python
     - pip
@@ -40,7 +40,7 @@ requirements:
     - multiprocess
     - importlib_metadata
     - fsspec
-    - huggingface-hub
+    - huggingface_hub
 
 test:
   imports:

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - importlib_metadata
     - fsspec
     - huggingface_hub
+    - packaging
   run:
     - python
     - pip
@@ -41,6 +42,7 @@ requirements:
     - importlib_metadata
     - fsspec
     - huggingface_hub
+    - packaging
 
 test:
   imports:


### PR DESCRIPTION
pip knows how to resolve to `huggingface_hub`, but conda doesn't!

The `packaging` dependency is also required for the build to complete.