### PR TITLE
Clone full repo to detect new tags when mirroring datasets on the Hub

### DIFF
--- a/.github/workflows/update-hub-repositories.yaml
+++ b/.github/workflows/update-hub-repositories.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
The new releases of `datasets` were not detected because the shallow clone in the CI wasn't getting the git tags.

By cloning the full repository we can properly detect a new release, and tag all the dataset repositories accordingly
cc @SBrandeis 