### PR TITLE
Fix code_search_net keys

### DIFF
--- a/datasets/code_search_net/README.md
+++ b/datasets/code_search_net/README.md
@@ -31,6 +31,7 @@ task_categories:
 task_ids:
 - language-modeling
 paperswithcode_id: codesearchnet
+pretty_name: CodeSearchNet
 ---
 
 # Dataset Card for CodeSearchNet corpus

--- a/datasets/code_search_net/code_search_net.py
+++ b/datasets/code_search_net/code_search_net.py
@@ -199,9 +199,9 @@ class CodeSearchNet(datasets.GeneratorBasedBuilder):
         for file_id_, filepath in enumerate(filepaths):
             with open(filepath, encoding="utf-8") as f:
                 for row_id_, row in enumerate(f):
-                    # Key of the example = dir_id_ + entry_id + row_id,
+                    # Key of the example = file_id + row_id,
                     # to ensure all examples have a distinct key
-                    id_ = file_id_ + row_id_
+                    id_ = f"{file_id_}_{row_id_}"
                     data = json.loads(row)
                     yield id_, {
                         "repository_name": data["repo"],


### PR DESCRIPTION
There were duplicate keys in the `code_search_net` dataset, as reported in https://github.com/huggingface/datasets/issues/2552

I fixed the keys (it was an addition of the file and row indices, which was causing collisions)