### PR TITLE
User-pickling with dynamic sub-classing

### DIFF
--- a/docs/source/custom_serialization.rst
+++ b/docs/source/custom_serialization.rst
@@ -1,0 +1,106 @@
+Custom serialization functions
+==============================
+
+When you process a dataset with methods such as :func:`datasets.Dataset.map` or :func:`datasets.Dataset.filter`, it
+fingerprints that process. ``datasets`` serializes (*pickles*) the objects that are related to the mapping or filtering
+function, and generates a unique fingerprint for that specific serialization. The consequence is that every different
+processing function will have a distinct fingerprint. This allows the library to use a very effective caching mechanic:
+if you process a dataset in the exact same way as you have already done before, it will find that that unique
+fingerprint already exists in cache. It can then simply retrieve the processed dataset from cache instead of running
+the, potentially expensive, preprocessing process again.
+
+In most cases, this works really well out of the box! However, sometimes you may find that your tedious data-crunching
+functions are running every time instead of being loaded from cache. This means that there is an object that is part of
+your processing function whose serialization is different on every run. Consequently, the fingerprint will also be
+different and ``datasets`` thinks it is a different processing function altogether. This is particularly likely to
+happen with complex, deep objects or third-party libraries. Luckily, it is possible to register your own serialization
+methods for specific objects to ensure deterministic serialization!
+
+Register your own serialization function
+----------------------------------------
+
+In this section we will go over an example on how to register your own serialization function. We will use the popular linguistic parser `spaCy <https://spacy.io/>`_ as an example.
+
+In the following snippet, we load up a large text file with plain text. We would like to tokenize the text with spaCy. We can easily do this with ``datasets`` by running our tokenization function in :func:`map()` on our dataset.
+
+.. code-block::
+
+    >>> input_file = /your/large/text/file.txt
+    >>> # Load the spaCy parser
+    >>> nlp = spacy.load("en_core_web_sm", disable=["parser", "tagger", "ner", "lemmatizer"])
+
+    >>> # Batch-processing with spaCy's nlp.pipe() is fast!
+    >>> def tokenize(batch):
+    >>>     return {"tokenized": [" ".join([t.text for t in doc])
+    >>>                           for doc in nlp.pipe(batch["text"])]}
+
+    >>> # Load our text file as a Dataset
+    >>> ds = load_dataset("text", data_files=input_file)
+    >>> # Tokenize batches of data efficiently
+    >>> ds = ds["train"].map(tokenize, batched=True, batch_size=128)
+
+This works great out of the box and provides us with a dataset with two columns: ``text`` and ``tokenized``, exactly
+was we wanted! However, when you run this exact code again you will notice that the tokenization step was not cached
+and that the whole dataset needs to be processed again! This happens because of the reason described above: some
+underlying object in spaCy is not deterministic across runs, so the caching system thinks this is a completely
+different function.
+
+.. tip::
+
+    As a rule of thumb when debugging behavior like above: read the documentation of the libraries that you are using
+    - they may provide useful background on how they save/load and serialize their own objects!
+
+In the spaCy documentation we find that it has `built-in serialization methods <https://spacy.io/usage/saving-loading#pipeline>`_
+that are preferred over other means of automatic serialization, like the one that we use in ``datasets`` (``dill``).
+Specifically, they use a custom method to convert their pipeline to a deterministic bytes-object with ``nlp.to_bytes()``.
+So, ultimately what we would like is to tell ``datasets`` that whenever it encounters an object of the type like ``nlp``
+(``English``, in this case), to use the built-in serialization method of spaCy before using our own to ensure that
+the serialization process is deterministic.
+
+To this end, we can *register* a function to a type with the decorator :func:`datasets.utils.py_utils.pklregister`.
+This is relatively easy and straightforward and does not require other changes to our code above.
+
+.. code-block::
+
+    >>> # We only need to add this part
+    >>> @pklregister(English)
+    >>> def pickle_spacy_language(pickler, nlp: English):
+    >>>     # Instead of pickler.save(nlp) (default, but not deterministic):
+    >>>     pickler.save(nlp.to_bytes())
+
+    >>> # Same as above...
+    >>> input_file = /your/large/text/file.txt
+    >>> # Load the spaCy parser
+    >>> nlp = spacy.load("en_core_web_sm", disable=["parser", "tagger", "ner", "lemmatizer"])
+
+    >>> # Batch-processing with spaCy's nlp.pipe() is fast!
+    >>> def tokenize(batch):
+    >>>     return {"tokenized": [" ".join([t.text for t in doc])
+    >>>                           for doc in nlp.pipe(batch["text"])]}
+
+    >>> # Load our text file as a Dataset
+    >>> ds = load_dataset("text", data_files=input_file)
+    >>> # Tokenize batches of data efficiently
+    >>> ds = ds["train"].map(tokenize, batched=True, batch_size=128)
+
+If you run this code twice, you'll find that the second run retireves the cached dataset successfully! The registered
+function above tells ``datasets`` that when it encounters an object of type ``English``, it should not try to
+pickle (serialize) this with the default method (``pickler.save(nlp)``) because we know that that is not deterministic
+and will lead to problems during caching, as illustrated above. Instead it should first use spaCy's built-in
+:func:`to_bytes` method and then :func:`pickler.save` the result.
+
+.. caution::
+
+    Do not forget :func:`pickler.save` in your custom functions! Depending on your exact use-case and objects,
+    this is a crucial part of creating unique, and deterministic, serialized objects.
+
+
+Registering functions for sub-classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TODO
+
+Temporarily using a user-defined serialization function
+-------------------------------------------------------
+
+TODO

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,6 +77,7 @@ Find your dataset today on the `Hugging Face Hub <https://huggingface.co/dataset
     dataset_card
     repository_structure
     cache
+    custom_serialization
     filesystems
     faiss_es
     how_to_metrics

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -339,6 +339,11 @@ class Pickler(dill.Pickler):
     dispatch = dill._dill.MetaCatchingDict(dill.Pickler.dispatch.copy())
     sublcass_dispatch = {}
 
+    def save(self, obj):
+        # Save is called before save_global
+        self.maybe_register_superfunc(obj)
+        return super(Pickler, self).save(obj)
+
     def save_global(self, obj, name=None):
         if sys.version_info[:2] < (3, 7) and _CloudPickleTypeHintFix._is_parametrized_type_hint(
             obj
@@ -376,10 +381,6 @@ class Pickler(dill.Pickler):
                         # that we traverse is that of MRO, which is depth-first with some quirks
                         # see # https://stackoverflow.com/a/2010732/1150683
                         break
-
-    def dump(self, obj):
-        self.maybe_register_superfunc(obj)
-        return super().dump(obj)
 
 
 def dump(obj, file):

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -419,6 +419,7 @@ def pklregister(t: Type, allow_subclasses: bool = False):
     type is encountered, it will be pickled with the provided function instead of the default.
     When `allow_subclasses=True, the type and function will also be saved in a special table so
     that future objects who are a subclass of `t` will also use the given function."""
+
     def proxy(func):
         if allow_subclasses:
             Pickler.sublcass_dispatch[t] = func

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -385,8 +385,8 @@ class Pickler(dill.Pickler):
         if type(obj) != str:
             dill.Pickler.memoize(self, obj)
 
-    @staticmethod
-    def maybe_register_superfunc(obj):
+    @classmethod
+    def maybe_register_superfunc(cls, obj):
         """Dynamically registers a custom pickling function for the type of this object `obj`
         by checking the `Pickler.sublcass_dispatch` table. All super-classes of `obj` are
         traversed through mro() and checked against the table. If there is a match between
