### PR TITLE
Support sliced list arrays in cast

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -59,7 +59,15 @@ from .formatting import format_table, get_format_type_from_alias, get_formatter,
 from .info import DatasetInfo
 from .search import IndexableMixin
 from .splits import NamedSplit
-from .table import ConcatenationTable, InMemoryTable, MemoryMappedTable, Table, concat_tables, list_table_cache_files
+from .table import (
+    ConcatenationTable,
+    InMemoryTable,
+    MemoryMappedTable,
+    Table,
+    cast_with_sliced_list_support,
+    concat_tables,
+    list_table_cache_files,
+)
 from .tasks import TaskTemplate
 from .utils import map_nested
 from .utils.deprecation_utils import deprecated
@@ -920,7 +928,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         schema = pa.schema({col_name: type[col_name].type for col_name in self._data.column_names})
         dataset = self.with_format("arrow")
         dataset = dataset.map(
-            lambda t: t.cast(schema),
+            lambda t: cast_with_sliced_list_support(t, schema),
             batched=True,
             batch_size=batch_size,
             keep_in_memory=keep_in_memory,
@@ -979,7 +987,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         format = self.format
         dataset = self.with_format("arrow")
         dataset = dataset.map(
-            lambda t: t.cast(schema),
+            lambda t: cast_with_sliced_list_support(t, schema),
             batched=True,
             batch_size=batch_size,
             keep_in_memory=keep_in_memory,

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from . import config
 from .utils.logging import get_logger
@@ -870,3 +871,34 @@ def list_table_cache_files(table: Table) -> List[str]:
         return [table.path]
     else:
         return []
+
+
+def cast_with_sliced_list_support(pa_table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Same as pyarrow.Table.cast, except it works for sliced list arrays"""
+
+    def wrap_for_chunked_arrays(func):
+        """Apply the function on each chunk of a pyarrow.ChunkedArray, or on the array directly"""
+
+        def wrapper(array):
+            if isinstance(array, pa.ChunkedArray):
+                return pa.chunked_array([func(chunk) for chunk in array.chunks])
+            else:
+                return func(array)
+
+        return wrapper
+
+    @wrap_for_chunked_arrays
+    def reset_sliced_list_offset(array: pa.ListArray):
+        """Return the same pyarrow.ListArray but with array.offset == 0 for compatibility with cast"""
+        if array.offset == 0:
+            return array
+        elif len(array) == 0:
+            return array.values.slice(0, 0)
+        else:
+            values_offset = array.offsets[0]  # the relevant values start at this index
+            new_values = array.values.slice(values_offset.as_py())  # get the values to start at the right position
+            new_offsets = pc.subtract(array.offsets, values_offset)  # update the offsets accordingly
+            return pa.ListArray.from_arrays(new_offsets, new_values)
+
+    arrays = [reset_sliced_list_offset(array) if isinstance(array.type, pa.ListType) else array for array in pa_table]
+    return pa.Table.from_arrays(arrays, schema=schema)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2285,6 +2285,15 @@ class MiscellaneousDatasetTest(TestCase):
             self.assertEqual(str(dset[:2]), str(encode({"text": ["hello there", "foo"]})))
 
 
+def test_cast_with_sliced_list():
+    old_features = Features({"foo": Sequence(Value("int64"))})
+    new_features = Features({"foo": Sequence(Value("int64"))})
+    dataset = Dataset.from_dict({"foo": [[i] * (i % 3) for i in range(20)]}, features=old_features)
+    casted_dataset = dataset.cast(new_features, batch_size=2)  # small batch size to slice the ListArray
+    assert dataset["foo"] == casted_dataset["foo"]
+    assert casted_dataset.features == new_features
+
+
 def test_update_metadata_with_features(dataset_dict):
     table1 = pa.Table.from_pydict(dataset_dict)
     features1 = Features.from_arrow_schema(table1.schema)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2287,7 +2287,7 @@ class MiscellaneousDatasetTest(TestCase):
 
 def test_cast_with_sliced_list():
     old_features = Features({"foo": Sequence(Value("int64"))})
-    new_features = Features({"foo": Sequence(Value("int64"))})
+    new_features = Features({"foo": Sequence(Value("int32"))})
     dataset = Dataset.from_dict({"foo": [[i] * (i % 3) for i in range(20)]}, features=old_features)
     casted_dataset = dataset.cast(new_features, batch_size=2)  # small batch size to slice the ListArray
     assert dataset["foo"] == casted_dataset["foo"]


### PR DESCRIPTION
There is this issue in pyarrow:
```python
import pyarrow as pa

arr = pa.array([[i * 10] for i in range(4)])
arr.cast(pa.list_(pa.int32()))  # works

arr = arr.slice(1)
arr.cast(pa.list_(pa.int32()))  # fails
# ArrowNotImplementedError("Casting sliced lists (non-zero offset) not yet implemented")
```

However in `Dataset.cast` we slice tables to cast their types (it's memory intensive), so we have the same issue.
Because of this it is currently not possible to cast a Dataset with a Sequence feature type (unless the table is small enough to not be sliced).

In this PR I fixed this by resetting the offset of `pyarrow.ListArray` arrays to zero in the table before casting.
I used `pyarrow.compute.subtract` function to update the offsets of the ListArray.

cc @abhi1thakur @SBrandeis 