### PR TITLE
Removing query params for dynamic URL caching

### DIFF
--- a/datasets/ami/ami.py
+++ b/datasets/ami/ami.py
@@ -361,12 +361,12 @@ class AMI(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
 
         # multi-processing doesn't work for AMI
-        if hasattr(dl_manager, "_download_config") and dl_manager._download_config.num_proc != 1:
+        if hasattr(dl_manager, "download_config") and dl_manager.download_config.num_proc != 1:
             logger.warning(
                 "AMI corpus cannot be downloaded using multi-processing. "
                 "Setting number of downloaded processes `num_proc` to 1. "
             )
-            dl_manager._download_config.num_proc = 1
+            dl_manager.download_config.num_proc = 1
 
         annotation_path = dl_manager.download_and_extract(_DL_URL_ANNOTATIONS)
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -583,7 +583,7 @@ class DatasetBuilder:
                     downloaded_from_gcs = False
                     if try_from_hf_gcs:
                         try:
-                            self._download_prepared_from_hf_gcs(dl_manager._download_config)
+                            self._download_prepared_from_hf_gcs(dl_manager.download_config)
                             downloaded_from_gcs = True
                         except (DatasetNotOnHfGcsError, MissingFilesOnHfGcsError):
                             logger.info("Dataset not on Hf google storage. Downloading and preparing it from source")

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -85,10 +85,10 @@ class DownloadManager:
         """
         self._dataset_name = dataset_name
         self._data_dir = data_dir
-        self._download_config = download_config or DownloadConfig()
         self._base_path = base_path or os.path.abspath(".")
         # To record what is being used: {url: {num_bytes: int, checksum: str}}
         self._recorded_sizes_checksums: Dict[str, Dict[str, Union[int, str]]] = {}
+        self.download_config = download_config or DownloadConfig()
         self.downloaded_paths = {}
         self.extracted_paths = {}
 
@@ -146,8 +146,8 @@ class DownloadManager:
             downloaded_path(s): `str`, The downloaded paths matching the given input
                 url_or_urls.
         """
-        cache_dir = self._download_config.cache_dir or config.DOWNLOADED_DATASETS_PATH
-        max_retries = self._download_config.max_retries
+        cache_dir = self.download_config.cache_dir or config.DOWNLOADED_DATASETS_PATH
+        max_retries = self.download_config.max_retries
 
         def url_to_downloaded_path(url):
             return os.path.join(cache_dir, hash_url_to_filename(url))
@@ -163,7 +163,7 @@ class DownloadManager:
                 cached = True
             except FileNotFoundError:
                 cached = False
-            if not cached or self._download_config.force_download:
+            if not cached or self.download_config.force_download:
                 custom_download(url, path)
                 get_from_cache(
                     url, cache_dir=cache_dir, local_files_only=True, use_etag=False, max_retries=max_retries
@@ -171,7 +171,7 @@ class DownloadManager:
         self._record_sizes_checksums(url_or_urls, downloaded_path_or_paths)
         return downloaded_path_or_paths.data
 
-    def download(self, url_or_urls, **caching_params):
+    def download(self, url_or_urls):
         """Download given url(s).
 
         Args:
@@ -182,14 +182,14 @@ class DownloadManager:
             downloaded_path(s): `str`, The downloaded paths matching the given input
                 url_or_urls.
         """
-        download_config = self._download_config.copy()
+        download_config = self.download_config.copy()
         download_config.extract_compressed_file = False
         # Default to using 16 parallel thread for downloading
         # Note that if we have less than 16 files, multi-processing is not activated
         if download_config.num_proc is None:
             download_config.num_proc = 16
 
-        download_func = partial(self._download, download_config=download_config, **caching_params)
+        download_func = partial(self._download, download_config=download_config)
 
         start_time = datetime.now()
         downloaded_path_or_paths = map_nested(
@@ -208,12 +208,12 @@ class DownloadManager:
 
         return downloaded_path_or_paths.data
 
-    def _download(self, url_or_filename: str, download_config: DownloadConfig, **caching_params) -> str:
+    def _download(self, url_or_filename: str, download_config: DownloadConfig) -> str:
         url_or_filename = str(url_or_filename)
         if is_relative_path(url_or_filename):
             # append the relative path to the base_path
             url_or_filename = url_or_path_join(self._base_path, url_or_filename)
-        return cached_path(url_or_filename, download_config=download_config, **caching_params)
+        return cached_path(url_or_filename, download_config=download_config)
 
     def iter_archive(self, path):
         """Returns iterator over files within archive.
@@ -254,7 +254,7 @@ class DownloadManager:
             extracted_path(s): `str`, The extracted paths matching the given input
                 path_or_paths.
         """
-        download_config = self._download_config.copy()
+        download_config = self.download_config.copy()
         download_config.extract_compressed_file = True
         extracted_paths = map_nested(
             partial(cached_path, download_config=download_config), path_or_paths, num_proc=num_proc, disable_tqdm=False
@@ -264,7 +264,7 @@ class DownloadManager:
         self.extracted_paths.update(dict(zip(path_or_paths.flatten(), extracted_paths.flatten())))
         return extracted_paths.data
 
-    def download_and_extract(self, url_or_urls, **caching_params):
+    def download_and_extract(self, url_or_urls):
         """Download and extract given url_or_urls.
 
         Is roughly equivalent to:
@@ -276,12 +276,11 @@ class DownloadManager:
         Args:
             url_or_urls: url or `list`/`dict` of urls to download and extract. Each
                 url is a `str`.
-            **caching_params: params to pass to :func:`datasets.utils.file_utils.get_from_cache`.
 
         Returns:
             extracted_path(s): `str`, extracted paths of given URL(s).
         """
-        return self.extract(self.download(url_or_urls, **caching_params))
+        return self.extract(self.download(url_or_urls))
 
     def get_recorded_sizes_checksums(self):
         return self._recorded_sizes_checksums.copy()
@@ -294,5 +293,5 @@ class DownloadManager:
                 del self.extracted_paths[key]
 
     def manage_extracted_files(self):
-        if self._download_config.delete_extracted:
+        if self.download_config.delete_extracted:
             self.delete_extracted_files()

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -191,7 +191,7 @@ def url_or_path_parent(url_or_path: str) -> str:
         return os.path.dirname(url_or_path)
 
 
-def hash_url_to_filename(url, etag=None, ignore_url_params=False):
+def hash_url_to_filename(url, etag=None):
     """
     Convert `url` into a hashed filename in a repeatable way.
     If `etag` is specified, append its hash to the url's, delimited
@@ -239,6 +239,8 @@ class DownloadConfig:
         max_retries (:obj:`int`, default ``1``): The number of times to retry an HTTP request if it fails.
         use_auth_token (:obj:`str` or :obj:`bool`, optional): Optional string or boolean to use as Bearer token
             for remote files on the Datasets Hub. If True, will get token from ~/.huggingface.
+        ignore_url_params (:obj:`bool`, default ``False``): Whether to strip all query parameters and #fragments from
+            the download URL before using it for caching the file.
     """
 
     cache_dir: Optional[Union[str, Path]] = None
@@ -254,6 +256,7 @@ class DownloadConfig:
     num_proc: Optional[int] = None
     max_retries: int = 1
     use_auth_token: Optional[Union[str, bool]] = None
+    ignore_url_params: bool = False
 
     def copy(self) -> "DownloadConfig":
         return self.__class__(**{k: copy.deepcopy(v) for k, v in self.__dict__.items()})
@@ -281,7 +284,6 @@ def cached_path(
         ValueError: if it couldn't parse the url or filename correctly
         requests.exceptions.ConnectionError: in case of internet connection issue
     """
-    ignore_url_params = kwargs.pop("ignore_url_params", False)
     if download_config is None:
         download_config = DownloadConfig(**download_kwargs)
 
@@ -304,7 +306,7 @@ def cached_path(
             use_etag=download_config.use_etag,
             max_retries=download_config.max_retries,
             use_auth_token=download_config.use_auth_token,
-            ignore_url_params=ignore_url_params
+            ignore_url_params=download_config.ignore_url_params,
         )
     elif os.path.exists(url_or_filename):
         # File, and it exists.

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -456,8 +456,8 @@ class StreamingDownloadManager(object):
     ):
         self._dataset_name = dataset_name
         self._data_dir = data_dir
-        self._download_config = download_config or DownloadConfig()
         self._base_path = base_path or os.path.abspath(".")
+        self.download_config = download_config or DownloadConfig()
 
     @property
     def manual_dir(self):
@@ -480,7 +480,7 @@ class StreamingDownloadManager(object):
 
     def _extract(self, urlpath: str) -> str:
         urlpath = str(urlpath)
-        protocol = _get_extraction_protocol(urlpath, use_auth_token=self._download_config.use_auth_token)
+        protocol = _get_extraction_protocol(urlpath, use_auth_token=self.download_config.use_auth_token)
         if protocol is None:
             # no extraction
             return urlpath
@@ -509,7 +509,7 @@ class StreamingDownloadManager(object):
             Generator yielding tuple (path_within_archive, file_obj).
             File-Obj are opened in byte mode (io.BufferedReader)
         """
-        with xopen(urlpath, "rb", use_auth_token=self._download_config.use_auth_token) as f:
+        with xopen(urlpath, "rb", use_auth_token=self.download_config.use_auth_token) as f:
             stream = tarfile.open(fileobj=f, mode="r|*")
             for tarinfo in stream:
                 file_path = tarinfo.name


### PR DESCRIPTION
The main use case for this is to make dynamically generated private URLs (like the ones returned by CommonVoice API) compatible with the datasets' caching logic.

Usage example:
```python
import datasets

class CommonVoice(datasets.GeneratorBasedBuilder):
    def _info(self):
        return datasets.DatasetInfo()

    def _split_generators(self, dl_manager):
        dl_manager.download_config.ignore_url_params = True
        HUGE_URL = "https://mozilla-common-voice-datasets.s3.dualstack.us-west-2.amazonaws.com/cv-corpus-7.0-2021-07-21/cv-corpus-7.0-2021-07-21-ab.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQ3GQRTO3IU5JYB5K%2F20211125%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211125T131423Z&X-Amz-Expires=43200&X-Amz-Security-Token=FwoGZXIvYXdzEL7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDLsZw7Nj0d9h4rgheyKSBJJ6bxo1JdWLXAUhLMrUB8AXfhP8Ge4F8dtjwXmvGJgkIvdMT7P4YOEE1pS3mW8AyKsz7Z7IRVCIGQrOH1AbxGVVcDoCMMswXEOqL3nJFihKLf99%2F6l8iJVZdzftRUNgMhX5Hz0xSIL%2BzRDpH5nYa7C6YpEdOdW81CFVXybx7WUrX13wc8X4ZlUj7zrWcWf5p2VEIU5Utb7YHVi0Y5TQQiZSDoedQl0j4VmMuFkDzoobIO%2BvilgGeE2kIX0E62X423mEGNu4uQV5JsOuLAtv3GVlemsqEH3ZYrXDuxLmnvGj5HfMtySwI4vKv%2BlnnirD29o7hxvtidXiA8JMWhp93aP%2Fw7sod%2BPPbb5EqP%2B4Qb2GJ1myClOKcLEY0cqoy7XWm8NeVljLJojnFJVS5mNFBAzCCTJ%2FidxNsj8fflzkRoAzYaaPBuOTL1dgtZCdslK3FAuEvw0cik7P9A7IYiULV33otSHKMPcVfNHFsWQljs03gDztsIUWxaXvu6ck5vCcGULsHbfe6xoMPm2bR9jtKLONsslPcnzWIf7%2Fch2w%2F%2BjtTCd9IxaH4kytyJ6mIjpV%2FA%2F2h9qeDnDFsCphnMjAzPQn6tqCgTtPcyJ2b8c94ncgUnE4mepx%2FDa%2FanAEsrg9RPdmbdoPswzHn1IClh91IfSN74u95DZUxlPeZrHG5HxVCN3dKO6j%2Ft1xd20L0hEtazDdKOr8%2FYwGMirp8rp%2BII0pYOwQOrYHqH%2FREX2dRJctJtwE86Qj1eU8BAdXuFIkLC4NWXw%3D&X-Amz-Signature=1b8108d29b0e9c2bf6c7246e58ca8d5749a83de0704757ad8e8a44d78194691f&X-Amz-SignedHeaders=host"
        dl_path = dl_manager.download_and_extract(HUGE_URL)
        print(dl_path)
        
        HUGE_URL += "&some_new_or_changed_param=12345"
        dl_path = dl_manager.download_and_extract(HUGE_URL)
        print(dl_path)

dl_manager = datasets.DownloadManager(dataset_name="common_voice")
CommonVoice()._split_generators(dl_manager)
```

Output:
```
/home/user/.cache/huggingface/datasets/downloads/6ef2a377398ff3309554be040caa78414e6562d623dbd0ce8fc262459a7f8ec6
/home/user/.cache/huggingface/datasets/downloads/6ef2a377398ff3309554be040caa78414e6562d623dbd0ce8fc262459a7f8ec6
```