### PR TITLE
Avoid PyArrow type optimization if it fails

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -157,6 +157,8 @@ class TypedSequence:
                             )
                         ) from None
                     elif trying_int_optimization and "not in range" in str(e):
+                        optimized_int_type_str = np.dtype(self.optimized_int_type.to_pandas_dtype()).name
+                        logger.info(f"Failed to cast a sequence to {optimized_int_type_str}. Falling back to int64.")
                         return out
                     else:
                         raise
@@ -167,6 +169,8 @@ class TypedSequence:
                     )
                 ) from None
             elif trying_int_optimization and "not in range" in str(e):
+                optimized_int_type_str = np.dtype(self.optimized_int_type.to_pandas_dtype()).name
+                logger.info(f"Failed to cast a sequence to {optimized_int_type_str}. Falling back to int64.")
                 return out
             else:
                 raise

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -82,13 +82,12 @@ class TypedSequence:
 
     """
 
-    def __init__(self, data, type=None, try_type=None, optimized_int_type=None, col=None):
+    def __init__(self, data, type=None, try_type=None, optimized_int_type=None):
         assert type is None or try_type is None, "You cannot specify both type and try_type"
         self.data = data
         self.type = type
         self.try_type = try_type  # is ignored if it doesn't match the data
         self.optimized_int_type = optimized_int_type
-        self.col = col  # ignore, here for consistency with `OptimizedTypedSequence`
 
     def __arrow_array__(self, type=None):
         """This function is called when calling pa.array(typed_sequence)"""
@@ -177,7 +176,7 @@ class OptimizedTypedSequence(TypedSequence):
         }
         if type is None and try_type is None:
             optimized_int_type = optimized_int_type_by_col.get(col, None)
-        super().__init__(data, type=type, try_type=try_type, optimized_int_type=optimized_int_type, col=col)
+        super().__init__(data, type=type, try_type=try_type, optimized_int_type=optimized_int_type)
 
 
 class ArrowWriter:

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -130,6 +130,7 @@ class TypedSequence:
                         "Specified try_type alters data. Please check that the type/feature that you provided match the type/features of the data."
                     )
             if self.optimized_int_type and self.type is None and self.try_type is None:
+                trying_int_optimization = True
                 if pa.types.is_int64(out.type):
                     out = out.cast(self.optimized_int_type)
                 elif pa.types.is_list(out.type):
@@ -154,6 +155,8 @@ class TypedSequence:
                                 type_(self.data), e
                             )
                         ) from None
+                    elif trying_int_optimization and "not in range" in str(e):
+                        return out
                     else:
                         raise
             elif "overflow" in str(e):
@@ -162,6 +165,8 @@ class TypedSequence:
                         type_(self.data), e
                     )
                 ) from None
+            elif trying_int_optimization and "not in range" in str(e):
+                return out
             else:
                 raise
 

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -242,7 +242,9 @@ class ArrowWriter:
         self.current_rows: List[pa.Table] = []
         self.pa_writer: Optional[pa.RecordBatchStreamWriter] = None
         self.hkey_record = []
-        self.typed_sequence_cls = TypedSequence if config.DISABLE_PYARROW_TYPES_OPTIMIZATION else OptimizedTypedSequence
+        self.typed_sequence_cls = (
+            TypedSequence if config.DISABLE_PYARROW_TYPES_OPTIMIZATION else OptimizedTypedSequence
+        )
 
     def __len__(self):
         """Return the number of writed and staged examples"""

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -242,7 +242,7 @@ class ArrowWriter:
         self.current_rows: List[pa.Table] = []
         self.pa_writer: Optional[pa.RecordBatchStreamWriter] = None
         self.hkey_record = []
-        self.typed_sequence_cls = OptimizedTypedSequence if config.OPTIMIZE_PYARROW_TYPES else TypedSequence
+        self.typed_sequence_cls = TypedSequence if config.DISABLE_PYARROW_TYPES_OPTIMIZATION else OptimizedTypedSequence
 
     def __len__(self):
         """Return the number of writed and staged examples"""

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -100,6 +100,7 @@ class TypedSequence:
             trying_type = True
         else:
             type = self.type
+        trying_int_optimization = False
         try:
             if isinstance(type, _ArrayXDExtensionType):
                 if isinstance(self.data, np.ndarray):

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -165,11 +165,6 @@ DEFAULT_MAX_BATCH_SIZE = 10_000
 # For big tables, we write them on disk instead
 MAX_TABLE_NBYTES_FOR_PICKLING = 4 << 30
 
-# Control PyArrow types optimization - used to reduce the size of the generated cache files
-DISABLE_PYARROW_TYPES_OPTIMIZATION = (
-    os.environ.get("HF_DATASETS_DISABLE_PYARROW_TYPES_OPTIMIZATION", "AUTO").upper() in ENV_VARS_TRUE_VALUES
-)
-
 # Offline mode
 HF_DATASETS_OFFLINE = os.environ.get("HF_DATASETS_OFFLINE", "AUTO").upper() in ENV_VARS_TRUE_VALUES
 

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -165,9 +165,9 @@ DEFAULT_MAX_BATCH_SIZE = 10_000
 # For big tables, we write them on disk instead
 MAX_TABLE_NBYTES_FOR_PICKLING = 4 << 30
 
-# Whether to optimize PyArrow types in order to reduce the size of the generated cache files
-OPTIMIZE_PYARROW_TYPES = (
-    os.environ.get("HF_DATASETS_OPTIMIZE_PYARROW_TYPES", "AUTO").upper() in ENV_VARS_TRUE_AND_AUTO_VALUES
+# Control PyArrow types optimization - used to reduce the size of the generated cache files
+DISABLE_PYARROW_TYPES_OPTIMIZATION = (
+    os.environ.get("HF_DATASETS_DISABLE_PYARROW_TYPES_OPTIMIZATION", "AUTO").upper() in ENV_VARS_TRUE_VALUES
 )
 
 # Offline mode

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -165,6 +165,11 @@ DEFAULT_MAX_BATCH_SIZE = 10_000
 # For big tables, we write them on disk instead
 MAX_TABLE_NBYTES_FOR_PICKLING = 4 << 30
 
+# Whether to optimize PyArrow types in order to reduce the size of the generated cache files
+OPTIMIZE_PYARROW_TYPES = (
+    os.environ.get("HF_DATASETS_OPTIMIZE_PYARROW_TYPES", "AUTO").upper() in ENV_VARS_TRUE_AND_AUTO_VALUES
+)
+
 # Offline mode
 HF_DATASETS_OFFLINE = os.environ.get("HF_DATASETS_OFFLINE", "AUTO").upper() in ENV_VARS_TRUE_VALUES
 

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -240,7 +240,7 @@ def test_arrow_writer_typed_sequence_cls(monkeypatch):
     with ArrowWriter(stream=stream) as writer:
         assert writer.typed_sequence_cls == OptimizedTypedSequence
 
-    monkeypatch.setattr(config, "OPTIMIZE_PYARROW_TYPES", False)
+    monkeypatch.setattr(config, "DISABLE_PYARROW_TYPES_OPTIMIZATION", True)
 
     with ArrowWriter(stream=stream) as writer:
         assert writer.typed_sequence_cls == TypedSequence

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -234,18 +234,6 @@ def test_optimized_typed_sequence(sequence, col, expected_dtype):
     assert get_base_dtype(arr.type) == expected_dtype
 
 
-def test_arrow_writer_typed_sequence_cls(monkeypatch):
-    stream = pa.BufferOutputStream()
-
-    with ArrowWriter(stream=stream) as writer:
-        assert writer.typed_sequence_cls == OptimizedTypedSequence
-
-    monkeypatch.setattr(config, "DISABLE_PYARROW_TYPES_OPTIMIZATION", True)
-
-    with ArrowWriter(stream=stream) as writer:
-        assert writer.typed_sequence_cls == TypedSequence
-
-
 @pytest.mark.parametrize("raise_exception", [False, True])
 def test_arrow_writer_closes_stream(raise_exception, tmp_path):
     path = str(tmp_path / "dataset-train.arrow")

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -234,6 +234,18 @@ def test_optimized_typed_sequence(sequence, col, expected_dtype):
     assert get_base_dtype(arr.type) == expected_dtype
 
 
+def test_arrow_writer_typed_sequence_cls(monkeypatch):
+    stream = pa.BufferOutputStream()
+
+    with ArrowWriter(stream=stream) as writer:
+        assert writer.typed_sequence_cls == OptimizedTypedSequence
+
+    monkeypatch.setattr(config, "OPTIMIZE_PYARROW_TYPES", False)
+
+    with ArrowWriter(stream=stream) as writer:
+        assert writer.typed_sequence_cls == TypedSequence
+
+
 @pytest.mark.parametrize("raise_exception", [False, True])
 def test_arrow_writer_closes_stream(raise_exception, tmp_path):
     path = str(tmp_path / "dataset-train.arrow")


### PR DESCRIPTION
Adds a new variable, `DISABLE_PYARROW_TYPES_OPTIMIZATION`, to `config.py` for easier control of the Arrow type optimization.

Fix #2206  