### PR TITLE
Fix unwanted tqdm bar when accessing examples

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -819,7 +819,7 @@ class DatasetBuilder:
             ),
             split,
             map_tuple=True,
-            disable_tqdm=False
+            disable_tqdm=False,
         )
         if isinstance(datasets, dict):
             datasets = DatasetDict(datasets)

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -819,6 +819,7 @@ class DatasetBuilder:
             ),
             split,
             map_tuple=True,
+            disable_tqdm=False
         )
         if isinstance(datasets, dict):
             datasets = DatasetDict(datasets)

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -124,7 +124,7 @@ class DownloadManager:
 
         uploaded_path_or_paths = map_nested(
             lambda local_file_path: upload(local_file_path),
-            downloaded_path_or_paths,
+            downloaded_path_or_paths, disable_tqdm=False
         )
         return uploaded_path_or_paths
 
@@ -154,7 +154,7 @@ class DownloadManager:
         def url_to_downloaded_path(url):
             return os.path.join(cache_dir, hash_url_to_filename(url))
 
-        downloaded_path_or_paths = map_nested(url_to_downloaded_path, url_or_urls)
+        downloaded_path_or_paths = map_nested(url_to_downloaded_path, url_or_urls, disable_tqdm=False)
         url_or_urls = NestedDataStructure(url_or_urls)
         downloaded_path_or_paths = NestedDataStructure(downloaded_path_or_paths)
         for url, path in zip(url_or_urls.flatten(), downloaded_path_or_paths.flatten()):
@@ -199,6 +199,7 @@ class DownloadManager:
             url_or_urls,
             map_tuple=True,
             num_proc=download_config.num_proc,
+            disable_tqdm=False
         )
         duration = datetime.now() - start_time
         logger.info("Downloading took {} min".format(duration.total_seconds() // 60))
@@ -265,6 +266,7 @@ class DownloadManager:
             partial(cached_path, download_config=download_config),
             path_or_paths,
             num_proc=num_proc,
+            disable_tqdm=False
         )
         path_or_paths = NestedDataStructure(path_or_paths)
         extracted_paths = NestedDataStructure(extracted_paths)

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -123,8 +123,7 @@ class DownloadManager:
             return remote_file_path
 
         uploaded_path_or_paths = map_nested(
-            lambda local_file_path: upload(local_file_path),
-            downloaded_path_or_paths, disable_tqdm=False
+            lambda local_file_path: upload(local_file_path), downloaded_path_or_paths, disable_tqdm=False
         )
         return uploaded_path_or_paths
 
@@ -195,11 +194,7 @@ class DownloadManager:
 
         start_time = datetime.now()
         downloaded_path_or_paths = map_nested(
-            download_func,
-            url_or_urls,
-            map_tuple=True,
-            num_proc=download_config.num_proc,
-            disable_tqdm=False
+            download_func, url_or_urls, map_tuple=True, num_proc=download_config.num_proc, disable_tqdm=False
         )
         duration = datetime.now() - start_time
         logger.info("Downloading took {} min".format(duration.total_seconds() // 60))
@@ -263,10 +258,7 @@ class DownloadManager:
         download_config.extract_compressed_file = True
         download_config.force_extract = False
         extracted_paths = map_nested(
-            partial(cached_path, download_config=download_config),
-            path_or_paths,
-            num_proc=num_proc,
-            disable_tqdm=False
+            partial(cached_path, download_config=download_config), path_or_paths, num_proc=num_proc, disable_tqdm=False
         )
         path_or_paths = NestedDataStructure(path_or_paths)
         extracted_paths = NestedDataStructure(extracted_paths)

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -176,6 +176,7 @@ def map_nested(
     map_numpy: bool = False,
     num_proc: Optional[int] = None,
     types=None,
+    disable_tqdm: bool = True,
 ):
     """Apply a function recursively to each element of a nested data struct.
     If num_proc > 1 and the length of data_struct is longer than num_proc: use multi-processing
@@ -195,7 +196,7 @@ def map_nested(
     if not isinstance(data_struct, dict) and not isinstance(data_struct, types):
         return function(data_struct)
 
-    disable_tqdm = bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled()
+    disable_tqdm = disable_tqdm or bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled()
     iterable = list(data_struct.values()) if isinstance(data_struct, dict) else data_struct
 
     if num_proc is None:

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -196,7 +196,9 @@ def map_nested(
     if not isinstance(data_struct, dict) and not isinstance(data_struct, types):
         return function(data_struct)
 
-    disable_tqdm = disable_tqdm or bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled()
+    disable_tqdm = (
+        disable_tqdm or bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled()
+    )
     iterable = list(data_struct.values()) if isinstance(data_struct, dict) else data_struct
 
     if num_proc is None:


### PR DESCRIPTION
A change in #2814 added bad progress bars in `map_nested`. Now they're disabled by default

Fix #2919 