### PR TITLE
Fixes to pubmed dataset download function

### DIFF
--- a/datasets/pubmed/pubmed.py
+++ b/datasets/pubmed/pubmed.py
@@ -40,7 +40,7 @@ _LICENSE = ""
 # TODO: Add link to the official dataset URLs here
 # The HuggingFace dataset library don't host the datasets but only point to the original files
 # This can be an arbitrary nested dict/list of URLs (see below in `_split_generators` method)
-_URLs = [f"ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/pubmed21n{i:04d}.xml.gz" for i in range(1, 1063)]
+_URLs = [f"ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/pubmed22n{i:04d}.xml.gz" for i in range(1, 1114)]
 
 
 # Copyright Ferry Boender, released under the MIT license.


### PR DESCRIPTION
Pubmed has updated its settings for 2022 and thus existing download script does not work. 