### PR TITLE
Add task template for automatic speech recognition

### DIFF
--- a/src/datasets/tasks/__init__.py
+++ b/src/datasets/tasks/__init__.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
 from ..utils.logging import get_logger
+from .automatic_speech_recognition import AutomaticSpeechRecognition
 from .base import TaskTemplate
 from .question_answering import QuestionAnsweringExtractive
 from .text_classification import TextClassification
-from .automatic_speech_recognition import AutomaticSpeechRecognition
 
 
 __all__ = ["TaskTemplate", "QuestionAnsweringExtractive", "TextClassification", "AutomaticSpeechRecognition"]

--- a/src/datasets/tasks/__init__.py
+++ b/src/datasets/tasks/__init__.py
@@ -4,9 +4,10 @@ from ..utils.logging import get_logger
 from .base import TaskTemplate
 from .question_answering import QuestionAnsweringExtractive
 from .text_classification import TextClassification
+from .automatic_speech_recognition import AutomaticSpeechRecognition
 
 
-__all__ = ["TaskTemplate", "QuestionAnsweringExtractive", "TextClassification"]
+__all__ = ["TaskTemplate", "QuestionAnsweringExtractive", "TextClassification", "AutomaticSpeechRecognition"]
 
 logger = get_logger(__name__)
 
@@ -14,6 +15,7 @@ logger = get_logger(__name__)
 NAME2TEMPLATE = {
     QuestionAnsweringExtractive.task: QuestionAnsweringExtractive,
     TextClassification.task: TextClassification,
+    AutomaticSpeechRecognition.task: AutomaticSpeechRecognition,
 }
 
 

--- a/src/datasets/tasks/__init__.py
+++ b/src/datasets/tasks/__init__.py
@@ -8,7 +8,13 @@ from .summarization import Summarization
 from .text_classification import TextClassification
 
 
-__all__ = ["TaskTemplate", "QuestionAnsweringExtractive", "TextClassification", "Summarization"]
+__all__ = [
+    "TaskTemplate",
+    "QuestionAnsweringExtractive",
+    "TextClassification",
+    "Summarization",
+    "AutomaticSpeechRecognition",
+]
 
 logger = get_logger(__name__)
 

--- a/src/datasets/tasks/automatic_speech_recognition.py
+++ b/src/datasets/tasks/automatic_speech_recognition.py
@@ -8,6 +8,8 @@ from .base import TaskTemplate
 @dataclass(frozen=True)
 class AutomaticSpeechRecognition(TaskTemplate):
     task: str = "automatic-speech-recognition"
+    # TODO(lewtun): Replace input path feature with dedicated `Audio` features
+    # when https://github.com/huggingface/datasets/pull/2324 is implemented
     input_schema: ClassVar[Features] = Features({"audio_file_path": Value("string")})
     label_schema: ClassVar[Features] = Features({"transcription": Value("string")})
     audio_file_path_column: str = "audio_file_path"

--- a/src/datasets/tasks/automatic_speech_recognition.py
+++ b/src/datasets/tasks/automatic_speech_recognition.py
@@ -8,11 +8,11 @@ from .base import TaskTemplate
 @dataclass(frozen=True)
 class AutomaticSpeechRecognition(TaskTemplate):
     task: str = "automatic-speech-recognition"
-    input_schema: ClassVar[Features] = Features({"audio_file": Value("string")})
+    input_schema: ClassVar[Features] = Features({"audio_file_path": Value("string")})
     label_schema: ClassVar[Features] = Features({"transcription": Value("string")})
-    audio_file_column: str = "audio_file"
+    audio_file_path_column: str = "audio_file_path"
     transcription_column: str = "transcription"
 
     @property
     def column_mapping(self) -> Dict[str, str]:
-        return {self.audio_file_column: "audio_file", self.transcription_column: "transcription"}
+        return {self.audio_file_path_column: "audio_file_path", self.transcription_column: "transcription"}

--- a/src/datasets/tasks/automatic_speech_recognition.py
+++ b/src/datasets/tasks/automatic_speech_recognition.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import ClassVar, Dict
+
+from ..features import Features, Value
+from .base import TaskTemplate
+
+
+@dataclass(frozen=True)
+class AutomaticSpeechRecognition(TaskTemplate):
+    task: str = "automatic-speech-recognition"
+    input_schema: ClassVar[Features] = Features({"audio_file": Value("string")})
+    label_schema: ClassVar[Features] = Features({"transcription": Value("string")})
+    audio_file_column: str = "audio_file"
+    transcription_column: str = "transcription"
+
+    @property
+    def column_mapping(self) -> Dict[str, str]:
+        return {self.audio_file_column: "audio_file", self.transcription_column: "transcription"}

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2551,6 +2551,43 @@ class TaskTemplatesTest(TestCase):
                 )
                 self.assertDictEqual(features_after_cast, dset.features)
 
