### PR TITLE
Pin torchmetrics to fix the COMET test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ TESTS_REQUIRE = [
     "scikit-learn",
     "jiwer",
     "sentencepiece",  # for bleurt
+    "torchmetrics==0.6.0",  # for comet: https://github.com/PyTorchLightning/metrics/issues/770
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",


### PR DESCRIPTION
Torchmetrics 0.7.0 got released and has issues with `transformers` (see https://github.com/PyTorchLightning/metrics/issues/770)

I'm pinning it to 0.6.0 in the CI, since 0.7.0 makes the COMET metric test fail. COMET requires torchmetrics==0.6.0 anyway.