### PR TITLE
Fix import `datasets` on python 3.10

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -353,23 +353,22 @@ class InMemoryTable(TableBlock):
         table = _in_memory_arrow_table_from_buffer(buffer)
         return cls(table)
 
-    @inject_arrow_table_documentation(pa.Table.from_pandas)
     @classmethod
+    @inject_arrow_table_documentation(pa.Table.from_pandas)
     def from_pandas(cls, *args, **kwargs):
         return cls(pa.Table.from_pandas(*args, **kwargs))
 
     @inject_arrow_table_documentation(pa.Table.from_arrays)
-    @classmethod
     def from_arrays(cls, *args, **kwargs):
         return cls(pa.Table.from_arrays(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.from_pydict)
     @classmethod
+    @inject_arrow_table_documentation(pa.Table.from_pydict)
     def from_pydict(cls, *args, **kwargs):
         return cls(pa.Table.from_pydict(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.from_batches)
     @classmethod
+    @inject_arrow_table_documentation(pa.Table.from_batches)
     def from_batches(cls, *args, **kwargs):
         return cls(pa.Table.from_batches(*args, **kwargs))
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -358,6 +358,7 @@ class InMemoryTable(TableBlock):
     def from_pandas(cls, *args, **kwargs):
         return cls(pa.Table.from_pandas(*args, **kwargs))
 
+    @classmethod
     @inject_arrow_table_documentation(pa.Table.from_arrays)
     def from_arrays(cls, *args, **kwargs):
         return cls(pa.Table.from_arrays(*args, **kwargs))


### PR DESCRIPTION
In python 3.10 it's no longer possible to use `functools.wraps` on a method decorated with `classmethod`.
To fix this I inverted the order of the `inject_arrow_table_documentation` and `classmethod` decorators

Fix #3324 