### PR TITLE
Add full tagset to conll2003 README

### DIFF
--- a/datasets/conll2003/README.md
+++ b/datasets/conll2003/README.md
@@ -114,7 +114,7 @@ The data fields are the same among all splits.
 #### conll2003
 - `id`: a `string` feature.
 - `tokens`: a `list` of `string` features.
-- `pos_tags`: a `list` of classification labels (`str`). Full tagset with indices:
+- `pos_tags`: a `list` of classification labels (`int`). Full tagset with indices:
 
 ```python
 {'"': 0, "''": 1, '#': 2, '$': 3, '(': 4, ')': 5, ',': 6, '.': 7, ':': 8, '``': 9, 'CC': 10, 'CD': 11, 'DT': 12,
@@ -124,7 +124,7 @@ The data fields are the same among all splits.
  'WP': 44, 'WP$': 45, 'WRB': 46}
 ```
 
-- `chunk_tags`: a `list` of classification labels (`str`). Full tagset with indices:
+- `chunk_tags`: a `list` of classification labels (`int`). Full tagset with indices:
 
 ```python
 {'O': 0, 'B-ADJP': 1, 'I-ADJP': 2, 'B-ADVP': 3, 'I-ADVP': 4, 'B-CONJP': 5, 'I-CONJP': 6, 'B-INTJ': 7, 'I-INTJ': 8,
@@ -132,7 +132,7 @@ The data fields are the same among all splits.
  'I-SBAR': 18, 'B-UCP': 19, 'I-UCP': 20, 'B-VP': 21, 'I-VP': 22}
 ```
 
-- `ner_tags`: a `list` of classification labels (`str`). Full tagset with indices:
+- `ner_tags`: a `list` of classification labels (`int`). Full tagset with indices:
 
 ```python
 {'O': 0, 'B-PER': 1, 'I-PER': 2, 'B-ORG': 3, 'I-ORG': 4, 'B-LOC': 5, 'I-LOC': 6, 'B-MISC': 7, 'I-MISC': 8}

--- a/datasets/conll2003/README.md
+++ b/datasets/conll2003/README.md
@@ -19,6 +19,7 @@ task_ids:
 - named-entity-recognition
 - part-of-speech-tagging
 paperswithcode_id: conll-2003
+pretty_name: CoNLL-2003
 ---
 
 # Dataset Card for "conll2003"

--- a/datasets/conll2003/README.md
+++ b/datasets/conll2003/README.md
@@ -113,9 +113,29 @@ The data fields are the same among all splits.
 #### conll2003
 - `id`: a `string` feature.
 - `tokens`: a `list` of `string` features.
-- `pos_tags`: a `list` of classification labels, with possible values including `"` (0), `''` (1), `#` (2), `$` (3), `(` (4).
-- `chunk_tags`: a `list` of classification labels, with possible values including `O` (0), `B-ADJP` (1), `I-ADJP` (2), `B-ADVP` (3), `I-ADVP` (4).
-- `ner_tags`: a `list` of classification labels, with possible values including `O` (0), `B-PER` (1), `I-PER` (2), `B-ORG` (3), `I-ORG` (4) `B-LOC` (5), `I-LOC` (6) `B-MISC` (7), `I-MISC` (8).
+- `pos_tags`: a `list` of classification labels (`str`). Full tagset with indices:
+
+```python
+{'"': 0, "''": 1, '#': 2, '$': 3, '(': 4, ')': 5, ',': 6, '.': 7, ':': 8, '``': 9, 'CC': 10, 'CD': 11, 'DT': 12,
+ 'EX': 13, 'FW': 14, 'IN': 15, 'JJ': 16, 'JJR': 17, 'JJS': 18, 'LS': 19, 'MD': 20, 'NN': 21, 'NNP': 22, 'NNPS': 23,
+ 'NNS': 24, 'NN|SYM': 25, 'PDT': 26, 'POS': 27, 'PRP': 28, 'PRP$': 29, 'RB': 30, 'RBR': 31, 'RBS': 32, 'RP': 33,
+ 'SYM': 34, 'TO': 35, 'UH': 36, 'VB': 37, 'VBD': 38, 'VBG': 39, 'VBN': 40, 'VBP': 41, 'VBZ': 42, 'WDT': 43,
+ 'WP': 44, 'WP$': 45, 'WRB': 46}
+```
+
+- `chunk_tags`: a `list` of classification labels (`str`). Full tagset with indices:
+
+```python
+{'O': 0, 'B-ADJP': 1, 'I-ADJP': 2, 'B-ADVP': 3, 'I-ADVP': 4, 'B-CONJP': 5, 'I-CONJP': 6, 'B-INTJ': 7, 'I-INTJ': 8,
+ 'B-LST': 9, 'I-LST': 10, 'B-NP': 11, 'I-NP': 12, 'B-PP': 13, 'I-PP': 14, 'B-PRT': 15, 'I-PRT': 16, 'B-SBAR': 17,
+ 'I-SBAR': 18, 'B-UCP': 19, 'I-UCP': 20, 'B-VP': 21, 'I-VP': 22}
+```
+
+- `ner_tags`: a `list` of classification labels (`str`). Full tagset with indices:
+
+```python
+{'O': 0, 'B-PER': 1, 'I-PER': 2, 'B-ORG': 3, 'I-ORG': 4, 'B-LOC': 5, 'I-LOC': 6, 'B-MISC': 7, 'I-MISC': 8}
+```
 
 ### Data Splits
 


### PR DESCRIPTION
Even though it is possible to manually get the tagset list with

```python
dset.features[field_name].feature.names
```

I think it is useful to have an overview of the used tagset on the dataset card. This is particularly useful in light of the **dataset viewer**: the tags are encoded, so it is not immediately obvious what they are for a given sample. Adding a label-int mapping should make it easier for visitors to get a grasp of what they mean.

From user-experience perspective, I would urge the full tagsets to always be available in the README's but I understand that that would take a lot of work, probably. Perhaps it can be automated?

closes #3189 