### PR TITLE
Bump huggingface_hub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ REQUIRED_PKGS = [
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
-    "huggingface_hub>=0.0.19,<0.1.0",
+    "huggingface_hub>=0.1.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
 ]


### PR DESCRIPTION
huggingface_hub just released its first minor version, so we need to update the dependency

It was supposed to be part of 1.15.0 but I'm adding it for 1.15.1