### PR TITLE
Set specific cache directories per test function call

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -72,9 +72,6 @@ def init_dynamic_modules(name: str, hf_modules_cache: Optional[Union[Path, str]]
     hf_modules_cache = init_hf_modules(hf_modules_cache)
     dynamic_modules_path = os.path.join(hf_modules_cache, name)
     os.makedirs(dynamic_modules_path, exist_ok=True)
-    if not os.path.exists(os.path.join(dynamic_modules_path, "__init__.py")):
-        with open(os.path.join(dynamic_modules_path, "__init__.py"), "w"):
-            pass
     return dynamic_modules_path
 
 

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)  # pylint: disable=invalid-name
 INCOMPLETE_SUFFIX = ".incomplete"
 
 
-def init_hf_modules(hf_modules_cache: Optional[Union[Path, str]] = None) -> str:
+def init_hf_modules(hf_modules_cache: Optional[Union[Path, str]] = None, original_sys_path=sys.path) -> str:
     """
     Add hf_modules_cache to the python path.
     By default hf_modules_cache='~/.cache/huggingface/modules'.
@@ -51,6 +51,7 @@ def init_hf_modules(hf_modules_cache: Optional[Union[Path, str]] = None) -> str:
     hf_modules_cache = hf_modules_cache if hf_modules_cache is not None else config.HF_MODULES_CACHE
     hf_modules_cache = str(hf_modules_cache)
     if hf_modules_cache not in sys.path:
+        sys.path = original_sys_path[:]
         sys.path.append(hf_modules_cache)
 
         os.makedirs(hf_modules_cache, exist_ok=True)

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -53,11 +53,7 @@ def init_hf_modules(hf_modules_cache: Optional[Union[Path, str]] = None, origina
     if hf_modules_cache not in sys.path:
         sys.path = original_sys_path[:]
         sys.path.append(hf_modules_cache)
-
         os.makedirs(hf_modules_cache, exist_ok=True)
-        if not os.path.exists(os.path.join(hf_modules_cache, "__init__.py")):
-            with open(os.path.join(hf_modules_cache, "__init__.py"), "w"):
-                pass
     return hf_modules_cache
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ from .s3_fixtures import *  # noqa: load s3 fixtures
 
 @pytest.fixture(autouse=True)
 def set_test_cache_config(tmp_path_factory, monkeypatch):
-    # test_hf_cache_home = tmp_path_factory.mktemp("cache")  # TODO: why a cache dir per test function does not work?
-    test_hf_cache_home = tmp_path_factory.getbasetemp() / "cache"
+    # A cache dir per test function
+    test_hf_cache_home = tmp_path_factory.mktemp("cache")
     test_hf_datasets_cache = str(test_hf_cache_home / "datasets")
     test_hf_metrics_cache = str(test_hf_cache_home / "metrics")
     test_hf_modules_cache = str(test_hf_cache_home / "modules")


### PR DESCRIPTION
Implement specific cache directories (datasets, metrics and modules) per test function call.

Currently, the cache directories are set within the temporary test directory, but they are shared across all test function calls.

This PR implements specific cache directories for each test function call, so that tests are atomic and there are no side effects.

