### PR TITLE
Fix xpathopen to accept positional arguments

### DIFF
--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -170,7 +170,7 @@ def xopen(file, mode="r", *args, **kwargs):
     return file_obj
 
 
-def xpathopen(path: Path, **kwargs):
+def xpathopen(path: Path, *args, **kwargs):
     """Extend :func:`xopen` to support argument of type :obj:`~pathlib.Path`.
 
     Args:
@@ -180,7 +180,7 @@ def xpathopen(path: Path, **kwargs):
     Returns:
         :obj:`io.FileIO`: File-like object.
     """
-    return xopen(_as_posix(path), **kwargs)
+    return xopen(_as_posix(path), *args, **kwargs)
 
 
 def xpathglob(path, pattern):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -206,16 +206,16 @@ def test_xdirname(input_path, expected_path):
 
 
 def test_xopen_local(text_path):
-    with xopen(text_path, encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
+    with xopen(text_path, "r", encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
         assert list(f) == list(expected_file)
-    with xpathopen(Path(text_path), encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
+    with xpathopen(Path(text_path), "r", encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
         assert list(f) == list(expected_file)
 
 
 def test_xopen_remote():
-    with xopen(TEST_URL, encoding="utf-8") as f:
+    with xopen(TEST_URL, "r", encoding="utf-8") as f:
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
-    with xpathopen(Path(TEST_URL), encoding="utf-8") as f:
+    with xpathopen(Path(TEST_URL), "r", encoding="utf-8") as f:
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
 
 


### PR DESCRIPTION
Fix `xpathopen()` so that it also accepts positional arguments.

Fix #2901.