### PR TITLE
Fix ValueError message formatting in int2str

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -832,7 +832,7 @@ class ClassLabel:
         """Conversion integer => class name string."""
         if not isinstance(values, int) and not isinstance(values, Iterable):
             raise ValueError(
-                "Values {values} should be an integer or an Iterable (list, numpy array, pytorch, tensorflow tensors)"
+                f"Values {values} should be an integer or an Iterable (list, numpy array, pytorch, tensorflow tensors)"
             )
         return_list = True
         if isinstance(values, int):


### PR DESCRIPTION
Hi!

I bumped into this particular `ValueError` during my work (because an instance of `np.int64` was passed instead of regular Python `int`), and so I had to `print(type(values))` myself. Apparently, it's just the missing `f` to make message an f-string.

It ain't much for a contribution, but it's honest work. Hope it spares someone else a few seconds in the future 😃