### PR TITLE
Decode audio from remote

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -4,6 +4,8 @@ from typing import Any, ClassVar, Optional
 
 import pyarrow as pa
 
+from ..utils.streaming_download_manager import xopen
+
 
 @dataclass(unsafe_hash=True)
 class Audio:
@@ -48,7 +50,7 @@ class Audio:
         except ImportError as err:
             raise ImportError("To support decoding audio files, please install 'librosa'.") from err
 
-        with open(value, "rb") as f:
+        with xopen(value, "rb") as f:
             array, sampling_rate = librosa.load(f, sr=self.sampling_rate, mono=self.mono)
         return array, sampling_rate
 


### PR DESCRIPTION
Currently the Audio feature type can only decode local audio files, not remote files.

To fix this I replaced `open` with our `xopen` functoin that is compatible with remote files in audio.py

cc @albertvillanova @mariosasko 