### PR TITLE
Fix streaming for servers not supporting HTTP range requests

### DIFF
--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -383,15 +383,7 @@ def xopen(file: str, mode="r", *args, use_auth_token: Optional[Union[str, bool]]
     else:
         new_kwargs = {}
     kwargs = {**kwargs, **new_kwargs}
-    try:
-        file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
-    except ValueError as e:
-        if str(e) == "Cannot seek streaming HTTP file":  # Workaround for servers not supporting HTTP range requests
-            file = file.split("::")
-            file = "::".join(file[:-1] + ["simplecache", file[-1]])
-            file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
-        else:
-            raise
+    file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
     _add_retries_to_file_obj_read_method(file_obj)
     return file_obj
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -77,6 +77,10 @@ MAGIC_NUMBER_MAX_LENGTH = max(
 )
 
 
+class NonStreamableDatasetError(Exception):
+    pass
+
+
 def xjoin(a, *p):
     """
     This function extends os.path.join to support the "::" hop separator. It supports both paths and urls.
@@ -383,7 +387,16 @@ def xopen(file: str, mode="r", *args, use_auth_token: Optional[Union[str, bool]]
     else:
         new_kwargs = {}
     kwargs = {**kwargs, **new_kwargs}
-    file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
+    try:
+        file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
+    except ValueError as e:
+        if str(e) == "Cannot seek streaming HTTP file":
+            raise NonStreamableDatasetError(
+                "Streaming is not possible for this dataset because data host server doesn't support HTTP range "
+                "requests. You can still load this dataset in non-streaming mode by passing `streaming=False` (default)"
+            ) from e
+        else:
+            raise
     _add_retries_to_file_obj_read_method(file_obj)
     return file_obj
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -383,7 +383,15 @@ def xopen(file: str, mode="r", *args, use_auth_token: Optional[Union[str, bool]]
     else:
         new_kwargs = {}
     kwargs = {**kwargs, **new_kwargs}
-    file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
+    try:
+        file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
+    except ValueError as e:
+        if str(e) == "Cannot seek streaming HTTP file":  # Workaround for servers not supporting HTTP range requests
+            file = file.split("::")
+            file = "::".join(file[:-1] + ["simplecache", file[-1]])
+            file_obj = fsspec.open(file, mode=mode, *args, **kwargs).open()
+        else:
+            raise
     _add_retries_to_file_obj_read_method(file_obj)
     return file_obj
 


### PR DESCRIPTION
Some servers do not support HTTP range requests, whereas this is required to stream some file formats (like ZIP).

~~This PR implements a workaround for those cases, by download the files locally in a temporary directory (cleaned up by the OS once the process is finished).~~

This PR raises custom error explaining that streaming is not possible because data host server does not support HTTP range requests.

Fix #3677.