### PR TITLE
Add Zenodo metadata file with license

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,3 @@
+{
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
This Zenodo metadata file fixes the name of the `Datasets` license appearing in the DOI as `"Apache-2.0"`, which otherwise by default is `"other-open"`.

Close #2472. 