### PR TITLE
Fix pick default config name message

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -253,6 +253,11 @@ class DatasetBuilder:
         # Prepare config: DatasetConfig contains name, version and description but can be extended by each dataset
         if "features" in inspect.signature(self.BUILDER_CONFIG_CLASS.__init__).parameters and features is not None:
             config_kwargs["features"] = features
+        # Discard default config parameters
+        if "data_files" in config_kwargs and config_kwargs["data_files"] is None:
+            del config_kwargs["data_files"]
+        if "data_dir" in config_kwargs and config_kwargs["data_dir"] is None:
+            del config_kwargs["data_dir"]
         self.config, self.config_id = self._create_builder_config(
             name,
             custom_features=features,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -643,6 +643,11 @@ class BuilderTest(TestCase):
 
     def test_config_names(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
+
+            with self.assertRaises(ValueError) as error_context:
+                DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, data_files=None, data_dir=None)
+            self.assertIn("Please pick one among the available configs", str(error_context.exception))
+
             dummy_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a")
             self.assertEqual(dummy_builder.config.name, "a")
 


### PR DESCRIPTION
The error message to tell which config name to load is not displayed. 

This is because in the code it was considering the config kwargs to be non-empty, which is a special case for custom configs created on the fly. It appears after this change: https://github.com/huggingface/datasets/pull/2659

I fixed that by making the config kwargs empty by default, even if default parameters are passed

Fix https://github.com/huggingface/datasets/issues/2703