### PR TITLE
Allow dataset config kwargs to be None

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -245,7 +245,6 @@ class DatasetBuilder:
         self.use_auth_token = use_auth_token
 
         # Prepare config: DatasetConfig contains name, version and description but can be extended by each dataset
-        config_kwargs = {key: value for key, value in config_kwargs.items() if value is not None}
         if "features" in inspect.signature(self.BUILDER_CONFIG_CLASS.__init__).parameters and features is not None:
             config_kwargs["features"] = features
         self.config, self.config_id = self._create_builder_config(


### PR DESCRIPTION
Close https://github.com/huggingface/datasets/issues/2658

The dataset config kwargs that were set to None we simply ignored.
This was an issue when None has some meaning for certain parameters of certain builders, like the `sep` parameter of the "csv" builder that allows to infer to separator.

cc @SBrandeis 