### PR TITLE
Add classes GenerateMode, DownloadConfig and Version to the documentation

### DIFF
--- a/docs/source/package_reference/builder_classes.rst
+++ b/docs/source/package_reference/builder_classes.rst
@@ -23,6 +23,6 @@ Two main classes are mostly used during the dataset building process.
 
 .. autoclass:: datasets.NamedSplit
 
-.. autoclass:: DownloadConfig
+.. autoclass:: datasets.utils::DownloadConfig
 
-.. autoclass:: Version
+.. autoclass:: datasets.utils::Version

--- a/docs/source/package_reference/builder_classes.rst
+++ b/docs/source/package_reference/builder_classes.rst
@@ -15,8 +15,14 @@ Two main classes are mostly used during the dataset building process.
 
 .. autoclass:: datasets.DownloadManager
 
+.. autoclass:: datasets.GenerateMode
+
 .. autoclass:: datasets.SplitGenerator
 
 .. autoclass:: datasets.Split
 
 .. autoclass:: datasets.NamedSplit
+
+.. autoclass:: DownloadConfig
+
+.. autoclass:: Version

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -68,10 +68,17 @@ class InvalidConfigName(ValueError):
 
 @dataclass
 class BuilderConfig:
-    """Base class for `DatasetBuilder` data configuration.
+    """Base class for :class:`DatasetBuilder` data configuration.
 
     DatasetBuilder subclasses with data configuration options should subclass
-    `BuilderConfig` and add their own properties.
+    :class:`BuilderConfig` and add their own properties.
+
+    Attributes:
+        name (:obj:`str`, default ``"default"``):
+        version (:class:`Version` or :obj:`str`, optional):
+        data_dir (:obj:`str`, optional):
+        data_files (:obj:`str` or :obj:`dict` or :obj:`list` or :obj:`tuple`, optional):
+        description (:obj:`str`, optional):
     """
 
     name: str = "default"

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -666,27 +666,27 @@ def load_dataset(
 
     Args:
 
-        path (``str``): Path to the dataset processing script with the dataset builder. Can be either:
+        path (:obj:`str`): Path to the dataset processing script with the dataset builder. Can be either:
 
             - a local path to processing script or the directory containing the script (if the script has the same name as the directory),
               e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``.
             - a dataset identifier in the HuggingFace Datasets Hub (list all available datasets and ids with ``datasets.list_datasets()``)
               e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``.
-        name (Optional ``str``): defining the name of the dataset configuration
-        data_files (Optional ``str``): defining the data_files of the dataset configuration
-        data_dir (Optional ``str``): defining the data_dir of the dataset configuration
-        split (`datasets.Split` or `str`): which split of the data to load.
+        name (:obj:`str`, optional): Defining the name of the dataset configuration.
+        data_files (:obj:`str`, optional): Defining the data_files of the dataset configuration.
+        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration.
+        split (:class:`Split` or :obj:`str`): Which split of the data to load.
             If None, will return a `dict` with all splits (typically `datasets.Split.TRAIN` and `datasets.Split.TEST`).
             If given, will return a single Dataset.
             Splits can be combined and specified like in tensorflow-datasets.
-        cache_dir (Optional ``str``): directory to read/write data. Defaults to "~/datasets".
-        features (Optional ``datasets.Features``): Set the features type to use for this dataset.
-        download_config (Optional ``datasets.DownloadConfig``): specific download configuration parameters.
-        download_mode (Optional `datasets.GenerateMode`): select the download/generate mode - Default to REUSE_DATASET_IF_EXISTS
-        ignore_verifications (bool): Ignore the verifications of the downloaded/processed dataset information (checksums/size/splits/...)
-        keep_in_memory (bool, default=False): Whether to copy the data in-memory.
-        save_infos (bool): Save the dataset information (checksums/size/splits/...)
-        script_version (Optional ``Union[str, datasets.Version]``): Version of the dataset script to load:
+        cache_dir (:obj:`str`, optional): Directory to read/write data. Defaults to "~/datasets".
+        features (:class:`Features`, optional): Set the features type to use for this dataset.
+        download_config (:class:`~utils.DownloadConfig`, optional): Specific download configuration parameters.
+        download_mode (:class:`GenerateMode`, optional): Select the download/generate mode - Default to REUSE_DATASET_IF_EXISTS
+        ignore_verifications (:obj:`bool`, default ``False``): Ignore the verifications of the downloaded/processed dataset information (checksums/size/splits/...).
+        keep_in_memory (:obj:`bool`, default ``False``): Whether to copy the data in-memory.
+        save_infos (:obj:`bool`, default ``False``): Save the dataset information (checksums/size/splits/...).
+        script_version (:class:`~utils.Version` or :obj:`str`, optional): Version of the dataset script to load:
 
             - For canonical datasets in the `huggingface/datasets` library like "squad", the default version of the module is the local version fo the lib.
               You can specify a different version from your local version of the lib (e.g. "master" or "1.2.0") but it might cause compatibility issues.
@@ -694,10 +694,10 @@ def load_dataset(
               You can specify a different version that the default "main" by using a commit sha or a git tag of the dataset repository.
         use_auth_token (Optional ``Union[str, bool]``): Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
             If True, will get token from `~/.huggingface`.
-        **config_kwargs (Optional ``dict``): keyword arguments to be passed to the ``datasets.BuilderConfig`` and used in the ``datasets.DatasetBuilder``.
+        **config_kwargs: Keyword arguments to be passed to the :class:`BuilderConfig` and used in the :class:`DatasetBuilder`.
 
     Returns:
-        ``datasets.Dataset`` or ``datasets.DatasetDict``
+        :class:`Dataset` or :class:`DatasetDict`:
             if `split` is not None: the dataset requested,
             if `split` is None, a ``datasets.DatasetDict`` with each split.
 

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -47,11 +47,15 @@ class GenerateMode(enum.Enum):
 
     The generations modes:
 
+    +------------------------------------+-----------+---------+
     |                                    | Downloads | Dataset |
-    | -----------------------------------|-----------|---------|
+    +====================================+===========+=========+
     | `REUSE_DATASET_IF_EXISTS` (default)| Reuse     | Reuse   |
+    +------------------------------------+-----------+---------+
     | `REUSE_CACHE_IF_EXISTS`            | Reuse     | Fresh   |
+    +------------------------------------+-----------+---------+
     | `FORCE_REDOWNLOAD`                 | Fresh     | Fresh   |
+    +------------------------------------+-----------+---------+
     """
 
     REUSE_DATASET_IF_EXISTS = "reuse_dataset_if_exists"

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -205,20 +205,27 @@ def hash_url_to_filename(url, etag=None):
 
 @dataclass
 class DownloadConfig:
