### PR TITLE
Add `gzip` for `to_json`

### DIFF
--- a/src/datasets/io/handler.py
+++ b/src/datasets/io/handler.py
@@ -1,0 +1,19 @@
+import gzip
+
+
+class IOHandler:
+    def __init__(self, file_name, file_mode, compression):
+        self._file_name = file_name
+        self._file_mode = file_mode
+        self._compression = compression
+
+    def __enter__(self):
+        if self._compression is None:
+            self._file = open(self._file_name, self._file_mode)
+        elif self._compression == "gzip":
+            self._file = gzip.open(self._file_name, self._file_mode)
+
+        return self._file
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._file.close()

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -8,6 +8,7 @@ from ..packaged_modules.json.json import Json
 from ..utils import logging
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
+from .handler import IOHandler
 
 
 class JsonDatasetReader(AbstractDatasetReader):
@@ -81,9 +82,13 @@ class JsonDatasetWriter:
         _ = self.to_json_kwargs.pop("path_or_buf", None)
         orient = self.to_json_kwargs.pop("orient", "records")
         lines = self.to_json_kwargs.pop("lines", True)
+        compression = self.to_json_kwargs.pop("compression", None)
+
+        if compression not in [None, "gzip"]:
+            raise NotImplementedError(f"Datasets currently does not support {compression} compression")
 
         if isinstance(self.path_or_buf, (str, bytes, os.PathLike)):
-            with open(self.path_or_buf, "wb+") as buffer:
+            with IOHandler(self.path_or_buf, "wb", compression) as buffer:
                 written = self._write(file_obj=buffer, orient=orient, lines=lines, **self.to_json_kwargs)
         else:
             written = self._write(file_obj=self.path_or_buf, orient=orient, lines=lines, **self.to_json_kwargs)


### PR DESCRIPTION
(Partially) closes #3480. I have added `gzip` compression for `to_json`. I realised we can run into this compression problem with `to_csv` as well. `IOHandler` can be used for `to_csv` too. Please let me know if any changes are required. 