### PR TITLE
fix multiple language downloading in mC4

### DIFF
--- a/datasets/mc4/mc4.py
+++ b/datasets/mc4/mc4.py
@@ -299,7 +299,7 @@ class Mc4(datasets.GeneratorBasedBuilder):
         for split in ["train", "validation"]:
             data_urls[split] = [
                 _DATA_URL.format(
-                    language=self.config.name,
+                    language=lang,
                     split_suffix="-validation" if split == "validation" else "",
                     index=index,
                     n_shards=_N_SHARDS_PER_SPLIT[lang][split],


### PR DESCRIPTION
If we try to access multiple languages of the [mC4 dataset](https://github.com/huggingface/datasets/tree/master/datasets/mc4), it will throw an error. For example, if we do 
```python
mc4_subset_two_langs = load_dataset("mc4", languages=["st", "su"])
```
we got
```
FileNotFoundError: Couldn't find file at https://huggingface.co/datasets/allenai/c4/resolve/1ddc917116b730e1859edef32896ec5c16be51d0/multilingual/c4-st+su.tfrecord-00000-of-00002.json.gz
```
Now it should work. Check it (from the root dir of a project): 
```python
mc4_subset_two_langs = load_dataset("./datasets/mc4/", languages=["st", "su"])
```