### PR TITLE
Remove unused parameter in xdirname

### DIFF
--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -57,7 +57,7 @@ def xjoin(a, *p):
     return "::".join([a] + b)
 
 
-def xdirname(a, *p):
+def xdirname(a):
     """
     This function extends os.path.dirname to support the "::" hop separator. It supports both paths and urls.
 


### PR DESCRIPTION
Minor fix to remove unused args `*p` in `xdirname`.