### PR TITLE
Actual "proper" install of ruamel.yaml in the windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             - checkout
             - run: conda update conda
             - run: conda install python=3.6 --yes
-            - run: rm c:\tools\miniconda3\lib\site-packages\ruamel*
+            - run: Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
             - run: pip install ruamel.yaml
             - run: conda install pytorch --yes
             - run: pip install virtualenv
@@ -64,7 +64,7 @@ jobs:
             - checkout
             - run: conda update conda
             - run: conda install python=3.6 --yes
-            - run: rm c:\tools\miniconda3\lib\site-packages\ruamel*
+            - run: Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
             - run: pip install ruamel.yaml
             - run: conda install pytorch --yes
             - run: pip install virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,12 @@ jobs:
             - checkout
             - run: conda update conda
             - run: conda install python=3.6 --yes
+            - run: rm c:\tools\miniconda3\lib\site-packages\ruamel*
+            - run: pip install ruamel.yaml
             - run: conda install pytorch --yes
             - run: pip install virtualenv
             - run: python -m virtualenv venv --system-site-packages
             - run: "& venv/Scripts/activate.ps1"
-            - run: pip install --ignore-installed ruamel-yaml
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
@@ -63,11 +64,12 @@ jobs:
             - checkout
             - run: conda update conda
             - run: conda install python=3.6 --yes
+            - run: rm c:\tools\miniconda3\lib\site-packages\ruamel*
+            - run: pip install ruamel.yaml
             - run: conda install pytorch --yes
             - run: pip install virtualenv
             - run: python -m virtualenv venv --system-site-packages
             - run: "& venv/Scripts/activate.ps1"
-            - run: pip install --ignore-installed ruamel-yaml
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0


### PR DESCRIPTION
It was impossible to update the package directly with `pip`. Indeed it was installed with `distutils` which prevents `pip` or `conda` to uninstall it.

I had to `rm` a directory from the `site-packages` python directory, and then do `pip install ruamel.yaml`

It's not that "proper" but I couldn't find better solutions