### PR TITLE
Add aiohttp to tests extras require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ TESTS_REQUIRE = [
     "pytest",
     "pytest-xdist",
     # optional dependencies
+    "aiohttp",
     "apache-beam>=2.26.0",
     "elasticsearch",
     "aiobotocore==1.2.2",


### PR DESCRIPTION
Currently, none of the streaming tests are runned within our CI test suite, because the streaming tests require aiohttp and this is missing from our tests extras require dependencies.

Our CI test suite should be exhaustive and test all the library functionalities.