### PR TITLE
Re-add faiss to windows testing suite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,9 +167,7 @@ TESTS_REQUIRE = [
     "importlib_resources;python_version<'3.7'",
 ]
 
-if os.name == "nt":  # windows
-    TESTS_REQUIRE.remove("faiss-cpu")  # faiss doesn't exist on windows
-else:
+if os.name != "nt":
     # dependencies of unbabel-comet
     # only test if not on windows since there're issues installing fairseq on windows
     TESTS_REQUIRE.extend(

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ TESTS_REQUIRE = [
     "aiobotocore",
     "boto3",
     "botocore",
-    "faiss-cpu",
+    "faiss-cpu>=1.6.4",
     "fsspec[s3]",
     "moto[s3,server]==2.0.4",
     "rarfile>=4.0",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -53,7 +53,9 @@ class IndexableDatasetTest(TestCase):
         )
 
         # Setting delete=False and unlinking manually is not pretty... but it is required on Windows to
-        # ensure somewhat stable behaviour
+        # ensure somewhat stable behaviour. If we don't, we get PermissionErrors. This is an age-old issue.
+        # see https://bugs.python.org/issue14243 and
+        # https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file/23212515
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             dset.save_faiss_index("vecs", tmp_file.name)
             dset.load_faiss_index("vecs2", tmp_file.name)
@@ -141,7 +143,9 @@ class FaissIndexTest(TestCase):
         index.add_vectors(np.eye(5, dtype=np.float32))
 
         # Setting delete=False and unlinking manually is not pretty... but it is required on Windows to
-        # ensure somewhat stable behaviour
+        # ensure somewhat stable behaviour. If we don't, we get PermissionErrors. This is an age-old issue.
+        # see https://bugs.python.org/issue14243 and
+        # https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file/23212515
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             index.save(tmp_file.name)
             index = FaissIndex.load(tmp_file.name)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 from functools import partial
-from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 


### PR DESCRIPTION
In recent versions, `faiss-cpu` seems to be available for Windows as well. See the [PyPi page](https://pypi.org/project/faiss-cpu/#files) to confirm. We can therefore included it for Windows in the setup file.

At first tests didn't pass due to problems with permissions as caused by `NamedTemporaryFile` on Windows. This built-in library is notoriously poor in playing nice on Windows. The required change isn't pretty, but it works. First set `delete=False` to not automatically try to delete the file on `exit`. Then, manually delete the file with `unlink`. It's weird, I know, but it works.

```python
with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
    # do stuff
os.unlink(tmp_file.name)
```

closes #3150 