### PR TITLE
Fix renaming of corpus_bleu args

### DIFF
--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -121,8 +121,8 @@ class Sacrebleu(datasets.Metric):
             raise ValueError("Sacrebleu requires the same number of references for each prediction")
         transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
         output = scb.corpus_bleu(
-            sys_stream=predictions,
-            ref_streams=transformed_references,
+            predictions,
+            transformed_references,
             smooth_method=smooth_method,
             smooth_value=smooth_value,
             force=force,

--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -309,8 +309,8 @@ def compute_sacrebleu(
         raise ValueError("Sacrebleu requires the same number of references for each prediction")
     transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
     output = sacrebleu.corpus_bleu(
-        sys_stream=predictions,
-        ref_streams=transformed_references,
+        predictions,
+        transformed_references,
         smooth_method=smooth_method,
         smooth_value=smooth_value,
         force=force,


### PR DESCRIPTION
Last `sacrebleu` release (v2.0.0) has renamed `sacrebleu.corpus_bleu` args from `(sys_stream, ref_streams)` to `(hipotheses, references)`: https://github.com/mjpost/sacrebleu/pull/152/files#diff-2553a315bb1f7e68c9c1b00d56eaeb74f5205aeb3a189bc3e527b122c6078795L17-R15

This PR passes the args without parameter names, so that it is valid for all versions of `sacrebleu`.

This is a partial hotfix of #2781.

Close #2781.