### PR TITLE
Push to hub capabilities for `Dataset` and `DatasetDict`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,8 @@ workflows:
         jobs:
             - check_code_quality
             - run_dataset_script_tests_pyarrow_latest
-            - run_dataset_script_tests_pyarrow_1
+            - run_dataset_script_tests_pyarrow_3
             - run_dataset_script_tests_pyarrow_latest_WIN
-            - run_dataset_script_tests_pyarrow_1_WIN
+            - run_dataset_script_tests_pyarrow_3_WIN
             - build_doc
             - deploy_doc: *workflow_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             - run: pip install pyarrow --upgrade
             - run: HF_SCRIPTS_VERSION=master HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
-    run_dataset_script_tests_pyarrow_1:
+    run_dataset_script_tests_pyarrow_3:
         working_directory: ~/datasets
         docker:
             - image: cimg/python:3.6
@@ -31,7 +31,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow==1.0.0
+            - run: pip install pyarrow==3.0.0
             - run: HF_SCRIPTS_VERSION=master HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_latest_WIN:
@@ -55,7 +55,7 @@ jobs:
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -n 2 --dist loadfile -sv ./tests/
 
-    run_dataset_script_tests_pyarrow_1_WIN:
+    run_dataset_script_tests_pyarrow_3_WIN:
         working_directory: ~/datasets
         executor:
             name: win/default
@@ -72,7 +72,7 @@ jobs:
             - run: "& venv/Scripts/activate.ps1"
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow==1.0.0
+            - run: pip install pyarrow==3.0.0
             - run: $env:HF_SCRIPTS_VERSION="master"
             - run: python -m pytest -n 2 --dist loadfile -sv ./tests/
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ REQUIRED_PKGS = [
     # Backend and serialization.
     # Minimum 3.0.0 to support mix of struct and list types in parquet, and batch iterators of parquet data
     # pyarrow 4.0.0 introduced segfault bug, see: https://github.com/huggingface/datasets/pull/2268
-    "pyarrow>=1.0.0,!=4.0.0",
+    "pyarrow>=3.0.0,!=4.0.0",
     # For smart caching dataset processing
     "dill",
     # For performance gains with apache arrow

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3409,10 +3409,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     total=len(file_shards_to_delete),
                 )
             else:
-                for file in tqdm(
+                for file in utils.tqdm(
                     file_shards_to_delete,
                     desc="Deleting unused files from dataset repository",
                     total=len(file_shards_to_delete),
+                    disable=bool(logging.get_verbosity() == logging.NOTSET),
                 ):
                     delete_file(file)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3387,7 +3387,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         files = [file for file in files if file.startswith("data/")]
 
         def path_in_repo(_index):
-            return f"data/{split_name}-{str(_index).zfill(5)}-of-{str(num_shards - 1).zfill(5)}.parquet"
+            return f"data/{split_name}_{_index:05d}_of_{num_shards:05d}.parquet"
 
         # Only delete file shards that don't currently exist. Others will be overwritten if the content is different
         # or will be left intact is the content is identical.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3397,7 +3397,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         files = [file for file in files if file.startswith("data/")]
 
         def path_in_repo(_index):
-            return f"data/{split_name}_{_index:05d}_of_{num_shards:05d}.parquet"
+            return f"data/{split}_{_index:05d}_of_{num_shards:05d}.parquet"
 
         # Only delete file shards that don't currently exist. Others will be overwritten if the content is different
         # or will be left intact is the content is identical.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3429,7 +3429,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     file_shards_to_delete,
                     desc="Deleting unused files from dataset repository",
                     total=len(file_shards_to_delete),
-                    disable=bool(logging.get_verbosity() == logging.NOTSET),
+                    disable=bool(logging.get_verbosity() == logging.NOTSET) or not utils.is_progress_bar_enabled(),
                 ):
                     delete_file(file)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3417,8 +3417,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 ):
                     delete_file(file)
 
