### PR TITLE
Fix IndexError by ignoring empty RecordBatch

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -95,7 +95,7 @@ def _interpolation_search(arr: List[int], x: int) -> int:
 class IndexedTableMixin:
     def __init__(self, table: pa.Table):
         self._schema = table.schema
-        self._batches = table.to_batches()
+        self._batches = [recordbatch for recordbatch in table.to_batches() if len(recordbatch) > 0]
         self._offsets: np.ndarray = np.cumsum([0] + [len(b) for b in self._batches], dtype=np.int64)
 
     def fast_gather(self, indices: Union[List[int], np.ndarray]) -> pa.Table:


### PR DESCRIPTION
We need to ignore the empty record batches for the interpolation search to work correctly when querying arrow tables

Close #2833

cc @SaulLu 