### PR TITLE
Fix ConnectionError in Scielo dataset

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -569,7 +569,10 @@ def get_from_cache(
                 or (response.status_code == 405 and "drive.google.com" in url)
                 or (
                     response.status_code == 403
-                    and re.match(r"^https?://github.com/.*?/.*?/releases/download/.*?/.*?$", url)
+                    and (
+                        re.match(r"^https?://github.com/.*?/.*?/releases/download/.*?/.*?$", url)
+                        or re.match(r"^https://.*?s3.*?amazonaws.com/.*?$", response.url)
+                    )
                 )
                 or (response.status_code == 403 and "ndownloader.figstatic.com" in url)
             ):


### PR DESCRIPTION
This PR:
* allows 403 status code in HEAD requests to S3 buckets to fix the connection error in the Scielo dataset (instead of `url`, uses `response.url` to check the URL of the final endpoint)
* makes the Scielo dataset streamable

Fixes #3255. 