-        for index, shard in tqdm(
-            enumerate(shards), desc="Pushing dataset shards to the dataset hub", total=num_shards
+        for index, shard in utils.tqdm(
+            enumerate(shards), desc="Pushing dataset shards to the dataset hub", total=num_shards, disable=bool(logging.get_verbosity() == logging.NOTSET)
         ):
             buffer = BytesIO()
             shard.to_parquet(buffer)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3355,7 +3355,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
 
         if split is None:
-            split = self.split
+            split = self.split or "train"
 
         identifier = repo_id.split("/")
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3319,7 +3319,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         token: Optional[str] = None,
         branch: Optional[str] = None,
         shard_size: Optional[int] = 500 << 20,
-        # Testing parameter only, should remove after investigation and before merging the PR.
         threading: Optional[bool] = False,
     ):
         """Pushes the dataset to the hub.
@@ -3345,6 +3344,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             shard_size (Optional :obj:`int`):
                 The size of the dataset shards to be uploaded to the hub. The dataset will be pushed in files
                 of the size specified here, in bytes. Defaults to a shard size of 500MB.
+            threading (Optional :obj:`bool`, defaults to :obj:`False`):
+                Whether to use multithreading where applicable. Experimental parameter as this will burst the
+                server with calls, some of which may fail.
 
         Example:
             .. code-block:: python

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -922,7 +922,10 @@ class DatasetDict(dict):
         """
         for key in self.keys():
             logger.warning(f"Pushing split {key} to the Hub.")
-            self[key].push_to_hub(repo_id, private=private, token=token, branch=branch, shard_size=shard_size)
+            # The split=key needs to be removed before merging
+            self[key].push_to_hub(
+                repo_id, split=key, private=private, token=token, branch=branch, shard_size=shard_size
+            )
 
 
 class IterableDatasetDict(dict):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -922,9 +922,7 @@ class DatasetDict(dict):
         """
         for key in self.keys():
             logger.warning(f"Pushing split {key} to the Hub.")
-            self[key].push_to_hub(
-                repo_id, split_name=key, private=private, token=token, branch=branch, shard_size=shard_size
-            )
+            self[key].push_to_hub(repo_id, private=private, token=token, branch=branch, shard_size=shard_size)
 
 
 class IterableDatasetDict(dict):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -18,8 +18,12 @@ from .features import Features
 from .filesystems import extract_path_from_uri, is_remote_filesystem
 from .table import Table
 from .tasks import TaskTemplate
+from .utils import logging
 from .utils.deprecation_utils import deprecated
 from .utils.typing import PathLike
+
+
+logger = logging.get_logger(__name__)
 
 
 class DatasetDict(dict):
@@ -888,7 +892,36 @@ class DatasetDict(dict):
         branch: Optional[None] = None,
         shard_size: Optional[int] = 500 << 20,
     ):
+        """Pushes the ``DatasetDict`` to the hub.
+        The ``DatasetDict`` is pushed using HTTP requests and does not need to have neither git or git-lfs installed.
+
+        Each dataset split will be pushed independently. The pushed dataset will keep the original split names.
+
+        Args:
+            repo_id (:obj:`str`):
+                The ID of the repository to push to in the following format: `<user>/<dataset_name>` or
+                `<org>/<dataset_name>`. Also accepts `<dataset_name>`, which will default to the namespace
+                of the logged-in user.
+            private (Optional :obj:`bool`):
+                Whether the dataset repository should be set to private or not. Only affects repository creation:
+                a repository that already exists will not be affected by that parameter.
+            token (Optional :obj:`str`):
+                An optional authentication token for the Hugging Face Hub. If no token is passed, will default
+                to the token saved locally when logging in with ``huggingface-cli login``. Will raise an error
+                if no token is passed and the user is not logged-in.
+            branch (Optional :obj:`str`):
+                The git branch on which to push the dataset.
+            shard_size (Optional :obj:`int`):
+                The size of the dataset shards to be uploaded to the hub. The dataset will be pushed in files
+                of the size specified here, in bytes.
+
+        Example:
+            .. code-block:: python
+
+                >>> dataset_dict.push_to_hub("<organization>/<dataset_id>")
+        """
         for key in self.keys():
+            logger.warning(f"Pushing split {key} to the Hub.")
             self[key].push_to_hub(
                 repo_id, split_name=key, private=private, token=token, branch=branch, shard_size=shard_size
             )

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -1,39 +1,252 @@
+import tempfile
 import time
+import unittest
+from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
+
+from huggingface_hub import HfApi
 
 from datasets import Dataset, DatasetDict, load_dataset
 
 
 REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
+ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
+
+# Should create a __DUMMY_DATASETS_USER__ :)
+USER = "__DUMMY_TRANSFORMERS_USER__"
+PASS = "__DUMMY_TRANSFORMERS_PASS__"
 
 
+def with_staging_testing(func):
+    file_download = patch(
+        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",
+        ENDPOINT_STAGING + "/{repo_id}/resolve/{revision}/{filename}",
+    )
+
+    hfh_hf_api = patch(
+        "huggingface_hub.hf_api.ENDPOINT",
+        ENDPOINT_STAGING,
+    )
+
+    repository = patch(
+        "huggingface_hub.repository.ENDPOINT",
+        ENDPOINT_STAGING,
+    )
+
+    config = patch.multiple(
+        "datasets.config",
+        HF_ENDPOINT=ENDPOINT_STAGING,
+        HUB_DATASETS_URL=ENDPOINT_STAGING + "/datasets/{path}/resolve/{revision}/{name}",
+    )
+
+    ds_hf_api = patch(
+        "datasets.hf_api.ENDPOINT",
+        ENDPOINT_STAGING,
+    )
+
+    return ds_hf_api(config(repository(hfh_hf_api(file_download(func)))))
+
+
+@with_staging_testing
 class TestPushToHub(TestCase):
+    _api = HfApi(endpoint=ENDPOINT_STAGING)
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Share this valid token in all tests below.
+        """
+        cls._token = cls._api.login(username=USER, password=PASS)
+
     def test_push_dataset_dict_to_hub(self):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({"random": ds})
