### PR TITLE
Do not pass tokenize to sacrebleu

### DIFF
--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -298,7 +298,6 @@ def compute_sacrebleu(
     smooth_value=None,
     force=False,
     lowercase=False,
-    tokenize=sacrebleu.DEFAULT_TOKENIZER,
     use_effective_order=False,
 ):
     references_per_prediction = len(references[0])
@@ -312,7 +311,6 @@ def compute_sacrebleu(
         smooth_value=smooth_value,
         force=force,
         lowercase=lowercase,
-        tokenize=tokenize,
         use_effective_order=use_effective_order,
     )
     return output.score


### PR DESCRIPTION
Last `sacrebleu` release (v2.0.0) has removed `sacrebleu.DEFAULT_TOKENIZER`: https://github.com/mjpost/sacrebleu/pull/152/files#diff-2553a315bb1f7e68c9c1b00d56eaeb74f5205aeb3a189bc3e527b122c6078795L17-R15

This PR does not pass `tokenize` to `sacrebleu` (note that the user cannot pass it anyway) and `sacrebleu` will use its default, no matter where it is and how it is called.

Related to #2739.

This is a partial hotfix of #2781.