### PR TITLE
Extend text to support yielding lines, paragraphs or documents

### DIFF
--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -75,7 +75,9 @@ class Text(datasets.ArrowBasedBuilder):
                             break
                         batch += f.readline()  # finish current line
                         batch = batch.split("\n\n")
-                        pa_table = pa.Table.from_arrays([pa.array(batch[:-1])], schema=schema)
+                        pa_table = pa.Table.from_arrays(
+                            [pa.array([example for example in batch[:-1] if example])], schema=schema
+                        )
                         # Uncomment for debugging (will print the Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))

--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -84,4 +84,5 @@ class Text(datasets.ArrowBasedBuilder):
                         batch = batch[-1]
                 elif self.config.row == "document":
                     text = f.read()
-                    yield file_idx, pa.Table.from_pydict({"text": [text]})
+                    pa_table = pa.Table.from_arrays([pa.array([text])], schema=schema)
+                    yield file_idx, pa_table

--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -17,6 +17,7 @@ class TextConfig(datasets.BuilderConfig):
     encoding: str = "utf-8"
     chunksize: int = 10 << 20  # 10MB
     keep_linebreaks: bool = False
+    row: str = "line"
 
 
 class Text(datasets.ArrowBasedBuilder):
@@ -51,15 +52,36 @@ class Text(datasets.ArrowBasedBuilder):
         for file_idx, file in enumerate(files):
             batch_idx = 0
             with open(file, "r", encoding=self.config.encoding) as f:
-                while True:
-                    batch = f.read(self.config.chunksize)
-                    if not batch:
-                        break
-                    batch += f.readline()  # finish current line
-                    batch = batch.splitlines(keepends=self.config.keep_linebreaks)
-                    pa_table = pa.Table.from_arrays([pa.array(batch)], schema=schema)
-                    # Uncomment for debugging (will print the Arrow table size and elements)
-                    # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
-                    # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
-                    yield (file_idx, batch_idx), pa_table
-                    batch_idx += 1
+                if self.config.row == "line":
+                    batch_idx = 0
+                    while True:
+                        batch = f.read(self.config.chunksize)
+                        if not batch:
+                            break
+                        batch += f.readline()  # finish current line
+                        batch = batch.splitlines(keepends=self.config.keep_linebreaks)
+                        pa_table = pa.Table.from_arrays([pa.array(batch)], schema=schema)
+                        # Uncomment for debugging (will print the Arrow table size and elements)
+                        # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
+                        # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
+                        yield (file_idx, batch_idx), pa_table
+                        batch_idx += 1
+                elif self.config.row == "paragraph":
+                    batch_idx = 0
+                    batch = ""
+                    while True:
+                        batch += f.read(self.config.chunksize)
+                        if not batch:
+                            break
+                        batch += f.readline()  # finish current line
+                        batch = batch.split("\n\n")
+                        pa_table = pa.Table.from_arrays([pa.array(batch[:-1])], schema=schema)
+                        # Uncomment for debugging (will print the Arrow table size and elements)
+                        # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
+                        # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
+                        yield (file_idx, batch_idx), pa_table
+                        batch_idx += 1
+                        batch = batch[-1]
+                elif self.config.row == "document":
+                    text = f.read()
+                    yield file_idx, pa.Table.from_pydict({"text": [text]})

--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -17,7 +17,7 @@ class TextConfig(datasets.BuilderConfig):
     encoding: str = "utf-8"
     chunksize: int = 10 << 20  # 10MB
     keep_linebreaks: bool = False
-    row: str = "line"
+    sample_by: str = "line"
 
 
 class Text(datasets.ArrowBasedBuilder):
@@ -52,7 +52,7 @@ class Text(datasets.ArrowBasedBuilder):
         for file_idx, file in enumerate(files):
             batch_idx = 0
             with open(file, "r", encoding=self.config.encoding) as f:
-                if self.config.row == "line":
+                if self.config.sample_by == "line":
                     batch_idx = 0
                     while True:
                         batch = f.read(self.config.chunksize)
@@ -66,7 +66,7 @@ class Text(datasets.ArrowBasedBuilder):
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
                         yield (file_idx, batch_idx), pa_table
                         batch_idx += 1
-                elif self.config.row == "paragraph":
+                elif self.config.sample_by == "paragraph":
                     batch_idx = 0
                     batch = ""
                     while True:
@@ -82,7 +82,7 @@ class Text(datasets.ArrowBasedBuilder):
                         yield (file_idx, batch_idx), pa_table
                         batch_idx += 1
                         batch = batch[-1]
-                elif self.config.row == "document":
+                elif self.config.sample_by == "document":
                     text = f.read()
                     pa_table = pa.Table.from_arrays([pa.array([text])], schema=schema)
                     yield file_idx, pa_table


### PR DESCRIPTION
Add `config.row` option to `text` module to allow yielding lines (default, current case), paragraphs or documents.

Feel free to comment on the name of the config parameter `row`:
- Currently, the docs state datasets are made of rows and columns
- Other names I considered: `example`, `item`