### PR TITLE
Fix overriding of filesystem info

### DIFF
--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -37,7 +37,6 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
         self.file = fsspec.open(
             fo, mode="rb", protocol=target_protocol, compression=self.compression, **(target_options or {})
         )
-        self.info = self.file.fs.info(self.file.path)
         self.compressed_name = os.path.basename(self.file.path.split("::")[0])
         self.uncompressed_name = (
             self.compressed_name[: self.compressed_name.rindex(".")]
@@ -53,7 +52,7 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
 
     def _get_dirs(self):
         if self.dir_cache is None:
-            f = {**self.info, "name": self.uncompressed_name}
+            f = {**self.file.fs.info(self.file.path), "name": self.uncompressed_name}
             self.dir_cache = {f["name"]: f}
 
     def cat(self, path: str):

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -75,6 +75,17 @@ def test_compression_filesystems(compression_fs_class, gz_file, bz2_file, lz4_fi
         assert f.read() == expected_file.read()
 
 
+@pytest.mark.parametrize("protocol", ["zip", "gzip"])
+def test_fs_isfile(protocol, zip_jsonl_path, jsonl_gz_path):
+    compressed_file_paths = {"zip": zip_jsonl_path, "gzip": jsonl_gz_path}
+    compressed_file_path = compressed_file_paths[protocol]
+    member_file_path = "dataset.jsonl"
+    path = f"{protocol}://{member_file_path}::{compressed_file_path}"
+    fs, *_ = fsspec.get_fs_token_paths(path)
+    assert fs.isfile(member_file_path)
+    assert not fs.isfile("non_existing_" + member_file_path)
+
+
 def test_hf_filesystem(hf_token, hf_api, hf_private_dataset_repo_txt_data, text_file):
     repo_info = hf_api.dataset_info(hf_private_dataset_repo_txt_data, token=hf_token)
     hffs = HfFileSystem(repo_info=repo_info, token=hf_token)


### PR DESCRIPTION
Previously, `BaseCompressedFileFileSystem.info` was overridden and transformed from function to dict.

This generated a bug for filesystem methods that use `self.info()`, like e.g. `fs.isfile()`.

This PR:
- Adds tests for `fs.isfile` (that use `fs.info`).
- Fixes custom `BaseCompressedFileFileSystem.info` by removing its overriding.