### PR TITLE
Fix `xnli` dataset tuple key

### DIFF
--- a/datasets/xnli/xnli.py
+++ b/datasets/xnli/xnli.py
@@ -193,7 +193,8 @@ class Xnli(datasets.GeneratorBasedBuilder):
                     file = open(filepath, encoding="utf-8")
                     reader = csv.DictReader(file, delimiter="\t", quoting=csv.QUOTE_NONE)
                     for row_idx, row in enumerate(reader):
-                        yield (file_idx, row_idx), {
+                        key = str(file_idx) + "_" + str(row_idx)
+                        yield key, {
                             "premise": row["premise"],
                             "hypothesis": row["hypo"],
                             "label": row["label"].replace("contradictory", "contradiction"),


### PR DESCRIPTION
Closes #2229 
The `xnli` dataset yields a tuple key in case of `ar` which is inconsistant with the acceptable key types (str/int).
The key was thus ported to `str` keeping the original information intact.