### PR TITLE
Fix FileSystems documentation

### DIFF
--- a/docs/source/filesystems.rst
+++ b/docs/source/filesystems.rst
@@ -44,7 +44,7 @@ Listing files from a private s3 bucket using ``aws_access_key_id`` and ``aws_sec
       >>> s3.ls('my-private-datasets/imdb/train')  # doctest: +SKIP
       ['dataset_info.json.json','dataset.arrow','state.json']
 
-Using ``S3Filesystem`` with ``botocore.session.Session`` and custom AWS ``profile``.
+Using ``S3FileSystem`` with ``botocore.session.Session`` and custom AWS ``profile``.
 
 .. code-block::
 

--- a/docs/source/filesystems.rst
+++ b/docs/source/filesystems.rst
@@ -44,13 +44,13 @@ Listing files from a private s3 bucket using ``aws_access_key_id`` and ``aws_sec
       >>> s3.ls('my-private-datasets/imdb/train')  # doctest: +SKIP
       ['dataset_info.json.json','dataset.arrow','state.json']
 
-Using ``S3Filesystem`` with ``botocore.session.Session`` and custom ``aws_profile``.
+Using ``S3Filesystem`` with ``botocore.session.Session`` and custom AWS ``profile``.
 
 .. code-block::
 
       >>> import botocore 
       >>> from datasets.filesystems import S3FileSystem
-      >>> s3_session = botocore.session.Session(profile_name='my_profile_name')
+      >>> s3_session = botocore.session.Session(profile='my_profile_name')
       >>> s3 = S3FileSystem(session=s3_session)  # doctest: +SKIP
 
 
@@ -95,15 +95,15 @@ Saving ``encoded_dataset`` to a private s3 bucket using ``aws_access_key_id`` an
       >>> # saves encoded_dataset to your s3 bucket
       >>> encoded_dataset.save_to_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
 
-Saving ``encoded_dataset`` to a private s3 bucket using ``botocore.session.Session`` and custom ``aws_profile``.
+Saving ``encoded_dataset`` to a private s3 bucket using ``botocore.session.Session`` and custom AWS ``profile``.
 
 .. code-block::
 
       >>> import botocore 
       >>> from datasets.filesystems import S3FileSystem
       >>>
-      >>> # creates a botocore session with the provided aws_profile
-      >>> s3_session = botocore.session.Session(profile_name='my_profile_name')
+      >>> # creates a botocore session with the provided AWS profile
+      >>> s3_session = botocore.session.Session(profile='my_profile_name')
       >>>
       >>> # create S3FileSystem instance with s3_session
       >>> s3 = S3FileSystem(sessions=s3_session)  # doctest: +SKIP
@@ -151,7 +151,7 @@ Loading ``encoded_dataset`` from a private s3 bucket using ``aws_access_key_id``
       >>> print(len(dataset))
       >>> # 25000
 
-Loading ``encoded_dataset`` from a private s3 bucket using ``botocore.session.Session`` and custom ``aws_profile``.
+Loading ``encoded_dataset`` from a private s3 bucket using ``botocore.session.Session`` and custom AWS ``profile``.
 
 .. code-block::
 
@@ -159,7 +159,7 @@ Loading ``encoded_dataset`` from a private s3 bucket using ``botocore.session.Se
       >>> from datasets.filesystems import S3FileSystem
       >>>
       >>> # create S3FileSystem instance with aws_access_key_id and aws_secret_access_key
-      >>> s3_session = botocore.session.Session(profile_name='my_profile_name')
+      >>> s3_session = botocore.session.Session(profile='my_profile_name')
       >>>
       >>> # create S3FileSystem instance with s3_session
       >>> s3 = S3FileSystem(sessions=s3_session)  

--- a/docs/source/filesystems.rst
+++ b/docs/source/filesystems.rst
@@ -106,7 +106,7 @@ Saving ``encoded_dataset`` to a private s3 bucket using ``botocore.session.Sessi
       >>> s3_session = botocore.session.Session(profile='my_profile_name')
       >>>
       >>> # create S3FileSystem instance with s3_session
-      >>> s3 = S3FileSystem(sessions=s3_session)  # doctest: +SKIP
+      >>> s3 = S3FileSystem(session=s3_session)  # doctest: +SKIP
       >>>
       >>> # saves encoded_dataset to your s3 bucket
       >>> encoded_dataset.save_to_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
@@ -162,7 +162,7 @@ Loading ``encoded_dataset`` from a private s3 bucket using ``botocore.session.Se
       >>> s3_session = botocore.session.Session(profile='my_profile_name')
       >>>
       >>> # create S3FileSystem instance with s3_session
-      >>> s3 = S3FileSystem(sessions=s3_session)  
+      >>> s3 = S3FileSystem(session=s3_session)  
       >>>
       >>> # load encoded_dataset to from s3 bucket
       >>> dataset = load_from_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP


### PR DESCRIPTION
### What this fixes:
This PR resolves several issues I discovered in the documentation on the `datasets.filesystems` module ([this page](https://huggingface.co/docs/datasets/filesystems.html)).

### What were the issues?
When I originally tried implementing the code examples I faced several bugs attributed to:

- out of date [botocore](https://github.com/boto/botocore) call signatures
- capitalization errors in the `S3FileSystem` class name (written as `S3Filesystem` in one place)
- call signature errors for the `S3FileSystem` class constructor (uses parameter `sessions` instead of `session` in some places) (see [`s3fs`](https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem) for where this constructor signature is defined)

### Testing/reviewing notes
Instructions for generating the documentation locally: [here](https://github.com/huggingface/datasets/tree/master/docs#generating-the-documentation).