### PR TITLE
Replace item with float in metrics

### DIFF
--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -83,7 +83,7 @@ class Accuracy(datasets.Metric):
 
     def _compute(self, predictions, references, normalize=True, sample_weight=None):
         return {
-            "accuracy": accuracy_score(
-                references, predictions, normalize=normalize, sample_weight=sample_weight
-            ).item(),
+            "accuracy": float(
+                accuracy_score(references, predictions, normalize=normalize, sample_weight=sample_weight)
+            )
         }

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -116,4 +116,4 @@ class F1(datasets.Metric):
         score = f1_score(
             references, predictions, labels=labels, pos_label=pos_label, average=average, sample_weight=sample_weight
         )
-        return {"f1": score.item() if score.size == 1 else score}
+        return {"f1": float(score) if score.size == 1 else score}

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -81,12 +81,12 @@ Examples:
 
 
 def simple_accuracy(preds, labels):
-    return (preds == labels).mean().item()
+    return float((preds == labels).mean())
 
 
 def acc_and_f1(preds, labels):
     acc = simple_accuracy(preds, labels)
-    f1 = f1_score(y_true=labels, y_pred=preds).item()
+    f1 = float(f1_score(y_true=labels, y_pred=preds))
     return {
         "accuracy": acc,
         "f1": f1,
@@ -94,8 +94,8 @@ def acc_and_f1(preds, labels):
 
 
 def pearson_and_spearman(preds, labels):
-    pearson_corr = pearsonr(preds, labels)[0].item()
-    spearman_corr = spearmanr(preds, labels)[0].item()
+    pearson_corr = float(pearsonr(preds, labels)[0])
+    spearman_corr = float(spearmanr(preds, labels)[0])
     return {
         "pearson": pearson_corr,
         "spearmanr": spearman_corr,

--- a/metrics/indic_glue/indic_glue.py
+++ b/metrics/indic_glue/indic_glue.py
@@ -74,12 +74,12 @@ Examples:
 
 
 def simple_accuracy(preds, labels):
-    return (preds == labels).mean().item()
+    return float((preds == labels).mean())
 
 
 def acc_and_f1(preds, labels):
     acc = simple_accuracy(preds, labels)
-    f1 = f1_score(y_true=labels, y_pred=preds).item()
+    f1 = float(f1_score(y_true=labels, y_pred=preds))
     return {
         "accuracy": acc,
         "f1": f1,
@@ -99,7 +99,7 @@ def precision_at_10(en_sentvecs, in_sentvecs):
     actual = np.array(range(n))
     preds = sim.argsort(axis=1)[:, :10]
     matches = np.any(preds == actual[:, None], axis=1)
-    return matches.mean().item()
+    return float(matches.mean())
 
 
 @datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)

--- a/metrics/pearsonr/pearsonr.py
+++ b/metrics/pearsonr/pearsonr.py
@@ -93,6 +93,4 @@ class Pearsonr(datasets.Metric):
         )
 
     def _compute(self, predictions, references):
-        return {
-            "pearsonr": pearsonr(references, predictions)[0].item(),
-        }
+        return {"pearsonr": float(pearsonr(references, predictions)[0])}

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -118,4 +118,4 @@ class Precision(datasets.Metric):
         score = precision_score(
             references, predictions, labels=labels, pos_label=pos_label, average=average, sample_weight=sample_weight
         )
-        return {"precision": score.item() if score.size == 1 else score}
+        return {"precision": float(score) if score.size == 1 else score}

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -118,4 +118,4 @@ class Recall(datasets.Metric):
         score = recall_score(
             references, predictions, labels=labels, pos_label=pos_label, average=average, sample_weight=sample_weight
         )
-        return {"recall": score.item() if score.size == 1 else score}
+        return {"recall": float(score) if score.size == 1 else score}

--- a/metrics/super_glue/super_glue.py
+++ b/metrics/super_glue/super_glue.py
@@ -107,12 +107,12 @@ Examples:
 
 
 def simple_accuracy(preds, labels):
-    return (preds == labels).mean().item()
+    return float((preds == labels).mean())
 
 
 def acc_and_f1(preds, labels, f1_avg="binary"):
     acc = simple_accuracy(preds, labels)
-    f1 = f1_score(y_true=labels, y_pred=preds, average=f1_avg).item()
+    f1 = float(f1_score(y_true=labels, y_pred=preds, average=f1_avg))
     return {
         "accuracy": acc,
         "f1": f1,
@@ -138,9 +138,9 @@ def evaluate_multirc(ids_preds, labels):
         f1s.append(f1)
         em = int(sum([p == l for p, l in preds_labels]) == len(preds_labels))
         ems.append(em)
-    f1_m = (sum(f1s) / len(f1s)).item()
+    f1_m = float((sum(f1s) / len(f1s)))
     em = sum(ems) / len(ems)
-    f1_a = f1_score(y_true=labels, y_pred=[id_pred["prediction"] for id_pred in ids_preds]).item()
+    f1_a = float(f1_score(y_true=labels, y_pred=[id_pred["prediction"] for id_pred in ids_preds]))
     return {"exact_match": em, "f1_m": f1_m, "f1_a": f1_a}
 
 


### PR DESCRIPTION
As pointed out by @mariosasko in #3001, calling `float()` instad of `.item()` is faster.

Moreover, it might avoid potential issues if any of the third-party functions eventually returns a `float` instead of an `np.float64`.

Related to #3001.