### PR TITLE
Fix dependencies conflicts in Windows CI after conda update to 4.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,20 +41,22 @@ jobs:
             shell: powershell
         steps:
             - checkout
-            - run: conda update conda
-            - run: conda create -n py36 python=3.6 anaconda
-            - run: conda activate py36
-            - run: Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
-            - run: pip install ruamel.yaml
-            - run: conda install pytorch --yes
-            - run: pip install virtualenv
-            - run: python -m virtualenv venv --system-site-packages
-            - run: "& venv/Scripts/activate.ps1"
-            - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow --upgrade
-            - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -n 2 --dist loadfile -sv ./tests/
+            - run: |
+                conda update conda
+                conda create -n py36 python=3.6 anaconda
+                conda activate py36
+                Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
+                pip install ruamel.yaml
+                conda install pytorch --yes
+            - run: |
+                conda activate py36
+                pip install .[tests]
+                pip install -r additional-tests-requirements.txt --no-deps
+                pip install pyarrow --upgrade
+            - run: |
+                conda activate py36
+                $env:HF_SCRIPTS_VERSION="master"
+                python -m pytest -n 2 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_3_WIN:
         working_directory: ~/datasets
@@ -63,20 +65,22 @@ jobs:
             shell: powershell
         steps:
             - checkout
-            - run: conda update conda
-            - run: conda create -n py36 python=3.6 anaconda
-            - run: conda activate py36
-            - run: Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
-            - run: pip install ruamel.yaml
-            - run: conda install pytorch --yes
-            - run: pip install virtualenv
-            - run: python -m virtualenv venv --system-site-packages
-            - run: "& venv/Scripts/activate.ps1"
-            - run: pip install .[tests]
-            - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow==3.0.0
-            - run: $env:HF_SCRIPTS_VERSION="master"
-            - run: python -m pytest -n 2 --dist loadfile -sv ./tests/
+            - run: |
+                conda update conda
+                conda create -n py36 python=3.6 anaconda
+                conda activate py36
+                Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
+                pip install ruamel.yaml
+                conda install pytorch --yes
+            - run: |
+                conda activate py36
+                pip install .[tests]
+                pip install -r additional-tests-requirements.txt --no-deps
+                pip install pyarrow==3.0.0
+            - run: |
+                conda activate py36
+                $env:HF_SCRIPTS_VERSION="master"
+                python -m pytest -n 2 --dist loadfile -sv ./tests/
 
     check_code_quality:
         working_directory: ~/datasets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,9 @@ jobs:
         steps:
             - checkout
             - run: |
+                conda init powershell
                 conda update conda
-                conda create -n py36 python=3.6 anaconda
-                conda activate py36
-                Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
-                pip install ruamel.yaml
-                conda install pytorch --yes
+                conda create -n py36 python=3.6 pytorch --yes
             - run: |
                 conda activate py36
                 pip install .[tests]
@@ -66,12 +63,9 @@ jobs:
         steps:
             - checkout
             - run: |
+                conda init powershell
                 conda update conda
-                conda create -n py36 python=3.6 anaconda
-                conda activate py36
-                Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
-                pip install ruamel.yaml
-                conda install pytorch --yes
+                conda create -n py36 python=3.6 pytorch --yes
             - run: |
                 conda activate py36
                 pip install .[tests]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
         steps:
             - checkout
             - run: conda update conda
-            - run: conda install python=3.6 --yes
+            - run: conda create -n py36 python=3.6 anaconda
+            - run: conda activate py36
             - run: Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
             - run: pip install ruamel.yaml
             - run: conda install pytorch --yes
@@ -63,7 +64,8 @@ jobs:
         steps:
             - checkout
             - run: conda update conda
-            - run: conda install python=3.6 --yes
+            - run: conda create -n py36 python=3.6 anaconda
+            - run: conda activate py36
             - run: Remove-Item c:\tools\miniconda3\lib\site-packages\ruamel* -Recurse -Force -Confirm:$false
             - run: pip install ruamel.yaml
             - run: conda install pytorch --yes


### PR DESCRIPTION
For some reason the CI wasn't using python 3.6 but python 3.7 after the update to conda 4.11