### PR TITLE
Fix bad config ids that name cache directories

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -123,6 +123,8 @@ class BuilderConfig:
         # it was previously ignored before the introduction of config id because we didn't want
         # to change the config name. Now it's fine to take it into account for the config id.
         # config_kwargs_to_add_to_suffix.pop("data_dir", None)
+        if "data_dir" in config_kwargs_to_add_to_suffix and config_kwargs_to_add_to_suffix["data_dir"] is None:
+            del config_kwargs_to_add_to_suffix["data_dir"]
         if config_kwargs_to_add_to_suffix:
             # we don't care about the order of the kwargs
             config_kwargs_to_add_to_suffix = {

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import types
+from pathlib import Path
 from unittest import TestCase
 
 import numpy as np
@@ -517,6 +518,12 @@ class BuilderTest(TestCase):
                     os.path.join(tmp_dir, "dummy_generator_based_builder", "dummy", "0.0.0", "dataset_info.json")
                 )
             )
+
+    def test_cache_dir_no_args(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_dir=None, data_files=None)
+            relative_cache_dir_parts = Path(dummy_builder._relative_data_dir()).parts
+            self.assertEqual(relative_cache_dir_parts, ("dummy_generator_based_builder", "dummy", "0.0.0"))
 
     def test_cache_dir_for_data_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
`data_dir=None` was considered a dataset config parameter, hence creating a special config_id for all dataset being loaded.
Since the config_id is used to name the cache directories, this leaded to datasets being regenerated for users.

I fixed this by ignoring the value of `data_dir` when it's `None` when computing the config_id.
I also added a test to make sure the cache directories are not unexpectedly renamed in the future.

Fix https://github.com/huggingface/datasets/issues/2683