### PR TITLE
Use scikit-learn package rather than sklearn in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ TESTS_REQUIRE = [
     "sacrebleu",
     "scipy",
     "seqeval",
-    "sklearn",
+    "scikit-learn",
     "jiwer",
     "sentencepiece",  # for bleurt
     # to speed up pip backtracking


### PR DESCRIPTION
The sklearn package is an historical thing and should probably not be used by anyone, see https://github.com/scikit-learn/scikit-learn/issues/8215#issuecomment-344679114 for some caveats.

Note: this affects only TESTS_REQUIRE so I guess only developers not end users.