### PR TITLE
Fix shuffle on IterableDataset that disables batching in case any functions were mapped

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -194,7 +194,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
     def shuffle_data_sources(self, seed: Optional[int]) -> "MappedExamplesIterable":
         """Shuffle the wrapped examples iterable."""
         return MappedExamplesIterable(
-            self.ex_iterable.shuffle_data_sources(seed), function=self.function, batched=self.batched, batch_size=self.batch_size
+            self.ex_iterable.shuffle_data_sources(seed),
+            function=self.function,
+            batched=self.batched,
+            batch_size=self.batch_size,
         )
 
     @property

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -194,7 +194,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
     def shuffle_data_sources(self, seed: Optional[int]) -> "MappedExamplesIterable":
         """Shuffle the wrapped examples iterable."""
         return MappedExamplesIterable(
-            self.ex_iterable.shuffle_data_sources(seed), function=self.function, batch_size=self.batch_size
+            self.ex_iterable.shuffle_data_sources(seed), function=self.function, batched=self.batched, batch_size=self.batch_size
         )
 
     @property


### PR DESCRIPTION
Made a very minor change to fix the issue#2716. Added the missing argument in the constructor call.

As discussed in the bug report, the change is made to prevent the `shuffle` method call from resetting the value of `batched` attribute in `MappedExamplesIterable`