### PR TITLE
Update meteor score from nltk update

### DIFF
--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -72,7 +72,7 @@ Examples:
     >>> references = ["It is a guide to action that ensures that the military will forever heed Party commands"]
     >>> results = meteor.compute(predictions=predictions, references=references)
     >>> print(round(results["meteor"], 4))
-    0.7398
+    0.6944
 """
 
 


### PR DESCRIPTION
It looks like there were issues in NLTK on the way the METEOR score was computed.
A fix was added in NLTK at https://github.com/nltk/nltk/pull/2763, and therefore the scoring function no longer returns the same values.

I updated the score of the example in the docs