### PR TITLE
Extend support for streaming datasets that use pathlib.Path stem/suffix

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from .utils.logging import get_logger
 from .utils.patching import patch_submodule
-from .utils.streaming_download_manager import xdirname, xjoin, xopen, xpathjoin, xpathopen
+from .utils.streaming_download_manager import xdirname, xjoin, xopen, xpathjoin, xpathopen, xpathstem, xpathsuffix
 
 
 logger = get_logger(__name__)
@@ -43,3 +43,5 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch.object(module.Path, "joinpath", xpathjoin).start()
         patch.object(module.Path, "__truediv__", xpathjoin).start()
         patch.object(module.Path, "open", xpathopen).start()
+        patch.object(module.Path, "stem", property(fget=xpathstem)).start()
+        patch.object(module.Path, "suffix", property(fget=xpathsuffix)).start()

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional, Tuple
 
 import fsspec
@@ -178,6 +178,30 @@ def xpathopen(path: Path, **kwargs):
         :obj:`io.FileIO`: File-like object.
     """
     return xopen(_as_posix(path), **kwargs)
+
+
+def xpathstem(path: Path):
+    """Stem function for argument of type :obj:`~pathlib.Path` that supports both local paths end remote URLs.
+
+    Args:
+        path (:obj:`~pathlib.Path`): Calling Path instance.
+
+    Returns:
+        :obj:`str`
+    """
+    return PurePosixPath(_as_posix(path).split("::")[0]).stem
+
+
+def xpathsuffix(path: Path):
+    """Suffix function for argument of type :obj:`~pathlib.Path` that supports both local paths end remote URLs.
+
+    Args:
+        path (:obj:`~pathlib.Path`): Calling Path instance.
+
+    Returns:
+        :obj:`str`
+    """
+    return PurePosixPath(_as_posix(path).split("::")[0]).suffix
 
 
 class StreamingDownloadManager(object):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -13,6 +13,8 @@ from datasets.utils.streaming_download_manager import (
     xopen,
     xpathjoin,
     xpathopen,
+    xpathstem,
+    xpathsuffix,
 )
 
 from .utils import require_lz4, require_zstandard
@@ -122,6 +124,30 @@ def test_xopen_remote():
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
     with xpathopen(Path(TEST_URL), encoding="utf-8") as f:
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
+
+
+@pytest.mark.parametrize(
+    "input_path, expected",
+    [
+        ("zip://file.txt::https://host.com/archive.zip", "file"),
+        ("file.txt", "file"),
+        ((Path().resolve() / "file.txt").as_posix(), "file"),
+    ],
+)
+def test_xpathstem(input_path, expected):
+    assert xpathstem(Path(input_path)) == expected
+
+
+@pytest.mark.parametrize(
+    "input_path, expected",
+    [
+        ("zip://file.txt::https://host.com/archive.zip", ".txt"),
+        ("file.txt", ".txt"),
+        ((Path().resolve() / "file.txt").as_posix(), ".txt"),
+    ],
+)
+def test_xpathsuffix(input_path, expected):
+    assert xpathsuffix(Path(input_path)) == expected
 
 
 @pytest.mark.parametrize("urlpath", [r"C:\\foo\bar.txt", "/foo/bar.txt", "https://f.oo/bar.txt"])


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `pathlib`, by patching the properties `pathlib.Path.stem` and `pathlib.Path.suffix`.

Related to #2876, #2874, #2866.

CC: @severo