### PR TITLE
Add ASR task and new languages to resources

### DIFF
--- a/src/datasets/utils/resources/languages.json
+++ b/src/datasets/utils/resources/languages.json
@@ -1,4 +1,5 @@
 {
+    "ab": "Abkhazian",
     "af": "Afrikaans",
     "af-NA": "Afrikaans (Namibia)",
     "af-ZA": "Afrikaans (South Africa)",
@@ -109,6 +110,7 @@
     "ckb": "Central Kurdish",
     "ckb-IQ": "Central Kurdish (Iraq)",
     "ckb-IR": "Central Kurdish (Iran)",
+    "cnh": "Hakha Chin",
     "cs": "Czech",
     "cs-CZ": "Czech (Czechia)",
     "cu": "Church Slavic",
@@ -825,6 +827,7 @@
     "vi-VN": "Vietnamese (Vietnam)",
     "vo": "Volap\u00fck",
     "vo-001": "Volap\u00fck (World)",
+    "vot": "Votic",
     "vun": "Vunjo",
     "vun-TZ": "Vunjo (Tanzania)",
     "wa": "Walloon",

--- a/src/datasets/utils/resources/tasks.json
+++ b/src/datasets/utils/resources/tasks.json
@@ -77,6 +77,19 @@
             "other"
         ]
     },
+    "automatic-speech-recognition": {
+        "description": "recognising speech within audio and converting it to text",
+        "options": [
+            "speech-recognition",
+            "visual-speech-recognition",
+            "distant-speech-recognition",
+            "robust-speech-recognition",
+            "seq2seq-speech-recognition",
+            "accented-speech-recognition",
+            "noisy-speech-recognition",
+            "other"
+        ]
+    },
     "other": {
         "description": "other task family not mentioned here",
         "options": [

--- a/src/datasets/utils/resources/tasks.json
+++ b/src/datasets/utils/resources/tasks.json
@@ -84,7 +84,6 @@
             "visual-speech-recognition",
             "distant-speech-recognition",
             "robust-speech-recognition",
-            "seq2seq-speech-recognition",
             "accented-speech-recognition",
             "noisy-speech-recognition",
             "other"


### PR DESCRIPTION
This PR adds a new `automatic-speech-recognition` task to the list of supported tasks in `tasks.json` and also includes a few new languages missing from `common_voice`.

Note: I used the [Papers with Code list](https://www.paperswithcode.com/area/speech/speech-recognition) as inspiration for the ASR subtasks