### PR TITLE
Support streaming in size estimation function in `push_to_hub`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -101,7 +101,7 @@ from .utils.deprecation_utils import deprecated
 from .utils.file_utils import estimate_dataset_size
 from .utils.info_utils import is_small_dataset
 from .utils.py_utils import temporary_assignment, unique_values
-from .utils.streaming_download_manager import xgetsize, xopen
+from .utils.streaming_download_manager import xgetsize
 from .utils.typing import PathLike
 
 
@@ -3565,9 +3565,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     for x in array.to_pylist():
                         if x["bytes"] is None and x["path"] is not None:
                             size = xgetsize(x["path"])
-                            if size is None:
-                                with xopen(x["path"], "rb") as f:
-                                    size = len(f.read())
                             extra_nbytes += size
                     extra_nbytes -= array.field("path").nbytes
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -102,6 +102,7 @@ from .utils.file_utils import estimate_dataset_size
 from .utils.info_utils import is_small_dataset
 from .utils.py_utils import temporary_assignment, unique_values
 from .utils.typing import PathLike
+from .utils.streaming_download_manager import xgetsize
 
 
 if TYPE_CHECKING:
@@ -3563,7 +3564,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 if isinstance(feature, (Audio, Image)):
                     for x in array.to_pylist():
                         if x["bytes"] is None and x["path"] is not None:
-                            extra_nbytes += os.path.getsize(x["path"])
+                            extra_nbytes += xsize(x["path"])
                     extra_nbytes -= array.field("path").nbytes
 
             table = self.with_format("arrow")[:1000]

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -101,8 +101,8 @@ from .utils.deprecation_utils import deprecated
 from .utils.file_utils import estimate_dataset_size
 from .utils.info_utils import is_small_dataset
 from .utils.py_utils import temporary_assignment, unique_values
+from .utils.streaming_download_manager import xgetsize, xopen
 from .utils.typing import PathLike
-from .utils.streaming_download_manager import xgetsize
 
 
 if TYPE_CHECKING:
@@ -3564,7 +3564,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 if isinstance(feature, (Audio, Image)):
                     for x in array.to_pylist():
                         if x["bytes"] is None and x["path"] is not None:
-                            extra_nbytes += xsize(x["path"])
+                            size = xgetsize(x["path"])
+                            if size is None:
+                                with xopen(x["path"], "rb") as f:
+                                    size = len(f.read())
+                            extra_nbytes += size
                     extra_nbytes -= array.field("path").nbytes
 
             table = self.with_format("arrow")[:1000]
@@ -3577,6 +3581,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             dataset_nbytes = dataset_nbytes * len(self._indices) / len(self.data)
 
         num_shards = int(dataset_nbytes / shard_size) + 1
+        num_shards = max(num_shards, 1)
         shards = (self.shard(num_shards=num_shards, index=i, contiguous=True) for i in range(num_shards))
 
         if decodable_columns:

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -82,7 +82,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     # allow checks on paths
     patch_submodule(module, "os.path.isdir", wrap_auth(xisdir)).start()
     patch_submodule(module, "os.path.isfile", wrap_auth(xisfile)).start()
