### PR TITLE
Fix potential DuplicatedKeysError in LibriSpeech

### DIFF
--- a/datasets/librispeech_asr/librispeech_asr.py
+++ b/datasets/librispeech_asr/librispeech_asr.py
@@ -137,19 +137,20 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, archive_path):
         """Generate examples from a Librispeech archive_path."""
         transcripts_glob = os.path.join(archive_path, "LibriSpeech", "*/*/*/*.txt")
+        key = 0
         for transcript_path in sorted(glob.glob(transcripts_glob)):
             transcript_dir_path = os.path.dirname(transcript_path)
             with open(transcript_path, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
-                    key, transcript = line.split(" ", 1)
-                    audio_file = f"{key}.flac"
-                    speaker_id, chapter_id = [int(el) for el in key.split("-")[:2]]
-                    example = {
-                        "id": key,
+                    id_, transcript = line.split(" ", 1)
+                    audio_file = f"{id_}.flac"
+                    speaker_id, chapter_id = [int(el) for el in id_.split("-")[:2]]
+                    yield key, {
+                        "id": id_,
                         "speaker_id": speaker_id,
                         "chapter_id": chapter_id,
                         "file": os.path.join(transcript_dir_path, audio_file),
                         "text": transcript,
                     }
-                    yield key, example
+                    key += 1

--- a/datasets/librispeech_asr/librispeech_asr.py
+++ b/datasets/librispeech_asr/librispeech_asr.py
@@ -137,9 +137,9 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, archive_path):
         """Generate examples from a Librispeech archive_path."""
         transcripts_glob = os.path.join(archive_path, "LibriSpeech", "*/*/*/*.txt")
-        for transcript_file in sorted(glob.glob(transcripts_glob)):
-            path = os.path.dirname(transcript_file)
-            with open(transcript_file, "r", encoding="utf-8") as f:
+        for transcript_path in sorted(glob.glob(transcripts_glob)):
+            path = os.path.dirname(transcript_path)
+            with open(transcript_path, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     key, transcript = line.split(" ", 1)

--- a/datasets/librispeech_asr/librispeech_asr.py
+++ b/datasets/librispeech_asr/librispeech_asr.py
@@ -138,7 +138,7 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
         """Generate examples from a Librispeech archive_path."""
         transcripts_glob = os.path.join(archive_path, "LibriSpeech", "*/*/*/*.txt")
         for transcript_path in sorted(glob.glob(transcripts_glob)):
-            path = os.path.dirname(transcript_path)
+            transcript_dir_path = os.path.dirname(transcript_path)
             with open(transcript_path, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
@@ -149,7 +149,7 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
                         "id": key,
                         "speaker_id": speaker_id,
                         "chapter_id": chapter_id,
-                        "file": os.path.join(path, audio_file),
+                        "file": os.path.join(transcript_dir_path, audio_file),
                         "text": transcript,
                     }
                     yield key, example

--- a/datasets/librispeech_asr/librispeech_asr.py
+++ b/datasets/librispeech_asr/librispeech_asr.py
@@ -135,7 +135,7 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
         ]
 
     def _generate_examples(self, archive_path):
-        """Generate examples from a Librispeech archive_path."""
+        """Generate examples from a LibriSpeech archive_path."""
         transcripts_glob = os.path.join(archive_path, "LibriSpeech", "*/*/*/*.txt")
         key = 0
         for transcript_path in sorted(glob.glob(transcripts_glob)):

--- a/datasets/librispeech_asr/librispeech_asr.py
+++ b/datasets/librispeech_asr/librispeech_asr.py
@@ -139,7 +139,7 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
         transcripts_glob = os.path.join(archive_path, "LibriSpeech", "*/*/*/*.txt")
         for transcript_file in sorted(glob.glob(transcripts_glob)):
             path = os.path.dirname(transcript_file)
-            with open(os.path.join(path, transcript_file), "r", encoding="utf-8") as f:
+            with open(transcript_file, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     key, transcript = line.split(" ", 1)

--- a/datasets/superb/superb.py
+++ b/datasets/superb/superb.py
@@ -173,19 +173,20 @@ class Superb(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, archive_path):
         """Generate examples."""
         transcripts_glob = os.path.join(archive_path, "LibriSpeech", "*/*/*/*.txt")
-        for transcript_file in sorted(glob.glob(transcripts_glob)):
-            path = os.path.dirname(transcript_file)
-            with open(os.path.join(path, transcript_file), "r", encoding="utf-8") as f:
+        key = 0
+        for transcript_path in sorted(glob.glob(transcripts_glob)):
+            transcript_dir_path = os.path.dirname(transcript_path)
+            with open(transcript_path, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
-                    key, transcript = line.split(" ", 1)
-                    audio_file = f"{key}.flac"
-                    speaker_id, chapter_id = [int(el) for el in key.split("-")[:2]]
-                    example = {
-                        "id": key,
+                    id_, transcript = line.split(" ", 1)
+                    audio_file = f"{id_}.flac"
+                    speaker_id, chapter_id = [int(el) for el in id_.split("-")[:2]]
+                    yield key, {
+                        "id": id_,
                         "speaker_id": speaker_id,
                         "chapter_id": chapter_id,
-                        "file": os.path.join(path, audio_file),
+                        "file": os.path.join(transcript_dir_path, audio_file),
                         "text": transcript,
                     }
-                    yield key, example
+                    key += 1


### PR DESCRIPTION
DONE:
- Fix unnecessary path join.
- Fix potential DiplicatedKeysError by ensuring keys are unique.

We should promote as a good practice, that the keys should be programmatically generated as unique, instead of read from data (which might be not unique).