### PR TITLE
Pin version exclusion for Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,7 @@ EXTRAS_REQUIRE = {
         "sphinx-panels",
         "sphinx-inline-tabs",
         "myst-parser",
+        "Markdown!=3.3.5",
     ],
 }
 


### PR DESCRIPTION
As Markdown version 3.3.5 has a bug, it is better to exclude it in case the users have it previously installed in their environment.

Related to #3289, #3286.