### PR TITLE
Fix dict source_datasets tagset validator

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from collections import Counter
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
@@ -84,24 +85,25 @@ def tagset_validator(
     url: str,
     escape_validation_predicate_fn: Optional[Callable[[Any], bool]] = None,
 ) -> ValidatorOutput:
+    reference_values = re.compile("^(?:" + "|".join(reference_values) + ")$")
     if isinstance(items, list):
         if escape_validation_predicate_fn is not None:
             invalid_values = [
-                v for v in items if v not in reference_values and escape_validation_predicate_fn(v) is False
+                v for v in items if not reference_values.match(v) and escape_validation_predicate_fn(v) is False
             ]
         else:
-            invalid_values = [v for v in items if v not in reference_values]
+            invalid_values = [v for v in items if not reference_values.match(v)]
 
     else:
         invalid_values = []
         if escape_validation_predicate_fn is not None:
             for config_name, values in items.items():
                 invalid_values += [
-                    v for v in values if v not in reference_values and escape_validation_predicate_fn(v) is False
+                    v for v in values if not reference_values.match(v) and escape_validation_predicate_fn(v) is False
                 ]
         else:
             for config_name, values in items.items():
-                invalid_values += [v for v in values if v not in reference_values]
+                invalid_values += [v for v in values if not reference_values.match(v)]
 
     if len(invalid_values) > 0:
         return [], f"{invalid_values} are not registered tags for '{name}', reference at {url}"

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -38,6 +38,7 @@ known_task_ids, known_task_ids_url = load_json_resource("tasks.json")
 known_creators, known_creators_url = load_json_resource("creators.json")
 known_size_categories, known_size_categories_url = load_json_resource("size_categories.json")
 known_multilingualities, known_multilingualities_url = load_json_resource("multilingualities.json")
+known_source_datasets, known_source_datasets_url = ["original", "extended", r"extended\|.*"], this_url
 
 
 class NoDuplicateSafeLoader(yaml.SafeLoader):
@@ -343,18 +344,7 @@ class DatasetMetadata:
 
     @staticmethod
     def validate_source_datasets(sources: Union[List[str], Dict[str, List[str]]]) -> ValidatorOutput:
-        invalid_values = []
-        for src in sources:
-            is_ok = src in ["original", "extended"] or src.startswith("extended|")
-            if not is_ok:
-                invalid_values.append(src)
-        if len(invalid_values) > 0:
-            return (
-                [],
-                f"'source_datasets' has invalid values: {invalid_values}, refer to source code to understand {this_url}",
-            )
-
-        return sources, None
+        return tagset_validator(sources, known_source_datasets, "source_datasets", known_source_datasets_url)
 
     @staticmethod
     def validate_paperswithcode_id_errors(paperswithcode_id: Optional[str]) -> ValidatorOutput:


### PR DESCRIPTION
Currently, the `source_datasets` tag validation does not support passing a dict with configuration keys.

This PR:
- Extends `tagset_validator` to support regex tags
- Uses `tagset_validator` to validate dict `source_datasets`