### PR TITLE
First draft of a method to auto-convert our datasets to TF datasets!

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -159,6 +159,51 @@ class DatasetInfoMixin:
         return self._info.version
 
 
+class TensorflowDatasetMixIn:
+    def __init__(self):
+        pass
+
+    def to_tf_dataset(self, tokenizer, cols_to_remove, batch_size, shuffle):
+        import tensorflow as tf
+        dataset_in = self.remove_columns(cols_to_remove)
+        tf_cols = [col for col in dataset_in.features]
+        label_index = tf_cols.index("label")
+        dtypes_out = []
+        for col in tf_cols:
+            try:
+                col_feature = dataset_in.features[col]
+                if hasattr(col_feature, 'feature'):
+                    col_feature = col_feature.feature
+                dtype_str = col_feature.dtype
+                dtypes_out.append(tf.as_dtype(dtype_str))
+            except TypeError:
+                raise TypeError(f"Couldn't convert column {col}, dtype {dtype_str} to TF Tensor!")
+
+        def indices_to_samples(indices):
+            batch = dataset_in.select(list(indices), keep_in_memory=True).to_dict()
+            batch = tokenizer.pad(batch)
+            output = []
+            for col in tf_cols:
+                output.append(batch[col])
+            return output
+
+        def graph_indices_to_samples(indices):
+            return tf.py_function(indices_to_samples, [indices], Tout=dtypes_out)
+
+        def reform_dict(*batch_list):
+            return ({col: batch_list[i] for i, col in enumerate(tf_cols)}, batch_list[label_index])
+
+        indices = tf.range(len(dataset_in))
+        tf_dataset = tf.data.Dataset.from_tensor_slices(indices)
+        if shuffle:
+            tf_dataset = tf_dataset.shuffle(buffer_size=len(tf_dataset))
+        tf_dataset = tf_dataset.batch(batch_size)
+        tf_dataset = tf_dataset.map(graph_indices_to_samples).map(reform_dict)
+        return tf_dataset
+
+
+
+
 class DatasetTransformationNotAllowedError(Exception):
     pass
 
@@ -232,7 +277,7 @@ def _check_table(table) -> Table:
         raise TypeError(f"Expected a pyarrow.Table or a datasets.table.Table object, but got {table}.")
 
 
-class Dataset(DatasetInfoMixin, IndexableMixin):
+class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixIn):
     """A Dataset backed by an Arrow table."""
 
     def __init__(


### PR DESCRIPTION
Oh my **god** do not merge this yet, it's just a draft.

I've added a method (via a mixin) to the `arrow_dataset.Dataset` class that automatically converts our Dataset classes to TF Dataset classes ready for training. It hopefully has most of the features we want, including streaming from disk (no need to load the whole dataset in memory!), correct shuffling, variable-length batches to reduce compute, and correct support for unusual padding. It achieves that by calling the tokenizer `pad` method in the middle of a TF compute graph via a very hacky call to `tf.py_function`, which is heretical but seems to work.

A number of issues need to be resolved before it's ready to merge, though:

1) Is a MixIn the right way to do this? Do other classes besides `arrow_dataset.Dataset` need this method too?
2) Needs an argument to support constant-length batches for TPU training - this is easy to add and I'll do it soon.
3) Needs the user to supply the list of columns to drop from the arrow `Dataset`. Is there some automatic way to get the columns we want, or see which columns were added by the tokenizer?
4) Assumes the label column is always present and always called "label" - this is probably not great, but I'm not sure what the 'correct' thing to do here is.