### PR TITLE
feat: 🎸 add a function to get a dataset config's split names

### DIFF
--- a/docs/source/load_hub.rst
+++ b/docs/source/load_hub.rst
@@ -30,30 +30,6 @@ Once you are happy with the dataset you want, load it in a single line with :fun
    >>> from datasets import load_dataset
    >>> dataset = load_dataset('glue', 'mrpc', split='train')
 
-Select a split
---------------
-
-A split is a specific subset of the dataset like ``train`` and ``test``. Make sure you select a split when you load a dataset. If you don't supply a ``split`` argument, 🤗 Datasets will only return a dictionary containing the subsets of the dataset.
-
-.. code-block::
-
-   >>> from datasets import load_dataset
-   >>> datasets = load_dataset('glue', 'mrpc')
-   >>> print(datasets)
-   {train: Dataset({
-       features: ['idx', 'label', 'sentence1', 'sentence2'],
-       num_rows: 3668
-   })
-   validation: Dataset({
-       features: ['idx', 'label', 'sentence1', 'sentence2'],
-       num_rows: 408
-   })
-   test: Dataset({
-       features: ['idx', 'label', 'sentence1', 'sentence2'],
-       num_rows: 1725
-   })
-   }
-
 Select a configuration
 ----------------------
 
@@ -94,3 +70,37 @@ Use ``get_dataset_config_names`` to retrieve a list of all the possible configur
        'validation': Dataset(schema: {'sentence': 'string', 'label': 'int64', 'idx': 'int32'}, num_rows: 872),
        'test': Dataset(schema: {'sentence': 'string', 'label': 'int64', 'idx': 'int32'}, num_rows: 1821)
    }
+
+Select a split
+--------------
+
+A split is a specific subset of the dataset like ``train`` and ``test``. Make sure you select a split when you load a dataset. If you don't supply a ``split`` argument, 🤗 Datasets will only return a dictionary containing the subsets of the dataset.
+
+.. code-block::
+
+   >>> from datasets import load_dataset
+   >>> datasets = load_dataset('glue', 'mrpc')
+   >>> print(datasets)
+   {train: Dataset({
+       features: ['idx', 'label', 'sentence1', 'sentence2'],
+       num_rows: 3668
+   })
+   validation: Dataset({
+       features: ['idx', 'label', 'sentence1', 'sentence2'],
+       num_rows: 408
+   })
+   test: Dataset({
+       features: ['idx', 'label', 'sentence1', 'sentence2'],
+       num_rows: 1725
+   })
+   }
+
+You can list the split names for a dataset, or a specific configuration, with the :func:`datasets.get_dataset_split_names` method:
+
+.. code-block::
+
+  >>> from datasets import get_dataset_split_names
+  >>> get_dataset_split_names('sent_comp')
+  ['validation', 'train']
+  >>> get_dataset_split_names('glue', 'cola')
+  ['test', 'train', 'validation']

--- a/docs/source/load_hub.rst
+++ b/docs/source/load_hub.rst
@@ -88,7 +88,7 @@ Use ``get_dataset_config_names`` to retrieve a list of all the possible configur
    >>> dataset = load_dataset('glue', 'sst2')
    Downloading and preparing dataset glue/sst2 (download: 7.09 MiB, generated: 4.81 MiB, total: 11.90 MiB) to /Users/thomwolf/.cache/huggingface/datasets/glue/sst2/1.0.0...
    Downloading: 100%|██████████████████████████████████████████████████████████████| 7.44M/7.44M [00:01<00:00, 7.03MB/s]
