### PR TITLE
Add support for multiple dynamic dimensions and to_pandas conversion for dynamic arrays

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -360,7 +360,7 @@ class _ArrayXDExtensionType(pa.PyExtensionType):
         assert (
             self.ndims is not None and self.ndims > 1
         ), "You must instantiate an array type with a value for dim that is > 1"
-        assert len(shape) == self.ndims, f"shape={shape} and ndims={self.ndims} dom't match"
+        assert len(shape) == self.ndims, f"shape={shape} and ndims={self.ndims} don't match"
         self.shape = tuple(shape)
         self.value_type = dtype
         self.storage_dtype = self._generate_dtype(self.value_type)
@@ -377,8 +377,8 @@ class _ArrayXDExtensionType(pa.PyExtensionType):
 
     def _generate_dtype(self, dtype):
         dtype = string_to_arrow(dtype)
-        for d in reversed(self.shape):
-            dtype = pa.list_(dtype, list_size=d if d is not None else -1)
+        for _ in reversed(self.shape):
+            dtype = pa.list_(dtype)
         return dtype
 
     def to_pandas_dtype(self):
@@ -424,7 +424,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
         return self.storage[i]
 
     def to_numpy(self, zero_copy_only=True):
-        storage: pa.Array = self.storage
+        storage: pa.ListArray = self.storage
         for _ in range(self.type.ndims):
             storage = storage.flatten()
         numpy_arr = storage.to_numpy(zero_copy_only=zero_copy_only)
@@ -434,7 +434,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
     def to_list_of_numpy(self, zero_copy_only=True):
         shape = self.type.shape
         ndims = self.type.ndims
-        storage: pa.Array = self.storage
+        storage: pa.ListArray = self.storage
 
         nelems = len(storage)
         elem_shapes = np.diff(storage.offsets) if shape[0] is None else np.array([shape[0]] * nelems)

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -172,7 +172,9 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
                 array: List = pa_array.to_pylist()
             else:
                 array: List = pa_array.to_numpy(zero_copy_only=zero_copy_only).tolist()
-        if len(array) > 0 and any(isinstance(x, np.ndarray) and (x.dtype == np.object or x.shape != array[0].shape) for x in array):
+        if len(array) > 0 and any(
+            isinstance(x, np.ndarray) and (x.dtype == np.object or x.shape != array[0].shape) for x in array
+        ):
             return np.array(array, copy=False, **{**self.np_array_kwargs, "dtype": np.object})
         else:
             return np.array(array, copy=False, **self.np_array_kwargs)

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -172,10 +172,10 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
                 array: List = pa_array.to_pylist()
             else:
                 array: List = pa_array.to_numpy(zero_copy_only=zero_copy_only).tolist()
-        if len(array) > 0:
-            if any(isinstance(x, np.ndarray) and (x.dtype == np.object or x.shape != array[0].shape) for x in array):
-                return np.array(array, copy=False, **{**self.np_array_kwargs, "dtype": np.object})
-        return np.array(array, copy=False, **self.np_array_kwargs)
+        if len(array) > 0 and any(isinstance(x, np.ndarray) and (x.dtype == np.object or x.shape != array[0].shape) for x in array):
+            return np.array(array, copy=False, **{**self.np_array_kwargs, "dtype": np.object})
+        else:
+            return np.array(array, copy=False, **self.np_array_kwargs)
 
 
 class PandasArrowExtractor(BaseArrowExtractor[pd.DataFrame, pd.Series, pd.DataFrame]):

--- a/tests/test_array_xd.py
+++ b/tests/test_array_xd.py
@@ -279,12 +279,6 @@ class ArrayXDDynamicTest(unittest.TestCase):
             self.assertIsInstance(single_arr, np.ndarray)
             self.assertEqual(single_arr.shape, (first_dim, *fixed_shape))
 
-    def test_to_pandas_fail(self):
-        fixed_shape = (2, 2)
-        first_dim_list = [1, 3, 10]
-        dataset = self.get_one_col_dataset(first_dim_list, fixed_shape)
-        with self.assertRaises(NotImplementedError):
-            dataset.to_pandas()
 
     def test_map_dataset(self):
         fixed_shape = (2, 2)

--- a/tests/test_array_xd.py
+++ b/tests/test_array_xd.py
@@ -279,7 +279,6 @@ class ArrayXDDynamicTest(unittest.TestCase):
             self.assertIsInstance(single_arr, np.ndarray)
             self.assertEqual(single_arr.shape, (first_dim, *fixed_shape))
 
-
     def test_map_dataset(self):
         fixed_shape = (2, 2)
         first_dim_list = [1, 3, 10]


### PR DESCRIPTION
Add support for multiple dynamic dimensions (e.g. `(None, None, 3)` for arbitrary sized images) and `to_pandas()` conversion for dynamic arrays.

TODOs:
* [ ] Cleaner code
* [ ] Formatting issues (if NumPy doesn't allow broadcasting even though dtype is np.object)
* [ ] Fix some issues with zero-dim tensors 
* [ ] Tests
