### PR TITLE
fix: 🐛 be more specific when catching exceptions

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 
 import fsspec
 import huggingface_hub
+import requests
 from huggingface_hub import HfApi
 
 from . import config
@@ -544,7 +545,7 @@ def prepare_module(
                         dataset_info = hf_api.dataset_info(
                             repo_id=path, revision=script_version, token=download_config.use_auth_token
                         )
-                    except FileNotFoundError:
+                    except requests.exceptions.RequestException:
                         raise FileNotFoundError(
                             f"Couldn't find a directory or a {resource_type} named '{path}'. "
                             f"It doesn't exist locally at {expected_dir_for_combined_path_abs} or remotely on {hf_api.endpoint}/datasets"

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -544,7 +544,7 @@ def prepare_module(
                         dataset_info = hf_api.dataset_info(
                             repo_id=path, revision=script_version, token=download_config.use_auth_token
                         )
-                    except Exception:
+                    except FileNotFoundError:
                         raise FileNotFoundError(
                             f"Couldn't find a directory or a {resource_type} named '{path}'. "
                             f"It doesn't exist locally at {expected_dir_for_combined_path_abs} or remotely on {hf_api.endpoint}/datasets"


### PR DESCRIPTION
The same specific exception is catched in other parts of the same
function.