### PR TITLE
Decode images when iterating

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1655,10 +1655,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         selected format.
         """
         for index in range(self.num_rows):
-            yield self._getitem(
-                index,
-                decoded=False,
-            )
+            yield self._getitem(index)
 
     def __repr__(self):
         return f"Dataset({{\n    features: {list(self.features.keys())},\n    num_rows: {self.num_rows}\n}})"


### PR DESCRIPTION
If I iterate over a vision dataset, the images are not decoded, and the dictionary with the bytes is returned.

This PR enables image decoding in `Dataset.__iter__`

Close https://github.com/huggingface/datasets/issues/3473