### PR TITLE
Keep original features order

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3077,7 +3077,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         Returns:
             :class:`Dataset`
         """
-        item_table = InMemoryTable.from_pydict({k: [v] for k, v in item.items()})
+        item_table = InMemoryTable.from_pydict({k: [item[k]] for k in self.features.keys() if k in item})
         # Cast item
         schema = pa.schema(self.features.type)
         item_table = item_table.cast(schema)

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -272,7 +272,7 @@ class ArrowWriter:
             return
 
         # Since current_examples contains (example, key) tuples
-        cols = sorted(self.current_examples[0][0].keys())
+        cols = self.current_examples[0][0].keys()
 
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -276,7 +276,7 @@ class ArrowWriter:
 
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None
-        arrays = []
+        arrays = {}
         inferred_types = []
         for col in cols:
             col_type = schema.field(col).type if schema is not None else None
@@ -293,9 +293,10 @@ class ArrowWriter:
                         type(pa_array)
                     )
                 )
-            arrays.append(pa_array)
+            arrays[col] = pa_array
             inferred_types.append(inferred_type)
-        schema = pa.schema(zip(cols, inferred_types)) if self.pa_writer is None else self._schema
+        schema = pa.schema(sorted(zip(cols, inferred_types))) if self.pa_writer is None else self._schema
+        arrays = [arrays[col] for col in schema.names]
         table = pa.Table.from_arrays(arrays, schema=schema)
         self.write_table(table)
         self.current_examples = []

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -276,7 +276,7 @@ class ArrowWriter:
 
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None
-        arrays = {}
+        arrays = []
         inferred_types = []
         for col in cols:
             col_type = schema.field(col).type if schema is not None else None
@@ -293,10 +293,9 @@ class ArrowWriter:
                         type(pa_array)
                     )
                 )
-            arrays[col] = pa_array
+            arrays.append(pa_array)
             inferred_types.append(inferred_type)
-        schema = pa.schema(sorted(zip(cols, inferred_types))) if self.pa_writer is None else self._schema
-        arrays = [arrays[col] for col in schema.names]
+        schema = pa.schema(zip(cols, inferred_types)) if self.pa_writer is None else self._schema
         table = pa.Table.from_arrays(arrays, schema=schema)
         self.write_table(table)
         self.current_examples = []

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -272,7 +272,7 @@ class ArrowWriter:
             return
 
         # Since current_examples contains (example, key) tuples
-        cols = self.current_examples[0][0].keys()
+        cols = [col for col in self._schema.names if col in self.current_examples[0][0]]
 
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -272,7 +272,11 @@ class ArrowWriter:
             return
 
         # Since current_examples contains (example, key) tuples
-        cols = [col for col in self._schema.names if col in self.current_examples[0][0]]
+        cols = (
+            [col for col in self._schema.names if col in self.current_examples[0][0]]
+            if self._schema
+            else self.current_examples[0][0].keys()
+        )
 
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -274,6 +274,7 @@ class ArrowWriter:
         # Since current_examples contains (example, key) tuples
         cols = (
             [col for col in self._schema.names if col in self.current_examples[0][0]]
+            + [col for col in self.current_examples[0][0].keys() if col not in self._schema.names]
             if self._schema
             else self.current_examples[0][0].keys()
         )

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -829,7 +829,7 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
         return pa.list_(value_type)
     elif isinstance(schema, Sequence):
         value_type = get_nested_type(schema.feature)
-        # We allow to reverse list of dict => dict of list for compatiblity with tfds
+        # We allow to reverse list of dict => dict of list for compatibility with tfds
         if isinstance(value_type, pa.StructType):
             return pa.struct({f.name: pa.list_(f.type, schema.length) for f in value_type})
         return pa.list_(value_type, schema.length)

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -818,7 +818,7 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
     if isinstance(schema, Features):
         return pa.struct(
             {key: get_nested_type(schema[key]) for key in schema}
-        )  # Features is subclass of dict, and dict order is deterministic since Python 3.7
+        )  # Features is subclass of dict, and dict order is deterministic since Python 3.6
     elif isinstance(schema, dict):
         return pa.struct(
             {key: get_nested_type(schema[key]) for key in schema}

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -817,8 +817,8 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
     # Nested structures: we allow dict, list/tuples, sequences
     if isinstance(schema, Features):
         return pa.struct(
-            {key: get_nested_type(schema[key]) for key in sorted(schema)}
-        )  # sort to make the order of columns deterministic
+            {key: get_nested_type(schema[key]) for key in schema}
+        )  # Features is subclass of dict, and dict order is deterministic since Python 3.7
     elif isinstance(schema, dict):
         return pa.struct(
             {key: get_nested_type(schema[key]) for key in schema}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,11 @@ DATA_DICT_OF_LISTS = {
     "col_3": [0.0, 1.0, 2.0, 3.0],
 }
 
+DATA_312 = [
+    {"col_3": 0.0, "col_1": "0", "col_2": 0},
+    {"col_3": 1.0, "col_1": "1", "col_2": 1},
+]
+
 
 @pytest.fixture(scope="session")
 def dataset_dict():
@@ -178,6 +183,15 @@ def jsonl_path(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("data") / "dataset.jsonl")
     with open(path, "w") as f:
         for item in DATA:
+            f.write(json.dumps(item))
+    return path
+
+
+@pytest.fixture(scope="session")
+def jsonl_312_path(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "dataset_312.jsonl")
+    with open(path, "w") as f:
+        for item in DATA_312:
             f.write(json.dumps(item))
     return path
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2393,7 +2393,11 @@ def test_dataset_add_column(column, expected_dtype, in_memory, transform, datase
         original_dataset: Dataset = getattr(original_dataset, transform_name)(*args, **kwargs)
     dataset = original_dataset.add_column(column_name, column)
     assert dataset.data.shape == (4, 4)
-    expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64", column_name: expected_dtype}
+    expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    # Sort expected features as in the original dataset
+    expected_features = {feature: expected_features[feature] for feature in original_dataset.features}
+    # Add new column feature
+    expected_features[column_name] = expected_dtype
     assert dataset.data.column_names == list(expected_features.keys())
     for feature, expected_dtype in expected_features.items():
         assert dataset.features[feature].dtype == expected_dtype


### PR DESCRIPTION
When loading a Dataset from a JSON file whose column names are not sorted alphabetically, we should get the same column name order, whether we pass features (in the same order as in the file) or not.

I found this issue while working on #2366.