### PR TITLE
Group tests in multiprocessing workers by test file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
-            - run: HF_SCRIPTS_VERSION=master python -m pytest -d --tx 2*popen//python=python3.6 -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:
         working_directory: ~/datasets
@@ -32,7 +32,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
-            - run: HF_SCRIPTS_VERSION=master python -m pytest -d --tx 2*popen//python=python3.6 -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_latest_WIN:
         working_directory: ~/datasets
@@ -53,7 +53,7 @@ jobs:
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
             - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -n 2 -sv ./tests/
+            - run: python -m pytest -n 2 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1_WIN:
         working_directory: ~/datasets
@@ -74,7 +74,7 @@ jobs:
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==1.0.0
             - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -n 2 -sv ./tests/
+            - run: python -m pytest -n 2 --dist loadfile -sv ./tests/
 
     check_code_quality:
         working_directory: ~/datasets


### PR DESCRIPTION
By grouping tests by test file, we make sure that all the tests in `test_load.py` are sent to the same worker.

Therefore, the fixture `hf_token` will be called only once (and from the same worker).

Fix #3219.