### PR TITLE
Fix flaky test again for s3 serialization

### DIFF
--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2945,7 +2945,7 @@ def test_dummy_dataset_serialize_s3(s3, dataset):
 def test_build_local_temp_path(uri_or_path):
     extracted_path = extract_path_from_uri(uri_or_path)
     local_temp_path = Dataset._build_local_temp_path(extracted_path)
-    path_relative_to_tmp_dir = local_temp_path.as_posix().split("tmp", 1)[1].split("/", 1)[1]
+    path_relative_to_tmp_dir = local_temp_path.as_posix().split("tmp")[-1].split("/", 1)[1]
 
     assert (
         "tmp" in local_temp_path.as_posix()


### PR DESCRIPTION
Following https://github.com/huggingface/datasets/pull/3388 that wasn't enough (see CI error [here](https://app.circleci.com/pipelines/github/huggingface/datasets/9080/workflows/b971fb27-ff20-4220-9416-c19acdfdf6f4/jobs/55985))