### PR TITLE
Fix push to hub to allow individual split push

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3597,10 +3597,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         organization, dataset_name = repo_id.split("/")
         info_to_dump = self.info.copy()
         info_to_dump.download_checksums = None
-        info_to_dump.download_size = uploaded_size
-        info_to_dump.dataset_size = dataset_nbytes
-        info_to_dump.size_in_bytes = uploaded_size + dataset_nbytes
+        info_to_dump.download_size = uploaded_size + self.info.download_size
+        info_to_dump.dataset_size = dataset_nbytes + self.info.dataset_size
+        info_to_dump.size_in_bytes = uploaded_size + dataset_nbytes + self.info.size_in_bytes
         info_to_dump.splits = {
+            **self.info.splits,
             split: SplitInfo(split, num_bytes=dataset_nbytes, num_examples=len(self), dataset_name=dataset_name)
         }
         buffer = BytesIO()

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3601,7 +3601,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             token=token if token is not None else HfFolder.get_token(),
             revision=branch,
         )
-        fs = HfFileSystem(repo_info=dataset_info_hub)
+        fs = HfFileSystem(repo_info=dataset_info_hub, token=token if token is not None else HfFolder.get_token())
         with fs.open("dataset_infos.json") as fi:
             dataset_config_dict = json.load(fi)
             old_config = DatasetInfo.from_dict(dataset_config_dict)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3604,9 +3604,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         fs = HfFileSystem(repo_info=dataset_info_hub, token=token if token is not None else HfFolder.get_token())
         with fs.open("dataset_infos.json") as fi:
             dataset_config_dict = json.load(fi)
-            assert len(dataset_config_dict) == 1
-            dataset_config_dict = dataset_config_dict[next(iter(dataset_config_dict))]
-            old_config = DatasetInfo.from_dict(dataset_config_dict)
+            key = repo_id.replace("/", "--")
+            old_config = DatasetInfo.from_dict(dataset_config_dict[key])
 
         organization, dataset_name = repo_id.split("/")
         info_to_dump = self.info.copy()

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -51,11 +51,12 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
-from datasets.filesystems import HfFileSystem
 from huggingface_hub import HfApi, HfFolder
 from multiprocess import Pool, RLock
 from requests import HTTPError
 from tqdm.auto import tqdm
+
+from datasets.filesystems import HfFileSystem
 
 from . import config, utils
 from .arrow_reader import ArrowReader
@@ -3560,9 +3561,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         token: Optional[str] = None,
         branch: Optional[str] = None,
     ) -> DatasetInfo:
-        """
-
-        """
+        """ """
         dataset_info_hub = HfApi(endpoint=config.HF_ENDPOINT).dataset_info(
             repo_id=repo_id,
             token=token if token is not None else HfFolder.get_token(),
@@ -3631,7 +3630,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         info_to_dump.size_in_bytes = uploaded_size + dataset_nbytes + old_dataset_infos.size_in_bytes
         info_to_dump.splits = {
             **old_dataset_infos.splits,
-            split: SplitInfo(split, num_bytes=dataset_nbytes, num_examples=len(self), dataset_name=dataset_name)
+            split: SplitInfo(split, num_bytes=dataset_nbytes, num_examples=len(self), dataset_name=dataset_name),
         }
         buffer = BytesIO()
         buffer.write(f'{{"{organization}--{dataset_name}": '.encode())

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3604,6 +3604,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         fs = HfFileSystem(repo_info=dataset_info_hub, token=token if token is not None else HfFolder.get_token())
         with fs.open("dataset_infos.json") as fi:
             dataset_config_dict = json.load(fi)
+            assert len(dataset_config_dict) == 1
+            dataset_config_dict = dataset_config_dict[next(iter(dataset_config_dict))]
             old_config = DatasetInfo.from_dict(dataset_config_dict)
 
         organization, dataset_name = repo_id.split("/")

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3561,7 +3561,22 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         token: Optional[str] = None,
         branch: Optional[str] = None,
     ) -> DatasetInfo:
