### PR TITLE
Minor documentation fix

### DIFF
--- a/docs/source/add_dataset.rst
+++ b/docs/source/add_dataset.rst
@@ -355,4 +355,4 @@ Here is a list of datasets of reference. Feel free to reuse parts of their code 
 - summarization: `billsum <https://github.com/huggingface/datasets/blob/master/datasets/billsum/billsum.py>`__ (original data are in json files)
 - benchmark: `glue <https://github.com/huggingface/datasets/blob/master/datasets/glue/glue.py>`__ (original data are various formats)
 - multilingual: `xquad <https://github.com/huggingface/datasets/blob/master/datasets/xquad/xquad.py>`__ (original data are in json)
-- multitask: `matinf <https://github.com/huggingface/datasets/blob/master/datasets/xquad/xquad.py>`__ (original data need to be downloaded by the user because it requires authentificaition)
+- multitask: `matinf <https://github.com/huggingface/datasets/blob/master/datasets/matinf/matinf.py>`__ (original data need to be downloaded by the user because it requires authentificaition)


### PR DESCRIPTION
Currently, [Writing a dataset loading script](https://huggingface.co/docs/datasets/add_dataset.html) page has a small error. A link to `matinf` dataset in [_Dataset scripts of reference_](https://huggingface.co/docs/datasets/add_dataset.html#dataset-scripts-of-reference) section actually leads to `xsquad`, instead. This PR fixes that. 