### PR TITLE
Set encoding in OSCAR dataset

### DIFF
--- a/datasets/oscar/oscar.py
+++ b/datasets/oscar/oscar.py
@@ -355,7 +355,7 @@ class Oscar(datasets.GeneratorBasedBuilder):
         current_lines = []
         for filepath in filepaths:
             logger.info("generating examples from = %s", filepath)
-            with gzip.open(filepath, "rt") as f:
+            with gzip.open(filepath, "rt", encoding="utf-8") as f:
                 for line in f:
                     if len(line.strip()) > 0:
                         current_lines.append(line)


### PR DESCRIPTION
Set explicit `utf-8` encoding in OSCAR dataset, to avoid using the system default `cp1252` on Windows platforms.

Fix #2319.