### PR TITLE
Fix bookcorpusopen RAM usage

### DIFF
--- a/datasets/bookcorpus/README.md
+++ b/datasets/bookcorpus/README.md
@@ -1,10 +1,27 @@
 ---
+annotations_creators:
+- no-annotation
+language_creators:
+- found
 languages:
 - en
+licenses:
+- unknown
+multilinguality:
+- monolingual
+pretty_name: BookCorpus
+size_categories:
+- 10M<n<100M
+source_datasets:
+- original
+task_categories:
+- sequence-modeling
+task_ids:
+- language-modeling
 paperswithcode_id: bookcorpus
 ---
 
-# Dataset Card for "bookcorpus"
+# Dataset Card for BookCorpus
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)

--- a/datasets/bookcorpusopen/README.md
+++ b/datasets/bookcorpusopen/README.md
@@ -1,11 +1,27 @@
 ---
-pretty_name: BookCorpusOpen
+annotations_creators:
+- no-annotation
+language_creators:
+- found
 languages:
 - en
-paperswithcode_id: null
+licenses:
+- unknown
+multilinguality:
+- monolingual
+pretty_name: BookCorpusOpen
+size_categories:
+- 10K<n<100K
+source_datasets:
+- original
+task_categories:
+- sequence-modeling
+task_ids:
+- language-modeling
+paperswithcode_id: bookcorpus
 ---
 
-# Dataset Card for "bookcorpusopen"
+# Dataset Card for BookCorpusOpen
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)

--- a/datasets/bookcorpusopen/bookcorpusopen.py
+++ b/datasets/bookcorpusopen/bookcorpusopen.py
@@ -64,6 +64,8 @@ class BookCorpusOpenConfig(datasets.BuilderConfig):
 class BookCorpusOpen(datasets.GeneratorBasedBuilder):
     """BookCorpus dataset."""
 
+    DEFAULT_WRITER_BATCH_SIZE = 256  # documents are full books and are quite heavy
+
     BUILDER_CONFIGS = [
         BookCorpusOpenConfig(
             name="plain_text",


### PR DESCRIPTION
Each document is a full book, so the default arrow writer batch size of 10,000 is too big, and it can fill up RAM quickly before flushing the first batch on disk. I changed its batch size to 256 to use maximum 100MB of memory