### PR TITLE
Faster search_batch for ElasticsearchIndex due to threading

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -188,13 +188,13 @@ class ElasticSearchIndex(BaseIndex):
 
     def search_batch(self, queries, k: int = 10, max_workers=10) -> BatchedSearchResults:
         import concurrent.futures
-        total_scores, total_indices = [None]*len(queries), [None]*len(queries)
+
+        total_scores, total_indices = [None] * len(queries), [None] * len(queries)
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_index = {executor.submit(self.search, query, k): i
-                               for i, query in enumerate(queries)}
+            future_to_index = {executor.submit(self.search, query, k): i for i, query in enumerate(queries)}
             for future in concurrent.futures.as_completed(future_to_index):
                 index = future_to_index[future]
-                results:SearchResults = future.result()
+                results: SearchResults = future.result()
                 total_scores[index] = results.scores
                 total_indices[index] = results.indices
         return BatchedSearchResults(total_indices=total_indices, total_scores=total_scores)

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -186,6 +186,19 @@ class ElasticSearchIndex(BaseIndex):
         hits = response["hits"]["hits"]
         return SearchResults([hit["_score"] for hit in hits], [int(hit["_id"]) for hit in hits])
 
+    def search_batch(self, queries, k: int = 10, max_workers=10) -> BatchedSearchResults:
+        import concurrent.futures
+        total_scores, total_indices = [None]*len(queries), [None]*len(queries)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_index = {executor.submit(self.search, query, k): i
+                               for i, query in enumerate(queries)}
+            for future in concurrent.futures.as_completed(future_to_index):
+                index = future_to_index[future]
+                results:SearchResults = future.result()
+                total_scores[index] = results.scores
+                total_indices[index] = results.indices
+        return BatchedSearchResults(total_indices=total_indices, total_scores=total_scores)
+
 
 class FaissIndex(BaseIndex):
     """


### PR DESCRIPTION
Hey, 
I think it makes sense to perform search_batch threaded, so ES can perform search in parallel.
Cheers!