### PR TITLE
Disallow duplicate keys in yaml tags

### DIFF
--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -15,7 +15,7 @@ from datasets.utils.metadata import (
 
 def _dedent(string: str) -> str:
     indent_level = min(re.search("^ +", t).end() if t.startswith(" ") else 0 for t in string.splitlines())
-    return "\n".join([line[indent_level:] for line in string.splitlines()])
+    return "\n".join([line[indent_level:] for line in string.splitlines() if indent_level < len(line)])
 
 
 README_YAML = """\
@@ -126,7 +126,7 @@ class TestMetadataUtils(unittest.TestCase):
                     - en
                     task_ids:
                     - sentiment-classification
-"""
+                    """
                 ),
             )
 
@@ -263,3 +263,56 @@ class TestMetadataUtils(unittest.TestCase):
         )
         with self.assertRaises(TypeError):
             DatasetMetadata.from_yaml_string(missing_tag_yaml)
+
+        duplicate_yaml_keys = _dedent(
+            """\
+            annotations_creators:
+            - found
+            languages:
+            - en
+            licenses:
+            - unknown
+            multilinguality:
+            - monolingual
+            size_categories:
+            - 10K<n<100K
+            source_datasets:
+            - extended|other-yahoo-webscope-l6
+            task_categories:
+            - question-answering
+            task_ids:
+            - open-domain-qa
+            task_ids:
+            - open-domain-qa
+            """
+        )
+        with self.assertRaises(TypeError):
+            DatasetMetadata.from_yaml_string(duplicate_yaml_keys)
+
+        valid_yaml_string_with_duplicate_configs = _dedent(
+            """\
+            annotations_creators:
+            - found
+            language_creators:
+            - found
+            languages:
+              en:
+              - en
+              en:
+              - en
+            licenses:
+            - unknown
+            multilinguality:
+            - monolingual
+            size_categories:
+            - 10K<n<100K
+            source_datasets:
+            - extended|other-yahoo-webscope-l6
+            task_categories:
+            - question-answering
+            task_ids:
+            - open-domain-qa
+            """
+        )
+        with self.assertRaises(TypeError):
+            DatasetMetadata.from_yaml_string(valid_yaml_string_with_duplicate_configs)


### PR DESCRIPTION
Make sure that there's no duplidate keys in yaml tags.
I added the check in the yaml tree constructor's method, so that the verification is done at every level in the yaml structure.

cc @julien-c 