### PR TITLE
Ignore empty batch when writing

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -372,10 +372,14 @@ class ArrowWriter:
         writer_batch_size: Optional[int] = None,
     ):
         """Write a batch of Example to file.
+        Ignores the batch if it appears to be empty,
+        preventing a potential schema update of unknown types.
 
         Args:
             example: the Example to add.
         """
+        if len(next(iter(batch_examples.values()))) == 0:
+            return
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None
         typed_sequence_examples = {}

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -376,9 +376,9 @@ class ArrowWriter:
         preventing a potential schema update of unknown types.
 
         Args:
-            example: the Example to add.
+            batch_examples: the batch of examples to add.
         """
-        if len(next(iter(batch_examples.values()))) == 0:
+        if batch_examples and len(next(iter(batch_examples.values()))) == 0:
             return
         schema = None if self.pa_writer is None and self.update_features else self._schema
         try_schema = self._schema if self.pa_writer is None and self.update_features else None


### PR DESCRIPTION
This prevents an schema update with unknown column types, as reported in #2644.

This is my first attempt at fixing the issue. I tested the following:
- First batch returned by a batched map operation is empty.
- An intermediate batch is empty.
- `python -m unittest tests.test_arrow_writer` passes.

However, `arrow_writer` looks like a pretty generic interface, I'm not sure if there are other uses I may have overlooked. Let me know if that's the case, or if a better approach would be preferable.