### PR TITLE
Raise ManualDownloadError when loading a dataset that requires previous manual download

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -22,6 +22,7 @@ import copy
 import inspect
 import os
 import shutil
+import textwrap
 import urllib
 from dataclasses import dataclass
 from functools import partial
@@ -597,11 +598,14 @@ class DatasetBuilder:
                 f"total: {utils.size_str(self.info.size_in_bytes)}) to {self._cache_dir}..."
             )
 
-            if self.manual_download_instructions is not None:
-                assert (
-                    dl_manager.manual_dir is not None
-                ), "The dataset {} with config {} requires manual data. \n Please follow the manual download instructions: {}. \n Manual data can be loaded with `datasets.load_dataset({}, data_dir='<path/to/manual/data>')".format(
-                    self.name, self.config.name, self.manual_download_instructions, self.name
+            if self.manual_download_instructions is not None and dl_manager.manual_dir is None:
+                raise ManualDownloadError(
+                    textwrap.dedent(
+                        f"""The dataset {self.name} with config {self.config.name} requires manual data.
+                    Please follow the manual download instructions: {self.manual_download_instructions}.
+                    Manual data can be loaded with:
+                     datasets.load_dataset({self.name}, data_dir='<path/to/manual/data>')"""
+                    )
                 )
 
             # Create a tmp dir and rename to self._cache_dir on successful exit.

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -528,7 +528,6 @@ class DatasetBuilder:
         download_mode = GenerateMode(download_mode or GenerateMode.REUSE_DATASET_IF_EXISTS)
         verify_infos = not ignore_verifications
         base_path = base_path if base_path is not None else self.base_path
-
         if dl_manager is None:
             if download_config is None:
                 download_config = DownloadConfig(
@@ -598,15 +597,7 @@ class DatasetBuilder:
                 f"total: {utils.size_str(self.info.size_in_bytes)}) to {self._cache_dir}..."
             )
 
-            if self.manual_download_instructions is not None and dl_manager.manual_dir is None:
-                raise ManualDownloadError(
-                    textwrap.dedent(
-                        f"""The dataset {self.name} with config {self.config.name} requires manual data.
-                    Please follow the manual download instructions: {self.manual_download_instructions}.
-                    Manual data can be loaded with:
-                     datasets.load_dataset({self.name}, data_dir='<path/to/manual/data>')"""
-                    )
-                )
+            self._check_manual_download(dl_manager)
 
             # Create a tmp dir and rename to self._cache_dir on successful exit.
             with incomplete_dir(self._cache_dir) as tmp_data_dir:
@@ -640,6 +631,18 @@ class DatasetBuilder:
             print(
                 f"Dataset {self.name} downloaded and prepared to {self._cache_dir}. "
                 f"Subsequent calls will reuse this data."
+            )
+
+    def _check_manual_download(self, dl_manager):
+        if self.manual_download_instructions is not None and dl_manager.manual_dir is None:
+            raise ManualDownloadError(
+                textwrap.dedent(
+                    f"""The dataset {self.name} with config {self.config.name} requires manual data.
+                    Please follow the manual download instructions:
+                     {self.manual_download_instructions}
+                    Manual data can be loaded with:
+                     datasets.load_dataset({self.name}, data_dir='<path/to/manual/data>')"""
+                )
             )
 
     def _download_prepared_from_hf_gcs(self, download_config: DownloadConfig):

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -54,6 +54,14 @@ class InvalidConfigName(ValueError):
     pass
 
 
+class DatasetBuildError(Exception):
+    pass
+
+
+class ManualDownloadError(DatasetBuildError):
+    pass
+
+
 @dataclass
 class BuilderConfig:
     """Base class for :class:`DatasetBuilder` data configuration.

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -936,6 +936,7 @@ class DatasetBuilder:
             dataset_name=self.name,
             data_dir=self.config.data_dir,
         )
+        self._check_manual_download(dl_manager)
         splits_generators = {sg.name: sg for sg in self._split_generators(dl_manager)}
         # By default, return all splits
         if split is None:


### PR DESCRIPTION
This PR implements the raising of a `ManualDownloadError` when loading a dataset that requires previous manual download, and this is missing.

The `ManualDownloadError` is raised whether the dataset is loaded in normal or streaming mode.

Close #2749.

cc: @severo 