### PR TITLE
Fix `add_column` on datasets with indices mapping

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3647,13 +3647,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         column_table = InMemoryTable.from_pydict({name: column})
         _check_column_names(self._data.column_names + column_table.column_names)
+        dataset = self.flatten_indices() if self._indices is not None else self
         # Concatenate tables horizontally
-        table = concat_tables([self._data, column_table], axis=1)
+        table = concat_tables([dataset._data, column_table], axis=1)
         # Update features
-        info = self.info.copy()
+        info = dataset.info.copy()
         info.features.update(Features.from_arrow_schema(column_table.schema))
         table = update_metadata_with_features(table, info.features)
-        return Dataset(table, info=info, split=self.split, indices_table=self._indices, fingerprint=new_fingerprint)
+        return Dataset(table, info=info, split=self.split, indices_table=None, fingerprint=new_fingerprint)
 
     def add_faiss_index(
         self,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2487,7 +2487,13 @@ def test_interleave_datasets_probabilities():
 @pytest.mark.parametrize("in_memory", [False, True])
 @pytest.mark.parametrize(
     "transform",
-    [None, ("shuffle", (42,), {}), ("with_format", ("pandas",), {}), ("class_encode_column", ("col_2",), {})],
+    [
+        None,
+        ("shuffle", (42,), {}),
+        ("with_format", ("pandas",), {}),
+        ("class_encode_column", ("col_2",), {}),
+        ("select", (range(3),), {}),
+    ],
 )
 def test_dataset_add_column(column, expected_dtype, in_memory, transform, dataset_dict, arrow_path):
     column_name = "col_4"
@@ -2499,8 +2505,9 @@ def test_dataset_add_column(column, expected_dtype, in_memory, transform, datase
     if transform is not None:
         transform_name, args, kwargs = transform
         original_dataset: Dataset = getattr(original_dataset, transform_name)(*args, **kwargs)
+    column = column[:3] if transform is not None and transform_name == "select" else column
     dataset = original_dataset.add_column(column_name, column)
-    assert dataset.data.shape == (4, 4)
+    assert dataset.data.shape == (3, 4) if transform is not None and transform_name == "select" else (4, 4)
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     # Sort expected features as in the original dataset
     expected_features = {feature: expected_features[feature] for feature in original_dataset.features}
@@ -2514,7 +2521,9 @@ def test_dataset_add_column(column, expected_dtype, in_memory, transform, datase
     assert dataset._fingerprint != original_dataset._fingerprint
     dataset.reset_format()
     original_dataset.reset_format()
-    assert all(dataset[col] == original_dataset[col] for col in original_dataset.column_names)
+    assert all(
+        dataset[col][: len(dataset)] == original_dataset[col][: len(dataset)] for col in original_dataset.column_names
+    )
     assert set(dataset["col_4"]) == set(column)
     if dataset._indices is not None:
         dataset_indices = dataset._indices["indices"].to_pylist()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2521,9 +2521,7 @@ def test_dataset_add_column(column, expected_dtype, in_memory, transform, datase
     assert dataset._fingerprint != original_dataset._fingerprint
     dataset.reset_format()
     original_dataset.reset_format()
-    assert all(
-        dataset[col][: len(dataset)] == original_dataset[col][: len(dataset)] for col in original_dataset.column_names
-    )
+    assert all(dataset[col] == original_dataset[col] for col in original_dataset.column_names)
     assert set(dataset["col_4"]) == set(column)
     if dataset._indices is not None:
         dataset_indices = dataset._indices["indices"].to_pylist()


### PR DESCRIPTION
My initial idea was to avoid the `flatten_indices` call and reorder a new column instead, but in the end I decided to follow `concatenate_datasets` and use `flatten_indices` to avoid padding when `dataset._indices.num_rows != dataset._data.num_rows`.

Fix #3599