+    def test_task_automatic_speech_recognition(self):
+        # Include a dummy extra column `dummy` to test we drop it correctly
+        features_before_cast = Features(
+            {
+                "input_audio_file_path": Value("string"),
+                "input_transcription": Value("string"),
+                "dummy": Value("string"),
+            }
+        )
+        features_after_cast = Features({"audio_file_path": Value("string"), "transcription": Value("string")})
+        task = AutomaticSpeechRecognition(
+            audio_file_path_column="input_audio_file_path", transcription_column="input_transcription"
+        )
+        info = DatasetInfo(features=features_before_cast, task_templates=task)
+        data = {
+            "input_audio_file_path": ["path/to/some/audio/file.wav"],
+            "input_transcription": ["hello, my name is bob!"],
+            "dummy": ["123456"],
+        }
+        # Test we can load from task name
+        with Dataset.from_dict(data, info=info) as dset:
+            with dset.prepare_for_task(task="automatic-speech-recognition") as dset:
+                self.assertSetEqual(
+                    set(["audio_file_path", "transcription"]),
+                    set(dset.column_names),
+                )
+                self.assertDictEqual(features_after_cast, dset.features)
+        # Test we can load from Summarization template
+        info.task_templates = None
+        with Dataset.from_dict(data, info=info) as dset:
+            with dset.prepare_for_task(task=task) as dset:
+                self.assertSetEqual(
+                    set(["audio_file_path", "transcription"]),
+                    set(dset.column_names),
+                )
+                self.assertDictEqual(features_after_cast, dset.features)
+
     def test_task_with_no_template(self):
         data = {"input_text": ["i love transformers!"], "input_labels": [1]}
         with Dataset.from_dict(data) as dset:
@@ -2773,40 +2810,3 @@ class TaskTemplatesTest(TestCase):
         ) as dset2, Dataset.from_dict(data, info=info3) as dset3:
             with concatenate_datasets([dset1, dset2, dset3]) as dset_concat:
                 self.assertEqual(dset_concat.info.task_templates, None)
-
-    def test_task_automatic_speech_recognition(self):
-        # Include a dummy extra column `dummy` to test we drop it correctly
-        features_before_cast = Features(
-            {
-                "input_audio_file_path": Value("string"),
-                "input_transcription": Value("string"),
-                "dummy": Value("string"),
-            }
-        )
-        features_after_cast = Features({"audio_file_path": Value("string"), "transcription": Value("string")})
-        task = AutomaticSpeechRecognition(
-            audio_file_path_column="input_audio_file_path", transcription_column="input_transcription"
-        )
-        info = DatasetInfo(features=features_before_cast, task_templates=task)
-        data = {
-            "input_audio_file_path": ["path/to/some/audio/file.wav"],
-            "input_transcription": ["hello, my name is bob!"],
-            "dummy": ["123456"],
-        }
-        # Test we can load from task name
-        with Dataset.from_dict(data, info=info) as dset:
-            with dset.prepare_for_task(task="automatic-speech-recognition") as dset:
-                self.assertSetEqual(
-                    set(["audio_file_path", "transcription"]),
-                    set(dset.column_names),
-                )
-                self.assertDictEqual(features_after_cast, dset.features)
-        # Test we can load from Summarization template
-        info.task_templates = None
-        with Dataset.from_dict(data, info=info) as dset:
-            with dset.prepare_for_task(task=task) as dset:
-                self.assertSetEqual(
-                    set(["audio_file_path", "transcription"]),
-                    set(dset.column_names),
-                )
-                self.assertDictEqual(features_after_cast, dset.features)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -20,7 +20,7 @@ from datasets.features import Array2D, Array3D, ClassLabel, Features, Sequence, 
 from datasets.info import DatasetInfo
 from datasets.splits import NamedSplit
 from datasets.table import ConcatenationTable, InMemoryTable, MemoryMappedTable
-from datasets.tasks import QuestionAnsweringExtractive, TextClassification
+from datasets.tasks import AutomaticSpeechRecognition, QuestionAnsweringExtractive, TextClassification
 from datasets.utils.logging import WARNING
 
 from .conftest import s3_test_bucket_name
