### PR TITLE
Fix ClassLabel to/from dict when passed names_file

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -19,7 +19,7 @@ import json
 import re
 import sys
 from collections.abc import Iterable
-from dataclasses import _asdict_inner, dataclass, field, fields
+from dataclasses import InitVar, _asdict_inner, dataclass, field, fields
 from functools import reduce
 from operator import mul
 from typing import Any, ClassVar, Dict, List, Optional
@@ -761,7 +761,7 @@ class ClassLabel:
 
     num_classes: int = None
     names: List[str] = None
-    names_file: Optional[str] = None
+    names_file: InitVar[Optional[str]] = None
     id: Optional[str] = None
     # Automatically constructed
     dtype: ClassVar[str] = "int64"
@@ -770,7 +770,8 @@ class ClassLabel:
     _int2str: ClassVar[Dict[int, int]] = None
     _type: str = field(default="ClassLabel", init=False, repr=False)
 
-    def __post_init__(self):
+    def __post_init__(self, names_file):
+        self.names_file = names_file
         if self.names_file is not None and self.names is not None:
             raise ValueError("Please provide either names or names_file but not both.")
         # Set self.names

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -17,6 +17,7 @@ from datasets.features import (
     _cast_to_python_objects,
     cast_to_python_objects,
     encode_nested_example,
+    generate_from_dict,
     string_to_arrow,
 )
 from datasets.info import DatasetInfo
@@ -267,6 +268,20 @@ def test_classlabel_int2str():
         assert classlabel.int2str(i) == names[i]
     with pytest.raises(ValueError):
         classlabel.int2str(len(names))
+
+
+@pytest.mark.parametrize("class_label_arg", ["names", "names_file"])
+def test_class_label_to_and_from_dict(class_label_arg, tmp_path_factory):
+    names = ["negative", "positive"]
+    names_file = str(tmp_path_factory.mktemp("features") / "labels.txt")
+    with open(names_file, "w", encoding="utf-8") as f:
+        f.write("\n".join(names))
+    if class_label_arg == "names":
+        class_label = ClassLabel(names=names)
+    elif class_label_arg == "names_file":
+        class_label = ClassLabel(names_file=names_file)
+    generated_class_label = generate_from_dict(asdict(class_label))
+    assert generated_class_label == class_label
 
 
 def test_encode_nested_example_sequence_with_none():


### PR DESCRIPTION
Currently, `names_file` is a field of the data class `ClassLabel`, thus appearing when transforming it to dict (when saving infos). Afterwards, when trying to read it from infos, it conflicts with the other field `names`.

This PR, removes `names_file` as a field of the data class `ClassLabel`.
- it is only used at instantiation to generate the `labels` field

Fix #3631.