### PR TITLE
asserts replaced with exception for ``fingerprint.py``, ``search.py``, ``arrow_writer.py`` and ``metric.py``

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -83,7 +83,9 @@ class TypedSequence:
     """
 
     def __init__(self, data, type=None, try_type=None, optimized_int_type=None):
-        assert type is None or try_type is None, "You cannot specify both type and try_type"
+        # assert type is None or try_type is None,
+        if type is not None and try_type is not None:
+            raise ValueError("You cannot specify both type and try_type")
         self.data = data
         self.type = type
         self.try_type = try_type  # is ignored if it doesn't match the data
@@ -91,7 +93,8 @@ class TypedSequence:
 
     def __arrow_array__(self, type=None):
         """This function is called when calling pa.array(typed_sequence)"""
-        assert type is None, "TypedSequence is supposed to be used with pa.array(typed_sequence, type=None)"
+        if type is not None:
+            raise ValueError("TypedSequence is supposed to be used with pa.array(typed_sequence, type=None)")
         trying_type = False
         if type is not None:  # user explicitly passed the feature
             pass

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -335,23 +335,27 @@ def fingerprint_transform(
             It should be in the format "MAJOR.MINOR.PATCH".
     """
 
-    assert use_kwargs is None or isinstance(
-        use_kwargs, list
-    ), f"use_kwargs is supposed to be a list, not {type(use_kwargs)}"
-    assert ignore_kwargs is None or isinstance(
-        ignore_kwargs, list
-    ), f"ignore_kwargs is supposed to be a list, not {type(use_kwargs)}"
-    assert not inplace or not fingerprint_names, "fingerprint_names are only used when inplace is False"
+    if use_kwargs is not None and not isinstance(use_kwargs, list):
+        raise ValueError(f"use_kwargs is supposed to be a list, not {type(use_kwargs)}")
+
+    if ignore_kwargs is not None and not isinstance(ignore_kwargs, list):
+        raise ValueError(f"ignore_kwargs is supposed to be a list, not {type(use_kwargs)}")
+
+    if inplace and fingerprint_names:
+        raise ValueError(f"fingerprint_names are only used when inplace is False")
+
     fingerprint_names = fingerprint_names if fingerprint_names is not None else ["new_fingerprint"]
 
     def _fingerprint(func):
 
-        assert inplace or all(  # check that not in-place functions require fingerprint parameters
-            name in func.__code__.co_varnames for name in fingerprint_names
-        ), f"function {func} is missing parameters {fingerprint_names} in signature"
+        if not inplace and not all(name in func.__code__.co_varnames for name in fingerprint_names):
+            raise ValueError("function {func} is missing parameters {fingerprint_names} in signature")
+
         if randomized_function:  # randomized function have seed and generator parameters
-            assert "seed" in func.__code__.co_varnames, f"'seed' must be in {func}'s signature"
-            assert "generator" in func.__code__.co_varnames, f"'generator' must be in {func}'s signature"
+            if "seed" not in func.__code__.co_varnames:
+                raise ValueError(f"'seed' must be in {func}'s signature")
+            if "generator" not in func.__code__.co_varnames:
+                raise ValueError(f"'generator' must be in {func}'s signature")
         # this has to be outside the wrapper or since __qualname__ changes in multiprocessing
         transform = f"{func.__module__}.{func.__qualname__}"
         if version is not None:

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -167,13 +167,13 @@ class Metric(MetricInfoMixin):
         MetricInfoMixin.__init__(self, info)  # For easy access on low level
 
         # Safety checks on num_process and process_id
-        assert isinstance(process_id, int) and process_id >= 0, "'process_id' should be a number greater than 0"
-        assert (
-            isinstance(num_process, int) and num_process > process_id
-        ), "'num_process' should be a number greater than process_id"
-        assert (
-            num_process == 1 or not keep_in_memory
-        ), "Using 'keep_in_memory' is not possible in distributed setting (num_process > 1)."
+        if not isinstance(process_id, int) or process_id < 0:
+            raise ValueError("'process_id' should be a number greater than 0")
+        if not isinstance(num_process, int) or num_process < process_id:
+            raise ValueError("'num_process' should be a number greater than process_id")
+        if keep_in_memory and num_process != 1:
+            raise ValueError("Using 'keep_in_memory' is not possible in distributed setting (num_process > 1).")
+
         self.num_process = num_process
         self.process_id = process_id
         self.max_concurrent_cache_files = max_concurrent_cache_files

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -169,7 +169,7 @@ class Metric(MetricInfoMixin):
         # Safety checks on num_process and process_id
         if not isinstance(process_id, int) or process_id < 0:
             raise ValueError("'process_id' should be a number greater than 0")
