### PR TITLE
Bump tqdm version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ REQUIRED_PKGS = [
     # for downloading datasets over HTTPS
     "requests>=2.19.0",
     # progress bars in download and scripts
-    "tqdm>=4.42",  # tqdm.contrib.concurrent
+    "tqdm>=4.62.1",
     # dataclasses for Python versions that don't have it
     "dataclasses;python_version<'3.7'",
     # for fast hashing

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -561,10 +561,4 @@ def parquet_to_arrow(sources, destination):
                     df[col] = df[col].apply(json.loads)
                 reconstructed_table = pa.Table.from_pandas(df)
                 writer.write_table(reconstructed_table)
-    # Collect the gc or the tqdm progress bar keeps references to the open files
-    # and it causes permission errors on windows
-    # see https://app.circleci.com/pipelines/github/huggingface/datasets/6365/workflows/24f7c960-3176-43a5-9652-7830a23a981e/jobs/39232
-    import gc
-
-    gc.collect()
     return destination

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -836,11 +836,6 @@ class DatasetBuilder:
             }
             post_processed = self._post_process(ds, resources_paths)
             if post_processed is not None:
-                del ds
-                # collect the gc to make sure the windows file lock on arrow files is gone
-                import gc
-
-                gc.collect()
                 ds = post_processed
                 recorded_checksums = {}
                 for resource_name, resource_path in resources_paths.items():

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -195,7 +195,7 @@ def map_nested(
     if not isinstance(data_struct, dict) and not isinstance(data_struct, types):
         return function(data_struct)
 
-    disable_tqdm = bool(logger.getEffectiveLevel() > logging.INFO) or not utils.is_progress_bar_enabled()
+    disable_tqdm = bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled()
     iterable = list(data_struct.values()) if isinstance(data_struct, dict) else data_struct
 
     if num_proc is None:


### PR DESCRIPTION
The recently released tqdm 4.62.1 includes a fix for PermissionError on Windows (submitted by me in https://github.com/tqdm/tqdm/pull/1207), which means we can remove expensive `gc.collect` calls by bumping tqdm to that version. This PR does exactly that and, additionally, fixes a `disable_tqdm` definition that would previously, if used, raise a PermissionError on Windows.