### PR TITLE
Fix query table with iterable

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -87,10 +87,11 @@ def _query_table(table: Table, key: Union[int, slice, range, str, Iterable]) -> 
     if isinstance(key, str):
         return table.table.drop([column for column in table.column_names if column != key])
     if isinstance(key, Iterable):
+        key = np.fromiter(key, np.int64)
         if len(key) == 0:
             return table.table.slice(0, 0)
         # don't use pyarrow.Table.take even for pyarrow >=1.0 (see https://issues.apache.org/jira/browse/ARROW-9773)
-        return table.fast_gather(np.array(key) % table.num_rows)
+        return table.fast_gather(key % table.num_rows)
 
     _raise_bad_key_type(key)
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -97,7 +97,7 @@ class IndexedTableMixin:
         self._batches = table.to_batches()
         self._offsets = np.cumsum([0] + [len(b) for b in self._batches])
 
-    def fast_gather(self, indices) -> pa.Table:
+    def fast_gather(self, indices: Union[List[int], np.ndarray]) -> pa.Table:
         """
         Create a pa.Table by gathering the records at the records at the specified indices. Should be faster
         than pa.concat_tables(table.fast_slice(int(i) % table.num_rows, 1) for i in indices) since NumPy can compute


### PR DESCRIPTION
The benchmark runs are failing on master because it tries to use an iterable to query the dataset.
However there's currently an issue caused by the use of `np.array` instead of `np.fromiter` on the iterable.
This PR fixes it