### PR TITLE
Use ndarray.item instead of ndarray.tolist

### DIFF
--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -85,5 +85,5 @@ class Accuracy(datasets.Metric):
         return {
             "accuracy": accuracy_score(
                 references, predictions, normalize=normalize, sample_weight=sample_weight
-            ).tolist(),
+            ).item(),
         }

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -106,5 +106,5 @@ class F1(datasets.Metric):
                 pos_label=pos_label,
                 average=average,
                 sample_weight=sample_weight,
-            ).tolist(),
+            ).item(),
         }

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -81,12 +81,12 @@ Examples:
 
 
 def simple_accuracy(preds, labels):
-    return (preds == labels).mean().tolist()
+    return (preds == labels).mean().item()
 
 
 def acc_and_f1(preds, labels):
     acc = simple_accuracy(preds, labels)
-    f1 = f1_score(y_true=labels, y_pred=preds).tolist()
+    f1 = f1_score(y_true=labels, y_pred=preds).item()
     return {
         "accuracy": acc,
         "f1": f1,
@@ -94,8 +94,8 @@ def acc_and_f1(preds, labels):
 
 
 def pearson_and_spearman(preds, labels):
-    pearson_corr = pearsonr(preds, labels)[0].tolist()
-    spearman_corr = spearmanr(preds, labels)[0].tolist()
+    pearson_corr = pearsonr(preds, labels)[0].item()
+    spearman_corr = spearmanr(preds, labels)[0].item()
     return {
         "pearson": pearson_corr,
         "spearmanr": spearman_corr,

--- a/metrics/indic_glue/indic_glue.py
+++ b/metrics/indic_glue/indic_glue.py
@@ -74,12 +74,12 @@ Examples:
 
 
 def simple_accuracy(preds, labels):
-    return (preds == labels).mean().tolist()
+    return (preds == labels).mean().item()
 
 
 def acc_and_f1(preds, labels):
     acc = simple_accuracy(preds, labels)
-    f1 = f1_score(y_true=labels, y_pred=preds).tolist()
+    f1 = f1_score(y_true=labels, y_pred=preds).item()
     return {
         "accuracy": acc,
         "f1": f1,
@@ -99,7 +99,7 @@ def precision_at_10(en_sentvecs, in_sentvecs):
     actual = np.array(range(n))
     preds = sim.argsort(axis=1)[:, :10]
     matches = np.any(preds == actual[:, None], axis=1)
-    return matches.mean().tolist()
+    return matches.mean().item()
 
 
 @datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)

--- a/metrics/matthews_correlation/matthews_correlation.py
+++ b/metrics/matthews_correlation/matthews_correlation.py
@@ -82,5 +82,5 @@ class MatthewsCorrelation(datasets.Metric):
 
     def _compute(self, predictions, references, sample_weight=None):
         return {
-            "matthews_correlation": matthews_corrcoef(references, predictions, sample_weight=sample_weight).tolist(),
+            "matthews_correlation": matthews_corrcoef(references, predictions, sample_weight=sample_weight).item(),
         }

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -108,5 +108,5 @@ class Precision(datasets.Metric):
                 pos_label=pos_label,
                 average=average,
                 sample_weight=sample_weight,
-            ).tolist(),
+            ).item(),
         }

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -108,5 +108,5 @@ class Recall(datasets.Metric):
                 pos_label=pos_label,
                 average=average,
                 sample_weight=sample_weight,
-            ).tolist(),
+            ).item(),
         }

--- a/metrics/super_glue/super_glue.py
+++ b/metrics/super_glue/super_glue.py
@@ -107,12 +107,12 @@ Examples:
 
 
 def simple_accuracy(preds, labels):
-    return (preds == labels).mean().tolist()
+    return (preds == labels).mean().item()
 
 
 def acc_and_f1(preds, labels, f1_avg="binary"):
     acc = simple_accuracy(preds, labels)
-    f1 = f1_score(y_true=labels, y_pred=preds, average=f1_avg).tolist()
+    f1 = f1_score(y_true=labels, y_pred=preds, average=f1_avg).item()
     return {
         "accuracy": acc,
         "f1": f1,
@@ -138,9 +138,9 @@ def evaluate_multirc(ids_preds, labels):
         f1s.append(f1)
         em = int(sum([p == l for p, l in preds_labels]) == len(preds_labels))
         ems.append(em)
-    f1_m = (sum(f1s) / len(f1s)).tolist()
+    f1_m = (sum(f1s) / len(f1s)).item()
     em = sum(ems) / len(ems)
-    f1_a = f1_score(y_true=labels, y_pred=[id_pred["prediction"] for id_pred in ids_preds]).tolist()
+    f1_a = f1_score(y_true=labels, y_pred=[id_pred["prediction"] for id_pred in ids_preds]).item()
     return {"exact_match": em, "f1_m": f1_m, "f1_a": f1_a}
 
 


### PR DESCRIPTION
This PR follows up on #2612 to use `numpy.ndarray.item` instead of `numpy.ndarray.tolist` as the latter is somewhat confusing to the developer (even though it works).

Judging from the `numpy` docs, `ndarray.item` is closer to what we want: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.item.html#numpy-ndarray-item

PS. Sorry for the duplicate work here. I should have read the numpy docs more carefully in #2612 
