### PR TITLE
Fix `filter` with multiprocessing in case all samples are discarded

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1652,6 +1652,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         if fn_kwargs is None:
             fn_kwargs = {}
+            
+        if num_proc > len(self):
+            num_proc = len(self)
+            logger.warning(
+                f"num_proc must be <= {len(self)}. Reducing num_proc to {num_proc} for dataset of size {len(self)}."
+            )
 
         if num_proc is None or num_proc == 1:
             return self._map_single(
@@ -1673,12 +1679,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 desc=desc,
             )
         else:
-            if num_proc > len(self):
-                num_proc = len(self)
-                logger.warning(
-                    f"num_proc must be <= {len(self)}. Reducing num_proc to {num_proc} for dataset of size {len(self)}."
-                )
-
             def format_cache_file_name(cache_file_name, rank):
                 sep = cache_file_name.rindex(".")
                 base_name, extension = cache_file_name[:sep], cache_file_name[sep:]

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1652,7 +1652,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         if fn_kwargs is None:
             fn_kwargs = {}
-            
+
         if num_proc > len(self):
             num_proc = len(self)
             logger.warning(
@@ -1679,6 +1679,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 desc=desc,
             )
         else:
+
             def format_cache_file_name(cache_file_name, rank):
                 sep = cache_file_name.rindex(".")
                 base_name, extension = cache_file_name[:sep], cache_file_name[sep:]

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3256,7 +3256,11 @@ def concatenate_datasets(
         logger.info("Some of the datasets have disparate format. Resetting the format of the concatenated dataset.")
 
     # Concatenate tables
-    table = concat_tables([dset._data for dset in dsets if len(dset._data) > 0], axis=axis)
+    tables_to_concat = [dset._data for dset in dsets if len(dset._data) > 0]
+    # There might be no table with data left hence return first empty table
+    if not tables_to_concat:
+        return dsets[0]
+    table = concat_tables(tables_to_concat, axis=axis)
     if axis == 1:
         table = update_metadata_with_features(table, None)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1653,7 +1653,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if fn_kwargs is None:
             fn_kwargs = {}
 
-        if num_proc > len(self):
+        if num_proc is not None and num_proc > len(self):
             num_proc = len(self)
             logger.warning(
                 f"num_proc must be <= {len(self)}. Reducing num_proc to {num_proc} for dataset of size {len(self)}."


### PR DESCRIPTION
Fixes #2600 

Also I moved the check for `num_proc` larger than dataset size added in #2566 up so that multiprocessing is not used with one process.