### PR TITLE
Fix fingerprint when moving cache dir

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -847,7 +847,7 @@ class DatasetBuilder:
         )
         hasher = Hasher()
         hasher.update(self._relative_data_dir().replace(os.sep, "/"))
-        hasher.update(split.to_spec() if isinstance(split, ReadInstruction) else str(split))
+        hasher.update(str(split))
         fingerprint = hasher.hexdigest()
         return Dataset(fingerprint=fingerprint, **dataset_kwargs)
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -25,7 +25,6 @@ import shutil
 import urllib
 from dataclasses import dataclass
 from functools import partial
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 from datasets.features import Features
@@ -393,11 +392,11 @@ class DatasetBuilder:
         hash = self.hash
         if builder_config:
             # use the enriched name instead of the name to make it unique
-            builder_data_dir = Path(builder_data_dir, self.config_id).as_posix()
+            builder_data_dir = os.path.join(builder_data_dir, self.config_id)
         if with_version:
-            builder_data_dir = Path(builder_data_dir, str(self.config.version)).as_posix()
+            builder_data_dir = os.path.join(builder_data_dir, str(self.config.version))
         if with_hash and hash and isinstance(hash, str):
-            builder_data_dir = Path(builder_data_dir, hash).as_posix()
+            builder_data_dir = os.path.join(builder_data_dir, hash)
         return builder_data_dir
 
     def _build_cache_dir(self):
@@ -847,7 +846,7 @@ class DatasetBuilder:
             in_memory=in_memory,
         )
         hasher = Hasher()
-        hasher.update(self._relative_data_dir())
+        hasher.update(self._relative_data_dir().replace(os.sep, "/"))
         hasher.update(split.to_spec() if isinstance(split, ReadInstruction) else str(split))
         fingerprint = hasher.hexdigest()
         return Dataset(fingerprint=fingerprint, **dataset_kwargs)

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -846,7 +846,10 @@ class DatasetBuilder:
             split_infos=self.info.splits.values(),
             in_memory=in_memory,
         )
-        fingerprint = Hasher.hash(self._relative_data_dir())
+        hasher = Hasher()
+        hasher.update(self._relative_data_dir())
+        hasher.update(split.to_spec() if isinstance(split, ReadInstruction) else str(split))
+        fingerprint = hasher.hexdigest()
         return Dataset(fingerprint=fingerprint, **dataset_kwargs)
 
     def _post_process(self, dataset: Dataset, resources_paths: Dict[str, str]) -> Optional[Dataset]:

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -62,7 +62,15 @@ except NameError:
 
 # Data
 # ------------------------------------------------
-__all__ = ["Timeout", "BaseFileLock", "WindowsFileLock", "UnixFileLock", "SoftFileLock", "FileLock"]
+__all__ = [
+    "Timeout",
+    "BaseFileLock",
+    "WindowsFileLock",
+    "UnixFileLock",
+    "SoftFileLock",
+    "FileLock",
+    "hash_filename_if_too_long",
+]
 
 __version__ = "3.0.12"
 
@@ -94,6 +102,24 @@ class Timeout(TimeoutError):
     def __str__(self):
         temp = "The file lock '{}' could not be acquired.".format(self.lock_file)
         return temp