-        if not isinstance(num_process, int) or num_process < process_id:
+        if not isinstance(num_process, int) or num_process <= process_id:
             raise ValueError("'num_process' should be a number greater than process_id")
         if keep_in_memory and num_process != 1:
             raise ValueError("Using 'keep_in_memory' is not possible in distributed setting (num_process > 1).")

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -102,12 +102,12 @@ class ElasticSearchIndex(BaseIndex):
         es_index_name: Optional[str] = None,
         es_index_config: Optional[dict] = None,
     ):
-        assert (
-            _has_elasticsearch
-        ), "You must install ElasticSearch to use ElasticSearchIndex. To do so you can run `pip install elasticsearch==7.7.1 for example`"
-        assert es_client is None or (
-            host is None and port is None
-        ), "Please specify either `es_client` or `(host, port)`, but not both."
+        if not _has_elasticsearch:
+            raise ImportError(
+                "You must install ElasticSearch to use ElasticSearchIndex. To do so you can run `pip install elasticsearch==7.7.1 for example`"
+            )
+        if es_client is not None and (host is not None and port is not None):
+            raise ValueError("Please specify either `es_client` or `(host, port)`, but not both.")
         host = host or "localhost"
         port = port or 9200
 
@@ -224,9 +224,8 @@ class FaissIndex(BaseIndex):
         You can find more information about Faiss here:
         - For `string factory`: https://github.com/facebookresearch/faiss/wiki/The-index-factory
         """
-        assert not (
-            string_factory is not None and custom_index is not None
-        ), "Please specify either `string_factory` or `custom_index` but not both."
+        if string_factory is not None and custom_index is not None:
+            raise ValueError("Please specify either `string_factory` or `custom_index` but not both.")
         self.device = device
         self.string_factory = string_factory
         self.metric_type = metric_type
@@ -306,7 +305,9 @@ class FaissIndex(BaseIndex):
             scores (`List[List[float]`): The retrieval scores of the retrieved examples.
             indices (`List[List[int]]`): The indices of the retrieved examples.
         """
-        assert len(query.shape) == 1 or (len(query.shape) == 2 and query.shape[0] == 1)
+        if len(query.shape) != 1 or (len(query.shape) == 2 and query.shape[0] != 1):
+            raise ValueError("Shape of query is incorrect, it has to be either a 1D array or 2D (1,N)")
+
         queries = query.reshape(1, -1)
         if not queries.flags.c_contiguous:
             queries = np.asarray(queries, order="C")
@@ -324,7 +325,8 @@ class FaissIndex(BaseIndex):
             total_scores (`List[List[float]`): The retrieval scores of the retrieved examples per query.
             total_indices (`List[List[int]]`): The indices of the retrieved examples per query.
         """
-        assert len(queries.shape) == 2
+        if len(queries.shape) != 2:
+            raise ValueError("Shape of query must be 2D")
         if not queries.flags.c_contiguous:
             queries = np.asarray(queries, order="C")
         scores, indices = self.faiss_index.search(queries, k)
@@ -496,9 +498,10 @@ class IndexableMixin:
             device (Optional :obj:`int`): If not None, this is the index of the GPU to use. By default it uses the CPU.
         """
         index = FaissIndex.load(file, device=device)
-        assert index.faiss_index.ntotal == len(
-            self
-        ), f"Index size should match Dataset size, but Index '{index_name}' at {file} has {index.faiss_index.ntotal} elements while the dataset has {len(self)} examples."
+        if index.faiss_index.ntotal != len(self):
+            raise ValueError(
+                f"Index size should match Dataset size, but Index '{index_name}' at {file} has {index.faiss_index.ntotal} elements while the dataset has {len(self)} examples."
+            )
         self._indexes[index_name] = index
         logger.info(f"Loaded FaissIndex {index_name} from {file}")
 

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -106,7 +106,7 @@ class ElasticSearchIndex(BaseIndex):
             raise ImportError(
                 "You must install ElasticSearch to use ElasticSearchIndex. To do so you can run `pip install elasticsearch==7.7.1 for example`"
             )
-        if es_client is not None and (host is not None and port is not None):
+        if es_client is not None and (host is not None or port is not None):
             raise ValueError("Please specify either `es_client` or `(host, port)`, but not both.")
         host = host or "localhost"
         port = port or 9200
