### PR TITLE
Create Language Modeling task

### DIFF
--- a/src/datasets/tasks/__init__.py
+++ b/src/datasets/tasks/__init__.py
@@ -4,29 +4,32 @@ from ..utils.logging import get_logger
 from .automatic_speech_recognition import AutomaticSpeechRecognition
 from .base import TaskTemplate
 from .image_classification import ImageClassification
+from .language_modeling import LanguageModeling
 from .question_answering import QuestionAnsweringExtractive
 from .summarization import Summarization
 from .text_classification import TextClassification
 
 
 __all__ = [
-    "TaskTemplate",
-    "QuestionAnsweringExtractive",
-    "TextClassification",
-    "Summarization",
     "AutomaticSpeechRecognition",
     "ImageClassification",
+    "LanguageModeling",
+    "QuestionAnsweringExtractive",
+    "Summarization",
+    "TaskTemplate",
+    "TextClassification",
 ]
 
 logger = get_logger(__name__)
 
 
 NAME2TEMPLATE = {
-    QuestionAnsweringExtractive.task: QuestionAnsweringExtractive,
-    TextClassification.task: TextClassification,
     AutomaticSpeechRecognition.task: AutomaticSpeechRecognition,
-    Summarization.task: Summarization,
     ImageClassification.task: ImageClassification,
+    LanguageModeling.task: LanguageModeling,
+    QuestionAnsweringExtractive.task: QuestionAnsweringExtractive,
+    Summarization.task: Summarization,
+    TextClassification.task: TextClassification,
 }
 
 

--- a/src/datasets/tasks/language_modeling.py
+++ b/src/datasets/tasks/language_modeling.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import ClassVar, Dict
+
+from ..features import Features, Value
+from .base import TaskTemplate
+
+
+@dataclass(frozen=True)
+class LanguageModeling(TaskTemplate):
+    task: str = "language-modeling"
+
+    input_schema: ClassVar[Features] = Features({"text": Value("string")})
+    label_schema: ClassVar[Features] = Features({})
+    text_column: str = "text"
+
+    @property
+    def column_mapping(self) -> Dict[str, str]:
+        return {self.text_column: "text"}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,6 +7,7 @@ from datasets.info import DatasetInfo
 from datasets.tasks import (
     AutomaticSpeechRecognition,
     ImageClassification,
+    LanguageModeling,
     QuestionAnsweringExtractive,
     Summarization,
     TextClassification,
@@ -20,6 +21,19 @@ SAMPLE_QUESTION_ANSWERING_EXTRACTIVE = {
     "question": "To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?",
     "answers": {"text": ["Saint Bernadette Soubirous"], "answer_start": [515]},
 }
+
+
+class TestLanguageModeling:
+    def test_column_mapping(self):
+        task = LanguageModeling(text_column="input_text")
+        assert {"input_text": "text"} == task.column_mapping
+
+    def test_from_dict(self):
+        input_schema = Features({"text": Value("string")})
+        template_dict = {"text_column": "input_text"}
+        task = LanguageModeling.from_dict(template_dict)
+        assert "language-modeling" == task.task
+        assert input_schema == task.input_schema
 
 
 class TextClassificationTest(TestCase):


### PR DESCRIPTION
Create Language Modeling task to be able to specify the input "text" column in a dataset.

This can be useful for datasets which are not exclusively used for language modeling and have more than one column:
- for text classification datasets (with columns "review" and "rating", for example), the Language Modeling task can be used to specify the "text" column ("review" in this case).

TODO:
- [ ] Add the LanguageModeling task to all dataset scripts which can be used for language modeling