### PR TITLE
Add TER (as implemented in sacrebleu)

### DIFF
--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -84,6 +84,8 @@ Examples:
     >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
     >>> ter = datasets.load_metric("ter")
     >>> results = ter.compute(predictions=predictions, references=references)
+    >>> print(results)
+    {'score': 0.0, 'num_edits': 0, 'ref_length': 6.5}
 """
 
 

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -67,7 +67,7 @@ Args:
    case_sensitive: Whether to disable lowercasing.
 
 Returns:
-    'score': TER score
+    'score': TER score (num_edits / sum_ref_lengths * 100)
     'num_edits': number of edits required
     'ref_length': reference length
 
@@ -111,13 +111,9 @@ class Ter(datasets.Metric):
                  asian_support: bool = False,
                  case_sensitive: bool = False
                  ):
-        references_per_prediction = len(references[0])
-        if any(len(refs) != references_per_prediction for refs in references):
-            raise ValueError("Sacrebleu requires the same number of references for each prediction")
-        transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
         output = scb.corpus_ter(
             predictions,
-            transformed_references,
+            references,
             normalized=normalized,
             no_punct=no_punct,
             asian_support=asian_support,

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ TER metric as available in sacrebleu. """
+import sacrebleu as scb
 from packaging import version
+from sacrebleu import TER
 
 import datasets
-import sacrebleu as scb
-from sacrebleu import TER
 
 
 _CITATION = """\
@@ -35,7 +35,6 @@ _CITATION = """\
     publisher = "Association for Machine Translation in the Americas",
     url = "https://aclanthology.org/2006.amta-papers.25",
     pages = "223--231",
-    abstract = "We examine a new, intuitive measure for evaluating machine-translation output that avoids the knowledge intensiveness of more meaning-based approaches, and the labor-intensiveness of human judgments. Translation Edit Rate (TER) measures the amount of editing that a human would have to perform to change a system output so it exactly matches a reference translation. We show that the single-reference variant of TER correlates as well with human judgments of MT quality as the four-reference variant of BLEU. We also define a human-targeted TER (or HTER) and show that it yields higher correlations with human judgments than BLEU{---}even when BLEU is given human-targeted references. Our results indicate that HTER correlates with human judgments better than HMETEOR and that the four-reference variants of TER and HTER correlate with human judgments as well as{---}or better than{---}a second human judgment does.",
 }
 @inproceedings{post-2018-call,
     title = "A Call for Clarity in Reporting {BLEU} Scores",

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2020 The HuggingFace Datasets Authors.
+# Copyright 2021 The HuggingFace Datasets Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +14,13 @@
 # limitations under the License.
 """ TER metric as available in sacrebleu. """
 import sacrebleu as scb
+from packaging import version
+from sacrebleu import TER
 
 import datasets
 
 
 _CITATION = """\
-@inproceedings{post-2018-call,
-    title = "A Call for Clarity in Reporting {BLEU} Scores",
-    author = "Post, Matt",
-    booktitle = "Proceedings of the Third Conference on Machine Translation: Research Papers",
-    month = oct,
-    year = "2018",
-    address = "Belgium, Brussels",
-    publisher = "Association for Computational Linguistics",
-    url = "https://www.aclweb.org/anthology/W18-6319",
-    pages = "186--191",
-}
 @inproceedings{snover-etal-2006-study,
     title = "A Study of Translation Edit Rate with Targeted Human Annotation",
     author = "Snover, Matthew  and
@@ -46,13 +37,28 @@ _CITATION = """\
     pages = "223--231",
     abstract = "We examine a new, intuitive measure for evaluating machine-translation output that avoids the knowledge intensiveness of more meaning-based approaches, and the labor-intensiveness of human judgments. Translation Edit Rate (TER) measures the amount of editing that a human would have to perform to change a system output so it exactly matches a reference translation. We show that the single-reference variant of TER correlates as well with human judgments of MT quality as the four-reference variant of BLEU. We also define a human-targeted TER (or HTER) and show that it yields higher correlations with human judgments than BLEU{---}even when BLEU is given human-targeted references. Our results indicate that HTER correlates with human judgments better than HMETEOR and that the four-reference variants of TER and HTER correlate with human judgments as well as{---}or better than{---}a second human judgment does.",
 }
