### PR TITLE
Fix backward compatibility in Dataset.load_from_disk

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -589,7 +589,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             ]
         }
         state["_data_files"] = [{"filename": config.DATASET_ARROW_FILENAME}]
-        state["_indices_files"] = (
+        state["_indices_data_files"] = (
             [{"filename": config.DATASET_INDICES_FILENAME}] if self._indices is not None else None
         )
         for k in state["_format_kwargs"].keys():
@@ -657,10 +657,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
             for data_file in state["_data_files"]
         )
-        if state.get("_indices_files") or state.get("_indices_data_files"):  # the latter for backward compatibility
+        if state.get("_indices_data_files"):
             indices_table = concat_tables(
                 table_cls.from_file(Path(dataset_path, indices_file["filename"]).as_posix())
-                for indices_file in state.get("_indices_files", []) + state.get("_indices_data_files", [])
+                for indices_file in state.["_indices_data_files"]
             )
         else:
             indices_table = None

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -657,10 +657,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
             for data_file in state["_data_files"]
         )
-        if state.get("_indices_files"):
+        if state.get("_indices_files") or state.get("_indices_data_files"):  # the latter for backward compatibility
             indices_table = concat_tables(
                 table_cls.from_file(Path(dataset_path, indices_file["filename"]).as_posix())
-                for indices_file in state["_indices_files"]
+                for indices_file in state.get("_indices_files", []) + state.get("_indices_data_files", [])
             )
         else:
             indices_table = None

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -660,7 +660,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if state.get("_indices_data_files"):
             indices_table = concat_tables(
                 table_cls.from_file(Path(dataset_path, indices_file["filename"]).as_posix())
-                for indices_file in state.["_indices_data_files"]
+                for indices_file in state["_indices_data_files"]
             )
         else:
             indices_table = None


### PR DESCRIPTION
Fix backward compatibility when loading from disk an old dataset saved to disk with indices using key "_indices_data_files".

Related to #2195.