### PR TITLE
Remove a reference to the open Arrow file when deleting a TF dataset created with to_tf_dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -247,22 +247,22 @@ class TensorflowDatasetMixIn:
             only columns that the model can use as input should be included here (numeric data only).
             batch_size (:obj:`int`): Size of batches to load from the dataset.
             shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
-             validation/evaluation.
+                validation/evaluation.
             drop_remainder(:obj:`bool`, default ``None``): Drop the last incomplete batch when loading. If not provided,
-             defaults to the same setting as shuffle.
+                defaults to the same setting as shuffle.
             collate_fn(:obj:`Callable`): A function or callable object (such as a `DataCollator`) that will collate
-             lists of samples into a batch.
+                lists of samples into a batch.
             collate_fn_args (:obj:`Dict`, optional): An optional `dict` of keyword arguments to be passed to the
-             `collate_fn`.
+                `collate_fn`.
             label_cols (:obj:`List[str]` or :obj:`str`, default ``None``): Dataset column(s) to load as
-             labels. Note that many models compute loss internally rather than letting Keras do it, in which case it is
-              not necessary to actually pass the labels here, as long as they're in the input `columns`.
+                labels. Note that many models compute loss internally rather than letting Keras do it, in which case it is
+                not necessary to actually pass the labels here, as long as they're in the input `columns`.
             dummy_labels (:obj:`bool`, default ``False``): If no `label_cols` are set, output an array of "dummy" labels
-             with each batch. This can avoid problems with `fit()` or `train_on_batch()` that expect labels to be
-             a Tensor or np.ndarray, but should (hopefully) not be necessary with our standard train_step().
+                with each batch. This can avoid problems with `fit()` or `train_on_batch()` that expect labels to be
+                a Tensor or np.ndarray, but should (hopefully) not be necessary with our standard train_step().
             prefetch (:obj:`bool`, default ``True``): Whether to run the dataloader in a separate thread and maintain