-    patch_submodule(module, "os.path.isfile", wrap_auth(xgetsize)).start()
+    patch_submodule(module, "os.path.getsize", wrap_auth(xgetsize)).start()
     if hasattr(module, "Path"):
         patch.object(module.Path, "joinpath", xpathjoin).start()
         patch.object(module.Path, "__truediv__", xpathjoin).start()

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -9,6 +9,7 @@ from .utils.streaming_download_manager import (
     xbasename,
     xdirname,
     xet_parse,
+    xgetsize,
     xglob,
     xisdir,
     xisfile,
@@ -81,6 +82,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     # allow checks on paths
     patch_submodule(module, "os.path.isdir", wrap_auth(xisdir)).start()
     patch_submodule(module, "os.path.isfile", wrap_auth(xisfile)).start()
+    patch_submodule(module, "os.path.isfile", wrap_auth(xgetsize)).start()
     if hasattr(module, "Path"):
         patch.object(module.Path, "joinpath", xpathjoin).start()
         patch.object(module.Path, "__truediv__", xpathjoin).start()

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -237,7 +237,8 @@ def xgetsize(path, use_auth_token: Optional[Union[str, bool]] = None) -> int:
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
         size = fs.size(main_hop)
         if size is None:
-            with fs.open(main_hop, "rb") as f:
+            # use xopen instead of fs.open to make data fetching more robust
+            with xopen(path, use_auth_token=use_auth_token) as f:
                 size = len(f.read())
         return size
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -215,7 +215,7 @@ def xisfile(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
         return fs.isfile(main_hop)
 
 
-def xgetsize(path, use_auth_token: Optional[Union[str, bool]] = None) -> Optional[int]:
+def xgetsize(path, use_auth_token: Optional[Union[str, bool]] = None) -> int:
     """Extend `os.path.getsize` function to support remote files.
 
     Args:
@@ -235,7 +235,11 @@ def xgetsize(path, use_auth_token: Optional[Union[str, bool]] = None) -> Optiona
         else:
             storage_options = None
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
-        return fs.size(main_hop)
+        size = fs.size(main_hop)
+        if size is None:
+            with fs.open(path, "rb") as f:
+                size = len(f.read())
+        return size
 
 
 def xisdir(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -215,6 +215,29 @@ def xisfile(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
         return fs.isfile(main_hop)
 
 
+def xgetsize(path, use_auth_token: Optional[Union[str, bool]] = None) -> Optional[int]:
+    """Extend `os.path.getsize` function to support remote files.
+
+    Args:
+        path (:obj:`str`): URL path.
+
+    Returns:
+        :obj:`int`, optional
+    """
+    main_hop, *rest_hops = path.split("::")
+    if is_local_path(main_hop):
+        return os.path.getsize(path)
+    else:
+        if rest_hops and fsspec.get_fs_token_paths(rest_hops[0])[0].protocol == "https":
+            storage_options = {
+                "https": {"headers": get_authentication_headers_for_url(rest_hops[0], use_auth_token=use_auth_token)}
+            }
+        else:
+            storage_options = None
+        fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
+        return fs.size(main_hop)
+
+
 def xisdir(path, use_auth_token: Optional[Union[str, bool]] = None) -> bool:
     """Extend `os.path.isdir` function to support remote files.
 

--- a/src/datasets/utils/streaming_download_manager.py
+++ b/src/datasets/utils/streaming_download_manager.py
@@ -237,7 +237,7 @@ def xgetsize(path, use_auth_token: Optional[Union[str, bool]] = None) -> int:
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
         size = fs.size(main_hop)
         if size is None:
-            with fs.open(path, "rb") as f:
+            with fs.open(main_hop, "rb") as f:
                 size = len(f.read())
         return size
 

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -13,6 +13,7 @@ from datasets.utils.streaming_download_manager import (
     _as_posix,
     _get_extraction_protocol,
     xbasename,
+    xgetsize,
     xglob,
     xisdir,
     xisfile,
@@ -316,6 +317,23 @@ def test_xisfile(input_path, isfile, tmp_path, mock_fsspec):
         input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
         (tmp_path / "file.txt").touch()
     assert xisfile(input_path) == isfile
+
+
+@pytest.mark.parametrize(
+    "input_path, size",
+    [
+        ("tmp_path", 0),
+        ("tmp_path/file.txt", 100),
+        ("mock://", 0),
+        ("mock://top_level/second_level/date=2019-10-01/a.parquet", 100),
+    ],
+)
+def test_xgetsize(input_path, size, tmp_path, mock_fsspec):
+    if input_path.startswith("tmp_path"):
+        input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
+        (tmp_path / "file.txt").touch()
+        (tmp_path / "file.txt").write_bytes(b"x" * 100)
+    assert xgetsize(input_path) == size
 
 
 @pytest.mark.parametrize(

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -322,7 +322,6 @@ def test_xisfile(input_path, isfile, tmp_path, mock_fsspec):
 @pytest.mark.parametrize(
     "input_path, size",
     [
-        ("tmp_path", 0),
         ("tmp_path/file.txt", 100),
         ("mock://", 0),
         ("mock://top_level/second_level/date=2019-10-01/a.parquet", 100),


### PR DESCRIPTION
This PR adds the streamable version of `os.path.getsize` (`fsspec` can return `None`, so we fall back to `fs.open` to make it more robust) to account for possible streamable paths in the nested `extra_nbytes_visitor` function inside `push_to_hub`.