### PR TITLE
Free datasets with cache file in temp dir on exit

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -45,6 +45,7 @@ from .arrow_writer import ArrowWriter, OptimizedTypedSequence
 from .features import ClassLabel, Features, Value, cast_to_python_objects
 from .filesystems import extract_path_from_uri, is_remote_filesystem
 from .fingerprint import (
+    check_if_dataset_with_cache_file_in_temp_dir,
     fingerprint_transform,
     generate_fingerprint,
     generate_random_fingerprint,
@@ -239,6 +240,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         self._data: Table = _check_table(arrow_table)
         self._indices: Optional[Table] = _check_table(indices_table) if indices_table is not None else None
+        check_if_dataset_with_cache_file_in_temp_dir(self)
 
         self._format_type: Optional[str] = None
         self._format_kwargs: dict = {}

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -45,12 +45,12 @@ from .arrow_writer import ArrowWriter, OptimizedTypedSequence
 from .features import ClassLabel, Features, Value, cast_to_python_objects
 from .filesystems import extract_path_from_uri, is_remote_filesystem
 from .fingerprint import (
-    check_if_dataset_with_cache_file_in_temp_dir,
     fingerprint_transform,
     generate_fingerprint,
     generate_random_fingerprint,
     get_temporary_cache_files_directory,
     is_caching_enabled,
+    maybe_register_dataset_for_temp_dir_deletion,
     update_fingerprint,
 )
 from .formatting import format_table, get_format_type_from_alias, get_formatter, query_table
@@ -240,7 +240,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         self._data: Table = _check_table(arrow_table)
         self._indices: Optional[Table] = _check_table(indices_table) if indices_table is not None else None
-        check_if_dataset_with_cache_file_in_temp_dir(self)
+        maybe_register_dataset_for_temp_dir_deletion(self)
 
         self._format_type: Optional[str] = None
         self._format_kwargs: dict = {}

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -46,6 +46,12 @@ _DATASETS_WITH_TABLE_IN_TEMP_DIR: Optional[weakref.WeakSet] = None
 
 
 class _TempDirWithCustomCleanup:
+    """
+    A temporary directory with a custom cleanup function.
+    We need a custom temporary directory cleanup in order to delete the dataset objects that have
+    cache files in the temporary directory before deleting the dorectory itself.
+    """
+
     def __init__(self, cleanup_func=None, *cleanup_func_args, **cleanup_func_kwargs):
         self.name = tempfile.mkdtemp()
         self._finalizer = weakref.finalize(self, self._cleanup)
@@ -63,8 +69,12 @@ class _TempDirWithCustomCleanup:
             self._cleanup()
 
 
-def check_if_dataset_with_cache_file_in_temp_dir(dataset):
-    # No-op
+def maybe_register_dataset_for_temp_dir_deletion(dataset):
+    """
+    This function registers the datasets that have cache files in _TEMP_DIR_FOR_TEMP_CACHE_FILES in order
+    to properly delete them before deleting the temporary directory.
+    The temporary directory _TEMP_DIR_FOR_TEMP_CACHE_FILES is used when caching is disabled.
+    """
     if _TEMP_DIR_FOR_TEMP_CACHE_FILES is None:
         return
 

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -129,6 +129,8 @@ def get_temporary_cache_files_directory() -> str:
     global _TEMP_DIR_FOR_TEMP_CACHE_FILES
     if _TEMP_DIR_FOR_TEMP_CACHE_FILES is None:
 
+        # Avoids a PermissionError on Windows caused by the datasets referencing
+        # the files from the cache directory on clean-up
         def cleanup_func():
             for dset in get_datasets_with_cache_file_in_temp_dir():
                 dset.__del__()


### PR DESCRIPTION
This PR properly cleans up the memory-mapped tables that reference the cache files inside the temp dir.
Since the built-in `_finalizer` of `TemporaryDirectory` can't be modified, this PR defines its own `TemporaryDirectory` class that accepts a custom clean-up function.

Fixes #2402