### PR TITLE
Add skip and take

### DIFF
--- a/docs/source/dataset_streaming.rst
+++ b/docs/source/dataset_streaming.rst
@@ -113,9 +113,10 @@ You can create new dataset with the first ``n`` examples using :func:`datasets.I
     >>> train_dataset = shuffled_dataset.skip(1000)
     >>> eval_dataset = shuffled_dataset.take(1000)
 
-.. note::
-    When you use :func:`datasets.IterableDataset.skip`, on a dataset, then iterating on the new dataset will take some time to start.
-    This is because under the hood it has to iterate over the skipped examples first.
+Some things to keep in mind:
+
+- When you use ``skip``, on a dataset, then iterating on the new dataset will take some time to start. This is because under the hood it has to iterate over the skipped examples first.
+- Using ``take`` (or ``skip``) prevents future calls to ``shuffle`` from shuffling the dataset shards order, otherwise the taken examples could come from other shards. In this case it only uses the shuffle buffer. Therefore it is advised to shuffle the dataset before splitting using ``take`` or ``skip``.
 
 
 Mix several iterable datasets together with ``interleave_datasets``

--- a/docs/source/dataset_streaming.rst
+++ b/docs/source/dataset_streaming.rst
@@ -52,6 +52,9 @@ Moreover, for larger datasets that are sharded into multiple files, :func:`datas
 In this example, the shuffle buffer contains 10,000 examples that were downloaded from one random shard of the dataset (here it actually comes from the 480-th shard out of 670).
 The example was selected randomly from this buffer, and replaced by the 10,001-st example of the dataset shard.
 
+Note that if the order of the shards has been fixed by using :func:`datasets.IterableDataset.skip` or :func:`datasets.IterableDataset.take` then the order of the shards is kept unchanged.
+
+
 Reshuffle the dataset at each epoch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -91,6 +94,28 @@ Tokenizers are written in Rust and use parallelism to speed up tokenization. To 
     >>> tokenized_dataset = dataset.map(lambda x: tokenizer(x["text"]), batched=True)  # default batch_size is 1000 but you can specify another batch_size if needed
     >>> print(next(iter(tokenized_dataset)))
     {'input_ids': [101, 11047, 10497, 7869, 2352...], 'token_type_ids': [0, 0, 0, 0, 0...], 'attention_mask': [1, 1, 1, 1, 1...]}
+
+
+Split your dataset with ``take`` and ``skip``
+--------------------------------------------------
+
+You can split your dataset by taking or skipping the first ``n`` examples.
+
+You can create new dataset with the first ``n`` examples using :func:`datasets.IterableDataset.take`, or you can get a dataset with the rest of the examples by skipping the first ``n`` examples with :func:`datasets.IterableDataset.skip`:
+
+
+.. code-block::
+
+    >>> dataset_head = dataset.take(2)
+    >>> list(dataset_head)
+    [{'id': 0, 'text': 'Mtendere Village was...'}, '{id': 1, 'text': 'Lily James cannot fight the music...'}]
+    >>> # You can also create splits from a shuffled dataset
+    >>> train_dataset = shuffled_dataset.skip(1000)
+    >>> eval_dataset = shuffled_dataset.take(1000)
+
+.. note::
+    When you use :func:`datasets.IterableDataset.skip`, on a dataset, then iterating on the new dataset will take some time to start.
+    This is because under the hood it has to iterate over the skipped examples first.
 
 
 Mix several iterable datasets together with ``interleave_datasets``

--- a/docs/source/dataset_streaming.rst
+++ b/docs/source/dataset_streaming.rst
@@ -23,6 +23,7 @@ Even though the dataset is 1.2 terabytes of data, you can start using it right a
     The dataset that is returned is a :class:`datasets.IterableDataset`, not the classic map-style :class:`datasets.Dataset`. To get examples from an iterable dataset, you have to iterate over it using a for loop for example. To get the very last example of the dataset, you first have to iterate on all the previous examples.
     Therefore iterable datasets are mostly useful for iterative jobs like training a model, but not for jobs that require random access of examples.
 
+.. _iterable-dataset-shuffling:
 
 Shuffling the dataset: ``shuffle``
 --------------------------------------------------
@@ -101,11 +102,12 @@ Split your dataset with ``take`` and ``skip``
 
 You can split your dataset by taking or skipping the first ``n`` examples.
 