@@ -2141,6 +2141,39 @@ class BaseDatasetTest(TestCase):
                 self.assertSetEqual(
                     set(["context", "question", "answers.text", "answers.answer_start"]),
                     set(dset.flatten().column_names),
+                )
+                self.assertDictEqual(features_after_cast, dset.features)
+
+    def test_task_automatic_speech_recognition(self, in_memory):
+        # Include a dummy extra column `dummy` to test we drop it correctly
+        features_before_cast = Features(
+            {"input_audio_file": Value("string"), "input_transcription": Value("string"), "dummy": Value("string")}
+        )
+        features_after_cast = Features({"audio_file": Value("string"), "transcription": Value("string")})
+        task = AutomaticSpeechRecognition(
+            audio_file_column="input_audio_file", transcription_column="input_transcription"
+        )
+        info = DatasetInfo(features=features_before_cast, task_templates=task)
+        data = {
+            "input_audio_file": ["path/to/some/audio/file.wav"],
+            "input_transcription": ["hello, my name is bob!"],
+            "dummy": ["123456"],
+        }
+        # Test we can load from task name
+        with Dataset.from_dict(data, info=info) as dset:
+            with dset.prepare_for_task(task="automatic-speech-recognition") as dset:
+                self.assertSetEqual(
+                    set(["audio_file", "transcription"]),
+                    set(dset.column_names),
+                )
+                self.assertDictEqual(features_after_cast, dset.features)
+        # Test we can load from Summarization template
+        info.task_templates = None
+        with Dataset.from_dict(data, info=info) as dset:
+            with dset.prepare_for_task(task=task) as dset:
+                self.assertSetEqual(
+                    set(["audio_file", "transcription"]),
+                    set(dset.column_names),
                 )
                 self.assertDictEqual(features_after_cast, dset.features)
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2144,39 +2144,6 @@ class BaseDatasetTest(TestCase):
                 )
                 self.assertDictEqual(features_after_cast, dset.features)
 
-    def test_task_automatic_speech_recognition(self, in_memory):
-        # Include a dummy extra column `dummy` to test we drop it correctly
-        features_before_cast = Features(
-            {"input_audio_file": Value("string"), "input_transcription": Value("string"), "dummy": Value("string")}
-        )
-        features_after_cast = Features({"audio_file": Value("string"), "transcription": Value("string")})
-        task = AutomaticSpeechRecognition(
-            audio_file_column="input_audio_file", transcription_column="input_transcription"
-        )
-        info = DatasetInfo(features=features_before_cast, task_templates=task)
-        data = {
-            "input_audio_file": ["path/to/some/audio/file.wav"],
-            "input_transcription": ["hello, my name is bob!"],
-            "dummy": ["123456"],
-        }
-        # Test we can load from task name
-        with Dataset.from_dict(data, info=info) as dset:
-            with dset.prepare_for_task(task="automatic-speech-recognition") as dset:
-                self.assertSetEqual(
-                    set(["audio_file", "transcription"]),
-                    set(dset.column_names),
-                )
-                self.assertDictEqual(features_after_cast, dset.features)
-        # Test we can load from Summarization template
-        info.task_templates = None
-        with Dataset.from_dict(data, info=info) as dset:
-            with dset.prepare_for_task(task=task) as dset:
-                self.assertSetEqual(
-                    set(["audio_file", "transcription"]),
-                    set(dset.column_names),
-                )
-                self.assertDictEqual(features_after_cast, dset.features)
-
     def test_task_with_no_template(self, in_memory):
         data = {"input_text": ["i love transformers!"], "input_labels": [1]}
         with tempfile.TemporaryDirectory() as tmp_dir, Dataset.from_dict(data) as dset:
@@ -2796,3 +2763,37 @@ def test_dummy_dataset_serialize_s3(s3, dataset):
     assert dataset.features == features
     assert dataset[0]["id"] == 0
     assert dataset["id"][0] == 0
+
+
+def test_task_automatic_speech_recognition(self):
+    # Include a dummy extra column `dummy` to test we drop it correctly
+    features_before_cast = Features(
+        {"input_audio_file_path": Value("string"), "input_transcription": Value("string"), "dummy": Value("string")}
+    )
+    features_after_cast = Features({"audio_file_path": Value("string"), "transcription": Value("string")})
+    task = AutomaticSpeechRecognition(
+        audio_file_column="input_audio_file_path", transcription_column="input_transcription"
+    )
+    info = DatasetInfo(features=features_before_cast, task_templates=task)
+    data = {
+        "input_audio_file_path": ["path/to/some/audio/file.wav"],
+        "input_transcription": ["hello, my name is bob!"],
+        "dummy": ["123456"],
+    }
+    # Test we can load from task name
+    with Dataset.from_dict(data, info=info) as dset:
+        with dset.prepare_for_task(task="automatic-speech-recognition") as dset:
+            self.assertSetEqual(
+                set(["audio_file_path", "transcription"]),
+                set(dset.column_names),
+            )
+            self.assertDictEqual(features_after_cast, dset.features)
+    # Test we can load from Summarization template
+    info.task_templates = None
+    with Dataset.from_dict(data, info=info) as dset:
+        with dset.prepare_for_task(task=task) as dset:
+            self.assertSetEqual(
+                set(["audio_file_path", "transcription"]),
+                set(dset.column_names),
+            )
+            self.assertDictEqual(features_after_cast, dset.features)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,7 @@
 from unittest.case import TestCase
 
 from datasets.features import ClassLabel, Features, Sequence, Value
