### PR TITLE
Fix cast to Python scalar in Matthews Correlation metric

### DIFF
--- a/metrics/matthews_correlation/matthews_correlation.py
+++ b/metrics/matthews_correlation/matthews_correlation.py
@@ -82,5 +82,5 @@ class MatthewsCorrelation(datasets.Metric):
 
     def _compute(self, predictions, references, sample_weight=None):
         return {
-            "matthews_correlation": matthews_corrcoef(references, predictions, sample_weight=sample_weight).item(),
+            "matthews_correlation": float(matthews_corrcoef(references, predictions, sample_weight=sample_weight)),
         }


### PR DESCRIPTION
This PR is motivated by issue #2964.

The Matthews Correlation metric relies on sklearn's `matthews_corrcoef` function to compute the result. This function returns either `float` or `np.float64` (see the [source](https://github.com/scikit-learn/scikit-learn/blob/844b4be24d20fc42cc13b957374c718956a0db39/sklearn/metrics/_classification.py#L906-L909)). Obviously, calling `.item()` on the float value will fail, so I'm fixing this with the built-in `float()` function, which covers both cases. Surprisingly, on my machine, casting `np.float64` to a Python scalar with `float()` is even faster than with the `.item()` method.