### PR TITLE
Increase json reader block_size automatically

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -116,7 +116,7 @@ class Json(datasets.ArrowBasedBuilder):
                                     )
                                     break
                                 except pa.ArrowInvalid as e:
-                                    if "straddling" in str(e) and block_size > len(batch):
+                                    if "straddling" not in str(e) or block_size > len(batch):
                                         raise
                                     else:
                                         # Increase the block size in case it was too small.

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -100,14 +100,32 @@ class Json(datasets.ArrowBasedBuilder):
             else:
                 with open(file, "rb") as f:
                     batch_idx = 0
+                    # Use block_size equal to the chunk size divided by 32 to leverage multithreading
+                    # Set a default minimum value of 16kB if the chunk size is really small
+                    block_size = max(self.config.chunksize // 32, 16 << 10)
                     while True:
                         batch = f.read(self.config.chunksize)
                         if not batch:
                             break
                         batch += f.readline()  # finish current line
                         try:
-                            pa_table = paj.read_json(BytesIO(batch))
-                        except json.JSONDecodeError as e:
+                            while True:
+                                try:
+                                    pa_table = paj.read_json(
+                                        BytesIO(batch), read_options=paj.ReadOptions(block_size=block_size)
+                                    )
+                                    break
+                                except pa.ArrowInvalid as e:
+                                    if "straddling" in str(e) and block_size > len(batch):
+                                        raise
+                                    else:
+                                        # Increase the block size in case it was too small.
+                                        # The block size will be reset for the next file.
+                                        logger.debug(
+                                            f"Batch of {len(batch)} bytes couldn't be parsed with block_size={block_size}. Retrying with block_size={block_size * 2}."
+                                        )
+                                        block_size *= 2
+                        except pa.ArrowInvalid as e:
                             logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")
                             try:
                                 with open(file, encoding="utf-8") as f:


### PR DESCRIPTION
Currently some files can't be read with the default parameters of the JSON lines reader.
For example this one:
https://huggingface.co/datasets/thomwolf/codeparrot/resolve/main/file-000000000006.json.gz

raises a pyarrow error:
```python
ArrowInvalid: straddling object straddles two block boundaries (try to increase block size?)
```

The block size that is used is the default one by pyarrow (related to this [jira issue](https://issues.apache.org/jira/browse/ARROW-9612)).

To fix this issue I changed the block_size to increase automatically if there is a straddling issue when parsing a batch of json lines.

By default the value is `chunksize // 32` in order to leverage multithreading, and it doubles every time a straddling issue occurs. The block_size is then reset for each file.

cc @thomwolf @albertvillanova 