### PR TITLE
QOL improvements: auto-flatten_indices and desc in map calls

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1166,7 +1166,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             lambda batch: {column: dst_feat.str2int(batch)},
             input_columns=column,
             batched=True,
-            desc="Casting to the labels",
+            desc="Casting to class labels",
         )
         dset = concatenate_datasets([self.remove_columns([column]), dset], axis=1)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -953,7 +953,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             dataset_path = extract_path_from_uri(dataset_path)
         else:
             fs = fsspec.filesystem("file")
-            cache_files_paths = [Path(cache_filename["filename"]) for cache_filename in dataset.cache_files]
+            cache_files_paths = [Path(cache_filename["filename"]) for cache_filename in self.cache_files]
             # Check that the dataset doesn't overwrite iself. It can cause a permission error on Windows and a segfault on linux.
             if Path(dataset_path, config.DATASET_ARROW_FILENAME) in cache_files_paths:
                 raise PermissionError(

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -937,18 +937,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Saves a dataset to a dataset directory, or in a filesystem using either :class:`~filesystems.S3FileSystem` or
         any implementation of ``fsspec.spec.AbstractFileSystem``.
 
-
-        Note regarding sliced datasets:
-
-        If you sliced the dataset in some way (using shard, train_test_split or select for example), then an indices mapping
-        is added to avoid having to rewrite a new arrow Table (save time + disk/memory usage).
-        It maps the indices used by __getitem__ to the right rows if the arrow Table.
-        By default save_to_disk does save the full dataset table + the mapping.
-
-        If you want to only save the shard of the dataset instead of the original arrow file and the indices,
-        then you have to call :func:`datasets.Dataset.flatten_indices` before saving.
-        This will create a new arrow table by using the right rows of the original table.
-
         Args:
             dataset_path (:obj:`str`): Path (e.g. `dataset/train`) or remote URI (e.g. `s3://my-bucket/dataset/train`)
                 of the dataset directory where the dataset will be saved to.
@@ -959,11 +947,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             not self.list_indexes()
         ), "please remove all the indexes using `dataset.drop_index` before saving a dataset"
 
+        dataset = self.flatten_indices() if self._indices is not None else self
+
         if is_remote_filesystem(fs):
             dataset_path = extract_path_from_uri(dataset_path)
         else:
             fs = fsspec.filesystem("file")
-            cache_files_paths = [Path(cache_filename["filename"]) for cache_filename in self.cache_files]
+            cache_files_paths = [Path(cache_filename["filename"]) for cache_filename in dataset.cache_files]
             # Check that the dataset doesn't overwrite iself. It can cause a permission error on Windows and a segfault on linux.
             if Path(dataset_path, config.DATASET_ARROW_FILENAME) in cache_files_paths:
                 raise PermissionError(
@@ -976,7 +966,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         # Get json serializable state
         state = {
-            key: self.__dict__[key]
+            key: dataset.__dict__[key]
             for key in [
                 "_fingerprint",
                 "_format_columns",
@@ -987,13 +977,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             ]
         }
 
-        split = self.__dict__["_split"]
+        split = dataset.__dict__["_split"]
         state["_split"] = str(split) if split is not None else split
 
         state["_data_files"] = [{"filename": config.DATASET_ARROW_FILENAME}]
-        state["_indices_data_files"] = (
-            [{"filename": config.DATASET_INDICES_FILENAME}] if self._indices is not None else None
-        )
         for k in state["_format_kwargs"].keys():
             try:
                 json.dumps(state["_format_kwargs"][k])
@@ -1003,19 +990,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 ) from None
 
         # Get json serializable dataset info
-        dataset_info = asdict(self._info)
+        dataset_info = asdict(dataset._info)
 
         # Save dataset + indices + state + info
         fs.makedirs(dataset_path, exist_ok=True)
         with fs.open(Path(dataset_path, config.DATASET_ARROW_FILENAME).as_posix(), "wb") as dataset_file:
             with ArrowWriter(stream=dataset_file) as writer:
-                writer.write_table(self._data)
+                writer.write_table(dataset._data)
                 writer.finalize()
-        if self._indices is not None:
-            with fs.open(Path(dataset_path, config.DATASET_INDICES_FILENAME).as_posix(), "wb") as indices_file:
-                with ArrowWriter(stream=indices_file) as writer:
-                    writer.write_table(self._indices)
-                    writer.finalize()
         with fs.open(
             Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), "w", encoding="utf-8"
         ) as state_file:
@@ -1083,20 +1065,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
             for data_file in state["_data_files"]
         )
