### PR TITLE
Fix links in metrics description

### DIFF
--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -53,8 +53,7 @@ It has been shown to correlate with human judgment on sentence-level and system-
 Moreover, BERTScore computes precision, recall, and F1 measure, which can be useful for evaluating different language
 generation tasks.
 
-See the `README.md` file at [https://github.com/Tiiiger/bert_score](https://github.com/Tiiiger/bert_score) for more
-information.
+See the project's README at https://github.com/Tiiiger/bert_score#readme for more information.
 """
 
 _KWARGS_DESCRIPTION = """

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -39,7 +39,7 @@ BLEURT a learnt evaluation metric for Natural Language Generation. It is built u
 and then employing another pre-training phrase using synthetic data. Finally it is trained on WMT human annotations. You may run BLEURT out-of-the-box or fine-tune
 it for your specific application (the latter is expected to perform better).
 
-See the project's README at https://github.com/google-research/bleurt for more information.
+See the project's README at https://github.com/google-research/bleurt#readme for more information.
 """
 
 _KWARGS_DESCRIPTION = """


### PR DESCRIPTION
Remove Markdown syntax for links in metrics description, as it is not properly rendered.

Related to #3437.