### PR TITLE
Fix Windows CI: bump python to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,14 @@ jobs:
             - run: |
                 conda init powershell
                 conda update conda
-                conda create -n py36 python=3.6 pytorch --yes
+                conda create -n py37 python=3.7 pytorch --yes
             - run: |
-                conda activate py36
+                conda activate py37
                 pip install .[tests]
                 pip install -r additional-tests-requirements.txt --no-deps
                 pip install pyarrow --upgrade
             - run: |
-                conda activate py36
+                conda activate py37
                 $env:HF_SCRIPTS_VERSION="master"
                 python -m pytest -n 2 --dist loadfile -sv ./tests/
 
@@ -67,14 +67,14 @@ jobs:
             - run: |
                 conda init powershell
                 conda update conda
-                conda create -n py36 python=3.6 pytorch --yes
+                conda create -n py37 python=3.7 pytorch --yes
             - run: |
-                conda activate py36
+                conda activate py37
                 pip install .[tests]
                 pip install -r additional-tests-requirements.txt --no-deps
                 pip install pyarrow==3.0.0
             - run: |
-                conda activate py36
+                conda activate py37
                 $env:HF_SCRIPTS_VERSION="master"
                 python -m pytest -n 2 --dist loadfile -sv ./tests/
 


### PR DESCRIPTION
Python>=3.7 is needed to install `tokenizers` 0.11