### PR TITLE
Fix s3fs version in CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ REQUIRED_PKGS = [
     "importlib_metadata;python_version<'3.8'",
     # to save datasets locally or on any filesystem
     # minimum 2021.05.0 to have the AbstractArchiveFileSystem
-    "fsspec[http]>=2021.05.0",
+    "fsspec[http]==2021.08.1",
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
@@ -128,7 +128,7 @@ TESTS_REQUIRE = [
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",
     "rarfile>=4.0",
-    "s3fs>=2021.05.0",
+    "s3fs==2021.08.1",
     "tensorflow>=2.3",
     "torch",
     "transformers",
@@ -191,7 +191,7 @@ EXTRAS_REQUIRE = {
         "fsspec",
         "boto3==1.16.43",
         "botocore==1.19.52",
-        "s3fs>=2021.05.0",
+        "s3fs==2021.08.1",
     ],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
@@ -207,7 +207,7 @@ EXTRAS_REQUIRE = {
         "sphinxext-opengraph==0.4.1",
         "sphinx-copybutton",
         "fsspec",
-        "s3fs>=2021.05.0",
+        "s3fs==2021.08.1",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ REQUIRED_PKGS = [
     "importlib_metadata;python_version<'3.8'",
     # to save datasets locally or on any filesystem
     # minimum 2021.05.0 to have the AbstractArchiveFileSystem
-    "fsspec[http]==2021.08.1",
+    "fsspec[http]>=2021.05.0",
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ TESTS_REQUIRE = [
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",
     "rarfile>=4.0",
-    "s3fs>=2021.08.1",
+    "s3fs==2021.08.1",
     "tensorflow>=2.3",
     "torch",
     "transformers",

--- a/setup.py
+++ b/setup.py
@@ -121,9 +121,9 @@ TESTS_REQUIRE = [
     # optional dependencies
     "apache-beam>=2.26.0",
     "elasticsearch",
-    "aiobotocore==1.2.2",
-    "boto3==1.16.43",
-    "botocore==1.19.52",
+    "aiobotocore",
+    "boto3",
+    "botocore",
     "faiss-cpu",
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ TESTS_REQUIRE = [
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",
     "rarfile>=4.0",
-    "s3fs==2021.08.1",
+    "s3fs",
     "tensorflow>=2.3",
     "torch",
     "transformers",

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ TESTS_REQUIRE = [
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",
     "rarfile>=4.0",
-    "s3fs",
+    "s3fs>=2021.05.0",
     "tensorflow>=2.3",
     "torch",
     "transformers",

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ EXTRAS_REQUIRE = {
         "fsspec",
         "boto3==1.16.43",
         "botocore==1.19.52",
-        "s3fs",
+        "s3fs>=2021.05.0",
     ],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
@@ -207,7 +207,7 @@ EXTRAS_REQUIRE = {
         "sphinxext-opengraph==0.4.1",
         "sphinx-copybutton",
         "fsspec",
-        "s3fs",
+        "s3fs>=2021.05.0",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -189,9 +189,9 @@ EXTRAS_REQUIRE = {
     "torch": ["torch"],
     "s3": [
         "fsspec",
-        "boto3==1.16.43",
-        "botocore==1.19.52",
-        "s3fs==2021.08.1",
+        "boto3",
+        "botocore",
+        "s3fs",
     ],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
@@ -207,7 +207,7 @@ EXTRAS_REQUIRE = {
         "sphinxext-opengraph==0.4.1",
         "sphinx-copybutton",
         "fsspec",
-        "s3fs==2021.08.1",
+        "s3fs",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ TESTS_REQUIRE = [
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",
     "rarfile>=4.0",
-    "s3fs",
+    "s3fs>=2021.08.1",
     "tensorflow>=2.3",
     "torch",
     "transformers",


### PR DESCRIPTION
The latest s3fs version has new constrains on aiobotocore, and therefore on boto3 and botocore

This PR changes the constrains to avoid the new conflicts