### PR TITLE
Support streaming datasets that use pathlib

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -12,12 +12,22 @@ logger = get_logger(__name__)
 
 
 def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str, bool]] = None):
-    """
-    Extend the `open` and `os.path.join` functions of the module to support data streaming.
-    They are replaced by `xopen` and `xjoin` defined to work with the StreamingDownloadManager.
+    """Extend the module to support streaming.
 
-    We use fsspec to extend `open` to be able to read remote files.
-    To join paths and navigate in remote compressed archives, we use the "::" separator.
+    We patch some functions in the module to use `fsspec` to support data streaming:
+    - We use `fsspec.open` to open and read remote files. We patch the module function:
+      - `open`
+    - We use the "::" hop separator to join paths and navigate remote compressed/archive files. We patch the module
+      functions:
+      - `os.path.join`
+      - `pathlib.Path.joinpath` and `pathlib.Path.__truediv__` (called when using the "/" operator)
+
+    The patched functions are replaced with custom functions defined to work with the
+    :class:`~utils.streaming_download_manager.StreamingDownloadManager`.
+
+    Args:
+        module_path: Path to the module to be extended.
+        use_auth_token: Whether to use authentication token.
     """
 
     module = importlib.import_module(module_path)

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -1,10 +1,11 @@
 import importlib
 from functools import partial
 from typing import Optional, Union
+from unittest.mock import patch
 
 from .utils.logging import get_logger
 from .utils.patching import patch_submodule
-from .utils.streaming_download_manager import xjoin, xopen
+from .utils.streaming_download_manager import xjoin, xopen, xpathjoin
 
 
 logger = get_logger(__name__)
@@ -13,7 +14,7 @@ logger = get_logger(__name__)
 def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str, bool]] = None):
     """
     Extend the `open` and `os.path.join` functions of the module to support data streaming.
-    They rare replaced by `xopen` and `xjoin` defined to work with the StreamingDownloadManager.
+    They are replaced by `xopen` and `xjoin` defined to work with the StreamingDownloadManager.
 
     We use fsspec to extend `open` to be able to read remote files.
     To join paths and navigate in remote compressed archives, we use the "::" separator.
@@ -27,3 +28,6 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch_submodule(module, "open", xopen).start()
     # allow to navigate in remote zip files
     patch_submodule(module, "os.path.join", xjoin).start()
+    if hasattr(module, "Path"):
+        patch.object(module.Path, "joinpath", xpathjoin).start()
+        patch.object(module.Path, "__truediv__", xpathjoin).start()

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from .utils.logging import get_logger
 from .utils.patching import patch_submodule
-from .utils.streaming_download_manager import xjoin, xopen, xpathjoin
+from .utils.streaming_download_manager import xjoin, xopen, xpathjoin, xpathopen
 
 
 logger = get_logger(__name__)
@@ -41,3 +41,4 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     if hasattr(module, "Path"):
         patch.object(module.Path, "joinpath", xpathjoin).start()
         patch.object(module.Path, "__truediv__", xpathjoin).start()
+        patch.object(module.Path, "open", xpathopen).start()

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -118,6 +118,10 @@ def xopen(file, mode="r", *args, **kwargs):
     return file_obj
 
 
