### PR TITLE
Fix optimized encoding for arrays

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -847,7 +847,8 @@ def encode_nested_example(schema, obj):
                 for first_elmt in obj:
                     if first_elmt is not None:
                         break
-                if encode_nested_example(schema.feature, first_elmt) != first_elmt:
+                # be careful when comparing tensors here
+                if not isinstance(first_elmt, list) or encode_nested_example(schema.feature, first_elmt) != first_elmt:
                     return [encode_nested_example(schema.feature, o) for o in obj]
             return list(obj)
     # Object with special encoding:


### PR DESCRIPTION
Hi !

#3124 introduced a regression that made the benchmarks CI fail because of a bad array comparison when checking the first encoded element. This PR fixes this by making sure that encoding is applied on all sequence types except lists.

cc @eladsegal fyi (no big deal)