### PR TITLE
Patch all module attributes in its namespace

### DIFF
--- a/src/datasets/utils/patching.py
+++ b/src/datasets/utils/patching.py
@@ -10,7 +10,7 @@ class _PatchedModuleObj:
     def __init__(self, module, attrs=None):
         attrs = attrs or []
         if module is not None:
-            for key in getattr(module, "__all__", module.__dict__):
+            for key in module.__dict__:
                 if key in attrs or not key.startswith("__"):
                     setattr(self, key, getattr(module, key))
 


### PR DESCRIPTION
When patching module attributes, only those defined in its `__all__` variable were considered by default (only falling back to `__dict__` if `__all__` was None).

However those are only a subset of all the module attributes in its namespace (`__dict__` variable).

This PR fixes the problem of modules that have non-None `__all__` variable, but try to access an attribute present in `__dict__` (and not in `__all__`).

For example, `pandas` has attribute `__version__` only present in `__dict__`.
- Before version 1.4, pandas `__all__` was None, thus all attributes in `__dict__` were patched
- From version 1.4, pandas `__all__` is not None, thus attributes in `__dict__` not present in `__all__` are ignored

Fix #3724.

CC: @severo @lvwerra 