@@ -306,7 +306,7 @@ class FaissIndex(BaseIndex):
             indices (`List[List[int]]`): The indices of the retrieved examples.
         """
         if len(query.shape) != 1 or (len(query.shape) == 2 and query.shape[0] != 1):
-            raise ValueError("Shape of query is incorrect, it has to be either a 1D array or 2D (1,N)")
+            raise ValueError("Shape of query is incorrect, it has to be either a 1D array or 2D (1, N)")
 
         queries = query.reshape(1, -1)
         if not queries.flags.c_contiguous:

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -19,11 +19,11 @@ class TypedSequenceTest(TestCase):
         self.assertEqual(arr.type, pa.int64())
 
     def test_array_type_forbidden(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(ValueError):
             _ = pa.array(TypedSequence([1, 2, 3]), type=pa.int64())
 
     def test_try_type_and_type_forbidden(self):
-        with self.assertRaises(AssertionError):
+        with pytest.raises(ValueError):
             _ = pa.array(TypedSequence([1, 2, 3], try_type=pa.bool_(), type=pa.int64()))
 
     def test_compatible_type(self):

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -19,11 +19,11 @@ class TypedSequenceTest(TestCase):
         self.assertEqual(arr.type, pa.int64())
 
     def test_array_type_forbidden(self):
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             _ = pa.array(TypedSequence([1, 2, 3]), type=pa.int64())
 
     def test_try_type_and_type_forbidden(self):
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             _ = pa.array(TypedSequence([1, 2, 3], try_type=pa.bool_(), type=pa.int64()))
 
     def test_compatible_type(self):

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -384,7 +384,7 @@ class TestMetric(TestCase):
             del results
 
             # With keep_in_memory is not allowed
-            with pytest.raises(ValueError):
+            with self.assertRaises(ValueError):
                 DummyMetric(
                     experiment_id="test_distributed_metrics_4",
                     keep_in_memory=True,

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -522,7 +522,7 @@ def test_metric_with_multilabel(config_name, predictions, references, expected, 
 
 def test_safety_checks_process_vars():
     with pytest.raises(ValueError):
-        metric = DummyMetric(process_id=-2)
+        _ = DummyMetric(process_id=-2)
 
     with pytest.raises(ValueError):
-        metric = DummyMetric(num_process=2, process_id=3)
+        _ = DummyMetric(num_process=2, process_id=3)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -384,7 +384,7 @@ class TestMetric(TestCase):
             del results
 
             # With keep_in_memory is not allowed
-            with self.assertRaises(AssertionError):
+            with pytest.raises(ValueError):
                 DummyMetric(
                     experiment_id="test_distributed_metrics_4",
                     keep_in_memory=True,
@@ -518,3 +518,11 @@ def test_metric_with_multilabel(config_name, predictions, references, expected, 
     metric = MetricWithMultiLabel(config_name, cache_dir=cache_dir)
     results = metric.compute(predictions=predictions, references=references)
     assert results["accuracy"] == expected
+
+
+def test_safety_checks_process_vars():
+    with pytest.raises(ValueError):
+        metric = DummyMetric(process_id=-2)
+
+    with pytest.raises(ValueError):
+        metric = DummyMetric(num_process=2, process_id=3)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -107,12 +107,14 @@ class FaissIndexTest(TestCase):
         query = np.zeros(5, dtype=np.float32)
         query[1] = 1
         scores, indices = index.search(query)
+        self.assertRaises(ValueError, index.search, query.reshape(-1, 1))
         self.assertGreater(scores[0], 0)
         self.assertEqual(indices[0], 1)
 
         # batched queries
         queries = np.eye(5, dtype=np.float32)[::-1]
         total_scores, total_indices = index.search_batch(queries)
+        self.assertRaises(ValueError, index.search_batch, queries[0])
         best_scores = [scores[0] for scores in total_scores]
         best_indices = [indices[0] for indices in total_indices]
         self.assertGreater(np.min(best_scores), 0)
@@ -127,6 +129,8 @@ class FaissIndexTest(TestCase):
         index = FaissIndex(string_factory="LSH")
         index.add_vectors(np.eye(5, dtype=np.float32))
         self.assertIsInstance(index.faiss_index, faiss.IndexLSH)
+        with self.assertRaises(ValueError):
+            _ = FaissIndex(string_factory="Flat", custom_index=faiss.IndexFlat(5))
 
     def test_custom(self):
         import faiss


### PR DESCRIPTION
Addresses #3171 
Fixes exception for ``fingerprint.py``, ``search.py``, ``arrow_writer.py`` and ``metric.py`` and modified tests