+        local_ds = DatasetDict({"train": ds})
 
-        ds_name = f"Jikiwa/test-{int(time.time() * 10e3)}"
-        local_ds.push_to_hub(ds_name)
-        hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+        ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+        try:
+            local_ds.push_to_hub(ds_name, token=self._token)
+            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
-        self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
-        self.assertListEqual(list(local_ds["random"].features.keys()), list(hub_ds["random"].features.keys()))
-        self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
+            self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(local_ds["train"].features.keys()), list(hub_ds["train"].features.keys()))
+            self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
+
+            # Ensure that there is a single file on the repository that has the correct name
+            files = self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token)
+            self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00000.parquet"])
+        finally:
+            self._api.delete_repo(
+                ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+            )
+
+    def test_push_dataset_dict_to_hub_multiple_files(self):
+        ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
+
+        local_ds = DatasetDict({"train": ds})
+
+        ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+        try:
+            local_ds.push_to_hub(ds_name, token=self._token, shard_size=500 << 5)
+            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
+            self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(local_ds["train"].features.keys()), list(hub_ds["train"].features.keys()))
+            self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
+
+            # Ensure that there are two files on the repository that have the correct name
+            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            self.assertListEqual(
+                files, [".gitattributes", "data/train-00000-of-00001.parquet", "data/train-00001-of-00001.parquet"]
+            )
+        finally:
+            self._api.delete_repo(
+                ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+            )
+
+    def test_push_dataset_dict_to_hub_overwrite_files(self):
+        ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
+
+        local_ds = DatasetDict({"train": ds})
+
+        ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+
+        # Push to hub two times, but the second time with a larger amount of files.
+        # Verify that the new files contain the correct dataset.
+        try:
+            local_ds.push_to_hub(ds_name, token=self._token)
+
+            with tempfile.TemporaryDirectory() as tmp:
+                # Add a file starting with "data" to ensure it doesn't get deleted.
+                path = Path(tmp) / "datafile.txt"
+                with open(path, "w") as f:
+                    f.write("Bogus file")
+
+                self._api.upload_file(
+                    str(path), path_in_repo="datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token
+                )
+
+            local_ds.push_to_hub(ds_name, token=self._token, shard_size=500 << 5)
+
+            # Ensure that there are two files on the repository that have the correct name
+            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            self.assertListEqual(
+                files,
+                [
+                    ".gitattributes",
+                    "data/train-00000-of-00001.parquet",
+                    "data/train-00001-of-00001.parquet",
+                    "datafile.txt",
+                ],
+            )
+
+            self._api.delete_file("datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token)
+
+            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
+            self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(local_ds["train"].features.keys()), list(hub_ds["train"].features.keys()))
+            self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
+
+        finally:
+            self._api.delete_repo(
+                ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+            )
+
+        # Push to hub two times, but the second time with fewer files.
+        # Verify that the new files contain the correct dataset and that non-necessary files have been deleted.
+        try:
+            local_ds.push_to_hub(ds_name, token=self._token, shard_size=500 << 5)
+
+            with tempfile.TemporaryDirectory() as tmp:
+                # Add a file starting with "data" to ensure it doesn't get deleted.
+                path = Path(tmp) / "datafile.txt"
+                with open(path, "w") as f:
+                    f.write("Bogus file")
+
+                self._api.upload_file(
+                    str(path), path_in_repo="datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token
+                )
+
+            local_ds.push_to_hub(ds_name, token=self._token)
+
+            # Ensure that there are two files on the repository that have the correct name
+            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00000.parquet", "datafile.txt"])
+
+            # Keeping the "datafile.txt" breaks the load_dataset to think it's a text-based dataset
+            self._api.delete_file("datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token)
+
+            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
+            self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(local_ds["train"].features.keys()), list(hub_ds["train"].features.keys()))
+            self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
+
+        finally:
+            self._api.delete_repo(
+                ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+            )
 
     def test_push_dataset_to_hub(self):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        ds_name = f"Jikiwa/test-{int(time.time() * 10e3)}"
