### PR TITLE
Fix json loader when conversion not implemented

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -119,8 +119,8 @@ class Json(datasets.ArrowBasedBuilder):
                                         io.BytesIO(batch), read_options=paj.ReadOptions(block_size=block_size)
                                     )
                                     break
-                                except pa.ArrowInvalid as e:
-                                    if "straddling" not in str(e) or block_size > len(batch):
+                                except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
+                                    if isinstance(e, pa.ArrowInvalid) and "straddling" not in str(e) or block_size > len(batch):
                                         raise
                                     else:
                                         # Increase the block size in case it was too small.

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -120,7 +120,11 @@ class Json(datasets.ArrowBasedBuilder):
                                     )
                                     break
                                 except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
-                                    if isinstance(e, pa.ArrowInvalid) and "straddling" not in str(e) or block_size > len(batch):
+                                    if (
+                                        isinstance(e, pa.ArrowInvalid)
+                                        and "straddling" not in str(e)
+                                        or block_size > len(batch)
+                                    ):
                                         raise
                                     else:
                                         # Increase the block size in case it was too small.


### PR DESCRIPTION
Sometimes the arrow json parser fails if the `block_size` is too small and returns an `ArrowNotImplementedError: JSON conversion to struct...` error.

By increasing the block size it makes it work again.

Hopefully it should help with https://github.com/huggingface/datasets/issues/2799

I tried with the file mentioned in the issue and it worked for me
cc @lewtun can you try again from this branch ?