### PR TITLE
Use tqdm from tqdm_utils

### DIFF
--- a/datasets/ncslgr/ncslgr.py
+++ b/datasets/ncslgr/ncslgr.py
@@ -19,8 +19,6 @@ import os
 import re
 from dataclasses import dataclass
 
-from tqdm import tqdm
-
 import datasets
 
 
@@ -128,7 +126,7 @@ class NCSLGR(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, eaf_path: str, videos_path: str):
         """Yields examples."""
 
-        for i, eaf_file in enumerate(tqdm(os.listdir(eaf_path))):
+        for i, eaf_file in enumerate(os.listdir(eaf_path)):
             eaf_file_path = os.path.join(eaf_path, eaf_file)
             videos = []
             with open(eaf_file_path, "r", encoding="utf-8") as f:

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -74,7 +74,6 @@ from .splits import (
     percent,
 )
 from .utils import *
-from .utils.tqdm_utils import disable_progress_bar
 
 
 SCRIPTS_VERSION = "master" if __version__.split(".")[-1].startswith("dev") else __version__

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -21,9 +21,8 @@ from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pyarrow as pa
-from tqdm.auto import tqdm
 
-from . import config
+from . import config, utils
 from .features import Features, _ArrayXDExtensionType
 from .info import DatasetInfo
 from .keyhash import DuplicatedKeysError, KeyHasher
@@ -538,9 +537,9 @@ def parquet_to_arrow(sources, destination):
     stream = None if isinstance(destination, str) else destination
     disable = bool(logging.get_verbosity() == logging.NOTSET)
     with ArrowWriter(path=destination, stream=stream) as writer:
-        for source in tqdm(sources, unit="sources", disable=disable):
+        for source in utils.tqdm(sources, unit="sources", disable=disable):
             pf = pa.parquet.ParquetFile(source)
-            for i in tqdm(range(pf.num_row_groups), unit="row_groups", leave=False, disable=disable):
+            for i in utils.tqdm(range(pf.num_row_groups), unit="row_groups", leave=False, disable=disable):
                 df = pf.read_row_group(i).to_pandas()
                 for col in df.columns:
                     df[col] = df[col].apply(json.loads)

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -1,5 +1,4 @@
 import os
-from logging import disable
 from typing import BinaryIO, Optional, Union
 
 from .. import Dataset, Features, NamedSplit, config, utils

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -1,10 +1,11 @@
 import os
+from logging import disable
 from typing import BinaryIO, Optional, Union
 
-from .. import Dataset, Features, NamedSplit, config
+from .. import Dataset, Features, NamedSplit, config, utils
 from ..formatting import query_table
 from ..packaged_modules.json.json import Json
-from ..utils.tqdm_utils import tqdm
+from ..utils import logging
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
 
@@ -96,7 +97,9 @@ class JsonDatasetWriter:
         written = 0
         _ = to_json_kwargs.pop("path_or_buf", None)
 
