### PR TITLE
Fix flaky test of the temporary directory used by load_from_disk

### DIFF
--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2818,11 +2818,12 @@ def test_dummy_dataset_serialize_s3(s3, dataset):
 def test_build_local_temp_path(uri_or_path):
     extracted_path = extract_path_from_uri(uri_or_path)
     local_temp_path = Dataset._build_local_temp_path(extracted_path)
+    path_relative_to_tmp_dir = local_temp_path.as_posix().split("tmp", 1)[1].split("/", 1)[1]
 
     assert (
         "tmp" in local_temp_path.as_posix()
-        and "hdfs" not in local_temp_path.as_posix()
-        and "s3" not in local_temp_path.as_posix()
+        and "hdfs" not in path_relative_to_tmp_dir
+        and "s3" not in path_relative_to_tmp_dir
         and not local_temp_path.as_posix().startswith(extracted_path)
         and local_temp_path.as_posix().endswith(extracted_path)
     ), f"Local temp path: {local_temp_path.as_posix()}"


### PR DESCRIPTION
The test is flaky, here is an example of random CI failure:
https://github.com/huggingface/datasets/commit/73ed6615b4b3eb74d5311684f7b9e05cdb76c989

I fixed that by not checking the content of the random part of the temporary directory name