### PR TITLE
Add support for `Audio` and `Image` feature in `push_to_hub`

### DIFF
--- a/src/datasets/features/__init__.py
+++ b/src/datasets/features/__init__.py
@@ -6,7 +6,6 @@ from .features import (
     _ArrayXDExtensionType,
     _arrow_to_datasets_dtype,
     _cast_to_python_objects,
-    _check_non_null_non_empty_recursive,
     _is_zero_copy_only,
 )
 from .image import Image, objects_to_list_of_image_dicts

--- a/src/datasets/features/__init__.py
+++ b/src/datasets/features/__init__.py
@@ -6,6 +6,7 @@ from .features import (
     _ArrayXDExtensionType,
     _arrow_to_datasets_dtype,
     _cast_to_python_objects,
+    _check_non_null_non_empty_recursive,
     _is_zero_copy_only,
 )
 from .image import Image, objects_to_list_of_image_dicts

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1152,7 +1152,7 @@ def require_decoding(feature: FeatureType, ignore_decode_attribute: bool = False
     Args:
         feature (FeatureType): the feature type to be checked
         ignore_decode_attribute (:obj:`bool`, default ``False``): Whether to ignore the current value
-            of the `decode` attribute of the complex feature types.
+            of the `decode` attribute of the decodable feature types.
     Returns:
         :obj:`bool`
     """

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1146,7 +1146,16 @@ def list_of_np_array_to_pyarrow_listarray(l_arr: List[np.ndarray], type: pa.Data
         return pa.array([], type=type)
 
 
-def require_decoding(feature: FeatureType) -> bool:
+def require_decoding(feature: FeatureType, ignore_decode_attribute: bool = False) -> bool:
+    """Check if a (possibly nested) feature requires decoding.
+
+    Args:
+        feature (FeatureType): the feature type to be checked
+        ignore_decode_attribute (:obj:`bool`, default ``False``): Whether to ignore the current value
+            of the `decode` attribute of the complex feature types.
+    Returns:
+        :obj:`bool`
+    """
     if isinstance(feature, dict):
         return any(require_decoding(f) for f in feature.values())
     elif isinstance(feature, (list, tuple)):
@@ -1154,7 +1163,7 @@ def require_decoding(feature: FeatureType) -> bool:
     elif isinstance(feature, Sequence):
         return require_decoding(feature.feature)
     else:
-        return hasattr(feature, "decode_example") and feature.decode
+        return hasattr(feature, "decode_example") and (feature.decode if not ignore_decode_attribute else True)
 
 
 class Features(dict):

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -1,8 +1,5 @@
 import os
-import sys
 import tarfile
-from ctypes.util import find_library
-from importlib.util import find_spec
 
 import pyarrow as pa
 import pytest
@@ -10,23 +7,7 @@ import pytest
 from datasets import Dataset, concatenate_datasets, load_dataset
 from datasets.features import Audio, Features, Sequence, Value
 
-
-# pytestmark = pytest.mark.audio
-
-
-require_sndfile = pytest.mark.skipif(
-    # In Windows and OS X, soundfile installs sndfile
-    (sys.platform != "linux" and find_spec("soundfile") is None)
-    # In Linux, soundfile throws RuntimeError if sndfile not installed with distribution package manager
-    or (sys.platform == "linux" and find_library("sndfile") is None),
-    reason="Test requires 'sndfile': `pip install soundfile`; "
-    "Linux requires sndfile installed with distribution package manager, e.g.: `sudo apt-get install libsndfile1`",
-)
-require_sox = pytest.mark.skipif(
-    find_library("sox") is None,
-    reason="Test requires 'sox'; only available in non-Windows, e.g.: `sudo apt-get install sox`",
-)
-require_torchaudio = pytest.mark.skipif(find_spec("torchaudio") is None, reason="Test requires 'torchaudio'")
+from ..utils import require_sndfile, require_sox, require_torchaudio
 
 
 @pytest.fixture()

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import time
 import unittest
@@ -6,10 +7,12 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
+import numpy as np
 from huggingface_hub import HfApi
 from huggingface_hub.hf_api import HfFolder
 
-from datasets import ClassLabel, Dataset, DatasetDict, Features, Value, load_dataset
+from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
+from tests.utils import require_pil, require_sndfile
 
 
 REPO_NAME = f"repo-{int(time.time() * 10e3)}"
@@ -308,15 +311,70 @@ class TestPushToHub(TestCase):
         ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
         try:
             ds.push_to_hub(ds_name, token=self._token)
-            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+            hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
 
-            self.assertListEqual(ds.column_names, hub_ds["train"].column_names)
-            self.assertListEqual(list(ds.features.keys()), list(hub_ds["train"].features.keys()))
-            self.assertDictEqual(ds.features, hub_ds["train"].features)
+            self.assertListEqual(ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(ds.features.keys()), list(hub_ds.features.keys()))
+            self.assertDictEqual(ds.features, hub_ds.features)
+            self.assertEqual(ds[:], hub_ds[:])
         finally:
             self._api.delete_repo(
                 ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
             )
+
+    @require_sndfile
+    def test_push_dataset_to_hub_custom_features_audio(self):
+        audio_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_audio_44100.wav")
+        data = {"x": [audio_path], "y": [0]}
+        features = Features({"x": Audio(), "y": Value("int32")})
+        ds = Dataset.from_dict(data, features=features)
+
+        for allow_cast in [True, False]:
+            ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+            try:
+                ds.push_to_hub(ds_name, allow_cast=allow_cast, token=self._token)
+                hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+
+                self.assertListEqual(ds.column_names, hub_ds.column_names)
+                self.assertListEqual(list(ds.features.keys()), list(hub_ds.features.keys()))
+                self.assertDictEqual(ds.features, hub_ds.features)
+                np.testing.assert_equal(ds[0]["x"]["array"], hub_ds[0]["x"]["array"])
+                hub_ds = hub_ds.cast_column("x", Audio(decode=False))
+                elem = hub_ds[0]["x"]
+                path, bytes_ = elem["path"], elem["bytes"]
+                self.assertTrue(bool(path) == (not allow_cast))
+                self.assertTrue(bool(bytes_) == allow_cast)
+            finally:
+                self._api.delete_repo(
+                    ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+                )
+
+    @require_pil
+    def test_push_dataset_to_hub_custom_features_image(self):
+        image_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg")
+        data = {"x": [image_path], "y": [0]}
+        features = Features({"x": Image(), "y": Value("int32")})
+        ds = Dataset.from_dict(data, features=features)
+
+        for allow_cast in [True, False]:
+            ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+            try:
+                ds.push_to_hub(ds_name, allow_cast=allow_cast, token=self._token)
+                hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+
+                self.assertListEqual(ds.column_names, hub_ds.column_names)
+                self.assertListEqual(list(ds.features.keys()), list(hub_ds.features.keys()))
+                self.assertDictEqual(ds.features, hub_ds.features)
+                self.assertEqual(ds[:], hub_ds[:])
+                hub_ds = hub_ds.cast_column("x", Image(decode=False))
+                elem = hub_ds[0]["x"]
+                path, bytes_ = elem["path"], elem["bytes"]
+                self.assertTrue(bool(path) == (not allow_cast))
+                self.assertTrue(bool(bytes_) == allow_cast)
+            finally:
+                self._api.delete_repo(
+                    ds_name.split("/")[1], organization=ds_name.split("/")[0], token=self._token, repo_type="dataset"
+                )
 
     def test_push_dataset_dict_to_hub_custom_features(self):
         features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,12 @@
 import os
+import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
+from ctypes.util import find_library
 from distutils.util import strtobool
 from enum import Enum
+from importlib.util import find_spec
 from pathlib import Path
 from unittest.mock import patch
 
@@ -133,6 +136,47 @@ def require_pil(test_case):
     """
     if not config.PIL_AVAILABLE:
         test_case = unittest.skip("test requires Pillow")(test_case)
+    return test_case
+
+
+def require_sndfile(test_case):
+    """
+    Decorator marking a test that requires soundfile.
+
+    These tests are skipped when soundfile isn't installed.
+
+    """
+    if (sys.platform != "linux" and find_spec("soundfile") is None) or (
+        sys.platform == "linux" and find_library("sndfile") is None
+    ):
+        test_case = unittest.skip(
+            "test requires 'sndfile': `pip install soundfile`; "
+            "Linux requires sndfile installed with distribution package manager, e.g.: `sudo apt-get install libsndfile1`",
+        )(test_case)
+    return test_case
+
+
+def require_sox(test_case):
+    """
+    Decorator marking a test that requires sox.
+
+    These tests are skipped when sox isn't installed.
+    """
+    if find_library("sox") is None:
+        return unittest.skip("test requires 'sox'; only available in non-Windows, e.g.: `sudo apt-get install sox`")(
+            test_case
+        )
+    return test_case
+
+
+def require_torchaudio(test_case):
+    """
+    Decorator marking a test that requires torchaudio.
+
+    These tests are skipped when torchaudio isn't installed.
+    """
+    if find_spec("sox") is None:
+        return unittest.skip("test requires 'torchaudio'")(test_case)
     return test_case
 
 


### PR DESCRIPTION
Add support for the `Audio` and the `Image` feature in `push_to_hub`. 

The idea is to remove local path information and store file content under "bytes" in the Arrow table before the push.

My initial approach (https://github.com/huggingface/datasets/commit/34c652afeff9686b6b8bf4e703c84d2205d670aa) was to use a map transform similar to [`decode_nested_example`](https://github.com/huggingface/datasets/blob/5e0f6068741464f833ff1802e24ecc2064aaea9f/src/datasets/features/features.py#L1023-L1056) while having decoding turned off, but I wasn't satisfied with the code quality, so I ended up using the `temporary_assignment` decorator to override `cast_storage`, which allows me to directly modify the underlying storage (the final op is similar to `Dataset.cast`) and results in a much simpler code. 

Additionally, I added the `allow_cast` flag that can disable this behavior in the situations where it's not needed (e.g. the dataset is already in the correct format for the Hub, etc.)