### PR TITLE
Set test cache config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ from .s3_fixtures import *  # noqa: load s3 fixtures
 
 @pytest.fixture(autouse=True)
 def set_test_cache_config(tmp_path_factory, monkeypatch):
-    test_hf_cache_home = tmp_path_factory.mktemp("cache", numbered=False)
+    # test_hf_cache_home = tmp_path_factory.mktemp("cache")  # TODO: why a cache dir per test function does not work?
+    test_hf_cache_home = tmp_path_factory.getbasetemp() / "cache"
+    test_hf_cache_home.mkdir(exist_ok=True)
     test_hf_datasets_cache = str(test_hf_cache_home / "datasets")
     test_hf_metrics_cache = str(test_hf_cache_home / "metrics")
     test_hf_modules_cache = str(test_hf_cache_home / "modules")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ from .s3_fixtures import *  # noqa: load s3 fixtures
 def set_test_cache_config(tmp_path_factory, monkeypatch):
     # test_hf_cache_home = tmp_path_factory.mktemp("cache")  # TODO: why a cache dir per test function does not work?
     test_hf_cache_home = tmp_path_factory.getbasetemp() / "cache"
-    test_hf_cache_home.mkdir(exist_ok=True)
     test_hf_datasets_cache = str(test_hf_cache_home / "datasets")
     test_hf_metrics_cache = str(test_hf_cache_home / "metrics")
     test_hf_modules_cache = str(test_hf_cache_home / "modules")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from .s3_fixtures import *  # noqa: load s3 fixtures
 
 @pytest.fixture(autouse=True)
 def set_test_cache_config(tmp_path_factory, monkeypatch):
-    test_hf_cache_home = tmp_path_factory.mktemp("cache")
+    test_hf_cache_home = tmp_path_factory.mktemp("cache", numbered=False)
     test_hf_datasets_cache = str(test_hf_cache_home / "datasets")
     test_hf_metrics_cache = str(test_hf_cache_home / "metrics")
     test_hf_modules_cache = str(test_hf_cache_home / "modules")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,17 @@ from datasets.features import ClassLabel, Features, Sequence, Value
 from .s3_fixtures import *  # noqa: load s3 fixtures
 
 
+@pytest.fixture(autouse=True)
+def set_test_cache_config(tmp_path_factory, monkeypatch):
+    test_hf_cache_home = tmp_path_factory.mktemp("cache")
+    test_hf_datasets_cache = str(test_hf_cache_home / "datasets")
+    test_hf_metrics_cache = str(test_hf_cache_home / "metrics")
+    test_hf_modules_cache = str(test_hf_cache_home / "modules")
+    monkeypatch.setattr("datasets.config.HF_DATASETS_CACHE", test_hf_datasets_cache)
+    monkeypatch.setattr("datasets.config.HF_METRICS_CACHE", test_hf_metrics_cache)
+    monkeypatch.setattr("datasets.config.HF_MODULES_CACHE", test_hf_modules_cache)
+
+
 FILE_CONTENT = """\
     Text data.
     Second line of data."""


### PR DESCRIPTION
Currently, running the tests populates the default cache directory `"~/.cache"`.

This PR monkey-patches the config to set the cache directory within the temporary test directory, avoiding side effects.