### PR TITLE
fix: adjusting indexing for the labels.

### DIFF
--- a/datasets/climate_fever/README.md
+++ b/datasets/climate_fever/README.md
@@ -80,7 +80,7 @@ The text in the dataset is in English, as found in real-world claims about clima
 {
   "claim_id": "0",
   "claim": "Global warming is driving polar bears toward extinction",
-  "claim_label": 1,  # "SUPPORTS"
+  "claim_label": 0,  # "SUPPORTS"
   "evidences": [
     {
      "evidence_id": "Extinction risk from global warming:170",
@@ -98,7 +98,7 @@ The text in the dataset is in English, as found in real-world claims about clima
     },
     {
      "evidence_id": "Global warming:14",
-     "evidence_label": 1,  # "SUPPORTS"
+     "evidence_label": 0,  # "SUPPORTS"
      "article": "Global warming",
      "evidence": "Environmental impacts include the extinction or relocation of many species as their ecosystems change, most immediately the environments of coral reefs, mountains, and the Arctic.",
      "entropy": 0.0,
@@ -126,7 +126,7 @@ The text in the dataset is in English, as found in real-world claims about clima
     },
     {
      "evidence_id": "Habitat destruction:61",
-     "evidence_label": 1,  # "SUPPORTS"
+     "evidence_label": 0,  # "SUPPORTS"
      "article": "Habitat destruction",
      "evidence": "Rising global temperatures, caused by the greenhouse effect, contribute to habitat destruction, endangering various species, such as the polar bear.",
      "entropy": 0.0,
@@ -160,10 +160,10 @@ The text in the dataset is in English, as found in real-world claims about clima
 
 - `claim_id`: a `string` feature, unique claim identifier.
 - `claim`: a `string` feature, claim text.
-- `claim_label`: a `int` feature, overall label assigned to claim (based on evidence majority vote). The label correspond to 0: "refutes", 1: "supports" and 2: "not enough info"
+- `claim_label`: a `int` feature, overall label assigned to claim (based on evidence majority vote). The label correspond to 0: "supports", 1: "refutes", 2: "not enough info" and 3: "disputed".
 - `evidences`: a list of evidences with fields:
  - `evidence_id`: a `string` feature,  unique evidence identifier.
- - `evidence_label`: a `int` feature, micro-verdict label. The label correspond to 0: "refutes", 1: "supports" and 2: "not enough info"
+ - `evidence_label`: a `int` feature, micro-verdict label. The label correspond to 0: "supports", 1: "refutes" and 2: "not enough info".
  - `article`: a `string` feature, title of source article (Wikipedia page).
  - `evidence`: a `string` feature, evidence sentence.
  - `entropy`: a `float32` feature, entropy reflecting uncertainty of `evidence_label`.


### PR DESCRIPTION
The labels index were mismatching the actual ones used in the dataset. Specifically `0` is used  for `SUPPORTS` and `1` is used for `REFUTES`
After this change, the `README.md` now reflects the content of `dataset_infos.json`.

Signed-off-by: Matteo Manica <drugilsberg@gmail.com>