### PR TITLE
Allow latest pyarrow version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow==3.0.0
+            - run: pip install pyarrow --upgrade
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:
@@ -46,7 +46,7 @@ jobs:
             - run: "& venv/Scripts/activate.ps1"
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow==3.0.0
+            - run: pip install pyarrow --upgrade
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -sv ./tests/
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ REQUIRED_PKGS = [
     "numpy>=1.17",
     # Backend and serialization.
     # Minimum 1.0.0 to avoid permission errors on windows when using the compute layer on memory mapped data
-    "pyarrow>=1.0.0,<4.0.0",
+    # pyarrow 4.0.0 introduced segfault bug, see: https://github.com/huggingface/datasets/pull/2268
+    "pyarrow>=1.0.0,!=4.0.0",
     # For smart caching dataset processing
     "dill",
     # For performance gains with apache arrow

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -745,8 +745,9 @@ def test_concatenation_table_cast(
             for k, v in zip(in_memory_pa_table.schema.names, in_memory_pa_table.schema.types)
         }
     )
-    with pytest.raises(pa.ArrowNotImplementedError):
-        ConcatenationTable.from_blocks(blocks).cast(schema)
+    if pa.__version__ < "4":
+        with pytest.raises(pa.ArrowNotImplementedError):
+            ConcatenationTable.from_blocks(blocks).cast(schema)
     schema = pa.schema(
         {
             k: v if v != pa.int64() else pa.int32()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -748,6 +748,10 @@ def test_concatenation_table_cast(
     if pa.__version__ < "4":
         with pytest.raises(pa.ArrowNotImplementedError):
             ConcatenationTable.from_blocks(blocks).cast(schema)
+    else:
+        table = ConcatenationTable.from_blocks(blocks).cast(schema)
+        assert table.table == in_memory_pa_table.cast(schema)
+        assert isinstance(table, ConcatenationTable)
     schema = pa.schema(
         {
             k: v if v != pa.int64() else pa.int32()


### PR DESCRIPTION
Allow latest pyarrow version, once that version 4.0.1 fixes the segfault bug introduced in version 4.0.0.

Close #2489.