### PR TITLE
fix: files counted twice in inferred structure

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -41,7 +41,7 @@ DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
 }
 
 DEFAULT_PATTERNS_ALL = {
-    str(Split.TRAIN): ["*"],
+    str(Split.TRAIN): ["**"],
 }
 
 ALL_SPLIT_PATTERNS = [SPLIT_PATTERN_SHARDED]

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -154,13 +154,29 @@ def resolve_patterns_locally_or_by_urls(
     Resolve the paths and URLs of the data files from the patterns passed by the user.
     URLs are just returned as is.
 
+    You can use patterns to resolve multiple local files. Here are a few examples:
+    - *.csv to match all the CSV files at the first level
+    - **.csv to match all the CSV files at any level
+    - data/* to match all the files inside "data"
+    - data/** to match all the files inside "data" and its subdirectories
+
+    The patterns are resolved using the fsspec glob.
+    Here are some behaviors specific to fsspec glob that are different from glob.glob, Path.glob, Path.match or fnmatch:
+    - '*' matches only first level items
+    - '**' matches all items
+    - '**/*' matches all at least second level items
+
+    More generally:
+    - '*' matches any character except a forward-slash (to match just the file or directory name)
+    - '**' matches any character including a forward-slash /
+
     Examples:
 
         >>> import huggingface_hub
-        >>> from datasets.data_files import resolve_patterns_in_dataset_repository
-        >>> base_path = /Users/username/Desktop/hf/datasets
+        >>> from datasets.data_files import resolve_patterns_locally_or_by_urls
+        >>> base_path = "."
         >>> resolve_patterns_locally_or_by_urls(base_path, ["src/**/*.yaml"])
-        [PosixPath('/Users/quentinlhoest/Desktop/hf/shirte/datasets/src/datasets/utils/resources/readme_structure.yaml')]
+        [PosixPath('/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/utils/resources/readme_structure.yaml')]
 
     Args:
         base_path (str): Base path to use when resolving relative paths.
@@ -321,12 +337,28 @@ def resolve_patterns_in_dataset_repository(
     """
     Resolve the URLs of the data files from the patterns passed by the user.
 
+    You can use patterns to resolve multiple files. Here are a few examples:
+    - *.csv to match all the CSV files at the first level
+    - **.csv to match all the CSV files at any level
+    - data/* to match all the files inside "data"
+    - data/** to match all the files inside "data" and its subdirectories
+
+    The patterns are resolved using the fsspec glob.
+    Here are some behaviors specific to fsspec glob that are different from glob.glob, Path.glob, Path.match or fnmatch:
+    - '*' matches only first level items
+    - '**' matches all items
+    - '**/*' matches all at least second level items
+
+    More generally:
+    - '*' matches any character except a forward-slash (to match just the file or directory name)
+    - '**' matches any character including a forward-slash /
+
     Examples:
 
         >>> import huggingface_hub
         >>> from datasets.data_files import resolve_patterns_in_dataset_repository
         >>> dataset_info = huggingface_hub.HfApi().dataset_info("lhoestq/demo1")
-        >>> resolve_patterns_in_dataset_repository(dataset_info, ["*.csv"])
+        >>> resolve_patterns_in_dataset_repository(dataset_info, ["data/*.csv"])
         ['https://huggingface.co/datasets/lhoestq/demo1/resolve/0ca0d9f35b390ad11516095aeb27fd30cfe72578/data/test.csv',
         'https://huggingface.co/datasets/lhoestq/demo1/resolve/0ca0d9f35b390ad11516095aeb27fd30cfe72578/data/train.csv']
 
@@ -367,7 +399,7 @@ def get_patterns_in_dataset_repository(dataset_info: huggingface_hub.hf_api.Data
 
     Output:
 
-        {"train": ["*"]}
+        {"train": ["**"]}
 
     Input:
 
@@ -393,7 +425,7 @@ def get_patterns_in_dataset_repository(dataset_info: huggingface_hub.hf_api.Data
 
     Output:
 
-        {"train": ["*train*"], "test": ["*test*"]}
+        {"train": ["**train*"], "test": ["**test*"]}
 
     Input:
 
@@ -411,7 +443,7 @@ def get_patterns_in_dataset_repository(dataset_info: huggingface_hub.hf_api.Data
 
     Output:
 
-        {"train": ["*train*/*", "*train*/**/*"], "test": ["*test*/*", "*test*/**/*"]}
+        {"train": ["**train*/**"], "test": ["**test*/**"]}
 
     Input:
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -219,7 +219,7 @@ def get_patterns_locally(base_path: str) -> Dict[str, List[str]]:
 
     Output:
 
-        {"train": ["*"]}
+        {"train": ["**"]}
 
     Input:
 
@@ -245,7 +245,7 @@ def get_patterns_locally(base_path: str) -> Dict[str, List[str]]:
 
     Output:
 
-        {"train": [*train*], "test": ["*test*"]}
+        {"train": [**train*], "test": ["**test*"]}
 
     Input:
 
@@ -263,7 +263,7 @@ def get_patterns_locally(base_path: str) -> Dict[str, List[str]]:
 
     Output:
 
-        {"train": [*train*/*, "*train*/**/*"], "test": ["*test*/*", "*test*/**/*"]}
+        {"train": ["**train*/**"], "test": ["**test*/**"]}
 
     Input:
 
@@ -281,9 +281,9 @@ def get_patterns_locally(base_path: str) -> Dict[str, List[str]]:
     Output:
 
         {
-            "train": [data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*],
-            "test": [data/test-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*],
-            "random": [data/random-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*],
+            "train": ["data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*"],
+            "test": ["data/test-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*"],
+            "random": ["data/random-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*"],
         }
 
     In order, it first tests if SPLIT_PATTERN_SHARDED works, otherwise it tests the patterns in ALL_DEFAULT_PATTERNS.

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -33,9 +33,9 @@ DEFAULT_PATTERNS_SPLIT_IN_FILENAME = {
 }
 
 DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
-    str(Split.TRAIN): ["*train*/*", "*train*/**/*"],
-    str(Split.TEST): ["*test*/*", "*test*/**/*", "*eval*/*", "*eval*/**/*"],
-    str(Split.VALIDATION): ["*dev*/*", "*dev*/**/*", "*valid*/*", "*valid*/**/*"],
+    str(Split.TRAIN): ["*train*/**/*"],
+    str(Split.TEST): ["*test*/**/*", "*eval*/**/*"],
+    str(Split.VALIDATION): ["*dev*/**/*", "*valid*/**/*"],
 }
 
 DEFAULT_PATTERNS_ALL = {

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -29,21 +29,15 @@ class Url(str):
 SPLIT_PATTERN_SHARDED = "data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*"
 
 DEFAULT_PATTERNS_SPLIT_IN_FILENAME = {
-    str(Split.TRAIN): ["*train*", "**/*train*"],
-    str(Split.TEST): ["*test*", "*eval*", "**/*test*", "**/*eval*"],
-    str(Split.VALIDATION): ["*dev*", "*valid*", "**/*dev*", "**/*valid*"],
+    str(Split.TRAIN): ["**train*"],
+    str(Split.TEST): ["**test*", "**eval*"],
+    str(Split.VALIDATION): ["**dev*", "**valid*"],
 }
 
 DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
-    str(Split.TRAIN): ["*train*/*", "*train*/**/*"],
-    str(Split.TEST): ["*test*/*", "*test*/**/*", "*eval*/*", "*eval*/**/*"],
-    str(Split.VALIDATION): ["*dev*/*", "*dev*/**/*", "*valid*/*", "*valid*/**/*"],
-}
-
-DEFAULT_PATTERNS_SPLIT_IN_SUBDIR_NAME = {
-    str(Split.TRAIN): ["**/*train*/*", "**/*train*/**/*"],
-    str(Split.TEST): ["**/*test*/*", "**/*test*/**/*", "**/*eval*/*", "**/*eval*/**/*"],
-    str(Split.VALIDATION): ["**/*dev*/*", "**/dev**/**/*", "**/*valid*/*", "**/*valid*/**/*"],
+    str(Split.TRAIN): ["**train*/**"],
+    str(Split.TEST): ["**test*/**", "**eval*/**"],
+    str(Split.VALIDATION): ["**dev*/**", "**valid*/**"],
 }
 
 DEFAULT_PATTERNS_ALL = {
@@ -54,7 +48,6 @@ ALL_SPLIT_PATTERNS = [SPLIT_PATTERN_SHARDED]
 ALL_DEFAULT_PATTERNS = [
     DEFAULT_PATTERNS_SPLIT_IN_FILENAME,
     DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME,
-    DEFAULT_PATTERNS_SPLIT_IN_SUBDIR_NAME,
     DEFAULT_PATTERNS_ALL,
 ]
 WILDCARD_CHARACTERS = "*[]"
@@ -151,10 +144,6 @@ def _resolve_single_pattern_locally(
         if allowed_extensions is not None:
             error_msg += f" with any supported extension {list(allowed_extensions)}"
         raise FileNotFoundError(error_msg)
-
-    import warnings
-
-    warnings.warn(f"[{pattern}]={len(out)}")
     return sorted(out)
 
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -1,4 +1,3 @@
-import glob
 import os
 from functools import partial
 from pathlib import Path, PurePath
@@ -30,9 +29,9 @@ class Url(str):
 SPLIT_PATTERN_SHARDED = "data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*"
 
 DEFAULT_PATTERNS_SPLIT_IN_FILENAME = {
-    str(Split.TRAIN): ["*train*"],
-    str(Split.TEST): ["*test*", "*eval*"],
-    str(Split.VALIDATION): ["*dev*", "*valid*"],
+    str(Split.TRAIN): ["*train*", "**/*train*"],
+    str(Split.TEST): ["*test*", "*eval*", "**/*test*", "**/*eval*"],
+    str(Split.VALIDATION): ["*dev*", "*valid*", "**/*dev*", "**/*valid*"],
 }
 
 DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
@@ -41,12 +40,23 @@ DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
     str(Split.VALIDATION): ["*dev*/*", "*dev*/**/*", "*valid*/*", "*valid*/**/*"],
 }
 
+DEFAULT_PATTERNS_SPLIT_IN_SUBDIR_NAME = {
+    str(Split.TRAIN): ["**/*train*/*", "**/*train*/**/*"],
+    str(Split.TEST): ["**/*test*/*", "**/*test*/**/*", "**/*eval*/*", "**/*eval*/**/*"],
+    str(Split.VALIDATION): ["**/*dev*/*", "**/dev**/**/*", "**/*valid*/*", "**/*valid*/**/*"],
+}
+
 DEFAULT_PATTERNS_ALL = {
     str(Split.TRAIN): ["*"],
 }
 
 ALL_SPLIT_PATTERNS = [SPLIT_PATTERN_SHARDED]
-ALL_DEFAULT_PATTERNS = [DEFAULT_PATTERNS_SPLIT_IN_FILENAME, DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME, DEFAULT_PATTERNS_ALL]
+ALL_DEFAULT_PATTERNS = [
+    DEFAULT_PATTERNS_SPLIT_IN_FILENAME,
+    DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME,
+    DEFAULT_PATTERNS_SPLIT_IN_SUBDIR_NAME,
+    DEFAULT_PATTERNS_ALL,
+]
 WILDCARD_CHARACTERS = "*[]"
 FILES_TO_IGNORE = ["README.md", "config.json", "dataset_infos.json", "dummy_data.zip", "dataset_dict.json"]
 
@@ -141,6 +151,10 @@ def _resolve_single_pattern_locally(
         if allowed_extensions is not None:
             error_msg += f" with any supported extension {list(allowed_extensions)}"
         raise FileNotFoundError(error_msg)
+
+    import warnings
+
+    warnings.warn(f"[{pattern}]={len(out)}")
     return sorted(out)
 
 

--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -4,6 +4,7 @@ from typing import List
 import fsspec
 
 from . import compression
+from .hffilesystem import HfFileSystem
 
 
 _has_s3fs = importlib.util.find_spec("s3fs") is not None
@@ -20,7 +21,7 @@ COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
 ]
 
 # Register custom filesystems
-for fs_class in COMPRESSION_FILESYSTEMS:
+for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
     fsspec.register_implementation(fs_class.protocol, fs_class)
 
 

--- a/src/datasets/filesystems/hffilesystem.py
+++ b/src/datasets/filesystems/hffilesystem.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import fsspec
 from fsspec.archive import AbstractArchiveFileSystem
-from huggingface_hub.hf_api import DatasetInfo, HfApi
+from huggingface_hub.hf_api import DatasetInfo
 
 from ..utils.file_utils import get_authentication_headers_for_url, hf_hub_url
 

--- a/src/datasets/filesystems/hffilesystem.py
+++ b/src/datasets/filesystems/hffilesystem.py
@@ -1,0 +1,60 @@
+from typing import Optional
+
+import fsspec
+from fsspec.archive import AbstractArchiveFileSystem
+from huggingface_hub.hf_api import DatasetInfo, HfApi
+
+from ..utils.file_utils import get_authentication_headers_for_url, hf_hub_url
+
+
+class HfFileSystem(AbstractArchiveFileSystem):
+    """Interface to files in a Hugging face repository"""
+
+    root_marker = ""
+    protocol = "hf"
+
+    def __init__(
+        self,
+        repo_info: Optional[str] = None,
+        token: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        The compressed file system can be instantiated from any compressed file.
+        It reads the contents of compressed file as a filesystem with one file inside, as if it was an archive.
+
+        The single file inside the filesystem is named after the compresssed file,
+        without the compression extension at the end of the filename.
+
+        Args:
+            repo_info (:obj:``DatasetInfo``, `optional`):
+                Dataset repository info from huggingface_hub.HfApi().dataset_info(...)
+            token (:obj:``str``, `optional`):
+                Hugging Face token. Will default to the locally saved token if not provided.
+        """
+        super().__init__(self, **kwargs)
+        self.repo_info = repo_info
+        self.token = token
+        self.dir_cache = None
+
+    def _get_dirs(self):
+        if self.dir_cache is None:
+            self.dir_cache = {
+                hf_file.rfilename: {"name": hf_file.rfilename, "size": 0 or None, "type": "file"}  # TODO(QL): add size
+                for hf_file in self.repo_info.siblings
+            }
+
+    def _open(
+        self,
+        path: str,
+        mode: str = "rb",
+        **kwargs,
+    ):
+        if not isinstance(self.repo_info, DatasetInfo):
+            raise NotImplementedError(f"Open is only implemented for dataset repositories, but got {self.repo_info}")
+        url = hf_hub_url(self.repo_info.id, path, revision=self.repo_info.sha)
+        return fsspec.open(
+            url,
+            mode=mode,
+            headers=get_authentication_headers_for_url(url, use_auth_token=self.token),
+        ).open()

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -53,8 +53,8 @@ def pattern_results(complex_data_dir):
     # - '**/*' matches all at least second level items
     #
     # More generally:
-    # - `*`` matches any character except a forward-slash (to match just the file or directory name)
-    # - `**`` matches any character including a forward-slash /
+    # - '*' matches any character except a forward-slash (to match just the file or directory name)
+    # - '**' matches any character including a forward-slash /
 
     return {
         pattern: sorted(

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -61,7 +61,7 @@ def pattern_results(complex_data_dir):
     return {
         pattern: sorted(
             [
-                path
+                str(Path(path).resolve())
                 for path in fsspec.filesystem("file").glob(os.path.join(complex_data_dir, pattern))
                 if Path(path).name not in _FILES_TO_IGNORE and Path(path).is_file()
             ]

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -1,3 +1,4 @@
+import glob
 import os
 from itertools import chain
 from pathlib import Path, PurePath
@@ -20,7 +21,7 @@ from datasets.utils.file_utils import hf_hub_url
 
 _TEST_PATTERNS = ["*", "**/*", "*.txt", "data/*", "**/*.txt", "**/train.txt"]
 _FILES_TO_IGNORE = {".dummy", "README.md", "dummy_data.zip", "dataset_infos.json"}
-_TEST_PATTERNS_SIZES = dict([("*", 2), ("**/*", 2), ("*.txt", 2), ("data/*", 2), ("**/*.txt", 2), ("**/train.txt", 1)])
+_TEST_PATTERNS_SIZES = dict([("*", 0), ("**/*", 2), ("*.txt", 0), ("data/*", 2), ("**/*.txt", 2), ("**/train.txt", 1)])
 
 _TEST_URL = "https://raw.githubusercontent.com/huggingface/datasets/9675a5a1e7b99a86f9c250f6ea5fa5d1e6d5cc7d/setup.py"
 
@@ -43,12 +44,18 @@ def complex_data_dir(tmp_path):
 
 @pytest.fixture
 def pattern_results(complex_data_dir):
+    # We use glob.glob as a reference for data files resolution from patterns
+    # This is the same as dask for example.
+    #
+    # /!\ Here are some behaviors specific to glob.glob that are different from Path.glob, Path.match or fnmatch:
+    # - '*' matches only first level files
+    # - '**/*' matches only at least second level files
     return {
         pattern: sorted(
             [
-                str(path)
-                for path in Path(complex_data_dir).rglob(pattern)
-                if path.name not in _FILES_TO_IGNORE and path.is_file()
+                path
+                for path in glob.glob(os.path.join(complex_data_dir, pattern))
+                if Path(path).name not in _FILES_TO_IGNORE and Path(path).is_file()
             ]
         )
         for pattern in _TEST_PATTERNS
@@ -89,9 +96,12 @@ def test_pattern_results_fixture(pattern_results, pattern):
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_resolve_patterns_locally_or_by_urls(complex_data_dir, pattern, pattern_results):
-    resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, [pattern])
-    assert sorted(str(f) for f in resolved_data_files) == pattern_results[pattern]
-    assert all(isinstance(path, Path) for path in resolved_data_files)
+    try:
+        resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, [pattern])
+        assert sorted(str(f) for f in resolved_data_files) == pattern_results[pattern]
+        assert all(isinstance(path, Path) for path in resolved_data_files)
+    except FileNotFoundError:
+        assert len(pattern_results[pattern]) == 0
 
 
 def test_resolve_patterns_locally_or_by_urls_with_absolute_path(tmp_path, complex_data_dir):
@@ -100,7 +110,9 @@ def test_resolve_patterns_locally_or_by_urls_with_absolute_path(tmp_path, comple
     assert len(resolved_data_files) == 1
 
 
-@pytest.mark.parametrize("pattern,size,extensions", [("*", 2, ["txt"]), ("*", 2, None), ("*", 0, ["blablabla"])])
+@pytest.mark.parametrize(
+    "pattern,size,extensions", [("**/*", 2, ["txt"]), ("**/*", 2, None), ("**/*", 0, ["blablabla"])]
+)
 def test_resolve_patterns_locally_or_by_urls_with_extensions(complex_data_dir, pattern, size, extensions):
     if size > 0:
         resolved_data_files = resolve_patterns_locally_or_by_urls(
@@ -130,12 +142,17 @@ def test_resolve_patterns_locally_or_by_urls_sorted_files(tmp_path_factory):
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_resolve_patterns_in_dataset_repository(hub_dataset_info, pattern, hub_dataset_info_patterns_results):
-    resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, [pattern])
-    assert sorted(str(f) for f in resolved_data_files) == hub_dataset_info_patterns_results[pattern]
-    assert all(isinstance(url, Url) for url in resolved_data_files)
+    try:
+        resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, [pattern])
+        assert sorted(str(f) for f in resolved_data_files) == hub_dataset_info_patterns_results[pattern]
+        assert all(isinstance(url, Url) for url in resolved_data_files)
+    except FileNotFoundError:
+        assert len(hub_dataset_info_patterns_results[pattern]) == 0
 
 
-@pytest.mark.parametrize("pattern,size,extensions", [("*", 2, ["txt"]), ("*", 2, None), ("*", 0, ["blablabla"])])
+@pytest.mark.parametrize(
+    "pattern,size,extensions", [("**/*", 2, ["txt"]), ("**/*", 2, None), ("**/*", 0, ["blablabla"])]
+)
 def test_resolve_patterns_in_dataset_repository_with_extensions(hub_dataset_info, pattern, size, extensions):
     if size > 0:
         resolved_data_files = resolve_patterns_in_dataset_repository(
@@ -165,18 +182,24 @@ def test_resolve_patterns_in_dataset_repository_sorted_files():
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_DataFilesList_from_hf_repo(hub_dataset_info, hub_dataset_info_patterns_results, pattern):
-    data_files_list = DataFilesList.from_hf_repo([pattern], hub_dataset_info)
-    assert sorted(str(f) for f in data_files_list) == hub_dataset_info_patterns_results[pattern]
-    assert all(isinstance(url, Url) for url in data_files_list)
-    assert len(data_files_list.origin_metadata) > 0
+    try:
+        data_files_list = DataFilesList.from_hf_repo([pattern], hub_dataset_info)
+        assert sorted(str(f) for f in data_files_list) == hub_dataset_info_patterns_results[pattern]
+        assert all(isinstance(url, Url) for url in data_files_list)
+        assert len(data_files_list.origin_metadata) > 0
+    except FileNotFoundError:
+        assert len(hub_dataset_info_patterns_results[pattern]) == 0
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_DataFilesList_from_local_or_remote(complex_data_dir, pattern_results, pattern):
-    data_files_list = DataFilesList.from_local_or_remote([pattern], complex_data_dir)
-    assert sorted(str(f) for f in data_files_list) == pattern_results[pattern]
-    assert all(isinstance(path, Path) for path in data_files_list)
-    assert len(data_files_list.origin_metadata) > 0
+    try:
+        data_files_list = DataFilesList.from_local_or_remote([pattern], complex_data_dir)
+        assert sorted(str(f) for f in data_files_list) == pattern_results[pattern]
+        assert all(isinstance(path, Path) for path in data_files_list)
+        assert len(data_files_list.origin_metadata) > 0
+    except FileNotFoundError:
+        assert len(pattern_results[pattern]) == 0
 
 
 def test_DataFilesList_from_local_or_remote_with_extra_files(complex_data_dir, text_file):
@@ -188,19 +211,25 @@ def test_DataFilesList_from_local_or_remote_with_extra_files(complex_data_dir, t
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_DataFilesDict_from_hf_repo(hub_dataset_info, hub_dataset_info_patterns_results, pattern):
     split_name = "train"
-    data_files = DataFilesDict.from_hf_repo({split_name: [pattern]}, hub_dataset_info)
-    assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
-    assert sorted(str(f) for f in data_files[split_name]) == hub_dataset_info_patterns_results[pattern]
-    assert all(isinstance(url, Url) for url in data_files[split_name])
+    try:
+        data_files = DataFilesDict.from_hf_repo({split_name: [pattern]}, hub_dataset_info)
+        assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
+        assert sorted(str(f) for f in data_files[split_name]) == hub_dataset_info_patterns_results[pattern]
+        assert all(isinstance(url, Url) for url in data_files[split_name])
+    except FileNotFoundError:
+        assert len(hub_dataset_info_patterns_results[pattern]) == 0
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_DataFilesDict_from_local_or_remote(complex_data_dir, pattern_results, pattern):
     split_name = "train"
-    data_files = DataFilesDict.from_local_or_remote({split_name: [pattern]}, complex_data_dir)
-    assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
-    assert sorted(str(f) for f in data_files[split_name]) == pattern_results[pattern]
-    assert all(isinstance(url, Path) for url in data_files[split_name])
+    try:
+        data_files = DataFilesDict.from_local_or_remote({split_name: [pattern]}, complex_data_dir)
+        assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
+        assert sorted(str(f) for f in data_files[split_name]) == pattern_results[pattern]
+        assert all(isinstance(url, Path) for url in data_files[split_name])
+    except FileNotFoundError:
+        assert len(pattern_results[pattern]) == 0
 
 
 def test_DataFilesDict_from_hf_repo_hashing(hub_dataset_info):

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -44,10 +44,10 @@ def complex_data_dir(tmp_path):
 
 @pytest.fixture
 def pattern_results(complex_data_dir):
-    # We use fsspec glob as a reference for data files resolution from patterns
+    # We use fsspec glob as a reference for data files resolution from patterns.
     # This is the same as dask for example.
     #
-    # /!\ Here are some behaviors specific to that are different from glob.glob, Path.glob, Path.match or fnmatch:
+    # /!\ Here are some behaviors specific to fsspec glob that are different from glob.glob, Path.glob, Path.match or fnmatch:
     # - '*' matches only first level items
     # - '**' matches all items
     # - '**/*' matches all at least second level items

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -21,7 +21,9 @@ from datasets.utils.file_utils import hf_hub_url
 
 _TEST_PATTERNS = ["*", "**", "**/*", "*.txt", "data/*", "**/*.txt", "**/train.txt"]
 _FILES_TO_IGNORE = {".dummy", "README.md", "dummy_data.zip", "dataset_infos.json"}
-_TEST_PATTERNS_SIZES = dict([("*", 0), ("**", 2), ("**/*", 2), ("*.txt", 0), ("data/*", 2), ("**/*.txt", 2), ("**/train.txt", 1)])
+_TEST_PATTERNS_SIZES = dict(
+    [("*", 0), ("**", 2), ("**/*", 2), ("*.txt", 0), ("data/*", 2), ("**/*.txt", 2), ("**/train.txt", 1)]
+)
 
 _TEST_URL = "https://raw.githubusercontent.com/huggingface/datasets/9675a5a1e7b99a86f9c250f6ea5fa5d1e6d5cc7d/setup.py"
 
@@ -116,9 +118,7 @@ def test_resolve_patterns_locally_or_by_urls_with_absolute_path(tmp_path, comple
     assert len(resolved_data_files) == 1
 
 
-@pytest.mark.parametrize(
-    "pattern,size,extensions", [("**", 2, ["txt"]), ("**", 2, None), ("**", 0, ["blablabla"])]
-)
+@pytest.mark.parametrize("pattern,size,extensions", [("**", 2, ["txt"]), ("**", 2, None), ("**", 0, ["blablabla"])])
 def test_resolve_patterns_locally_or_by_urls_with_extensions(complex_data_dir, pattern, size, extensions):
     if size > 0:
         resolved_data_files = resolve_patterns_locally_or_by_urls(
@@ -156,9 +156,7 @@ def test_resolve_patterns_in_dataset_repository(hub_dataset_info, pattern, hub_d
         assert len(hub_dataset_info_patterns_results[pattern]) == 0
 
 
-@pytest.mark.parametrize(
-    "pattern,size,extensions", [("**", 2, ["txt"]), ("**", 2, None), ("**", 0, ["blablabla"])]
-)
+@pytest.mark.parametrize("pattern,size,extensions", [("**", 2, ["txt"]), ("**", 2, None), ("**", 0, ["blablabla"])])
 def test_resolve_patterns_in_dataset_repository_with_extensions(hub_dataset_info, pattern, size, extensions):
     if size > 0:
         resolved_data_files = resolve_patterns_in_dataset_repository(

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -5,7 +5,13 @@ from datasets import get_dataset_config_names
 
 @pytest.mark.parametrize(
     "path, expected",
-    [("squad", "plain_text"), ("acronym_identification", "default"), ("Check/region_1", "Check___region_1")],
+    [
+        ("squad", "plain_text"),
+        ("acronym_identification", "default"),
+        ("lhoestq/squad", "plain_text"),
+        ("lhoestq/test", "default"),
+        ("lhoestq/demo1", "lhoestq___demo1"),
+    ],
 )
 def test_get_dataset_config_names(path, expected):
     config_names = get_dataset_config_names(path)


### PR DESCRIPTION
Files were counted twice in a structure like:
```
my_dataset_local_path/
├── README.md
└── data/
    ├── train/
    │   ├── shard_0.csv
    │   ├── shard_1.csv
    │   ├── shard_2.csv
    │   └── shard_3.csv
    └── valid/
        ├── shard_0.csv
        └── shard_1.csv
```

The reason is that they were matching both `*train*/*` and `*train*/**/*`.

This PR fixes it. @lhoestq 