-    """Configuration for our cached path manager
-    Args:
-        cache_dir: specify a cache directory to save the file to (overwrite the default cache dir).
-        force_download: if True, re-dowload the file even if it's already cached in the cache dir.
-        resume_download: if True, resume the download if incompletly recieved file is found.
-        user_agent: Optional string or dict that will be appended to the user-agent on remote requests.
-        extract_compressed_file: if True and the path point to a zip or tar file, extract the compressed
-            file in a folder along the archive.
-        force_extract: if True when extract_compressed_file is True and the archive was already extracted,
-            re-extract the archive and overide the folder where it was extracted.
-        max_retries: the number of times to retry an HTTP request if it fails. Defaults to 1.
-        use_auth_token (Optional ``Union[str, bool]``): Optional string or boolean to use as Bearer token
-            for remote files on the Datasets Hub. If True, will get token from ~/.huggingface.
+    """Configuration for our cached path manager.
 
+    Attributes:
+        cache_dir (:obj:`str` or :obj:`Path`, optional): Specify a cache directory to save the file to (overwrite the
+            default cache dir).
+        force_download (:obj:`bool`, default ``False``): If True, re-dowload the file even if it's already cached in
+            the cache dir.
+        resume_download (:obj:`bool`, default ``False``): If True, resume the download if incompletly recieved file is
+            found.
+        proxies (:obj:`dict`, optional):
+        user_agent (:obj:`str`, optional): Optional string or dict that will be appended to the user-agent on remote
+            requests.
+        extract_compressed_file (:obj:`bool`, default ``False``): If True and the path point to a zip or tar file,
+            extract the compressed file in a folder along the archive.
+        force_extract (:obj:`bool`, default ``False``): If True when extract_compressed_file is True and the archive
+            was already extracted, re-extract the archive and override the folder where it was extracted.
+        use_etag (:obj:`bool`, default ``True``):
+        num_proc (:obj:`int`, optional):
+        max_retries (:obj:`int`, default ``1``): The number of times to retry an HTTP request if it fails.
+        use_auth_token (:obj:`str` or :obj:`bool`, optional): Optional string or boolean to use as Bearer token
+            for remote files on the Datasets Hub. If True, will get token from ~/.huggingface.
     """
 
     cache_dir: Optional[Union[str, Path]] = None

--- a/src/datasets/utils/version.py
+++ b/src/datasets/utils/version.py
@@ -30,9 +30,17 @@ _VERSION_RESOLVED_REG = re.compile(_VERSION_TMPL.format(v=r"\d+"))
 @dataclass
 class Version:
     """Dataset version MAJOR.MINOR.PATCH.
+
     Args:
-        version_str: string. Eg: "1.2.3".
-        description: string, a description of what is new in this version.
+        version_str (:obj:`str`): Eg: "1.2.3".
+        description (:obj:`str`): A description of what is new in this version.
+
+    Attributes:
+        version_str (:obj:`str`): Eg: "1.2.3".
+        description (:obj:`str`): A description of what is new in this version.
+        major (:obj:`str`):
+        minor (:obj:`str`):
+        patch (:obj:`str`):
     """
 
     version_str: str


### PR DESCRIPTION
Add documentation for classes `GenerateMode`, `DownloadConfig` and `Version`.

Update the docstring of `load_dataset` to create cross-reference links to the classes.

Related to #2187.