### PR TITLE
Fix typo in other-structured-to-text task tag

### DIFF
--- a/datasets/atomic/README.md
+++ b/datasets/atomic/README.md
@@ -17,7 +17,7 @@ source_datasets:
 task_categories:
 - conditional-text-generation
 task_ids:
-- other-stuctured-to-text
+- other-structured-to-text
 paperswithcode_id: atomic
 ---
 

--- a/datasets/atomic/README.md
+++ b/datasets/atomic/README.md
@@ -76,6 +76,10 @@ you have any concerns.
 
 For more information, see: https://homes.cs.washington.edu/~msap/atomic/
 
+### Supported Tasks and Leaderboards
+
+[More Information Needed]
+
 ### Languages
 en
 

--- a/datasets/cs_restaurants/README.md
+++ b/datasets/cs_restaurants/README.md
@@ -114,7 +114,13 @@ The original data was produced in interactions between Amazon Mechanical Turk wo
 
 ### Annotations
 
-No annotations.
+#### Annotation process
+
+[More Information Needed]
+
+#### Who are the annotators?
+
+[More Information Needed]
 
 ### Personal and Sensitive Information
 

--- a/datasets/cs_restaurants/README.md
+++ b/datasets/cs_restaurants/README.md
@@ -20,7 +20,7 @@ task_categories:
 task_ids:
 - dialogue-modeling
 - language-modeling
-- other-stuctured-to-text
+- other-structured-to-text
 paperswithcode_id: czech-restaurant-information
 ---
 
@@ -61,7 +61,7 @@ This is a dataset for NLG in task-oriented spoken dialogue systems with Czech as
 
 ### Supported Tasks and Leaderboards
 
-- `other-stuctured-to-text`: The dataset can be used to train a model for data-to-text generation: from a desired dialogue act, the model must produce textual output that conveys this intention.
+- `other-structured-to-text`: The dataset can be used to train a model for data-to-text generation: from a desired dialogue act, the model must produce textual output that conveys this intention.
 
 ### Languages
 

--- a/datasets/cs_restaurants/README.md
+++ b/datasets/cs_restaurants/README.md
@@ -22,9 +22,10 @@ task_ids:
 - language-modeling
 - other-structured-to-text
 paperswithcode_id: czech-restaurant-information
+pretty_name: Czech Restaurant
 ---
 
-# Dataset Card Creation Guide
+# Dataset Card for Czech Restaurant
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)

--- a/datasets/enriched_web_nlg/README.md
+++ b/datasets/enriched_web_nlg/README.md
@@ -21,6 +21,7 @@ task_categories:
 task_ids:
 - other-structured-to-text
 paperswithcode_id: null
+pretty_name: Enriched WebNLG
 ---
 
 # Dataset Card for WebNLG

--- a/datasets/enriched_web_nlg/README.md
+++ b/datasets/enriched_web_nlg/README.md
@@ -19,7 +19,7 @@ source_datasets:
 task_categories:
 - conditional-text-generation
 task_ids:
-- other-stuctured-to-text
+- other-structured-to-text
 paperswithcode_id: null
 ---
 

--- a/datasets/gem/README.md
+++ b/datasets/gem/README.md
@@ -248,13 +248,13 @@ task_categories:
   - conditional-text-generation
 task_ids:
   common_gen:
-  - other-stuctured-to-text
+  - other-structured-to-text
   cs_restaurants:
-  - other-stuctured-to-text
+  - other-structured-to-text
   dart:
-  - other-stuctured-to-text
+  - other-structured-to-text
   e2e_nlg:
-  - other-stuctured-to-text
+  - other-structured-to-text
   mlsum_de:
   - summarization
   mlsum_es:
@@ -264,9 +264,9 @@ task_ids:
   totto:
   - table-to-text
   web_nlg_en:
-  - other-stuctured-to-text
+  - other-structured-to-text
   web_nlg_ru:
-  - other-stuctured-to-text
+  - other-structured-to-text
   wiki_auto_asset_turk:
   - text-simplification
   wiki_lingua_es_en:

