### PR TITLE
Fix streaming tar files from canonical datasets

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -185,6 +185,10 @@ def url_or_path_parent(url_or_path: str) -> str:
         return os.path.dirname(url_or_path)
 
 
+def url_or_path_extension(url_or_path: str) -> str:
+    return Path(url_or_path).suffix
+
+
 def hash_url_to_filename(url, etag=None):
     """
     Convert `url` into a hashed filename in a repeatable way.

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -9,7 +9,13 @@ from aiohttp.client_exceptions import ClientError
 
 from .. import config
 from .download_manager import DownloadConfig, map_nested
-from .file_utils import get_authentication_headers_for_url, is_local_path, is_relative_path, url_or_path_join
+from .file_utils import (
+    get_authentication_headers_for_url,
+    is_local_path,
+    is_relative_path,
+    url_or_path_extension,
+    url_or_path_join,
+)
 from .logging import get_logger
 
 
@@ -41,10 +47,10 @@ def xjoin(a, *p):
     if is_local_path(a):
         a = Path(a, *p).as_posix()
     else:
-        compression = fsspec.core.get_compression(a, "infer")
-        if compression in ["zip"]:
+        extension = url_or_path_extension(a)
+        if extension in [".tar", ".zip"]:
             b = [a] + b
-            a = posixpath.join(f"{compression}://", *p)
+            a = posixpath.join(f"{extension[1:]}://", *p)
         else:
             a = posixpath.join(a, *p)
     return "::".join([a] + b)

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -11,6 +11,7 @@ TEST_URL_CONTENT = "foo\nbar\nfoobar"
 @pytest.mark.parametrize(
     "input_path, paths_to_join, expected_path",
     [
+        ("https://host.com/archive.tar", ("file.txt",), "tar://file.txt::https://host.com/archive.tar"),
         ("https://host.com/archive.zip", ("file.txt",), "zip://file.txt::https://host.com/archive.zip"),
         (
             "zip://folder::https://host.com/archive.zip",


### PR DESCRIPTION
Previous PR #2800 implemented support to stream remote tar files when passing the parameter `data_files`.

This PR fixes this issue and allows streaming tar files both from:
- canonical datasets scripts and
- data files.
