### PR TITLE
Fix potential DuplicatedKeysError in SQuAD

### DIFF
--- a/datasets/squad/squad.py
+++ b/datasets/squad/squad.py
@@ -117,6 +117,7 @@ class Squad(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath):
         """This function returns the examples in the raw (text) form."""
         logger.info("generating examples from = %s", filepath)
+        key = 0
         with open(filepath, encoding="utf-8") as f:
             squad = json.load(f)
             for article in squad["data"]:
@@ -124,21 +125,18 @@ class Squad(datasets.GeneratorBasedBuilder):
                 for paragraph in article["paragraphs"]:
                     context = paragraph["context"]  # do not strip leading blank spaces GH-2585
                     for qa in paragraph["qas"]:
-                        question = qa["question"]
-                        id_ = qa["id"]
-
                         answer_starts = [answer["answer_start"] for answer in qa["answers"]]
                         answers = [answer["text"] for answer in qa["answers"]]
-
                         # Features currently used are "context", "question", and "answers".
                         # Others are extracted here for the ease of future expansions.
-                        yield id_, {
+                        yield key, {
                             "title": title,
                             "context": context,
-                            "question": question,
-                            "id": id_,
+                            "question": qa["question"],
+                            "id": qa["id"],
                             "answers": {
                                 "answer_start": answer_starts,
                                 "text": answers,
                             },
                         }
+                        key += 1


### PR DESCRIPTION
DONE:
- Fix potential DiplicatedKeysError by ensuring keys are unique.
- Align examples in the docs with SQuAD code.

We should promote as a good practice, that the keys should be programmatically generated as unique, instead of read from data (which might be not unique).