### PR TITLE
Fix logging levels

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1320,7 +1320,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         self._format_kwargs = format_kwargs
         self._format_columns = columns
         self._output_all_columns = output_all_columns
-        logger.info(
+        logger.debug(
             "Set __getitem__(key) output type to %s for %s columns "
             " (when key is int or slice) and %s output other (un-formatted) columns.",
             "python objects" if type is None else type,

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -423,7 +423,7 @@ class ArrowWriter:
         self.pa_writer.close()
         if close_stream:
             self.stream.close()
-        logger.info(
+        logger.debug(
             "Done writing %s %s in %s bytes %s.",
             self._num_examples,
             self.unit,

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -729,7 +729,7 @@ class DatasetBuilder:
                 % (self.name, self._cache_dir_root)
             )
 
-        logger.info(
+        logger.debug(
             "Constructing Dataset for split %s, from %s", split or ", ".join(self.info.splits), self._cache_dir
         )
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -507,7 +507,7 @@ class DatasetBuilder:
         with FileLock(lock_path):
             data_exists = os.path.exists(self._cache_dir)
             if data_exists and download_mode == GenerateMode.REUSE_DATASET_IF_EXISTS:
-                logger.warning("Reusing dataset %s (%s)", self.name, self._cache_dir)
+                logger.info("Reusing dataset %s (%s)", self.name, self._cache_dir)
                 # We need to update the info in case some splits were added in the meantime
                 # for example when calling load_dataset from multiple workers.
                 self.info = self._load_info()

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -507,7 +507,7 @@ class DatasetBuilder:
         with FileLock(lock_path):
             data_exists = os.path.exists(self._cache_dir)
             if data_exists and download_mode == GenerateMode.REUSE_DATASET_IF_EXISTS:
-                logger.info("Reusing dataset %s (%s)", self.name, self._cache_dir)
+                logger.warning("Reusing dataset %s (%s)", self.name, self._cache_dir)
                 # We need to update the info in case some splits were added in the meantime
                 # for example when calling load_dataset from multiple workers.
                 self.info = self._load_info()

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -171,7 +171,7 @@ def get_imports(file_path: str):
     with open(file_path, mode="r", encoding="utf-8") as f:
         lines.extend(f.readlines())
 
-    logger.info("Checking %s for additional imports.", file_path)
+    logger.debug("Checking %s for additional imports.", file_path)
     imports: List[Tuple[str, str, str, Optional[str]]] = []
     is_in_docstring = False
     for line in lines:

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -272,7 +272,7 @@ class BaseFileLock:
                         self._acquire()
 
                 if self.is_locked:
-                    logger().info("Lock %s acquired on %s", lock_id, lock_filename)
+                    logger().debug("Lock %s acquired on %s", lock_id, lock_filename)
                     break
                 elif timeout >= 0 and time.time() - start_time > timeout:
                     logger().debug("Timeout on acquiring lock %s on %s", lock_id, lock_filename)
@@ -315,7 +315,7 @@ class BaseFileLock:
                     logger().debug("Attempting to release lock %s on %s", lock_id, lock_filename)
                     self._release()
                     self._lock_counter = 0
-                    logger().info("Lock %s released on %s", lock_id, lock_filename)
+                    logger().debug("Lock %s released on %s", lock_id, lock_filename)
 
         return None
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -272,7 +272,7 @@ def test_load_dataset_then_move_then_reload(dataset_loading_script_dir, data_dir
     del dataset
     os.rename(cache_dir1, cache_dir2)
     caplog.clear()
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.INFO, logger="datasets")
     dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="train", cache_dir=cache_dir2)
     assert "Reusing dataset" in caplog.text
     assert dataset._fingerprint == fingerprint1, "for the caching mechanism to work, fingerprint should stay the same"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,5 +1,4 @@
 import importlib
-import logging
 import os
 import shutil
 import tempfile

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import os
 import shutil
 import tempfile
@@ -271,6 +272,7 @@ def test_load_dataset_then_move_then_reload(dataset_loading_script_dir, data_dir
     del dataset
     os.rename(cache_dir1, cache_dir2)
     caplog.clear()
+    caplog.set_level(logging.INFO)
     dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="train", cache_dir=cache_dir2)
     assert "Reusing dataset" in caplog.text
     assert dataset._fingerprint == fingerprint1, "for the caching mechanism to work, fingerprint should stay the same"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -272,7 +272,6 @@ def test_load_dataset_then_move_then_reload(dataset_loading_script_dir, data_dir
     del dataset
     os.rename(cache_dir1, cache_dir2)
     caplog.clear()
-    caplog.set_level(logging.INFO, logger="datasets")
     dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, split="train", cache_dir=cache_dir2)
     assert "Reusing dataset" in caplog.text
     assert dataset._fingerprint == fingerprint1, "for the caching mechanism to work, fingerprint should stay the same"


### PR DESCRIPTION
Sometimes default `datasets` logging can be too verbose. One approach could be reducing some logging levels, from info to debug, or from warning to info.

Close #2543.

cc: @stas00 