### PR TITLE
Fix infinite loop in WindowsFileLock

### DIFF
--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -338,8 +338,8 @@ class WindowsFileLock(BaseFileLock):
 
         try:
             fd = os.open(self._lock_file, open_mode)
-        except OSError:
-            pass
+        except OSError as e:
+            raise e
         else:
             try:
                 msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -338,8 +338,10 @@ class WindowsFileLock(BaseFileLock):
 
         try:
             fd = os.open(self._lock_file, open_mode)
-        except OSError as e:
-            raise e
+        except PermissionError:
+            pass
+        except OSError:
+            raise
         else:
             try:
                 msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)


### PR DESCRIPTION
Raise exception to avoid infinite loop.