### PR TITLE
Fix Hub repos update when there's a new release

### DIFF
--- a/.github/hub/update_hub_repositories.py
+++ b/.github/hub/update_hub_repositories.py
@@ -216,14 +216,14 @@ if __name__ == "__main__":
     dataset_names = sys.argv[1:]
     if dataset_names:
         if dataset_names[0] == "--all":
-            dataset_names = sorted([d.name for d in (ROOT / HUB_DIR_NAME).glob("*") if d.is_dir()])
+            dataset_names = sorted([d.name for d in (datasets_lib_path / DATASETS_LIB_CATALOG_DIR_NAME).glob("*") if d.is_dir()])
         if dataset_names[0] == "--auto":
             if new_tag:
                 logger.info(
                     "All the datasets will be updated since --auto was used and "
                     f"this is a new release {new_tag.name} of the `datasets` library."
                 )
-                dataset_names = sorted([d.name for d in (ROOT / HUB_DIR_NAME).glob("*") if d.is_dir()])
+                dataset_names = sorted([d.name for d in (datasets_lib_path / DATASETS_LIB_CATALOG_DIR_NAME).glob("*") if d.is_dir()])
             else:
                 logger.info(
                     "All the datasets that have been changed in the latest commit of `datasets` will be updated "


### PR DESCRIPTION
It was not listing the full list of datasets correctly

cc @SBrandeis this is why it failed for 1.18.0

We should be good now !