### PR TITLE
Deal with the bad check in test_load.py

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -20,7 +20,7 @@ from datasets.dataset_dict import DatasetDict, IterableDatasetDict
 from datasets.features import Features, Value
 from datasets.iterable_dataset import IterableDataset
 from datasets.load import prepare_module
-from datasets.utils.file_utils import DownloadConfig, is_remote_url
+from datasets.utils.file_utils import DownloadConfig
 
 from .utils import (
     OfflineSimulationMode,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -20,7 +20,7 @@ from datasets.dataset_dict import DatasetDict, IterableDatasetDict
 from datasets.features import Features, Value
 from datasets.iterable_dataset import IterableDataset
 from datasets.load import prepare_module
-from datasets.utils.file_utils import DownloadConfig
+from datasets.utils.file_utils import DownloadConfig, is_remote_url
 
 from .utils import (
     OfflineSimulationMode,
@@ -227,8 +227,6 @@ def test_load_dataset_local(dataset_loading_script_dir, data_dir, keep_in_memory
         datasets.load_dataset("_dummy")
     m_combined_path = re.search(fr"\S*{re.escape(os.path.join('_dummy', '_dummy.py'))}\b", str(exc_info.value))
     assert m_combined_path is not None and os.path.isabs(m_combined_path.group())
-    m_path = re.search(r"\S*_dummy\b", str(exc_info.value))
-    assert m_path is not None and os.path.isabs(m_path.group())
 
 
 @require_streaming


### PR DESCRIPTION
This PR removes a check that's been added in #2684. My intention with this check was to capture an URL in the error message, but instead, it captures a substring of the previous regex match in the test function. Another option would be to replace this check with:
```python
m_paths = re.findall(r"\S*_dummy/_dummy.py\b", str(exc_info.value))  # on Linux this will match an URL as well as a local_path due to different os.sep, so take the last element (an URL always comes last in the list)
assert len(m_paths) > 0 and is_remote_url(m_paths[-1])  # is_remote_url comes from datasets.utils.file_utils
```

@lhoestq Let me know which one of these two approaches (delete or replace) do you prefer?