### PR TITLE
Add DOI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
     <a href="CODE_OF_CONDUCT.md">
         <img alt="Contributor Covenant" src="https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg">
     </a>
+    <a href="https://zenodo.org/badge/latestdoi/250213286"><img src="https://zenodo.org/badge/250213286.svg" alt="DOI"></a>
 </p>
 
 `🤗Datasets` is a lightweight library providing **two** main features:


### PR DESCRIPTION
Once published the latest release, the DOI badge has been automatically generated by Zenodo.