### PR TITLE
Deprecate prepare_module

### DIFF
--- a/src/datasets/commands/dummy_data.py
+++ b/src/datasets/commands/dummy_data.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from datasets import config
 from datasets.commands import BaseDatasetsCLICommand
-from datasets.load import import_main_class, prepare_module
+from datasets.load import dataset_module_factory, import_main_class
 from datasets.utils import MockDownloadManager
 from datasets.utils.download_manager import DownloadManager
 from datasets.utils.file_utils import DownloadConfig
@@ -287,8 +287,8 @@ class DummyDataCommand(BaseDatasetsCLICommand):
 
     def run(self):
         set_verbosity_warning()
-        module_path, hash = prepare_module(self._path_to_dataset)
-        builder_cls = import_main_class(module_path)
+        dataset_module = dataset_module_factory(self._path_to_dataset)
+        builder_cls = import_main_class(dataset_module.module_path)
 
         # use `None` as config if no configs
         builder_configs = builder_cls.BUILDER_CONFIGS or [None]
@@ -302,7 +302,7 @@ class DummyDataCommand(BaseDatasetsCLICommand):
                     version = builder_config.version
                     name = builder_config.name
 
-                dataset_builder = builder_cls(name=name, hash=hash, cache_dir=tmp_dir)
+                dataset_builder = builder_cls(name=name, hash=dataset_module.hash, cache_dir=tmp_dir)
                 mock_dl_manager = MockDownloadManager(
                     dataset_name=self._dataset_name,
                     config=builder_config,

--- a/src/datasets/commands/run_beam.py
+++ b/src/datasets/commands/run_beam.py
@@ -101,7 +101,7 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                     builder_cls(
                         name=builder_config.name,
                         data_dir=self._data_dir,
-                        hash=dataset_module.builder_kwargs.get("hash"),
+                        hash=dataset_module.hash,
                         beam_options=beam_options,
                         cache_dir=self._cache_dir,
                         base_path=dataset_module.builder_kwargs.get("base_path"),

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Mapping, Optional, Sequence, Union
 
 from .features import Features
 from .hf_api import HfApi
-from .load import import_main_class, load_dataset_builder, prepare_module
+from .load import dataset_module_factory, import_main_class, load_dataset_builder, metric_module_factory
 from .utils import DownloadConfig
 from .utils.download_manager import GenerateMode
 from .utils.logging import get_logger
@@ -72,12 +72,12 @@ def inspect_dataset(path: str, local_path: str, download_config: Optional[Downlo
         download_config (Optional ``datasets.DownloadConfig``: specific download configuration parameters.
         **download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied.
     """
-    module_path, _ = prepare_module(
-        path, download_config=download_config, dataset=True, force_local_path=local_path, **download_kwargs
+    dataset_module = dataset_module_factory(
+        path, download_config=download_config, force_local_path=local_path, **download_kwargs
     )
     print(
         f"The processing script for dataset {path} can be inspected at {local_path}. "
-        f"The main class is in {module_path}. "
+        f"The main class is in {dataset_module.module_path}. "
         f"You can modify this processing script and use it with `datasets.load_dataset({local_path})`."
     )
 
@@ -97,12 +97,12 @@ def inspect_metric(path: str, local_path: str, download_config: Optional[Downloa
         download_config (Optional ``datasets.DownloadConfig``: specific download configuration parameters.
         **download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied.
     """
-    module_path, _ = prepare_module(
-        path, download_config=download_config, dataset=False, force_local_path=local_path, **download_kwargs
+    metric_module = metric_module_factory(
+        path, download_config=download_config, force_local_path=local_path, **download_kwargs
     )
     print(
         f"The processing scripts for metric {path} can be inspected at {local_path}. "
-        f"The main class is in {module_path}. "
+        f"The main class is in {metric_module.module_path}. "
         f"You can modify this processing scripts and use it with `datasets.load_metric({local_path})`."
     )
 
@@ -143,9 +143,8 @@ def get_dataset_infos(
         download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied,
             for example ``use_auth_token``
     """
-    module_path, _ = prepare_module(
+    dataset_module = dataset_module_factory(
         path,
-        dataset=True,
         revision=revision,
         download_config=download_config,
         download_mode=download_mode,
@@ -154,7 +153,7 @@ def get_dataset_infos(
         data_files=data_files,
         **download_kwargs,
     )
-    builder_cls = import_main_class(module_path, dataset=True)
+    builder_cls = import_main_class(dataset_module.module_path, dataset=True)
     return builder_cls.get_all_exported_dataset_infos()
 
 
@@ -194,9 +193,8 @@ def get_dataset_config_names(
         download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied,
             for example ``use_auth_token``
     """
-    module_path, _ = prepare_module(
+    dataset_module = dataset_module_factory(
         path,
-        dataset=True,
         revision=revision,
         download_config=download_config,
         download_mode=download_mode,
@@ -205,7 +203,7 @@ def get_dataset_config_names(
         data_files=data_files,
         **download_kwargs,
     )
-    builder_cls = import_main_class(module_path, dataset=True)
+    builder_cls = import_main_class(dataset_module.module_path, dataset=True)
     return list(builder_cls.builder_configs.keys())
 
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -47,6 +47,7 @@ from .packaged_modules import _EXTENSION_TO_MODULE, _PACKAGED_DATASETS_MODULES, 
 from .splits import Split
 from .streaming import extend_module_for_streaming
 from .tasks import TaskTemplate
+from .utils.deprecation_utils import deprecated
 from .utils.download_manager import GenerateMode
 from .utils.file_utils import (
     DownloadConfig,
@@ -1250,6 +1251,7 @@ def metric_module_factory(
         raise FileNotFoundError(f"Couldn't find a metric script at {relative_to_absolute_path(combined_path)}.")
 
 
+@deprecated("Use dataset_module_factory or metric_module_factory instead.")
 def prepare_module(
     path: str,
     revision: Optional[Union[str, Version]] = None,
@@ -1263,11 +1265,6 @@ def prepare_module(
     **download_kwargs,
 ) -> Union[Tuple[str, str], Tuple[str, str, Optional[str]]]:
     """For backward compatibility. Please use dataset_module_factory or metric_module_factory instead."""
-    warnings.warn(
-        "'prepare_module' was superseded by 'dataset_module_factory' and 'metric_module_factory' in version 1.13 and "
-        "will be removed in version 1.15.",
-        FutureWarning,
-    )
     if script_version != "deprecated":
         warnings.warn(
             "'script_version' was renamed to 'revision' in version 1.13 and will be removed in 1.15.", FutureWarning

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1264,7 +1264,11 @@ def prepare_module(
     script_version="deprecated",
     **download_kwargs,
 ) -> Union[Tuple[str, str], Tuple[str, str, Optional[str]]]:
-    """For backward compatibility. Please use dataset_module_factory or metric_module_factory instead."""
+    """
+    .. deprecated:: 1.13
+        `prepare_module` was deprecated in version 1.13 and will be removed in the next major version.
+        For backward compatibility, please use :func:`dataset_module_factory` or :func:`metric_module_factory` instead.
+    """
     if script_version != "deprecated":
         warnings.warn(
             "'script_version' was renamed to 'revision' in version 1.13 and will be removed in 1.15.", FutureWarning

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1263,6 +1263,11 @@ def prepare_module(
     **download_kwargs,
 ) -> Union[Tuple[str, str], Tuple[str, str, Optional[str]]]:
     """For backward compatibility. Please use dataset_module_factory or metric_module_factory instead."""
+    warnings.warn(
+        "'prepare_module' was superseded by 'dataset_module_factory' and 'metric_module_factory' in version 1.13 and "
+        "will be removed in version 1.15.",
+        FutureWarning,
+    )
     if script_version != "deprecated":
         warnings.warn(
             "'script_version' was renamed to 'revision' in version 1.13 and will be removed in 1.15.", FutureWarning

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1268,8 +1268,8 @@ def prepare_module(
             "'script_version' was renamed to 'revision' in version 1.13 and will be removed in 1.15.", FutureWarning
         )
         revision = script_version
-    if dataset:
-        results = dataset_module_factory(
+    module = (
+        dataset_module_factory(
             path,
             revision=revision,
             download_config=download_config,
@@ -1279,9 +1279,8 @@ def prepare_module(
             data_files=data_files,
             **download_kwargs,
         )
-        return results.module_path, results.hash
-    else:
-        results = metric_module_factory(
+        if dataset
+        else metric_module_factory(
             path,
             revision=revision,
             download_config=download_config,
@@ -1290,7 +1289,8 @@ def prepare_module(
             dynamic_modules_path=dynamic_modules_path,
             **download_kwargs,
         )
-        return results.module_path, results.hash
+    )
+    return module.module_path, module.hash
 
 
 def load_metric(

--- a/src/datasets/utils/patching.py
+++ b/src/datasets/utils/patching.py
@@ -22,11 +22,11 @@ class patch_submodule:
     Examples:
 
         >>> import importlib
-        >>> from datasets.load import prepare_module
+        >>> from datasets.load import dataset_module_factory
         >>> from datasets.streaming import patch_submodule, xjoin
         >>>
-        >>> snli_module_path, _ = prepare_module("snli")
-        >>> snli_module = importlib.import_module(snli_module_path)
+        >>> dataset_module = dataset_module_factory("snli")
+        >>> snli_module = importlib.import_module(dataset_module.module_path)
         >>> patcher = patch_submodule(snli_module, "os.path.join", xjoin)
         >>> patcher.start()
         >>> assert snli_module.os.path.join is xjoin

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -25,13 +25,13 @@ from unittest import TestCase
 from absl.testing import parameterized
 
 import datasets
-from datasets import cached_path, import_main_class, load_dataset, prepare_module
 from datasets.builder import BuilderConfig, DatasetBuilder
 from datasets.features import ClassLabel, Features, Value
+from datasets.load import dataset_module_factory, import_main_class, load_dataset
 from datasets.packaged_modules import _PACKAGED_DATASETS_MODULES
 from datasets.search import _has_faiss
 from datasets.utils.download_manager import GenerateMode
-from datasets.utils.file_utils import DownloadConfig, is_remote_url
+from datasets.utils.file_utils import DownloadConfig, cached_path, is_remote_url
 from datasets.utils.logging import get_logger
 from datasets.utils.mock_download_manager import MockDownloadManager
 
@@ -100,11 +100,11 @@ class DatasetTester:
     def load_builder_class(self, dataset_name, is_local=False):
         # Download/copy dataset script
         if is_local is True:
-            module_path, _ = prepare_module(os.path.join("datasets", dataset_name))
+            dataset_module = dataset_module_factory(os.path.join("datasets", dataset_name))
         else:
-            module_path, _ = prepare_module(dataset_name, download_config=DownloadConfig(force_download=True))
+            dataset_module = dataset_module_factory(dataset_name, download_config=DownloadConfig(force_download=True))
         # Get dataset builder class
-        builder_cls = import_main_class(module_path)
+        builder_cls = import_main_class(dataset_module.module_path)
         return builder_cls
 
     def load_all_configs(self, dataset_name, is_local=False) -> List[Optional[BuilderConfig]]:
@@ -254,8 +254,8 @@ class LocalDatasetTest(parameterized.TestCase):
     @slow
     def test_load_real_dataset(self, dataset_name):
         path = "./datasets/" + dataset_name
-        module_path, hash = prepare_module(path, download_config=DownloadConfig(local_files_only=True), dataset=True)
-        builder_cls = import_main_class(module_path, dataset=True)
+        dataset_module = dataset_module_factory(path, download_config=DownloadConfig(local_files_only=True))
+        builder_cls = import_main_class(dataset_module.module_path)
         name = builder_cls.BUILDER_CONFIGS[0].name if builder_cls.BUILDER_CONFIGS else None
         with tempfile.TemporaryDirectory() as temp_cache_dir:
             dataset = load_dataset(
@@ -268,8 +268,8 @@ class LocalDatasetTest(parameterized.TestCase):
     @slow
     def test_load_real_dataset_all_configs(self, dataset_name):
         path = "./datasets/" + dataset_name
-        module_path, hash = prepare_module(path, download_config=DownloadConfig(local_files_only=True), dataset=True)
-        builder_cls = import_main_class(module_path, dataset=True)
+        dataset_module = dataset_module_factory(path, download_config=DownloadConfig(local_files_only=True))
+        builder_cls = import_main_class(dataset_module.module_path)
         config_names = (
             [config.name for config in builder_cls.BUILDER_CONFIGS] if len(builder_cls.BUILDER_CONFIGS) > 0 else [None]
         )

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -7,7 +7,7 @@ from absl.testing import parameterized
 from datasets import config
 from datasets.arrow_reader import HF_GCP_BASE_URL
 from datasets.builder import DatasetBuilder
-from datasets.load import import_main_class, prepare_module
+from datasets.load import dataset_module_factory, import_main_class
 from datasets.utils import cached_path
 
 
@@ -52,16 +52,16 @@ class TestDatasetOnHfGcp(TestCase):
     def test_dataset_info_available(self, dataset, config_name):
 
         with TemporaryDirectory() as tmp_dir:
-            local_module_path, local_hash = prepare_module(
-                os.path.join("datasets", dataset), dataset=True, cache_dir=tmp_dir, local_files_only=True
+            dataset_module = dataset_module_factory(
+                os.path.join("datasets", dataset), cache_dir=tmp_dir, local_files_only=True
             )
 
-            builder_cls = import_main_class(local_module_path, dataset=True)
+            builder_cls = import_main_class(dataset_module.module_path, dataset=True)
 
             builder_instance: DatasetBuilder = builder_cls(
                 cache_dir=tmp_dir,
                 name=config_name,
-                hash=local_hash,
+                hash=dataset_module.hash,
             )
 
             dataset_info_url = os.path.join(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -295,58 +295,58 @@ class LoadTest(TestCase):
             f.write(dummy_code)
         return module_dir
 
-    def test_prepare_module(self):
+    def test_dataset_module_factory(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # prepare module from directory path
             dummy_code = "MY_DUMMY_VARIABLE = 'hello there'"
             module_dir = self._dummy_module_dir(tmp_dir, "__dummy_module_name1__", dummy_code)
-            importable_module_path, module_hash = datasets.load.prepare_module(
+            dataset_module = datasets.load.dataset_module_factory(
                 module_dir, dynamic_modules_path=self.dynamic_modules_path
             )
-            dummy_module = importlib.import_module(importable_module_path)
+            dummy_module = importlib.import_module(dataset_module.module_path)
             self.assertEqual(dummy_module.MY_DUMMY_VARIABLE, "hello there")
-            self.assertEqual(module_hash, sha256(dummy_code.encode("utf-8")).hexdigest())
+            self.assertEqual(dataset_module.hash, sha256(dummy_code.encode("utf-8")).hexdigest())
             # prepare module from file path + check resolved_file_path
             dummy_code = "MY_DUMMY_VARIABLE = 'general kenobi'"
             module_dir = self._dummy_module_dir(tmp_dir, "__dummy_module_name1__", dummy_code)
             module_path = os.path.join(module_dir, "__dummy_module_name1__.py")
-            importable_module_path, module_hash = datasets.load.prepare_module(
+            dataset_module = datasets.load.dataset_module_factory(
                 module_path, dynamic_modules_path=self.dynamic_modules_path
             )
-            dummy_module = importlib.import_module(importable_module_path)
+            dummy_module = importlib.import_module(dataset_module.module_path)
             self.assertEqual(dummy_module.MY_DUMMY_VARIABLE, "general kenobi")
-            self.assertEqual(module_hash, sha256(dummy_code.encode("utf-8")).hexdigest())
+            self.assertEqual(dataset_module.hash, sha256(dummy_code.encode("utf-8")).hexdigest())
             # missing module
             for offline_simulation_mode in list(OfflineSimulationMode):
                 with offline(offline_simulation_mode):
                     with self.assertRaises((FileNotFoundError, ConnectionError, requests.exceptions.ConnectionError)):
-                        datasets.load.prepare_module(
+                        datasets.load.dataset_module_factory(
                             "__missing_dummy_module_name__", dynamic_modules_path=self.dynamic_modules_path
                         )
 
-    def test_offline_prepare_module(self):
+    def test_offline_dataset_module_factory(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dummy_code = "MY_DUMMY_VARIABLE = 'hello there'"
             module_dir = self._dummy_module_dir(tmp_dir, "__dummy_module_name2__", dummy_code)
-            importable_module_path1, _ = datasets.load.prepare_module(
+            dataset_module_1 = datasets.load.dataset_module_factory(
                 module_dir, dynamic_modules_path=self.dynamic_modules_path
             )
             time.sleep(0.1)  # make sure there's a difference in the OS update time of the python file
             dummy_code = "MY_DUMMY_VARIABLE = 'general kenobi'"
             module_dir = self._dummy_module_dir(tmp_dir, "__dummy_module_name2__", dummy_code)
-            importable_module_path2, _ = datasets.load.prepare_module(
+            dataset_module_2 = datasets.load.dataset_module_factory(
                 module_dir, dynamic_modules_path=self.dynamic_modules_path
             )
         for offline_simulation_mode in list(OfflineSimulationMode):
             with offline(offline_simulation_mode):
                 self._caplog.clear()
                 # allow provide the module name without an explicit path to remote or local actual file
-                importable_module_path3, _ = datasets.load.prepare_module(
+                dataset_module_3 = datasets.load.dataset_module_factory(
                     "__dummy_module_name2__", dynamic_modules_path=self.dynamic_modules_path
                 )
                 # it loads the most recent version of the module
-                self.assertEqual(importable_module_path2, importable_module_path3)
-                self.assertNotEqual(importable_module_path1, importable_module_path3)
+                self.assertEqual(dataset_module_2.module_path, dataset_module_3.module_path)
+                self.assertNotEqual(dataset_module_1.module_path, dataset_module_3.module_path)
                 self.assertIn("Using the latest cached version of the module", self._caplog.text)
 
     def test_load_dataset_canonical(self):

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -63,7 +63,7 @@ class LocalMetricTest(parameterized.TestCase):
     def test_load_metric(self, metric_name):
         doctest.ELLIPSIS_MARKER = "[...]"
         metric_module = importlib.import_module(
-            datasets.load.prepare_module(os.path.join("metrics", metric_name), dataset=False)[0]
+            datasets.load.metric_module_factory(os.path.join("metrics", metric_name)).module_path
         )
         metric = datasets.load.import_main_class(metric_module.__name__, dataset=False)
         # check parameters
@@ -81,7 +81,9 @@ class LocalMetricTest(parameterized.TestCase):
     @slow
     def test_load_real_metric(self, metric_name):
         doctest.ELLIPSIS_MARKER = "[...]"
-        metric_module = importlib.import_module(datasets.load.prepare_module(os.path.join("metrics", metric_name))[0])
+        metric_module = importlib.import_module(
+            datasets.load.metric_module_factory(os.path.join("metrics", metric_name)).module_path
+        )
         # run doctest
         with self.use_local_metrics():
             results = doctest.testmod(metric_module, verbose=True, raise_on_error=True)


### PR DESCRIPTION
In version 1.13, `prepare_module` was deprecated.

This PR adds a deprecation warning and removes it from all the library, using `dataset_module_factory` or `metric_module_factory` instead.

Fix #3165.