### PR TITLE
Fix metadata validation with config names

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -175,6 +175,10 @@ class DatasetMetadata:
             :obj:`TypeError`: If the dataset's metadata is invalid
         """
         metada_dict = yaml.safe_load(string) or dict()
+        # flatten the metadata of each config
+        for key in metada_dict:
+            if isinstance(metada_dict[key], dict):
+                metada_dict[key] = list(set(sum(metada_dict[key].values(), [])))
         return cls(**metada_dict)
 
     @staticmethod

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -187,7 +187,7 @@ class TestMetadataUtils(unittest.TestCase):
             - open-domain-qa
             """
         )
-        # DatasetMetadata.from_yaml_string(valid_yaml_string)
+        DatasetMetadata.from_yaml_string(valid_yaml_string)
 
         valid_yaml_string_with_configs = _dedent(
             """\

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -13,7 +14,8 @@ from datasets.utils.metadata import (
 
 
 def _dedent(string: str) -> str:
-    return "\n".join([line.lstrip() for line in string.splitlines()])
+    indent_level = min(re.search("^ +", t).end() if t.startswith(" ") else 0 for t in string.splitlines())
+    return "\n".join([line[indent_level:] for line in string.splitlines()])
 
 
 README_YAML = """\
@@ -185,7 +187,34 @@ class TestMetadataUtils(unittest.TestCase):
             - open-domain-qa
             """
         )
-        DatasetMetadata.from_yaml_string(valid_yaml_string)
+        # DatasetMetadata.from_yaml_string(valid_yaml_string)
+
+        valid_yaml_string_with_configs = _dedent(
+            """\
+            annotations_creators:
+            - found
+            language_creators:
+            - found
+            languages:
+              en:
+              - en
+              fr:
+              - fr
+            licenses:
+            - unknown
+            multilinguality:
+            - monolingual
+            size_categories:
+            - 10K<n<100K
+            source_datasets:
+            - extended|other-yahoo-webscope-l6
+            task_categories:
+            - question-answering
+            task_ids:
+            - open-domain-qa
+            """
+        )
+        DatasetMetadata.from_yaml_string(valid_yaml_string_with_configs)
 
         invalid_tag_yaml = _dedent(
             """\


### PR DESCRIPTION
I noticed in https://github.com/huggingface/datasets/pull/2280 that the metadata validator doesn't parse the tags in the readme properly when then contain the tags per config.