### PR TITLE
Fix project description in PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,6 @@ import sys
 from setuptools import find_packages, setup
 
 
-DOCLINES = __doc__.split("\n")
-
-
 REQUIRED_PKGS = [
     # We use numpy>=1.17 to have np.random.Generator (Dataset shuffling)
     "numpy>=1.17",
@@ -224,8 +221,8 @@ EXTRAS_REQUIRE = {
 setup(
     name="datasets",
     version="1.13.4.dev0",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
-    description=DOCLINES[0],
-    long_description="\n".join(DOCLINES[2:]),
+    description="HuggingFace community-driven open-source library of datasets",
+    long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="HuggingFace Inc.",
     author_email="thomas@huggingface.co",


### PR DESCRIPTION
Fix project description appearing in PyPI, so that it contains the content of the README.md file (like transformers).

Currently, `datasets` project description appearing in PyPI shows the release instructions addressed to core maintainers: https://pypi.org/project/datasets/1.13.3/

Fix #3102.