### PR TITLE
Pass new_fingerprint in multiprocessing

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2094,6 +2094,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 logger.info(f"Process #{rank} will write at {cache_file_name}")
                 return cache_file_name
 
+            def format_new_fingerprint(new_fingerprint, rank):
+                return new_fingerprint + suffix_template.format(rank=rank, num_proc=num_proc)
+
             prev_env = deepcopy(os.environ)
             # check if parallelism if off
             # from https://github.com/huggingface/tokenizers/blob/bb668bc439dc34389b71dbb8ce0c597f15707b53/tokenizers/src/utils/parallelism.rs#L22
@@ -2139,6 +2142,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     rank=rank,
                     offset=sum(len(s) for s in shards[:rank]),
                     disable_tqdm=disable_tqdm,
+                    new_fingerprint=format_new_fingerprint(new_fingerprint, rank)
+                    if new_fingerprint is not None
+                    else None,
                     desc=desc,
                 )
                 for rank in range(num_proc)


### PR DESCRIPTION
Following https://github.com/huggingface/datasets/pull/3045

Currently one can pass `new_fingerprint` to `.map()` to use a custom fingerprint instead of the one computed by hashing the map transform. However it's ignored if `num_proc>1`.

In this PR I fixed that by passing `new_fingerprint` to `._map_single()` when `num_proc>1`.
More specifically, `new_fingerprint` with a suffix based on the process `rank` is passed, so that each process has a different `new_fingerprint`

cc @TevenLeScao @vlievin