### PR TITLE
Fix missing EOL issue in to_json for old versions of pandas

### DIFF
--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -103,5 +103,7 @@ class JsonDatasetWriter:
                 indices=self.dataset._indices if self.dataset._indices is not None else None,
             )
             json_str = batch.to_pandas().to_json(path_or_buf=None, orient=orient, lines=lines, **to_json_kwargs)
+            if not json_str.endswith("\n"):
+                json_str += "\n"
             written += file_obj.write(json_str.encode(encoding))
         return written


### PR DESCRIPTION
Some versions of pandas don't add an EOL at the end of the output of `to_json`.
Therefore users could end up having two samples in the same line

Close https://github.com/huggingface/datasets/issues/2615