### PR TITLE
Force data files extraction if download_mode='force_redownload'

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -517,6 +517,7 @@ class DatasetBuilder:
                 download_config = DownloadConfig(
                     cache_dir=self._cache_downloaded_dir,
                     force_download=bool(download_mode == GenerateMode.FORCE_REDOWNLOAD),
+                    force_extract=bool(download_mode == GenerateMode.FORCE_REDOWNLOAD),
                     use_etag=False,
                     use_auth_token=use_auth_token,
                 )  # We don't use etag for data files to speed up the process

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -258,7 +258,6 @@ class DownloadManager:
         """
         download_config = self._download_config.copy()
         download_config.extract_compressed_file = True
-        download_config.force_extract = False
         extracted_paths = map_nested(
             partial(cached_path, download_config=download_config), path_or_paths, num_proc=num_proc, disable_tqdm=False
         )


### PR DESCRIPTION
Avoids weird issues when redownloading a dataset due to cached data not being fully updated.

With this change, issues #3122 and https://github.com/huggingface/datasets/issues/2956 (not a fix, but a workaround) can be fixed as follows:
```python
dset = load_dataset(..., download_mode="force_redownload")
```