### PR TITLE
Update BLEURT hyperlink

### DIFF
--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -39,7 +39,7 @@ BLEURT a learnt evaluation metric for Natural Language Generation. It is built u
 and then employing another pre-training phrase using synthetic data. Finally it is trained on WMT human annotations. You may run BLEURT out-of-the-box or fine-tune
 it for your specific application (the latter is expected to perform better).
 
-See the project's `README <https://github.com/google-research/bleurt>`__ for more information.
+See the project's README at https://github.com/google-research/bleurt for more information.
 """
 
 _KWARGS_DESCRIPTION = """

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -39,7 +39,7 @@ BLEURT a learnt evaluation metric for Natural Language Generation. It is built u
 and then employing another pre-training phrase using synthetic data. Finally it is trained on WMT human annotations. You may run BLEURT out-of-the-box or fine-tune
 it for your specific application (the latter is expected to perform better).
 
-See the project's [README](https://github.com/google-research/bleurt) for more information.
+See the project's `README <https://github.com/google-research/bleurt>`__ for more information.
 """
 
 _KWARGS_DESCRIPTION = """

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -39,7 +39,7 @@ BLEURT a learnt evaluation metric for Natural Language Generation. It is built u
 and then employing another pre-training phrase using synthetic data. Finally it is trained on WMT human annotations. You may run BLEURT out-of-the-box or fine-tune
 it for your specific application (the latter is expected to perform better).
 
-See the [README.md] file at https://github.com/google-research/bleurt for more information.
+See the project's [README](https://github.com/google-research/bleurt) for more information.
 """
 
 _KWARGS_DESCRIPTION = """


### PR DESCRIPTION
The description of BLEURT on the hf.co website has a strange use of URL hyperlinking. This PR attempts to fix this, although I am not 100% sure Markdown syntax is allowed on the frontend or not.

![Screen Shot 2021-12-15 at 17 31 27](https://user-images.githubusercontent.com/26859204/146226432-c83cbdaf-f57d-4999-b53c-85da718ff7fb.png)