-        local_ds.push_to_hub(ds_name, split_name="random")
-        local_ds_dict = {"random": local_ds}
-        hub_ds_dict = load_dataset(ds_name, download_mode="force_redownload")
+        ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+        try:
+            local_ds.push_to_hub(ds_name, split_name="train", token=self._token)
+            local_ds_dict = {"train": local_ds}
+            hub_ds_dict = load_dataset(ds_name, download_mode="force_redownload")
 
-        self.assertListEqual(list(local_ds_dict.keys()), list(hub_ds_dict.keys()))
+            self.assertListEqual(list(local_ds_dict.keys()), list(hub_ds_dict.keys()))
 
-        for ds_split_name in local_ds_dict.keys():
-            local_ds = local_ds_dict[ds_split_name]
-            hub_ds = hub_ds_dict[ds_split_name]
+            for ds_split_name in local_ds_dict.keys():
+                local_ds = local_ds_dict[ds_split_name]
+                hub_ds = hub_ds_dict[ds_split_name]
+                self.assertListEqual(local_ds.column_names, hub_ds.column_names)
+                self.assertListEqual(list(local_ds.features.keys()), list(hub_ds.features.keys()))
+                self.assertDictEqual(local_ds.features, hub_ds.features)
+        finally:
+            self._api.delete_repo(
+                ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+            )
+
+    @unittest.skip("This test cannot pass until #3027 is resolved")
+    def test_push_dataset_dict_to_hub_custom_splits(self):
+        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+        local_ds = DatasetDict({"random": ds})
+
+        ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+        try:
+            local_ds.push_to_hub(ds_name, token=self._token)
+            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
             self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
             self.assertListEqual(list(local_ds["random"].features.keys()), list(hub_ds["random"].features.keys()))
             self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
+        finally:
+            self._api.delete_repo(
+                ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+            )
+
+    @unittest.skip("This test cannot pass until iterable datasets have push to hub")
+    def test_push_streaming_dataset_dict_to_hub(self):
+        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
+        local_ds = DatasetDict({"train": ds})
+        with tempfile.TemporaryDirectory() as tmp:
+            local_ds.save_to_disk(tmp)
+            local_ds = load_dataset(tmp, streaming=True)
+
+            ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+            try:
+                local_ds.push_to_hub(ds_name, token=self._token)
+                hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
+                self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+                self.assertListEqual(list(local_ds["train"].features.keys()), list(hub_ds["train"].features.keys()))
+                self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
+            finally:
+                self._api.delete_repo(
+                    ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+                )

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+from datasets import Dataset, DatasetDict, load_dataset
+import time
+
+
+REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
+
+
+class TestPushToHub(TestCase):
+    def test_push_dataset_dict_to_hub(self):
+        ds = Dataset.from_dict({
+            "x": [1, 2, 3],
+            "y": [4, 5, 6]
+        })
+
+        local_ds = DatasetDict({
+            "random": ds
+        })
+
+        ds_name = f"Jikiwa/test-{int(time.time() * 10e3)}"
+        local_ds.push_to_hub(ds_name)
+        hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
+        self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+        self.assertListEqual(list(local_ds["random"].features.keys()), list(hub_ds["random"].features.keys()))
+        self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
+
+    def test_push_dataset_to_hub(self):
+        local_ds = Dataset.from_dict({
+            "x": [1, 2, 3],
+            "y": [4, 5, 6]
+        })
+
+        ds_name = f"Jikiwa/test-{int(time.time() * 10e3)}"
+        local_ds.push_to_hub(ds_name, split_name="random")
+        local_ds_dict = {"random": local_ds}
+        hub_ds_dict = load_dataset(ds_name, download_mode="force_redownload")
+
+        self.assertListEqual(list(local_ds_dict.keys()), list(hub_ds_dict.keys()))
+
+        for ds_split_name in local_ds_dict.keys():
+            local_ds = local_ds_dict[ds_split_name]
+            hub_ds = hub_ds_dict[ds_split_name]
+            self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(local_ds["random"].features.keys()), list(hub_ds["random"].features.keys()))
+            self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
+

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -1,6 +1,7 @@
-from unittest import TestCase
-from datasets import Dataset, DatasetDict, load_dataset
 import time
