### PR TITLE
Don't memoize strings when hashing since two identical strings may have different python ids

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -323,6 +323,11 @@ class Pickler(dill.Pickler):
         else:
             dill.Pickler.save_global(self, obj, name=name)
 
+    def memoize(self, obj):
+        # don't memoize strings since two identical strings can have different python ids
+        if type(obj) != str:
+            dill.Pickler.memoize(self, obj)
+
 
 def dump(obj, file):
     """pickle an object to a file"""

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -278,12 +278,15 @@ class HashingTest(TestCase):
 
     def test_hash_same_strings(self):
         string = "abc"
-        obj1 = [string, string]
+        obj1 = [string, string]  # two strings have the same ids
         obj2 = [string, string]
-        obj3 = json.loads(f'["{string}", "{string}"]')
+        obj3 = json.loads(f'["{string}", "{string}"]')  # two strings have different ids
         self.assertIs(obj1[0], string)
+        self.assertIs(obj1[0], obj1[1])
         self.assertIs(obj2[0], string)
+        self.assertIs(obj2[0], obj2[1])
         self.assertIsNot(obj3[0], string)
+        self.assertIsNot(obj3[0], obj3[1])
         hash1 = Hasher.hash(obj1)
         hash2 = Hasher.hash(obj2)
         hash3 = Hasher.hash(obj3)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 import subprocess
 from hashlib import md5
@@ -274,6 +275,20 @@ class HashingTest(TestCase):
     def test_hash_unpicklable(self):
         with self.assertRaises(pickle.PicklingError):
             Hasher.hash(UnpicklableCallable(Foo("hello")))
+
+    def test_hash_same_strings(self):
+        string = "abc"
+        obj1 = [string, string]
+        obj2 = [string, string]
+        obj3 = json.loads(f'["{string}", "{string}"]')
+        self.assertIs(obj1[0], string)
+        self.assertIs(obj2[0], string)
+        self.assertIsNot(obj3[0], string)
+        hash1 = Hasher.hash(obj1)
+        hash2 = Hasher.hash(obj2)
+        hash3 = Hasher.hash(obj3)
+        self.assertEqual(hash1, hash2)
+        self.assertEqual(hash1, hash3)
 
 
 def test_move_script_doesnt_change_hash(tmp_path: Path):


### PR DESCRIPTION
When hashing an object that has several times the same string, the hashing could return a different hash if the identical strings share the same python `id()` or not.

Here is an example code that shows how the issue can affect the caching:
```python
import json
import pyarrow as pa
from datasets.features import Features
from datasets.fingerprint import Hasher

schema = pa.schema([pa.field("some_string", pa.string()), pa.field("another_string", pa.string())])
features_from_schema = Features.from_arrow_schema(schema)
Hasher.hash(features_from_schema) # dffa9dca9a73fd8c

features_dict = json.loads('{"some_string": {"dtype": "string", "id": null, "_type": "Value"}, "another_string": {"dtype": "string", "id": null, "_type": "Value"}}')
features_from_json = Features.from_dict(features_dict)
Hasher.hash(features_from_json) # 3812e76b15e6420e

features_from_schema == features_from_json # True
```

This is because in `features_dict`, some strings like "dtype" are repeated but don't share the same id, contrary to the ones in `features_from_schema`.

I fixed that by disabling memoization for strings.

This could be optimized in the future by implementing a smarter memoization with a special handling for strings.