@@ -394,16 +394,15 @@ class Pickler(dill.Pickler):
         of the found super-class to Pickler.dispatch. This will internally tell Pickle to use
         this function, originally related to the super-class, for this function as well."""
         t = type(obj)
-        if t not in Pickler.dispatch and t not in Pickler.sublcass_dispatch:
-            if hasattr(obj.__class__, "__mro__"):
-                for supercls in obj.__class__.__mro__:
-                    if supercls in Pickler.sublcass_dispatch:
-                        pklregister(t)(Pickler.sublcass_dispatch[supercls])
-                        # Break as soon as one match is found. We only want to most direct
-                        # ancestor class. _Some_ caution is needed here because the order
-                        # that we traverse is that of MRO, which is depth-first with some quirks
-                        # see # https://stackoverflow.com/a/2010732/1150683
-                        break
+        if t not in cls.dispatch and t not in cls.sublcass_dispatch:
+            for supercls in t.__mro__:
+                if supercls in cls.sublcass_dispatch:
+                    pklregister(t)(cls.sublcass_dispatch[supercls])
+                    # Break as soon as one match is found. We only want to most direct
+                    # ancestor class. _Some_ caution is needed here because the order
+                    # that we traverse is that of MRO, which is depth-first with some quirks
+                    # see # https://stackoverflow.com/a/2010732/1150683
+                    break
 
 
 def dump(obj, file):

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -333,6 +333,17 @@ def has_sufficient_disk_space(needed_bytes, directory="."):
     return needed_bytes < free_bytes
 
 
+class TempPickleRegistry:
+    """Class to use as a context manager. It allows you to register and use functions
+    only within this block. When the block is exited, the registry is reset to the default"""
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        Pickler.dispatch = dill._dill.MetaCatchingDict(dill.Pickler.dispatch.copy())
+        Pickler.sublcass_dispatch = {}
+
+
 class Pickler(dill.Pickler):
     """Same Pickler as the one from dill, but improved for notebooks and shells"""
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -363,7 +363,7 @@ class Pickler(dill.Pickler):
     def save(self, obj):
         """Overwrites the underyling pickle's save. To dynamically, potentially, set custom functions
         we do this right before actually saving with pickle. `dump` is not the right place for this,
