### PR TITLE
Skip None encoding (line deleted by accident in #3195)

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -901,7 +901,7 @@ def encode_nested_example(schema, obj):
     # Object with special encoding:
     # ClassLabel will convert from string to int, TranslationVariableLanguages does some checks
     elif isinstance(schema, (Audio, Image, ClassLabel, TranslationVariableLanguages, Value, _ArrayXD)):
-        return schema.encode_example(obj)
+        return schema.encode_example(obj) if obj is not None else None
     # Other object should be directly convertible to a native Arrow type (like Translation and Translation)
     return obj
 


### PR DESCRIPTION
Return the line deleted by accident in #3195 while [resolving merge conflicts](https://github.com/huggingface/datasets/pull/3195/commits/8b0ed15be08559056b817836a07d47acda0c4510).


Fix #3181 (finally :))
