### PR TITLE
Fix ArrowWriter overwriting features in ArrowBasedBuilder

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1033,7 +1033,7 @@ class ArrowBasedBuilder(DatasetBuilder):
 
         generator = self._generate_tables(**split_generator.gen_kwargs)
         not_verbose = bool(logger.getEffectiveLevel() > WARNING)
-        with ArrowWriter(path=fpath) as writer:
+        with ArrowWriter(features=self.info.features, path=fpath) as writer:
             for key, table in utils.tqdm(generator, unit=" tables", leave=False, disable=not_verbose):
                 writer.write_table(table)
             num_examples, num_bytes = writer.finalize()

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1040,7 +1040,8 @@ class ArrowBasedBuilder(DatasetBuilder):
 
         split_generator.split_info.num_examples = num_examples
         split_generator.split_info.num_bytes = num_bytes
-        self.info.features = writer._features
+        if self.info.features is None:
+            self.info.features = writer._features
 
 
 class MissingBeamOptions(ValueError):

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -814,10 +814,14 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
         datasets.Feature->pa.struct
     """
     # Nested structures: we allow dict, list/tuples, sequences
-    if isinstance(schema, dict):
+    if isinstance(schema, Features):
         return pa.struct(
             {key: get_nested_type(schema[key]) for key in sorted(schema)}
-        )  # sort to make the type deterministic
+        )  # sort to make the order of columns deterministic
+    elif isinstance(schema, dict):
+        return pa.struct(
+            {key: get_nested_type(schema[key]) for key in schema}
+        )  # however don't sort on struct types since the order matters
     elif isinstance(schema, (list, tuple)):
         assert len(schema) == 1, "We defining list feature, you should just provide one example of the inner type"
         value_type = get_nested_type(schema[0])

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -38,6 +38,7 @@ from datasets import (
     load_dataset,
     prepare_module,
 )
+from datasets.features import ClassLabel
 from datasets.packaged_modules import _PACKAGED_DATASETS_MODULES
 from datasets.search import _has_faiss
 from datasets.utils.file_utils import is_remote_url
@@ -515,13 +516,13 @@ class CsvTest(TestCase):
         n_cols = 3
 
         def get_features(type):
-            return Features({str(i): Value(type) for i in range(n_cols)})
+            return Features({str(i): type for i in range(n_cols)})
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             open(os.path.join(tmp_dir, "table.csv"), "w", encoding="utf-8").write(
                 "\n".join(",".join([str(i) for i in range(n_cols)]) for _ in range(n_rows + 1))
             )
-            for type in ["float64", "int8"]:
+            for type in [Value("float64"), Value("int8"), ClassLabel(num_classes=n_cols)]:
                 features = get_features(type)
                 ds = load_dataset(
                     "csv",


### PR DESCRIPTION
This should fix the issues with CSV loading experienced in #2153 and #2200.

The CSV builder is an ArrowBasedBuilder that had an issue with its ArrowWriter used to write the arrow file from the csv data.
The writer wasn't initialized with the features passed by the user. Therefore the writer was inferring the features from the arrow data, discarding the features passed by the user.

I fixed that and I updated the tests