### PR TITLE
simpllify faiss index save

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -319,18 +319,11 @@ class FaissIndex(BaseIndex):
         """Serialize the FaissIndex on disk"""
         import faiss  # noqa: F811
 
-        if (
-            hasattr(self.faiss_index, "device")
-            and self.faiss_index.device is not None
-            and self.faiss_index.device > -1
-        ) or (
-            hasattr(self.faiss_index, "getDevice")
-            and self.faiss_index.getDevice() is not None
-            and self.faiss_index.getDevice() > -1
-        ):
+        if self.device is not None and self.device > -1:
             index = faiss.index_gpu_to_cpu(self.faiss_index)
         else:
             index = self.faiss_index
+
         faiss.write_index(index, str(file))
 
     @classmethod


### PR DESCRIPTION
Fixes #2350

In some cases, Faiss GPU index objects do not have neither "device" nor "getDevice". Possibly this happens when some part of the index is computed on CPU.

In particular, this would happen with the index `OPQ16_128,IVF512,PQ32` (issue #2350). I did check it, but it is likely that `OPQ` or `PQ` transforms cause it.

I propose, instead of using the index object to get the device, to infer it form the `FaissIndex.device` field as it is done in `.add_vectors`. Here we assume that `.device` always corresponds to the index placement and it seems reasonable. 