### PR TITLE
Use prefix to allow exceed Windows MAX_PATH

### DIFF
--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -356,7 +356,7 @@ class WindowsFileLock(BaseFileLock):
         open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
 
         try:
-            fd = os.open(self._lock_file, open_mode)
+            fd = os.open("\\\\?\\" + self._lock_file, open_mode)
         except FileNotFoundError:
             raise
         except OSError:

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -356,7 +356,7 @@ class WindowsFileLock(BaseFileLock):
         open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
 
         try:
-            fd = os.open("\\\\?\\" + self._lock_file, open_mode)
+            fd = os.open("\\\\?\\" + self._lock_file if os.path.isabs(self._lock_file) else self._lock_file, open_mode)
         except FileNotFoundError:
             raise
         except OSError:

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -356,7 +356,7 @@ class WindowsFileLock(BaseFileLock):
         open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
 
         try:
-            fd = os.open("\\\\?\\" + self._lock_file if os.path.isabs(self._lock_file) else self._lock_file, open_mode)
+            fd = os.open("\\\\?\\" + os.path.abspath(self._lock_file), open_mode)
         except OSError:
             pass
         else:
@@ -375,7 +375,7 @@ class WindowsFileLock(BaseFileLock):
         os.close(fd)
 
         try:
-            os.remove(self._lock_file)
+            os.remove("\\\\?\\" + os.path.abspath(self._lock_file))
         # Probably another instance of the application
         # that acquired the file lock.
         except OSError:

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -352,11 +352,15 @@ class WindowsFileLock(BaseFileLock):
     windows systems.
     """
 
+    def __init__(self, lock_file, timeout=-1, max_filename_length=255):
+        super().__init__(lock_file, timeout=timeout, max_filename_length=max_filename_length)
+        self._lock_file = "\\\\?\\" + os.path.abspath(os.path.expanduser(os.path.expandvars(self._lock_file)))
+
     def _acquire(self):
         open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
 
         try:
-            fd = os.open("\\\\?\\" + os.path.abspath(self._lock_file), open_mode)
+            fd = os.open(self._lock_file, open_mode)
         except OSError:
             pass
         else:
@@ -375,7 +379,7 @@ class WindowsFileLock(BaseFileLock):
         os.close(fd)
 
         try:
-            os.remove("\\\\?\\" + os.path.abspath(self._lock_file))
+            os.remove(self._lock_file)
         # Probably another instance of the application
         # that acquired the file lock.
         except OSError:

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -357,8 +357,6 @@ class WindowsFileLock(BaseFileLock):
 
         try:
             fd = os.open("\\\\?\\" + self._lock_file if os.path.isabs(self._lock_file) else self._lock_file, open_mode)
-        except FileNotFoundError:
-            raise
         except OSError:
             pass
         else:

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -7,8 +7,8 @@ from datasets.utils.filelock import FileLock, Timeout
 
 
 def test_filelock(tmpdir):
-    lock1 = FileLock(tmpdir / "foo.lock")
-    lock2 = FileLock(tmpdir / "foo.lock")
+    lock1 = FileLock(str(tmpdir / "foo.lock"))
+    lock2 = FileLock(str(tmpdir / "foo.lock"))
     timeout = 0.01
     with lock1.acquire():
         with pytest.raises(Timeout):
@@ -19,7 +19,7 @@ def test_filelock(tmpdir):
 
 def test_long_filename(tmpdir):
     filename = "a" * 1000 + ".lock"
-    lock1 = FileLock(tmpdir / filename)
+    lock1 = FileLock(str(tmpdir / filename))
     assert lock1._lock_file.endswith(".lock")
     assert not lock1._lock_file.endswith(filename)
     assert len(os.path.basename(lock1._lock_file)) <= 255


### PR DESCRIPTION
By using this prefix, you can exceed the Windows MAX_PATH limit.

See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces

Related to #2524, #2220.