### PR TITLE
Fix missing conda deps

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - fsspec
     - huggingface_hub <0.1.0
     - packaging
+    - aiohttp
   run:
     - python
     - pip
@@ -43,6 +44,7 @@ requirements:
     - fsspec
     - huggingface_hub <0.1.0
     - packaging
+    - aiohttp
 
 test:
   imports:


### PR DESCRIPTION
`aiohttp` was added as a dependency in #2662 but was missing for the conda build, which causes the 1.12.0 and 1.12.1 to fail