### PR TITLE
Fix multidim arrays in list to arrow

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -44,7 +44,7 @@ from datasets.tasks.text_classification import TextClassification
 from . import config, utils
 from .arrow_reader import ArrowReader
 from .arrow_writer import ArrowWriter, OptimizedTypedSequence
-from .features import ClassLabel, Features, Value, cast_to_python_objects
+from .features import ClassLabel, Features, Value
 from .filesystems import extract_path_from_uri, is_remote_filesystem
 from .fingerprint import (
     fingerprint_transform,
@@ -449,8 +449,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         info.features = features
         if features is not None:
             mapping = features.encode_batch(mapping)
-        else:
-            mapping = cast_to_python_objects(mapping)
         mapping = {
             col: OptimizedTypedSequence(data, type=features.type[col].type if features is not None else None, col=col)
             for col, data in mapping.items()
@@ -2037,7 +2035,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                             if isinstance(example, pa.Table):
                                 writer.write_row(example)
                             else:
-                                example = cast_to_python_objects(example)
                                 writer.write(example)
                 else:
                     for i in pbar:
@@ -2065,7 +2062,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                             if isinstance(batch, pa.Table):
                                 writer.write_table(batch)
                             else:
-                                batch = cast_to_python_objects(batch)
                                 writer.write_batch(batch)
                 if update_data and writer is not None:
                     writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -144,7 +144,7 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     return pa.__dict__[arrow_data_factory_function_name]()
 
 
-def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
+def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool) -> Tuple[Any, bool]:
     """
     Cast pytorch/tensorflow/pandas objects to python numpy array/lists.
     It works recursively.
@@ -155,6 +155,9 @@ def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
 
     Args:
         obj: the object (nested struct) to cast
+        only_1d_for_numpy (bool): whether to keep the full multi-dim tensors as multi-dim numpy arrays, or convert them to
+            nested lists of 1-dimensional numpy arrays. This can be useful to keep only 1-d arrays to instantiate Arrow arrays.
+            Indeed Arrow only support converting 1-dimensional array values.
 
     Returns:
         casted_obj: the casted object
@@ -171,13 +174,27 @@ def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
         import jax.numpy as jnp
 
     if isinstance(obj, np.ndarray):
-        return obj.tolist(), False
+        if only_1d_for_numpy and obj.ndim == 1:
+            return obj, False
+        else:
+            return [_cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in obj], True
     elif config.TORCH_AVAILABLE and "torch" in sys.modules and isinstance(obj, torch.Tensor):
-        return obj.detach().cpu().numpy(), True
+        if only_1d_for_numpy and obj.ndim == 1:
+            return obj.detach().cpu().numpy(), True
+        else:
+            return [
+                _cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in obj.detach().cpu().numpy()
+            ], True
     elif config.TF_AVAILABLE and "tensorflow" in sys.modules and isinstance(obj, tf.Tensor):
-        return obj.numpy(), True
+        if only_1d_for_numpy and obj.ndim == 1:
+            return obj.numpy(), True
+        else:
+            return [_cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in obj.numpy()], True
     elif config.JAX_AVAILABLE and "jax" in sys.modules and isinstance(obj, jnp.ndarray):
-        return np.asarray(obj), True
+        if only_1d_for_numpy and obj.ndim == 1:
+            return np.asarray(obj), True
+        else:
+            return [_cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in np.asarray(obj)], True
     elif isinstance(obj, pd.Series):
         return obj.values.tolist(), True
     elif isinstance(obj, pd.DataFrame):
@@ -186,7 +203,7 @@ def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
         output = {}
         has_changed = False
         for k, v in obj.items():
-            casted_v, has_changed_v = _cast_to_python_objects(v)
+            casted_v, has_changed_v = _cast_to_python_objects(v, only_1d_for_numpy=only_1d_for_numpy)
             has_changed |= has_changed_v
             output[k] = casted_v
         return output if has_changed else obj, has_changed
@@ -195,9 +212,11 @@ def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
             for first_elmt in obj:
                 if first_elmt is not None:
                     break
-            casted_first_elmt, has_changed_first_elmt = _cast_to_python_objects(first_elmt)
+            casted_first_elmt, has_changed_first_elmt = _cast_to_python_objects(
+                first_elmt, only_1d_for_numpy=only_1d_for_numpy
+            )
             if has_changed_first_elmt:
-                return [_cast_to_python_objects(elmt)[0] for elmt in obj], True
+                return [_cast_to_python_objects(elmt, only_1d_for_numpy=only_1d_for_numpy)[0] for elmt in obj], True
             else:
                 if isinstance(obj, list):
                     return obj, False
@@ -209,7 +228,7 @@ def _cast_to_python_objects(obj: Any) -> Tuple[Any, bool]:
         return obj, False
 
 
-def cast_to_python_objects(obj: Any) -> Any:
+def cast_to_python_objects(obj: Any, only_1d_for_numpy=False) -> Any:
     """
     Cast numpy/pytorch/tensorflow/pandas objects to python lists.
     It works recursively.
@@ -224,7 +243,7 @@ def cast_to_python_objects(obj: Any) -> Any:
     Returns:
         casted_obj: the casted object
     """
-    return _cast_to_python_objects(obj)[0]
+    return _cast_to_python_objects(obj, only_1d_for_numpy=only_1d_for_numpy)[0]
 
 
 @dataclass
@@ -961,6 +980,20 @@ def numpy_to_pyarrow_listarray(arr: np.ndarray, type: pa.DataType = None) -> pa.
         offsets = pa.array(np.arange(n_offsets + 1) * step_offsets, type=pa.int32())
         values = pa.ListArray.from_arrays(offsets, values)
     return values
+
+
+def list_of_pa_arrays_to_pyarrow_listarray(l_arr: List[pa.Array]) -> pa.ListArray:
+    offsets = pa.array(np.cumsum([0] + [len(arr) for arr in l_arr]), type=pa.int32())
+    values = pa.concat_arrays(l_arr)
+    return pa.ListArray.from_arrays(offsets, values)
+
+
+def list_of_np_array_to_pyarrow_listarray(l_arr: List[np.ndarray], type: pa.DataType = None) -> pa.ListArray:
+    """Build a PyArrow ListArray from a possibly nested list of NumPy arrays"""
+    if len(l_arr) > 0:
+        return list_of_pa_arrays_to_pyarrow_listarray([numpy_to_pyarrow_listarray(arr, type=type) for arr in l_arr])
+    else:
+        return pa.array([], type=type)
 
 
 class Features(dict):

--- a/src/datasets/features.py
+++ b/src/datasets/features.py
@@ -174,24 +174,24 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool) -> Tuple[Any, boo
         import jax.numpy as jnp
 
     if isinstance(obj, np.ndarray):
-        if only_1d_for_numpy and obj.ndim == 1:
+        if not only_1d_for_numpy or obj.ndim == 1:
             return obj, False
         else:
             return [_cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in obj], True
     elif config.TORCH_AVAILABLE and "torch" in sys.modules and isinstance(obj, torch.Tensor):
-        if only_1d_for_numpy and obj.ndim == 1:
+        if not only_1d_for_numpy or obj.ndim == 1:
             return obj.detach().cpu().numpy(), True
         else:
             return [
                 _cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in obj.detach().cpu().numpy()
             ], True
     elif config.TF_AVAILABLE and "tensorflow" in sys.modules and isinstance(obj, tf.Tensor):
-        if only_1d_for_numpy and obj.ndim == 1:
+        if not only_1d_for_numpy or obj.ndim == 1:
             return obj.numpy(), True
         else:
             return [_cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in obj.numpy()], True
     elif config.JAX_AVAILABLE and "jax" in sys.modules and isinstance(obj, jnp.ndarray):
-        if only_1d_for_numpy and obj.ndim == 1:
+        if not only_1d_for_numpy or obj.ndim == 1:
             return np.asarray(obj), True
         else:
             return [_cast_to_python_objects(x, only_1d_for_numpy=only_1d_for_numpy)[0] for x in np.asarray(obj)], True


### PR DESCRIPTION
Arrow only supports 1-dim arrays. Previously we were converting all the numpy arrays to python list before instantiating arrow arrays to workaround this limitation.
However in #2361 we started to keep numpy arrays in order to keep their dtypes.
It works when we pass any multi-dim numpy array (the conversion to arrow has been added on our side), but not for lists of multi-dim numpy arrays.

In this PR I added two strategies:
- one that takes a list of multi-dim numpy arrays on returns an arrow array in an optimized way (more common case)
- one that takes a list of possibly very nested data (lists, dicts, tuples) containing multi-dim arrays. This one is less optimized since it converts all the multi-dim numpy arrays into lists of 1-d arrays for compatibility with arrow. This strategy is simpler that just trying to create the arrow array from a possibly very nested data structure, but in the future we can improve it if needed.

Fix https://github.com/huggingface/datasets/issues/2921