### PR TITLE
Fix extraction protocol inference from urls with params

### DIFF
--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -150,7 +150,7 @@ class StreamingDownloadManager(object):
 
     def _get_extraction_protocol(self, urlpath: str) -> Optional[str]:
         path = urlpath.split("::")[0]
-        extension = path.split(".")[-1]
+        extension = path.split(".")[-1].split("?")[0]  # https://foo.bar/train.json.gz?dl=1 -> gz
         if extension in BASE_KNOWN_EXTENSIONS:
             return None
         elif path.endswith(".tar.gz") or path.endswith(".tgz"):

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -149,7 +149,7 @@ class StreamingDownloadManager(object):
             return f"{protocol}://::{urlpath}"
 
     def _get_extraction_protocol(self, urlpath: str) -> Optional[str]:
-        # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://data/train-00000.json.gz
+        # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://train-00000.json.gz
         path = urlpath.split("::")[0]
         # remove query params: https://foo.bar/train.json.gz?dl=1 -> https://foo.bar/train.json.gz
         path = path.split("?")[0]

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -149,8 +149,12 @@ class StreamingDownloadManager(object):
             return f"{protocol}://::{urlpath}"
 
     def _get_extraction_protocol(self, urlpath: str) -> Optional[str]:
+        # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://data/train-00000.json.gz
         path = urlpath.split("::")[0]
-        extension = path.split(".")[-1].split("?")[0]  # https://foo.bar/train.json.gz?dl=1 -> gz
+        # remove query params: https://foo.bar/train.json.gz?dl=1 -> https://foo.bar/train.json.gz
+        path = path.split("?")[0]
+        # Get extension: https://foo.bar/train.json.gz -> gz
+        extension = path.split(".")[-1]
         if extension in BASE_KNOWN_EXTENSIONS:
             return None
         elif path.endswith(".tar.gz") or path.endswith(".tgz"):


### PR DESCRIPTION
Previously it was unable to infer the compression protocol for files at URLs like
```
https://foo.bar/train.json.gz?dl=1
```
because of the query parameters.

I fixed that, this should allow 10+ datasets to work in streaming mode:
```
  "discovery",
  "emotion",
  "grail_qa",
  "guardian_authorship",
  "pragmeval",
  "simple_questions_v2",
  "versae/adobo",
  "w-nicole/childes_data",
  "w-nicole/childes_data_no_tags_",
  "w-nicole/childes_data_with_tags",
  "w-nicole/childes_data_with_tags_"
```

cc @severo 