-        as it is iteratively called in this subclass directly. For more, see `Pickler.maybe_register_superfunc`."""
+        as it is iteratively called in this subclass directly. For more, see `Pickler.maybe_register_superfunc`.make s"""
         self.maybe_register_superfunc(obj)
         return super(Pickler, self).save(obj)
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -361,7 +361,9 @@ class Pickler(dill.Pickler):
     sublcass_dispatch: Dict = {}
 
     def save(self, obj):
-        # Save is called before save_global
+        """Overwrites the underyling pickle's save. To dynamically, potentially, set custom functions
+        we do this right before actually saving with pickle. `dump` is not the right place for this,
+        as it is iteratively called in this subclass directly. For more, see `Pickler.maybe_register_superfunc`."""
         self.maybe_register_superfunc(obj)
         return super(Pickler, self).save(obj)
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -30,7 +30,7 @@ from io import BytesIO as StringIO
 from multiprocessing import Pool, RLock
 from shutil import disk_usage
 from types import CodeType, FunctionType
-from typing import Callable, ClassVar, Dict, Generic, Optional, Tuple, Union
+from typing import Callable, ClassVar, Dict, Generic, Optional, Tuple, Type, Union
 
 import dill
 import numpy as np
@@ -337,6 +337,7 @@ class Pickler(dill.Pickler):
     """Same Pickler as the one from dill, but improved for notebooks and shells"""
 
     dispatch = dill._dill.MetaCatchingDict(dill.Pickler.dispatch.copy())
