### PR TITLE
Fix sacrebleu tokenizers

### DIFF
--- a/metrics/sari/sari.py
+++ b/metrics/sari/sari.py
@@ -239,7 +239,7 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
         sentence = sentence.lower()
 
     if tokenizer in ["13a", "intl"]:
-        normalized_sent = sacrebleu.TOKENIZERS[tokenizer]()(sentence)
+        normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)(sentence)
     elif tokenizer == "moses":
         normalized_sent = sacremoses.MosesTokenizer().tokenize(sentence, return_str=True, escape=False)
     elif tokenizer == "penn":

--- a/metrics/sari/sari.py
+++ b/metrics/sari/sari.py
@@ -18,6 +18,7 @@ from collections import Counter
 
 import sacrebleu
 import sacremoses
+from packaging import version
 
 import datasets
 
@@ -239,7 +240,10 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
         sentence = sentence.lower()
 
     if tokenizer in ["13a", "intl"]:
-        normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)(sentence)
+        if version.parse(sacrebleu.__version__).major >= 2:
+            normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)(sentence)
+        else:
+            normalized_sent = sacrebleu.TOKENIZERS[tokenizer]()(sentence)
     elif tokenizer == "moses":
         normalized_sent = sacremoses.MosesTokenizer().tokenize(sentence, return_str=True, escape=False)
     elif tokenizer == "penn":

--- a/metrics/sari/sari.py
+++ b/metrics/sari/sari.py
@@ -241,7 +241,7 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
 
     if tokenizer in ["13a", "intl"]:
         if version.parse(sacrebleu.__version__).major >= 2:
-            normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)(sentence)
+            normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)()(sentence)
         else:
             normalized_sent = sacrebleu.TOKENIZERS[tokenizer]()(sentence)
     elif tokenizer == "moses":

--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -20,6 +20,7 @@ from collections import Counter
 
 import sacrebleu
 import sacremoses
+from packaging import version
 
 import datasets
 
@@ -266,7 +267,10 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
         sentence = sentence.lower()
 
     if tokenizer in ["13a", "intl"]:
-        normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)()(sentence)
+        if version.parse(sacrebleu.__version__).major >= 2:
+            normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)(sentence)
+        else:
+            normalized_sent = sacrebleu.TOKENIZERS[tokenizer]()(sentence)
     elif tokenizer == "moses":
         normalized_sent = sacremoses.MosesTokenizer().tokenize(sentence, return_str=True, escape=False)
     elif tokenizer == "penn":

--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -266,7 +266,7 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
         sentence = sentence.lower()
 
     if tokenizer in ["13a", "intl"]:
-        normalized_sent = sacrebleu.TOKENIZERS[tokenizer]()(sentence)
+        normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)()(sentence)
     elif tokenizer == "moses":
         normalized_sent = sacremoses.MosesTokenizer().tokenize(sentence, return_str=True, escape=False)
     elif tokenizer == "penn":

--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -268,7 +268,7 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
 
     if tokenizer in ["13a", "intl"]:
         if version.parse(sacrebleu.__version__).major >= 2:
-            normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)(sentence)
+            normalized_sent = sacrebleu.metrics.bleu._get_tokenizer(tokenizer)()(sentence)
         else:
             normalized_sent = sacrebleu.TOKENIZERS[tokenizer]()(sentence)
     elif tokenizer == "moses":


### PR DESCRIPTION
Last `sacrebleu` release (v2.0.0) has removed `sacrebleu.TOKENIZERS`: https://github.com/mjpost/sacrebleu/pull/152/files#diff-2553a315bb1f7e68c9c1b00d56eaeb74f5205aeb3a189bc3e527b122c6078795L17-R15

This PR, makes a hot fix of the bug by using a private function in `sacrebleu`: `sacrebleu.metrics.bleu._get_tokenizer()`.

Eventually, this should be further fixed in order to use only public functions.

This is a partial hotfix of #2781.