-        if state.get("_indices_data_files"):
-            indices_table = concat_tables(
-                table_cls.from_file(Path(dataset_path, indices_file["filename"]).as_posix())
-                for indices_file in state["_indices_data_files"]
-            )
-        else:
-            indices_table = None
 
         split = state["_split"]
         split = Split(split) if split is not None else split
 
         return Dataset(
             arrow_table=arrow_table,
-            indices_table=indices_table,
             info=dataset_info,
             split=split,
             fingerprint=state["_fingerprint"],
@@ -1154,13 +1128,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise ValueError(f"Column ({column}) not in table columns ({self._data.column_names}).")
 
         if self._indices is not None and self._indices.num_rows != self._data.num_rows:
-            raise ValueError(
-                f"This dataset is a shallow copy using an indices mapping of another Datset {self._data.num_rows}."
-                f"The `Dataset.unique()` method is currently not handled on shallow copy. Please use `Dataset.flatten_indices()` "
-                f"to create a deep copy of the dataset and be able to use `Dataset.unique()`."
-            )
+            dataset = self.flatten_indices()
+        else:
+            dataset = self
 
-        return self._data.column(column).unique().to_pylist()
+        return dataset._data.column(column).unique().to_pylist()
 
     def class_encode_column(self, column: str) -> "Dataset":
         """Casts the given column as :obj:``datasets.features.ClassLabel`` and updates the table.
@@ -1177,10 +1149,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 f"Class encoding is only supported for {type(Value)} column, and column {column} is {type(src_feat)}."
             )
 
-        # Stringify the column
         if src_feat.dtype != "string":
             dset = self.map(
-                lambda batch: {column: [str(sample) for sample in batch]}, input_columns=column, batched=True
+                lambda batch: {column: [str(sample) for sample in batch]},
+                input_columns=column,
+                batched=True,
+                desc="Stringifying the column",
             )
         else:
             dset = self
@@ -1188,7 +1162,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Create the new feature
         class_names = sorted(dset.unique(column))
         dst_feat = ClassLabel(names=class_names)
-        dset = dset.map(lambda batch: {column: dst_feat.str2int(batch)}, input_columns=column, batched=True)
+        dset = dset.map(
+            lambda batch: {column: dst_feat.str2int(batch)},
+            input_columns=column,
+            batched=True,
+            desc="Casting to the labels",
+        )
         dset = concatenate_datasets([self.remove_columns([column]), dset], axis=1)
 
         new_features = dset.features.copy()
@@ -1319,6 +1298,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             writer_batch_size=writer_batch_size,
             num_proc=num_proc,
             features=features,
+            desc="Casting the dataset",
         )
         self._data = dataset._data
         self._info = dataset._info
@@ -1380,6 +1360,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             writer_batch_size=writer_batch_size,
             num_proc=num_proc,
             features=features,
+            desc="Casting the dataset",
         )
         dataset = dataset.with_format(**format)
         return dataset
@@ -2593,6 +2574,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             features=features,
             disable_nullable=disable_nullable,
             new_fingerprint=new_fingerprint,
+            desc="Flattening the indices",
         )
 
     def _new_dataset_with_indices(
@@ -3619,21 +3601,31 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 label2id = {'CONTRADICTION': 0, 'NEUTRAL': 1, 'ENTAILMENT': 2}
                 ds_aligned = ds.align_labels_with_mapping(label2id, "label")
         """
-        features = self.features.copy()
-        int2str_function = features[label_column].int2str
+        # Sanity checks
+        if label_column not in self._data.column_names:
+            raise ValueError(f"Column ({label_column}) not in table columns ({self._data.column_names}).")
+
+        label_feature = self.features[label_column]
+        if not isinstance(label_feature, ClassLabel):
+            raise ValueError(
+                f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} column, and column {label_feature} is {type(label_feature).__name__}."
+            )
+
         # Sort input mapping by ID value to ensure the label names are aligned
         label2id = dict(sorted(label2id.items(), key=lambda item: item[1]))
         label_names = list(label2id.keys())
-        features[label_column] = ClassLabel(num_classes=len(label_names), names=label_names)
         # Some label mappings use uppercase label names so we lowercase them during alignment
         label2id = {k.lower(): v for k, v in label2id.items()}
+        int2str_function = label_feature.int2str
 
         def process_label_ids(batch):
             dset_label_names = [int2str_function(label_id).lower() for label_id in batch[label_column]]
             batch[label_column] = [label2id[label_name] for label_name in dset_label_names]
             return batch
 
-        return self.map(process_label_ids, features=features, batched=True)
+        features = self.features.copy()
+        features[label_column] = ClassLabel(num_classes=len(label_names), names=label_names)
+        return self.map(process_label_ids, features=features, batched=True, desc="Aligning the labels")
 
 
 def concatenate_datasets(

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -612,8 +612,6 @@ class ClassLabel:
      * `names`: a list of label strings
      * `names_file`: a file containing the list of labels.
 
-    Note: On python2, the strings are encoded as utf-8.
-
     Args:
         num_classes: `int`, number of classes. All labels must be < num_classes.
         names: `list<str>`, string names for the integer classes. The

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1823,10 +1823,6 @@ class BaseDatasetTest(TestCase):
 
                     self.assertNotEqual(dset._indices, None)
 
-                    # Test unique fail
-                    with self.assertRaises(ValueError):
-                        dset.unique(dset.column_names[0])
-
                     tmp_file_2 = os.path.join(tmp_dir, "test_2.arrow")
                     fingerprint = dset._fingerprint
                     dset.set_format("numpy")


### PR DESCRIPTION
This PR:
* automatically calls `flatten_indices` where needed: in `unique` and `save_to_disk` to avoid saving the indices file
* adds descriptions to the map calls

Fix #3040 