### PR TITLE
Update legacy Python image for CI tests in Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     run_dataset_script_tests_pyarrow_latest:
         working_directory: ~/datasets
         docker:
-            - image: circleci/python:3.6
+            - image: cimg/python:3.6
         resource_class: medium
         steps:
             - checkout
@@ -21,7 +21,7 @@ jobs:
     run_dataset_script_tests_pyarrow_1:
         working_directory: ~/datasets
         docker:
-            - image: circleci/python:3.6
+            - image: cimg/python:3.6
         resource_class: medium
         steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 #            - run: python -m venv venv
 #            - run: source venv/bin/activate
             - run: pip install --upgrade pip
-            - run: pip install --only-binary=faiss-cpu .[tests]
+            - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
@@ -26,6 +26,7 @@ jobs:
         resource_class: medium
         steps:
             - checkout
+            - run: pip install --upgrade pip
             - run: python -m venv venv
             - run: source venv/bin/activate
             - run: pip install .[tests]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ jobs:
         resource_class: medium
         steps:
             - checkout
-#            - run: python -m venv venv
-#            - run: source venv/bin/activate
             - run: pip install --upgrade pip
+            - run: python -m venv venv
+            - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
         resource_class: medium
         steps:
             - checkout
-            - run: python -m venv venv
-            - run: source venv/bin/activate
+#            - run: python -m venv venv
+#            - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
             - checkout
 #            - run: python -m venv venv
 #            - run: source venv/bin/activate
-            - run: pip install --user .[tests]
-            - run: pip install --user -r additional-tests-requirements.txt --no-deps
-            - run: pip install --user pyarrow --upgrade
+            - run: pip install --only-binary=faiss-cpu .[tests]
+            - run: pip install -r additional-tests-requirements.txt --no-deps
+            - run: pip install pyarrow --upgrade
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
             - checkout
 #            - run: python -m venv venv
 #            - run: source venv/bin/activate
+            - run: pip install --upgrade pip
             - run: pip install --only-binary=faiss-cpu .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
             - checkout
 #            - run: python -m venv venv
 #            - run: source venv/bin/activate
-            - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow --upgrade
+            - run: pip install --user .[tests]
+            - run: pip install --user -r additional-tests-requirements.txt --no-deps
+            - run: pip install --user pyarrow --upgrade
             - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:


### PR DESCRIPTION
Instead of legacy, use next-generation convenience images, built from the ground up with CI, efficiency, and determinism in mind. Here are some of the highlights:

- Faster spin-up time - In Docker terminology, these next-gen images will generally have fewer and smaller layers. Using these new images will lead to faster image downloads when a build starts, and a higher likelihood that the image is already cached on the host.

- Improved reliability and stability - The existing legacy convenience images are rebuilt practically every day with potential changes from upstream that we cannot always test fast enough. This leads to frequent breaking changes, which is not the best environment for stable, deterministic builds. Next-gen images will only be rebuilt for security and critical-bugs, leading to more stable and deterministic images.

More info: https://circleci.com/docs/2.0/circleci-images