### PR TITLE
Pass tokenize to sacrebleu only if explicitly passed by user

### DIFF
--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -113,7 +113,7 @@ class Sacrebleu(datasets.Metric):
         smooth_value=None,
         force=False,
         lowercase=False,
-        tokenize=scb.DEFAULT_TOKENIZER,
+        tokenize=None,
         use_effective_order=False,
     ):
         references_per_prediction = len(references[0])
@@ -127,8 +127,8 @@ class Sacrebleu(datasets.Metric):
             smooth_value=smooth_value,
             force=force,
             lowercase=lowercase,
-            tokenize=tokenize,
             use_effective_order=use_effective_order,
+            **(dict(tokenize=tokenize) if tokenize else {})
         )
         output_dict = {
             "score": output.score,

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -128,7 +128,7 @@ class Sacrebleu(datasets.Metric):
             force=force,
             lowercase=lowercase,
             use_effective_order=use_effective_order,
-            **(dict(tokenize=tokenize) if tokenize else {})
+            **(dict(tokenize=tokenize) if tokenize else {}),
         )
         output_dict = {
             "score": output.score,


### PR DESCRIPTION
Next `sacrebleu` release (v2.0.0) will remove `sacrebleu.DEFAULT_TOKENIZER`: https://github.com/mjpost/sacrebleu/pull/152/files#diff-2553a315bb1f7e68c9c1b00d56eaeb74f5205aeb3a189bc3e527b122c6078795L17-R15

This PR passes `tokenize` to `sacrebleu` only if explicitly passed by the user, otherwise it will not pass it (and `sacrebleu` will use its default, no matter where it is and how it is called).

Close: #2737.