### PR TITLE
Fix build_docs CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -208,6 +208,7 @@ EXTRAS_REQUIRE = {
         "sphinx-rtd-theme==0.4.3",
         "sphinxext-opengraph==0.4.1",
         "sphinx-copybutton",
+        "Markdown==3.3.4",  # to fix https://github.com/Python-Markdown/markdown/issues/1196  
         "fsspec<2021.9.0",
         "s3fs",
         "sphinx-panels",


### PR DESCRIPTION
Because of https://github.com/Python-Markdown/markdown/issues/1196 we have to temporarily pin `markdown` to 3.3.4 for the docs to build without issues