### PR TITLE
Fix caching when moving script

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -405,12 +405,18 @@ def _save_code(pickler, obj):
     # ex: <ipython-input-13-9ed2afe61d25> for ipython, and <stdin> for shell
     # Moreover lambda functions have a special name: '<lambda>'
     # ex: (lambda x: x).__code__.co_name == "<lambda>"  # True
+    #
     # For the hashing mechanism we ignore where the function has been defined
     # More specifically:
     # - we ignore the filename of special functions (filename starts with '<')
     # - we always ignore the line number
+    # - we only use the base name of the file instead of the whole path,
+    # to be robust in case a script is moved for example.
+    #
     # Only those two lines are different from the original implementation:
-    co_filename = "" if obj.co_filename.startswith("<") or obj.co_name == "<lambda>" else obj.co_filename
+    co_filename = (
+        "" if obj.co_filename.startswith("<") or obj.co_name == "<lambda>" else os.path.basename(obj.co_filename)
+    )
     co_firstlineno = 1
     # The rest is the same as in the original dill implementation
     if dill._dill.PY3:


### PR DESCRIPTION
When caching the result of a `map` function, the hash that is computed depends on many properties of this function, such as all the python objects it uses, its code and also the location of this code.

Using the full path of the python script for the location of the code makes the hash change if a script like `run_mlm.py` is moved.

I changed this by simply using the base name of the script instead of the full path.

Note that this change also affects the hash of the code used from imported modules, but I think it's fine. Indeed it hashes the code of the imported modules anyway, so the location of the python files of the imported modules doesn't matter when computing the hash.

Close https://github.com/huggingface/datasets/issues/2825