--- a/datasets/gem/README.md
+++ b/datasets/gem/README.md
@@ -280,9 +280,10 @@ task_ids:
   xsum:
   - summarization
 paperswithcode_id: gem
+pretty_name: GEM
 ---
 
-# Dataset Card for "gem"
+# Dataset Card for GEM
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)

--- a/datasets/id_puisi/README.md
+++ b/datasets/id_puisi/README.md
@@ -20,6 +20,7 @@ task_ids:
 - language-modeling
 - other-structured-to-text
 paperswithcode_id: null
+pretty_name: Indonesian Puisi
 ---
 
 # Dataset Card for id_puisi

--- a/datasets/id_puisi/README.md
+++ b/datasets/id_puisi/README.md
@@ -18,7 +18,7 @@ task_categories:
 - sequence-modeling
 task_ids:
 - language-modeling
-- other-stuctured-to-text
+- other-structured-to-text
 paperswithcode_id: null
 ---
 

--- a/datasets/nell/README.md
+++ b/datasets/nell/README.md
@@ -103,6 +103,10 @@ Learn to read better than yesterday. NELL uses a variety of methods to extract b
 
 For more information, see: http://rtw.ml.cmu.edu/rtw/resources
 
+### Supported Tasks and Leaderboards
+
+[More Information Needed]
+
 ### Languages
 en, and perhaps some others
 

--- a/datasets/nell/README.md
+++ b/datasets/nell/README.md
@@ -26,7 +26,7 @@ task_categories:
 task_ids:
 - entity-linking-retrieval
 - fact-checking-retrieval
-- other-stuctured-to-text
+- other-structured-to-text
 paperswithcode_id: nell
 ---
 

--- a/datasets/nell/README.md
+++ b/datasets/nell/README.md
@@ -28,6 +28,7 @@ task_ids:
 - fact-checking-retrieval
 - other-structured-to-text
 paperswithcode_id: nell
+pretty_name: Never Ending Language Learning (NELL)
 ---
 
 # Dataset Card for Never Ending Language Learning (NELL)

--- a/datasets/ollie/README.md
+++ b/datasets/ollie/README.md
@@ -22,6 +22,7 @@ task_ids:
 - other-structured-to-text
 - other-other-relation-extraction
 paperswithcode_id: null
+pretty_name: Ollie
 ---
 
 # Dataset Card for Ollie
@@ -81,6 +82,10 @@ conditions (if X then).
 
 More information is available at the Ollie homepage:
 https://knowitall.github.io/ollie/
+
+### Supported Tasks and Leaderboards
+
+[More Information Needed]
 
 ### Languages
 en
@@ -195,7 +200,6 @@ Since the data is gathered from the web, there is likely to be biased text and r
 
 [More Information Needed]
 
-
 ## Additional Information
 
 ### Dataset Curators
@@ -208,12 +212,15 @@ The University of Washington academic license: https://raw.githubusercontent.com
 
 
 ### Citation Information
+
+```
 @inproceedings{ollie-emnlp12,
   author = {Mausam and Michael Schmitz and Robert Bart and Stephen Soderland and Oren Etzioni},
   title = {Open Language Learning for Information Extraction},
   booktitle = {Proceedings of Conference on Empirical Methods in Natural Language Processing and Computational Natural Language Learning (EMNLP-CONLL)},
   year = {2012}
 }
+```
 
 ### Contributions
 

--- a/datasets/ollie/README.md
+++ b/datasets/ollie/README.md
@@ -19,7 +19,7 @@ source_datasets:
 task_categories:
 - other
 task_ids:
-- other-stuctured-to-text
+- other-structured-to-text
 - other-other-relation-extraction
 paperswithcode_id: null
 ---

--- a/datasets/pubmed/README.md
+++ b/datasets/pubmed/README.md
@@ -24,9 +24,10 @@ task_ids:
 - text-scoring-other-citation-estimation
 - topic-classification
 paperswithcode_id: pubmed
