### PR TITLE
[WIP] Allow user-defined hash functions via a registry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,8 @@ REQUIRED_PKGS = [
     "huggingface_hub>=0.1.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
+    # Allowing user-registered functions
+    "catalogue"
 ]
 
 AUDIO_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,7 @@ To create the package for pypi.
    Push the commit to remote: "git push origin master"
 """
 
-import datetime
-import itertools
 import os
-import sys
 
 from setuptools import find_packages, setup
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -20,6 +20,7 @@
 
 import contextlib
 import functools
+import importlib
 import itertools
 import os
 import pickle
@@ -79,6 +80,30 @@ def size_str(size_in_bytes):
         if value >= 1.0:
             return "{:.2f} {}".format(value, name)
     return "{} {}".format(int(size_in_bytes), "bytes")
+
+
+def get_cls_from_qualname(full_qualname: str):
+    """Dynmically get the class based on a full qualified name (str).
+    For instance, given the string `torch.nn.Module` returns the `Module` class.
+    Args:
+        full_qualname: `str`, the full qualified name for the class to load (must be importable)
+    """
+    module_name, class_name = full_qualname.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
+
+
+def get_qualname_from_cls(cls) -> str:
+    """Convert a given (uninstantiated) class to its full qualified name (str).
+    For instance, give `Module` class, return `torch.nn.Module`.
+    Args:
+        cls: class to convert into string representation by its qualname
+    """
+    module = cls.__module__
+    # Do not include `builtins` in full name
+    if module == "builtins":
+        return cls.__qualname__
+    return module + "." + cls.__qualname__
 
 
 @contextlib.contextmanager

--- a/src/datasets/utils/registry.py
+++ b/src/datasets/utils/registry.py
@@ -1,0 +1,42 @@
+from inspect import isclass
+from typing import Any, Callable, Optional
+
+from catalogue import InFunc, Registry
+
+from datasets.utils.py_utils import get_qualname_from_cls
+
+
+class DatasetsRegistry(Registry):
+    """The original catalogue.Registry is restricted to using strings as the registry key.
+    In our case we want to extend this to classes specifically. This allows users to register
+    specific functions that have to be used to hash objects with a specific class.
+
+    To make this work consistently, we get the full module name + the class' qualname of the object
+    (py_utils.get_qualname_from_cls), which allows us to later retrieve the class
+    (py_utils.get_cls_from_qualname).
+    """
+
+    # TODO: also incorporate other functions: get_all, get_entry_points, get_entry_point
+    # Do not think find() is necessary as it calls get() anyway
+    @staticmethod
+    def get_arg_as_str(name: Any) -> str:
+        if isclass(name):
+            name = get_qualname_from_cls(name)
+        elif not isinstance(name, str):
+            name = repr(name)
+        return name
+
+    def __contains__(self, name: Any) -> bool:
+        return super().__contains__(self.get_arg_as_str(name))
+
+    def __call__(self, name: Any, func: Optional[Any] = None) -> Callable[[InFunc], InFunc]:
+        return super().__call__(self.get_arg_as_str(name), func=func)
+
+    def register(self, name: Any, *, func: Optional[Any] = None) -> Callable[[InFunc], InFunc]:
+        return super().register(self.get_arg_as_str(name), func=func)
+
+    def get(self, name: Any) -> Any:
+        return super().get(self.get_arg_as_str(name))
+
+
+hashers = DatasetsRegistry(("datasets_registry", "hashers"))


### PR DESCRIPTION
Inspired by the discussion on hashing in https://github.com/huggingface/datasets/issues/3178#issuecomment-959016329, @lhoestq suggested that it would be neat to allow users more control over the hashing process. Specifically, it would be great if users can specify specific hashing functions depending on the **class** of the object.

As an example, we found in the linked topic that loaded spaCy models (`Language` objects) have different hashes when `dump`'d, but their byte representation with `Language.to_bytes()` _is_ deterministic. It would therefore be great if we could specify that for `Language` objects, the hasher should hash the objects `to_bytes()` return value instead of the object itself.

This PR adds a new, but tiny, dependency to manage the registry, namely [`catalogue`](https://github.com/explosion/catalogue). 

Two files have been changed (apart from the added dependency in `setup.py`) and one file has been added.

**utils.registry** (added)

This file defines our custom Registry and builds a registry called "hashers". A Registry is basically dictionary from names (str) to functions. A function can be added to the registry by a decorator, e.g. 

```python
@hashers.register(spacy.Language)
def hash_spacy_language(nlp):
    return Hasher.hash(nlp.to_bytes())
```

You'll notice that `spacy.Language` is not a string, even though the registry holds a str->func mapping. To accomplish this with classes in a dynamic way, catalogue.Registry needed to be subclassed and modified as `DatasetsRegistry`. All methods that use a name as an input are now modified so that classes are deterministically converted in strings in such a way that we can later retrieve the actual class from the string (below).

**utils.py_utils** (modified)

Added two functions to deal with classes and their qualified names, that is, their full descriptive name including the module. On the one hand it allows us to retrieve a string from a given class, e.g. given `Module` class, return `torch.nn.Module` str. Conversly, a function is added to convert such a full qualified name into a class. For instance, given the string `torch.nn.Module`, return the `Module` class. These straightforward methods allow us to interchangeably use classes and strings without any needed user interaction - they can just register a class, and behind the scenes `DatasetsRegistry` converts these to deterministic strings.

**fingerprint** (modified)

Updated Hasher.hash so that if the object to hash is an instance of a class in the registry, the registered function is used to hash the object instead of the default behavior. To do so we iterate over the registry `hashers` and convert its keys (strings) into classes, and then we can use `isinstance`.

```python
# Check if the current object is an instance that is
# applicable to the user-defined hashers. If so, hash
# with the user-defined function
for full_module_name, func in hashers.get_all().items():
    registered_cls = get_cls_from_qualname(full_module_name)
    if isinstance(value, registered_cls):
        return func(value)
```

**Putting it all together**

To test this, you can try the following example with spaCy. First install spaCy from source and checkout a specific commit.

```shell
git clone https://github.com/explosion/spaCy.git
cd spaCy/
git checkout cab9209c3dfcd1b75dfe5657f10e52c4d847a3cf
cd ..

git clone https://github.com/BramVanroy/datasets.git
cd datasets
git checkout registry
pip install -e .
pip install ../spaCy
spacy download en_core_web_sm
```

Now you can run the following script. By default it will use the custom hasher function for the Language object. You can enable the default behavior by commenting out `@hashers.register...`.

```python
import spacy

from datasets.fingerprint import Hasher
from datasets.utils.registry import hashers

# Register a function so that when the Hasher encounters a spacy.Language object
# it uses this custom function to hash instead of the default
@hashers.register(spacy.Language)
def hash_spacy_language(nlp):
    return Hasher.hash(nlp.to_bytes())


def main():
    print(hashers.get_all())
    nlp = spacy.load("en_core_web_sm")
    dump1 = Hasher.hash(nlp)
    nlp = spacy.load("en_core_web_sm")
    dump2 = Hasher.hash(nlp)
    print(dump1)
    # succeeds when using the registered custom function
    # fails if using the default
    assert dump1 == dump2


if __name__ == '__main__':
    main()
```

To do
====
- The above is just a proof-of-concept. I am open to changes/suggestions
- Tests still need to be written
- We should consider whether we can make `DatasetsRegistry` very restrictive and ONLY allowing classes. That would make testing easier - otherwise we also need to test for other sorts of objects.
- Maybe the `hashers` definition is better suited in `fingerprint`?
- Documentation/examples need to be updated
- Not sure why the logger is not working in `hash()`
- `get_cls_from_qualname` might need a fail-safe: is it possible for a full_qualname to not have a module, and if so how do we deal with that?
