### PR TITLE
Streaming for the Pandas loader

### DIFF
--- a/src/datasets/packaged_modules/pandas/pandas.py
+++ b/src/datasets/packaged_modules/pandas/pandas.py
@@ -29,5 +29,6 @@ class Pandas(datasets.ArrowBasedBuilder):
 
     def _generate_tables(self, files):
         for i, file in enumerate(files):
-            pa_table = pa.Table.from_pandas(pd.read_pickle(file))
-            yield i, pa_table
+            with open(file, "rb") as f:
+                pa_table = pa.Table.from_pandas(pd.read_pickle(f))
+                yield i, pa_table


### PR DESCRIPTION
It was not using open in the builder. Therefore pd.read_pickle could fail when streaming from a private repo for example.

Indeed, when streaming, open is extended to support reading from remote files and handles authentication to the HF Hub