### PR TITLE
Remove all query parameters when extracting protocol

### DIFF
--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -140,11 +140,10 @@ def _add_retries_to_file_obj_read_method(file_obj):
 def _get_extraction_protocol(urlpath: str) -> Optional[str]:
     # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://train-00000.json.gz
     path = urlpath.split("::")[0]
-    # Remove query params ("dl=1", "raw=true"): https://foo.bar/train.json.gz?dl=1 -> https://foo.bar/train.json.gz
-    path = path.split("?")[0]
-
     # Get extension: https://foo.bar/train.json.gz -> gz
     extension = path.split(".")[-1]
+    # Remove query params ("dl=1", "raw=true"): gz?dl=1 -> gz
+    extension = extension.split("?")[0]
     if extension in BASE_KNOWN_EXTENSIONS:
         return None
     elif path.endswith(".tar.gz") or path.endswith(".tgz"):

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -150,7 +150,7 @@ def _get_extraction_protocol(urlpath: str) -> Optional[str]:
         pass
     elif extension in COMPRESSION_EXTENSION_TO_PROTOCOL:
         return COMPRESSION_EXTENSION_TO_PROTOCOL[extension]
-    raise NotImplementedError(f"Extraction protocol {extension} for file at {urlpath} is not implemented yet")
+    raise NotImplementedError(f"Extraction protocol '{extension}' for file at '{urlpath}' is not implemented yet")
 
 
 def xopen(file, mode="r", *args, **kwargs):

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -150,7 +150,7 @@ def _get_extraction_protocol(urlpath: str) -> Optional[str]:
         pass
     elif extension in COMPRESSION_EXTENSION_TO_PROTOCOL:
         return COMPRESSION_EXTENSION_TO_PROTOCOL[extension]
-    raise NotImplementedError(f"Extraction protocol for file at {urlpath} is not implemented yet")
+    raise NotImplementedError(f"Extraction protocol {extension} for file at {urlpath} is not implemented yet")
 
 
 def xopen(file, mode="r", *args, **kwargs):

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -140,10 +140,8 @@ def _add_retries_to_file_obj_read_method(file_obj):
 def _get_extraction_protocol(urlpath: str) -> Optional[str]:
     # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://train-00000.json.gz
     path = urlpath.split("::")[0]
-    # remove "dl=1" query param: https://foo.bar/train.json.gz?dl=1 -> https://foo.bar/train.json.gz
-    suf = "?dl=1"
-    if path.endswith(suf):
-        path = path[: -len(suf)]
+    # Remove query params ("dl=1", "raw=true"): https://foo.bar/train.json.gz?dl=1 -> https://foo.bar/train.json.gz
+    path = path.split("?")[0]
 
     # Get extension: https://foo.bar/train.json.gz -> gz
     extension = path.split(".")[-1]

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -425,6 +425,10 @@ def test_streaming_dl_manager_extract_all_supported_single_file_compression_type
         ("zip://train-00000.json.gz::https://foo.bar/data.zip", "gzip"),
         ("https://foo.bar/train.json.gz?dl=1", "gzip"),
         ("http://opus.nlpl.eu/download.php?f=Bianet/v1/moses/en-ku.txt.zip", "zip"),
+        ("https://github.com/user/what-time-is-it/blob/master/gutenberg_time_phrases.zip?raw=true", "zip"),
+        ("https://github.com/user/repo/blob/master/data/morph_train.tsv?raw=true", None),
+        ("https://repo.org/bitstream/handle/20.500.12185/346/annotated_corpus.zip?sequence=3&isAllowed=y", "zip"),
+        ("https://zenodo.org/record/2787612/files/SICK.zip?download=1", "zip"),
     ],
 )
 def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol):


### PR DESCRIPTION
Fix `_get_extraction_protocol` to remove all query parameters, like `?raw=true`,  `?dl=1`,...