### PR TITLE
Use `iter_files` instead of `str(Path(...)` in image dataset

### DIFF
--- a/datasets/beans/beans.py
+++ b/datasets/beans/beans.py
@@ -74,19 +74,19 @@ class Beans(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "files": dl_manager.iter_files(data_files["train"]),
+                    "files": dl_manager.iter_files([data_files["train"]]),
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
-                    "files": dl_manager.iter_files(data_files["validation"]),
+                    "files": dl_manager.iter_files([data_files["validation"]]),
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "files": dl_manager.iter_files(data_files["test"]),
+                    "files": dl_manager.iter_files([data_files["test"]]),
                 },
             ),
         ]

--- a/datasets/beans/beans.py
+++ b/datasets/beans/beans.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Beans leaf dataset with images of diseased and health leaves."""
 
-from pathlib import Path
+import os
 
 import datasets
 from datasets.tasks import ImageClassification
@@ -74,24 +74,29 @@ class Beans(datasets.GeneratorBasedBuilder):
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "archive": data_files["train"],
+                    "files": dl_manager.iter_files(data_files["train"]),
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
-                    "archive": data_files["validation"],
+                    "files": dl_manager.iter_files(data_files["validation"]),
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "archive": data_files["test"],
+                    "files": dl_manager.iter_files(data_files["test"]),
                 },
             ),
         ]
 
-    def _generate_examples(self, archive):
-        for i, path in enumerate(Path(archive).glob("**/*")):
-            if path.suffix == ".jpg":
-                yield i, {"image_file_path": str(path), "image": str(path), "labels": path.parent.name.lower()}
+    def _generate_examples(self, files):
+        for i, path in enumerate(files):
+            file_name = os.path.basename(path)
+            if file_name.endswith(".jpg"):
+                yield i, {
+                    "image_file_path": path,
+                    "image": path,
+                    "labels": os.path.basename(os.path.dirname(path)).lower(),
+                }

--- a/datasets/cats_vs_dogs/cats_vs_dogs.py
+++ b/datasets/cats_vs_dogs/cats_vs_dogs.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """The Microsoft Cats vs. Dogs dataset"""
 
-from pathlib import Path
+import os
 from typing import List
 
 import datasets
@@ -61,19 +61,20 @@ class CatsVsDogs(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager: datasets.DownloadManager) -> List[datasets.SplitGenerator]:
-        images_path = Path(dl_manager.download_and_extract(_URL)) / "PetImages"
+        images_path = os.path.join(dl_manager.download_and_extract(_URL), "PetImages")
         return [
-            datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"images_path": images_path}),
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN, gen_kwargs={"files": dl_manager.iter_files(images_path)}
+            ),
         ]
 
-    def _generate_examples(self, images_path):
-        logger.info("generating examples from = %s", images_path)
-        for i, filepath in enumerate(images_path.glob("**/*.jpg")):
-            with filepath.open("rb") as f:
-                if b"JFIF" in f.peek(10):
-                    yield str(i), {
-                        "image_file_path": str(filepath),
-                        "image": str(filepath),
-                        "labels": filepath.parent.name.lower(),
-                    }
-                    continue
+    def _generate_examples(self, files):
+        for i, file in enumerate(files):
+            if os.path.basename(file).endswith(".jpg"):
+                with open(file, "rb") as f:
+                    if b"JFIF" in f.peek(10):
+                        yield str(i), {
+                            "image_file_path": file,
+                            "image": file,
+                            "labels": os.path.basename(os.path.dirname(file)).lower(),
+                        }

--- a/datasets/cats_vs_dogs/cats_vs_dogs.py
+++ b/datasets/cats_vs_dogs/cats_vs_dogs.py
@@ -64,7 +64,7 @@ class CatsVsDogs(datasets.GeneratorBasedBuilder):
         images_path = os.path.join(dl_manager.download_and_extract(_URL), "PetImages")
         return [
             datasets.SplitGenerator(
-                name=datasets.Split.TRAIN, gen_kwargs={"files": dl_manager.iter_files(images_path)}
+                name=datasets.Split.TRAIN, gen_kwargs={"files": dl_manager.iter_files([images_path])}
             ),
         ]
 

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -9,6 +9,8 @@ from .utils.streaming_download_manager import (
     xbasename,
     xdirname,
     xglob,
+    xisdir,
+    xisfile,
     xjoin,
     xlistdir,
     xopen,
@@ -68,6 +70,9 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     patch_submodule(module, "os.path.join", xjoin).start()
     patch_submodule(module, "os.path.dirname", xdirname).start()
     patch_submodule(module, "os.path.basename", xbasename).start()
+    # allow checks on paths
+    patch_submodule(module, "os.path.isfile", wrap_auth(xisdir)).start()
+    patch_submodule(module, "os.path.isfile", wrap_auth(xisfile)).start()
     if hasattr(module, "Path"):
         patch.object(module.Path, "joinpath", xpathjoin).start()
         patch.object(module.Path, "__truediv__", xpathjoin).start()

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -74,7 +74,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     patch_submodule(module, "os.path.dirname", xdirname).start()
     patch_submodule(module, "os.path.basename", xbasename).start()
     # allow checks on paths
-    patch_submodule(module, "os.path.isfile", wrap_auth(xisdir)).start()
+    patch_submodule(module, "os.path.isdir", wrap_auth(xisdir)).start()
     patch_submodule(module, "os.path.isfile", wrap_auth(xisfile)).start()
     if hasattr(module, "Path"):
         patch.object(module.Path, "joinpath", xpathjoin).start()

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -22,7 +22,7 @@ import os
 import tarfile
 from datetime import datetime
 from functools import partial
-from typing import Dict, Optional, Union
+from typing import Dict, Iterable, Optional, Union
 
 from .. import config
 from .file_utils import (
@@ -36,6 +36,7 @@ from .file_utils import (
 from .info_utils import get_size_checksum_dict
 from .logging import get_logger
 from .py_utils import NestedDataStructure, map_nested, size_str
+from .typing import PathLike
 
 
 logger = get_logger(__name__)
@@ -249,15 +250,18 @@ class DownloadManager:
             with open(path_or_buf, "rb") as f:
                 yield from _iter_archive(f)
 
-    def iter_files(self, paths):
+    def iter_files(self, path_or_paths: Union[PathLike, Iterable[PathLike]]):
         """Iterate over file paths.
 
         Args:
-            paths (list): Root paths.
+            path_or_paths (Union[PathLike, Iterable[PathLike]])): Root paths.
 
         Yields:
             str: File path.
         """
+        if isinstance(path_or_paths, (str, bytes, os.PathLike)):
+            path_or_paths = [path_or_paths]
+        paths = path_or_paths
         for path in paths:
             if os.path.isfile(path):
                 yield path

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -250,18 +250,15 @@ class DownloadManager:
             with open(path_or_buf, "rb") as f:
                 yield from _iter_archive(f)
 
-    def iter_files(self, path_or_paths: Union[PathLike, Iterable[PathLike]]):
+    def iter_files(self, paths):
         """Iterate over file paths.
 
         Args:
-            path_or_paths (Union[PathLike, Iterable[PathLike]])): Root path/paths.
+            paths (list): Root paths.
 
         Yields:
             str: File path.
         """
-        if isinstance(path_or_paths, (str, bytes, os.PathLike)):
-            path_or_paths = [path_or_paths]
-        paths = path_or_paths
         for path in paths:
             if os.path.isfile(path):
                 yield path

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -22,7 +22,7 @@ import os
 import tarfile
 from datetime import datetime
 from functools import partial
-from typing import Dict, Iterable, Optional, Union
+from typing import Dict, Optional, Union
 
 from .. import config
 from .file_utils import (
@@ -36,7 +36,6 @@ from .file_utils import (
 from .info_utils import get_size_checksum_dict
 from .logging import get_logger
 from .py_utils import NestedDataStructure, map_nested, size_str
-from .typing import PathLike
 
 
 logger = get_logger(__name__)

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -254,7 +254,7 @@ class DownloadManager:
         """Iterate over file paths.
 
         Args:
-            path_or_paths (Union[PathLike, Iterable[PathLike]])): Root paths.
+            path_or_paths (Union[PathLike, Iterable[PathLike]])): Root path/paths.
 
         Yields:
             str: File path.

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -214,6 +214,9 @@ class MockDownloadManager:
             if file_path.is_file() and not file_path.name.startswith(".") and not file_path.name.startswith("__"):
                 yield file_path.relative_to(path).as_posix(), file_path.open("rb")
 
-    def iter_files(self, paths):
+    def iter_files(self, path_or_paths):
+        if isinstance(path_or_paths, (str, bytes, os.PathLike)):
+            path_or_paths = [path_or_paths]
+        paths = path_or_paths
         for path in paths:
             yield path

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -219,4 +219,9 @@ class MockDownloadManager:
             path_or_paths = [path_or_paths]
         paths = path_or_paths
         for path in paths:
-            yield path
+            if os.path.isfile(path):
+                yield path
+            else:
+                for dirpath, _, filenames in os.walk(path):
+                    for filename in filenames:
+                        yield os.path.join(dirpath, filename)

--- a/src/datasets/utils/mock_download_manager.py
+++ b/src/datasets/utils/mock_download_manager.py
@@ -214,10 +214,7 @@ class MockDownloadManager:
             if file_path.is_file() and not file_path.name.startswith(".") and not file_path.name.startswith("__"):
                 yield file_path.relative_to(path).as_posix(), file_path.open("rb")
 
-    def iter_files(self, path_or_paths):
-        if isinstance(path_or_paths, (str, bytes, os.PathLike)):
-            path_or_paths = [path_or_paths]
-        paths = path_or_paths
+    def iter_files(self, paths):
         for path in paths:
             if os.path.isfile(path):
                 yield path

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -9,7 +9,7 @@ from asyncio import TimeoutError
 from io import BytesIO
 from itertools import chain
 from pathlib import Path, PurePath, PurePosixPath
-from typing import List, Optional, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union
 
 import fsspec
 from aiohttp.client_exceptions import ClientError
@@ -26,6 +26,7 @@ from .file_utils import (
     url_or_path_join,
 )
 from .logging import get_logger
+from .typing import PathLike
 
 
 logger = get_logger(__name__)
@@ -595,15 +596,18 @@ class StreamingDownloadManager(object):
             with xopen(urlpath_or_buf, "rb", use_auth_token=self.download_config.use_auth_token) as f:
                 yield from _iter_archive(f)
 
-    def iter_files(self, urlpaths):
+    def iter_files(self, urlpath_or_urlpaths: Union[PathLike, Iterable[PathLike]]):
         """Iterate over files.
 
         Args:
-            urlpaths (list): Root URL paths.
+            urlpath_or_urlpaths (Union[PathLike, Iterable[PathLike]]): Root URL path/paths.
 
         Yields:
             str: File URL path.
         """
+        if isinstance(urlpath_or_urlpaths, (str, bytes, os.PathLike)):
+            urlpath_or_urlpaths = [urlpath_or_urlpaths]
+        urlpaths = urlpath_or_urlpaths
         for urlpath in urlpaths:
             if "://::" not in urlpath:  # workaround for os.path.isfile(urlpath):
                 yield urlpath

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -609,7 +609,17 @@ class StreamingDownloadManager(object):
             urlpath_or_urlpaths = [urlpath_or_urlpaths]
         urlpaths = urlpath_or_urlpaths
         for urlpath in urlpaths:
-            if "://::" not in urlpath:  # workaround for os.path.isfile(urlpath):
+            main_hop, *rest_hops = urlpath.split("::")
+            # # globbing inside a zip in a private repo requires authentication
+            # if rest_hops and fsspec.get_fs_token_paths(rest_hops[0])[0].protocol == "https":
+            #     storage_options = {
+            #         "https": {"headers": get_authentication_headers_for_url(rest_hops[0], use_auth_token=use_auth_token)}
+            #     }
+            # else:
+            #     storage_options = None
+            # fs, *_ = fsspec.get_fs_token_paths(urlpath, storage_options=storage_options)
+            fs, *_ = fsspec.get_fs_token_paths(urlpath, storage_options=None)
+            if fs.isfile(main_hop.split("://")[1]):
                 yield urlpath
             else:
                 for dirpath, _, filenames in xwalk(urlpath, use_auth_token=self.download_config.use_auth_token):

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -180,7 +180,7 @@ def xisfile(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
         else:
             storage_options = None
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
-        return fs.isfile(path)
+        return fs.isfile(main_hop)
 
 
 def xisdir(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
@@ -203,7 +203,7 @@ def xisdir(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
         else:
             storage_options = None
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
-        return fs.isdir(path)
+        return fs.isdir(main_hop)
 
 
 def _as_posix(path: Path):

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -9,7 +9,7 @@ from asyncio import TimeoutError
 from io import BytesIO
 from itertools import chain
 from pathlib import Path, PurePath, PurePosixPath
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import fsspec
 from aiohttp.client_exceptions import ClientError
@@ -26,7 +26,6 @@ from .file_utils import (
     url_or_path_join,
 )
 from .logging import get_logger
-from .typing import PathLike
 
 
 logger = get_logger(__name__)

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -14,6 +14,8 @@ from datasets.utils.streaming_download_manager import (
     _get_extraction_protocol,
     xbasename,
     xglob,
+    xisdir,
+    xisfile,
     xjoin,
     xlistdir,
     xopen,
@@ -257,6 +259,39 @@ def test_xlistdir(input_path, expected_paths, tmp_path, mock_fsspec):
             (tmp_path / file).touch()
     output_paths = sorted(xlistdir(input_path))
     assert output_paths == expected_paths
+
+
+@pytest.mark.parametrize(
+    "input_path, isdir",
+    [
+        ("tmp_path", True),
+        ("tmp_path/file.txt", False),
+        ("mock://", True),
+        ("mock://top_level", True),
+        ("mock://dir_that_doesnt_exist", False),
+    ],
+)
+def test_xisdir(input_path, isdir, tmp_path, mock_fsspec):
+    if input_path.startswith("tmp_path"):
+        input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
+        (tmp_path / "file.txt").touch()
+    assert xisdir(input_path) == isdir
+
+
+@pytest.mark.parametrize(
+    "input_path, isfile",
+    [
+        ("tmp_path/file.txt", True),
+        ("tmp_path/file_that_doesnt_exist.txt", False),
+        ("mock://", False),
+        ("mock://top_level/second_level/date=2019-10-01/a.parquet", True),
+    ],
+)
+def test_xisfile(input_path, isfile, tmp_path, mock_fsspec):
+    if input_path.startswith("tmp_path"):
+        input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
+        (tmp_path / "file.txt").touch()
+    assert xisfile(input_path) == isfile
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use `iter_files` in the `beans` and the `cats_vs_dogs` dataset scripts as suggested by @albertvillanova.

Additional changes:
* Fix `iter_files` in `MockDownloadManager` (see this [CI error](https://app.circleci.com/pipelines/github/huggingface/datasets/9247/workflows/2657ff8a-b531-4fd9-a9fc-6541a72e8d83/jobs/57028))
* Add support for `os.path.isdir` and `os.path.isfile` in streaming (`os.path.isfile` is needed in `StreamingDownloadManager`'s `iter_files` to make `cats_vs_dogs` streamable)

TODO:
- [ ] add tests for `xisdir` and `xisfile`