### PR TITLE
fix Dataset.map when num_procs > num rows

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -287,7 +287,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if self.info.features.type != inferred_features.type:
             raise ValueError(
                 "External features info don't match the dataset:\nGot\n{}\nwith type\n{}\n\nbut expected something like\n{}\nwith type\n{}".format(
-                    self.info.features, self.info.features.type, inferred_features, inferred_features.type
+                    self.info.features,
+                    self.info.features.type,
+                    inferred_features,
+                    inferred_features.type,
                 )
             )
 
@@ -446,7 +449,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         else:
             mapping = cast_to_python_objects(mapping)
         mapping = {
-            col: OptimizedTypedSequence(data, type=features.type[col].type if features is not None else None, col=col)
+            col: OptimizedTypedSequence(
+                data,
+                type=features.type[col].type if features is not None else None,
+                col=col,
+            )
             for col, data in mapping.items()
         }
         pa_table = InMemoryTable.from_pydict(mapping=mapping)
@@ -478,7 +485,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         from .io.csv import CsvDatasetReader
 
         return CsvDatasetReader(
-            path_or_paths, split=split, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
+            path_or_paths,
+            split=split,
+            features=features,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
+            **kwargs,
         ).read()
 
     @staticmethod
@@ -544,7 +556,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         from .io.text import TextDatasetReader
 
         return TextDatasetReader(
-            path_or_paths, split=split, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
+            path_or_paths,
+            split=split,
+            features=features,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
+            **kwargs,
         ).read()
 
     def __del__(self):
@@ -643,11 +660,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     writer.write_table(self._indices)
                     writer.finalize()
         with fs.open(
-            Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), "w", encoding="utf-8"
+            Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(),
+            "w",
+            encoding="utf-8",
         ) as state_file:
             json.dump(state, state_file, indent=2, sort_keys=True)
         with fs.open(
-            Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), "w", encoding="utf-8"
+            Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(),
+            "w",
+            encoding="utf-8",
         ) as dataset_info_file:
             # Sort only the first level of keys, or we might shuffle fields of nested features if we use sort_keys=True
             sorted_keys_dataset_info = {key: dataset_info[key] for key in sorted(dataset_info)}
@@ -692,11 +713,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             fs.download(src_dataset_path, dataset_path.as_posix(), recursive=True)
 
         with open(
-            Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), "r", encoding="utf-8"
+            Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(),
+            "r",
+            encoding="utf-8",
         ) as state_file:
             state = json.load(state_file)
         with open(
-            Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), "r", encoding="utf-8"
+            Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(),
+            "r",
+            encoding="utf-8",
         ) as dataset_info_file:
             dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
 
@@ -806,7 +831,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         # Stringify the column
         if src_feat.dtype != "string":
             dset = self.map(
-                lambda batch: {column: [str(sample) for sample in batch]}, input_columns=column, batched=True
+                lambda batch: {column: [str(sample) for sample in batch]},
+                input_columns=column,
+                batched=True,
             )
         else:
             dset = self
@@ -814,7 +841,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         # Create the new feature
         class_names = sorted(dset.unique(column))
         dst_feat = ClassLabel(names=class_names)
-        dset = dset.map(lambda batch: {column: dst_feat.str2int(batch)}, input_columns=column, batched=True)
+        dset = dset.map(
+            lambda batch: {column: dst_feat.str2int(batch)},
+            input_columns=column,
+            batched=True,
+        )
         dset = concatenate_datasets([self.remove_columns([column]), dset], axis=1)
 
         new_features = dset.features.copy()
@@ -1270,7 +1301,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             self.set_format(type, columns, output_all_columns, **format_kwargs)
             yield
         finally:
-            self.set_format(old_format_type, old_format_columns, old_output_all_columns, **old_format_kwargs)
+            self.set_format(
+                old_format_type,
+                old_format_columns,
+                old_output_all_columns,
+                **old_format_kwargs,
+            )
 
     @fingerprint_transform(inplace=True)
     def set_format(
@@ -1311,7 +1347,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if columns is not None and any(col not in self._data.column_names for col in columns):
             raise ValueError(
                 "Columns {} not in the dataset. Current columns in the dataset: {}".format(
-                    list(filter(lambda col: col not in self._data.column_names, columns)), self._data.column_names
+                    list(filter(lambda col: col not in self._data.column_names, columns)),
+                    self._data.column_names,
                 )
             )
 
@@ -1353,7 +1390,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 If set to True, then the other un-formatted columns are kept with the output of the transform.
 
         """
-        self.set_format("custom", columns=columns, output_all_columns=output_all_columns, transform=transform)
+        self.set_format(
+            "custom",
+            columns=columns,
+            output_all_columns=output_all_columns,
+            transform=transform,
+        )
 
     def with_format(
         self,
@@ -1379,7 +1421,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             format_kwargs: keywords arguments passed to the convert function like `np.array`, `torch.tensor` or `tensorflow.ragged.constant`.
         """
         dataset = copy.deepcopy(self)
-        dataset.set_format(type=type, columns=columns, output_all_columns=output_all_columns, **format_kwargs)
+        dataset.set_format(
+            type=type,
+            columns=columns,
+            output_all_columns=output_all_columns,
+            **format_kwargs,
+        )
         return dataset
 
     def with_transform(
@@ -1467,9 +1514,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         """
         format_kwargs = format_kwargs if format_kwargs is not None else {}
         formatter = get_formatter(format_type, **format_kwargs)
-        pa_subtable = query_table(self._data, key, indices=self._indices if self._indices is not None else None)
+        pa_subtable = query_table(
+            self._data,
+            key,
+            indices=self._indices if self._indices is not None else None,
+        )
         formatted_output = format_table(
-            pa_subtable, key, formatter=formatter, format_columns=format_columns, output_all_columns=output_all_columns
+            pa_subtable,
+            key,
+            formatter=formatter,
+            format_columns=format_columns,
+            output_all_columns=output_all_columns,
         )
         return formatted_output
 
@@ -1634,6 +1689,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 desc=desc,
             )
         else:
+            if num_proc > len(self):
+                num_proc = len(self)
+                logger.info(
+                    f"num_proc must be <= {len(self)}. Reducing num_proc to {num_proc} for dataset of size {len(self)}."
+                )
 
             def format_cache_file_name(cache_file_name, rank):
                 sep = cache_file_name.rindex(".")
@@ -1659,7 +1719,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             with Pool(num_proc, initargs=(RLock(),), initializer=tqdm.set_lock) as pool:
                 os.environ = prev_env
                 shards = [
-                    self.shard(num_shards=num_proc, index=rank, contiguous=True, keep_in_memory=keep_in_memory)
+                    self.shard(
+                        num_shards=num_proc,
+                        index=rank,
+                        contiguous=True,
+                        keep_in_memory=keep_in_memory,
+                    )
                     for rank in range(num_proc)
                 ]
                 kwds_per_shard = [
@@ -1774,7 +1839,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if remove_columns is not None and any(col not in self._data.column_names for col in remove_columns):
             raise ValueError(
                 "Column to remove {} not in the dataset. Current columns in the dataset: {}".format(
-                    list(filter(lambda col: col not in self._data.column_names, remove_columns)),
+                    list(
+                        filter(
+                            lambda col: col not in self._data.column_names,
+                            remove_columns,
+                        )
+                    ),
                     self._data.column_names,
                 )
             )
@@ -1836,7 +1906,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 if all_dict_values_are_lists is False:
                     raise TypeError(
                         "Provided `function` which is applied to all elements of table returns a `dict` of types {}. When using `batched=True`, make sure provided `function` returns a `dict` of types like `{}`.".format(
-                            [type(x) for x in processed_inputs.values()], allowed_batch_return_types
+                            [type(x) for x in processed_inputs.values()],
+                            allowed_batch_return_types,
                         )
                     )
 
@@ -1920,7 +1991,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 # Only load the columns we actually need
                 if input_columns:
                     input_dataset = self.with_format(
-                        self._format_type, columns=input_columns, output_all_columns=False, **self._format_kwargs
+                        self._format_type,
+                        columns=input_columns,
+                        output_all_columns=False,
+                        **self._format_kwargs,
                     )
                     if remove_columns:
                         remove_columns = list(set(remove_columns) & set(input_columns))
@@ -2220,14 +2294,20 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             buf_writer = pa.BufferOutputStream()
             tmp_file = None
             writer = ArrowWriter(
-                stream=buf_writer, writer_batch_size=writer_batch_size, fingerprint=new_fingerprint, unit="indices"
+                stream=buf_writer,
+                writer_batch_size=writer_batch_size,
+                fingerprint=new_fingerprint,
+                unit="indices",
             )
         else:
             buf_writer = None
             logger.info("Caching indices mapping at %s", indices_cache_file_name)
             tmp_file = tempfile.NamedTemporaryFile("wb", dir=os.path.dirname(indices_cache_file_name), delete=False)
             writer = ArrowWriter(
-                path=tmp_file.name, writer_batch_size=writer_batch_size, fingerprint=new_fingerprint, unit="indices"
+                path=tmp_file.name,
+                writer_batch_size=writer_batch_size,
+                fingerprint=new_fingerprint,
+                unit="indices",
             )
 
         indices_array = pa.array(indices, type=pa.uint64())
@@ -2258,7 +2338,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         # Return new Dataset object
         if buf_writer is None:
             return self._new_dataset_with_indices(
-                indices_cache_file_name=indices_cache_file_name, fingerprint=new_fingerprint
+                indices_cache_file_name=indices_cache_file_name,
+                fingerprint=new_fingerprint,
             )
         else:
             return self._new_dataset_with_indices(indices_buffer=buf_writer.getvalue(), fingerprint=new_fingerprint)
@@ -2321,13 +2402,21 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 # we create a unique hash from the function, current dataset file and the mapping args
                 indices_cache_file_name = self._get_cache_file_path(new_fingerprint)
             if os.path.exists(indices_cache_file_name) and load_from_cache_file:
-                logger.warning("Loading cached sorted indices for dataset at %s", indices_cache_file_name)
+                logger.warning(
+                    "Loading cached sorted indices for dataset at %s",
+                    indices_cache_file_name,
+                )
                 return self._new_dataset_with_indices(
-                    fingerprint=new_fingerprint, indices_cache_file_name=indices_cache_file_name
+                    fingerprint=new_fingerprint,
+                    indices_cache_file_name=indices_cache_file_name,
                 )
 
         column_data = self._getitem(
-            column, format_type="numpy", format_columns=None, output_all_columns=False, format_kwargs=None
+            column,
+            format_type="numpy",
+            format_columns=None,
+            output_all_columns=False,
+            format_kwargs=None,
         )
         indices = np.argsort(column_data, kind=kind)
         if reverse:
@@ -2343,7 +2432,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
     @transmit_format
     @fingerprint_transform(
-        inplace=False, randomized_function=True, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"]
+        inplace=False,
+        randomized_function=True,
+        ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"],
     )
     def shuffle(
         self,
@@ -2404,9 +2495,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 # we create a unique hash from the function, current dataset file and the mapping args
                 indices_cache_file_name = self._get_cache_file_path(new_fingerprint)
             if os.path.exists(indices_cache_file_name) and load_from_cache_file:
-                logger.warning("Loading cached shuffled indices for dataset at %s", indices_cache_file_name)
+                logger.warning(
+                    "Loading cached shuffled indices for dataset at %s",
+                    indices_cache_file_name,
+                )
                 return self._new_dataset_with_indices(
-                    fingerprint=new_fingerprint, indices_cache_file_name=indices_cache_file_name
+                    fingerprint=new_fingerprint,
+                    indices_cache_file_name=indices_cache_file_name,
                 )
 
         permutation = generator.permutation(len(self))
@@ -2424,7 +2519,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         inplace=False,
         randomized_function=True,
         fingerprint_names=["train_new_fingerprint", "test_new_fingerprint"],
-        ignore_kwargs=["load_from_cache_file", "train_indices_cache_file_name", "test_indices_cache_file_name"],
+        ignore_kwargs=[
+            "load_from_cache_file",
+            "train_indices_cache_file_name",
+            "test_indices_cache_file_name",
+        ],
     )
     def train_test_split(
         self,
@@ -2586,10 +2685,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 return DatasetDict(
                     {
                         "train": self._new_dataset_with_indices(
-                            fingerprint=train_new_fingerprint, indices_cache_file_name=train_indices_cache_file_name
+                            fingerprint=train_new_fingerprint,
+                            indices_cache_file_name=train_indices_cache_file_name,
                         ),
                         "test": self._new_dataset_with_indices(
-                            fingerprint=test_new_fingerprint, indices_cache_file_name=test_indices_cache_file_name
+                            fingerprint=test_new_fingerprint,
+                            indices_cache_file_name=test_indices_cache_file_name,
                         ),
                     }
                 )
@@ -2893,7 +2994,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         info = self.info.copy()
         info.features.update(Features.from_arrow_schema(column_table.schema))
         table = update_metadata_with_features(table, info.features)
-        return Dataset(table, info=info, split=self.split, indices_table=self._indices, fingerprint=new_fingerprint)
+        return Dataset(
+            table,
+            info=info,
+            split=self.split,
+            indices_table=self._indices,
+            fingerprint=new_fingerprint,
+        )
 
     def add_faiss_index(
         self,
@@ -3232,7 +3339,9 @@ def concatenate_datasets(
     if info is None:
         info = DatasetInfo.from_merge([dset.info for dset in dsets])
     fingerprint = update_fingerprint(
-        "".join(dset._fingerprint for dset in dsets), concatenate_datasets, {"info": info, "split": split}
+        "".join(dset._fingerprint for dset in dsets),
+        concatenate_datasets,
+        {"info": info, "split": split},
     )
 
     # Make final concatenated dataset

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1691,7 +1691,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         else:
             if num_proc > len(self):
                 num_proc = len(self)
-                logger.info(
+                logger.warning(
                     f"num_proc must be <= {len(self)}. Reducing num_proc to {num_proc} for dataset of size {len(self)}."
                 )
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -64,9 +64,7 @@ def picklable_filter_function(x):
 def assert_arrow_metadata_are_synced_with_dataset_features(dataset: Dataset):
     assert dataset.data.schema.metadata is not None
     assert "huggingface".encode("utf-8") in dataset.data.schema.metadata
-    metadata = json.loads(
-        dataset.data.schema.metadata["huggingface".encode("utf-8")].decode()
-    )
+    metadata = json.loads(dataset.data.schema.metadata["huggingface".encode("utf-8")].decode())
     assert "info" in metadata
     features = DatasetInfo.from_dict(metadata["info"]).features
     assert features is not None
@@ -75,8 +73,7 @@ def assert_arrow_metadata_are_synced_with_dataset_features(dataset: Dataset):
 
 
 IN_MEMORY_PARAMETERS = [
-    {"testcase_name": name, "in_memory": im}
-    for im, name in [(True, "in_memory"), (False, "on_disk")]
+    {"testcase_name": name, "in_memory": im} for im, name in [(True, "in_memory"), (False, "on_disk")]
 ]
 
 
@@ -113,8 +110,7 @@ class BaseDatasetTest(TestCase):
         elif array_features:
             data = {
                 "col_1": [[[True, False], [False, True]]] * 4,  # 2D
-                "col_2": [[[["a", "b"], ["c", "d"]], [["e", "f"], ["g", "h"]]]]
-                * 4,  # 3D array
+                "col_2": [[[["a", "b"], ["c", "d"]], [["e", "f"], ["g", "h"]]]] * 4,  # 3D array
                 "col_3": [[3, 2, 1, 0]] * 4,  # Sequence
             }
             features = Features(
@@ -126,9 +122,7 @@ class BaseDatasetTest(TestCase):
             )
             dset = Dataset.from_dict(data, features=features)
         elif nested_features:
-            data = {
-                "nested": [{"a": i, "x": i * 10, "c": i * 100} for i in range(1, 11)]
-            }
+            data = {"nested": [{"a": i, "x": i * 10, "c": i * 100} for i in range(1, 11)]}
             features = Features(
                 {
                     "nested": {
@@ -140,13 +134,7 @@ class BaseDatasetTest(TestCase):
             )
             dset = Dataset.from_dict(data, features=features)
         else:
-            dset = Dataset.from_dict(
-                {
-                    "filename": [
-                        "my_name-train" + "_" + str(x) for x in np.arange(30).tolist()
-                    ]
-                }
-            )
+            dset = Dataset.from_dict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
         if not in_memory:
             dset = self._to(in_memory, tmp_dir, dset)
         return dset
@@ -159,9 +147,7 @@ class BaseDatasetTest(TestCase):
             while os.path.isfile(os.path.join(tmp_dir, f"dataset{start}.arrow")):
                 start += 1
             datasets = [
-                dataset.map(
-                    cache_file_name=os.path.join(tmp_dir, f"dataset{start + i}.arrow")
-                )
+                dataset.map(cache_file_name=os.path.join(tmp_dir, f"dataset{start + i}.arrow"))
                 for i, dataset in enumerate(datasets)
             ]
         return datasets if len(datasets) > 1 else datasets[0]
@@ -170,15 +156,11 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
 
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 self.assertEqual(dset[0]["filename"], "my_name-train_0")
                 self.assertEqual(dset["filename"][0], "my_name-train_0")
 
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 self.assertDictEqual(
                     dset.features,
                     Features(
@@ -193,9 +175,7 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset["col_1"][0], 3)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, array_features=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, array_features=True) as dset:
                 self.assertDictEqual(
                     dset.features,
                     Features(
@@ -224,19 +204,13 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset[-1]["filename"], "my_name-train_29")
                 self.assertEqual(dset["filename"][-1], "my_name-train_29")
 
-                self.assertListEqual(
-                    dset[:2]["filename"], ["my_name-train_0", "my_name-train_1"]
-                )
-                self.assertListEqual(
-                    dset["filename"][:2], ["my_name-train_0", "my_name-train_1"]
-                )
+                self.assertListEqual(dset[:2]["filename"], ["my_name-train_0", "my_name-train_1"])
+                self.assertListEqual(dset["filename"][:2], ["my_name-train_0", "my_name-train_1"])
 
                 self.assertEqual(dset[:-1]["filename"][-1], "my_name-train_28")
                 self.assertEqual(dset["filename"][:-1][-1], "my_name-train_28")
 
-                self.assertListEqual(
-                    dset[[0, -1]]["filename"], ["my_name-train_0", "my_name-train_29"]
-                )
+                self.assertListEqual(dset[[0, -1]]["filename"], ["my_name-train_0", "my_name-train_29"])
                 self.assertListEqual(
                     dset[np.array([0, -1])]["filename"],
                     ["my_name-train_0", "my_name-train_29"],
@@ -244,16 +218,12 @@ class BaseDatasetTest(TestCase):
 
     def test_dummy_dataset_deepcopy(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(in_memory, tmp_dir).select(
-                range(10)
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir).select(range(10)) as dset:
                 with assert_arrow_memory_doesnt_increase():
                     dset2 = copy.deepcopy(dset)
                 # don't copy the underlying arrow data using memory
                 self.assertEqual(len(dset2), 10)
-                self.assertDictEqual(
-                    dset2.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset2.features, Features({"filename": Value("string")}))
                 self.assertEqual(dset2[0]["filename"], "my_name-train_0")
                 self.assertEqual(dset2["filename"][0], "my_name-train_0")
                 del dset2
@@ -262,18 +232,14 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_file = os.path.join(tmp_dir, "dset.pt")
 
-            with self._create_dummy_dataset(in_memory, tmp_dir).select(
-                range(10)
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir).select(range(10)) as dset:
                 with open(tmp_file, "wb") as f:
                     pickle.dump(dset, f)
 
             with open(tmp_file, "rb") as f:
                 with pickle.load(f) as dset:
                     self.assertEqual(len(dset), 10)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertEqual(dset[0]["filename"], "my_name-train_0")
                     self.assertEqual(dset["filename"][0], "my_name-train_0")
 
@@ -289,40 +255,30 @@ class BaseDatasetTest(TestCase):
             with open(tmp_file, "rb") as f:
                 with pickle.load(f) as dset:
                     self.assertEqual(len(dset), 10)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertEqual(dset[0]["filename"], "my_name-train_0")
                     self.assertEqual(dset["filename"][0], "my_name-train_0")
 
     def test_dummy_dataset_serialize(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with set_current_working_directory_to_temp_dir():
-                with self._create_dummy_dataset(in_memory, tmp_dir).select(
-                    range(10)
-                ) as dset:
+                with self._create_dummy_dataset(in_memory, tmp_dir).select(range(10)) as dset:
                     dataset_path = "my_dataset"  # rel path
                     dset.save_to_disk(dataset_path)
 
                 with Dataset.load_from_disk(dataset_path) as dset:
                     self.assertEqual(len(dset), 10)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertEqual(dset[0]["filename"], "my_name-train_0")
                     self.assertEqual(dset["filename"][0], "my_name-train_0")
 
-            with self._create_dummy_dataset(in_memory, tmp_dir).select(
-                range(10)
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir).select(range(10)) as dset:
                 dataset_path = os.path.join(tmp_dir, "my_dataset")  # abs path
                 dset.save_to_disk(dataset_path)
 
             with Dataset.load_from_disk(dataset_path) as dset:
                 self.assertEqual(len(dset), 10)
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 self.assertEqual(dset[0]["filename"], "my_name-train_0")
                 self.assertEqual(dset["filename"][0], "my_name-train_0")
 
@@ -334,15 +290,11 @@ class BaseDatasetTest(TestCase):
 
             with Dataset.load_from_disk(dataset_path) as dset:
                 self.assertEqual(len(dset), 10)
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 self.assertEqual(dset[0]["filename"], "my_name-train_0")
                 self.assertEqual(dset["filename"][0], "my_name-train_0")
 
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, nested_features=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, nested_features=True) as dset:
                 with assert_arrow_memory_doesnt_increase():
                     dset.save_to_disk(dataset_path)
 
@@ -366,25 +318,19 @@ class BaseDatasetTest(TestCase):
     def test_dummy_dataset_load_from_disk(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
 
-            with self._create_dummy_dataset(in_memory, tmp_dir).select(
-                range(10)
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir).select(range(10)) as dset:
                 dataset_path = os.path.join(tmp_dir, "my_dataset")
                 dset.save_to_disk(dataset_path)
 
             with load_from_disk(dataset_path) as dset:
                 self.assertEqual(len(dset), 10)
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 self.assertEqual(dset[0]["filename"], "my_name-train_0")
                 self.assertEqual(dset["filename"][0], "my_name-train_0")
 
     def test_set_format_numpy_multiple_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 fingerprint = dset._fingerprint
                 dset.set_format(type="numpy", columns=["col_1"])
                 self.assertEqual(len(dset[0]), 1)
@@ -409,9 +355,7 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset.format["columns"], dset.column_names)
                 self.assertEqual(dset.format["output_all_columns"], False)
 
-                dset.set_format(
-                    type="numpy", columns=["col_1"], output_all_columns=True
-                )
+                dset.set_format(type="numpy", columns=["col_1"], output_all_columns=True)
                 self.assertEqual(len(dset[0]), 3)
                 self.assertIsInstance(dset[0]["col_2"], str)
                 self.assertEqual(dset[0]["col_2"], "a")
@@ -426,9 +370,7 @@ class BaseDatasetTest(TestCase):
         import torch
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.set_format(type="torch", columns=["col_1"])
                 self.assertEqual(len(dset[0]), 1)
                 self.assertIsInstance(dset[0]["col_1"], torch.Tensor)
@@ -436,9 +378,7 @@ class BaseDatasetTest(TestCase):
                 self.assertListEqual(list(dset[0]["col_1"].shape), [])
                 self.assertEqual(dset[0]["col_1"].item(), 3)
 
-                dset.set_format(
-                    type="torch", columns=["col_1"], output_all_columns=True
-                )
+                dset.set_format(type="torch", columns=["col_1"], output_all_columns=True)
                 self.assertEqual(len(dset[0]), 3)
                 self.assertIsInstance(dset[0]["col_2"], str)
                 self.assertEqual(dset[0]["col_2"], "a")
@@ -452,18 +392,14 @@ class BaseDatasetTest(TestCase):
         import tensorflow as tf
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.set_format(type="tensorflow", columns=["col_1"])
                 self.assertEqual(len(dset[0]), 1)
                 self.assertIsInstance(dset[0]["col_1"], tf.Tensor)
                 self.assertListEqual(list(dset[0]["col_1"].shape), [])
                 self.assertEqual(dset[0]["col_1"].numpy().item(), 3)
 
-                dset.set_format(
-                    type="tensorflow", columns=["col_1"], output_all_columns=True
-                )
+                dset.set_format(type="tensorflow", columns=["col_1"], output_all_columns=True)
                 self.assertEqual(len(dset[0]), 3)
                 self.assertIsInstance(dset[0]["col_2"], str)
                 self.assertEqual(dset[0]["col_2"], "a")
@@ -474,9 +410,7 @@ class BaseDatasetTest(TestCase):
 
     def test_set_format_pandas(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.set_format(type="pandas", columns=["col_1"])
                 self.assertEqual(len(dset[0].columns), 1)
                 self.assertIsInstance(dset[0], pd.DataFrame)
@@ -492,9 +426,7 @@ class BaseDatasetTest(TestCase):
             return {k: [str(i).upper() for i in v] for k, v in batch.items()}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.set_transform(transform=transform, columns=["col_1"])
                 self.assertEqual(dset.format["type"], "custom")
                 self.assertEqual(len(dset[0].keys()), 1)
@@ -512,9 +444,7 @@ class BaseDatasetTest(TestCase):
 
     def test_transmit_format(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 transform = datasets.arrow_dataset.transmit_format(lambda x: x)
                 # make sure identity transform doesn't apply unnecessary format
                 self.assertEqual(dset._fingerprint, transform(dset)._fingerprint)
@@ -530,9 +460,7 @@ class BaseDatasetTest(TestCase):
 
     def test_cast_in_place(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 features = dset.features
                 features["col_1"] = Value("float64")
                 features = Features({k: features[k] for k in list(features)[::-1]})
@@ -546,9 +474,7 @@ class BaseDatasetTest(TestCase):
 
     def test_cast(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 features = dset.features
                 features["col_1"] = Value("float64")
                 features = Features({k: features[k] for k in list(features)[::-1]})
@@ -564,17 +490,13 @@ class BaseDatasetTest(TestCase):
 
     def test_class_encode_column(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 with self.assertRaises(ValueError):
                     dset.class_encode_column(column="does not exist")
 
                 with dset.class_encode_column("col_1") as casted_dset:
                     self.assertIsInstance(casted_dset.features["col_1"], ClassLabel)
-                    self.assertListEqual(
-                        casted_dset.features["col_1"].names, ["0", "1", "2", "3"]
-                    )
+                    self.assertListEqual(casted_dset.features["col_1"].names, ["0", "1", "2", "3"])
                     self.assertListEqual(casted_dset["col_1"], [3, 2, 1, 0])
                     self.assertNotEqual(casted_dset._fingerprint, dset._fingerprint)
                     self.assertNotEqual(casted_dset, dset)
@@ -582,9 +504,7 @@ class BaseDatasetTest(TestCase):
 
                 with dset.class_encode_column("col_2") as casted_dset:
                     self.assertIsInstance(casted_dset.features["col_2"], ClassLabel)
-                    self.assertListEqual(
-                        casted_dset.features["col_2"].names, ["a", "b", "c", "d"]
-                    )
+                    self.assertListEqual(casted_dset.features["col_2"].names, ["a", "b", "c", "d"])
                     self.assertListEqual(casted_dset["col_2"], [0, 1, 2, 3])
                     self.assertNotEqual(casted_dset._fingerprint, dset._fingerprint)
                     self.assertNotEqual(casted_dset, dset)
@@ -592,27 +512,21 @@ class BaseDatasetTest(TestCase):
 
                 with dset.class_encode_column("col_3") as casted_dset:
                     self.assertIsInstance(casted_dset.features["col_3"], ClassLabel)
-                    self.assertListEqual(
-                        casted_dset.features["col_3"].names, ["False", "True"]
-                    )
+                    self.assertListEqual(casted_dset.features["col_3"].names, ["False", "True"])
                     self.assertListEqual(casted_dset["col_3"], [0, 1, 0, 1])
                     self.assertNotEqual(casted_dset._fingerprint, dset._fingerprint)
                     self.assertNotEqual(casted_dset, dset)
                     assert_arrow_metadata_are_synced_with_dataset_features(casted_dset)
 
             # Test raises if feature is an array / sequence
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, array_features=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, array_features=True) as dset:
                 for column in dset.column_names:
                     with self.assertRaises(ValueError):
                         dset.class_encode_column(column)
 
     def test_remove_columns_in_place(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 fingerprint = dset._fingerprint
                 with assert_arrow_memory_doesnt_increase():
                     dset.remove_columns_(column_names="col_1")
@@ -620,9 +534,7 @@ class BaseDatasetTest(TestCase):
                 self.assertListEqual(list(dset.column_names), ["col_2", "col_3"])
                 assert_arrow_metadata_are_synced_with_dataset_features(dset)
 
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.remove_columns_(column_names=["col_1", "col_2", "col_3"])
                 self.assertEqual(dset.num_columns, 0)
                 self.assertNotEqual(dset._fingerprint, fingerprint)
@@ -630,89 +542,55 @@ class BaseDatasetTest(TestCase):
 
     def test_remove_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 fingerprint = dset._fingerprint
                 with dset.remove_columns(column_names="col_1") as new_dset:
                     self.assertEqual(new_dset.num_columns, 2)
-                    self.assertListEqual(
-                        list(new_dset.column_names), ["col_2", "col_3"]
-                    )
+                    self.assertListEqual(list(new_dset.column_names), ["col_2", "col_3"])
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
 
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
-                with dset.remove_columns(
-                    column_names=["col_1", "col_2", "col_3"]
-                ) as new_dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
+                with dset.remove_columns(column_names=["col_1", "col_2", "col_3"]) as new_dset:
                     self.assertEqual(new_dset.num_columns, 0)
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
 
     def test_rename_column_in_place(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 fingerprint = dset._fingerprint
-                dset.rename_column_(
-                    original_column_name="col_1", new_column_name="new_name"
-                )
+                dset.rename_column_(original_column_name="col_1", new_column_name="new_name")
                 self.assertEqual(dset.num_columns, 3)
-                self.assertListEqual(
-                    list(dset.column_names), ["new_name", "col_2", "col_3"]
-                )
+                self.assertListEqual(list(dset.column_names), ["new_name", "col_2", "col_3"])
                 self.assertNotEqual(dset._fingerprint, fingerprint)
                 assert_arrow_metadata_are_synced_with_dataset_features(dset)
 
     def test_rename_column(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 fingerprint = dset._fingerprint
-                with dset.rename_column(
-                    original_column_name="col_1", new_column_name="new_name"
-                ) as new_dset:
+                with dset.rename_column(original_column_name="col_1", new_column_name="new_name") as new_dset:
                     self.assertEqual(new_dset.num_columns, 3)
-                    self.assertListEqual(
-                        list(new_dset.column_names), ["new_name", "col_2", "col_3"]
-                    )
-                    self.assertListEqual(
-                        list(dset.column_names), ["col_1", "col_2", "col_3"]
-                    )
+                    self.assertListEqual(list(new_dset.column_names), ["new_name", "col_2", "col_3"])
+                    self.assertListEqual(list(dset.column_names), ["col_1", "col_2", "col_3"])
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
 
     def test_rename_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 fingerprint = dset._fingerprint
                 with dset.rename_columns({"col_1": "new_name"}) as new_dset:
                     self.assertEqual(new_dset.num_columns, 3)
-                    self.assertListEqual(
-                        list(new_dset.column_names), ["new_name", "col_2", "col_3"]
-                    )
-                    self.assertListEqual(
-                        list(dset.column_names), ["col_1", "col_2", "col_3"]
-                    )
+                    self.assertListEqual(list(new_dset.column_names), ["new_name", "col_2", "col_3"])
+                    self.assertListEqual(list(dset.column_names), ["col_1", "col_2", "col_3"])
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
 
-                with dset.rename_columns(
-                    {"col_1": "new_name", "col_2": "new_name2"}
-                ) as new_dset:
+                with dset.rename_columns({"col_1": "new_name", "col_2": "new_name2"}) as new_dset:
                     self.assertEqual(new_dset.num_columns, 3)
-                    self.assertListEqual(
-                        list(new_dset.column_names), ["new_name", "new_name2", "col_3"]
-                    )
-                    self.assertListEqual(
-                        list(dset.column_names), ["col_1", "col_2", "col_3"]
-                    )
+                    self.assertListEqual(list(new_dset.column_names), ["new_name", "new_name2", "col_3"])
+                    self.assertListEqual(list(dset.column_names), ["col_1", "col_2", "col_3"])
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
 
                 # Original column not in dataset
@@ -744,9 +622,7 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(len(dset_concat), len(dset1) + len(dset2) + len(dset3))
                 self.assertListEqual(dset_concat["id"], [0, 1, 2, 3, 4, 5, 6, 7])
                 self.assertEqual(len(dset_concat.cache_files), 0 if in_memory else 3)
-                self.assertEqual(
-                    dset_concat.info.description, "Dataset1\n\nDataset2\n\n"
-                )
+                self.assertEqual(dset_concat.info.description, "Dataset1\n\nDataset2\n\n")
             del dset1, dset2, dset3
 
     def test_concatenate_formatted(self, in_memory):
@@ -801,9 +677,7 @@ class BaseDatasetTest(TestCase):
                 # in_memory = True:
                 # no cache files since both dset_concat._data and dset_concat._indices are in memory
                 self.assertEqual(len(dset_concat.cache_files), 0 if in_memory else 3)
-                self.assertEqual(
-                    dset_concat.info.description, "Dataset1\n\nDataset2\n\n"
-                )
+                self.assertEqual(dset_concat.info.description, "Dataset1\n\nDataset2\n\n")
             del dset1, dset2, dset3
 
     def test_concatenate_with_indices_from_disk(self, in_memory):
@@ -822,15 +696,9 @@ class BaseDatasetTest(TestCase):
             )
             dset1, dset2, dset3 = self._to(in_memory, tmp_dir, dset1, dset2, dset3)
             dset1, dset2, dset3 = (
-                dset1.select(
-                    [0, 1, 2], indices_cache_file_name=os.path.join(tmp_dir, "i1.arrow")
-                ),
-                dset2.select(
-                    [0, 1, 2], indices_cache_file_name=os.path.join(tmp_dir, "i2.arrow")
-                ),
-                dset3.select(
-                    [0, 1], indices_cache_file_name=os.path.join(tmp_dir, "i3.arrow")
-                ),
+                dset1.select([0, 1, 2], indices_cache_file_name=os.path.join(tmp_dir, "i1.arrow")),
+                dset2.select([0, 1, 2], indices_cache_file_name=os.path.join(tmp_dir, "i2.arrow")),
+                dset3.select([0, 1], indices_cache_file_name=os.path.join(tmp_dir, "i3.arrow")),
             )
 
             with concatenate_datasets([dset1, dset2, dset3]) as dset_concat:
@@ -843,12 +711,8 @@ class BaseDatasetTest(TestCase):
                 # Indeed, the others are brought to memory since an offset is applied to them.
                 # in_memory = True:
                 # 1 cache file for i1.arrow since both dset_concat._data and dset_concat._indices are in memory
-                self.assertEqual(
-                    len(dset_concat.cache_files), 1 if in_memory else 3 + 1
-                )
-                self.assertEqual(
-                    dset_concat.info.description, "Dataset1\n\nDataset2\n\n"
-                )
+                self.assertEqual(len(dset_concat.cache_files), 1 if in_memory else 3 + 1)
+                self.assertEqual(dset_concat.info.description, "Dataset1\n\nDataset2\n\n")
             del dset1, dset2, dset3
 
     def test_concatenate_pickle(self, in_memory):
@@ -872,23 +736,17 @@ class BaseDatasetTest(TestCase):
                 dset1.select(
                     [0, 1, 2],
                     keep_in_memory=in_memory,
-                    indices_cache_file_name=os.path.join(tmp_dir, "i1.arrow")
-                    if not in_memory
-                    else None,
+                    indices_cache_file_name=os.path.join(tmp_dir, "i1.arrow") if not in_memory else None,
                 ),
                 dset2.select(
                     [0, 1, 2],
                     keep_in_memory=in_memory,
-                    indices_cache_file_name=os.path.join(tmp_dir, "i2.arrow")
-                    if not in_memory
-                    else None,
+                    indices_cache_file_name=os.path.join(tmp_dir, "i2.arrow") if not in_memory else None,
                 ),
                 dset3.select(
                     [0, 1],
                     keep_in_memory=in_memory,
-                    indices_cache_file_name=os.path.join(tmp_dir, "i3.arrow")
-                    if not in_memory
-                    else None,
+                    indices_cache_file_name=os.path.join(tmp_dir, "i3.arrow") if not in_memory else None,
                 ),
             )
 
@@ -898,26 +756,18 @@ class BaseDatasetTest(TestCase):
                 dset3._data.table = Unpicklable()
             else:
                 dset1._data.table, dset2._data.table = Unpicklable(), Unpicklable()
-            dset1, dset2, dset3 = [
-                pickle.loads(pickle.dumps(d)) for d in (dset1, dset2, dset3)
-            ]
+            dset1, dset2, dset3 = [pickle.loads(pickle.dumps(d)) for d in (dset1, dset2, dset3)]
             with concatenate_datasets([dset1, dset2, dset3]) as dset_concat:
                 if not in_memory:
                     dset_concat._data.table = Unpicklable()
                 with pickle.loads(pickle.dumps(dset_concat)) as dset_concat:
                     self.assertEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
-                    self.assertEqual(
-                        len(dset_concat), len(dset1) + len(dset2) + len(dset3)
-                    )
+                    self.assertEqual(len(dset_concat), len(dset1) + len(dset2) + len(dset3))
                     self.assertListEqual(dset_concat["id"], [0, 1, 2, 3, 4, 5, 6, 7])
                     # in_memory = True: 1 cache file for dset3
                     # in_memory = False: 2 caches files for dset1 and dset2, and 1 cache file for i1.arrow
-                    self.assertEqual(
-                        len(dset_concat.cache_files), 1 if in_memory else 2 + 1
-                    )
-                    self.assertEqual(
-                        dset_concat.info.description, "Dataset1\n\nDataset2\n\n"
-                    )
+                    self.assertEqual(len(dset_concat.cache_files), 1 if in_memory else 2 + 1)
+                    self.assertEqual(dset_concat.info.description, "Dataset1\n\nDataset2\n\n")
             del dset1, dset2, dset3
 
     def test_flatten(self, in_memory):
@@ -938,9 +788,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(list(dset.features.keys()), ["a.b.c", "foo"])
                     self.assertDictEqual(
                         dset.features,
-                        Features(
-                            {"a.b.c": Sequence(Value("string")), "foo": Value("int64")}
-                        ),
+                        Features({"a.b.c": Sequence(Value("string")), "foo": Value("int64")}),
                     )
                     self.assertNotEqual(dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset)
@@ -949,9 +797,7 @@ class BaseDatasetTest(TestCase):
         # standard
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 fingerprint = dset._fingerprint
                 with dset.map(
                     lambda x: {
@@ -960,9 +806,7 @@ class BaseDatasetTest(TestCase):
                     }
                 ) as dset_test:
                     self.assertEqual(len(dset_test), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test.features,
                         Features(
@@ -994,9 +838,7 @@ class BaseDatasetTest(TestCase):
                     with_indices=True,
                 ) as dset_test_with_indices:
                     self.assertEqual(len(dset_test_with_indices), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test_with_indices.features,
                         Features(
@@ -1008,9 +850,7 @@ class BaseDatasetTest(TestCase):
                         ),
                     )
                     self.assertListEqual(dset_test_with_indices["id"], list(range(30)))
-                    assert_arrow_metadata_are_synced_with_dataset_features(
-                        dset_test_with_indices
-                    )
+                    assert_arrow_metadata_are_synced_with_dataset_features(dset_test_with_indices)
 
         # interrupted
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1039,9 +879,7 @@ class BaseDatasetTest(TestCase):
                 ) as dset_test_with_indices:
                     self.assertTrue(os.path.exists(tmp_file))
                     self.assertEqual(len(dset_test_with_indices), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test_with_indices.features,
                         Features(
@@ -1053,26 +891,18 @@ class BaseDatasetTest(TestCase):
                         ),
                     )
                     self.assertListEqual(dset_test_with_indices["id"], list(range(30)))
-                    assert_arrow_metadata_are_synced_with_dataset_features(
-                        dset_test_with_indices
-                    )
+                    assert_arrow_metadata_are_synced_with_dataset_features(dset_test_with_indices)
 
         # formatted
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.set_format("numpy", columns=["col_1"])
-                with dset.map(
-                    lambda x: {"col_1_plus_one": x["col_1"] + 1}
-                ) as dset_test:
+                with dset.map(lambda x: {"col_1_plus_one": x["col_1"] + 1}) as dset_test:
                     self.assertEqual(len(dset_test), 4)
                     self.assertEqual(dset_test.format["type"], "numpy")
                     self.assertIsInstance(dset_test["col_1"], np.ndarray)
                     self.assertIsInstance(dset_test["col_1_plus_one"], np.ndarray)
-                    self.assertListEqual(
-                        sorted(dset_test[0].keys()), ["col_1", "col_1_plus_one"]
-                    )
+                    self.assertListEqual(sorted(dset_test[0].keys()), ["col_1", "col_1_plus_one"])
                     self.assertListEqual(
                         sorted(dset_test.column_names),
                         ["col_1", "col_1_plus_one", "col_2", "col_3"],
@@ -1082,15 +912,11 @@ class BaseDatasetTest(TestCase):
     def test_map_multiprocessing(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:  # standard
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 fingerprint = dset._fingerprint
                 with dset.map(picklable_map_function, num_proc=2) as dset_test:
                     self.assertEqual(len(dset_test), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test.features,
                         Features({"filename": Value("string"), "id": Value("int64")}),
@@ -1102,16 +928,12 @@ class BaseDatasetTest(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # num_proc > len(dset)
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 fingerprint = dset._fingerprint
                 dset = dset.select([0, 1])
                 with dset.map(picklable_map_function, num_proc=5) as dset_test:
                     self.assertEqual(len(dset_test), 2)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test.features,
                         Features({"filename": Value("string"), "id": Value("int64")}),
@@ -1124,13 +946,9 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_indices
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 fingerprint = dset._fingerprint
-                with dset.map(
-                    picklable_map_function_with_indices, num_proc=3, with_indices=True
-                ) as dset_test:
+                with dset.map(picklable_map_function_with_indices, num_proc=3, with_indices=True) as dset_test:
                     self.assertEqual(len(dset_test), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test.features,
                         Features({"filename": Value("string"), "id": Value("int64")}),
@@ -1143,13 +961,9 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:  # lambda (requires multiprocess from pathos)
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 fingerprint = dset._fingerprint
-                with dset.map(
-                    lambda x: {"id": int(x["filename"].split("_")[-1])}, num_proc=2
-                ) as dset_test:
+                with dset.map(lambda x: {"id": int(x["filename"].split("_")[-1])}, num_proc=2) as dset_test:
                     self.assertEqual(len(dset_test), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test.features,
                         Features({"filename": Value("string"), "id": Value("int64")}),
@@ -1176,9 +990,7 @@ class BaseDatasetTest(TestCase):
                         dset_test_with_indices.features,
                         features,
                     )
-                    assert_arrow_metadata_are_synced_with_dataset_features(
-                        dset_test_with_indices
-                    )
+                    assert_arrow_metadata_are_synced_with_dataset_features(dset_test_with_indices)
 
     def test_map_batched(self, in_memory):
         def map_batched(example):
@@ -1188,9 +1000,7 @@ class BaseDatasetTest(TestCase):
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 with dset.map(map_batched, batched=True) as dset_test_batched:
                     self.assertEqual(len(dset_test_batched), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test_batched.features,
                         Features(
@@ -1200,18 +1010,14 @@ class BaseDatasetTest(TestCase):
                             }
                         ),
                     )
-                    assert_arrow_metadata_are_synced_with_dataset_features(
-                        dset_test_batched
-                    )
+                    assert_arrow_metadata_are_synced_with_dataset_features(dset_test_batched)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 with dset.formatted_as("numpy", columns=["filename"]):
                     with dset.map(map_batched, batched=True) as dset_test_batched:
                         self.assertEqual(len(dset_test_batched), 30)
-                        self.assertDictEqual(
-                            dset.features, Features({"filename": Value("string")})
-                        )
+                        self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                         self.assertDictEqual(
                             dset_test_batched.features,
                             Features(
@@ -1221,16 +1027,10 @@ class BaseDatasetTest(TestCase):
                                 }
                             ),
                         )
-                        assert_arrow_metadata_are_synced_with_dataset_features(
-                            dset_test_batched
-                        )
+                        assert_arrow_metadata_are_synced_with_dataset_features(dset_test_batched)
 
         def map_batched_with_indices(example, idx):
-            return {
-                "filename_new": [
-                    x + "_extension_" + str(idx) for x in example["filename"]
-                ]
-            }
+            return {"filename_new": [x + "_extension_" + str(idx) for x in example["filename"]]}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1238,9 +1038,7 @@ class BaseDatasetTest(TestCase):
                     map_batched_with_indices, batched=True, with_indices=True
                 ) as dset_test_with_indices_batched:
                     self.assertEqual(len(dset_test_with_indices_batched), 30)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_test_with_indices_batched.features,
                         Features(
@@ -1250,24 +1048,14 @@ class BaseDatasetTest(TestCase):
                             }
                         ),
                     )
-                    assert_arrow_metadata_are_synced_with_dataset_features(
-                        dset_test_with_indices_batched
-                    )
+                    assert_arrow_metadata_are_synced_with_dataset_features(dset_test_with_indices_batched)
 
     def test_map_nested(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with Dataset.from_dict({"field": ["a", "b"]}) as dset:
                 with self._to(in_memory, tmp_dir, dset) as dset:
-                    with dset.map(
-                        lambda example: {
-                            "otherfield": {"capital": example["field"].capitalize()}
-                        }
-                    ) as dset:
-                        with dset.map(
-                            lambda example: {
-                                "otherfield": {"append_x": example["field"] + "x"}
-                            }
-                        ) as dset:
+                    with dset.map(lambda example: {"otherfield": {"capital": example["field"].capitalize()}}) as dset:
+                        with dset.map(lambda example: {"otherfield": {"append_x": example["field"] + "x"}}) as dset:
                             self.assertEqual(
                                 dset[0],
                                 {"field": "a", "otherfield": {"append_x": "ax"}},
@@ -1282,13 +1070,8 @@ class BaseDatasetTest(TestCase):
                         dset_test1_data_files = list(dset_test1.cache_files)
                     with dset.map(lambda x: {"foo": "bar"}) as dset_test2:
                         self.assertEqual(dset_test1_data_files, dset_test2.cache_files)
-                        self.assertEqual(
-                            len(dset_test2.cache_files), 1 - int(in_memory)
-                        )
-                        self.assertTrue(
-                            ("Loading cached processed dataset" in self._caplog.text)
-                            ^ in_memory
-                        )
+                        self.assertEqual(len(dset_test2.cache_files), 1 - int(in_memory))
+                        self.assertTrue(("Loading cached processed dataset" in self._caplog.text) ^ in_memory)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._caplog.clear()
@@ -1296,16 +1079,10 @@ class BaseDatasetTest(TestCase):
                 with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                     with dset.map(lambda x: {"foo": "bar"}) as dset_test1:
                         dset_test1_data_files = list(dset_test1.cache_files)
-                    with dset.map(
-                        lambda x: {"foo": "bar"}, load_from_cache_file=False
-                    ) as dset_test2:
+                    with dset.map(lambda x: {"foo": "bar"}, load_from_cache_file=False) as dset_test2:
                         self.assertEqual(dset_test1_data_files, dset_test2.cache_files)
-                        self.assertEqual(
-                            len(dset_test2.cache_files), 1 - int(in_memory)
-                        )
-                        self.assertNotIn(
-                            "Loading cached processed dataset", self._caplog.text
-                        )
+                        self.assertEqual(len(dset_test2.cache_files), 1 - int(in_memory))
+                        self.assertNotIn("Loading cached processed dataset", self._caplog.text)
 
         if not in_memory:
             try:
@@ -1316,9 +1093,7 @@ class BaseDatasetTest(TestCase):
                             datasets.set_caching_enabled(False)
                             with dset.map(lambda x: {"foo": "bar"}) as dset_test1:
                                 with dset.map(lambda x: {"foo": "bar"}) as dset_test2:
-                                    self.assertNotEqual(
-                                        dset_test1.cache_files, dset_test2.cache_files
-                                    )
+                                    self.assertNotEqual(dset_test1.cache_files, dset_test2.cache_files)
                                     self.assertEqual(len(dset_test1.cache_files), 1)
                                     self.assertEqual(len(dset_test2.cache_files), 1)
                                     self.assertNotIn(
@@ -1326,12 +1101,8 @@ class BaseDatasetTest(TestCase):
                                         self._caplog.text,
                                     )
                                     # make sure the arrow files are going to be removed
-                                    self.assertIn(
-                                        "tmp", dset_test1.cache_files[0]["filename"]
-                                    )
-                                    self.assertIn(
-                                        "tmp", dset_test2.cache_files[0]["filename"]
-                                    )
+                                    self.assertIn("tmp", dset_test1.cache_files[0]["filename"])
+                                    self.assertIn("tmp", dset_test2.cache_files[0]["filename"])
             finally:
                 datasets.set_caching_enabled(True)
 
@@ -1421,26 +1192,18 @@ class BaseDatasetTest(TestCase):
                         self.assertTrue("id" not in dset[0])
                         self.assertDictEqual(
                             dset.features,
-                            Features(
-                                {"filename": Value("string"), "name": Value("string")}
-                            ),
+                            Features({"filename": Value("string"), "name": Value("string")}),
                         )
                         assert_arrow_metadata_are_synced_with_dataset_features(dset)
-                        with dset.with_format(
-                            "numpy", columns=dset.column_names
-                        ) as dset:
-                            with dset.map(
-                                lambda x: {"name": 1}, remove_columns=dset.column_names
-                            ) as dset:
+                        with dset.with_format("numpy", columns=dset.column_names) as dset:
+                            with dset.map(lambda x: {"name": 1}, remove_columns=dset.column_names) as dset:
                                 self.assertTrue("filename" not in dset[0])
                                 self.assertTrue("name" in dset[0])
                                 self.assertDictEqual(
                                     dset.features,
                                     Features({"name": Value(dtype="int64")}),
                                 )
-                                assert_arrow_metadata_are_synced_with_dataset_features(
-                                    dset
-                                )
+                                assert_arrow_metadata_are_synced_with_dataset_features(dset)
 
     def test_map_stateful_callable(self, in_memory):
         # be sure that the state of the map callable is unaffected
@@ -1475,33 +1238,23 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 fingerprint = dset._fingerprint
-                with dset.filter(
-                    lambda x, i: i < 5, with_indices=True
-                ) as dset_filter_first_five:
+                with dset.filter(lambda x, i: i < 5, with_indices=True) as dset_filter_first_five:
                     self.assertEqual(len(dset_filter_first_five), 5)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_filter_first_five.features,
                         Features({"filename": Value("string")}),
                     )
-                    self.assertNotEqual(
-                        dset_filter_first_five._fingerprint, fingerprint
-                    )
+                    self.assertNotEqual(dset_filter_first_five._fingerprint, fingerprint)
 
         # filter filenames with even id at the end + formatted
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 dset.set_format("numpy")
                 fingerprint = dset._fingerprint
-                with dset.filter(
-                    lambda x: (int(x["filename"][-1]) % 2 == 0)
-                ) as dset_filter_even_num:
+                with dset.filter(lambda x: (int(x["filename"][-1]) % 2 == 0)) as dset_filter_even_num:
                     self.assertEqual(len(dset_filter_even_num), 15)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_filter_even_num.features,
                         Features({"filename": Value("string")}),
@@ -1513,21 +1266,15 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 fingerprint = dset._fingerprint
-                with dset.filter(
-                    picklable_filter_function, num_proc=2
-                ) as dset_filter_first_ten:
+                with dset.filter(picklable_filter_function, num_proc=2) as dset_filter_first_ten:
                     self.assertEqual(len(dset_filter_first_ten), 10)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_filter_first_ten.features,
                         Features({"filename": Value("string")}),
                     )
                     # only one cache file since the there is only 10 examples from the 1 processed shard
-                    self.assertEqual(
-                        len(dset_filter_first_ten.cache_files), 0 if in_memory else 1
-                    )
+                    self.assertEqual(len(dset_filter_first_ten.cache_files), 0 if in_memory else 1)
                     self.assertNotEqual(dset_filter_first_ten._fingerprint, fingerprint)
 
     def test_keep_features_after_transform_specified(self, in_memory):
@@ -1550,9 +1297,7 @@ class BaseDatasetTest(TestCase):
                     with dset.map(invert_labels, features=features) as inverted_dset:
                         self.assertEqual(inverted_dset.features.type, features.type)
                         self.assertDictEqual(inverted_dset.features, features)
-                        assert_arrow_metadata_are_synced_with_dataset_features(
-                            inverted_dset
-                        )
+                        assert_arrow_metadata_are_synced_with_dataset_features(inverted_dset)
 
     def test_keep_features_after_transform_unspecified(self, in_memory):
         features = Features(
@@ -1574,9 +1319,7 @@ class BaseDatasetTest(TestCase):
                     with dset.map(invert_labels) as inverted_dset:
                         self.assertEqual(inverted_dset.features.type, features.type)
                         self.assertDictEqual(inverted_dset.features, features)
-                        assert_arrow_metadata_are_synced_with_dataset_features(
-                            inverted_dset
-                        )
+                        assert_arrow_metadata_are_synced_with_dataset_features(inverted_dset)
 
     def test_keep_features_after_transform_to_file(self, in_memory):
         features = Features(
@@ -1678,13 +1421,9 @@ class BaseDatasetTest(TestCase):
             ) as dset:
                 with self._to(in_memory, tmp_dir, dset) as dset:
                     with dset.map(invert_labels) as inverted_dset:
-                        self.assertEqual(
-                            inverted_dset.features.type, expected_features.type
-                        )
+                        self.assertEqual(inverted_dset.features.type, expected_features.type)
                         self.assertDictEqual(inverted_dset.features, expected_features)
-                        assert_arrow_metadata_are_synced_with_dataset_features(
-                            inverted_dset
-                        )
+                        assert_arrow_metadata_are_synced_with_dataset_features(inverted_dset)
 
     def test_select(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1693,15 +1432,11 @@ class BaseDatasetTest(TestCase):
                 indices = list(range(0, len(dset), 2))
                 tmp_file = os.path.join(tmp_dir, "test.arrow")
                 fingerprint = dset._fingerprint
-                with dset.select(
-                    indices, indices_cache_file_name=tmp_file
-                ) as dset_select_even:
+                with dset.select(indices, indices_cache_file_name=tmp_file) as dset_select_even:
                     self.assertEqual(len(dset_select_even), 15)
                     for row in dset_select_even:
                         self.assertEqual(int(row["filename"][-1]) % 2, 0)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_select_even.features,
                         Features({"filename": Value("string")}),
@@ -1732,9 +1467,7 @@ class BaseDatasetTest(TestCase):
                     self.assertEqual(dset_select_five.format["type"], "numpy")
                     for i, row in enumerate(dset_select_five):
                         self.assertEqual(int(row["filename"][-1]), i)
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_select_five.features,
                         Features({"filename": Value("string")}),
@@ -1744,31 +1477,19 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 with dset.select([0]) as d1:
-                    with d1.map(
-                        lambda x: {"id": int(x["filename"].split("_")[-1])}
-                    ) as d1:
+                    with d1.map(lambda x: {"id": int(x["filename"].split("_")[-1])}) as d1:
                         self.assertEqual(d1[0]["id"], 0)
                 with dset.select([1]) as d2:
-                    with d2.map(
-                        lambda x: {"id": int(x["filename"].split("_")[-1])}
-                    ) as d2:
+                    with d2.map(lambda x: {"id": int(x["filename"].split("_")[-1])}) as d2:
                         self.assertEqual(d2[0]["id"], 1)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
-                with dset.select(
-                    [0], indices_cache_file_name=os.path.join(tmp_dir, "i1.arrow")
-                ) as d1:
-                    with d1.map(
-                        lambda x: {"id": int(x["filename"].split("_")[-1])}
-                    ) as d1:
+                with dset.select([0], indices_cache_file_name=os.path.join(tmp_dir, "i1.arrow")) as d1:
+                    with d1.map(lambda x: {"id": int(x["filename"].split("_")[-1])}) as d1:
                         self.assertEqual(d1[0]["id"], 0)
-                with dset.select(
-                    [1], indices_cache_file_name=os.path.join(tmp_dir, "i2.arrow")
-                ) as d2:
-                    with d2.map(
-                        lambda x: {"id": int(x["filename"].split("_")[-1])}
-                    ) as d2:
+                with dset.select([1], indices_cache_file_name=os.path.join(tmp_dir, "i2.arrow")) as d2:
+                    with d2.map(lambda x: {"id": int(x["filename"].split("_")[-1])}) as d2:
                         self.assertEqual(d2[0]["id"], 1)
 
     def test_pickle_after_many_transforms_on_disk(self, in_memory):
@@ -1782,9 +1503,7 @@ class BaseDatasetTest(TestCase):
                     with dset.map(lambda x: {"id": int(x["file"][-1])}) as dset:
                         self.assertListEqual(sorted(dset.column_names), ["file", "id"])
                         dset.rename_column_("id", "number")
-                        self.assertListEqual(
-                            sorted(dset.column_names), ["file", "number"]
-                        )
+                        self.assertListEqual(sorted(dset.column_names), ["file", "number"])
                         with dset.select([1]) as dset:
                             self.assertEqual(dset[0]["file"], "my_name-train_1")
                             self.assertEqual(dset[0]["number"], 1)
@@ -1796,9 +1515,7 @@ class BaseDatasetTest(TestCase):
                                     dset._data.replays,
                                 )
                             if not in_memory:
-                                dset._data.table = (
-                                    Unpicklable()
-                                )  # check that we don't pickle the entire table
+                                dset._data.table = Unpicklable()  # check that we don't pickle the entire table
 
                             pickled = pickle.dumps(dset)
                             with pickle.loads(pickled) as loaded:
@@ -1810,28 +1527,18 @@ class BaseDatasetTest(TestCase):
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 tmp_file = os.path.join(tmp_dir, "test.arrow")
                 fingerprint = dset._fingerprint
-                with dset.shuffle(
-                    seed=1234, indices_cache_file_name=tmp_file
-                ) as dset_shuffled:
+                with dset.shuffle(seed=1234, indices_cache_file_name=tmp_file) as dset_shuffled:
                     self.assertEqual(len(dset_shuffled), 30)
                     self.assertEqual(dset_shuffled[0]["filename"], "my_name-train_28")
                     self.assertEqual(dset_shuffled[2]["filename"], "my_name-train_10")
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
-                    self.assertDictEqual(
-                        dset_shuffled.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                    self.assertDictEqual(dset_shuffled.features, Features({"filename": Value("string")}))
                     self.assertNotEqual(dset_shuffled._fingerprint, fingerprint)
 
                     # Reproducibility
                     tmp_file = os.path.join(tmp_dir, "test_2.arrow")
-                    with dset.shuffle(
-                        seed=1234, indices_cache_file_name=tmp_file
-                    ) as dset_shuffled_2:
-                        self.assertListEqual(
-                            dset_shuffled["filename"], dset_shuffled_2["filename"]
-                        )
+                    with dset.shuffle(seed=1234, indices_cache_file_name=tmp_file) as dset_shuffled_2:
+                        self.assertListEqual(dset_shuffled["filename"], dset_shuffled_2["filename"])
 
                     # Compatible with temp_seed
                     with temp_seed(42), dset.shuffle() as d1:
@@ -1848,23 +1555,17 @@ class BaseDatasetTest(TestCase):
                 tmp_file = os.path.join(tmp_dir, "test.arrow")
                 with dset.select(range(10), indices_cache_file_name=tmp_file) as dset:
                     tmp_file = os.path.join(tmp_dir, "test_2.arrow")
-                    with dset.shuffle(
-                        seed=1234, indices_cache_file_name=tmp_file
-                    ) as dset:
+                    with dset.shuffle(seed=1234, indices_cache_file_name=tmp_file) as dset:
                         self.assertEqual(len(dset), 10)
                         self.assertEqual(dset[0]["filename"], "my_name-train_8")
                         self.assertEqual(dset[1]["filename"], "my_name-train_9")
                         # Sort
                         tmp_file = os.path.join(tmp_dir, "test_3.arrow")
                         fingerprint = dset._fingerprint
-                        with dset.sort(
-                            "filename", indices_cache_file_name=tmp_file
-                        ) as dset_sorted:
+                        with dset.sort("filename", indices_cache_file_name=tmp_file) as dset_sorted:
                             for i, row in enumerate(dset_sorted):
                                 self.assertEqual(int(row["filename"][-1]), i)
-                            self.assertDictEqual(
-                                dset.features, Features({"filename": Value("string")})
-                            )
+                            self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                             self.assertDictEqual(
                                 dset_sorted.features,
                                 Features({"filename": Value("string")}),
@@ -1891,15 +1592,11 @@ class BaseDatasetTest(TestCase):
                                     dset_sorted.features,
                                     Features({"filename": Value("string")}),
                                 )
-                                self.assertNotEqual(
-                                    dset_sorted._fingerprint, fingerprint
-                                )
+                                self.assertNotEqual(dset_sorted._fingerprint, fingerprint)
                             # formatted
                             dset.set_format("numpy")
                             with dset.sort("filename") as dset_sorted_formatted:
-                                self.assertEqual(
-                                    dset_sorted_formatted.format["type"], "numpy"
-                                )
+                                self.assertEqual(dset_sorted_formatted.format["type"], "numpy")
 
     @require_tf
     def test_export(self, in_memory):
@@ -1934,9 +1631,7 @@ class BaseDatasetTest(TestCase):
                         "answers.answer_start": tf.io.VarLenFeature(tf.int64),
                     }
                     tf_parsed_dset = tf_dset.map(
-                        lambda example_proto: tf.io.parse_single_example(
-                            example_proto, feature_description
-                        )
+                        lambda example_proto: tf.io.parse_single_example(example_proto, feature_description)
                     )
                     # Test that keys match original dataset
                     for i, ex in enumerate(tf_parsed_dset):
@@ -1947,9 +1642,7 @@ class BaseDatasetTest(TestCase):
     def test_to_csv(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # File path argument
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 file_path = os.path.join(tmp_dir, "test_path.csv")
                 bytes_written = dset.to_csv(path_or_buf=file_path)
 
@@ -1961,9 +1654,7 @@ class BaseDatasetTest(TestCase):
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))
 
             # File buffer argument
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 file_path = os.path.join(tmp_dir, "test_buffer.csv")
                 with open(file_path, "wb+") as buffer:
                     bytes_written = dset.to_csv(path_or_buf=buffer)
@@ -1976,9 +1667,7 @@ class BaseDatasetTest(TestCase):
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))
 
             # After a select/shuffle transform
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset = dset.select(range(0, len(dset), 2)).shuffle()
                 file_path = os.path.join(tmp_dir, "test_path.csv")
                 bytes_written = dset.to_csv(path_or_buf=file_path)
@@ -1991,9 +1680,7 @@ class BaseDatasetTest(TestCase):
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))
 
             # With array features
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, array_features=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, array_features=True) as dset:
                 file_path = os.path.join(tmp_dir, "test_path.csv")
                 bytes_written = dset.to_csv(path_or_buf=file_path)
 
@@ -2007,17 +1694,13 @@ class BaseDatasetTest(TestCase):
     def test_to_dict(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Batched
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 bacth_size = dset.num_rows - 1
                 to_dict_generator = dset.to_dict(batched=True, batch_size=bacth_size)
 
                 for batch in to_dict_generator:
                     self.assertIsInstance(batch, dict)
-                    self.assertListEqual(
-                        sorted(batch.keys()), sorted(dset.column_names)
-                    )
+                    self.assertListEqual(sorted(batch.keys()), sorted(dset.column_names))
                     for col_name in dset.column_names:
                         self.assertIsInstance(batch[col_name], list)
                         self.assertLessEqual(len(batch[col_name]), bacth_size)
@@ -2025,9 +1708,7 @@ class BaseDatasetTest(TestCase):
                 # Full
                 dset_to_dict = dset.to_dict()
                 self.assertIsInstance(dset_to_dict, dict)
-                self.assertListEqual(
-                    sorted(dset_to_dict.keys()), sorted(dset.column_names)
-                )
+                self.assertListEqual(sorted(dset_to_dict.keys()), sorted(dset.column_names))
 
                 for col_name in dset.column_names:
                     self.assertLessEqual(len(dset_to_dict[col_name]), len(dset))
@@ -2037,9 +1718,7 @@ class BaseDatasetTest(TestCase):
                     dset_to_dict = dset.to_dict()
                     self.assertIsInstance(dset_to_dict, dict)
                     self.assertEqual(len(dset_to_dict), 3)
-                    self.assertListEqual(
-                        sorted(dset_to_dict.keys()), sorted(dset.column_names)
-                    )
+                    self.assertListEqual(sorted(dset_to_dict.keys()), sorted(dset.column_names))
 
                     for col_name in dset.column_names:
                         self.assertIsInstance(dset_to_dict[col_name], list)
@@ -2048,28 +1727,20 @@ class BaseDatasetTest(TestCase):
     def test_to_pandas(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Batched
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 bacth_size = dset.num_rows - 1
-                to_pandas_generator = dset.to_pandas(
-                    batched=True, batch_size=bacth_size
-                )
+                to_pandas_generator = dset.to_pandas(batched=True, batch_size=bacth_size)
 
                 for batch in to_pandas_generator:
                     self.assertIsInstance(batch, pd.DataFrame)
-                    self.assertListEqual(
-                        sorted(batch.columns), sorted(dset.column_names)
-                    )
+                    self.assertListEqual(sorted(batch.columns), sorted(dset.column_names))
                     for col_name in dset.column_names:
                         self.assertLessEqual(len(batch[col_name]), bacth_size)
 
                 # Full
                 dset_to_pandas = dset.to_pandas()
                 self.assertIsInstance(dset_to_pandas, pd.DataFrame)
-                self.assertListEqual(
-                    sorted(dset_to_pandas.columns), sorted(dset.column_names)
-                )
+                self.assertListEqual(sorted(dset_to_pandas.columns), sorted(dset.column_names))
                 for col_name in dset.column_names:
                     self.assertEqual(len(dset_to_pandas[col_name]), len(dset))
 
@@ -2078,9 +1749,7 @@ class BaseDatasetTest(TestCase):
                     dset_to_pandas = dset.to_pandas()
                     self.assertIsInstance(dset_to_pandas, pd.DataFrame)
                     self.assertEqual(len(dset_to_pandas), 3)
-                    self.assertListEqual(
-                        sorted(dset_to_pandas.columns), sorted(dset.column_names)
-                    )
+                    self.assertListEqual(sorted(dset_to_pandas.columns), sorted(dset.column_names))
 
                     for col_name in dset.column_names:
                         self.assertEqual(len(dset_to_pandas[col_name]), dset.num_rows)
@@ -2100,15 +1769,9 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset_train[-1]["filename"], "my_name-train_19")
                 self.assertEqual(dset_test[0]["filename"], "my_name-train_20")
                 self.assertEqual(dset_test[-1]["filename"], "my_name-train_29")
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_train.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_test.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_train.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_test.features, Features({"filename": Value("string")}))
                 self.assertNotEqual(dset_train._fingerprint, fingerprint)
                 self.assertNotEqual(dset_test._fingerprint, fingerprint)
                 self.assertNotEqual(dset_train._fingerprint, dset_test._fingerprint)
@@ -2124,15 +1787,9 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset_train[-1]["filename"], "my_name-train_14")
                 self.assertEqual(dset_test[0]["filename"], "my_name-train_15")
                 self.assertEqual(dset_test[-1]["filename"], "my_name-train_29")
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_train.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_test.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_train.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_test.features, Features({"filename": Value("string")}))
 
                 dset_dict = dset.train_test_split(train_size=10, shuffle=False)
                 self.assertListEqual(list(dset_dict.keys()), ["train", "test"])
@@ -2145,15 +1802,9 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset_train[-1]["filename"], "my_name-train_9")
                 self.assertEqual(dset_test[0]["filename"], "my_name-train_10")
                 self.assertEqual(dset_test[-1]["filename"], "my_name-train_29")
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_train.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_test.features, Features({"filename": Value("string")})
-                )
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_train.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_test.features, Features({"filename": Value("string")}))
 
                 dset.set_format("numpy")
                 dset_dict = dset.train_test_split(train_size=10, seed=42)
@@ -2166,47 +1817,27 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset_train.format["type"], "numpy")
                 self.assertEqual(dset_test.format["type"], "numpy")
                 self.assertNotEqual(dset_train[0]["filename"].item(), "my_name-train_0")
-                self.assertNotEqual(
-                    dset_train[-1]["filename"].item(), "my_name-train_9"
-                )
+                self.assertNotEqual(dset_train[-1]["filename"].item(), "my_name-train_9")
                 self.assertNotEqual(dset_test[0]["filename"].item(), "my_name-train_10")
-                self.assertNotEqual(
-                    dset_test[-1]["filename"].item(), "my_name-train_29"
-                )
-                self.assertDictEqual(
-                    dset.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_train.features, Features({"filename": Value("string")})
-                )
-                self.assertDictEqual(
-                    dset_test.features, Features({"filename": Value("string")})
-                )
+                self.assertNotEqual(dset_test[-1]["filename"].item(), "my_name-train_29")
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_train.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(dset_test.features, Features({"filename": Value("string")}))
                 del dset_test, dset_train, dset_dict  # DatasetDict
 
     def test_shard(self, in_memory):
-        with tempfile.TemporaryDirectory() as tmp_dir, self._create_dummy_dataset(
-            in_memory, tmp_dir
-        ) as dset:
+        with tempfile.TemporaryDirectory() as tmp_dir, self._create_dummy_dataset(in_memory, tmp_dir) as dset:
             tmp_file = os.path.join(tmp_dir, "test.arrow")
             with dset.select(range(10), indices_cache_file_name=tmp_file) as dset:
                 self.assertEqual(len(dset), 10)
                 # Shard
                 tmp_file_1 = os.path.join(tmp_dir, "test_1.arrow")
                 fingerprint = dset._fingerprint
-                with dset.shard(
-                    num_shards=8, index=1, indices_cache_file_name=tmp_file_1
-                ) as dset_sharded:
+                with dset.shard(num_shards=8, index=1, indices_cache_file_name=tmp_file_1) as dset_sharded:
                     self.assertEqual(2, len(dset_sharded))
-                    self.assertEqual(
-                        ["my_name-train_1", "my_name-train_9"], dset_sharded["filename"]
-                    )
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
-                    self.assertDictEqual(
-                        dset_sharded.features, Features({"filename": Value("string")})
-                    )
+                    self.assertEqual(["my_name-train_1", "my_name-train_9"], dset_sharded["filename"])
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                    self.assertDictEqual(dset_sharded.features, Features({"filename": Value("string")}))
                     self.assertNotEqual(dset_sharded._fingerprint, fingerprint)
                 # Shard contiguous
                 tmp_file_2 = os.path.join(tmp_dir, "test_2.arrow")
@@ -2220,9 +1851,7 @@ class BaseDatasetTest(TestCase):
                         [f"my_name-train_{i}" for i in (0, 1, 2, 3)],
                         dset_sharded_contiguous["filename"],
                     )
-                    self.assertDictEqual(
-                        dset.features, Features({"filename": Value("string")})
-                    )
+                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(
                         dset_sharded_contiguous.features,
                         Features({"filename": Value("string")}),
@@ -2283,9 +1912,7 @@ class BaseDatasetTest(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir, self._create_dummy_dataset(
             in_memory, tmp_dir
-        ) as dset, dset.map(
-            lambda ex, i: {"vec": np.ones(3) * i}, with_indices=True
-        ) as dset:
+        ) as dset, dset.map(lambda ex, i: {"vec": np.ones(3) * i}, with_indices=True) as dset:
             columns = dset.column_names
 
             self.assertIsNotNone(dset[0])
@@ -2295,9 +1922,7 @@ class BaseDatasetTest(TestCase):
                 self.assertIsInstance(dset[:2][col], list)
             self.assertDictEqual(
                 dset.features,
-                Features(
-                    {"filename": Value("string"), "vec": Sequence(Value("float64"))}
-                ),
+                Features({"filename": Value("string"), "vec": Sequence(Value("float64"))}),
             )
 
             dset.set_format("tensorflow")
@@ -2341,9 +1966,7 @@ class BaseDatasetTest(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir, self._create_dummy_dataset(
             in_memory, tmp_dir
-        ) as dset, dset.map(
-            lambda ex, i: {"vec": np.ones(3 + i) * i}, with_indices=True
-        ) as dset:
+        ) as dset, dset.map(lambda ex, i: {"vec": np.ones(3 + i) * i}, with_indices=True) as dset:
             columns = dset.column_names
 
             self.assertIsNotNone(dset[0])
@@ -2353,9 +1976,7 @@ class BaseDatasetTest(TestCase):
                 self.assertIsInstance(dset[:2][col], list)
             self.assertDictEqual(
                 dset.features,
-                Features(
-                    {"filename": Value("string"), "vec": Sequence(Value("float64"))}
-                ),
+                Features({"filename": Value("string"), "vec": Sequence(Value("float64"))}),
             )
 
             dset.set_format("tensorflow")
@@ -2418,16 +2039,10 @@ class BaseDatasetTest(TestCase):
 
             dset.set_format("tensorflow")
             self.assertIsNotNone(dset[0])
-            self.assertIsInstance(
-                dset[0]["nested"]["foo"], (tf.Tensor, tf.RaggedTensor)
-            )
+            self.assertIsInstance(dset[0]["nested"]["foo"], (tf.Tensor, tf.RaggedTensor))
             self.assertIsNotNone(dset[:2])
-            self.assertIsInstance(
-                dset[:2]["nested"][0]["foo"], (tf.Tensor, tf.RaggedTensor)
-            )
-            self.assertIsInstance(
-                dset["nested"][0]["foo"], (tf.Tensor, tf.RaggedTensor)
-            )
+            self.assertIsInstance(dset[:2]["nested"][0]["foo"], (tf.Tensor, tf.RaggedTensor))
+            self.assertIsInstance(dset["nested"][0]["foo"], (tf.Tensor, tf.RaggedTensor))
 
             dset.set_format("numpy")
             self.assertIsNotNone(dset[0])
@@ -2447,9 +2062,7 @@ class BaseDatasetTest(TestCase):
         import pandas as pd
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset.set_format("pandas")
                 self.assertIsInstance(dset[0], pd.DataFrame)
                 self.assertIsInstance(dset[:2], pd.DataFrame)
@@ -2495,9 +2108,7 @@ class BaseDatasetTest(TestCase):
 
     def test_with_format(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 with dset.with_format("numpy", columns=["col_1"]) as dset2:
                     dset.set_format("numpy", columns=["col_1"])
                     self.assertDictEqual(dset.format, dset2.format)
@@ -2508,9 +2119,7 @@ class BaseDatasetTest(TestCase):
 
     def test_with_transform(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(
-                in_memory, tmp_dir, multiple_columns=True
-            ) as dset:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 transform = lambda x: {"foo": x["col_1"]}  # noqa: E731
                 with dset.with_transform(transform, columns=["col_1"]) as dset2:
                     dset.set_transform(transform, columns=["col_1"])
@@ -2545,9 +2154,7 @@ class MiscellaneousDatasetTest(TestCase):
             )
 
         features = Features({"col_1": Value("int64"), "col_2": Value("string")})
-        with Dataset.from_pandas(
-            df, features=features, info=DatasetInfo(features=features)
-        ) as dset:
+        with Dataset.from_pandas(df, features=features, info=DatasetInfo(features=features)) as dset:
             self.assertListEqual(dset["col_1"], data["col_1"])
             self.assertListEqual(dset["col_2"], data["col_2"])
             self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
@@ -2581,9 +2188,7 @@ class MiscellaneousDatasetTest(TestCase):
             )
 
         features = Features({"col_1": Value("int64"), "col_2": Value("string")})
-        with Dataset.from_dict(
-            data, features=features, info=DatasetInfo(features=features)
-        ) as dset:
+        with Dataset.from_dict(data, features=features, info=DatasetInfo(features=features)) as dset:
             self.assertListEqual(dset["col_1"], data["col_1"])
             self.assertListEqual(dset["col_2"], data["col_2"])
             self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
@@ -2608,12 +2213,8 @@ class MiscellaneousDatasetTest(TestCase):
                 data3
             ) as dset3:
                 with concatenate_datasets([dset1, dset2, dset3]) as concatenated_dset:
-                    self.assertEqual(
-                        len(concatenated_dset), len(dset1) + len(dset2) + len(dset3)
-                    )
-                    self.assertListEqual(
-                        concatenated_dset["id"], dset1["id"] + dset2["id"] + dset3["id"]
-                    )
+                    self.assertEqual(len(concatenated_dset), len(dset1) + len(dset2) + len(dset3))
+                    self.assertListEqual(concatenated_dset["id"], dset1["id"] + dset2["id"] + dset3["id"])
 
     @require_transformers
     def test_set_format_encode(self):
@@ -2626,20 +2227,14 @@ class MiscellaneousDatasetTest(TestCase):
 
         with Dataset.from_dict({"text": ["hello there", "foo"]}) as dset:
             dset.set_transform(transform=encode)
-            self.assertEqual(
-                str(dset[:2]), str(encode({"text": ["hello there", "foo"]}))
-            )
+            self.assertEqual(str(dset[:2]), str(encode({"text": ["hello there", "foo"]})))
 
 
 def test_cast_with_sliced_list():
     old_features = Features({"foo": Sequence(Value("int64"))})
     new_features = Features({"foo": Sequence(Value("int32"))})
-    dataset = Dataset.from_dict(
-        {"foo": [[i] * (i % 3) for i in range(20)]}, features=old_features
-    )
-    casted_dataset = dataset.cast(
-        new_features, batch_size=2
-    )  # small batch size to slice the ListArray
+    dataset = Dataset.from_dict({"foo": [[i] * (i % 3) for i in range(20)]}, features=old_features)
+    casted_dataset = dataset.cast(new_features, batch_size=2)  # small batch size to slice the ListArray
     assert dataset["foo"] == casted_dataset["foo"]
     assert casted_dataset.features == new_features
 
@@ -2652,9 +2247,7 @@ def test_update_metadata_with_features(dataset_dict):
     assert features1 != features2
 
     table2 = update_metadata_with_features(table1, features2)
-    metadata = json.loads(
-        table2.schema.metadata["huggingface".encode("utf-8")].decode()
-    )
+    metadata = json.loads(table2.schema.metadata["huggingface".encode("utf-8")].decode())
     assert features2 == Features.from_dict(metadata["info"]["features"])
 
     with Dataset(table1) as dset1, Dataset(table2) as dset2:
@@ -2664,34 +2257,24 @@ def test_update_metadata_with_features(dataset_dict):
 
 @pytest.mark.parametrize("dataset_type", ["in_memory", "memory_mapped", "mixed"])
 @pytest.mark.parametrize("axis, expected_shape", [(0, (4, 3)), (1, (2, 6))])
-def test_concatenate_datasets(
-    dataset_type, axis, expected_shape, dataset_dict, arrow_path
-):
+def test_concatenate_datasets(dataset_type, axis, expected_shape, dataset_dict, arrow_path):
     table = {
         "in_memory": InMemoryTable.from_pydict(dataset_dict),
         "memory_mapped": MemoryMappedTable.from_file(arrow_path),
     }
     tables = [
-        table[dataset_type if dataset_type != "mixed" else "memory_mapped"].slice(
-            0, 2
-        ),  # shape = (2, 3)
-        table[dataset_type if dataset_type != "mixed" else "in_memory"].slice(
-            2, 4
-        ),  # shape = (2, 3)
+        table[dataset_type if dataset_type != "mixed" else "memory_mapped"].slice(0, 2),  # shape = (2, 3)
+        table[dataset_type if dataset_type != "mixed" else "in_memory"].slice(2, 4),  # shape = (2, 3)
     ]
     if axis == 1:  # don't duplicate columns
-        tables[1] = tables[1].rename_columns(
-            [col + "_bis" for col in tables[1].column_names]
-        )
+        tables[1] = tables[1].rename_columns([col + "_bis" for col in tables[1].column_names])
     datasets = [Dataset(table) for table in tables]
     dataset = concatenate_datasets(datasets, axis=axis)
     assert dataset.shape == expected_shape
     assert_arrow_metadata_are_synced_with_dataset_features(dataset)
 
 
-@pytest.mark.parametrize(
-    "other_dataset_type", ["in_memory", "memory_mapped", "concatenation"]
-)
+@pytest.mark.parametrize("other_dataset_type", ["in_memory", "memory_mapped", "concatenation"])
 @pytest.mark.parametrize("axis, expected_shape", [(0, (8, 3)), (1, (4, 6))])
 def test_concatenate_datasets_with_concatenation_tables(
     axis, expected_shape, other_dataset_type, dataset_dict, arrow_path
@@ -2729,9 +2312,7 @@ def test_concatenate_datasets_with_concatenation_tables(
     tables = [concatenation_table, other_table]
 
     if axis == 1:  # don't duplicate columns
-        tables[1] = tables[1].rename_columns(
-            [col + "_bis" for col in tables[1].column_names]
-        )
+        tables[1] = tables[1].rename_columns([col + "_bis" for col in tables[1].column_names])
 
     for tables in [tables, reversed(tables)]:
         datasets = [Dataset(table) for table in tables]
@@ -2763,9 +2344,7 @@ def test_concatenate_datasets_duplicate_columns(dataset):
         ("class_encode_column", ("col_2",), {}),
     ],
 )
-def test_dataset_add_column(
-    column, expected_dtype, in_memory, transform, dataset_dict, arrow_path
-):
+def test_dataset_add_column(column, expected_dtype, in_memory, transform, dataset_dict, arrow_path):
     column_name = "col_4"
     original_dataset = (
         Dataset(InMemoryTable.from_pydict(dataset_dict))
@@ -2774,31 +2353,23 @@ def test_dataset_add_column(
     )
     if transform is not None:
         transform_name, args, kwargs = transform
-        original_dataset: Dataset = getattr(original_dataset, transform_name)(
-            *args, **kwargs
-        )
+        original_dataset: Dataset = getattr(original_dataset, transform_name)(*args, **kwargs)
     dataset = original_dataset.add_column(column_name, column)
     assert dataset.data.shape == (4, 4)
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     # Sort expected features as in the original dataset
-    expected_features = {
-        feature: expected_features[feature] for feature in original_dataset.features
-    }
+    expected_features = {feature: expected_features[feature] for feature in original_dataset.features}
     # Add new column feature
     expected_features[column_name] = expected_dtype
     assert dataset.data.column_names == list(expected_features.keys())
     for feature, expected_dtype in expected_features.items():
         assert dataset.features[feature].dtype == expected_dtype
-    assert (
-        len(dataset.data.blocks) == 1 if in_memory else 2
-    )  # multiple InMemoryTables are consolidated as one
+    assert len(dataset.data.blocks) == 1 if in_memory else 2  # multiple InMemoryTables are consolidated as one
     assert dataset.format["type"] == original_dataset.format["type"]
     assert dataset._fingerprint != original_dataset._fingerprint
     dataset.reset_format()
     original_dataset.reset_format()
-    assert all(
-        dataset[col] == original_dataset[col] for col in original_dataset.column_names
-    )
+    assert all(dataset[col] == original_dataset[col] for col in original_dataset.column_names)
     assert set(dataset["col_4"]) == set(column)
     if dataset._indices is not None:
         dataset_indices = dataset._indices["indices"].to_pylist()
@@ -2834,26 +2405,20 @@ def test_dataset_add_item(item, in_memory, dataset_dict, arrow_path, transform):
     )
     if transform is not None:
         transform_name, args, kwargs = transform
-        dataset_to_test: Dataset = getattr(dataset_to_test, transform_name)(
-            *args, **kwargs
-        )
+        dataset_to_test: Dataset = getattr(dataset_to_test, transform_name)(*args, **kwargs)
     dataset = dataset_to_test.add_item(item)
     assert dataset.data.shape == (5, 3)
     expected_features = dataset_to_test.features
     assert sorted(dataset.data.column_names) == sorted(expected_features.keys())
     for feature, expected_dtype in expected_features.items():
         assert dataset.features[feature] == expected_dtype
-    assert (
-        len(dataset.data.blocks) == 1 if in_memory else 2
-    )  # multiple InMemoryTables are consolidated as one
+    assert len(dataset.data.blocks) == 1 if in_memory else 2  # multiple InMemoryTables are consolidated as one
     assert dataset.format["type"] == dataset_to_test.format["type"]
     assert dataset._fingerprint != dataset_to_test._fingerprint
     dataset.reset_format()
     dataset_to_test.reset_format()
     assert dataset[:-1] == dataset_to_test[:]
-    assert {k: int(v) for k, v in dataset[-1].items()} == {
-        k: int(v) for k, v in item.items()
-    }
+    assert {k: int(v) for k, v in dataset[-1].items()} == {k: int(v) for k, v in item.items()}
     if dataset._indices is not None:
         dataset_indices = dataset._indices["indices"].to_pylist()
         dataset_to_test_indices = dataset_to_test._indices["indices"].to_pylist()
@@ -2867,9 +2432,7 @@ def test_dataset_from_file(in_memory, dataset, arrow_file):
         dataset_from_file = Dataset.from_file(filename, in_memory=in_memory)
     assert dataset_from_file.features.type == dataset.features.type
     assert dataset_from_file.features == dataset.features
-    assert dataset_from_file.cache_files == (
-        [{"filename": filename}] if not in_memory else []
-    )
+    assert dataset_from_file.cache_files == ([{"filename": filename}] if not in_memory else [])
 
 
 def _check_csv_dataset(dataset, expected_features):
@@ -2886,9 +2449,7 @@ def test_dataset_from_csv_keep_in_memory(keep_in_memory, csv_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = Dataset.from_csv(
-            csv_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
-        )
+        dataset = Dataset.from_csv(csv_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory)
     _check_csv_dataset(dataset, expected_features)
 
 
@@ -2908,9 +2469,7 @@ def test_dataset_from_csv_features(features, csv_path, tmp_path):
     default_expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()})
-        if features is not None
-        else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
     )
     dataset = Dataset.from_csv(csv_path, features=features, cache_dir=cache_dir)
     _check_csv_dataset(dataset, expected_features)
@@ -2951,9 +2510,7 @@ def test_dataset_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = Dataset.from_json(
-            jsonl_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
-        )
+        dataset = Dataset.from_json(jsonl_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory)
     _check_json_dataset(dataset, expected_features)
 
 
@@ -2977,9 +2534,7 @@ def test_dataset_from_json_features(features, jsonl_path, tmp_path):
     }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()})
-        if features is not None
-        else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
     )
     dataset = Dataset.from_json(jsonl_path, features=features, cache_dir=cache_dir)
     _check_json_dataset(dataset, expected_features)
@@ -3033,9 +2588,7 @@ def test_dataset_from_text_keep_in_memory(keep_in_memory, text_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"text": "string"}
     with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = Dataset.from_text(
-            text_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
-        )
+        dataset = Dataset.from_text(text_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory)
     _check_text_dataset(dataset, expected_features)
 
 
@@ -3054,9 +2607,7 @@ def test_dataset_from_text_features(features, text_path, tmp_path):
     default_expected_features = {"text": "string"}
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()})
-        if features is not None
-        else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
     )
     dataset = Dataset.from_text(text_path, features=features, cache_dir=cache_dir)
     _check_text_dataset(dataset, expected_features)
@@ -3151,13 +2702,9 @@ def test_dataset_to_json(dataset, tmp_path):
         ("flatten_", tuple(), {}),
     ],
 )
-def test_pickle_dataset_after_transforming_the_table(
-    in_memory, method_and_params, arrow_file
-):
+def test_pickle_dataset_after_transforming_the_table(in_memory, method_and_params, arrow_file):
     method, args, kwargs = method_and_params
-    with Dataset.from_file(
-        arrow_file, in_memory=in_memory
-    ) as dataset, Dataset.from_file(
+    with Dataset.from_file(arrow_file, in_memory=in_memory) as dataset, Dataset.from_file(
         arrow_file, in_memory=in_memory
     ) as reference_dataset:
         out = getattr(dataset, method)(*args, **kwargs)
@@ -3200,18 +2747,14 @@ class TaskTemplatesTest(TestCase):
             }
         )
         # Label names are added in `DatasetInfo.__post_init__` so not needed here
-        task_without_labels = TextClassification(
-            text_column="input_text", label_column="input_labels"
-        )
+        task_without_labels = TextClassification(text_column="input_text", label_column="input_labels")
         info1 = DatasetInfo(
             features=features_before_cast,
             task_templates=task_without_labels,
         )
         # Label names are required when passing a TextClassification template directly to `Dataset.prepare_for_task`
         # However they also can be used to define `DatasetInfo` so we include a test for this too
-        task_with_labels = TextClassification(
-            text_column="input_text", label_column="input_labels", labels=labels
-        )
+        task_with_labels = TextClassification(text_column="input_text", label_column="input_labels", labels=labels)
         info2 = DatasetInfo(
             features=features_before_cast,
             task_templates=task_with_labels,
@@ -3219,18 +2762,14 @@ class TaskTemplatesTest(TestCase):
         data = {"input_text": ["i love transformers!"], "input_labels": [1]}
         # Test we can load from task name when label names not included in template (default behaviour)
         with Dataset.from_dict(data, info=info1) as dset:
-            self.assertSetEqual(
-                set(["input_text", "input_labels"]), set(dset.column_names)
-            )
+            self.assertSetEqual(set(["input_text", "input_labels"]), set(dset.column_names))
             self.assertDictEqual(features_before_cast, dset.features)
             with dset.prepare_for_task(task="text-classification") as dset:
                 self.assertSetEqual(set(["labels", "text"]), set(dset.column_names))
                 self.assertDictEqual(features_after_cast, dset.features)
         # Test we can load from task name when label names included in template
         with Dataset.from_dict(data, info=info2) as dset:
-            self.assertSetEqual(
-                set(["input_text", "input_labels"]), set(dset.column_names)
-            )
+            self.assertSetEqual(set(["input_text", "input_labels"]), set(dset.column_names))
             self.assertDictEqual(features_before_cast, dset.features)
             with dset.prepare_for_task(task="text-classification") as dset:
                 self.assertSetEqual(set(["labels", "text"]), set(dset.column_names))
@@ -3294,9 +2833,7 @@ class TaskTemplatesTest(TestCase):
             self.assertDictEqual(features_before_cast, dset.features)
             with dset.prepare_for_task(task="question-answering-extractive") as dset:
                 self.assertSetEqual(
-                    set(
-                        ["context", "question", "answers.text", "answers.answer_start"]
-                    ),
+                    set(["context", "question", "answers.text", "answers.answer_start"]),
                     set(dset.flatten().column_names),
                 )
                 self.assertDictEqual(features_after_cast, dset.features)
@@ -3305,9 +2842,7 @@ class TaskTemplatesTest(TestCase):
         with Dataset.from_dict(data, info=info) as dset:
             with dset.prepare_for_task(task=task) as dset:
                 self.assertSetEqual(
-                    set(
-                        ["context", "question", "answers.text", "answers.answer_start"]
-                    ),
+                    set(["context", "question", "answers.text", "answers.answer_start"]),
                     set(dset.flatten().column_names),
                 )
                 self.assertDictEqual(features_after_cast, dset.features)
@@ -3321,15 +2856,11 @@ class TaskTemplatesTest(TestCase):
                 "dummy": Value("string"),
             }
         )
-        features_after_cast = Features(
-            {"text": Value("string"), "summary": Value("string")}
-        )
+        features_after_cast = Features({"text": Value("string"), "summary": Value("string")})
         task = Summarization(text_column="input_text", summary_column="input_summary")
         info = DatasetInfo(features=features_before_cast, task_templates=task)
         data = {
-            "input_text": [
-                "jack and jill took a taxi to attend a super duper party in the city."
-            ],
+            "input_text": ["jack and jill took a taxi to attend a super duper party in the city."],
             "input_summary": ["jack and jill attend party"],
             "dummy": ["123456"],
         }
@@ -3360,9 +2891,7 @@ class TaskTemplatesTest(TestCase):
                 "dummy": Value("string"),
             }
         )
-        features_after_cast = Features(
-            {"audio_file_path": Value("string"), "transcription": Value("string")}
-        )
+        features_after_cast = Features({"audio_file_path": Value("string"), "transcription": Value("string")})
         task = AutomaticSpeechRecognition(
             audio_file_path_column="input_audio_file_path",
             transcription_column="input_transcription",
@@ -3413,9 +2942,7 @@ class TaskTemplatesTest(TestCase):
         data = {"input_text": ["i love transformers!"], "input_labels": [1]}
         with Dataset.from_dict(data, info=info) as dset:
             # Invalid task name
-            self.assertRaises(
-                ValueError, dset.prepare_for_task, "this-task-does-not-exist"
-            )
+            self.assertRaises(ValueError, dset.prepare_for_task, "this-task-does-not-exist")
             # Invalid task templates with incompatible labels
             task_with_wrong_labels = TextClassification(
                 text_column="input_text", label_column="input_labels", labels=["neut"]
@@ -3452,9 +2979,7 @@ class TaskTemplatesTest(TestCase):
         features = Features(
             {
                 "input_text": Value("string"),
-                "input_labels": ClassLabel(
-                    num_classes=3, names=["entailment", "neutral", "contradiction"]
-                ),
+                "input_labels": ClassLabel(num_classes=3, names=["entailment", "neutral", "contradiction"]),
             }
         )
         data = {
@@ -3468,10 +2993,7 @@ class TaskTemplatesTest(TestCase):
         with Dataset.from_dict(data, features=features) as dset:
             with dset.align_labels_with_mapping(label2id, "input_labels") as dset:
                 self.assertListEqual(expected_labels, dset["input_labels"])
-                aligned_label_names = [
-                    dset.features["input_labels"].int2str(idx)
-                    for idx in dset["input_labels"]
-                ]
+                aligned_label_names = [dset.features["input_labels"].int2str(idx) for idx in dset["input_labels"]]
                 self.assertListEqual(expected_label_names, aligned_label_names)
 
     def test_concatenate_with_no_task_templates(self):
@@ -3485,17 +3007,11 @@ class TaskTemplatesTest(TestCase):
 
     def test_concatenate_with_equal_task_templates(self):
         labels = ["neg", "pos"]
-        task_template = TextClassification(
-            text_column="text", label_column="labels", labels=labels
-        )
+        task_template = TextClassification(text_column="text", label_column="labels", labels=labels)
         info = DatasetInfo(
-            features=Features(
-                {"text": Value("string"), "labels": ClassLabel(names=labels)}
-            ),
+            features=Features({"text": Value("string"), "labels": ClassLabel(names=labels)}),
             # Label names are added in `DatasetInfo.__post_init__` so not included here
-            task_templates=TextClassification(
-                text_column="text", label_column="labels"
-            ),
+            task_templates=TextClassification(text_column="text", label_column="labels"),
         )
         data = {"text": ["i love transformers!"], "labels": [1]}
         with Dataset.from_dict(data, info=info) as dset1, Dataset.from_dict(
@@ -3651,7 +3167,5 @@ class TaskTemplatesTest(TestCase):
         )
         data = {"input_text": ["i love transformers!"], "input_labels": [1]}
         with Dataset.from_dict(data, info=info) as dset:
-            with dset.map(
-                lambda x: {"new_column": 0}, remove_columns=dset.column_names
-            ) as dset:
+            with dset.map(lambda x: {"new_column": 0}, remove_columns=dset.column_names) as dset:
                 self.assertDictEqual(dset.features, features_after_map)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -14,22 +14,13 @@ from absl.testing import parameterized
 
 import datasets.arrow_dataset
 from datasets import concatenate_datasets, load_from_disk, temp_seed
-from datasets.arrow_dataset import (
-    Dataset,
-    transmit_format,
-    update_metadata_with_features,
-)
+from datasets.arrow_dataset import Dataset, transmit_format, update_metadata_with_features
 from datasets.dataset_dict import DatasetDict
 from datasets.features import Array2D, Array3D, ClassLabel, Features, Sequence, Value
 from datasets.info import DatasetInfo
 from datasets.splits import NamedSplit
 from datasets.table import ConcatenationTable, InMemoryTable, MemoryMappedTable
-from datasets.tasks import (
-    AutomaticSpeechRecognition,
-    QuestionAnsweringExtractive,
-    Summarization,
-    TextClassification,
-)
+from datasets.tasks import AutomaticSpeechRecognition, QuestionAnsweringExtractive, Summarization, TextClassification
 from datasets.utils.logging import WARNING
 
 from .conftest import s3_test_bucket_name
@@ -930,7 +921,7 @@ class BaseDatasetTest(TestCase):
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 fingerprint = dset._fingerprint
-                with dset.select([0, 1]) as dset:
+                with dset.select([0, 1], keep_in_memory=True) as dset:
                     with dset.map(picklable_map_function, num_proc=5) as dset_test:
                         self.assertEqual(len(dset_test), 2)
                         self.assertDictEqual(dset.features, Features({"filename": Value("string")}))

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -930,18 +930,18 @@ class BaseDatasetTest(TestCase):
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                 fingerprint = dset._fingerprint
-                dset = dset.select([0, 1])
-                with dset.map(picklable_map_function, num_proc=5) as dset_test:
-                    self.assertEqual(len(dset_test), 2)
-                    self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
-                    self.assertDictEqual(
-                        dset_test.features,
-                        Features({"filename": Value("string"), "id": Value("int64")}),
-                    )
-                    self.assertEqual(len(dset_test.cache_files), 0 if in_memory else 2)
-                    self.assertListEqual(dset_test["id"], list(range(2)))
-                    self.assertNotEqual(dset_test._fingerprint, fingerprint)
-                    assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+                with dset.select([0, 1]) as dset:
+                    with dset.map(picklable_map_function, num_proc=5) as dset_test:
+                        self.assertEqual(len(dset_test), 2)
+                        self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                        self.assertDictEqual(
+                            dset_test.features,
+                            Features({"filename": Value("string"), "id": Value("int64")}),
+                        )
+                        self.assertEqual(len(dset_test.cache_files), 0 if in_memory else 2)
+                        self.assertListEqual(dset_test["id"], list(range(2)))
+                        self.assertNotEqual(dset_test._fingerprint, fingerprint)
+                        assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_indices
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:


### PR DESCRIPTION
closes #2470

## Testing notes
To run updated tests:
```sh
pytest tests/test_arrow_dataset.py -k "BaseDatasetTest and test_map_multiprocessing" -s
```
With Python code (to view warning):
```python
from datasets import Dataset


dataset = Dataset.from_dict({"x": ["sample"]})
print(len(dataset))
dataset.map(lambda x: x, num_proc=10)
```