### PR TITLE
added file_permission in load_dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1715,9 +1715,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             for file in self.cache_files:
                 if bool(re.search(r".*-train.arrow", file)):
                     train_arrow_permission = oct(os.stat(file).st_mode)[-3:]
+                    os.chmod(cache_file_name, int(train_arrow_permission, base=8))
                     break
-
-            os.chmod(cache_file_name, int(train_arrow_permission, base=8))
 
         if update_data:
             # Create new Dataset from buffer or file
@@ -1968,9 +1967,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             for file in self.cache_files:
                 if bool(re.search(r".*-train.arrow", file)):
                     train_arrow_permission = oct(os.stat(file).st_mode)[-3:]
+                    os.chmod(indices_cache_file_name, int(train_arrow_permission, base=8))
                     break
-
-            os.chmod(indices_cache_file_name, int(train_arrow_permission, base=8))
 
         # Return new Dataset object
         if buf_writer is None:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -22,7 +22,6 @@ import json
 import os
 import re
 import shutil
-import stat
 import tempfile
 from collections import defaultdict
 from collections.abc import Iterable, Mapping

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -657,7 +657,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
             for data_file in state["_data_files"]
         )
-        if state["_indices_files"]:
+        if state.get("_indices_files"):
             indices_table = concat_tables(
                 table_cls.from_file(Path(dataset_path, indices_file["filename"]).as_posix())
                 for indices_file in state["_indices_files"]

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -20,7 +20,9 @@ import contextlib
 import copy
 import json
 import os
+import re
 import shutil
+import stat
 import tempfile
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
@@ -1709,9 +1711,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if update_data and tmp_file is not None:
             tmp_file.close()
             shutil.move(tmp_file.name, cache_file_name)
-            umask = os.umask(0o666)
-            os.umask(umask)
-            os.chmod(cache_file_name, 0o666 & ~umask)
+
+            # iterate through cache files to find *-train.arrow file to fetch its permission
+            for file in self.cache_files:
+                if bool(re.search(r".*-train.arrow", file)):
+                    train_arrow_permission = oct(os.stat(file).st_mode)[-3:]
+                    break
+
+            os.chmod(cache_file_name, int(train_arrow_permission, base=8))
 
         if update_data:
             # Create new Dataset from buffer or file
@@ -1957,9 +1964,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if tmp_file is not None:
             tmp_file.close()
             shutil.move(tmp_file.name, indices_cache_file_name)
-            umask = os.umask(0o666)
-            os.umask(umask)
-            os.chmod(indices_cache_file_name, 0o666 & ~umask)
+
+            # iterate through cache files to find *-train.arrow file and fetch its permission
+            for file in self.cache_files:
+                if bool(re.search(r".*-train.arrow", file)):
+                    train_arrow_permission = oct(os.stat(file).st_mode)[-3:]
+                    break
+
+            os.chmod(indices_cache_file_name, int(train_arrow_permission, base=8))
 
         # Return new Dataset object
         if buf_writer is None:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -639,6 +639,7 @@ def load_dataset(
     save_infos: bool = False,
     script_version: Optional[Union[str, Version]] = None,
     use_auth_token: Optional[Union[bool, str]] = None,
+    file_permission: Optional[int] = None,
     **config_kwargs,
 ) -> Union[DatasetDict, Dataset]:
     r"""Load a dataset
@@ -694,6 +695,9 @@ def load_dataset(
               You can specify a different version that the default "main" by using a commit sha or a git tag of the dataset repository.
         use_auth_token (Optional ``Union[str, bool]``): Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
             If True, will get token from `~/.huggingface`.
+        file_permission (Optional ``int``): This represents access granted to users for this dataset on the system. Please make sure it is
+            an octal value, comprising of 3 digits, each one ranging in value from 0 - 7. On python 3 you have prefix with 0o (zero oh).
+            For example:  0o600 (its equivalent symbolic value would be -rw-------). By default it'll work on running user's umask.
         **config_kwargs (Optional ``dict``): keyword arguments to be passed to the ``datasets.BuilderConfig`` and used in the ``datasets.DatasetBuilder``.
 
     Returns:
@@ -745,6 +749,7 @@ def load_dataset(
         try_from_hf_gcs=try_from_hf_gcs,
         base_path=base_path,
         use_auth_token=use_auth_token,
+        file_permission=file_permission,
     )
 
     # Build dataset for splits


### PR DESCRIPTION
As discussed in #2065 I've added `file_permission` argument in `load_dataset`. 

Added mainly 2 things here:
1) Permission of downloaded datasets when converted to .arrow files  can be changed with argument `file_permission` argument in `load_dataset` (default is 0o644 only)
2) Incase the user uses `map` later on to generate another cache file of dataset, it ensures the permissions of newly generated file are similar to that of` *-train.arrow` file inside cache_dir for that dataset.