-        for offset in tqdm(range(0, len(self.dataset), batch_size)):
+        for offset in utils.tqdm(
+            range(0, len(self.dataset), batch_size), unit="ba", disable=bool(logging.get_verbosity() == logging.NOTSET)
+        ):
             batch = query_table(
                 table=self.dataset.data,
                 key=slice(offset, offset + batch_size),

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -5,8 +5,8 @@ from pathlib import PurePath
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Union
 
 import numpy as np
-from tqdm.auto import tqdm
 
+from . import utils
 from .utils import logging
 
 
@@ -141,7 +141,9 @@ class ElasticSearchIndex(BaseIndex):
         index_config = self.es_index_config
         self.es_client.indices.create(index=index_name, body=index_config)
         number_of_docs = len(documents)
-        progress = tqdm(unit="docs", total=number_of_docs, disable=bool(logging.get_verbosity() == logging.NOTSET))
+        progress = utils.tqdm(
+            unit="docs", total=number_of_docs, disable=bool(logging.get_verbosity() == logging.NOTSET)
+        )
         successes = 0
 
         def passage_generator():
@@ -287,7 +289,9 @@ class FaissIndex(BaseIndex):
 
         # Add vectors
         logger.info("Adding {} vectors to the faiss index".format(len(vectors)))
-        for i in tqdm(range(0, len(vectors), batch_size), disable=bool(logging.get_verbosity() == logging.NOTSET)):
+        for i in utils.tqdm(
+            range(0, len(vectors), batch_size), disable=bool(logging.get_verbosity() == logging.NOTSET)
+        ):
             vecs = vectors[i : i + batch_size] if column is None else vectors[i : i + batch_size][column]
             self.faiss_index.add(vecs)
 

--- a/src/datasets/utils/__init__.py
+++ b/src/datasets/utils/__init__.py
@@ -35,5 +35,5 @@ from .py_utils import (
     zip_dict,
     zip_nested,
 )
-from .tqdm_utils import async_tqdm, tqdm
+from .tqdm_utils import async_tqdm, disable_progress_bar, is_progress_bar_enabled, tqdm
 from .version import Version

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -24,9 +24,8 @@ from urllib.parse import urlparse
 import numpy as np
 import posixpath
 import requests
-from tqdm.auto import tqdm
 
-from .. import __version__, config
+from .. import __version__, config, utils
 from . import logging
 from .extract import ExtractManager
 from .filelock import FileLock
@@ -431,7 +430,7 @@ def http_get(url, temp_file, proxies=None, resume_size=0, headers=None, cookies=
         return
     content_length = response.headers.get("Content-Length")
     total = resume_size + int(content_length) if content_length is not None else None
-    progress = tqdm(
+    progress = utils.tqdm(
         unit="B",
         unit_scale=True,
         total=total,

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -195,7 +195,7 @@ def map_nested(
     if not isinstance(data_struct, dict) and not isinstance(data_struct, types):
         return function(data_struct)
 
-    disable_tqdm = bool(logging.get_verbosity() == logging.NOTSET)
+    disable_tqdm = bool(logger.getEffectiveLevel() > logging.INFO)
     iterable = list(data_struct.values()) if isinstance(data_struct, dict) else data_struct
 
     if num_proc is None:

--- a/src/datasets/utils/tqdm_utils.py
+++ b/src/datasets/utils/tqdm_utils.py
@@ -19,7 +19,7 @@
 
 import contextlib
 
-from tqdm import auto as tqdm_lib
+from tqdm import autonotebook as tqdm_lib
 
 
 class EmptyTqdm:
@@ -63,8 +63,13 @@ def async_tqdm(*args, **kwargs):
         return EmptyTqdm(*args, **kwargs)
 
 
+def is_progress_bar_enabled():
+    global _active
+    return bool(_active)
+
+
 def disable_progress_bar():
-    """Disabled Tqdm progress bar.
+    """Disable tqdm progress bar.
 
     Usage:
 
@@ -103,7 +108,7 @@ def _async_tqdm(*args, **kwargs):
 
 
 class _TqdmPbarAsync:
-    """Wrapper around Tqdm pbar which be shared between thread."""
+    """Wrapper around Tqdm pbar which can be shared between thread."""
 
     _tqdm_bars = []
 

--- a/src/datasets/utils/tqdm_utils.py
+++ b/src/datasets/utils/tqdm_utils.py
@@ -19,7 +19,7 @@
 
 import contextlib
 
-from tqdm import autonotebook as tqdm_lib
+from tqdm import auto as tqdm_lib
 
 
 class EmptyTqdm:


### PR DESCRIPTION
This PR replaces `tqdm` from the `tqdm` lib with `tqdm` from `datasets.utils.tqdm_utils`. With this change, it's possible to disable progress bars just by calling `disable_progress_bar`. Note this doesn't work on Windows when using multiprocessing due to how global variables are shared between processes. Currently, there is no easy way to disable progress bars in a multiprocess setting on Windows (patching logging with `datasets.utils.logging.get_verbosity = lambda: datasets.utils.logging.NOTSET` doesn't seem to work as well), so adding support for this is a future goal. Additionally, this PR adds a unit ("ba" for batches) to the bar printed by `Dataset.to_json` (this change is motivated by https://github.com/huggingface/datasets/issues/2657).