### PR TITLE
[WER] Better error message for wer

### DIFF
--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -94,6 +94,21 @@ class WER(datasets.Metric):
         )
 
     def _compute(self, predictions=None, references=None, concatenate_texts=False):
+        if type(predictions) != type(references):
+            raise ValueError(
+                f"`predictions` {predictions} are of type {type(predictions)}, "
+                f" while `targets` {references} are of type {type(references)}. "
+                "Make sure `predictions` and `targets` are of the same type."
+            )
+
+        inputs_are_lists = isinstance(predictions, (list, tuple)) and isinstance(references, (list, tuple))
+        if inputs_are_lists and (type(predictions[0]) != type(references[0])):  # noqa: E721
+            raise ValueError(
+                f"`predictions` {predictions} is a list/tuple of type {type(predictions[0])}, "
+                f" while `targets` {references} is a list/tuple of type {type(references[0])}. "
+                "Make sure `predictions` and `targets` are a list/tuple of the same type."
+            )
+
         if concatenate_texts:
             return compute_measures(references, predictions)["wer"]
         else:


### PR DESCRIPTION
Currently we have the following problem when using the WER. When the input format to the WER metric is wrong, instead of throwing an error message a word-error-rate is computed which is incorrect. E.g. when doing the following: 


```python
from datasets import load_metric

wer = load_metric("wer")

target_str = ["hello this is nice", "hello the weather is bloomy"]
pred_str = [["hello it's nice"], ["hello it's the weather"]]

print("Wrong:", wer.compute(predictions=pred_str, references=target_str))
print("Correct", wer.compute(predictions=[x[0] for x in pred_str], references=target_str))
```
We get:
```
Wrong: 1.0
Correct 0.5555555555555556
```

meaning that we get a word-error rate for incorrectly passed input formats. We should raise an error here instead so that people don't spent hours fixing a model while it's their incorrect evaluation metric is the problem for a low WER.