-        """ """
+        """Queries the dataset infos from the hub if available.
+        The dataset is queried using HTTP requests and does not need to have neither git or git-lfs installed.
+
+        Args:
+            repo_id (:obj:`str`):
+                The ID of the repository to push to in the following format: `<user>/<dataset_name>` or
+                `<org>/<dataset_name>`. Also accepts `<dataset_name>`, which will default to the namespace
+                of the logged-in user.
+            token (Optional :obj:`str`):
+                An optional authentication token for the Hugging Face Hub. If no token is passed, will default
+                to the token saved locally when logging in with ``huggingface-cli login``. Will raise an error
+                if no token is passed and the user is not logged-in.
+            branch (Optional :obj:`str`):
+                The git branch on which to push the dataset. This defaults to the default branch as specified
+                in your repository, which defaults to `"main"`.
+        """
         dataset_info_hub = HfApi(endpoint=config.HF_ENDPOINT).dataset_info(
             repo_id=repo_id,
             token=token if token is not None else HfFolder.get_token(),

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3602,8 +3602,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             revision=branch,
         )
         fs = HfFileSystem(repo_info=dataset_info_hub, token=token if token is not None else HfFolder.get_token())
-        with fs.open("dataset_infos.json") as fi:
-            dataset_config_dict = json.load(fi)
+        try:
+            with fs.open("dataset_infos.json") as fi:
+                dataset_config_dict = json.load(fi)
+        except FileNotFoundError:
+            # The dataset info
+            old_config = DatasetInfo()
+        else:
             key = repo_id.replace("/", "--")
             old_config = DatasetInfo.from_dict(dataset_config_dict[key])
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3650,9 +3650,21 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 split: SplitInfo(split, num_bytes=dataset_nbytes, num_examples=len(self), dataset_name=dataset_name),
             }
         else:
-            info_to_dump.download_size = uploaded_size if old_dataset_infos.download_size is None else uploaded_size + old_dataset_infos.download_size
-            info_to_dump.dataset_size = dataset_nbytes if old_dataset_infos.dataset_size is None else dataset_nbytes + old_dataset_infos.dataset_size
-            info_to_dump.size_in_bytes = uploaded_size + dataset_nbytes if old_dataset_infos.size_in_bytes is None else uploaded_size + dataset_nbytes + old_dataset_infos.size_in_bytes
+            info_to_dump.download_size = (
+                uploaded_size
+                if old_dataset_infos.download_size is None
+                else uploaded_size + old_dataset_infos.download_size
+            )
+            info_to_dump.dataset_size = (
+                dataset_nbytes
+                if old_dataset_infos.dataset_size is None
+                else dataset_nbytes + old_dataset_infos.dataset_size
+            )
+            info_to_dump.size_in_bytes = (
+                uploaded_size + dataset_nbytes
+                if old_dataset_infos.size_in_bytes is None
+                else uploaded_size + dataset_nbytes + old_dataset_infos.size_in_bytes
+            )
             info_to_dump.splits = {
                 **(old_dataset_infos.splits if old_dataset_infos.splits is not None else {}),
                 split: SplitInfo(split, num_bytes=dataset_nbytes, num_examples=len(self), dataset_name=dataset_name),

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3614,7 +3614,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         info_to_dump.dataset_size = dataset_nbytes + old_config.dataset_size
         info_to_dump.size_in_bytes = uploaded_size + dataset_nbytes + old_config.size_in_bytes
         info_to_dump.splits = {
-            **self.old_config.splits,
+            **old_config.splits,
             split: SplitInfo(split, num_bytes=dataset_nbytes, num_examples=len(self), dataset_name=dataset_name)
         }
         buffer = BytesIO()

--- a/src/datasets/filesystems/hffilesystem.py
+++ b/src/datasets/filesystems/hffilesystem.py
@@ -16,7 +16,7 @@ class HfFileSystem(AbstractFileSystem):
 
     def __init__(
         self,
-        repo_info: Optional[str] = None,
+        repo_info: Optional[DatasetInfo] = None,
         token: Optional[str] = None,
         **kwargs,
     ):

--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -193,7 +193,7 @@ class DatasetInfo:
 
     def _dump_info(self, file):
         """Dump info in `file` file-like object open in bytes mode (to support remote files)"""
-        file.write(json.dumps(asdict(self)).encode("utf-8"))
+        file.write(json.dumps(asdict(self), indent=2).encode("utf-8"))
 
     def _dump_license(self, file):
         """Dump license in `file` file-like object open in bytes mode (to support remote files)"""


### PR DESCRIPTION
# Description of the issue

If one decides to push a split on a datasets repo, he uploads the dataset and overrides the config. However previous config splits end up being lost despite still having the dataset necessary.

The new flow is the following:
 - query the old config from the repo
 - update into a new config (add/overwrite new split for example)
 - push the new config

# Side fix

 - `repo_id` in HfFileSystem was wrongly typed.
 - I've added `indent=2` as it becomes much easier to read now.

