### PR TITLE
Fix iter_archive generator

### DIFF
--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -239,15 +239,15 @@ class DownloadManager:
                     # skipping hidden files
                     continue
                 file_obj = stream.extractfile(tarinfo)
-                yield (file_path, file_obj)
+                yield file_path, file_obj
                 stream.members = []
             del stream
 
         if hasattr(path_or_buf, "read"):
-            return _iter_archive(path_or_buf)
+            yield from _iter_archive(path_or_buf)
         else:
             with open(path_or_buf, "rb") as f:
-                return _iter_archive(f)
+                yield from _iter_archive(f)
 
     def iter_files(self, paths):
         """Iterate over file paths.

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -586,15 +586,15 @@ class StreamingDownloadManager(object):
                     # skipping hidden files
                     continue
                 file_obj = stream.extractfile(tarinfo)
-                yield (file_path, file_obj)
+                yield file_path, file_obj
                 stream.members = []
             del stream
 
         if hasattr(urlpath_or_buf, "read"):
-            return _iter_archive(urlpath_or_buf)
+            yield from _iter_archive(urlpath_or_buf)
         else:
             with xopen(urlpath_or_buf, "rb", use_auth_token=self.download_config.use_auth_token) as f:
-                return _iter_archive(f)
+                yield from _iter_archive(f)
 
     def iter_files(self, urlpaths):
         """Iterate over files.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import csv
 import json
 import lzma
 import os
+import tarfile
 import textwrap
 
 import pyarrow as pa
@@ -397,6 +398,23 @@ def zip_jsonl_with_dir_path(jsonl_path, jsonl2_path, tmp_path_factory):
     with zipfile.ZipFile(path, "w") as f:
         f.write(jsonl_path, arcname=os.path.join("main_dir", os.path.basename(jsonl_path)))
         f.write(jsonl2_path, arcname=os.path.join("main_dir", os.path.basename(jsonl2_path)))
+    return path
+
+
+@pytest.fixture(scope="session")
+def tar_jsonl_path(jsonl_path, jsonl2_path, tmp_path_factory):
+    path = tmp_path_factory.mktemp("data") / "dataset.jsonl.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(jsonl_path, arcname=os.path.basename(jsonl_path))
+        f.add(jsonl2_path, arcname=os.path.basename(jsonl2_path))
+    return path
+
+
+@pytest.fixture(scope="session")
+def tar_nested_jsonl_path(tar_jsonl_path, jsonl_path, jsonl2_path, tmp_path_factory):
+    path = tmp_path_factory.mktemp("data") / "dataset_nested.jsonl.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(tar_jsonl_path, arcname=os.path.join("nested", os.path.basename(tar_jsonl_path)))
     return path
 
 

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -111,3 +111,27 @@ def test_download_manager_extract(paths_type, xz_file, text_file):
             extracted_file_content = extracted_path.read_text()
             expected_file_content = text_file.read_text()
             assert extracted_file_content == expected_file_content
+
+
+def _test_jsonl(path, file):
+    assert path.endswith(".jsonl")
+    for num_items, line in enumerate(file, start=1):
+        item = json.loads(line.decode("utf-8"))
+        assert item.keys() == {"col_1", "col_2", "col_3"}
+    assert num_items == 4
+
+
+def test_iter_archive_path(tar_jsonl_path):
+    dl_manager = DownloadManager()
+    for num_jsonl, (path, file) in enumerate(dl_manager.iter_archive(tar_jsonl_path), start=1):
+        _test_jsonl(path, file)
+    assert num_jsonl == 2
+
+
+def test_iter_archive_file(tar_nested_jsonl_path):
+    dl_manager = DownloadManager()
+    for num_tar, (path, file) in enumerate(dl_manager.iter_archive(tar_nested_jsonl_path), start=1):
+        for num_jsonl, (subpath, subfile) in enumerate(dl_manager.iter_archive(file), start=1):
+            _test_jsonl(subpath, subfile)
+    assert num_tar == 1
+    assert num_jsonl == 2

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from pathlib import Path
@@ -573,3 +574,27 @@ def test_streaming_gg_drive_zipped():
     assert xbasename(all_files[0]) == TEST_GG_DRIVE_FILENAME
     with xopen(all_files[0]) as f:
         assert f.read() == TEST_GG_DRIVE_CONTENT
+
+
+def _test_jsonl(path, file):
+    assert path.endswith(".jsonl")
+    for num_items, line in enumerate(file, start=1):
+        item = json.loads(line.decode("utf-8"))
+        assert item.keys() == {"col_1", "col_2", "col_3"}
+    assert num_items == 4
+
+
+def test_iter_archive_path(tar_jsonl_path):
+    dl_manager = StreamingDownloadManager()
+    for num_jsonl, (path, file) in enumerate(dl_manager.iter_archive(str(tar_jsonl_path)), start=1):
+        _test_jsonl(path, file)
+    assert num_jsonl == 2
+
+
+def test_iter_archive_file(tar_nested_jsonl_path):
+    dl_manager = StreamingDownloadManager()
+    for num_tar, (path, file) in enumerate(dl_manager.iter_archive(str(tar_nested_jsonl_path)), start=1):
+        for num_jsonl, (subpath, subfile) in enumerate(dl_manager.iter_archive(file), start=1):
+            _test_jsonl(subpath, subfile)
+    assert num_tar == 1
+    assert num_jsonl == 2


### PR DESCRIPTION
This PR:
- Adds tests to DownloadManager and StreamingDownloadManager `iter_archive` for both path and file inputs
- Fixes bugs in `iter_archive` introduced in:
  - #3443


Fix #3453.