### PR TITLE
Add os.listdir for streaming

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -10,6 +10,7 @@ from .utils.streaming_download_manager import (
     xdirname,
     xglob,
     xjoin,
+    xlistdir,
     xopen,
     xpandas_read_csv,
     xpathglob,
@@ -58,6 +59,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
 
     # open files in a streaming fashion
     patch_submodule(module, "open", wrap_auth(xopen)).start()
+    patch_submodule(module, "os.listdir", wrap_auth(xlistdir)).start()
     patch_submodule(module, "glob.glob", wrap_auth(xglob)).start()
     # allow to navigate in remote zip files
     patch_submodule(module, "os.path.join", xjoin).start()

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -14,6 +14,7 @@ from datasets.utils.streaming_download_manager import (
     xbasename,
     xglob,
     xjoin,
+    xlistdir,
     xopen,
     xpathglob,
     xpathjoin,
@@ -235,6 +236,24 @@ def test_xopen_remote():
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
     with xpathopen(Path(TEST_URL), "r", encoding="utf-8") as f:
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
+
+
+@pytest.mark.parametrize(
+    "input_path, expected_paths",
+    [
+        ("tmp_path", ["file1.txt", "file2.txt"]),
+        ("mock://", ["glob_test", "misc", "top_level"]),
+        ("mock://top_level", ["second_level"]),
+        ("mock://top_level/second_level/date=2019-10-01", ["a.parquet", "b.parquet"]),
+    ],
+)
+def test_xlistdir(input_path, expected_paths, tmp_path, mock_fsspec):
+    if input_path.startswith("tmp_path"):
+        input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
+        for file in ["file1.txt", "file2.txt"]:
+            (tmp_path / file).touch()
+    output_paths = sorted(xlistdir(input_path))
+    assert output_paths == expected_paths
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extend `os.listdir` to support streaming data from remote files. This is often used to navigate in remote ZIP files for example