### PR TITLE
Fix Windows path in MATH dataset

### DIFF
--- a/datasets/competition_math/competition_math.py
+++ b/datasets/competition_math/competition_math.py
@@ -82,7 +82,7 @@ class CompetitionMathDataset(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, math_dir, split):
         """Yields examples as (key, example) tuples."""
-        filepaths = glob.glob(os.path.join(math_dir, split, "*/*"))
+        filepaths = glob.glob(os.path.join(math_dir, split, "*", "*"))
         for id_, filepath in enumerate(filepaths):
             with open(filepath, "rb") as fin:
                 example = json.load(fin)


### PR DESCRIPTION
Minor fix in MATH dataset for Windows pathname component separator.

Related to #2982.