### PR TITLE
Allow PyArrow from source

### DIFF
--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -24,7 +24,7 @@ import pyarrow
 from pyarrow import total_allocated_bytes
 
 
-if tuple(int(i) for i in pyarrow.__version__.split(".")) < (1, 0, 0):
+if tuple(int(i) for i in pyarrow.__version__.split(".")[:3]) < (1, 0, 0):
     raise ImportWarning(
         "To use `datasets`, the module `pyarrow>=1.0.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."


### PR DESCRIPTION
When installing pyarrow from source the version is:

```python
>>> import pyarrow; pyarrow.__version__
'2.1.0.dev612'
```

-> however this breaks the install check at init of `datasets`. This PR makes sure that everything coming after the last `'.'` is removed.