### PR TITLE
Fix: wikicorpus - fix keys

### DIFF
--- a/datasets/wikicorpus/README.md
+++ b/datasets/wikicorpus/README.md
@@ -82,6 +82,7 @@ task_ids:
   - part-of-speech-tagging
   - text-classification-other-word-sense-disambiguation
 paperswithcode_id: null
+pretty_name: Wikicorpus
 ---
 
 # Dataset Card for Wikicorpus

--- a/datasets/wikicorpus/wikicorpus.py
+++ b/datasets/wikicorpus/wikicorpus.py
@@ -159,7 +159,7 @@ class Wikicorpus(datasets.GeneratorBasedBuilder):
                             pass
                         elif row.startswith("ENDOFARTICLE") or row.startswith("\n"):
                             if len(words) > 1:  # some content besides only (. . Fp 0)
-                                yield (file_idx, row_idx), {
+                                yield f"{file_idx}_{row_idx}", {
                                     "id": example["id"],
                                     "title": example["title"],
                                     "sentence": words,

--- a/datasets/wikicorpus/wikicorpus.py
+++ b/datasets/wikicorpus/wikicorpus.py
@@ -122,7 +122,7 @@ class Wikicorpus(datasets.GeneratorBasedBuilder):
         ]
 
     def _generate_examples(self, dirpath):
-        for filepath in sorted(Path(dirpath).iterdir()):
+        for file_idx, filepath in enumerate(sorted(Path(dirpath).iterdir())):
             with open(filepath, encoding="latin-1") as f:
                 example = {}
                 # raw
@@ -132,7 +132,7 @@ class Wikicorpus(datasets.GeneratorBasedBuilder):
                 lemmas = []
                 pos_tags = []
                 wordnet_senses = []
-                for id_, row in enumerate(f):
+                for row_idx, row in enumerate(f):
                     if self.config.form == "raw":
                         if row.startswith("<doc id"):
                             metadata_match = METADATA_PATTERN.match(row)
@@ -141,7 +141,7 @@ class Wikicorpus(datasets.GeneratorBasedBuilder):
                         elif row.startswith("</doc>"):
                             pass
                         elif row.startswith("ENDOFARTICLE"):
-                            yield id_, {
+                            yield f"{file_idx}_{row_idx}", {
                                 "id": example["id"],
                                 "title": example["title"],
                                 "text": "\n".join(text).strip(),
@@ -159,7 +159,7 @@ class Wikicorpus(datasets.GeneratorBasedBuilder):
                             pass
                         elif row.startswith("ENDOFARTICLE") or row.startswith("\n"):
                             if len(words) > 1:  # some content besides only (. . Fp 0)
-                                yield id_, {
+                                yield (file_idx, row_idx), {
                                     "id": example["id"],
                                     "title": example["title"],
                                     "sentence": words,


### PR DESCRIPTION
As mentioned in https://github.com/huggingface/datasets/issues/2552, there is a duplicate keys error in `wikicorpus`.

I fixed that by taking into account the file index in the keys