### PR TITLE
Proposed update to the documentation for WER

### DIFF
--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -48,7 +48,7 @@ I is the number of insertions,
 C is the number of correct words,
 N is the number of words in the reference (N=S+D+C).
 
-WER's output is always a number between 0 and 1. This value indicates the percentage of words that were incorrectly predicted. The lower the value, the better the
+This value indicates the average number of errors per reference word. The lower the value, the better the
 performance of the ASR system with a WER of 0 being a perfect score.
 """
 


### PR DESCRIPTION
I wanted to submit a minor update to the description of WER for your consideration. 

Because of the possibility of insertions, the numerator in the WER formula can be larger than N, so the value of WER can be greater than 1.0:

```
>>> from datasets import load_metric
>>> metric = load_metric("wer")
>>> metric.compute(predictions=["hello how are you"], references=["hello"])
3.0
```

and similarly from the underlying jiwer module's `wer` function:

```
>>> from jiwer import wer
>>> wer("hello", "hello how are you")
3.0
```