### PR TITLE
Fix conda release

### DIFF
--- a/.github/conda/build.sh
+++ b/.github/conda/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install     # Python command to install the script.
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - multiprocess
     - importlib_metadata
     - fsspec
-    - huggingface_hub
+    - huggingface_hub <0.1.0
     - packaging
   run:
     - python
@@ -41,7 +41,7 @@ requirements:
     - multiprocess
     - importlib_metadata
     - fsspec
-    - huggingface_hub
+    - huggingface_hub <0.1.0
     - packaging
 
 test:

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -25,6 +25,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: false
           activate-environment: "build-datasets"
+          python-version: 3.8
           channels: huggingface,conda-forge
 
       - name: Setup conda env


### PR DESCRIPTION
There were a few issues with conda releases (they've been failing for a while now).
To fix this I had to:
- add the --single-version-externally-managed tag to the build stage (suggestion from [here](https://stackoverflow.com/a/64825075))
- set the python version of the conda build stage to 3.8 since 3.9 isn't supported
- sync the evrsion requirement of `huggingface_hub`

With these changes I'm working on uploading all missing versions until 1.6.2 to conda

EDIT: I managed to build and upload all missing versions until 1.6.2 to conda :)