### PR TITLE
Fix NQ features loading: reorder fields of features to match nested fields order in arrow data

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -265,6 +265,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         inferred_features = Features.from_arrow_schema(arrow_table.schema)
         if self.info.features is None:
             self.info.features = inferred_features
+        else:  # make sure the nested columns are in the right order
+            self.info.features = self.info.features.reorder_fields_as(inferred_features)
 
         # Infer fingerprint if None
 

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -965,6 +965,25 @@ class Features(dict):
         return copy.deepcopy(self)
 
     def reorder_fields_as(self, other: "Features") -> "Features":
+        """
+        The order of the fields is important since it matters for the underlying arrow data.
+        This method is used to re-order your features to match the fields orders of other features.
+
+        Re-ordering the fields allows to make the underlying arrow data type match.
+
+        Example::
+
+            >>> from datasets import Features, Sequence, Value
+            >>> # let's say we have to features with a different order of nested fields (for a and b for example)
+            >>> f1 = Features({"root": Sequence({"a": Value("string"), "b": Value("string")})})
+            >>> f2 = Features({"root": {"b": Sequence(Value("string")), "a": Sequence(Value("string"))}})
+            >>> assert f1.type != f2.type
+            >>> # re-ordering keeps the base structure (here Sequence is defined at the root level), but make the fields order match
+            >>> f1.reorder_fields_as(f2)
+            {'root': Sequence(feature={'b': Value(dtype='string', id=None), 'a': Value(dtype='string', id=None)}, length=-1, id=None)}
+            >>> assert f1.reorder_fields_as(f2).type == f2.type
+
+        """
         def recursive_reorder(source, target, stack=""):
             stack_position = " at " + stack[1:] if stack else ""
             if isinstance(target, Sequence):

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -984,6 +984,7 @@ class Features(dict):
             >>> assert f1.reorder_fields_as(f2).type == f2.type
 
         """
+
         def recursive_reorder(source, target, stack=""):
             stack_position = " at " + stack[1:] if stack else ""
             if isinstance(target, Sequence):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -220,9 +220,13 @@ def test_in_memory_table_from_buffer(in_memory_pa_table):
 def test_in_memory_table_from_pandas(in_memory_pa_table):
     df = in_memory_pa_table.to_pandas()
     with assert_arrow_memory_increases():
+        # with no schema it might infer another order of the fields in the schema
         table = InMemoryTable.from_pandas(df)
-        assert table.table == in_memory_pa_table
         assert isinstance(table, InMemoryTable)
+    # by specifying schema we get the same order of features, and so the exact same table
+    table = InMemoryTable.from_pandas(df, schema=in_memory_pa_table.schema)
+    assert table.table == in_memory_pa_table
+    assert isinstance(table, InMemoryTable)
 
 
 def test_in_memory_table_from_arrays(in_memory_pa_table):


### PR DESCRIPTION
As mentioned in #2401, there is an issue when loading the features of `natural_questions` since the order of the nested fields in the features don't match. The order is important since it matters for the underlying arrow schema.

To fix that I re-order the features based on the arrow schema:

```python
inferred_features = Features.from_arrow_schema(arrow_table.schema)
self.info.features = self.info.features.reorder_fields_as(inferred_features)
assert self.info.features.type == inferred_features.type
```

The re-ordering is a recursive function. It takes into account that the `Sequence` feature type is a struct of list and not a list of struct.

Now it's possible to load `natural_questions` again :)