### PR TITLE
Fix streaming for id_newspapers_2018

### DIFF
--- a/datasets/id_newspapers_2018/README.md
+++ b/datasets/id_newspapers_2018/README.md
@@ -157,7 +157,7 @@ The dataset contains train set of 499164 samples.
 
 ### Licensing Information
 
-[More Information Needed]
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License. The dataset is shared for the sole purpose of aiding open scientific research in Bahasa Indonesia (computing or linguistics), and can only be used for that purpose. The ownership of each article within the dataset belongs to the respective newspaper from which it was extracted; and the maintainer of the repository does not claim ownership of any of the content within it. If you think, by any means, that this dataset breaches any established copyrights; please contact the repository maintainer.
 
 ### Citation Information
 

--- a/datasets/id_newspapers_2018/README.md
+++ b/datasets/id_newspapers_2018/README.md
@@ -18,6 +18,7 @@ task_categories:
 task_ids:
 - language-modeling
 paperswithcode_id: null
+pretty_name: Indonesian Newspapers 2018
 ---
 
 # Dataset Card for Indonesian Newspapers 2018

--- a/datasets/id_newspapers_2018/README.md
+++ b/datasets/id_newspapers_2018/README.md
@@ -85,7 +85,15 @@ Indonesian
 ```
 ### Data Instances
 
-[More Information Needed]
+An instance from the dataset is
+
+```
+{'id': '0',
+ 'url': 'https://www.cnnindonesia.com/olahraga/20161221234219-156-181385/lorenzo-ingin-samai-rekor-rossi-dan-stoner',
+ 'date': '2016-12-22 07:00:00',
+ 'title': 'Lorenzo Ingin Samai Rekor Rossi dan Stoner',
+ 'content': 'Jakarta, CNN Indonesia -- Setelah bergabung dengan Ducati, Jorge Lorenzo berharap bisa masuk dalam jajaran pebalap yang mampu jadi juara dunia kelas utama dengan dua pabrikan berbeda. Pujian Max Biaggi untuk Valentino Rossi Jorge Lorenzo Hadir dalam Ucapan Selamat Natal Yamaha Iannone: Saya Sering Jatuh Karena Ingin yang Terbaik Sepanjang sejarah, hanya ada lima pebalap yang mampu jadi juara kelas utama (500cc/MotoGP) dengan dua pabrikan berbeda, yaitu Geoff Duke, Giacomo Agostini, Eddie Lawson, Valentino Rossi, dan Casey Stoner. Lorenzo ingin bergabung dalam jajaran legenda tersebut. “Fakta ini sangat penting bagi saya karena hanya ada lima pebalap yang mampu menang dengan dua pabrikan berbeda dalam sejarah balap motor.” “Kedatangan saya ke Ducati juga menghadirkan tantangan yang sangat menarik karena hampir tak ada yang bisa menang dengan Ducati sebelumnya, kecuali Casey Stoner. Hal itu jadi motivasi yang sangat bagus bagi saya,” tutur Lorenzo seperti dikutip dari Crash Lorenzo saat ini diliputi rasa penasaran yang besar untuk menunggang sepeda motor Desmosedici yang dipakai tim Ducati karena ia baru sekali menjajal motor tersebut pada sesi tes di Valencia, usai MotoGP musim 2016 berakhir. “Saya sangat tertarik dengan Ducati arena saya hanya memiliki kesempatan mencoba motor itu di Valencia dua hari setelah musim berakhir. Setelah itu saya tak boleh lagi menjajalnya hingga akhir Januari mendatang. Jadi saya menjalani penantian selama dua bulan yang panjang,” kata pebalap asal Spanyol ini. Dengan kondisi tersebut, maka Lorenzo memanfaatkan waktu yang ada untuk liburan dan melepaskan penat. “Setidaknya apa yang terjadi pada saya saat ini sangat bagus karena saya jadi memiliki waktu bebas dan sedikit liburan.” “Namun tentunya saya tak akan larut dalam liburan karena saya harus lebih bersiap, terutama dalam kondisi fisik dibandingkan sebelumnya, karena saya akan menunggangi motor yang sulit dikendarai,” ucap Lorenzo. Selama sembilan musim bersama Yamaha, Lorenzo sendiri sudah tiga kali jadi juara dunia, yaitu pada 2010, 2012, dan 2015. (kid)'}
+```
 
 ### Data Fields
 - `id`: id of the sample
@@ -96,7 +104,7 @@ Indonesian
 
 ### Data Splits
 
-The dataset contains train set.
+The dataset contains train set of 499164 samples.
 
 ## Dataset Creation
 
@@ -153,7 +161,7 @@ The dataset contains train set.
 
 ### Citation Information
 
-[More Information Needed]
+[N/A]
 
 ### Contributions
 

--- a/datasets/id_newspapers_2018/id_newspapers_2018.py
+++ b/datasets/id_newspapers_2018/id_newspapers_2018.py
@@ -15,9 +15,7 @@
 """Indonesian Newspapers 2018"""
 
 
-import glob
 import json
-import os
 
 import datasets
 
@@ -47,7 +45,7 @@ _HOMEPAGE = "https://github.com/feryandi/Dataset-Artikel"
 
 _LICENSE = "Creative Commons Attribution-ShareAlike 4.0 International Public License"
 
-_URLs = ["http://cloud.uncool.ai/index.php/s/kF83dQHfGeS2LX2/download"]
+_URL = "http://cloud.uncool.ai/index.php/s/kF83dQHfGeS2LX2/download"
 
 
 class IdNewspapers2018Config(datasets.BuilderConfig):
@@ -92,24 +90,21 @@ class IdNewspapers2018(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        my_urls = _URLs[0]
-        data_dir = dl_manager.download_and_extract(my_urls)
+        archive = dl_manager.download(_URL)
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "article_dir": os.path.join(data_dir, "newspapers"),
-                    "split": "train",
+                    "files": dl_manager.iter_archive(archive),
                 },
             )
         ]
 
-    def _generate_examples(self, article_dir, split):
-        logger.info("⏳ Generating %s examples from = %s", split, article_dir)
+    def _generate_examples(self, files):
         id = 0
-        for path in sorted(glob.glob(os.path.join(article_dir, "**/*.json"), recursive=True)):
-            with open(path, encoding="utf-8") as f:
-                data = json.load(f)
+        for path, f in files:
+            if path.startswith("newspapers") and path.endswith(".json"):
+                data = json.loads(f.read().decode("utf-8"))
                 yield id, {
                     "id": str(id),
                     "url": data["url"],
@@ -117,4 +112,4 @@ class IdNewspapers2018(datasets.GeneratorBasedBuilder):
                     "title": data["title"],
                     "content": data["content"],
                 }
-            id += 1
+                id += 1


### PR DESCRIPTION
To be compatible with streaming, this dataset must use `dl_manager.iter_archive` since the data are in a .tgz file