### PR TITLE
Fix CI doc build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ EXTRAS_REQUIRE = {
         "sphinx-rtd-theme==0.4.3",
         "sphinxext-opengraph==0.4.1",
         "sphinx-copybutton",
-        "fsspec",
+        "fsspec<2021.9.0",
         "s3fs",
         "sphinx-panels",
         "sphinx-inline-tabs",


### PR DESCRIPTION
Pin `fsspec`.

Before the issue: 'fsspec-2021.8.1', 's3fs-2021.8.1'
Generating the issue: 'fsspec-2021.9.0', 's3fs-0.5.1'