+
+
+# Helpers
+# ------------------------------------------------
+
+
+MAX_LOCK_FILENAME_LENGTH = 255
+
+
+def hash_filename_if_too_long(path: str, max_length=MAX_LOCK_FILENAME_LENGTH) -> str:
+    filename = os.path.basename(path)
+    if len(filename) > max_length:
+        dirname = os.path.dirname(path)
+        hashed_filename = str(hash(filename))
+        new_filename = filename[: max_length - len(hashed_filename) - 3] + "..." + hashed_filename
+        return os.path.join(dirname, new_filename)
+    else:
+        return path
 
 
 # Classes

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -132,10 +132,10 @@ class BaseFileLock:
     Implements the base class of a file lock.
     """
 
-    def __init__(self, lock_file, timeout=-1, filename_max_length=255):
+    def __init__(self, lock_file, timeout=-1, max_filename_length=255):
         """ """
         # Hash the filename if it's too long
-        lock_file = self.hash_filename_if_too_long(lock_file, filename_max_length)
+        lock_file = self.hash_filename_if_too_long(lock_file, max_filename_length)
         # The path to the lock file.
         self._lock_file = lock_file
 

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -116,7 +116,7 @@ def hash_filename_if_too_long(path: str, max_length=MAX_LOCK_FILENAME_LENGTH) ->
     if len(filename) > max_length:
         dirname = os.path.dirname(path)
         hashed_filename = str(hash(filename))
-        new_filename = filename[: max_length - len(hashed_filename) - 3] + "..." + hashed_filename
+        new_filename = filename[: max_length - len(hashed_filename) - 8] + "..." + hashed_filename + ".lock"
         return os.path.join(dirname, new_filename)
     else:
         return path

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,0 +1,29 @@
+import time
+import os
+
+import pytest
+
+from datasets.utils.filelock import FileLock, Timeout
+
+
+def test_filelock(tmpdir):
+    lock1 = FileLock(tmpdir / "foo.lock")
+    lock2 = FileLock(tmpdir / "foo.lock")
+    timeout = 0.01
+    with lock1.acquire():
+        with pytest.raises(Timeout):
+            _start = time.time()
+            lock2.acquire(timeout)
+            assert time.time() - _start > timeout
+
+
+def test_long_filename(tmpdir):
+    filename = "a" * 1000 + ".lock"
+    lock1 = FileLock(tmpdir / filename)
+    assert lock1._lock_file.endswith(".lock")
+    assert not lock1._lock_file.endswith(filename)
+    assert len(os.path.basename(lock1._lock_file)) <= 255
+    lock2 = FileLock(tmpdir / filename)
+    with lock1.acquire():
+        with pytest.raises(Timeout):
+            lock2.acquire(0)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,5 +1,5 @@
-import time
 import os
+import time
 
 import pytest
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -227,6 +227,19 @@ def test_loading_from_the_datasets_hub_with_use_auth_token():
         mock_head.assert_called()
 
 
+def test_load_dataset_then_move_then_reload(dataset_loading_script_dir, data_dir, tmp_path, caplog):
+    cache_dir1 = tmp_path / "cache1"
+    cache_dir2 = tmp_path / "cache2"
+    dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="train", cache_dir=cache_dir1)
+    fingerprint1 = dataset._fingerprint
+    del dataset
+    os.rename(cache_dir1, cache_dir2)
+    caplog.clear()
+    dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="train", cache_dir=cache_dir2)
+    assert "Reusing dataset" in caplog.text
+    assert dataset._fingerprint == fingerprint1, "for the caching mechanism to work, fingerprint should stay the same"
+
+
 @pytest.mark.parametrize("max_in_memory_dataset_size", ["default", 0, 50, 500])
 def test_load_dataset_local_with_default_in_memory(
     max_in_memory_dataset_size, dataset_loading_script_dir, data_dir, monkeypatch

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -238,6 +238,8 @@ def test_load_dataset_then_move_then_reload(dataset_loading_script_dir, data_dir
     dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="train", cache_dir=cache_dir2)
     assert "Reusing dataset" in caplog.text
     assert dataset._fingerprint == fingerprint1, "for the caching mechanism to work, fingerprint should stay the same"
+    dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="test", cache_dir=cache_dir2)
+    assert dataset._fingerprint != fingerprint1
 
 
 @pytest.mark.parametrize("max_in_memory_dataset_size", ["default", 0, 50, 500])


### PR DESCRIPTION
The fingerprint of a dataset changes if the cache directory is moved.
I fixed that by setting the fingerprint to be the hash of:
- the relative cache dir (dataset_name/version/config_id)
- the requested split

Close #2496 

I had to fix an issue with the filelock filename that was too long (>255). It prevented the tests to run on my machine. I just added `hash_filename_if_too_long` in case this happens, to not get filenames longer than 255.
We usually have long filenames for filelocks because they are named after the path that is being locked. In case the path is a cache directory that has long directory names, then the filelock filename could en up being very long.