### PR TITLE
Add support for disable_progress_bar on Windows

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1659,6 +1659,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 f"num_proc must be <= {len(self)}. Reducing num_proc to {num_proc} for dataset of size {len(self)}."
             )
 
+        disable_tqdm = bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled()
+
         if num_proc is None or num_proc == 1:
             return self._map_single(
                 function=function,
@@ -1676,6 +1678,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 disable_nullable=disable_nullable,
                 fn_kwargs=fn_kwargs,
                 new_fingerprint=new_fingerprint,
+                disable_tqdm=disable_tqdm,
                 desc=desc,
             )
         else:
@@ -1702,7 +1705,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 logger.warning("Setting TOKENIZERS_PARALLELISM=false for forked processes.")
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
             initargs, initializer = None, None
-            if utils.is_progress_bar_enabled():
+            if not disable_tqdm:
                 initargs, initializer = (RLock(),), tqdm.set_lock
             with Pool(num_proc, initargs=initargs, initializer=initializer) as pool:
                 os.environ = prev_env
@@ -1731,6 +1734,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                         fn_kwargs=fn_kwargs,
                         rank=rank,
                         offset=sum(len(s) for s in shards[:rank]),
+                        disable_tqdm=disable_tqdm,
                         desc=desc,
                     )
                     for rank in range(num_proc)
@@ -1765,6 +1769,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         new_fingerprint: Optional[str] = None,
         rank: Optional[int] = None,
         offset: int = 0,
+        disable_tqdm: bool = False,
         desc: Optional[str] = None,
     ) -> "Dataset":
         """Apply a function to all the elements in the table (individually or in batches)
@@ -1803,7 +1808,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             new_fingerprint (`Optional[str]`, defaults to `None`): the new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
             rank: (`Optional[int]`, defaults to `None`): If specified, this is the process rank when doing multiprocessing
-            offset: (:obj:`int`, defaults to 0): If specified, this is an offset applied to the indices passed to `function` if `with_indices=True`
+            offset: (:obj:`int`, defaults to 0): If specified, this is an offset applied to the indices passed to `function` if `with_indices=True`.
+            disable_tqdm (:obj:`bool`, defaults to `False`): Whether to silence tqdm's output.
             desc (`Optional[str]`, defaults to `None`): Meaningful description to be displayed alongside with the progress bar while mapping examples.
         """
         assert (
@@ -1815,7 +1821,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             logging.set_verbosity_warning()
         # Print at least one thing to fix tqdm in notebooks in multiprocessing
         # see https://github.com/tqdm/tqdm/issues/485#issuecomment-473338308
-        if rank is not None and utils.is_progress_bar_enabled() and "notebook" in tqdm.__name__:
+        if rank is not None and not disable_tqdm and "notebook" in tqdm.__name__:
             print(" ", end="", flush=True)
 
         # Select the columns (arrow columns) to process
@@ -1981,7 +1987,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 pbar_desc = (desc or "") + " #" + str(rank) if rank is not None else desc
                 pbar = utils.tqdm(
                     pbar_iterable,
-                    disable=bool(logging.get_verbosity() == logging.NOTSET),
+                    disable=disable_tqdm,
                     position=rank,
                     unit=pbar_unit,
                     desc=pbar_desc,


### PR DESCRIPTION
This PR is a continuation of #2667 and adds support for `utils.disable_progress_bar()` on Windows when using multiprocessing. This [answer](https://stackoverflow.com/a/6596695/14095927) on SO explains it nicely why the current approach (with calling `utils.is_progress_bar_enabled()` inside `Dataset._map_single`) would not work on Windows.