### PR TITLE
Remove import of transformers

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -316,11 +316,8 @@ def dump(obj, file):
 @contextlib.contextmanager
 def _no_cache_fields(obj):
     try:
-        import transformers as tr
-
         if (
-            hasattr(tr, "PreTrainedTokenizerBase")
-            and isinstance(obj, tr.PreTrainedTokenizerBase)
+            "PreTrainedTokenizerBase" in [base_class.__name__ for base_class in type(obj).__mro__]
             and hasattr(obj, "cache")
             and isinstance(obj.cache, dict)
         ):


### PR DESCRIPTION
When pickling a tokenizer within multiprocessing, check that is instance of transformers PreTrainedTokenizerBase without importing transformers.

Related to huggingface/transformers#12549 and #502.