+    sublcass_dispatch = {}
 
     def save_global(self, obj, name=None):
         if sys.version_info[:2] < (3, 7) and _CloudPickleTypeHintFix._is_parametrized_type_hint(
@@ -355,6 +356,30 @@ class Pickler(dill.Pickler):
         # don't memoize strings since two identical strings can have different python ids
         if type(obj) != str:
             dill.Pickler.memoize(self, obj)
+
+    @staticmethod
+    def maybe_register_superfunc(obj):
+        """Dynamically registers a custom pickling function for the type of this object `obj`
+        by checking the `Pickler.sublcass_dispatch` table. All super-classes of `obj` are
+        traversed through mro() and checked against the table. If there is a match between
+        a super-class and the table, then we add the type() of the object along with the function
+        of the found super-class to Pickler.dispatch. This will internally tell Pickle to use
+        this function, originally related to the super-class, for this function as well."""
+        t = type(obj)
+        if t not in Pickler.dispatch and t not in Pickler.sublcass_dispatch:
+            if hasattr(obj.__class__, "__mro__"):
+                for supercls in obj.__class__.__mro__:
+                    if supercls in Pickler.sublcass_dispatch:
+                        pklregister(t)(Pickler.sublcass_dispatch[supercls])
+                        # Break as soon as one match is found. We only want to most direct
+                        # ancestor class. _Some_ caution is needed here because the order
+                        # that we traverse is that of MRO, which is depth-first with some quirks
+                        # see # https://stackoverflow.com/a/2010732/1150683
+                        break
+
+    def dump(self, obj):
+        self.maybe_register_superfunc(obj)
+        return super().dump(obj)
 
 
 def dump(obj, file):
@@ -388,8 +413,14 @@ def dumps(obj):
     return file.getvalue()
 
 
-def pklregister(t):
+def pklregister(t: Type, allow_subclasses: bool = False):
+    """Register custom pickling functions for specific objects. When an object of the given
+    type is encountered, it will be pickled with the provided function instead of the default.
+    When `allow_subclasses=True, the type and function will also be saved in a special table so
+    that future objects who are a subclass of `t` will also use the given function."""
     def proxy(func):
+        if allow_subclasses:
+            Pickler.sublcass_dispatch[t] = func
         Pickler.dispatch[t] = func
         return func
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -336,6 +336,7 @@ def has_sufficient_disk_space(needed_bytes, directory="."):
 class TempPickleRegistry:
     """Class to use as a context manager. It allows you to register and use functions
     only within this block. When the block is exited, the registry is reset to the default"""
+
     def __enter__(self):
         return self
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -363,7 +363,7 @@ class Pickler(dill.Pickler):
     def save(self, obj):
         """Overwrites the underyling pickle's save. To dynamically, potentially, set custom functions
         we do this right before actually saving with pickle. `dump` is not the right place for this,
-        as it is iteratively called in this subclass directly. For more, see `Pickler.maybe_register_superfunc`.make s"""
+        as it is iteratively called in this subclass directly. For more, see :func:`Pickler.maybe_register_superfunc`."""
         self.maybe_register_superfunc(obj)
         return super(Pickler, self).save(obj)
 

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -1,4 +1,4 @@
-from pickle import loads
+from dill import loads
 from unittest import TestCase
 
 import numpy as np

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -6,7 +6,8 @@ import pytest
 
 from datasets.utils.py_utils import (
     NestedDataStructure,
-    Pickler, TempPickleRegistry,
+    Pickler,
+    TempPickleRegistry,
     dumps,
     flatten_nest_dict,
     map_nested,
@@ -130,8 +131,9 @@ class PyUtilsTest(TestCase):
 
     def test_temp_pickle_registry(self):
         with TempPickleRegistry():
+
             @pklregister(ChildClass)
-            def pickle_registry_test(pickler, _):
+            def pickle_registry_test_child(pickler, _):
                 pickler.save(True)
 
             self.assertIn(ChildClass, Pickler.dispatch)
@@ -139,8 +141,9 @@ class PyUtilsTest(TestCase):
             for allow_subclasses in (True, False):
                 with self.subTest(allow_subclasses=allow_subclasses):
                     with TempPickleRegistry():
+
                         @pklregister(ParentClass, allow_subclasses=allow_subclasses)
-                        def pickle_registry_test(pickler, _):
+                        def pickle_registry_test_parent(pickler, _):
                             pickler.save(True)
 
                         self.assertIn(ParentClass, Pickler.dispatch)
@@ -155,7 +158,6 @@ class PyUtilsTest(TestCase):
             self.assertIn(ChildClass, Pickler.dispatch)
         # We exited the with-block, so ChildClass should not be in here
         self.assertNotIn(ChildClass, Pickler.dispatch)
-
 
     def test_pickle_registry_base(self):
         with TempPickleRegistry():

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -6,9 +6,12 @@ import pytest
 
 from datasets.utils.py_utils import (
     NestedDataStructure,
-    TempPickleRegistry, dumps, flatten_nest_dict,
+    TempPickleRegistry,
+    dumps,
+    flatten_nest_dict,
     map_nested,
-    pklregister, temporary_assignment,
+    pklregister,
+    temporary_assignment,
     zip_dict,
     zip_nested,
 )
@@ -129,6 +132,7 @@ class PyUtilsTest(TestCase):
         with TempPickleRegistry():
             for allow_subclasses in (True, False):
                 with self.subTest(allow_subclasses=allow_subclasses):
+
                     @pklregister(ParentClass, allow_subclasses=allow_subclasses)
                     def pickle_registry_test(pickler, _):
                         pickler.save(True)
@@ -142,8 +146,9 @@ class PyUtilsTest(TestCase):
 
     def test_pickle_registry_inheritance(self):
         with TempPickleRegistry():
+
             @pklregister(BaseClass, allow_subclasses=False)
-            def pickle_registry_test(pickler, _):
+            def pickle_registry_test_false(pickler, _):
                 pickler.save(True)
 
             # Registered on BaseClass, and allow_subclasses=False
@@ -155,8 +160,9 @@ class PyUtilsTest(TestCase):
             self.assertIsInstance(unpickled, ChildClass)
 
         with TempPickleRegistry():
+
             @pklregister(BaseClass, allow_subclasses=True)
-            def pickle_registry_test(pickler, _):
+            def pickle_registry_test_true(pickler, _):
                 pickler.save(True)
 
             # Registered on BaseClass, and allow_subclasses=True
@@ -169,7 +175,6 @@ class PyUtilsTest(TestCase):
             unpickled = loads(dumps(ChildClass()))
             self.assertIsInstance(unpickled, bool)
             self.assertTrue(unpickled)
-
 
 
 @pytest.mark.parametrize("input_data", [{}])
@@ -204,5 +209,3 @@ def test_nested_data_structure_data(input_data):
 def test_flatten(data, expected_output):
     output = NestedDataStructure(data).flatten()
     assert output == expected_output
-
-

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -1,17 +1,17 @@
-from dill import loads
 from unittest import TestCase
 
 import numpy as np
 import pytest
+from dill import loads
 
 from datasets.utils.py_utils import (
     NestedDataStructure,
     Pickler,
-    TempPickleRegistry,
     dumps,
     flatten_nest_dict,
     map_nested,
     pklregister,
+    temp_pickle_registry,
     temporary_assignment,
     zip_dict,
     zip_nested,
@@ -130,7 +130,7 @@ class PyUtilsTest(TestCase):
         self.assertEqual(foo.my_attr, "bar")
 
     def test_temp_pickle_registry(self):
-        with TempPickleRegistry():
+        with temp_pickle_registry():
 
             @pklregister(ChildClass)
             def pickle_registry_test_child(pickler, _):
@@ -140,7 +140,7 @@ class PyUtilsTest(TestCase):
 
             for allow_subclasses in (True, False):
                 with self.subTest(allow_subclasses=allow_subclasses):
-                    with TempPickleRegistry():
+                    with temp_pickle_registry():
 
                         @pklregister(ParentClass, allow_subclasses=allow_subclasses)
                         def pickle_registry_test_parent(pickler, _):
@@ -160,7 +160,7 @@ class PyUtilsTest(TestCase):
         self.assertNotIn(ChildClass, Pickler.dispatch)
 
     def test_pickle_registry_base(self):
-        with TempPickleRegistry():
+        with temp_pickle_registry():
             for allow_subclasses in (True, False):
                 with self.subTest(allow_subclasses=allow_subclasses):
 
@@ -176,7 +176,7 @@ class PyUtilsTest(TestCase):
                     self.assertTrue(unpickled)
 
     def test_pickle_registry_inheritance(self):
-        with TempPickleRegistry():
+        with temp_pickle_registry():
 
             @pklregister(BaseClass, allow_subclasses=False)
             def pickle_registry_test_false(pickler, _):
@@ -190,7 +190,7 @@ class PyUtilsTest(TestCase):
             unpickled = loads(dumps(ChildClass()))
             self.assertIsInstance(unpickled, ChildClass)
 
-        with TempPickleRegistry():
+        with temp_pickle_registry():
 
             @pklregister(BaseClass, allow_subclasses=True)
             def pickle_registry_test_true(pickler, _):


### PR DESCRIPTION
This is a continuation of the now closed PR in https://github.com/huggingface/datasets/pull/3206. The discussion there has shaped a new approach to do this.

In this PR, behavior of `pklregister` and `Pickler` is extended. Earlier, users were already able to register custom pickle functions. That is useful if they have objects that are not easily picklable with default methods. When one registers a custom function to a type, an object of that type will be pickled with the given function by `Pickler` which looks up the type in its `dispatch` table. The downside of this method, and of `pickle` in general, is that it is limited to direct type-matching and does not allow sub-classes. In many, default, cases that is not an issue. But when you are using external libraries where classes (e.g. parsers, models) are sub-classed this is not ideal. 

```python
from datasets.fingerprint import Hasher
from datasets.utils.py_utils import pklregister

class BaseParser:
    pass

class EnglishParser(BaseParser):
    pass

@pklregister(BaseParser)
def custom_pkl_func(pickler, obj):
    print(f"Called the custom pickle function for type {type(obj)}!")
    # do something with the obj and ultimately save with the pickler

base = BaseParser()
en = EnglishParser()

# Hasher.hash uses the Pickler behind the scenes
# `custom_pkl_func` called for base
Hasher.hash(base)
# `custom_pkl_func` not called for en :-(
Hasher.hash(en)
```

In the example above we'd want to sub-class `EnglishParser` to be handled in the same way as its super-class `BaseParser`. This PR solves that by allowing for a keyword-argument `allow_subclasses` in `pklregister` (default: `False`). 

```python
@pklregister(BaseParser, allow_subclasses=True)
```

When this option is enabled, we not only save the function in `Pickler.dispatch` but also save it in a custom table `Pickler.subclass_dispatch` **which allows us to dynamically add sub-classes of that class to the real dispatch table**. Then, if we want to pickle an  object `obj` with `Pickler.dump()` (which ultimately will call `Pickler.save()`) we _first_  check whether any of the object's super-classes exist in `Pickler.sublcass_dispatch` and get the related custom pickle function. If we find one, we add the type of `obj` alongside the function to `Pickler.dispatch`. All of this happens at the start of the call to `Pickler.save()`. _Only then_ dill.Pickler's `save` will be called, which in turn will call `pickle._Pickler.save` which handles everything. Here, the `Pickler.dispatch` table will be used to look up custom pickler functions - and it now also includes the function for `obj`, which was copied from its super-class, which we added at the very start of our custom `Pickler.save()`.

For edge cases and, especially, for testing, a contextmanager class `TempPickleRegistry` is included that resets the pickle registry on exit to its previous state.

```python
with TempPickleRegistry():
    @pklregister(MyObjClass)
    def pickle_registry_test_false(pickler, obj):
        pickler.save(obj.fancy_method())

    some_obj = MyObjClass()
    dumps(some_obj)
    # `MyObjClass` is in Pickler.dispatch

# ... `MyObjClass` is _not_ in Pickler.dispatch anymore
```

closes https://github.com/huggingface/datasets/issues/3178

To Do
====
- [x] Write tests
- [ ] Write documentation/examples?