+from unittest import TestCase
+
+from datasets import Dataset, DatasetDict, load_dataset
 
 
 REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
@@ -8,14 +9,9 @@ REPO_NAME = "repo-{}".format(int(time.time() * 10e3))
 
 class TestPushToHub(TestCase):
     def test_push_dataset_dict_to_hub(self):
-        ds = Dataset.from_dict({
-            "x": [1, 2, 3],
-            "y": [4, 5, 6]
-        })
+        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({
-            "random": ds
-        })
+        local_ds = DatasetDict({"random": ds})
 
         ds_name = f"Jikiwa/test-{int(time.time() * 10e3)}"
         local_ds.push_to_hub(ds_name)
@@ -26,10 +22,7 @@ class TestPushToHub(TestCase):
         self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
 
     def test_push_dataset_to_hub(self):
-        local_ds = Dataset.from_dict({
-            "x": [1, 2, 3],
-            "y": [4, 5, 6]
-        })
+        local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
         ds_name = f"Jikiwa/test-{int(time.time() * 10e3)}"
         local_ds.push_to_hub(ds_name, split_name="random")
@@ -44,4 +37,3 @@ class TestPushToHub(TestCase):
             self.assertDictEqual(local_ds.column_names, hub_ds.column_names)
             self.assertListEqual(list(local_ds["random"].features.keys()), list(hub_ds["random"].features.keys()))
             self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
-

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -135,8 +135,8 @@ class TestPushToHub(TestCase):
                 files,
                 [
                     ".gitattributes",
-                    "data/train-00000-of-00001.parquet",
-                    "data/train-00001-of-00001.parquet",
+                    "data/train-00000-of-00002.parquet",
+                    "data/train-00001-of-00002.parquet",
                     "datafile.txt",
                 ],
             )


### PR DESCRIPTION
This PR implements a `push_to_hub` method on `Dataset` and `DatasetDict`. This does not currently work in `IterableDatasetDict` nor `IterableDataset` as those are simple dicts and I would like your opinion on how you would like to implement this before going ahead and doing it.

This implementation needs to be used with the following `huggingface_hub` branch in order to work correctly: https://github.com/huggingface/huggingface_hub/pull/415

### Implementation

The `push_to_hub` API is entirely based on HTTP requests rather than a git-based workflow:
- This allows pushing changes without firstly cloning the repository, which reduces the time in half for the `push_to_hub` method.
- Collaboration, as well as the system of branches/merges/rebases is IMO less straightforward than for models and spaces. In the situation where such collaboration is needed, I would *heavily* advocate for the `Repository` helper of the `huggingface_hub` to be used instead of the `push_to_hub` method which will always be, by design, limiting in that regard (even if based on a git-workflow instead of HTTP requests)

In order to overcome the limit of 5GB files set by the HTTP requests, dataset sharding is used.

### Testing

The test suite implemented here makes use of the moon-staging instead of the production setup. As several repositories are created and deleted, it is better to use the staging.

It does not require setting an environment variable or any kind of special attention but introduces a new decorator `with_staging_testing` which patches global variables to use the staging endpoint instead of the production endpoint.

### Examples

The tests cover a lot of examples and behavior.