### PR TITLE
Fix METEOR missing NLTK's omw-1.4

### DIFF
--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -108,6 +108,8 @@ class Meteor(datasets.Metric):
         nltk.download("wordnet")
         if NLTK_VERSION >= version.Version("3.6.4"):
             nltk.download("punkt")
+        if NLTK_VERSION >= version.Version("3.6.6"):
+            nltk.download("omw-1.4")
 
     def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
         if NLTK_VERSION >= version.Version("3.6.4"):

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -88,7 +88,10 @@ class LocalMetricTest(parameterized.TestCase):
         # run doctest
         with self.patch_intensive_calls(metric_name, metric_module.__name__):
             with self.use_local_metrics():
-                results = doctest.testmod(metric_module, verbose=True, raise_on_error=True)
+                try:
+                    results = doctest.testmod(metric_module, verbose=True, raise_on_error=True)
+                except doctest.UnexpectedException as e:
+                    raise e.exc_info[1]  # raise the exception that doctest caught
         self.assertEqual(results.failed, 0)
         self.assertGreater(results.attempted, 1)
 


### PR DESCRIPTION
NLTK 3.6.6 now requires `omw-1.4` to be downloaded for METEOR to work.
This should fix the CI on master