### PR TITLE
Remove redundant isort module placement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,41 +5,6 @@ license_file = LICENSE
 ensure_newline_before_comments = True
 force_grid_wrap = 0
 include_trailing_comma = True
-known_first_party = datasets
-known_third_party =
-    absl
-    apache_beam
-    elasticsearch
-    fairseq
-    faiss
-    fastprogress
-    git
-    h5py
-    langdetect
-    MeCab
-    mwparserfromhell
-    datasets
-    nltk
-    numpy
-    packaging
-    PIL
-    posixpath
-    psutil
-    pyarrow
-    pytorch_lightning
-    requests
-    seqeval
-    sklearn
-    tensorboardX
-    tensorflow
-    tensorflow_datasets
-    torch
-    torchtext
-    torchvision
-    torch_xla
-    transformers
-    tokenizers
-
 line_length = 119
 lines_after_imports = 2
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ if os.name != "nt":
         ]
     )
 
-QUALITY_REQUIRE = ["black==21.4b0", "flake8==3.7.9", "isort", "pyyaml>=5.3.1"]
+QUALITY_REQUIRE = ["black==21.4b0", "flake8==3.7.9", "isort>=5.0.0", "pyyaml>=5.3.1"]
 
 
 EXTRAS_REQUIRE = {

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -8,6 +8,7 @@ import copy
 import io
 import json
 import os
+import posixpath
 import re
 import shutil
 import sys
@@ -24,7 +25,6 @@ from typing import Dict, Optional, TypeVar, Union
 from urllib.parse import urlparse
 
 import numpy as np
-import posixpath
 import requests
 
 from .. import __version__, config, utils

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import posixpath
 import re
 import tarfile
 import time
@@ -8,7 +9,6 @@ from pathlib import Path, PurePosixPath
 from typing import Optional, Tuple, Union
 
 import fsspec
-import posixpath
 from aiohttp.client_exceptions import ClientError
 
 from .. import config


### PR DESCRIPTION
`isort` can place modules by itself from [version 5.0.0](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html#module-placement-changes-known_third_party-known_first_party-default_section-etc) onwards, making the `known_first_party` and `known_third_party` fields in `setup.cfg` redundant (this is why our CI works, even though we haven't touched these options in a while).