### PR TITLE
Improve task api code quality

### DIFF
--- a/src/datasets/tasks/base.py
+++ b/src/datasets/tasks/base.py
@@ -1,8 +1,12 @@
 import abc
+import dataclasses
 from dataclasses import dataclass
-from typing import ClassVar, Dict
+from typing import ClassVar, Dict, Type, TypeVar
 
 from ..features import Features
+
+
+T = TypeVar("T", bound="TaskTemplate")
 
 
 @dataclass(frozen=True)
@@ -18,9 +22,9 @@ class TaskTemplate(abc.ABC):
     @property
     @abc.abstractmethod
     def column_mapping(self) -> Dict[str, str]:
-        return NotImplemented
+        raise NotImplementedError
 
     @classmethod
-    @abc.abstractmethod
-    def from_dict(cls, template_dict: dict) -> "TaskTemplate":
-        return NotImplemented
+    def from_dict(cls: Type[T], template_dict: dict) -> T:
+        field_names = set(f.name for f in dataclasses.fields(cls))
+        return cls(**{k: v for k, v in template_dict.items() if k in field_names})

--- a/src/datasets/tasks/question_answering.py
+++ b/src/datasets/tasks/question_answering.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import ClassVar, Dict
 
 from ..features import Features, Sequence, Value
 from .base import TaskTemplate
@@ -7,9 +7,9 @@ from .base import TaskTemplate
 
 @dataclass(frozen=True)
 class QuestionAnswering(TaskTemplate):
-    task = "question-answering"
-    input_schema = Features({"question": Value("string"), "context": Value("string")})
-    label_schema = Features(
+    task: ClassVar[str] = "question-answering"
+    input_schema: ClassVar[Features] = Features({"question": Value("string"), "context": Value("string")})
+    label_schema: ClassVar[Features] = Features(
         {
             "answers": Sequence(
                 {
@@ -23,19 +23,6 @@ class QuestionAnswering(TaskTemplate):
     context_column: str = "context"
     answers_column: str = "answers"
 
-    def __post_init__(self):
-        object.__setattr__(self, "question_column", self.question_column)
-        object.__setattr__(self, "context_column", self.context_column)
-        object.__setattr__(self, "answers_column", self.answers_column)
-
     @property
     def column_mapping(self) -> Dict[str, str]:
         return {self.question_column: "question", self.context_column: "context", self.answers_column: "answers"}
-
-    @classmethod
-    def from_dict(cls, template_dict: dict) -> "QuestionAnswering":
-        return cls(
-            question_column=template_dict["question_column"],
-            context_column=template_dict["context_column"],
-            answers_column=template_dict["answers_column"],
-        )

--- a/src/datasets/tasks/text_classification.py
+++ b/src/datasets/tasks/text_classification.py
@@ -9,6 +9,8 @@ from .base import TaskTemplate
 class TextClassification(TaskTemplate):
     task: ClassVar[str] = "text-classification"
     input_schema: ClassVar[Features] = Features({"text": Value("string")})
+    # TODO(lewtun): Since we update this in __post_init__ do we need to set a default? We'll need it for __init__ so
+    # investigate if there's a more elegant approach.
     label_schema: ClassVar[Features] = Features({"labels": ClassLabel})
     labels: List[str]
     text_column: str = "text"

--- a/src/datasets/tasks/text_classification.py
+++ b/src/datasets/tasks/text_classification.py
@@ -5,13 +5,28 @@ from ..features import ClassLabel, Features, Value
 from .base import TaskTemplate
 
 
+class FeaturesWithLazyClassLabel:
+    def __init__(self, features, label_column="labels"):
+        assert label_column in features, f"Key '{label_column}' missing in features {features}"
+        self._features = features
+        self._label_column = label_column
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self._features
+
+        assert hasattr(obj, self._label_column), f"Object has no attribute '{self._label_column}'"
+        features = self._features.copy()
+        features["labels"] = ClassLabel(names=getattr(obj, self._label_column))
+        return features
+
+
 @dataclass(frozen=True)
 class TextClassification(TaskTemplate):
     task: ClassVar[str] = "text-classification"
     input_schema: ClassVar[Features] = Features({"text": Value("string")})
-    # TODO(lewtun): Since we update this in __post_init__ do we need to set a default? We'll need it for __init__ so
-    # investigate if there's a more elegant approach.
-    label_schema: ClassVar[Features] = Features({"labels": ClassLabel})
+    # TODO(lewtun): Find a more elegant approach without descriptors.
+    label_schema: ClassVar[Features] = FeaturesWithLazyClassLabel(Features({"labels": ClassLabel}))
     labels: List[str]
     text_column: str = "text"
     label_column: str = "labels"
@@ -20,7 +35,6 @@ class TextClassification(TaskTemplate):
         assert len(self.labels) == len(set(self.labels)), "Labels must be unique"
         # Cast labels to tuple to allow hashing
         self.__dict__["labels"] = tuple(sorted(self.labels))
-        self.label_schema["labels"] = ClassLabel(names=self.labels)
 
     @property
     def column_mapping(self) -> Dict[str, str]:


### PR DESCRIPTION
Improves the code quality of the `TaskTemplate` dataclasses.

Changes:
* replaces `return NotImplemented` with raise `NotImplementedError` 
* replaces `sorted` with `len` in the uniqueness check 
* defines `label2id` and `id2label` in the `TextClassification` template as properties
* replaces the `object.__setattr__(self, attr, value)` syntax with (IMO nicer) `self.__dict__[attr] = value`