### PR TITLE
Faster map w/ input_columns & faster slicing w/ Iterable keys

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1774,10 +1774,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 # Only load the columns we actually need
                 if input_columns:
                     input_dataset = self.with_format(
-                        self._format_type,
-                        columns=input_columns,
-                        output_all_columns=False,
-                        **self._format_kwargs
+                        self._format_type, columns=input_columns, output_all_columns=False, **self._format_kwargs
                     )
                     if remove_columns:
                         remove_columns = list(set(remove_columns) & set(input_columns))
@@ -1806,10 +1803,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                         if drop_last_batch and i + batch_size > input_dataset.num_rows:
                             continue
                         batch = input_dataset[i : i + batch_size]
-                        indices = list(range(*(slice(i, i + batch_size).indices(input_dataset.num_rows))))  # Something simpler?
+                        indices = list(
+                            range(*(slice(i, i + batch_size).indices(input_dataset.num_rows)))
+                        )  # Something simpler?
                         try:
                             batch = apply_function_on_filtered_inputs(
-                                batch, indices, check_same_num_examples=len(input_dataset.list_indexes()) > 0, offset=offset
+                                batch,
+                                indices,
+                                check_same_num_examples=len(input_dataset.list_indexes()) > 0,
+                                offset=offset,
                             )
                         except NumExamplesMismatch:
                             raise DatasetTransformationNotAllowedError(

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -90,7 +90,7 @@ def _query_table(table: Table, key: Union[int, slice, range, str, Iterable]) -> 
         if len(key) == 0:
             return table.table.slice(0, 0)
         # don't use pyarrow.Table.take even for pyarrow >=1.0 (see https://issues.apache.org/jira/browse/ARROW-9773)
-        return pa.concat_tables(table.fast_slice(int(i) % table.num_rows, 1) for i in key)
+        return table.fast_gather(key)
 
     _raise_bad_key_type(key)
 

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -90,7 +90,7 @@ def _query_table(table: Table, key: Union[int, slice, range, str, Iterable]) -> 
         if len(key) == 0:
             return table.table.slice(0, 0)
         # don't use pyarrow.Table.take even for pyarrow >=1.0 (see https://issues.apache.org/jira/browse/ARROW-9773)
-        return table.fast_gather(key)
+        return table.fast_gather(np.array(key) % table.num_rows)
 
     _raise_bad_key_type(key)
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -104,11 +104,14 @@ class IndexedTableMixin:
         the binary searches in parallel, highly optimized C
         """
         assert len(indices), "Indices must be non-empty"
-        batch_indices = np.searchsorted(self._offsets, indices, side='right') - 1
-        return pa.Table.from_batches([
-            self._batches[batch_idx].slice(i - self._offsets[batch_idx], 1)
-            for batch_idx, i in zip(batch_indices, indices)
-        ], schema=self._schema)
+        batch_indices = np.searchsorted(self._offsets, indices, side="right") - 1
+        return pa.Table.from_batches(
+            [
+                self._batches[batch_idx].slice(i - self._offsets[batch_idx], 1)
+                for batch_idx, i in zip(batch_indices, indices)
+            ],
+            schema=self._schema,
+        )
 
     def fast_slice(self, offset=0, length=None) -> pa.Table:
         """

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -97,6 +97,19 @@ class IndexedTableMixin:
         self._batches = table.to_batches()
         self._offsets = np.cumsum([0] + [len(b) for b in self._batches])
 
+    def fast_gather(self, indices) -> pa.Table:
+        """
+        Create a pa.Table by gathering the records at the records at the specified indices. Should be faster
+        than pa.concat_tables(table.fast_slice(int(i) % table.num_rows, 1) for i in indices) since NumPy can compute
+        the binary searches in parallel, highly optimized C
+        """
+        assert indices, "Indices must be non-empty"
+        batch_indices = np.searchsorted(self._offsets, indices, side='right') - 1
+        return pa.Table.from_batches([
+            self._batches[batch_idx].slice(i - self._offsets[batch_idx], 1)
+            for batch_idx, i in zip(batch_indices, indices)
+        ], schema=self._schema)
+
     def fast_slice(self, offset=0, length=None) -> pa.Table:
         """
         Slice the Table using interpolation search.

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -103,7 +103,7 @@ class IndexedTableMixin:
         than pa.concat_tables(table.fast_slice(int(i) % table.num_rows, 1) for i in indices) since NumPy can compute
         the binary searches in parallel, highly optimized C
         """
-        assert indices, "Indices must be non-empty"
+        assert len(indices), "Indices must be non-empty"
         batch_indices = np.searchsorted(self._offsets, indices, side='right') - 1
         return pa.Table.from_batches([
             self._batches[batch_idx].slice(i - self._offsets[batch_idx], 1)


### PR DESCRIPTION
@lhoestq Fixes #2193 

- `map` now uses `with_format` to only load needed columns in memory when `input_columns` is set
- Slicing datasets with Iterables of indices now uses a new `Table.fast_gather` method, implemented with `np.searchsorted`, to find the appropriate batch indices all at once. `pa.concat_tables` is no longer used for this; we just call `pa.Table.from_batches` with a list of all the batch slices.

Together these changes have sped up batched `map()` calls over subsets of columns quite considerably in my initial testing.