### PR TITLE
Align tqdm control with cache control

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2048,7 +2048,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixIn):
 
     @transmit_format
     @fingerprint_transform(
-        inplace=False, ignore_kwargs=["load_from_cache_file", "cache_file_name", "desc", "cache_only"]
+        inplace=False, ignore_kwargs=["load_from_cache_file", "cache_file_name", "disable_tqdm", "desc", "cache_only"]
     )
     def _map_single(
         self,

--- a/src/datasets/utils/__init__.py
+++ b/src/datasets/utils/__init__.py
@@ -35,5 +35,5 @@ from .py_utils import (
     zip_dict,
     zip_nested,
 )
-from .tqdm_utils import async_tqdm, disable_progress_bar, is_progress_bar_enabled, set_progress_bar_enabled, tqdm
+from .tqdm_utils import disable_progress_bar, is_progress_bar_enabled, set_progress_bar_enabled, tqdm
 from .version import Version

--- a/src/datasets/utils/__init__.py
+++ b/src/datasets/utils/__init__.py
@@ -35,5 +35,5 @@ from .py_utils import (
     zip_dict,
     zip_nested,
 )
-from .tqdm_utils import async_tqdm, disable_progress_bar, is_progress_bar_enabled, tqdm
+from .tqdm_utils import async_tqdm, disable_progress_bar, is_progress_bar_enabled, set_progress_bar_enabled, tqdm
 from .version import Version

--- a/src/datasets/utils/tqdm_utils.py
+++ b/src/datasets/utils/tqdm_utils.py
@@ -21,6 +21,8 @@ import contextlib
 
 from tqdm import auto as tqdm_lib
 
+from datasets.utils.deprecation_utils import deprecated
+
 
 class EmptyTqdm:
     """Dummy tqdm which doesn't do anything."""
@@ -76,13 +78,24 @@ def async_tqdm(*args, **kwargs):
         return EmptyTqdm(*args, **kwargs)
 
 
-def is_progress_bar_enabled():
+def set_progress_bar_enabled(boolean: bool):
+    """Enable/disable tqdm progress bars."""
+    global _active
+    _active = bool(boolean)
+
+
+def is_progress_bar_enabled() -> bool:
+    """Return a boolean indicating whether tqdm progress bars are enabled."""
     global _active
     return bool(_active)
 
 
+@deprecated("Use set_progress_bar_enabled(False) instead.")
 def disable_progress_bar():
     """Disable tqdm progress bar.
+
+    .. deprecated:: 1.4.0
+        Use set_progress_bar_enabled(False) instead.
 
     Usage:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,9 @@ def set_test_cache_config(tmp_path_factory, monkeypatch):
     monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_PATH", str(test_extracted_datasets_path))
 
 
-# @pytest.fixture(autouse=True, scope="session")
-# def disable_tqdm_output():
-#     datasets.set_progress_bar_enabled(False)
+@pytest.fixture(autouse=True, scope="session")
+def disable_tqdm_output():
+    datasets.set_progress_bar_enabled(False)
 
 
 FILE_CONTENT = """\

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
+import datasets
 from datasets import config
 from datasets.arrow_dataset import Dataset
 from datasets.features import ClassLabel, Features, Sequence, Value
@@ -28,6 +29,11 @@ def set_test_cache_config(tmp_path_factory, monkeypatch):
     monkeypatch.setattr("datasets.config.DOWNLOADED_DATASETS_PATH", str(test_downloaded_datasets_path))
     test_extracted_datasets_path = test_hf_datasets_cache / "downloads" / "extracted"
     monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_PATH", str(test_extracted_datasets_path))
+
+
+@pytest.fixture(autouse=True, scope="session")
+def disable_tqdm_output():
+    datasets.set_progress_bar_enabled(False)
 
 
 FILE_CONTENT = """\

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,9 @@ def set_test_cache_config(tmp_path_factory, monkeypatch):
     monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_PATH", str(test_extracted_datasets_path))
 
 
-@pytest.fixture(autouse=True, scope="session")
-def disable_tqdm_output():
-    datasets.set_progress_bar_enabled(False)
+# @pytest.fixture(autouse=True, scope="session")
+# def disable_tqdm_output():
+#     datasets.set_progress_bar_enabled(False)
 
 
 FILE_CONTENT = """\

--- a/tests/test_tqdm_utils.py
+++ b/tests/test_tqdm_utils.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+import datasets
+from datasets import Dataset
+
+
+def test_set_progress_bar_enabled():
+    dset = Dataset.from_dict({"col_1": [3, 2, 0, 1]})
+
+    with patch("tqdm.auto.tqdm") as mock_tqdm:
+        datasets.set_progress_bar_enabled(True)
+        dset.map(lambda x: {"col_2": x["col_1"] + 1})
+        mock_tqdm.assert_called()
+
+        mock_tqdm.reset_mock()
+
+        datasets.set_progress_bar_enabled(False)
+        dset.map(lambda x: {"col_2": x["col_1"] + 1})
+        mock_tqdm.assert_not_called()


### PR DESCRIPTION
Currently, once disabled with `disable_progress_bar`, progress bars cannot be re-enabled again. To overcome this limitation, this PR introduces the `set_progress_bar_enabled` function that accepts a boolean indicating whether to display progress bars. The goal is to provide a similar API to the existing cache control API. Following the Zen of Python (😄), there should be one and preferably only one obvious way to do it, so I'm also deprecating the aforementioned `disable_progress_bar` function.

Moreover, similar API changes have recently been introduced to [`tfds`](https://github.com/tensorflow/datasets/blob/a1e8b98f45b0214082b546cc967c67c43fffda55/tensorflow_datasets/core/utils/tqdm_utils.py#L98-L112).

Considering the popularity of the [comment](https://github.com/huggingface/datasets/issues/1627#issuecomment-751383559) I made a while ago, this API (`set_progress_bar_enabled` and `is_progress_bar_enabled`) should be mentioned in the docs, but I'm not sure where to put it exactly. Maybe we can replace the `logging_methods` page under `package_reference` with `utility_methods` and then introduce two subsections on that page: `Logging methods` and `tqdm control`.

Additionally, this PR:
* adds the `disable_tqdm` keyword arg of `Dataset._map_single` to the `ignore_kwargs` list to ignore it when computing the fingerprint (forgot to add it in #2696)
* deletes the unused components in `tqdm_utils.py`, which seem to be inherited from `tfds`
* disables the tqdm output in the test suite. As I see it, this output doesn't seem informative, but let me know if this is not a good idea