-You can create new dataset with the first ``n`` examples using :func:`datasets.IterableDataset.take`, or you can get a dataset with the rest of the examples by skipping the first ``n`` examples with :func:`datasets.IterableDataset.skip`:
+You can create a new dataset with the first ``n`` examples by using :func:`datasets.IterableDataset.take`, or you can create a dataset with the rest of the examples by skipping the first ``n`` examples with :func:`datasets.IterableDataset.skip`:
 
 
 .. code-block::
 
+    >>> dataset = load_dataset('oscar', "unshuffled_deduplicated_en", split='train', streaming=True)
     >>> dataset_head = dataset.take(2)
     >>> list(dataset_head)
     [{'id': 0, 'text': 'Mtendere Village was...'}, '{id': 1, 'text': 'Lily James cannot fight the music...'}]
@@ -115,8 +117,8 @@ You can create new dataset with the first ``n`` examples using :func:`datasets.I
 
 Some things to keep in mind:
 
-- When you use ``skip``, on a dataset, then iterating on the new dataset will take some time to start. This is because under the hood it has to iterate over the skipped examples first.
-- Using ``take`` (or ``skip``) prevents future calls to ``shuffle`` from shuffling the dataset shards order, otherwise the taken examples could come from other shards. In this case it only uses the shuffle buffer. Therefore it is advised to shuffle the dataset before splitting using ``take`` or ``skip``.
+- When you apply ``skip`` to a dataset, iterating on the new dataset will take some time to start. This is because under the hood it has to iterate over the skipped examples first.
+- Using ``take`` (or ``skip``) prevents future calls to ``shuffle`` from shuffling the dataset shards order, otherwise the taken examples could come from other shards. In this case it only uses the shuffle buffer. Therefore it is advised to shuffle the dataset before splitting using ``take`` or ``skip``. See more details in the :ref:`iterable-dataset-shuffling` section.
 
 
 Mix several iterable datasets together with ``interleave_datasets``

--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -70,7 +70,7 @@ The base class :class:`datasets.IterableDataset` implements an iterable Dataset 
 .. autoclass:: datasets.IterableDataset
     :members:
         __iter__,
-        map, shuffle,
+        map, shuffle, skip, take,
         info, split, builder_name, citation, config_name, dataset_size,
         description, download_checksums, download_size, features, homepage,
         license, size_in_bytes, supervised_keys, version,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -46,7 +46,10 @@ class _BaseExamplesIterable:
         raise NotImplementedError()
 
     def shuffle_data_sources(self, seed: Optional[int]) -> "_BaseExamplesIterable":
-        """Either shuffle the shards/sources of the dataset, or propagate the shuffling to the underlying iterable."""
+        """
+        Either shuffle the shards/sources of the dataset, or propagate the shuffling to the underlying iterable.
+        If the order of the shards must stay fixed (when using .skip or .take for example), then this method returns self.
+        """
         raise NotImplementedError()
 
     @property
@@ -76,15 +79,26 @@ class ExamplesIterable(_BaseExamplesIterable):
             yield key, example
 
     def shuffle_data_sources(self, seed: Optional[int]) -> "ExamplesIterable":
-        """Shuffle the kwargs order to shuffle shards"""
-        rng = np.random.default_rng(seed)
-        kwargs = _shuffle_kwargs(rng, self.kwargs)
-        return ExamplesIterable(self.generate_examples_fn, kwargs)
+        return ShardShuffledExamplesIterable(self.generate_examples_fn, self.kwargs, seed)
 
     @property
     def n_shards(self) -> int:
         max_length = max([len(value) for value in self.kwargs.values() if isinstance(value, list)], default=0)
         return max(1, max_length)
+
+
+class ShardShuffledExamplesIterable(ExamplesIterable):
+
+    def __init__(self, generate_examples_fn: Callable, kwargs: dict, seed: Optional[int]):
+        super().__init__(generate_examples_fn, kwargs)
+        self.seed = seed
+
+    def __iter__(self):
+        """Shuffle the kwargs order to shuffle shards"""
+        rng = np.random.default_rng(self.seed)
+        kwargs_with_shuffled_shards = _shuffle_kwargs(rng, self.kwargs)
+        for key, example in self.generate_examples_fn(**kwargs_with_shuffled_shards):
+            yield key, example
 
 
 class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
@@ -228,6 +242,43 @@ class BufferShuffledExamplesIterable(_BaseExamplesIterable):
         return self.ex_iterable.n_shards
 
 
+class SkipExamplesIterable(_BaseExamplesIterable):
+    def __init__(self, ex_iterable: _BaseExamplesIterable, n: int):
+        self.ex_iterable = ex_iterable
+        self.n = n
+
+    def __iter__(self):
+        ex_iterator = iter(self.ex_iterable)
+        for _ in islice(ex_iterator, self.n):
+            pass
+        yield from ex_iterator
+
+    def shuffle_data_sources(self, seed: Optional[int]) -> "SkipExamplesIterable":
+        """Doesn't shuffle the wrapped examples iterable since it would skip exampels from other shards instead."""
+        return self
+
+    @property
+    def n_shards(self) -> int:
+        return self.ex_iterable.n_shards
+
+
+class TakeExamplesIterable(_BaseExamplesIterable):
+    def __init__(self, ex_iterable: _BaseExamplesIterable, n: int):
+        self.ex_iterable = ex_iterable
+        self.n = n
+
+    def __iter__(self):
+        yield from islice(self.ex_iterable, self.n)
+
+    def shuffle_data_sources(self, seed: Optional[int]) -> "TakeExamplesIterable":
+        """Doesn't shuffle the wrapped examples iterable since it would take examples from other shards instead."""
+        return self
+
+    @property
+    def n_shards(self) -> int:
+        return self.ex_iterable.n_shards
+
+
 def _generate_examples_from_tables_wrapper(generate_tables_fn):
     def wrapper(**kwargs):
         python_formatter = PythonFormatter()
@@ -364,6 +415,10 @@ class IterableDataset(DatasetInfoMixin):
         selected, its space in the buffer is replaced by the next (i.e. 1,001-st) element,
         maintaining the 1,000 element buffer.
 
+        If the dataset is made of several shards, it also does shuffle the order of the shards.
+        However if the order has been fixed by using :func:`datasets.IterableDataset.skip` or :func:`datasets.IterableDataset.take`
+        then the order of the shards is kept unchanged.
+
         Args:
 
             buffer_size (:obj:`int`): size of the buffer.
@@ -371,7 +426,7 @@ class IterableDataset(DatasetInfoMixin):
         """
         shuffling = ShuffingConfig(seed=seed)
         return iterable_dataset(
-            ex_iterable=BufferShuffledExamplesIterable(self._ex_iterable, buffer_size, seed=seed),
+            ex_iterable=BufferShuffledExamplesIterable(self._ex_iterable, buffer_size, seed=seed).shuffle_data_sources(seed=seed),
             info=copy.deepcopy(self._info),
             split=self._split,
             format_type=self._format_type,
@@ -380,6 +435,44 @@ class IterableDataset(DatasetInfoMixin):
 
     def set_epoch(self, epoch: int):
         self._epoch = epoch
+
+    def skip(self, n) -> "IterableDataset":
+        """
+        Create a new IterableDataset that skips the first ``n`` elements.
+
+        Args:
+
+            n (:obj:`int`): number of elements to skip.
+        """
+        ex_iterable = SkipExamplesIterable(
+            self._ex_iterable, n
+        )
+        return iterable_dataset(
+            ex_iterable=ex_iterable,
+            info=copy.deepcopy(self._info),
+            split=self._split,
+            format_type=self._format_type,
+            shuffling=copy.deepcopy(self._shuffling),
+        )
+
+    def take(self, n) -> "IterableDataset":
+        """
+        Create a new IterableDataset with only the first ``n`` elements.
+
+        Args:
+
+            n (:obj:`int`): number of elements to take.
+        """
+        ex_iterable = TakeExamplesIterable(
+            self._ex_iterable, n
+        )
+        return iterable_dataset(
+            ex_iterable=ex_iterable,
+            info=copy.deepcopy(self._info),
+            split=self._split,
+            format_type=self._format_type,
+            shuffling=copy.deepcopy(self._shuffling),
+        )
 
 
 def iterable_dataset(

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -419,7 +419,6 @@ class IterableDataset(DatasetInfoMixin):
         then the order of the shards is kept unchanged.
 
         Args:
-
             buffer_size (:obj:`int`): size of the buffer.
             seed (:obj:`int`, optional, default None): random seed that will be used to create the distribution.
         """
@@ -442,7 +441,6 @@ class IterableDataset(DatasetInfoMixin):
         Create a new IterableDataset that skips the first ``n`` elements.
 
         Args:
-
             n (:obj:`int`): number of elements to skip.
         """
         ex_iterable = SkipExamplesIterable(self._ex_iterable, n)
@@ -459,7 +457,6 @@ class IterableDataset(DatasetInfoMixin):
         Create a new IterableDataset with only the first ``n`` elements.
 
         Args:
-
             n (:obj:`int`): number of elements to take.
         """
         ex_iterable = TakeExamplesIterable(self._ex_iterable, n)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -88,7 +88,6 @@ class ExamplesIterable(_BaseExamplesIterable):
 
 
 class ShardShuffledExamplesIterable(ExamplesIterable):
-
     def __init__(self, generate_examples_fn: Callable, kwargs: dict, seed: Optional[int]):
         super().__init__(generate_examples_fn, kwargs)
         self.seed = seed
@@ -426,7 +425,9 @@ class IterableDataset(DatasetInfoMixin):
         """
         shuffling = ShuffingConfig(seed=seed)
         return iterable_dataset(
-            ex_iterable=BufferShuffledExamplesIterable(self._ex_iterable, buffer_size, seed=seed).shuffle_data_sources(seed=seed),
+            ex_iterable=BufferShuffledExamplesIterable(self._ex_iterable, buffer_size, seed=seed).shuffle_data_sources(
+                seed=seed
+            ),
             info=copy.deepcopy(self._info),
             split=self._split,
             format_type=self._format_type,
@@ -444,9 +445,7 @@ class IterableDataset(DatasetInfoMixin):
 
             n (:obj:`int`): number of elements to skip.
         """
-        ex_iterable = SkipExamplesIterable(
-            self._ex_iterable, n
-        )
+        ex_iterable = SkipExamplesIterable(self._ex_iterable, n)
         return iterable_dataset(
             ex_iterable=ex_iterable,
             info=copy.deepcopy(self._info),
@@ -463,9 +462,7 @@ class IterableDataset(DatasetInfoMixin):
 
             n (:obj:`int`): number of elements to take.
         """
-        ex_iterable = TakeExamplesIterable(
-            self._ex_iterable, n
-        )
+        ex_iterable = TakeExamplesIterable(self._ex_iterable, n)
         return iterable_dataset(
             ex_iterable=ex_iterable,
             info=copy.deepcopy(self._info),

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -48,13 +48,11 @@ def dataset(generate_examples_fn):
     return IterableDataset(ex_iterable, info=DatasetInfo(description="dummy"), split="train")
 
 
-
 ################################
 #
 #   _BaseExampleIterable tests
 #
 ################################
-
 
 
 def test_examples_iterable(generate_examples_fn):
@@ -373,6 +371,7 @@ def test_iterable_dataset_take(dataset: IterableDataset):
     assert take_dataset._ex_iterable.n == n
     assert list(take_dataset) == list(dataset)[:n]
 
+
 @pytest.mark.parametrize("method", ["skip", "take"])
 def test_iterable_dataset_shuffle_after_skip_or_take(generate_examples_fn, method):
     seed = 42
@@ -385,7 +384,6 @@ def test_iterable_dataset_shuffle_after_skip_or_take(generate_examples_fn, metho
     # shuffling a skip/take dataset should keep the same examples and don't shuffle the shards
     key = lambda x: f"{x['filepath']}_{x['id']}"  # noqa: E731
     assert sorted(dataset, key=key) == sorted(shuffled_dataset, key=key)
-
 
 
 @pytest.mark.parametrize(

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -356,16 +356,16 @@ def test_iterable_dataset_with_format(dataset: IterableDataset, format_type):
         assert isinstance(formatted_dataset, torch.utils.data.IterableDataset)
 
 
-def test_iterable_dataset_skip(dataset: IterableDataset):
-    n = 2
+@pytest.mark.parametrize("n", [0, 2, int(1e10)])
+def test_iterable_dataset_skip(dataset: IterableDataset, n):
     skip_dataset = dataset.skip(n)
     assert isinstance(skip_dataset._ex_iterable, SkipExamplesIterable)
     assert skip_dataset._ex_iterable.n == n
     assert list(skip_dataset) == list(dataset)[n:]
 
 
-def test_iterable_dataset_take(dataset: IterableDataset):
-    n = 2
+@pytest.mark.parametrize("n", [0, 2, int(1e10)])
+def test_iterable_dataset_take(dataset: IterableDataset, n):
     take_dataset = dataset.take(n)
     assert isinstance(take_dataset._ex_iterable, TakeExamplesIterable)
     assert take_dataset._ex_iterable.n == n

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -14,6 +14,8 @@ from datasets.iterable_dataset import (
     MappedExamplesIterable,
     RandomlyCyclingMultiSourcesExamplesIterable,
     ShuffingConfig,
+    SkipExamplesIterable,
+    TakeExamplesIterable,
     _batch_to_examples,
     _examples_to_batch,
     iterable_dataset,
@@ -44,6 +46,15 @@ def generate_examples_fn():
 def dataset(generate_examples_fn):
     ex_iterable = ExamplesIterable(generate_examples_fn, {})
     return IterableDataset(ex_iterable, info=DatasetInfo(description="dummy"), split="train")
+
+
+
+################################
+#
+#   _BaseExampleIterable tests
+#
+################################
+
 
 
 def test_examples_iterable(generate_examples_fn):
@@ -179,6 +190,31 @@ def test_mapped_examples_iterable(generate_examples_fn, n, func, batch_size):
         ]
     assert next(iter(ex_iterable)) == expected[0]
     assert list(ex_iterable) == expected
+
+
+def test_skip_examples_iterable(generate_examples_fn):
+    total, count = 10, 2
+    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": total})
+    skip_ex_iterable = SkipExamplesIterable(base_ex_iterable, n=count)
+    expected = list(generate_examples_fn(n=total))[count:]
+    assert list(skip_ex_iterable) == expected
+    assert skip_ex_iterable.shuffle_data_sources(42) is skip_ex_iterable, "skip examples makes the shards order fixed"
+
+
+def test_take_examples_iterable(generate_examples_fn):
+    total, count = 10, 2
+    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": total})
+    take_ex_iterable = TakeExamplesIterable(base_ex_iterable, n=count)
+    expected = list(generate_examples_fn(n=total))[:count]
+    assert list(take_ex_iterable) == expected
+    assert take_ex_iterable.shuffle_data_sources(42) is take_ex_iterable, "skip examples makes the shards order fixed"
+
+
+############################
+#
+#   IterableDataset tests
+#
+############################
 
 
 def test_iterable_dataset(generate_examples_fn):
@@ -320,6 +356,36 @@ def test_iterable_dataset_with_format(dataset: IterableDataset, format_type):
         import torch
 
         assert isinstance(formatted_dataset, torch.utils.data.IterableDataset)
+
+
+def test_iterable_dataset_skip(dataset: IterableDataset):
+    n = 2
+    skip_dataset = dataset.skip(n)
+    assert isinstance(skip_dataset._ex_iterable, SkipExamplesIterable)
+    assert skip_dataset._ex_iterable.n == n
+    assert list(skip_dataset) == list(dataset)[n:]
+
+
+def test_iterable_dataset_take(dataset: IterableDataset):
+    n = 2
+    take_dataset = dataset.take(n)
+    assert isinstance(take_dataset._ex_iterable, TakeExamplesIterable)
+    assert take_dataset._ex_iterable.n == n
+    assert list(take_dataset) == list(dataset)[:n]
+
+@pytest.mark.parametrize("method", ["skip", "take"])
+def test_iterable_dataset_shuffle_after_skip_or_take(generate_examples_fn, method):
+    seed = 42
+    n, n_shards = 3, 10
+    count = 7
+    ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n, "filepaths": [f"{i}.txt" for i in range(n_shards)]})
+    dataset = IterableDataset(ex_iterable)
+    dataset = dataset.skip(n) if method == "skip" else dataset.take(count)
+    shuffled_dataset = dataset.shuffle(DEFAULT_N_EXAMPLES, seed=seed)
+    # shuffling a skip/take dataset should keep the same examples and don't shuffle the shards
+    key = lambda x: f"{x['filepath']}_{x['id']}"  # noqa: E731
+    assert sorted(dataset, key=key) == sorted(shuffled_dataset, key=key)
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As discussed in https://github.com/huggingface/datasets/pull/2375#discussion_r657084544 I added the `IterableDataset.skip` and `IterableDataset.take` methods that allows to do basic splitting of iterable datasets.

You can create new dataset with the first `n` examples using `IterableDataset.take()`, or you can get a dataset with the rest of the examples by skipping the first `n` examples with `IterableDataset.skip()`

One implementation detail:

Using `take` (or `skip`) prevents future dataset shuffling from shuffling the dataset shards, otherwise the taken examples could come from other shards. In this case it only uses the shuffle buffer.
I would have loved to allow the shards of the taken examples to be shuffled anyway, but since we don't know in advance the length of each shard we don't know what shards to take or skip.
I think this is ok though since users can shuffle before doing take or skip. I mentioned this in the documentation

cc @vblagoje @lewtun 