-from datasets.tasks import QuestionAnsweringExtractive, Summarization, TextClassification
+from datasets.tasks import AutomaticSpeechRecognition, QuestionAnsweringExtractive, Summarization, TextClassification
 
 
 class TextClassificationTest(TestCase):
@@ -73,16 +73,19 @@ class SummarizationTest(TestCase):
 class AutomaticSpeechRecognitionTest(TestCase):
     def test_column_mapping(self):
         task = AutomaticSpeechRecognition(
-            audio_file_column="input_audio_file", transcription_column="input_transcription"
+            audio_file_path_column="input_audio_file_path", transcription_column="input_transcription"
         )
         self.assertDictEqual(
-            {"input_audio_file": "audio_file", "input_transcription": "transcription"}, task.column_mapping
+            {"input_audio_file_path": "audio_file_path", "input_transcription": "transcription"}, task.column_mapping
         )
 
     def test_from_dict(self):
-        input_schema = Features({"audio_file": Value("string")})
+        input_schema = Features({"audio_file_path": Value("string")})
         label_schema = Features({"transcription": Value("string")})
-        template_dict = {"audio_file_column": "input_audio_file", "transcription_column": "input_transcription"}
+        template_dict = {
+            "audio_file_path_column": "input_audio_file_path",
+            "transcription_column": "input_transcription",
+        }
         task = AutomaticSpeechRecognition.from_dict(template_dict)
         self.assertEqual("automatic-speech-recognition", task.task)
         self.assertEqual(input_schema, task.input_schema)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,7 @@
 from unittest.case import TestCase
 
 from datasets.features import ClassLabel, Features, Sequence, Value
-from datasets.tasks import QuestionAnsweringExtractive, TextClassification
+from datasets.tasks import AutomaticSpeechRecognition, QuestionAnsweringExtractive, TextClassification
 
 
 class TextClassificationTest(TestCase):
@@ -51,5 +51,24 @@ class QuestionAnsweringTest(TestCase):
         }
         task = QuestionAnsweringExtractive.from_dict(template_dict)
         self.assertEqual("question-answering-extractive", task.task)
+        self.assertEqual(input_schema, task.input_schema)
+        self.assertEqual(label_schema, task.label_schema)
+
+
+class AutomaticSpeechRecognitionTest(TestCase):
+    def test_column_mapping(self):
+        task = AutomaticSpeechRecognition(
+            audio_file_column="input_audio_file", transcription_column="input_transcription"
+        )
+        self.assertDictEqual(
+            {"input_audio_file": "audio_file", "input_transcription": "transcription"}, task.column_mapping
+        )
+
+    def test_from_dict(self):
+        input_schema = Features({"audio_file": Value("string")})
+        label_schema = Features({"transcription": Value("string")})
+        template_dict = {"audio_file_column": "input_audio_file", "transcription_column": "input_transcription"}
+        task = AutomaticSpeechRecognition.from_dict(template_dict)
+        self.assertEqual("automatic-speech-recognition", task.task)
         self.assertEqual(input_schema, task.input_schema)
         self.assertEqual(label_schema, task.label_schema)


### PR DESCRIPTION
This PR adds a task template for automatic speech recognition. In this task, the input is a path to an audio file which the model consumes to produce a transcription.

Usage:

```python
from datasets import load_dataset
from datasets.tasks import AutomaticSpeechRecognition

ds = load_dataset("timit_asr", split="train[:10]")
# Dataset({
#     features: ['file', 'text', 'phonetic_detail', 'word_detail', 'dialect_region', 'sentence_type', 'speaker_id', 'id'],
#     num_rows: 10
# })

task = AutomaticSpeechRecognition(audio_file_column="file", transcription_column="text")
ds.prepare_for_task(task)
# Dataset({
#     features: ['audio_file', 'transcription'],
#     num_rows: 10
# })
```