### PR TITLE
Add push_to_hub docs

### DIFF
--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -24,7 +24,7 @@ The base class :class:`datasets.Dataset` implements a Dataset backed by an Apach
         __len__, __iter__, formatted_as, set_format, set_transform, reset_format, with_format, with_transform,
         __getitem__, cleanup_cache_files,
         map, filter, select, sort, shuffle, train_test_split, shard, export,
-        save_to_disk, load_from_disk, flatten_indices,
+        push_to_hub, save_to_disk, load_from_disk, flatten_indices,
         to_csv, to_pandas, to_dict, to_json, to_parquet,
         add_faiss_index, add_faiss_index_from_external_arrays, save_faiss_index, load_faiss_index,
         add_elasticsearch_index, load_elasticsearch_index,
@@ -60,7 +60,7 @@ It also has dataset transform methods like map or filter, to process all the spl
         map, filter, sort, shuffle, set_format, reset_format, formatted_as, with_format, with_transform,
         flatten_, cast_, remove_columns_, rename_column_,
         flatten, cast, cast_column, remove_columns, rename_column, class_encode_column,
-        save_to_disk, load_from_disk,
+        push_to_hub, save_to_disk, load_from_disk,
         from_csv, from_json, from_parquet, from_text,
         prepare_for_task, align_labels_with_mapping
 

--- a/docs/source/upload_dataset.rst
+++ b/docs/source/upload_dataset.rst
@@ -80,7 +80,15 @@ Your dataset can now be loaded by anyone in a single line of code!
 Upload from Python
 ------------------
 
-To upload a :class:`datasets.DatasetDict` on the Hugging face Hub in python, you can use the :func:`datasets.DatasetDict.push_to_hub` method:
+To upload a :class:`datasets.DatasetDict` on the Hugging Face Hub in Python, you can login and use the :func:`datasets.DatasetDict.push_to_hub` method:
+
+1. Login from the command line:
+
+.. code-block::
+
+   huggingface-cli login
+
+2. Upload the dataset:
 
 .. code-block::
 
@@ -89,6 +97,11 @@ To upload a :class:`datasets.DatasetDict` on the Hugging face Hub in python, you
    >>> # dataset = dataset.map(...)  # do all your processing here
    >>> dataset.push_to_hub("stevhliu/processed_demo")
 
+With the ``private`` parameter you can choose whether your dataset is public or private:
+
+.. code-block::
+
+   >>> dataset.push_to_hub("stevhliu/private_processed_demo", private=True)
 
 Privacy
 -------

--- a/docs/source/upload_dataset.rst
+++ b/docs/source/upload_dataset.rst
@@ -77,6 +77,19 @@ Your dataset can now be loaded by anyone in a single line of code!
    })
 
 
+Upload from Python
+------------------
+
+To upload a :class:`datasets.DatasetDict` on the Hugging face Hub in python, you can use the :func:`datasets.DatasetDict.push_to_hub` method:
+
+.. code-block::
+
+   >>> from datasets import load_dataset
+   >>> dataset = load_dataset("stevhliu/demo")
+   >>> # dataset = dataset.map(...)  # do all your processing here
+   >>> dataset.push_to_hub("stevhliu/processed_demo")
+
+
 Privacy
 -------
 


### PR DESCRIPTION
Since #3098 it's now possible to upload a dataset on the Hub directly from python using the `push_to_hub` method.
I just added a section in the "Upload a dataset to the Hub" tutorial.

I kept the section quite simple but let me know if it sounds good to you @LysandreJik @stevhliu :)