### PR TITLE
Fix loading compressed CSV without streaming

### DIFF
--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -151,16 +151,14 @@ class Csv(datasets.ArrowBasedBuilder):
         # dtype allows reading an int column as str
         dtype = {name: dtype.to_pandas_dtype() for name, dtype in zip(schema.names, schema.types)} if schema else None
         for file_idx, file in enumerate(files):
-            with open(file, "rb") as f:
-                csv_file_reader = pd.read_csv(f, iterator=True, dtype=dtype, **self.config.read_csv_kwargs)
-
-                try:
-                    for batch_idx, df in enumerate(csv_file_reader):
-                        pa_table = pa.Table.from_pandas(df, schema=schema)
-                        # Uncomment for debugging (will print the Arrow table size and elements)
-                        # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
-                        # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
-                        yield (file_idx, batch_idx), pa_table
-                except ValueError as e:
-                    logger.error(f"Failed to read file '{csv_file_reader.f}' with error {type(e)}: {e}")
-                    raise
+            csv_file_reader = pd.read_csv(file, iterator=True, dtype=dtype, **self.config.read_csv_kwargs)
+            try:
+                for batch_idx, df in enumerate(csv_file_reader):
+                    pa_table = pa.Table.from_pandas(df, schema=schema)
+                    # Uncomment for debugging (will print the Arrow table size and elements)
+                    # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
+                    # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
+                    yield (file_idx, batch_idx), pa_table
+            except ValueError as e:
+                logger.error(f"Failed to read file '{csv_file_reader.f}' with error {type(e)}: {e}")
+                raise

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -9,6 +9,7 @@ from .utils.streaming_download_manager import (
     xdirname,
     xjoin,
     xopen,
+    xpandas_read_csv,
     xpathglob,
     xpathjoin,
     xpathopen,
@@ -57,3 +58,4 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch.object(module.Path, "rglob", xpathrglob).start()
         patch.object(module.Path, "stem", property(fget=xpathstem)).start()
         patch.object(module.Path, "suffix", property(fget=xpathsuffix)).start()
+    patch_submodule(module, "pd.read_csv", xpandas_read_csv, attrs=["__version__"]).start()

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -245,6 +245,12 @@ def xpathsuffix(path: Path):
     return PurePosixPath(_as_posix(path).split("::")[0]).suffix
 
 
+def xpandas_read_csv(path, **kwargs):
+    import pandas as pd
+
+    return pd.read_csv(xopen(path), **kwargs)
+
+
 class StreamingDownloadManager(object):
     """
     Download manager that uses the "::" separator to navigate through (possibly remote) compressed archives.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,6 +221,19 @@ def csv_path(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def bz2_csv_path(csv_path, tmp_path_factory):
+    import bz2
+
+    path = tmp_path_factory.mktemp("data") / "dataset.csv.bz2"
+    with open(csv_path, "rb") as f:
+        data = f.read()
+    # data = bytes(FILE_CONTENT, "utf-8")
+    with bz2.open(path, "wb") as f:
+        f.write(data)
+    return path
+
+
+@pytest.fixture(scope="session")
 def parquet_path(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("data") / "dataset.parquet")
     schema = pa.schema(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -359,6 +359,18 @@ def test_load_dataset_streaming_compressed_files(path):
     }
 
 
+@pytest.mark.parametrize("path_extension", ["csv", "csv.bz2"])
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_dataset_streaming_csv(path_extension, streaming, csv_path, bz2_csv_path):
+    paths = {"csv": csv_path, "csv.bz2": bz2_csv_path}
+    data_files = str(paths[path_extension])
+    features = Features({"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")})
+    ds = load_dataset("csv", split="train", data_files=data_files, features=features, streaming=streaming)
+    assert isinstance(ds, IterableDataset if streaming else Dataset)
+    ds_item = next(iter(ds))
+    assert ds_item == {"col_1": "0", "col_2": 0, "col_3": 0.0}
+
+
 def test_loading_from_the_datasets_hub():
     with tempfile.TemporaryDirectory() as tmp_dir:
         dataset = load_dataset(SAMPLE_DATASET_IDENTIFIER, cache_dir=tmp_dir)


### PR DESCRIPTION
When implementing support to stream CSV files (https://github.com/huggingface/datasets/commit/ad489d4597381fc2d12c77841642cbeaecf7a2e0#diff-6f60f8d0552b75be8b3bfd09994480fd60dcd4e7eb08d02f721218c3acdd2782), a regression was introduced preventing loading compressed CSV files in non-streaming mode.

This PR fixes it, allowing loading compressed/uncompressed CSV files in streaming/non-streaming mode.

Fix #2977.