### PR TITLE
Remove task templates if required features are removed during `Dataset.map`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1998,9 +1998,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             # Create new Dataset from buffer or file
             info = self.info.copy()
             # Remove task templates if the required features have been removed
-            for idx, task in enumerate(info.task_templates):
-                if not all(k in writer._features.keys() for k in task.features.keys()):
-                    _ = info.task_templates.pop(idx)
+            if info.task_templates:
+                for idx, task in enumerate(info.task_templates):
+                    if not all(k in writer._features.keys() for k in task.features.keys()):
+                        _ = info.task_templates.pop(idx)
             info.features = writer._features
             print(info.features)
             if buf_writer is None:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1999,9 +1999,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             info = self.info.copy()
             # Remove task templates if the required features have been removed
             if info.task_templates:
-                for idx, task in enumerate(info.task_templates):
-                    if not all(k in writer._features.keys() for k in task.features.keys()):
-                        _ = info.task_templates.pop(idx)
+                info.task_templates = [
+                    template
+                    for template in info.task_templates
+                    if all(k in writer._features.keys() for k in template.features)
+                ]
             info.features = writer._features
             if buf_writer is None:
                 return Dataset.from_file(cache_file_name, info=info, split=self.split)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1997,7 +1997,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if update_data:
             # Create new Dataset from buffer or file
             info = self.info.copy()
+            # Remove task templates if the required features have been removed
+            for idx, task in enumerate(info.task_templates):
+                if not all(k in writer._features.keys() for k in task.features.keys()):
+                    _ = info.task_templates.pop(idx)
             info.features = writer._features
+            print(info.features)
             if buf_writer is None:
                 return Dataset.from_file(cache_file_name, info=info, split=self.split)
             else:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2003,7 +2003,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     if not all(k in writer._features.keys() for k in task.features.keys()):
                         _ = info.task_templates.pop(idx)
             info.features = writer._features
-            print(info.features)
             if buf_writer is None:
                 return Dataset.from_file(cache_file_name, info=info, split=self.split)
             else:


### PR DESCRIPTION
This PR fixes a bug reported by @craffel where removing a dataset's columns during `Dataset.map` triggered a `KeyError` because the `TextClassification` template tried to access the removed columns during `DatasetInfo.__post_init__`:

```python
from datasets import load_dataset

# `yelp_polarity` comes with a `TextClassification` template
ds = load_dataset("yelp_polarity", split="test")
ds
# Dataset({
#     features: ['text', 'label'],
#     num_rows: 38000
# })

# Triggers KeyError: 'label' - oh noes!
ds.map(lambda x: {"inputs": 0}, remove_columns=ds.column_names)
```

I wrote a unit test to make sure I could reproduce the error and then patched a fix.