### PR TITLE
Fix three typos in two files for documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ If you would like to work on any of the open Issues:
    it with `pip uninstall datasets` before reinstalling it in editable
    mode with the `-e` flag.)
 
-5. Develop the features on your branch. If you want to add a dataset see more in-detail intsructions in the section [*How to add a dataset*](#how-to-add-a-dataset). Alternatively, you can follow the steps to [add a dataset](https://huggingface.co/docs/datasets/add_dataset.html) and [share a dataset](https://huggingface.co/docs/datasets/share_dataset.html) in the documentation.
+5. Develop the features on your branch. If you want to add a dataset see more in-detail instructions in the section [*How to add a dataset*](#how-to-add-a-dataset). Alternatively, you can follow the steps to [add a dataset](https://huggingface.co/docs/datasets/add_dataset.html) and [share a dataset](https://huggingface.co/docs/datasets/share_dataset.html) in the documentation.
 
 6. Format your code. Run black and isort so that your newly added files look nice with the following command:
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2842,7 +2842,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         Args:
             batched (``bool``): Set to :obj:`True` to return a generator that yields the dataset as batches
                 of ``batch_size`` rows. Defaults to :obj:`False` (returns the whole datasetas once)
-            bacth_size (Optional ``int``): The size (number of rows) of the batches if ``batched`` is `True`.
+            batch_size (Optional ``int``): The size (number of rows) of the batches if ``batched`` is `True`.
                 Defaults to :obj:`datasets.config.DEFAULT_MAX_BATCH_SIZE`.
 
         Returns:
@@ -2907,7 +2907,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         Args:
             batched (``bool``): Set to :obj:`True` to return a generator that yields the dataset as batches
                 of ``batch_size`` rows. Defaults to :obj:`False` (returns the whole datasetas once)
-            bacth_size (Optional ``int``): The size (number of rows) of the batches if ``batched`` is `True`.
+            batch_size (Optional ``int``): The size (number of rows) of the batches if ``batched`` is `True`.
                 Defaults to :obj:`datasets.config.DEFAULT_MAX_BATCH_SIZE`.
 
         Returns:


### PR DESCRIPTION
Changed "bacth_size" to "batch_size" (2x)
Changed "intsructions" to "instructions"