+@inproceedings{post-2018-call,
+    title = "A Call for Clarity in Reporting {BLEU} Scores",
+    author = "Post, Matt",
+    booktitle = "Proceedings of the Third Conference on Machine Translation: Research Papers",
+    month = oct,
+    year = "2018",
+    address = "Belgium, Brussels",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W18-6319",
+    pages = "186--191",
+}
 """
 
 _DESCRIPTION = """\
 Besides calculating BLEU scores, SacreBLEU is also capable in calculating TER scores, among other things.
 Specifically, it is inspired by the TERCOM implementation which can be found here: https://github.com/jhclark/tercom
 
-See the [README.md] file at https://github.com/mjpost/sacreBLEU#ter for more information.
+The implementation here is slightly different from sacrebleu in terms of the required input format. The length of
+the references and hypotheses lists need to be the same, so you may need to transpose your references compared to
+sacrebleu's required input format. See https://github.com/huggingface/datasets/issues/3154#issuecomment-950746534
+
+See the README.md file at https://github.com/mjpost/sacreBLEU#ter for more information.
 """
 
 _KWARGS_DESCRIPTION = """
@@ -61,15 +67,15 @@ Produces TER scores alongside the number of edits and reference length.
 Args:
     predictions: The system stream (a sequence of segments).
     references: A list of one or more reference streams (each a sequence of segments).
-   normalized: Whether to apply basic tokenization to sentences.
-   no_punct: Whether to remove punctuations from sentences.
-   asian_support: Whether to support Asian character processing.
-   case_sensitive: Whether to disable lowercasing.
+    normalized: Whether to apply basic tokenization to sentences.
+    no_punct: Whether to remove punctuations from sentences.
+    asian_support: Whether to support Asian character processing.
+    case_sensitive: Whether to disable lowercasing.
 
 Returns:
-    'score': TER score (num_edits / sum_ref_lengths * 100)
-    'num_edits': number of edits required
-    'ref_length': reference length
+    'score': TER score (num_edits / sum_ref_lengths * 100),
+    'num_edits': The cumulative number of edits,
+    'ref_length': The cumulative average reference length.
 
 Examples:
 
@@ -82,8 +88,12 @@ Examples:
 
 @datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Ter(datasets.Metric):
-    """Largely borrowed from the sacrebleu implementation in `datasets`"""
     def _info(self):
+        if version.parse(scb.__version__) < version.parse("1.4.12"):
+            raise ImportWarning(
+                "To use `sacrebleu`, the module `sacrebleu>=1.4.12` is required, and the current version of `sacrebleu` doesn't match this condition.\n"
+                'You can install it with `pip install "sacrebleu>=1.4.12"`.'
+            )
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
@@ -103,25 +113,21 @@ class Ter(datasets.Metric):
             ],
         )
 
-    def _compute(self,
-                 predictions,
-                 references,
-                 normalized: bool = False,
-                 no_punct: bool = False,
-                 asian_support: bool = False,
-                 case_sensitive: bool = False
-                 ):
-        output = scb.corpus_ter(
-            predictions,
-            references,
-            normalized=normalized,
-            no_punct=no_punct,
-            asian_support=asian_support,
-            case_sensitive=case_sensitive
-        )
-        output_dict = {
-            "score": output.score,
-            "num_edits": output.num_edits,
-            "ref_length": output.ref_length
-        }
-        return output_dict
+    def _compute(
+        self,
+        predictions,
+        references,
+        normalized: bool = False,
+        no_punct: bool = False,
+        asian_support: bool = False,
+        case_sensitive: bool = False,
+    ):
+        references_per_prediction = len(references[0])
+        if any(len(refs) != references_per_prediction for refs in references):
+            raise ValueError("Sacrebleu requires the same number of references for each prediction")
+        transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
+
+        sb_ter = TER(normalized, no_punct, asian_support, case_sensitive)
+        output = sb_ter.corpus_score(predictions, transformed_references)
+
+        return {"score": output.score, "num_edits": output.num_edits, "ref_length": output.ref_length}

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ TER metric as available in sacrebleu. """
-import sacrebleu as scb
 from packaging import version
-from sacrebleu import TER
 
 import datasets
+import sacrebleu as scb
+from sacrebleu import TER
 
 
 _CITATION = """\