-             a small buffer of batches for training. Improves performance by allowing data to be loaded in the
-             background while the model is training.
+                a small buffer of batches for training. Improves performance by allowing data to be loaded in the
+                background while the model is training.
         """
         if config.TF_AVAILABLE:
             import tensorflow as tf

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -161,6 +161,8 @@ class DatasetInfoMixin:
 
 
 class TensorflowDatasetMixin:
+    TF_DATASET_REFS = set()
+
     @staticmethod
     def _get_output_signature(dataset, cols_to_retain, test_batch, batch_size):
         if config.TF_AVAILABLE:
@@ -396,6 +398,12 @@ class TensorflowDatasetMixin:
         if prefetch:
             tf_dataset = tf_dataset.prefetch(tf.data.experimental.AUTOTUNE)
 
+        # Remove a reference to the open Arrow file on delete
+        def cleanup_callback(ref):
+            dataset.__del__()
+            self.TF_DATASET_REFS.remove(ref)
+
+        self.TF_DATASET_REFS.add(weakref.ref(tf_dataset, cleanup_callback))
         return tf_dataset
 
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -22,6 +22,7 @@ import json
 import os
 import shutil
 import tempfile
+import weakref
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
@@ -159,16 +160,13 @@ class DatasetInfoMixin:
         return self._info.version
 
 
-class TensorflowDatasetMixIn:
-    def __init__(self):
-        pass
-
+class TensorflowDatasetMixin:
     @staticmethod
     def _get_output_signature(dataset, cols_to_retain, test_batch, batch_size):
         if config.TF_AVAILABLE:
             import tensorflow as tf
         else:
-            raise ImportError("Called a Tensorflow-specific function but could not import it!")
+            raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
 
         signatures = {}
         for column, col_feature in dataset.features.items():
@@ -183,7 +181,7 @@ class TensorflowDatasetMixIn:
             elif dtype_str.startswith("float"):
                 dtype = tf.float32
             else:
-                raise ValueError(f"Could not convert datatype {dtype_str} in column {column}!")
+                raise ValueError(f"Could not convert datatype {dtype_str} in column {column}.")
 
             shape = []
             shape_feature = col_feature
@@ -202,7 +200,7 @@ class TensorflowDatasetMixIn:
                         "If you're getting this error with one of our datasets, and you're "
                         "sure the column should be convertable to tf.Tensor, please "
                         "file an issue at github.com/huggingface/datasets and tag "
-                        "@rocketknight1!"
+                        "@rocketknight1."
                     )
             shape = [batch_size] + shape
             shape = [dim if dim != -1 else None for dim in shape]
@@ -267,7 +265,7 @@ class TensorflowDatasetMixIn:
         if config.TF_AVAILABLE:
             import tensorflow as tf
         else:
-            raise ImportError("Called a Tensorflow-specific function but could not import it!")
+            raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
 
         if collate_fn_args is None:
             collate_fn_args = {}
@@ -277,13 +275,13 @@ class TensorflowDatasetMixIn:
         elif isinstance(label_cols, str):
             label_cols = [label_cols]
         elif len(set(label_cols)) < len(label_cols):
-            raise ValueError("List of label_cols contains duplicates!")
+            raise ValueError("List of label_cols contains duplicates.")
         if not columns:
-            raise ValueError("Need to specify at least one column!")
+            raise ValueError("Need to specify at least one column.")
         elif isinstance(columns, str):
             columns = [columns]
         elif len(set(columns)) < len(columns):
-            raise ValueError("List of columns contains duplicates!")
+            raise ValueError("List of columns contains duplicates.")
         if label_cols is not None:
             cols_to_retain = list(set(columns + label_cols))
         else:
@@ -293,7 +291,7 @@ class TensorflowDatasetMixIn:
             cols_to_retain[cols_to_retain.index("labels")] = "label"
         for col in cols_to_retain:
             if col not in self.features:
-                raise ValueError(f"Couldn't find column {col} in dataset!")
+                raise ValueError(f"Couldn't find column {col} in dataset.")
         if drop_remainder is None:
             # We assume that if you're shuffling it's the train set, so we drop the remainder unless told not to
             drop_remainder = shuffle
@@ -358,7 +356,7 @@ class TensorflowDatasetMixIn:
             return {key: output[i] for i, key in enumerate(cols_to_retain)}
 
         test_batch_dict = {key: test_batch[i] for i, key in enumerate(cols_to_retain)}
-        output_signature = dataset._get_output_signature(
+        output_signature = TensorflowDatasetMixin._get_output_signature(
             dataset, cols_to_retain, test_batch_dict, batch_size=batch_size if drop_remainder else None
         )
 
@@ -396,7 +394,8 @@ class TensorflowDatasetMixIn:
             tf_dataset = tf_dataset.map(add_dummy_labels)
 
         if prefetch:
-            tf_dataset = tf_dataset.prefetch(tf.data.AUTOTUNE)
+            tf_dataset = tf_dataset.prefetch(tf.data.experimental.AUTOTUNE)
+
         return tf_dataset
 
 
@@ -478,7 +477,7 @@ class NonExistentDatasetError(Exception):
     pass
 
 
-class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixIn):
+class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     """A Dataset backed by an Arrow table."""
 
     def __init__(


### PR DESCRIPTION
This [comment](https://github.com/huggingface/datasets/issues/2934#issuecomment-922970919) explains the issue. This PR fixes that with a `weakref` callback, and additionally:
* renames `TensorflowDatasetMixIn` to `TensorflowDatasetMixin` for consistency
* correctly indents `TensorflowDatasetMixin`'s docstring
* replaces `tf.data.AUTOTUNE` with `tf.data.experimental.AUTOTUNE` (we support TF>=2.2 according to the [setup.py](https://github.com/huggingface/datasets/blob/fc46bba66ba4f432cc10501c16a677112e13984c/setup.py#L188) and `AUTOTUNE` has been moved to the experimental part of `tf.data` in 1.X if I'm not mistaken)

Fixes #2934