### PR TITLE
add utf-8 while reading README

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -55,7 +55,7 @@ class NoDuplicateSafeLoader(yaml.SafeLoader):
 
 
 def yaml_block_from_readme(path: Path) -> Optional[str]:
-    with path.open() as readme_file:
+    with open(path, encoding="utf-8") as readme_file:
         content = [line.rstrip("\n") for line in readme_file]
 
     if content[0] == "---" and "---" in content[1:]:

--- a/src/datasets/utils/readme.py
+++ b/src/datasets/utils/readme.py
@@ -194,7 +194,7 @@ class ReadMe(Section):  # Level 0
 
     @classmethod
     def from_readme(cls, path: Path, structure: dict = None):
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             lines = f.readlines()
         return cls(path, lines, structure)
 


### PR DESCRIPTION
It was causing tests to fail in Windows (see #2416). In Windows, the default encoding is CP1252 which is unable to decode the character byte 0x9d 