### PR TITLE
Extend support for streaming datasets that use os.path.relpath

### DIFF
--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -25,6 +25,7 @@ from .utils.streaming_download_manager import (
     xpathrglob,
     xpathstem,
     xpathsuffix,
+    xrelpath,
     xsio_loadmat,
     xsplitext,
     xwalk,
@@ -75,6 +76,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     patch_submodule(module, "os.path.join", xjoin).start()
     patch_submodule(module, "os.path.dirname", xdirname).start()
     patch_submodule(module, "os.path.basename", xbasename).start()
+    patch_submodule(module, "os.path.relpath", xrelpath).start()
     patch_submodule(module, "os.path.splitext", xsplitext).start()
     # allow checks on paths
     patch_submodule(module, "os.path.isdir", wrap_auth(xisdir)).start()

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -234,6 +234,23 @@ def xisdir(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
         return fs.isdir(main_hop)
 
 
+def xrelpath(path, start=None):
+    """Extend `os.path.relpath` function to support remote files.
+
+    Args:
+        path (:obj:`str`): URL path.
+        start (:obj:`str`): Start URL directory path.
+
+    Returns:
+        :obj:`str`
+    """
+    main_hop, *rest_hops = path.split("::")
+    if is_local_path(main_hop):
+        return os.path.relpath(main_hop, start=start) if start else os.path.relpath(main_hop)
+    else:
+        return os.path.relpath(main_hop, start=start.split("::")[0]) if start else os.path.relpath(main_hop)
+
+
 def _as_posix(path: Path):
     """Extend :meth:`pathlib.PurePath.as_posix` to fix missing slashes after protocol.
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -248,7 +248,7 @@ def xrelpath(path, start=None):
     if is_local_path(main_hop):
         return os.path.relpath(main_hop, start=start) if start else os.path.relpath(main_hop)
     else:
-        return os.path.relpath(main_hop, start=start.split("::")[0]) if start else os.path.relpath(main_hop)
+        return posixpath.relpath(main_hop, start=start.split("::")[0]) if start else os.path.relpath(main_hop)
 
 
 def _as_posix(path: Path):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -27,6 +27,7 @@ from datasets.utils.streaming_download_manager import (
     xpathrglob,
     xpathstem,
     xpathsuffix,
+    xrelpath,
     xsplitext,
 )
 
@@ -350,6 +351,29 @@ def test_xglob(input_path, expected_paths, tmp_path, mock_fsspec):
             (tmp_path / file).touch()
     output_paths = sorted(xglob(input_path))
     assert output_paths == expected_paths
+
+
+@pytest.mark.parametrize(
+    "input_path, start_path, expected_path",
+    [
+        ("dir1/dir2/file.txt", "dir1", "dir2/file.txt"),
+        ("dir1/dir2/file.txt", "dir1/dir2", "file.txt"),
+        ("zip://file.txt::https://host.com/archive.zip", "zip://::https://host.com/archive.zip", "file.txt"),
+        (
+            "zip://folder/file.txt::https://host.com/archive.zip",
+            "zip://::https://host.com/archive.zip",
+            "folder/file.txt",
+        ),
+        (
+            "zip://folder/file.txt::https://host.com/archive.zip",
+            "zip://folder::https://host.com/archive.zip",
+            "file.txt",
+        ),
+    ],
+)
+def test_xrelpath(input_path, start_path, expected_path):
+    outut_path = xrelpath(input_path, start=start_path)
+    assert outut_path == expected_path
 
 
 @pytest.mark.parametrize(

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -356,8 +356,8 @@ def test_xglob(input_path, expected_paths, tmp_path, mock_fsspec):
 @pytest.mark.parametrize(
     "input_path, start_path, expected_path",
     [
-        ("dir1/dir2/file.txt", "dir1", "dir2/file.txt"),
-        ("dir1/dir2/file.txt", "dir1/dir2", "file.txt"),
+        ("dir1/dir2/file.txt".replace("/", os.path.sep), "dir1", "dir2/file.txt".replace("/", os.path.sep)),
+        ("dir1/dir2/file.txt".replace("/", os.path.sep), "dir1/dir2".replace("/", os.path.sep), "file.txt"),
         ("zip://file.txt::https://host.com/archive.zip", "zip://::https://host.com/archive.zip", "file.txt"),
         (
             "zip://folder/file.txt::https://host.com/archive.zip",


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `os.path.relpath`, by patching that function.

This feature will also be useful to yield the relative path of audio or image files, within an archive or parent dir.

Close #3622.