### PR TITLE
Support pandas 1.3 new `read_csv` parameters

### DIFF
--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -121,8 +121,7 @@ class CsvConfig(datasets.BuilderConfig):
         # Remove 1.3 new arguments
         if not (pandas_version[0] >= 1 and pandas_version[1] >= 3):
             for read_csv_parameter in _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS:
-                if read_csv_kwargs[read_csv_parameter] == getattr(CsvConfig(), read_csv_parameter):
-                    del read_csv_kwargs[read_csv_parameter]
+                del read_csv_kwargs[read_csv_parameter]
 
         return read_csv_kwargs
 

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 from dataclasses import dataclass
-from typing import List, Optional, Union, Tuple, Literal
+from typing import List, Literal, Optional, Tuple, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -15,8 +15,10 @@ _PANDAS_READ_CSV_NO_DEFAULT_PARAMETERS = ["names", "prefix"]
 _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS = ["encoding_errors", "on_bad_lines"]
 
+
 def parse_semver(version: str) -> Tuple[int, ...]:
     return tuple(int(part) for part in version.split(".")[:2])
+
 
 @dataclass
 class CsvConfig(datasets.BuilderConfig):
@@ -115,7 +117,7 @@ class CsvConfig(datasets.BuilderConfig):
         for read_csv_parameter in _PANDAS_READ_CSV_NO_DEFAULT_PARAMETERS + _PANDAS_READ_CSV_DEPRECATED_PARAMETERS:
             if read_csv_kwargs[read_csv_parameter] == getattr(CsvConfig(), read_csv_parameter):
                 del read_csv_kwargs[read_csv_parameter]
-        
+
         # Remove 1.3 new arguments
         if not (pandas_version[0] >= 1 and pandas_version[1] >= 3):
             for read_csv_parameter in _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS:

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,10 +1,10 @@
 # coding=utf-8
-
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
+from packaging import version
 from typing_extensions import Literal
 
 import datasets
@@ -15,10 +15,6 @@ logger = datasets.utils.logging.get_logger(__name__)
 _PANDAS_READ_CSV_NO_DEFAULT_PARAMETERS = ["names", "prefix"]
 _PANDAS_READ_CSV_DEPRECATED_PARAMETERS = ["warn_bad_lines", "error_bad_lines"]
 _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS = ["encoding_errors", "on_bad_lines"]
-
-
-def parse_semver(version: str) -> Tuple[int, ...]:
-    return tuple(int(part) for part in version.split(".")[:2])
 
 
 @dataclass
@@ -112,7 +108,7 @@ class CsvConfig(datasets.BuilderConfig):
             on_bad_lines=self.on_bad_lines,
         )
 
-        pandas_version = parse_semver(pd.__version__)
+        pandas_version = version.Version(pd.__version__)
         # some kwargs must not be passed if they don't have a default value
         # some others are deprecated and we can also not pass them if they are the default value
         for read_csv_parameter in _PANDAS_READ_CSV_NO_DEFAULT_PARAMETERS + _PANDAS_READ_CSV_DEPRECATED_PARAMETERS:
@@ -120,7 +116,7 @@ class CsvConfig(datasets.BuilderConfig):
                 del read_csv_kwargs[read_csv_parameter]
 
         # Remove 1.3 new arguments
-        if not (pandas_version[0] >= 1 and pandas_version[1] >= 3):
+        if not (pandas_version.major >= 1 and pandas_version.minor >= 3):
             for read_csv_parameter in _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS:
                 del read_csv_kwargs[read_csv_parameter]
 

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
+from typing_extensions import Literal
 
 import pandas as pd
 import pyarrow as pa

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -105,6 +105,8 @@ class CsvConfig(datasets.BuilderConfig):
             memory_map=self.memory_map,
             float_precision=self.float_precision,
             chunksize=self.chunksize,
+            encoding_errors=self.encoding_errors,
+            on_bad_lines=self.on_bad_lines,
         )
 
         pandas_version = parse_semver(pd.__version__)

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -2,10 +2,10 @@
 
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
-from typing_extensions import Literal
 
 import pandas as pd
 import pyarrow as pa
+from typing_extensions import Literal
 
 import datasets
 


### PR DESCRIPTION
Support two new arguments introduced in pandas v1.3.0:
- `encoding_errors`
- `on_bad_lines` 

`read_csv` reference: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html