### PR TITLE
Allow 'to_json' to run in unordered fashion in order to lower memory footprint

### DIFF
--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -80,7 +80,7 @@ class JsonDatasetWriter:
         self.to_json_kwargs = to_json_kwargs
 
         if (num_proc is None or num_proc == 1) and map_unordered:
-            raise ValueError(f"Unordered map is only defined when using multiprocessing.")
+            raise ValueError("Unordered map is only defined when using multiprocessing.")
         self.map_unordered = map_unordered
 
     def write(self) -> int:


### PR DESCRIPTION
I'm using `to_json(..., num_proc=num_proc, compressiong='gzip')` with `num_proc>1`. I'm having an issue where things seem to deadlock at some point. Eventually I see OOM. I'm guessing it's an issue where one process starts to take a long time for a specific batch, and so other process keep accumulating their results in memory.

In order to flush memory, I propose we use optional `imap_unordered`. This will prevent one process to block the other ones. The logical thinking is that index are rarily relevant, and in one wants to keep an index, one can still create another column and reconstruct from there.