### PR TITLE
Replace FSTimeoutError with parent TimeoutError

### DIFF
--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -2,13 +2,13 @@ import glob
 import os
 import re
 import time
+from asyncio import TimeoutError
 from pathlib import Path, PurePosixPath
 from typing import Optional, Tuple, Union
 
 import fsspec
 import posixpath
 from aiohttp.client_exceptions import ClientError
-from fsspec.exceptions import FSTimeoutError
 
 from .. import config
 from ..filesystems import COMPRESSION_FILESYSTEMS
@@ -127,7 +127,7 @@ def _add_retries_to_file_obj_read_method(file_obj):
             try:
                 out = read(*args, **kwargs)
                 break
-            except (ClientError, FSTimeoutError):
+            except (ClientError, TimeoutError):
                 logger.warning(
                     f"Got disconnected from remote data host. Retrying in {config.STREAMING_READ_RETRY_INTERVAL}sec [{retry}/{max_retries}]"
                 )


### PR DESCRIPTION
PR #3050 introduced a dependency on `fsspec.FSTiemoutError`. Note that this error only exists from `fsspec` version `2021.06.0` (June 2021).

To fix #3097, there are 2 alternatives:
- Either pinning `fsspec` to versions newer or equal to `2021.06.0`
- Or replacing `fsspec.FSTimeoutError` wth its parent `asyncio.TimeoutError`, which exists from Python 3.8.0 (Sep 2018).

This PR implements the second approach.

Fix #3097.