### PR TITLE
Use gc.collect only when needed to avoid slow downs

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -553,10 +553,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             del self._data
         if hasattr(self, "_indices"):
             del self._indices
-        # collect the gc to make sure the windows file lock on arrow files is gone
-        import gc
-
-        gc.collect()
 
     def __enter__(self):
         return self

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Dict, List, Optional, Tuple, Union
 
+import datasets
 from datasets.features import Features
 from datasets.utils.mock_download_manager import MockDownloadManager
 
@@ -775,6 +776,11 @@ class DatasetBuilder:
             }
             post_processed = self._post_process(ds, resources_paths)
             if post_processed is not None:
+                del ds
+                # collect the gc to make sure the windows file lock on arrow files is gone
+                import gc
+
+                gc.collect()
                 ds = post_processed
                 recorded_checksums = {}
                 for resource_name, resource_path in resources_paths.items():

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Dict, List, Optional, Tuple, Union
 
-import datasets
 from datasets.features import Features
 from datasets.utils.mock_download_manager import MockDownloadManager
 


### PR DESCRIPTION
In https://github.com/huggingface/datasets/commit/42320a110d9d072703814e1f630a0d90d626a1e6 we added a call to gc.collect to resolve some issues on windows (see https://github.com/huggingface/datasets/pull/2482)

However calling gc.collect too often causes significant slow downs (the CI run time doubled).
So I just moved the gc.collect call to the exact place where it's actually needed: when post-processing a dataset