### PR TITLE
Prioritize `module.builder_kwargs` over defaults in `TestCommand`

### DIFF
--- a/src/datasets/commands/test.py
+++ b/src/datasets/commands/test.py
@@ -129,17 +129,27 @@ class TestCommand(BaseDatasetsCLICommand):
             if self._all_configs and len(builder_cls.BUILDER_CONFIGS) > 0:
                 for i, config in enumerate(builder_cls.BUILDER_CONFIGS):
                     if i % self._num_proc == self._proc_rank:
-                        yield builder_cls(
-                            name=config.name,
-                            cache_dir=self._cache_dir,
-                            data_dir=self._data_dir,
-                            **module.builder_kwargs,
-                        )
+                        if "name" in module.builder_kwargs:
+                            yield builder_cls(
+                                cache_dir=self._cache_dir,
+                                data_dir=self._data_dir,
+                                **module.builder_kwargs,
+                            )
+                        else:
+                            yield builder_cls(
+                                name=config.name,
+                                cache_dir=self._cache_dir,
+                                data_dir=self._data_dir,
+                                **module.builder_kwargs,
+                            )
             else:
                 if self._proc_rank == 0:
-                    yield builder_cls(
-                        name=name, cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs
-                    )
+                    if "name" in module.builder_kwargs:
+                        yield builder_cls(cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs)
+                    else:
+                        yield builder_cls(
+                            name=name, cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs
+                        )
 
         for j, builder in enumerate(get_builders()):
             print(f"Testing builder '{builder.config.name}' ({j + 1}/{n_builders})")


### PR DESCRIPTION
This fixes a bug in the `TestCommand` where multiple kwargs for `name` were passed if it was set in both default and `module.builder_kwargs`. Example error:

```Python
Traceback (most recent call last):
  File "create_metadata.py", line 96, in <module>
    main(**vars(args))
  File "create_metadata.py", line 86, in main
    metadata_command.run()
  File "/opt/conda/lib/python3.7/site-packages/datasets/commands/test.py", line 144, in run
    for j, builder in enumerate(get_builders()):
  File "/opt/conda/lib/python3.7/site-packages/datasets/commands/test.py", line 141, in get_builders
    name=name, cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs
TypeError: type object got multiple values for keyword argument 'name'
```

Let me know what you think.