### PR TITLE
Run tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
-            - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -n auto -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:
         working_directory: ~/datasets
@@ -30,7 +30,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
-            - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -n auto -sv ./tests/
 
     run_dataset_script_tests_pyarrow_latest_WIN:
         working_directory: ~/datasets
@@ -49,7 +49,7 @@ jobs:
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
             - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -sv ./tests/
+            - run: python -m pytest -n auto -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1_WIN:
         working_directory: ~/datasets
@@ -68,7 +68,7 @@ jobs:
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
             - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -sv ./tests/
+            - run: python -m pytest -n auto -sv ./tests/
 
     check_code_quality:
         working_directory: ~/datasets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
             - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -n auto -sv ./tests/
+            - run: python -m pytest -n 2 -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1_WIN:
         working_directory: ~/datasets
@@ -68,7 +68,7 @@ jobs:
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
             - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -n auto -sv ./tests/
+            - run: python -m pytest -n 2 -sv ./tests/
 
     check_code_quality:
         working_directory: ~/datasets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
-            - run: HF_SCRIPTS_VERSION=master python -m pytest -n auto -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -d --tx 2*popen//python=python3.6 -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:
         working_directory: ~/datasets
@@ -30,7 +30,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
-            - run: HF_SCRIPTS_VERSION=master python -m pytest -n auto -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -d --tx 2*popen//python=python3.6 -sv ./tests/
 
     run_dataset_script_tests_pyarrow_latest_WIN:
         working_directory: ~/datasets

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ TESTS_REQUIRE = [
     # test dependencies
     "absl-py",
     "pytest",
-    "pytest-xdist",
+    "pytest-xdist[psutil]",
     # optional dependencies
     "apache-beam>=2.26.0",
     "elasticsearch",

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ TESTS_REQUIRE = [
     # test dependencies
     "absl-py",
     "pytest",
-    "pytest-xdist[psutil]",
+    "pytest-xdist",
     # optional dependencies
     "apache-beam>=2.26.0",
     "elasticsearch",


### PR DESCRIPTION
Run CI tests in parallel to speed up the test suite.

Speed up results:
- Linux: from `7m 30s` to `5m 32s`
- Windows: from `13m 52s` to `11m 10s`
