### PR TITLE
Adding license information for Openbookcorpus

### DIFF
--- a/datasets/bookcorpusopen/README.md
+++ b/datasets/bookcorpusopen/README.md
@@ -158,7 +158,9 @@ The data fields are the same among all splits.
 
 ### Licensing Information
 
-[MIT License](https://github.com/soskek/bookcorpus/blob/master/LICENSE)
+The books have been crawled from smashwords.com, see their [terms of service](https://www.smashwords.com/about/tos) for more information.
+
+A data sheet for this dataset has also been created and published in [Addressing "Documentation Debt" in Machine Learning Research: A Retrospective Datasheet for BookCorpus](https://arxiv.org/abs/2105.05241)
 
 ### Citation Information
 

--- a/datasets/bookcorpusopen/README.md
+++ b/datasets/bookcorpusopen/README.md
@@ -158,7 +158,7 @@ The data fields are the same among all splits.
 
 ### Licensing Information
 
-[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+[MIT License](https://github.com/soskek/bookcorpus/blob/master/LICENSE)
 
 ### Citation Information
 


### PR DESCRIPTION
Not entirely sure, following the links here, but it seems the relevant license is at https://github.com/soskek/bookcorpus/blob/master/LICENSE