### PR TITLE
fix: 🐛 change string format to allow copy/paste to work in bash

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -898,7 +898,7 @@ class DatasetBuilder:
         if not config.AIOHTTP_AVAILABLE:
             raise ImportError(
                 f"To be able to use dataset streaming, you need to install dependencies like aiohttp "
-                f"using 'pip install datasets[streaming]' or 'pip install aiohttp' for instance"
+                f"using \"pip install 'datasets[streaming]'\" or \"pip install aiohttp\" for instance"
             )
 
         from .utils.streaming_download_manager import StreamingDownloadManager

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -898,7 +898,7 @@ class DatasetBuilder:
         if not config.AIOHTTP_AVAILABLE:
             raise ImportError(
                 f"To be able to use dataset streaming, you need to install dependencies like aiohttp "
-                f"using \"pip install 'datasets[streaming]'\" or \"pip install aiohttp\" for instance"
+                f'using "pip install \'datasets[streaming]\'" or "pip install aiohttp" for instance'
             )
 
         from .utils.streaming_download_manager import StreamingDownloadManager

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -806,7 +806,7 @@ def load_dataset(
         if not config.AIOHTTP_AVAILABLE:
             raise ImportError(
                 f"To be able to use dataset streaming, you need to install dependencies like aiohttp "
-                f"using \"pip install 'datasets[streaming]'\" or \"pip install aiohttp\" for instance"
+                f'using "pip install \'datasets[streaming]\'" or "pip install aiohttp" for instance'
             )
     # Download/copy dataset processing script
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -806,7 +806,7 @@ def load_dataset(
         if not config.AIOHTTP_AVAILABLE:
             raise ImportError(
                 f"To be able to use dataset streaming, you need to install dependencies like aiohttp "
-                f"using 'pip install datasets[streaming]' or 'pip install aiohttp' for instance"
+                f"using \"pip install 'datasets[streaming]'\" or \"pip install aiohttp\" for instance"
             )
     # Download/copy dataset processing script
 


### PR DESCRIPTION
Before: copy/paste resulted in an error because the square bracket
characters `[]` are special characters in bash