### PR TITLE
Extend support for streaming datasets that use pd.read_excel

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -13,6 +13,7 @@ from .utils.streaming_download_manager import (
     xlistdir,
     xopen,
     xpandas_read_csv,
+    xpandas_read_excel,
     xpathglob,
     xpathjoin,
     xpathopen,
@@ -74,4 +75,5 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch.object(module.Path, "stem", property(fget=xpathstem)).start()
         patch.object(module.Path, "suffix", property(fget=xpathsuffix)).start()
     patch_submodule(module, "pd.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
+    patch_submodule(module, "pd.read_excel", xpandas_read_excel).start()
     module._patched_for_streaming = True

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -75,5 +75,5 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch.object(module.Path, "stem", property(fget=xpathstem)).start()
         patch.object(module.Path, "suffix", property(fget=xpathsuffix)).start()
     patch_submodule(module, "pd.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
-    patch_submodule(module, "pd.read_excel", xpandas_read_excel).start()
+    patch_submodule(module, "pd.read_excel", xpandas_read_excel, attrs=["__version__"]).start()
     module._patched_for_streaming = True

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -5,6 +5,7 @@ import re
 import tarfile
 import time
 from asyncio import TimeoutError
+from io import BytesIO
 from itertools import chain
 from pathlib import Path, PurePosixPath
 from typing import List, Optional, Tuple, Union
@@ -440,6 +441,12 @@ def xpandas_read_csv(filepath_or_buffer, use_auth_token: Optional[Union[str, boo
         return pd.read_csv(filepath_or_buffer, **kwargs)
     else:
         return pd.read_csv(xopen(filepath_or_buffer, use_auth_token=use_auth_token), **kwargs)
+
+
+def xpandas_read_excel(filepath_or_buffer, **kwargs):
+    import pandas as pd
+
+    return pd.read_excel(BytesIO(filepath_or_buffer.read()), **kwargs)
 
 
 class StreamingDownloadManager(object):


### PR DESCRIPTION
This PR fixes error:
```
ValueError: Cannot seek streaming HTTP file
```

CC: @severo 