### PR TITLE
Fix null sequence encoding

### DIFF
--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -868,7 +868,7 @@ def encode_nested_example(schema, obj):
         }
     elif isinstance(schema, (list, tuple)):
         sub_schema = schema[0]
-        return [encode_nested_example(sub_schema, o) for o in obj]
+        return [encode_nested_example(sub_schema, o) for o in obj] if obj is not None else None
     elif isinstance(schema, Sequence):
         # We allow to reverse list of dict => dict of list for compatiblity with tfds
         if isinstance(schema.feature, dict):
@@ -887,7 +887,7 @@ def encode_nested_example(schema, obj):
         # schema.feature is not a dict
         if isinstance(obj, str):  # don't interpret a string as a list
             raise ValueError("Got a string but expected a list instead: '{}'".format(obj))
-        return [encode_nested_example(schema.feature, o) for o in obj]
+        return [encode_nested_example(schema.feature, o) for o in obj] if obj is not None else None
     # Object with special encoding:
     # ClassLabel will convert from string to int, TranslationVariableLanguages does some checks
     elif isinstance(schema, (ClassLabel, TranslationVariableLanguages, Value, _ArrayXD)):


### PR DESCRIPTION
The Sequence feature encoding was failing when a `None` sequence was used in a dataset.

Fix https://github.com/huggingface/datasets/issues/2892