### PR TITLE
Fix Windows paths in LJ Speech dataset

### DIFF
--- a/datasets/lj_speech/lj_speech.py
+++ b/datasets/lj_speech/lj_speech.py
@@ -87,8 +87,8 @@ class LJSpeech(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         root_path = dl_manager.download_and_extract(_DL_URL)
-        root_path = os.path.join(root_path, "LJSpeech-1.1/")
-        wav_path = os.path.join(root_path, "wavs/")
+        root_path = os.path.join(root_path, "LJSpeech-1.1")
+        wav_path = os.path.join(root_path, "wavs")
         csv_path = os.path.join(root_path, "metadata.csv")
 
         return [


### PR DESCRIPTION
Minor fix in LJ Speech dataset for Windows pathname component separator.

Related to #1878.