### PR TITLE
Extend support for streaming datasets that use os.walk

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -23,6 +23,7 @@ from .utils.streaming_download_manager import (
     xpathrglob,
     xpathstem,
     xpathsuffix,
+    xwalk,
 )
 
 
@@ -64,6 +65,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     # open files in a streaming fashion
     patch_submodule(module, "open", wrap_auth(xopen)).start()
     patch_submodule(module, "os.listdir", wrap_auth(xlistdir)).start()
+    patch_submodule(module, "os.walk", wrap_auth(xwalk)).start()
     patch_submodule(module, "glob.glob", wrap_auth(xglob)).start()
     # allow to navigate in remote zip files
     patch_submodule(module, "os.path.join", xjoin).start()

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -466,10 +466,12 @@ def xwalk(urlpath, use_auth_token: Optional[Union[str, bool]] = None):
     """Extend `os.walk` function to support remote files.
 
     Args:
-        urlpath: URL root path.
+        urlpath (:obj:`str`): URL root path.
+        use_auth_token (:obj:`bool` or :obj:`str`, optional): Whether to use token or token to authenticate on the
+            Hugging Face Hub for private remote files.
 
     Yields:
-        tuple: 3-tuple (dirpath, dirnames, filenames).
+        :obj:`tuple`: 3-tuple (dirpath, dirnames, filenames).
     """
     main_hop, *rest_hops = urlpath.split("::")
     if is_local_path(main_hop):


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `os.walk`, by patching that function.

This PR adds support for streaming mode to datasets:
1. autshumato
1. code_x_glue_cd_code_to_text
1. code_x_glue_tc_nl_code_search_adv
1. nchlt

CC: @severo 