-   Dataset glue downloaded and prepared to /Users/huggignface/.cache/huggingface/datasets/glue/sst2/1.0.0. Subsequent calls will reuse this data.
+   Dataset glue downloaded and prepared to /Users/thomwolf/.cache/huggingface/datasets/glue/sst2/1.0.0. Subsequent calls will reuse this data.
    >>> print(dataset)
    {'train': Dataset(schema: {'sentence': 'string', 'label': 'int64', 'idx': 'int32'}, num_rows: 67349),
        'validation': Dataset(schema: {'sentence': 'string', 'label': 'int64', 'idx': 'int32'}, num_rows: 872),

--- a/docs/source/load_hub.rst
+++ b/docs/source/load_hub.rst
@@ -59,7 +59,7 @@ Select a configuration
 
 Some datasets, like the `General Language Understanding Evaluation (GLUE) <https://huggingface.co/datasets/glue>`_ benchmark, are actually made up of several datasets. These sub-datasets are called **configurations**, and you must explicitly select one when you load the dataset. If you don't provide a configuration name, 🤗 Datasets will raise a ``ValueError`` and remind you to select a configuration.
 
-Use ``get_dataset_config_names`` to retrieve a a list of all the possible configurations available to your dataset:
+Use ``get_dataset_config_names`` to retrieve a list of all the possible configurations available to your dataset:
 
 .. code-block::
 

--- a/docs/source/package_reference/loading_methods.rst
+++ b/docs/source/package_reference/loading_methods.rst
@@ -18,6 +18,8 @@ Datasets
 
 .. autofunction:: datasets.get_dataset_infos
 
+.. autofunction:: datasets.get_dataset_split_names
+
 .. autofunction:: datasets.inspect_dataset
 
 Metrics

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ setup(
     version="1.12.2.dev0",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
     description=DOCLINES[0],
     long_description="\n".join(DOCLINES[2:]),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author="HuggingFace Inc.",
     author_email="thomas@huggingface.co",
     url="https://github.com/huggingface/datasets",

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -54,6 +54,7 @@ from .info import DatasetInfo, MetricInfo
 from .inspect import (
     get_dataset_config_names,
     get_dataset_infos,
+    get_dataset_split_names,
     inspect_dataset,
     inspect_metric,
     list_datasets,

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -103,7 +103,7 @@ def inspect_metric(path: str, local_path: str, download_config: Optional[Downloa
     )
 
 
-def get_dataset_infos(path: str):
+def get_dataset_infos(path: str, **prepare_module_kwargs):
     """Get the meta information about a dataset, returned as a dict mapping config name to DatasetInfoDict.
 
     Args:
@@ -113,13 +113,14 @@ def get_dataset_infos(path: str):
                 e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``
             - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``datasets.list_datasets()``)
                 e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
+        prepare_module_kwargs: optional attributes for prepare_module, for example ``use_auth_token``
     """
-    module_path, _ = prepare_module(path)
+    module_path, _ = prepare_module(path, **prepare_module_kwargs)
     builder_cls = import_main_class(module_path, dataset=True)
     return builder_cls.get_all_exported_dataset_infos()
 
 
-def get_dataset_config_names(path: str):
+def get_dataset_config_names(path: str, **prepare_module_kwargs):
     """Get the list of available config names for a particular dataset.
 
     Args:
@@ -129,8 +130,9 @@ def get_dataset_config_names(path: str):
                 e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``
             - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``datasets.list_datasets()``)
                 e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
+        prepare_module_kwargs: optional attributes for prepare_module, for example ``use_auth_token``
     """
-    module_path, _ = prepare_module(path)
+    module_path, _ = prepare_module(path, **prepare_module_kwargs)
     builder_cls = import_main_class(module_path, dataset=True)
     return list(builder_cls.builder_configs.keys())
 

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -31,6 +31,10 @@ from .utils.version import Version
 logger = get_logger(__name__)
 
 
+class SplitsNotFoundError(ValueError):
+    pass
+
+
 def list_datasets(with_community_datasets=True, with_details=False):
     """List all the datasets scripts available on HuggingFace AWS bucket.
 
@@ -283,5 +287,5 @@ def get_dataset_split_names(
                 for split_generator in builder._split_generators(StreamingDownloadManager(base_path=builder.base_path))
             ]
         except Exception as err:
-            raise Exception("The split names could not be parsed from the dataset config.") from err
+            raise SplitsNotFoundError("The split names could not be parsed from the dataset config.") from err
     return list(builder.info.splits.keys())

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -114,8 +114,6 @@ def get_dataset_infos(
     download_mode: Optional[GenerateMode] = None,
     force_local_path: Optional[str] = None,
     dynamic_modules_path: Optional[str] = None,
-    return_resolved_file_path: bool = False,
-    return_associated_base_path: bool = False,
     data_files: Optional[Union[Dict, List, str]] = None,
     **download_kwargs,
 ):
@@ -141,11 +139,6 @@ def get_dataset_infos(
         dynamic_modules_path (Optional str, defaults to HF_MODULES_CACHE / "datasets_modules", i.e. ~/.cache/huggingface/modules/datasets_modules):
             Optional path to the directory in which the dynamic modules are saved. It must have been initialized with :obj:`init_dynamic_modules`.
             By default the datasets and metrics are stored inside the `datasets_modules` module.
-        return_resolved_file_path (Optional bool, defaults to False):
-            If True, the url or path to the resolved dataset is returned with the other outputs
-        return_associated_base_path (Optional bool, defaults to False):
-            If True, the base path associated to the dataset is returned with the other outputs.
-            It corresponds to the directory or base url where the dataset script/dataset repo is at.
         data_files (:obj:`Union[Dict, List, str]`, optional): Defining the data_files of the dataset configuration.
         download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied,
             for example ``use_auth_token``
@@ -158,8 +151,6 @@ def get_dataset_infos(
         download_mode=download_mode,
         force_local_path=force_local_path,
         dynamic_modules_path=dynamic_modules_path,
-        return_resolved_file_path=return_resolved_file_path,
-        return_associated_base_path=return_associated_base_path,
         data_files=data_files,
         **download_kwargs,
     )
@@ -174,8 +165,6 @@ def get_dataset_config_names(
     download_mode: Optional[GenerateMode] = None,
     force_local_path: Optional[str] = None,
     dynamic_modules_path: Optional[str] = None,
-    return_resolved_file_path: bool = False,
-    return_associated_base_path: bool = False,
     data_files: Optional[Union[Dict, List, str]] = None,
     **download_kwargs,
 ):
@@ -201,11 +190,6 @@ def get_dataset_config_names(
         dynamic_modules_path (Optional str, defaults to HF_MODULES_CACHE / "datasets_modules", i.e. ~/.cache/huggingface/modules/datasets_modules):
             Optional path to the directory in which the dynamic modules are saved. It must have been initialized with :obj:`init_dynamic_modules`.
             By default the datasets and metrics are stored inside the `datasets_modules` module.
-        return_resolved_file_path (Optional bool, defaults to False):
-            If True, the url or path to the resolved dataset is returned with the other outputs
-        return_associated_base_path (Optional bool, defaults to False):
-            If True, the base path associated to the dataset is returned with the other outputs.
-            It corresponds to the directory or base url where the dataset script/dataset repo is at.
         data_files (:obj:`Union[Dict, List, str]`, optional): Defining the data_files of the dataset configuration.
         download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied,
             for example ``use_auth_token``
@@ -218,8 +202,6 @@ def get_dataset_config_names(
         download_mode=download_mode,
         force_local_path=force_local_path,
         dynamic_modules_path=dynamic_modules_path,
-        return_resolved_file_path=return_resolved_file_path,
-        return_associated_base_path=return_associated_base_path,
         data_files=data_files,
         **download_kwargs,
     )

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -105,7 +105,7 @@ def inspect_metric(path: str, local_path: str, download_config: Optional[Downloa
 
 def get_dataset_infos(
     path: str,
-    script_version: Optional[Union[str, Version]] = None,
+    revision: Optional[Union[str, Version]] = None,
     download_config: Optional[DownloadConfig] = None,
     download_mode: Optional[GenerateMode] = None,
     force_local_path: Optional[str] = None,
@@ -124,7 +124,7 @@ def get_dataset_infos(
                 e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``
             - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``datasets.list_datasets()``)
                 e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
-        script_version (Optional ``Union[str, datasets.Version]``):
+        revision (Optional ``Union[str, datasets.Version]``):
             If specified, the dataset module will be loaded from the datasets repository at this version.
             By default:
             - it is set to the local version of the lib.
@@ -149,7 +149,7 @@ def get_dataset_infos(
     module_path, _ = prepare_module(
         path,
         dataset=True,
-        script_version=script_version,
+        revision=revision,
         download_config=download_config,
         download_mode=download_mode,
         force_local_path=force_local_path,
@@ -165,7 +165,7 @@ def get_dataset_infos(
 
 def get_dataset_config_names(
     path: str,
-    script_version: Optional[Union[str, Version]] = None,
+    revision: Optional[Union[str, Version]] = None,
     download_config: Optional[DownloadConfig] = None,
     download_mode: Optional[GenerateMode] = None,
     force_local_path: Optional[str] = None,
@@ -184,7 +184,7 @@ def get_dataset_config_names(
                 e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``
             - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``datasets.list_datasets()``)
                 e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
-        script_version (Optional ``Union[str, datasets.Version]``):
+        revision (Optional ``Union[str, datasets.Version]``):
             If specified, the dataset module will be loaded from the datasets repository at this version.
             By default:
             - it is set to the local version of the lib.
@@ -209,7 +209,7 @@ def get_dataset_config_names(
     module_path, _ = prepare_module(
         path,
         dataset=True,
-        script_version=script_version,
+        revision=revision,
         download_config=download_config,
         download_mode=download_mode,
         force_local_path=force_local_path,
@@ -232,7 +232,7 @@ def get_dataset_split_names(
     features: Optional[Features] = None,
     download_config: Optional[DownloadConfig] = None,
     download_mode: Optional[GenerateMode] = None,
-    script_version: Optional[Union[str, Version]] = None,
+    revision: Optional[Union[str, Version]] = None,
     use_auth_token: Optional[Union[bool, str]] = None,
     **config_kwargs,
 ):
@@ -252,7 +252,7 @@ def get_dataset_split_names(
         features (:class:`Features`, optional): Set the features type to use for this dataset.
         download_config (:class:`~utils.DownloadConfig`, optional): Specific download configuration parameters.
         download_mode (:class:`GenerateMode`, default ``REUSE_DATASET_IF_EXISTS``): Download/generate mode.
-        script_version (:class:`~utils.Version` or :obj:`str`, optional): Version of the dataset script to load:
+        revision (:class:`~utils.Version` or :obj:`str`, optional): Version of the dataset script to load:
 
             - For canonical datasets in the `huggingface/datasets` library like "squad", the default version of the module is the local version of the lib.
               You can specify a different version from your local version of the lib (e.g. "master" or "1.2.0") but it might cause compatibility issues.
@@ -272,7 +272,7 @@ def get_dataset_split_names(
         features=features,
         download_config=download_config,
         download_mode=download_mode,
-        script_version=script_version,
+        revision=revision,
         use_auth_token=use_auth_token,
         **config_kwargs,
     )


### PR DESCRIPTION
Also: pass additional arguments (use_auth_token) to get private configs + info of private datasets on the hub

Questions:

- [x] I'm not sure how the versions work: I changed 1.12.1.dev0 to 1.12.1.dev1, was it correct?
    -> no: reverted
- [x] Should I add a section in https://github.com/huggingface/datasets/blob/master/docs/source/load_hub.rst? (there is no section for get_dataset_infos)
    -> yes: added