### PR TITLE
Change `from_csv` default arguments

### DIFF
--- a/docs/source/loading_datasets.rst
+++ b/docs/source/loading_datasets.rst
@@ -189,7 +189,7 @@ CSV files
 
 🤗 Datasets can read a dataset made of on or several CSV files.
 
-All the CSV files in the dataset should have the same organization and in particular the same datatypes for the columns.
+All the CSV files in the dataset should have the same structure and in particular the same datatypes for the columns.
 
 A few interesting features are provided out-of-the-box by the Apache Arrow backend:
 
@@ -210,7 +210,7 @@ The ``csv`` loading script provides a few simple access options to control parsi
 
     - :obj:`skiprows` (int) - Number of first rows in the file to skip (default is 0)
     - :obj:`column_names` (list, optional) – The column names of the target table. If empty, fall back on autogenerate_column_names (default: empty).
-    - :obj:`delimiter` (1-character string) – The character delimiting individual cells in the CSV data (default ``','``).
+    - :obj:`delimiter` (1-character string) – The character delimiting individual cells in the CSV data (default ``','``). You can also pass ``None`` to auto-detect the delimiter, but it can hurt the performance.
     - :obj:`quotechar` (1-character string) – The character used optionally for quoting CSV values (default '"').
     - :obj:`quoting` (bool) – Control quoting behavior (default 0, setting this to 3 disables quoting, refer to pandas.read_csv documentation for more details).
 

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -16,17 +16,16 @@ _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 
 # Sentinel object to allow usersd to specify None parameters
 _default = object()
-_sep_default = ","
-_header_default = "infer"
+
 
 
 @dataclass
 class CsvConfig(datasets.BuilderConfig):
     """BuilderConfig for CSV."""
 
-    sep: Union[str, None, object] = _default
+    sep: Union[str, None, object] = _default  # ","
     delimiter: Union[str, None, object] = _default
-    header: Union[int, List[int], str, object] = _default
+    header: Union[int, List[int], str, object] = _default  # "infer"
     names: Optional[List[str]] = None
     column_names: Optional[List[str]] = None
     index_col: Optional[Union[int, str, List[int], List[str]]] = None
@@ -69,9 +68,9 @@ class CsvConfig(datasets.BuilderConfig):
             self.names = self.column_names
 
         if self.sep is _default:
-            self.sep = _sep_default
+            self.sep = ","
         if self.header is _default:
-            self.header = _header_default
+            self.header = "infer"
 
     @property
     def read_csv_kwargs(self):

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -16,15 +16,16 @@ _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 
 # Sentinel object to allow usersd to specify None parameters
 _default = object()
-
+_sep_default = ","
+_header_default = "infer"
 
 @dataclass
 class CsvConfig(datasets.BuilderConfig):
     """BuilderConfig for CSV."""
 
-    sep: Union[str, None, object] = _default  # ","
+    sep: Union[str, None, object] = _default
     delimiter: Union[str, None, object] = _default
-    header: Union[int, List[int], str, object] = _default  # "infer"
+    header: Union[int, List[int], str, object] = _default
     names: Optional[List[str]] = None
     column_names: Optional[List[str]] = None
     index_col: Optional[Union[int, str, List[int], List[str]]] = None
@@ -67,9 +68,9 @@ class CsvConfig(datasets.BuilderConfig):
             self.names = self.column_names
 
         if self.sep is _default:
-            self.sep = ","
+            self.sep = _sep_default
         if self.header is _default:
-            self.header = "infer"
+            self.header = _header_default
 
     @property
     def read_csv_kwargs(self):

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Type
 
 import pandas as pd
 import pyarrow as pa
@@ -14,14 +14,17 @@ logger = datasets.utils.logging.get_logger(__name__)
 _PANDAS_READ_CSV_NO_DEFAULT_PARAMETERS = ["names", "prefix"]
 _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 
+# Sentinel object to allow usersd to specify None parameters
+_default = object()
+
 
 @dataclass
 class CsvConfig(datasets.BuilderConfig):
     """BuilderConfig for CSV."""
 
-    sep: Optional[str] = None
-    delimiter: Optional[str] = None
-    header: Optional[Union[int, List[int], str]] = "infer"
+    sep: Union[str, None, object] = _default  # ","
+    delimiter: Union[str, None, object] = _default
+    header: Union[int, List[int], str, object] = _default  # "infer"
     names: Optional[List[str]] = None
     column_names: Optional[List[str]] = None
     index_col: Optional[Union[int, str, List[int], List[str]]] = None
@@ -58,10 +61,15 @@ class CsvConfig(datasets.BuilderConfig):
     features: Optional[datasets.Features] = None
 
     def __post_init__(self):
-        if self.delimiter is not None:
+        if self.delimiter is not _default:
             self.sep = self.delimiter
         if self.column_names is not None:
             self.names = self.column_names
+
+        if self.sep is _default:
+            self.sep = ","
+        if self.header is _default:
+            self.header = "infer"
 
     @property
     def read_csv_kwargs(self):

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 from dataclasses import dataclass
-from typing import List, Optional, Union, Type
+from typing import List, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -18,6 +18,7 @@ _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 _default = object()
 _sep_default = ","
 _header_default = "infer"
+
 
 @dataclass
 class CsvConfig(datasets.BuilderConfig):

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -18,7 +18,6 @@ _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 _default = object()
 
 
-
 @dataclass
 class CsvConfig(datasets.BuilderConfig):
     """BuilderConfig for CSV."""

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -19,7 +19,7 @@ _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 class CsvConfig(datasets.BuilderConfig):
     """BuilderConfig for CSV."""
 
-    sep: str = ","
+    sep: Optional[str] = None
     delimiter: Optional[str] = None
     header: Optional[Union[int, List[int], str]] = "infer"
     names: Optional[List[str]] = None


### PR DESCRIPTION
Passing `sep=None` to pandas's `read_csv` lets pandas guess the CSV file's separator

This PR allows users to use this pandas's feature by passing `sep=None` to `Dataset.from_csv`:

```python
Dataset.from_csv(
    ...,
    sep=None
)
```