### PR TITLE
Remove getchildren from hyperpartisan news detection

### DIFF
--- a/datasets/hyperpartisan_news_detection/hyperpartisan_news_detection.py
+++ b/datasets/hyperpartisan_news_detection/hyperpartisan_news_detection.py
@@ -145,7 +145,7 @@ class HyperpartisanNewsDetection(datasets.GeneratorBasedBuilder):
                 example["hyperpartisan"] = example["hyperpartisan"] == "true"
 
                 example["text"] = ""
-                for child in article.getchildren():
+                for child in article:
                     example["text"] += ET.tostring(child).decode() + "\n"
                 example["text"] = example["text"].strip()
                 del example["id"]


### PR DESCRIPTION
`Element.getchildren()` is now deprecated in the ElementTree library (I think in python 3.9, so it still passes the automated tests which are using 3.6. But for those of us on bleeding-edge distros it now fails).

https://bugs.python.org/issue29209