### PR TITLE
Extend support for streaming datasets that use ET.parse

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -8,6 +8,7 @@ from .utils.patching import patch_submodule
 from .utils.streaming_download_manager import (
     xbasename,
     xdirname,
+    xet_parse,
     xglob,
     xjoin,
     xlistdir,
@@ -80,4 +81,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
         patch.object(module.Path, "suffix", property(fget=xpathsuffix)).start()
     patch_submodule(module, "pd.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
     patch_submodule(module, "pd.read_excel", xpandas_read_excel, attrs=["__version__"]).start()
+    # xml.etree.ElementTree
+    for submodule in ["ElementTree", "ET"]:
+        patch_submodule(module, f"{submodule}.parse", xet_parse).start()
     module._patched_for_streaming = True

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -83,5 +83,5 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     patch_submodule(module, "pd.read_excel", xpandas_read_excel, attrs=["__version__"]).start()
     # xml.etree.ElementTree
     for submodule in ["ElementTree", "ET"]:
-        patch_submodule(module, f"{submodule}.parse", xet_parse).start()
+        patch_submodule(module, f"{submodule}.parse", wrap_auth(xet_parse)).start()
     module._patched_for_streaming = True

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -504,12 +504,14 @@ def xpandas_read_excel(filepath_or_buffer, **kwargs):
     return pd.read_excel(BytesIO(filepath_or_buffer.read()), **kwargs)
 
 
-def xet_parse(source, parser=None):
+def xet_parse(source, parser=None, use_auth_token: Optional[Union[str, bool]] = None):
     """Extend `xml.etree.ElementTree.parse` function to support remote files.
 
     Args:
         source: File path or file object.
         parser (optional, default `XMLParser`): Parser instance.
+        use_auth_token (:obj:`bool` or :obj:`str`, optional): Whether to use token or token to authenticate on the
+            Hugging Face Hub for private remote files.
 
     Returns:
         :obj:`xml.etree.ElementTree.Element`: Root element of the given source document.
@@ -517,7 +519,7 @@ def xet_parse(source, parser=None):
     if hasattr(source, "read"):
         return ET.parse(source, parser=parser)
     else:
-        with xopen(source, "rb") as f:
+        with xopen(source, "rb", use_auth_token=use_auth_token) as f:
             return ET.parse(f, parser=parser)
 
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from itertools import chain
 from pathlib import Path, PurePosixPath
 from typing import List, Optional, Tuple, Union
+from xml.etree import ElementTree as ET
 
 import fsspec
 from aiohttp.client_exceptions import ClientError
@@ -501,6 +502,23 @@ def xpandas_read_excel(filepath_or_buffer, **kwargs):
     import pandas as pd
 
     return pd.read_excel(BytesIO(filepath_or_buffer.read()), **kwargs)
+
+
+def xet_parse(source, parser=None):
+    """Extend `xml.etree.ElementTree.parse` function to support remote files.
+
+    Args:
+        source: File path or file object.
+        parser (optional, default `XMLParser`): Parser instance.
+
+    Returns:
+        :obj:`xml.etree.ElementTree.Element`: Root element of the given source document.
+    """
+    if hasattr(source, "read"):
+        return ET.parse(source, parser=parser)
+    else:
+        with xopen(source, "rb") as f:
+            return ET.parse(f, parser=parser)
 
 
 class StreamingDownloadManager(object):


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `ET.parse`, by patching the function.

This PR adds support for streaming mode to datasets:
1. ami
1. assin
1. assin2
1. counter
1. enriched_web_nlg
1. europarl_bilingual
1. hyperpartisan_news_detection
1. polsum
1. qa4mre
1. quail
1. ted_talks_iwslt
1. udhr
1. web_nlg
1. winograd_wsc

CC: @severo