### PR TITLE
Allow multiple task templates of the same type

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1864,6 +1864,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     f"This dataset has multiple task templates for task {task}. Please specify the id to unambiguously identify the task template to prepare the dataset for:"
                     f"{''.join(f'- `{idx}` for task {template}' for idx, template in enumerate(compatible_templates))}"
                 )
+            id = id or 0
             template = compatible_templates[id]
         elif isinstance(task, TaskTemplate):
             template = task

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -889,9 +889,9 @@ class DatasetDict(dict):
         ).read()
 
     @is_documented_by(Dataset.prepare_for_task)
-    def prepare_for_task(self, task: Union[str, TaskTemplate]) -> "DatasetDict":
+    def prepare_for_task(self, task: Union[str, TaskTemplate], id: Optional[int] = None) -> "DatasetDict":
         self._check_values_type()
-        return DatasetDict({k: dataset.prepare_for_task(task=task) for k, dataset in self.items()})
+        return DatasetDict({k: dataset.prepare_for_task(task=task, id=id) for k, dataset in self.items()})
 
     @is_documented_by(Dataset.align_labels_with_mapping)
     def align_labels_with_mapping(self, label2id: Dict, label_column: str) -> "DatasetDict":

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3188,9 +3188,11 @@ class TaskTemplatesTest(TestCase):
         )
         data = {"text1": ["i love transformers!"], "text2": ["i love datasets!"]}
         with Dataset.from_dict(data, info=info) as dset:
-            self.assertRaises(ValueError, dset.prepare_for_task, "language-modeling")
-            with dset.prepare_for_task("language-modeling", id=0) as dset:
-                self.assertEqual(dset[0]["text"], "i love transformers!")
+            self.assertRaises(ValueError, dset.prepare_for_task, "language-modeling", id=3)
+            with dset.prepare_for_task("language-modeling") as dset1:
+                self.assertEqual(dset1[0]["text"], "i love transformers!")
+            with dset.prepare_for_task("language-modeling", id=1) as dset2:
+                self.assertEqual(dset2[0]["text"], "i love datasets!")
 
     def test_task_templates_empty_after_preparation(self):
         features = Features(


### PR DESCRIPTION
Add support for multiple task templates of the same type. Fixes (partially) #2520.

CC: @lewtun 