### PR TITLE
Make numpy arrow extractor faster

### DIFF
--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -385,12 +385,6 @@ class ArrayExtensionArray(pa.ExtensionArray):
         for i in range(self.type.ndims):
             size *= self.type.shape[i]
             storage = storage.flatten()
-        # zero copy is available for all primitive types except booleans
-        # primitive types are types for which the physical representation in arrow and in numpy
-        # https://github.com/wesm/arrow/blob/c07b9b48cf3e0bbbab493992a492ae47e5b04cad/python/pyarrow/types.pxi#L821
-        # see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy
-        # and https://issues.apache.org/jira/browse/ARROW-2871?jql=text%20~%20%22boolean%20to_numpy%22
-        zero_copy_only = zero_copy_only and is_primitive(storage.type) and not is_boolean(storage.type)
         numpy_arr = storage.to_numpy(zero_copy_only=zero_copy_only)
         numpy_arr = numpy_arr.reshape(len(self), *self.type.shape)
         return numpy_arr
@@ -406,10 +400,16 @@ class PandasArrayExtensionDtype(PandasExtensionDtype):
         self._value_type = value_type
 
     def __from_arrow__(self, array):
+        # zero copy is available for all primitive types except booleans
+        # primitive types are types for which the physical representation in arrow and in numpy
+        # https://github.com/wesm/arrow/blob/c07b9b48cf3e0bbbab493992a492ae47e5b04cad/python/pyarrow/types.pxi#L821
+        # see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy
+        # and https://issues.apache.org/jira/browse/ARROW-2871?jql=text%20~%20%22boolean%20to_numpy%22
+        zero_copy_only = is_primitive(array.type) and not is_boolean(array.type)
         if isinstance(array, pa.ChunkedArray):
-            numpy_arr = np.vstack([chunk.to_numpy() for chunk in array.chunks])
+            numpy_arr = np.vstack([chunk.to_numpy(zero_copy_only=zero_copy_only) for chunk in array.chunks])
         else:
-            numpy_arr = array.to_numpy()
+            numpy_arr = array.to_numpy(zero_copy_only=zero_copy_only)
         return PandasArrayExtensionArray(numpy_arr)
 
     @classmethod

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -379,7 +379,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
     def __getitem__(self, i):
         return self.storage[i]
 
-    def to_numpy(self):
+    def to_numpy(self, zero_copy_only=True):
         storage: pa.ListArray = self.storage
         size = 1
         for i in range(self.type.ndims):
@@ -390,7 +390,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
         # https://github.com/wesm/arrow/blob/c07b9b48cf3e0bbbab493992a492ae47e5b04cad/python/pyarrow/types.pxi#L821
         # see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy
         # and https://issues.apache.org/jira/browse/ARROW-2871?jql=text%20~%20%22boolean%20to_numpy%22
-        zero_copy_only = is_primitive(storage.type) and not is_boolean(storage.type)
+        zero_copy_only = zero_copy_only and is_primitive(storage.type) and not is_boolean(storage.type)
         numpy_arr = storage.to_numpy(zero_copy_only=zero_copy_only)
         numpy_arr = numpy_arr.reshape(len(self), *self.type.shape)
         return numpy_arr

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -19,9 +19,8 @@ from typing import Any, Callable, Dict, Generic, Iterable, List, MutableMapping,
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from pyarrow.types import is_boolean, is_primitive
 
-from ..features import pandas_types_mapper
+from ..features import _is_zero_copy_only, pandas_types_mapper
 from ..table import Table
 
 
@@ -155,12 +154,7 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
         return {col: self._arrow_array_to_numpy(pa_table[col]) for col in pa_table.column_names}
 
     def _arrow_array_to_numpy(self, pa_array: pa.Array) -> np.ndarray:
-        # zero copy is available for all primitive types except booleans
-        # primitive types are types for which the physical representation in arrow and in numpy
-        # https://github.com/wesm/arrow/blob/c07b9b48cf3e0bbbab493992a492ae47e5b04cad/python/pyarrow/types.pxi#L821
-        # see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy
-        # and https://issues.apache.org/jira/browse/ARROW-2871?jql=text%20~%20%22boolean%20to_numpy%22
-        zero_copy_only = is_primitive(pa_array.type) and not is_boolean(pa_array.type)
+        zero_copy_only = _is_zero_copy_only(pa_array.type)
         if isinstance(pa_array, pa.ChunkedArray):
             # don't call to_numpy() directly or we end up with a np.array with dtype object
             # call to_numpy on the chunks instead

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -148,19 +148,21 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
         return _unnest(self.extract_batch(pa_table))
 
     def extract_column(self, pa_table: pa.Table) -> np.ndarray:
-        series = pa_table.to_pandas(types_mapper=pandas_types_mapper)[pa_table.column_names[0]]
-        return self._series_to_numpy(series)
+        return self._arrow_array_to_numpy(pa_table[pa_table.column_names[0]])
 
     def extract_batch(self, pa_table: pa.Table) -> dict:
-        df = pa_table.to_pandas(types_mapper=pandas_types_mapper)
-        return {k: self._series_to_numpy(v) for k, v in df.items()}
+        return {col: self._arrow_array_to_numpy(pa_table[col]) for col in pa_table.column_names}
 
-    def _series_to_numpy(self, series: pd.Series) -> np.ndarray:
-        # to_numpy takes too much time for series of objects (like series of np.array)
-        if series.dtype == np.object:
-            array = series.tolist()
+    def _arrow_array_to_numpy(self, pa_array: pa.Array) -> np.ndarray:
+        if isinstance(pa_array, pa.ChunkedArray):
+            # don't call to_numpy() directly or we end up with a np.array with dtype object
+            # call to_numpy on the chunks instead
+            array: List[np.ndarray] = [
+                row for chunk in pa_array.chunks for row in chunk.to_numpy(zero_copy_only=False)
+            ]
         else:
-            array = series.to_numpy()
+            # cast to list of arrays or we end up with a np.array with dtype object
+            array: List[np.ndarray] = pa_array.to_numpy().tolist()
         return np.array(array, copy=False, **self.np_array_kwargs)
 
 

--- a/tests/test_array_xd.py
+++ b/tests/test_array_xd.py
@@ -10,6 +10,7 @@ from absl.testing import parameterized
 import datasets
 from datasets.arrow_writer import ArrowWriter
 from datasets.features import Array2D, Array3D, Array4D, Array5D, Value, _ArrayXD
+from datasets.formatting.formatting import NumpyArrowExtractor
 
 
 SHAPE_TEST_1 = (30, 487)
@@ -237,4 +238,13 @@ def test_table_to_pandas(dtype, dummy_value):
     df = dataset._data.to_pandas()
     assert type(df.foo.dtype) == datasets.features.PandasArrayExtensionDtype
     arr = df.foo.to_numpy()
+    np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
+
+
+@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+def test_array_xd_numpy_arrow_extractor(dtype, dummy_value):
+    features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    arr = NumpyArrowExtractor().extract_column(dataset._data)
+    assert isinstance(arr, np.ndarray)
     np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))


### PR DESCRIPTION
I changed the NumpyArrowExtractor to call directly to_numpy and see if it can lead to speed-ups as discussed in https://github.com/huggingface/datasets/issues/2498

This could make the numpy/torch/tf/jax formatting faster