### PR TITLE
Addd options to use updated bleurt checkpoints

### DIFF
--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -70,9 +70,9 @@ CHECKPOINT_URLS = {
     "bleurt-large-128": "https://storage.googleapis.com/bleurt-oss/bleurt-large-128.zip",
     "bleurt-large-512": "https://storage.googleapis.com/bleurt-oss/bleurt-large-512.zip",
     "bleurt-20-d3": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D3.zip",
-    "bleurt-20-d6": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D6.zip",    
+    "bleurt-20-d6": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D6.zip",
     "bleurt-20-d12": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D12.zip",
-    "bleurt-20": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20.zip",    
+    "bleurt-20": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20.zip",
 }
 
 

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -69,6 +69,10 @@ CHECKPOINT_URLS = {
     "bleurt-base-512": "https://storage.googleapis.com/bleurt-oss/bleurt-base-512.zip",
     "bleurt-large-128": "https://storage.googleapis.com/bleurt-oss/bleurt-large-128.zip",
     "bleurt-large-512": "https://storage.googleapis.com/bleurt-oss/bleurt-large-512.zip",
+    "bleurt-20-d3": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D3.zip",
+    "bleurt-20-d6": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D6.zip",    
+    "bleurt-20-d12": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D12.zip",
+    "bleurt-20": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20.zip",    
 }
 
 


### PR DESCRIPTION
Adds options to use newer recommended checkpoint (as of 2021/10/8) bleurt-20 and its distilled versions. 

Updated checkpoints are described in https://github.com/google-research/bleurt/blob/master/checkpoints.md#the-recommended-checkpoint-bleurt-20

This change won't affect the default behavior of metrics/bleurt. It only adds option to load newer checkpoints as

`datasets.load_metric('bleurt', 'bleurt-20')`

`bluert-20` generates scores roughly between 0 and 1, which wasn't the case for the previous checkpoints. 