### PR TITLE
Support streaming tar files

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -5,6 +5,7 @@ Copyright by the AllenNLP authors.
 """
 
 import copy
+import io
 import json
 import os
 import re
@@ -682,3 +683,16 @@ def add_end_docstrings(*docstr):
 
 def estimate_dataset_size(paths):
     return sum(path.stat().st_size for path in paths)
+
+
+def readline(f: io.RawIOBase):
+    # From: https://github.com/python/cpython/blob/d27e2f4d118e7a9909b6a3e5da06c5ff95806a85/Lib/_pyio.py#L525
+    res = bytearray()
+    while True:
+        b = f.read(1)
+        if not b:
+            break
+        res += b
+        if res.endswith(b"\n"):
+            break
+    return bytes(res)

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -134,6 +134,8 @@ class StreamingDownloadManager(object):
             return None
         elif path.endswith(".gz") and not path.endswith(".tar.gz"):
             return "gzip"
+        elif path.endswith(".tar"):
+            return "tar"
         elif path.endswith(".zip"):
             return "zip"
         raise NotImplementedError(f"Extraction protocol for file at {urlpath} is not implemented yet")


### PR DESCRIPTION
This PR adds support to stream tar files by using the `fsspec` tar protocol.

It also uses the custom `readline` implemented in PR #2786.

The corresponding test is implemented in PR #2786.