+pretty_name: PubMed
 ---
 
-# Dataset Card for [Dataset Name]
+# Dataset Card for PubMed
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)
@@ -197,7 +198,7 @@ There are no splits in this dataset. It is given as is.
 
 ### Citation Information
 
-[More Information Needed]
+[Courtesy of the U.S. National Library of Medicine](https://www.nlm.nih.gov/databases/download/terms_and_conditions.html).
 
 ### Contributions
 

--- a/datasets/pubmed/README.md
+++ b/datasets/pubmed/README.md
@@ -20,7 +20,7 @@ task_categories:
 - text-scoring
 task_ids:
 - language-modeling
-- other-stuctured-to-text
+- other-structured-to-text
 - text-scoring-other-citation-estimation
 - topic-classification
 paperswithcode_id: pubmed

--- a/datasets/spider/README.md
+++ b/datasets/spider/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - conditional-text-generation
 task_ids:
-- conditional-text-generation
 - other-structured-to-text
 paperswithcode_id: spider-1
 pretty_name: Spider
@@ -143,6 +142,8 @@ The listed authors in the homepage are maintaining/supporting the dataset.
 ### Dataset Curators
 
 [More Information Needed]
+
+### Licensing Information
 
 The spider dataset is licensed under 
 the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/legalcode)

--- a/datasets/spider/README.md
+++ b/datasets/spider/README.md
@@ -17,7 +17,8 @@ source_datasets:
 task_categories:
 - conditional-text-generation
 task_ids:
-- conditional-text-generation-other-stuctured-to-text
+- conditional-text-generation
+- other-structured-to-text
 paperswithcode_id: spider-1
 pretty_name: Spider
 ---

--- a/datasets/times_of_india_news_headlines/README.md
+++ b/datasets/times_of_india_news_headlines/README.md
@@ -23,9 +23,10 @@ task_ids:
 - other-structured-to-text
 - text-simplification
 paperswithcode_id: null
+pretty_name: Times of India News Headlines
 ---
 
-# Dataset Card for [Needs More Information]
+# Dataset Card for Times of India News Headlines
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)

--- a/datasets/times_of_india_news_headlines/README.md
+++ b/datasets/times_of_india_news_headlines/README.md
@@ -20,7 +20,7 @@ task_ids:
 - document-retrieval
 - explanation-generation
 - fact-checking-retrieval
-- other-stuctured-to-text
+- other-structured-to-text
 - text-simplification
 paperswithcode_id: null
 ---

--- a/datasets/web_nlg/README.md
+++ b/datasets/web_nlg/README.md
@@ -50,21 +50,21 @@ task_categories:
   - conditional-text-generation
 task_ids:
   release_v1:
-  - other-stuctured-to-text
+  - other-structured-to-text
   release_v2:
-  - other-stuctured-to-text
+  - other-structured-to-text
   release_v2.1:
-  - other-stuctured-to-text
+  - other-structured-to-text
   release_v2.1_constrained:
-  - other-stuctured-to-text
+  - other-structured-to-text
   release_v2_constrained:
-  - other-stuctured-to-text
+  - other-structured-to-text
   release_v3.0_en:
-  - other-stuctured-to-text
+  - other-structured-to-text
   release_v3.0_ru:
-  - other-stuctured-to-text
+  - other-structured-to-text
   webnlg_challenge_2017:
-  - other-stuctured-to-text
+  - other-structured-to-text
 paperswithcode_id: webnlg
 pretty_name: WebNLG
 ---

--- a/src/datasets/utils/resources/tasks.json
+++ b/src/datasets/utils/resources/tasks.json
@@ -8,7 +8,7 @@
             "table-to-text",
             "text-simplification",
             "explanation-generation",
-            "other-stuctured-to-text",
+            "other-structured-to-text",
             "other"
         ]
     },


### PR DESCRIPTION
Fix typo in task tag: 
- `other-stuctured-to-text` (before)
- `other-structured-to-text` (now)