### PR TITLE
Don't use old, incompatible cache for the new `filter`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2353,7 +2353,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixIn):
             return self
 
     @transmit_format
-    @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "cache_file_name"])
+    @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "cache_file_name"], version="2.0.0")
     def filter(
         self,
         function: Optional[Callable] = None,

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -304,6 +304,7 @@ def fingerprint_transform(
     ignore_kwargs: Optional[List[str]] = None,
     fingerprint_names: Optional[List[str]] = None,
     randomized_function: bool = False,
+    version: Optional[str] = None,
 ):
     """
     Wrapper for dataset transforms to update the dataset fingerprint using ``update_fingerprint``
@@ -326,6 +327,11 @@ def fingerprint_transform(
             This way, even if users set "seed" and "generator" to None, then the fingerprint is
             going to be randomly generated depending on numpy's current state. In this case, the
             generator is set to np.random.default_rng(np.random.get_state()[1][0]).
+        version (Optional ``str``): version of the transform. The version is taken into account when
+            computing the fingerprint. If a datase transform changes (or at least if the output data
+            that are cached changes), then one should increase the version. If the version stays the
+            same, then old cached data could be reused that are not compatible with the new transform.
+            It should be in the format "MAJOR.MINOR.PATCH".
     """
 
     assert use_kwargs is None or isinstance(use_kwargs, list), "use_kwargs is supposed to be a list, not {}".format(
@@ -346,7 +352,9 @@ def fingerprint_transform(
             assert "seed" in func.__code__.co_varnames, "'seed' must be in {}'s signature".format(func)
             assert "generator" in func.__code__.co_varnames, "'generator' must be in {}'s signature".format(func)
         # this has to be outside the wrapper or since __qualname__ changes in multiprocessing
-        transform = func.__module__ + "." + func.__qualname__
+        transform = f"{func.__module__}.{func.__qualname__}"
+        if version is not None:
+            transform += f"@{version}"
 
         @wraps(func)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
#2836 changed `Dataset.filter` and the resulting data that are stored in the cache are different and incompatible with the ones of the previous `filter` implementation.

However the caching mechanism wasn't able to differentiate between the old and the new implementation of filter (only the method name was taken into account). 

This is an issue because anyone that update `datasets` and re-runs some code that uses `filter` would see an error, because the cache would try to load an incompatible `filter` result.

To fix this I added the notion of versioning for dataset transform in the caching mechanism, and bumped the version of the `filter` implementation to 2.0.0

This way the new `filter` outputs are now considered different from the old ones from the caching point of view.

This should fix issue https://github.com/huggingface/datasets/issues/2943

cc @anton-l