@@ -51,8 +51,10 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-Besides calculating BLEU scores, SacreBLEU is also capable in calculating TER scores, among other things.
-Specifically, it is inspired by the TERCOM implementation which can be found here: https://github.com/jhclark/tercom
+TER (Translation Edit Rate, also called Translation Error Rate) is a metric to quantify the edit operations that a
+hypothesis requires to match a reference translation. We use the implementation that is already present in sacrebleu
+(https://github.com/mjpost/sacreBLEU#ter), which in turn is inspired by the TERCOM implementation, which can be found
+here: https://github.com/jhclark/tercom.
 
 The implementation here is slightly different from sacrebleu in terms of the required input format. The length of
 the references and hypotheses lists need to be the same, so you may need to transpose your references compared to
@@ -97,7 +99,7 @@ class Ter(datasets.Metric):
         return datasets.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
-            homepage="https://github.com/mjpost/sacreBLEU#ter",
+            homepage="http://www.cs.umd.edu/~snover/tercom/",
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
@@ -107,8 +109,6 @@ class Ter(datasets.Metric):
             ),
             codebase_urls=["https://github.com/mjpost/sacreBLEU#ter"],
             reference_urls=[
-                "https://github.com/mjpost/sacreBLEU#ter",
-                "http://www.cs.umd.edu/~snover/tercom/",
                 "https://github.com/jhclark/tercom",
             ],
         )

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" TER metric as available in sacrebleu. """
+import sacrebleu as scb
+
+import datasets
+
+
+_CITATION = """\
+@inproceedings{post-2018-call,
+    title = "A Call for Clarity in Reporting {BLEU} Scores",
+    author = "Post, Matt",
+    booktitle = "Proceedings of the Third Conference on Machine Translation: Research Papers",
+    month = oct,
+    year = "2018",
+    address = "Belgium, Brussels",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W18-6319",
+    pages = "186--191",
+}
+@inproceedings{snover-etal-2006-study,
+    title = "A Study of Translation Edit Rate with Targeted Human Annotation",
+    author = "Snover, Matthew  and
+      Dorr, Bonnie  and
+      Schwartz, Rich  and
+      Micciulla, Linnea  and
+      Makhoul, John",
+    booktitle = "Proceedings of the 7th Conference of the Association for Machine Translation in the Americas: Technical Papers",
+    month = aug # " 8-12",
+    year = "2006",
+    address = "Cambridge, Massachusetts, USA",
+    publisher = "Association for Machine Translation in the Americas",
+    url = "https://aclanthology.org/2006.amta-papers.25",
+    pages = "223--231",
+    abstract = "We examine a new, intuitive measure for evaluating machine-translation output that avoids the knowledge intensiveness of more meaning-based approaches, and the labor-intensiveness of human judgments. Translation Edit Rate (TER) measures the amount of editing that a human would have to perform to change a system output so it exactly matches a reference translation. We show that the single-reference variant of TER correlates as well with human judgments of MT quality as the four-reference variant of BLEU. We also define a human-targeted TER (or HTER) and show that it yields higher correlations with human judgments than BLEU{---}even when BLEU is given human-targeted references. Our results indicate that HTER correlates with human judgments better than HMETEOR and that the four-reference variants of TER and HTER correlate with human judgments as well as{---}or better than{---}a second human judgment does.",
+}
+"""
+
+_DESCRIPTION = """\
+Besides calculating BLEU scores, SacreBLEU is also capable in calculating TER scores, among other things.
+Specifically, it is inspired by the TERCOM implementation which can be found here: https://github.com/jhclark/tercom
+
+See the [README.md] file at https://github.com/mjpost/sacreBLEU#ter for more information.
+"""
+
+_KWARGS_DESCRIPTION = """
+Produces TER scores alongside the number of edits and reference length.
+
+Args:
+    predictions: The system stream (a sequence of segments).
+    references: A list of one or more reference streams (each a sequence of segments).
+   normalized: Whether to apply basic tokenization to sentences.
+   no_punct: Whether to remove punctuations from sentences.
+   asian_support: Whether to support Asian character processing.
+   case_sensitive: Whether to disable lowercasing.
+
+Returns:
+    'score': TER score
+    'num_edits': number of edits required
+    'ref_length': reference length
+
+Examples:
+
+    >>> predictions = ["hello there general kenobi", "foo bar foobar"]
+    >>> references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
+    >>> ter = datasets.load_metric("ter")
+    >>> results = ter.compute(predictions=predictions, references=references)
+"""
+
+
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class Ter(datasets.Metric):
+    """Largely borrowed from the sacrebleu implementation in `datasets`"""
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            homepage="https://github.com/mjpost/sacreBLEU#ter",
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("string", id="sequence"),
+                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                }
+            ),
+            codebase_urls=["https://github.com/mjpost/sacreBLEU#ter"],
+            reference_urls=[
+                "https://github.com/mjpost/sacreBLEU#ter",
+                "http://www.cs.umd.edu/~snover/tercom/",
+                "https://github.com/jhclark/tercom",
+            ],
+        )
+
+    def _compute(self,
+                 predictions,
+                 references,
+                 normalized: bool = False,
+                 no_punct: bool = False,
+                 asian_support: bool = False,
+                 case_sensitive: bool = False
+                 ):
+        references_per_prediction = len(references[0])
+        if any(len(refs) != references_per_prediction for refs in references):
+            raise ValueError("Sacrebleu requires the same number of references for each prediction")
+        transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
+        output = scb.corpus_ter(
+            predictions,
+            transformed_references,
+            normalized=normalized,
+            no_punct=no_punct,
+            asian_support=asian_support,
+            case_sensitive=case_sensitive
+        )
+        output_dict = {
+            "score": output.score,
+            "num_edits": output.num_edits,
+            "ref_length": output.ref_length
+        }
+        return output_dict


