### PR TITLE
Fix to_tf_dataset references in docs

### DIFF
--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -23,7 +23,7 @@ The base class :class:`datasets.Dataset` implements a Dataset backed by an Apach
         flatten, cast, cast_column, remove_columns, rename_column, class_encode_column,
         __len__, __iter__, formatted_as, set_format, set_transform, reset_format, with_format, with_transform,
         __getitem__, cleanup_cache_files,
-        map, filter, select, sort, shuffle, train_test_split, shard, export,
+        map, filter, select, sort, shuffle, train_test_split, shard, export, to_tf_dataset,
         push_to_hub, save_to_disk, load_from_disk, flatten_indices,
         to_csv, to_pandas, to_dict, to_json, to_parquet,
         add_faiss_index, add_faiss_index_from_external_arrays, save_faiss_index, load_faiss_index,

--- a/docs/source/use_dataset.rst
+++ b/docs/source/use_dataset.rst
@@ -85,9 +85,9 @@ After you set the format, wrap the dataset with ``torch.utils.data.DataLoader``.
 TensorFlow
 ^^^^^^^^^^
 
-If you are using TensorFlow, you can use ``to_tf_dataset`` to wrap the dataset with a `tf.data.Dataset`.
+If you are using TensorFlow, you can use :func:`datasets.Dataset.to_tf_dataset` to wrap the dataset with a `tf.data.Dataset`.
 `tf.data.Dataset` objects are natively understood by Keras. This means a `tf.data.Dataset` object can be iterated over to yield batches of data, and can be passed directly to methods like `model.fit()`.
-means they can be passed directly to methods like `model.fit()`. `to_tf_dataset()` accepts several arguments:
+means they can be passed directly to methods like `model.fit()`. :func:`datasets.Dataset.to_tf_dataset` accepts several arguments:
 
 1. ``columns`` specify which columns should be formatted (includes the inputs and labels).
 
@@ -132,6 +132,6 @@ means they can be passed directly to methods like `model.fit()`. `to_tf_dataset(
 
 .. tip::
 
-   ``to_tf_dataset`` is the easiest way to create a TensorFlow compatible dataset. If you don't want a ``tf.data.Dataset`` and would rather the dataset emit ``tf.Tensor`` objects, take a look at the :ref:`format` section instead!
+   :func:`datasets.Dataset.to_tf_dataset` is the easiest way to create a TensorFlow compatible dataset. If you don't want a ``tf.data.Dataset`` and would rather the dataset emit ``tf.Tensor`` objects, take a look at the :ref:`format` section instead!
 
 Your dataset is now ready for use in a training loop!

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -317,7 +317,7 @@ class TensorflowDatasetMixin:
 
         Args:
             columns (:obj:`List[str]` or :obj:`str`): Dataset column(s) to load in the tf.data.Dataset. In general,
-            only columns that the model can use as input should be included here (numeric data only).
+                only columns that the model can use as input should be included here (numeric data only).
             batch_size (:obj:`int`): Size of batches to load from the dataset.
             shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
                 validation/evaluation.


### PR DESCRIPTION
Fix the `to_tf_dataset` references in the docs. The currently failing example of usage will be fixed by #3338.  