### PR TITLE
Add speech processing tasks

### DIFF
--- a/src/datasets/utils/resources/tasks.json
+++ b/src/datasets/utils/resources/tasks.json
@@ -77,16 +77,19 @@
             "other"
         ]
     },
-    "automatic-speech-recognition": {
-        "description": "recognising speech within audio and converting it to text",
+    "speech-prcoessing": {
+        "description": "tasks related to the analysis and representations of speech signals",
         "options": [
-            "speech-recognition",
-            "visual-speech-recognition",
-            "distant-speech-recognition",
-            "robust-speech-recognition",
-            "accented-speech-recognition",
-            "noisy-speech-recognition",
-            "other"
+            "automatic-speech-recognition",
+            "phoneme-recognition",
+            "keyword-spotting",
+            "query-by-example-spoken-term-detection",
+            "speaker-identification",
+            "automatic-speaker-verification",
+            "speaker-diarization",
+            "intent-classification",
+            "slot-filling",
+            "emotion-recognition"
         ]
     },
     "other": {

--- a/src/datasets/utils/resources/tasks.json
+++ b/src/datasets/utils/resources/tasks.json
@@ -77,7 +77,7 @@
             "other"
         ]
     },
-    "speech-prcoessing": {
+    "speech-processing": {
         "description": "tasks related to the analysis and representations of speech signals",
         "options": [
             "automatic-speech-recognition",


### PR DESCRIPTION
This PR replaces the `automatic-speech-recognition` task category with a broader `speech-processing` category. 

The tasks associated with this category are derived from the [SUPERB benchmark](https://arxiv.org/abs/2105.01051), and ASR is included in this set.