### PR DESCRIPTION
Implements TER (Translation Edit Rate) as per its implementation in sacrebleu. Sacrebleu for BLEU scores is already implemented in `datasets` so I thought this would be a nice addition.

I started from the sacrebleu implementation, as the two metrics have a lot in common.

Verified with sacrebleu's [testing suite](https://github.com/mjpost/sacrebleu/blob/078c440168c6adc89ba75fe6d63f0d922d42bcfe/test/test_ter.py) that this indeed works as intended.

```python
import datasets


test_cases = [
    (['aaaa bbbb cccc dddd'], ['aaaa bbbb cccc dddd'], 0),  # perfect match
    (['dddd eeee ffff'], ['aaaa bbbb cccc'], 1),  # no overlap
    ([''], ['a'], 1),  # corner case, empty hypothesis
    (['d e f g h a b c'], ['a b c d e f g h'], 1 / 8),  # a single shift fixes MT
    (
        [
            'wählen Sie " Bild neu berechnen , " um beim Ändern der Bildgröße Pixel hinzuzufügen oder zu entfernen , damit das Bild ungefähr dieselbe Größe aufweist wie die andere Größe .',
            'wenn Sie alle Aufgaben im aktuellen Dokument aktualisieren möchten , wählen Sie im Menü des Aufgabenbedienfelds die Option " Alle Aufgaben aktualisieren . "',
            'klicken Sie auf der Registerkarte " Optionen " auf die Schaltfläche " Benutzerdefiniert " und geben Sie Werte für " Fehlerkorrektur-Level " und " Y / X-Verhältnis " ein .',
            'Sie können beispielsweise ein Dokument erstellen , das ein Auto über die Bühne enthält .',
            'wählen Sie im Dialogfeld " Neu aus Vorlage " eine Vorlage aus und klicken Sie auf " Neu . "',
        ],
        [
            'wählen Sie " Bild neu berechnen , " um beim Ändern der Bildgröße Pixel hinzuzufügen oder zu entfernen , damit die Darstellung des Bildes in einer anderen Größe beibehalten wird .',
            'wenn Sie alle Aufgaben im aktuellen Dokument aktualisieren möchten , wählen Sie im Menü des Aufgabenbedienfelds die Option " Alle Aufgaben aktualisieren . "',
            'klicken Sie auf der Registerkarte " Optionen " auf die Schaltfläche " Benutzerdefiniert " und geben Sie für " Fehlerkorrektur-Level " und " Y / X-Verhältnis " niedrigere Werte ein .',
            'Sie können beispielsweise ein Dokument erstellen , das ein Auto enthalt , das sich über die Bühne bewegt .',
            'wählen Sie im Dialogfeld " Neu aus Vorlage " eine Vorlage aus und klicken Sie auf " Neu . "',
        ],
        0.136  # realistic example from WMT dev data (2019)
    ),
]

ter = datasets.load_metric(r"path\to\datasets\metrics\ter")

predictions = ["hello there general kenobi", "foo bar foobar"]
references = [["hello there general kenobi", "hello there !"], ["foo bar foobar", "foo bar foobar"]]
print(ter.compute(predictions=predictions, references=references))

for hyp, ref, score in test_cases:
    # Note the reference transformation which is different from scarebleu's input format
    results = ter.compute(predictions=hyp, references=[[r] for r in ref])
    assert 100*score == results["score"], f"expected {100*score}, got {results['score']}"
```