+def xpathopen(path, **kwargs):
+    return xopen(_as_posix(path), **kwargs)
+
+
 class StreamingDownloadManager(object):
     """
     Download manager that uses the "::" separator to navigate through (possibly remote) compressed archives.

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -56,6 +56,14 @@ def xjoin(a, *p):
     return "::".join([a] + b)
 
 
+def _as_posix(path):
+    return path.as_posix().replace(":/", "://")
+
+
+def xpathjoin(a, *p):
+    return type(a)(xjoin(_as_posix(a), *p))
+
+
 def _add_retries_to_file_obj_read_method(file_obj):
     read = file_obj.read
     max_retries = config.STREAMING_READ_MAX_RETRIES

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -2,7 +2,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import fsspec
 import posixpath
@@ -57,11 +57,28 @@ def xjoin(a, *p):
     return "::".join([a] + b)
 
 
-def _as_posix(path):
+def _as_posix(path: Path):
+    """Extend :meth:`pathlib.PurePath.as_posix` to fix missing slash after protocol.
+
+    Args:
+        path (:obj:`~pathlib.Path`): Calling Path instance.
+
+    Returns:
+        obj:`str`
+    """
     return SINGLE_SLASH_AFTER_PROTOCOL_PATTERN.sub("://", path.as_posix())
 
 
-def xpathjoin(a, *p):
+def xpathjoin(a: Path, *p: Tuple[str, ...]):
+    """Extend :func:`xjoin` to support argument of type :obj:`~pathlib.Path`.
+
+    Args:
+        a (:obj:`~pathlib.Path`): Calling Path instance.
+        *p (:obj:`tuple` of :obj:`str`): Other path components.
+
+    Returns:
+        obj:`str`
+    """
     return type(a)(xjoin(_as_posix(a), *p))
 
 
@@ -119,7 +136,16 @@ def xopen(file, mode="r", *args, **kwargs):
     return file_obj
 
 
-def xpathopen(path, **kwargs):
+def xpathopen(path: Path, **kwargs):
+    """Extend :func:`xopen` to support argument of type :obj:`~pathlib.Path`.
+
+    Args:
+        path (:obj:`~pathlib.Path`): Calling Path instance.
+        **kwargs: Keyword arguments passed to :func:`fsspec.open`.
+
+    Returns:
+        :obj:`io.FileIO`: File-like object.
+    """
     return xopen(_as_posix(path), **kwargs)
 
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from pathlib import Path
 from typing import Optional
@@ -15,8 +16,8 @@ from .logging import get_logger
 
 
 logger = get_logger(__name__)
-BASE_KNOWN_EXTENSIONS = ["txt", "csv", "json", "jsonl", "tsv", "conll", "conllu", "parquet", "pkl", "pickle", "xml"]
 
+BASE_KNOWN_EXTENSIONS = ["txt", "csv", "json", "jsonl", "tsv", "conll", "conllu", "parquet", "pkl", "pickle", "xml"]
 COMPRESSION_EXTENSION_TO_PROTOCOL = {
     # single file compression
     **{fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS},
@@ -25,8 +26,8 @@ COMPRESSION_EXTENSION_TO_PROTOCOL = {
     "tar": "tar",
     "tgz": "tar",
 }
-
 SINGLE_FILE_COMPRESSION_PROTOCOLS = {fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS}
+SINGLE_SLASH_AFTER_PROTOCOL_PATTERN = re.compile(r"(?<!:):/")
 
 
 def xjoin(a, *p):
@@ -57,7 +58,7 @@ def xjoin(a, *p):
 
 
 def _as_posix(path):
-    return path.as_posix().replace(":/", "://")
+    return SINGLE_SLASH_AFTER_PROTOCOL_PATTERN.sub("://", path.as_posix())
 
 
 def xpathjoin(a, *p):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from datasets.filesystems import COMPRESSION_FILESYSTEMS
-from datasets.utils.streaming_download_manager import xopen
+from datasets.utils.streaming_download_manager import xopen, xpathopen
 
 from .utils import require_lz4, require_zstandard
 
@@ -43,12 +43,16 @@ def test_xopen_local(text_path):
 
     with xopen(text_path, encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
         assert list(f) == list(expected_file)
+    with xpathopen(Path(text_path), encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
+        assert list(f) == list(expected_file)
 
 
 def test_xopen_remote():
-    from datasets.utils.streaming_download_manager import xopen
+    from datasets.utils.streaming_download_manager import xopen, xpathopen
 
     with xopen(TEST_URL, encoding="utf-8") as f:
+        assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
+    with xpathopen(Path(TEST_URL), encoding="utf-8") as f:
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
 
 

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -29,10 +30,13 @@ TEST_URL_CONTENT = "foo\nbar\nfoobar"
     ],
 )
 def test_xjoin(input_path, paths_to_join, expected_path):
-    from datasets.utils.streaming_download_manager import xjoin
+    from datasets.utils.streaming_download_manager import xjoin, xpathjoin
 
     output_path = xjoin(input_path, *paths_to_join)
     assert output_path == expected_path
+
+    output_path = xpathjoin(Path(input_path), *paths_to_join)
+    assert output_path == Path(expected_path)
 
 
 def test_xopen_local(text_path):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -6,6 +6,7 @@ import pytest
 from datasets.filesystems import COMPRESSION_FILESYSTEMS
 from datasets.utils.streaming_download_manager import (
     StreamingDownloadManager,
+    _as_posix,
     _get_extraction_protocol,
     xjoin,
     xopen,
@@ -18,6 +19,14 @@ from .utils import require_lz4, require_zstandard
 
 TEST_URL = "https://huggingface.co/datasets/lhoestq/test/raw/main/some_text.txt"
 TEST_URL_CONTENT = "foo\nbar\nfoobar"
+
+
+@pytest.mark.parametrize(
+    "input_path, expected_path",
+    [("zip:/test.txt::/Users/username/bar.zip", "zip://test.txt::/Users/username/bar.zip")],
+)
+def test_as_posix(input_path, expected_path):
+    assert _as_posix(Path(input_path)) == expected_path
 
 
 @pytest.mark.parametrize(

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -43,6 +43,16 @@ def test_as_posix(input_path, expected_path):
             ("file.txt",),
             "zip://folder/file.txt::https://host.com/archive.zip",
         ),
+        (
+            ".",
+            ("file.txt",),
+            "file.txt",
+        ),
+        (
+            Path().resolve().as_posix(),
+            ("file.txt",),
+            (Path().resolve() / "file.txt").as_posix(),
+        ),
     ],
 )
 def test_xjoin(input_path, paths_to_join, expected_path):


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `pathlib.Path`.

Related to: #2866.
CC: @severo 