### PR TITLE
Fix windows CI CondaError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
             shell: powershell
         steps:
             - checkout
+            - run: conda update conda
             - run: conda install python=3.6 --yes
             - run: conda install pytorch --yes
             - run: pip install virtualenv
@@ -56,7 +57,8 @@ jobs:
             name: win/default
             shell: powershell
         steps:
-            - checkout
+            - checkoutcheckout
+            - run: conda update anaconda
             - run: conda install python=3.6 --yes
             - run: conda install pytorch --yes
             - run: pip install virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             shell: powershell
         steps:
             - checkout
-            - run: conda update anaconda
+            - run: conda update conda
             - run: conda install python=3.6 --yes
             - run: conda install pytorch --yes
             - run: pip install virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             name: win/default
             shell: powershell
         steps:
-            - checkoutcheckout
+            - checkout
             - run: conda update anaconda
             - run: conda install python=3.6 --yes
             - run: conda install pytorch --yes


### PR DESCRIPTION
From this thread: https://github.com/conda/conda/issues/6057

We can fix the conda error
```
CondaError: Cannot link a source that does not exist.
C:\Users\...\Anaconda3\Scripts\conda.exe
```

by doing
```bash
conda update conda
```

before doing any install in the windows CI