### PR TITLE
Fix map when removing columns on a formatted dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1704,8 +1704,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 inputs = self._getitem(
                     key=(indices if isinstance(indices, int) else slice(indices[0], indices[-1] + 1)),
                     format_type=None,
-                    format_columns=self._format_columns,
-                    output_all_columns=self._output_all_columns,
+                    format_columns=None,
                     format_kwargs=None,
                 )
             if remove_columns is not None:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1700,16 +1700,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 validate_function_output(processed_inputs, indices)
             if not update_data:
                 return None  # Nothing to update, let's move on
-            if remove_columns is not None:
-                for column in remove_columns:
-                    inputs.pop(column)
             if self._format_type is not None:
                 inputs = self._getitem(
                     key=(indices if isinstance(indices, int) else slice(indices[0], indices[-1] + 1)),
                     format_type=None,
-                    format_columns=None,
+                    format_columns=self._format_columns,
+                    output_all_columns=self._output_all_columns,
                     format_kwargs=None,
                 )
+            if remove_columns is not None:
+                for column in remove_columns:
+                    inputs.pop(column)
             if check_same_num_examples:
                 input_num_examples = len(inputs[next(iter(inputs.keys()))])
                 processed_inputs_num_examples = len(processed_inputs[next(iter(processed_inputs.keys()))])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1020,7 +1020,7 @@ class BaseDatasetTest(TestCase):
             self.assertListEqual(dset_test[0]["tensor"], [1, 2, 3])
             del dset, dset_test
 
-    def test_map_remove_colums(self, in_memory):
+    def test_map_remove_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dset = self._create_dummy_dataset(in_memory, tmp_dir)
             dset = dset.map(lambda x, i: {"name": x["filename"][:-2], "id": i}, with_indices=True)
@@ -1032,6 +1032,12 @@ class BaseDatasetTest(TestCase):
             dset = dset.map(lambda x: x, remove_columns=["id"])
             self.assertTrue("id" not in dset[0])
             self.assertDictEqual(dset.features, Features({"filename": Value("string"), "name": Value("string")}))
+
+            dset = dset.with_format("numpy", columns=dset.column_names)
+            dset = dset.map(lambda x: {"name": 1}, remove_columns=dset.column_names)
+            self.assertTrue("filename" not in dset[0])
+            self.assertTrue("name" in dset[0])
+            self.assertDictEqual(dset.features, Features({"name": Value(dtype="int64")}))
             del dset
 
     def test_map_stateful_callable(self, in_memory):


### PR DESCRIPTION
This should fix issue #2226

The `remove_columns` argument was ignored on formatted datasets