### PR TITLE
[WIP] Update text classification template labels in DatasetInfo __post_init__

### DIFF
--- a/src/datasets/tasks/text_classification.py
+++ b/src/datasets/tasks/text_classification.py
@@ -12,19 +12,14 @@ class TextClassification(TaskTemplate):
     # TODO(lewtun): Since we update this in __post_init__ do we need to set a default? We'll need it for __init__ so
     # investigate if there's a more elegant approach.
     label_schema = Features({"labels": ClassLabel})
-    labels: List[str]
+    labels: List[str] = None
     text_column: str = "text"
     label_column: str = "labels"
 
     def __post_init__(self):
-        assert sorted(set(self.labels)) == sorted(self.labels), "Labels must be unique"
-        # Cast labels to tuple to allow hashing
-        object.__setattr__(self, "labels", tuple(sorted(self.labels)))
+        object.__setattr__(self, "labels", self.labels)
         object.__setattr__(self, "text_column", self.text_column)
         object.__setattr__(self, "label_column", self.label_column)
-        self.label_schema["labels"] = ClassLabel(names=self.labels)
-        object.__setattr__(self, "label2id", {label: idx for idx, label in enumerate(self.labels)})
-        object.__setattr__(self, "id2label", {idx: label for label, idx in self.label2id.items()})
 
     @property
     def column_mapping(self) -> Dict[str, str]:
@@ -40,3 +35,11 @@ class TextClassification(TaskTemplate):
             label_column=template_dict["label_column"],
             labels=template_dict["labels"],
         )
+
+    @property
+    def label2id(self):
+        return {label: idx for idx, label in enumerate(self.labels)}
+
+    @property
+    def id2label(self):
+        return {idx: label for idx, label in enumerate(self.labels)}


### PR DESCRIPTION
Hi @yjernite and @lhoestq, here's a first stab at the suggestion discussed in #2389 to update the `labels` of the `TextClassification` template in the `DatasetInfo.__post_init__`.

One problem I've spotted is that my current implementation introduces state into the `__post_init__`: 

* When we call `load_dataset`, `DatasetInfo.features` are the "raw" features without any casting so we can access the column names by the `label_column` specified in `TextClassification`
* When we call `Dataset.prepare_for_task` we run into a problem because the `DatasetInfo.features` are first cast into the new schema which triggers a `KeyError` when we update the infos [here](https://github.com/huggingface/datasets/blob/8b2a78520828e0cc13c14a31f413a5395ef25110/src/datasets/arrow_dataset.py#L1959).

What do you think? I did this a bit quickly, so maybe I'm overlooking something obvious :)