### PR TITLE
Fix error related to huggingface_hub timeout parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ REQUIRED_PKGS = [
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
-    "huggingface_hub>=0.0.18,<0.1.0",
+    "huggingface_hub>=0.0.19,<0.1.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
 ]


### PR DESCRIPTION
The `huggingface_hub` package added the parameter `timeout` from version 0.0.19.

This PR bumps this minimal version.

Fix #3080.