### PR TITLE
Fix stream oscar

### DIFF
--- a/datasets/oscar/oscar.py
+++ b/datasets/oscar/oscar.py
@@ -355,7 +355,7 @@ class Oscar(datasets.GeneratorBasedBuilder):
         current_lines = []
         for filepath in filepaths:
             logger.info("generating examples from = %s", filepath)
-            with gzip.open(open(filepath, "rb"), "rt", encoding="utf-8") as f:
+            with gzip.open(filepath, "rt", encoding="utf-8") as f:
                 for line in f:
                     if len(line.strip()) > 0:
                         current_lines.append(line)

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -25,5 +25,6 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch_submodule(module, "open", partial(xopen, use_auth_token=use_auth_token)).start()
     else:
         patch_submodule(module, "open", xopen).start()
+    patch_submodule(module, "gzip.open", partial(xopen, compression="gzip")).start()
     # allow to navigate in remote zip files
     patch_submodule(module, "os.path.join", xjoin).start()


### PR DESCRIPTION
Previously, an additional `open` was added to oscar to make it stream-compatible: 587bbb94e891b22863b312b99696e32708c379f4.

This was argued that might be problematic: https://github.com/huggingface/datasets/pull/2786#discussion_r690045921

This PR:
- removes that additional `open`
- patches `gzip.open` with `xopen` + `compression="gzip"`