### PR TITLE
Fix numpy rngs when seed is None

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2916,8 +2916,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
-                seed = seed[0] if pos == 624 else seed[pos]
-                _ = np.random.random()  # do 1 step of rng
+                if pos < 624:
+                    seed = seed[pos]
+                    _ = np.random.random()  # do 1 step of rng
+                else:
+                    seed = seed[0]  # fixed seed
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)
@@ -3083,8 +3086,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None and shuffle is True:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
-                seed = seed[0] if pos == 624 else seed[pos]
-                _ = np.random.random()  # do 1 step of rng
+                if pos < 624:
+                    seed = seed[pos]
+                    _ = np.random.random()  # do 1 step of rng
+                else:
+                    seed = seed[0]  # fixed seed
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2916,7 +2916,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
-                seed = seed[pos]
+                seed = seed[0] if pos == 624 else seed[pos]
                 _ = np.random.random()  # do 1 step of rng
             generator = np.random.default_rng(seed)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2916,8 +2916,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
+                seed = seed[pos]
                 _ = np.random.random()  # do 1 step of rng
-            generator = np.random.default_rng(seed[pos])
+            generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)
         if self.cache_files:
@@ -3082,8 +3083,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None and shuffle is True:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
+                seed = seed[pos]
                 _ = np.random.random()  # do 1 step of rng
-            generator = np.random.default_rng(seed[pos])
+            generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)
         if self.cache_files:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3083,7 +3083,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None and shuffle is True:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
-                seed = seed[pos]
+                seed = seed[0] if pos == 624 else seed[pos]
                 _ = np.random.random()  # do 1 step of rng
             generator = np.random.default_rng(seed)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2916,11 +2916,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
-                if pos < 624:
-                    seed = seed[pos]
-                    _ = np.random.random()  # do 1 step of rng
-                else:
-                    seed = seed[0]  # fixed seed
+                seed = seed[pos] if pos < 624 else seed[0]
+                _ = np.random.random()  # do 1 step of rng
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)
@@ -3086,11 +3083,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if generator is None and shuffle is True:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()
-                if pos < 624:
-                    seed = seed[pos]
-                    _ = np.random.random()  # do 1 step of rng
-                else:
-                    seed = seed[0]  # fixed seed
+                seed = seed[pos] if pos < 624 else seed[0]
+                _ = np.random.random()  # do 1 step of rng
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2915,9 +2915,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         if generator is None:
             if seed is None:
-                seed = np.random.get_state()[1][0]
+                _, seed, pos, *_ = np.random.get_state()
                 _ = np.random.random()  # do 1 step of rng
-            generator = np.random.default_rng(seed)
+            generator = np.random.default_rng(seed[pos])
 
         # Check if we've already cached this computation (indexed by a hash)
         if self.cache_files:
@@ -3081,9 +3081,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         if generator is None and shuffle is True:
             if seed is None:
-                seed = np.random.get_state()[1][0]
+                _, seed, pos, *_ = np.random.get_state()
                 _ = np.random.random()  # do 1 step of rng
-            generator = np.random.default_rng(seed)
+            generator = np.random.default_rng(seed[pos])
 
         # Check if we've already cached this computation (indexed by a hash)
         if self.cache_files:

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -382,7 +382,7 @@ def fingerprint_transform(
             if randomized_function:  # randomized functions have `seed` and `generator` parameters
                 if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
                     _, seed, pos, *_ = np.random.get_state()
-                    seed = seed[0] if pos == 624 else seed[pos]
+                    seed = seed[pos] if pos < 624 else seed[0]
                     kwargs_for_fingerprint["generator"] = np.random.default_rng(seed)
 
             # remove kwargs that are the default values

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -382,7 +382,7 @@ def fingerprint_transform(
             if randomized_function:  # randomized functions have `seed` and `generator` parameters
                 if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
                     _, seed, pos, *_ = np.random.get_state()
-                    seed = seed[pos]
+                    seed = seed[0] if pos == 624 else seed[pos]
                     kwargs_for_fingerprint["generator"] = np.random.default_rng(seed)
 
             # remove kwargs that are the default values

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -381,7 +381,8 @@ def fingerprint_transform(
                 kwargs_for_fingerprint = {k: v for k, v in kwargs_for_fingerprint.items() if k not in ignore_kwargs}
             if randomized_function:  # randomized functions have `seed` and `generator` parameters
                 if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
-                    kwargs_for_fingerprint["generator"] = np.random.default_rng(np.random.get_state()[1][0])
+                    _, seed, pos, *_ = np.random.get_state()
+                    kwargs_for_fingerprint["generator"] = np.random.default_rng(seed[pos])
 
             # remove kwargs that are the default values
 

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -382,7 +382,8 @@ def fingerprint_transform(
             if randomized_function:  # randomized functions have `seed` and `generator` parameters
                 if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
                     _, seed, pos, *_ = np.random.get_state()
-                    kwargs_for_fingerprint["generator"] = np.random.default_rng(seed[pos])
+                    seed = seed[pos]
+                    kwargs_for_fingerprint["generator"] = np.random.default_rng(seed)
 
             # remove kwargs that are the default values
 

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -183,7 +183,7 @@ class Metric(MetricInfoMixin):
         self.data_dir = self._build_data_dir()
         if seed is None:
             _, seed, pos, *_ = np.random.get_state()
-            self.seed: int = seed[0] if pos == 624 else seed[pos]
+            self.seed: int = seed[pos] if pos < 624 else seed[0]
         else:
             self.seed: int = seed
         self.timeout: Union[int, float] = timeout

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -181,7 +181,11 @@ class Metric(MetricInfoMixin):
         self.keep_in_memory = keep_in_memory
         self._data_dir_root = os.path.expanduser(cache_dir or config.HF_METRICS_CACHE)
         self.data_dir = self._build_data_dir()
-        self.seed: int = seed or np.random.get_state()[1][0]
+        if seed is None:
+            _, seed, pos, *_ = np.random.get_state()
+            self.seed: int = seed[pos]
+        else:
+            self.seed: int = seed
         self.timeout: Union[int, float] = timeout
 
         # Update 'compute' and 'add' docstring

--- a/src/datasets/metric.py
+++ b/src/datasets/metric.py
@@ -183,7 +183,7 @@ class Metric(MetricInfoMixin):
         self.data_dir = self._build_data_dir()
         if seed is None:
             _, seed, pos, *_ = np.random.get_state()
-            self.seed: int = seed[pos]
+            self.seed: int = seed[0] if pos == 624 else seed[pos]
         else:
             self.seed: int = seed
         self.timeout: Union[int, float] = timeout


### PR DESCRIPTION
Fixes the NumPy RNG when `seed` is `None`.

The problem becomes obvious after reading the NumPy notes on RNG (returned by `np.random.get_state()`):
> The MT19937 state vector consists of a 624-element array of 32-bit unsigned integers plus a single integer value between 0 and 624 that indexes the current position within the main array.

`The MT19937 state vector`: the seed which we currently index, but this value stays the same for multiple rounds.
`plus a single integer value`: the `pos` value in this PR (is 624 if `seed` is set to a fixed value with `np.random.seed`, so we take the first value in the `seed` array returned by `np.random.get_state()`: https://stackoverflow.com/questions/32172054/how-can-i-retrieve-the-current-seed-of-numpys-random-number-generator)

NumPy notes: https://numpy.org/doc/stable/reference/random/bit_generators/mt19937.html

Fix #3634 