### PR TITLE
Start removing canonical datasets logic

### DIFF
--- a/docs/source/about_dataset_load.rst
+++ b/docs/source/about_dataset_load.rst
@@ -8,15 +8,23 @@ ELI5: ``load_dataset``
 
 Let's begin with a basic Explain Like I'm Five.
 
-For community datasets, :func:`datasets.load_dataset` downloads and imports the dataset loading script associated with the requested dataset from the Hugging Face Hub. The Hub is a central repository where all the Hugging Face datasets and models are stored. Code in the loading script defines the dataset information (description, features, URL to the original files, etc.), and tells 🤗 Datasets how to generate and display examples from it.
+A dataset is a directory that contains:
 
-If you are working with a canonical dataset, :func:`datasets.load_dataset` downloads and imports the dataset loading script from GitHub.
+- some data files in generic formats (JSON, CSV, Parquet, text, etc.)
+- and optionally a dataset script, if it requires some code to read the data files. This is used to load any kind of formats or structures.
+
+The :func:`datasets.load_dataset` function fetches the requested dataset, locally or from the Hugging Face Hub.
+The Hub is a central repository where all the Hugging Face datasets and models are stored.
+
+If the dataset only contains data files alone, then :func:`datasets.load_dataset` automatically infers how to load the data files from their extensions (json, csv, parquet, txt, etc.).
+If the dataset has a dataset script, then it downloads and imports it from the Hugging Face Hub. 
+Code in the loading script defines the dataset information (description, features, URL to the original files, etc.), and tells 🤗 Datasets how to generate and display examples from it.
 
 .. seealso::
 
-   Read the :doc:`Share <./share>` section to learn more about the difference between community and canonical datasets. This section also provides a step-by-step guide on how to write your own dataset loading script!
+   Read the :doc:`Share <./share>` section to learn more about how to share a dataset. This section also provides a step-by-step guide on how to write your own dataset loading script!
 
-The loading script downloads the dataset files from the original URL, generates the dataset and caches it in an Arrow table on your drive. If you've downloaded the dataset before, then 🤗 Datasets will reload it from the cache to save you the trouble of downloading it again.
+The dataset script downloads the dataset files from the original URL, generates the dataset and caches it in an Arrow table on your drive. If you've downloaded the dataset before, then 🤗 Datasets will reload it from the cache to save you the trouble of downloading it again.
 
 Now that you have a high-level understanding about how datasets are built, let's take a closer look at the nuts and bolts of how all this works.
 

--- a/docs/source/about_dataset_load.rst
+++ b/docs/source/about_dataset_load.rst
@@ -111,3 +111,13 @@ If the dataset doesn't pass the verifications, it is likely that the original ho
 In this case, an error is raised to alert that the dataset has changed.
 To ignore the error, one needs to specify ``ignore_verifications=True`` in :func:`load_dataset`.
 Anytime you see a verification error, feel free to `open an issue on GitHub <https://github.com/huggingface/datasets/issues>`_ so that we can update the integrity checks for this dataset.
+
+
+Security
+--------
+
+The dataset repositories on the Hub are scanned for malware, see more information [here](https://huggingface.co/docs/hub/security#malware-scanning).
+
+Moreover the datasets that were constributed on our GitHub repository have all been reviewed by our maintainers.
+The code of these datasets is considered **safe**.
+It concerns datasets that are not under a namespace, e.g. "squad" or "glue", unlike the other datasets that are named "username/dataset_name" or "org/dataset_name".

--- a/docs/source/about_dataset_load.rst
+++ b/docs/source/about_dataset_load.rst
@@ -11,14 +11,14 @@ Let's begin with a basic Explain Like I'm Five.
 A dataset is a directory that contains:
 
 - some data files in generic formats (JSON, CSV, Parquet, text, etc.)
-- and optionally a dataset script, if it requires some code to read the data files. This is used to load any kind of formats or structures.
+- An optional dataset script if it requires some code to read the data files. This is used to load files of all formats and structures.
 
-The :func:`datasets.load_dataset` function fetches the requested dataset, locally or from the Hugging Face Hub.
+The :func:`datasets.load_dataset` function fetches the requested dataset locally or from the Hugging Face Hub.
 The Hub is a central repository where all the Hugging Face datasets and models are stored.
 
-If the dataset only contains data files alone, then :func:`datasets.load_dataset` automatically infers how to load the data files from their extensions (json, csv, parquet, txt, etc.).
+If the dataset only contains data files, then :func:`datasets.load_dataset` automatically infers how to load the data files from their extensions (json, csv, parquet, txt, etc.).
 If the dataset has a dataset script, then it downloads and imports it from the Hugging Face Hub. 
-Code in the loading script defines the dataset information (description, features, URL to the original files, etc.), and tells 🤗 Datasets how to generate and display examples from it.
+Code in the dataset script defines the dataset information (description, features, URL to the original files, etc.), and tells 🤗 Datasets how to generate and display examples from it.
 
 .. seealso::
 

--- a/docs/source/dataset_script.rst
+++ b/docs/source/dataset_script.rst
@@ -264,7 +264,7 @@ Testing data and checksum metadata
 ----------------------------------
 
 We strongly recommend adding testing data and checksum metadata to your dataset to verify and test its behavior. This ensures the generated dataset matches your expectations.
-Testing data and checksum metadata are mandatory for Canonical datasets stored in the GitHub repository of the 🤗 Datasets library.
+Testing data and checksum metadata are mandatory for datasets stored in the GitHub repository of the 🤗 Datasets library.
 
 .. important::
 

--- a/docs/source/share.rst
+++ b/docs/source/share.rst
@@ -130,14 +130,16 @@ Congratulations, your dataset has now been uploaded to the Hugging Face Hub wher
 Datasets on GitHub (legacy)
 ---------------------------
 
-Most datasets have been added to the GitHub repository of the huggingface/datasets repository before being moved to the Hugging Face Hub.
-Editing them still has to be done using Pull Requests on GitHub for now.
+Datasets used to be hosted on our GitHub repository, but all datasets have now been migrated to the Hugging Face Hub.
+The legacy GitHub datasets were added originally on our GitHub repository and therefore don't have a namespace: "squad", "glue", etc. unlike the other datasets that are named "username/dataset_name" or "org/dataset_name".
+Those datasets are still maintained, and if you'd like to edit them, please open a Pull Request on the huggingface/datasets repository.
+Sharing your dataset to the Hub is the recommended way of adding a dataset.
 
 .. important::
 
     The distinction between a Hub dataset and a dataset from GitHub only comes from the legacy sharing workflow. It does not involve any ranking, decisioning, or opinion regarding the contents of the dataset itself.
 
 
-The code of these datasets are reviewed by the Hugging Face team and is considered **safe**, and they require test data in order to be regularly tested.
+The code of these datasets are reviewed by the Hugging Face team, and they require test data in order to be regularly tested.
 
 For more info, please take a look at the documentation on [How to add a new dataset in the huggingface/datasets repository](https://github.com/huggingface/datasets/blob/master/ADD_NEW_DATASET.md).

--- a/docs/source/share.rst
+++ b/docs/source/share.rst
@@ -1,57 +1,26 @@
 Share
 ======
 
-At Hugging Face, we are on a mission to democratize NLP and we believe in the value of open source. That's why we designed 🤗 Datasets so that anyone can share a dataset with the greater NLP community. There are currently over 900 datasets in over 100 languages in the Hugging Face Hub, and the Hugging Face team always welcomes new contributions!
+At Hugging Face, we are on a mission to democratize good Machine Learning and we believe in the value of open source. That's why we designed 🤗 Datasets so that anyone can share a dataset with the greater ML community. There are currently thousands datasets in over 100 languages in the Hugging Face Hub, and the Hugging Face team always welcomes new contributions!
 
-This guide will show you how to share a dataset that can be easily accessed by anyone.
+Dataset repositories offer you nice features such as:
 
-There are two options to share a new dataset:
-
-- Directly upload it on the Hub as a community provided dataset.
-- Add it as a canonical dataset by opening a pull-request on the `GitHub repository for 🤗 Datasets <https://github.com/huggingface/datasets>`__.
-
-Community vs. canonical
------------------------
-
-Both options offer the same features such as:
-
+- Free dataset hosting
 - Dataset versioning
 - Commit history and diffs
 - Metadata for discoverability
 - Dataset cards for documentation, licensing, limitations, etc.
 
-The main differences between the two are highlighted in the table below:
-
-.. list-table::
-    :header-rows: 1
-
-    * - Community datasets
-      - Canonical datasets
-    * - Faster to share, no review process.
-      - Slower to add, needs to be reviewed.
-    * - Data files can be stored on the Hub.
-      - Data files are typically retrieved from the original host URLs.
-    * - Identified by a user or organization namespace like **thomwolf/my_dataset** or **huggingface/our_dataset**.
-      - Identified by a root namespace. Need to select a short name that is available.
-    * - Requires data files and/or a dataset loading script.
-      - Always requires a dataset loading script.
-    * - Flagged as **unsafe** because the dataset contains executable code.
-      - Flagged as **safe** because the dataset has been reviewed.
-
-For community datasets, if your dataset is in a supported format, you can skip directly below to learn how to upload your files and add a :doc:`dataset card <dataset_card>`. There is no need to write your own dataset loading script (unless you want more control over how to load your dataset). However, if the dataset isn't in one of the supported formats, you will need to write a :doc:`dataset loading script <dataset_script>`. The dataset loading script is a Python script that defines the dataset splits, feature types, and how to download and process the data.
-
-On the other hand, a dataset script is always required for canonical datasets.
-
-.. important::
-
-    The distinction between a canonical and community dataset is based solely on the selected sharing workflow. It does not involve any ranking, decisioning, or opinion regarding the contents of the dataset itself.
+This guide will show you how to share a dataset that can be easily accessed by anyone.
 
 .. _upload_dataset_repo:
 
-Add a community dataset
------------------------
+Add a dataset
+-------------
 
 You can share your dataset with the community with a dataset repository on the Hugging Face Hub.
+It can also be a private dataset if you want to control who has access to it.
+
 In a dataset repository, you can either host all your data files and/or use a dataset script.
 
 The dataset script is optional if your dataset is in one of the following formats: CSV, JSON, JSON lines, text or Parquet.
@@ -113,11 +82,11 @@ Prepare your files
 
 * ``README.md`` is a Dataset card that describes the datasets contents, creation, and usage. To write a Dataset card, see the :doc:`dataset card <dataset_card>` page.
 
-* The raw data files of the dataset (optional, if they are hosted elsewhere you can specify the URLs in the dataset script).
+* The raw data files of the dataset (optional, if they are hosted elsewhere you can specify the URLs in the dataset script). If you don't need a dataset script, you can take a look at :doc:`how to structure your dataset repository for your data files <repository_structure>`.
 
 * ``your_dataset_name.py`` is your dataset loading script (optional if your data files are already in the supported formats csv/jsonl/json/parquet/txt). To create a dataset script, see the :doc:`dataset script <dataset_script>` page.
 
-* ``dataset_infos.json`` contains metadata about the dataset (required only if you have a dataset script).
+* ``dataset_infos.json`` contains metadata about the dataset (required only if you have a dataset script, or if you want to specify custom feature types).
 
 Upload your files
 ^^^^^^^^^^^^^^^^^
@@ -157,67 +126,18 @@ Congratulations, your dataset has now been uploaded to the Hugging Face Hub wher
 
    dataset = load_dataset("namespace/your_dataset_name")
 
-Add a canonical dataset
------------------------
 
-Canonical datasets are dataset scripts hosted in the GitHub repository of the 🤗 Dataset library.
-The code of these datasets are reviewed by the Hugging Face team, and they require test data in order to be regularly tested.
+Datasets on GitHub (legacy)
+---------------------------
 
-Clone the repository
-^^^^^^^^^^^^^^^^^^^^
+Most datasets have been added on the GitHub repository of the huggingface/datasets repository before being moved to the Hugging face Hub.
+Editing them still has to be done using Pull Requests on GitHub for now.
 
-To share a canonical dataset:
+.. important::
 
-1. Fork the 🤗 `Datasets repository <https://github.com/huggingface/datasets>`_ by clicking on the **Fork** button.
+    The distinction between a Hub dataset and a dataset from GitHub only comes from the legacy sharing workflow. It does not involve any ranking, decisioning, or opinion regarding the contents of the dataset itself.
 
-2. Clone your fork to your local disk, and add the base repository as a remote:
 
-.. code-block::
+The code of these datasets are reviewed by the Hugging Face team and is considered **safe**, and they require test data in order to be regularly tested.
 
-   git clone https://github.com/<your_GitHub_handle>/datasets
-   cd datasets
-   git remote add upstream https://github.com/huggingface/datasets.git
-
-Prepare your files
-^^^^^^^^^^^^^^^^^^
-
-3. Create a new branch to hold your changes. You can name the new branch using the short name of your dataset:
-
-.. code::
-
-   git checkout -b my-new-dataset
-
-4. Set up a development environment by running the following command in a virtual environment:
-
-.. code::
-
-   pip install -e ".[dev]"
-
-5. Create a new folder with the dataset name inside ``huggingface/datasets``, and add the dataset loading script. To create a dataset script, see the :doc:`dataset script <dataset_script>` page.
-
-6. Check your directory to ensure the only files you're uploading are:
-
-* ``README.md`` is a Dataset card that describes the datasets contents, creation, and usage. To write a Dataset card, see the :doc:`dataset card <dataset_card>` page.
-
-* ``your_dataset_name.py`` is your dataset loading script.
-
-* ``dataset_infos.json`` contains metadata about the dataset.
-
-* ``dummy`` folder with ``dummy_data.zip`` files that hold a small subset of data from the dataset for tests and preview.
-
-7. Run `Black <https://black.readthedocs.io/en/stable/index.html>`_ and `isort <https://pycqa.github.io/isort/>`_ to tidy up your code and files:
-
-.. code-block::
-
-   make style
-   make quality
-
-8. Add your changes, and make a commit to record your changes locally. Then you can push the changes to your account:
-
-.. code-block::
-
-   git add datasets/<my-new-dataset>
-   git commit
-   git push -u origin my-new-dataset
-
-9. Go back to your fork on GitHub, and click on **Pull request** to open a pull request on the main 🤗 `Datasets repository <https://github.com/huggingface/datasets>`_ for review.
+For more info, please take a look at the documentation on [How to add a new dataset in the huggingface/datasets repository](https://github.com/huggingface/datasets/blob/master/ADD_NEW_DATASET.md).

--- a/docs/source/share.rst
+++ b/docs/source/share.rst
@@ -1,9 +1,9 @@
 Share
 ======
 
-At Hugging Face, we are on a mission to democratize good Machine Learning and we believe in the value of open source. That's why we designed 🤗 Datasets so that anyone can share a dataset with the greater ML community. There are currently thousands datasets in over 100 languages in the Hugging Face Hub, and the Hugging Face team always welcomes new contributions!
+At Hugging Face, we are on a mission to democratize good Machine Learning and we believe in the value of open source. That's why we designed 🤗 Datasets so that anyone can share a dataset with the greater ML community. There are currently thousands of datasets in over 100 languages in the Hugging Face Hub, and the Hugging Face team always welcomes new contributions!
 
-Dataset repositories offer you nice features such as:
+Dataset repositories offer features such as:
 
 - Free dataset hosting
 - Dataset versioning
@@ -130,7 +130,7 @@ Congratulations, your dataset has now been uploaded to the Hugging Face Hub wher
 Datasets on GitHub (legacy)
 ---------------------------
 
-Most datasets have been added on the GitHub repository of the huggingface/datasets repository before being moved to the Hugging face Hub.
+Most datasets have been added to the GitHub repository of the huggingface/datasets repository before being moved to the Hugging Face Hub.
 Editing them still has to be done using Pull Requests on GitHub for now.
 
 .. important::

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -249,9 +249,9 @@ def get_dataset_config_info(
         download_mode (:class:`DownloadMode`, default ``REUSE_DATASET_IF_EXISTS``): Download/generate mode.
         revision (:class:`~utils.Version` or :obj:`str`, optional): Version of the dataset script to load:
 
-            - For canonical datasets in the `huggingface/datasets` library like "squad", the default version of the module is the local version of the lib.
+            - For datasets in the `huggingface/datasets` library on GitHub like "squad", the default version of the module is the local version of the lib.
               You can specify a different version from your local version of the lib (e.g. "master" or "1.2.0") but it might cause compatibility issues.
-            - For community provided datasets like "lhoestq/squad" that have their own git repository on the Datasets Hub, the default version "main" corresponds to the "main" branch.
+            - For community datasets like "lhoestq/squad" that have their own git repository on the Datasets Hub, the default version "main" corresponds to the "main" branch.
               You can specify a different version that the default "main" by using a commit sha or a git tag of the dataset repository.
         use_auth_token (``str`` or ``bool``, optional): Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
             If True, will get token from `"~/.huggingface"`.
@@ -311,9 +311,9 @@ def get_dataset_split_names(
         download_mode (:class:`DownloadMode`, default ``REUSE_DATASET_IF_EXISTS``): Download/generate mode.
         revision (:class:`~utils.Version` or :obj:`str`, optional): Version of the dataset script to load:
 
-            - For canonical datasets in the `huggingface/datasets` library like "squad", the default version of the module is the local version of the lib.
+            - For datasets in the `huggingface/datasets` library on GitHub like "squad", the default version of the module is the local version of the lib.
               You can specify a different version from your local version of the lib (e.g. "master" or "1.2.0") but it might cause compatibility issues.
-            - For community provided datasets like "lhoestq/squad" that have their own git repository on the Datasets Hub, the default version "main" corresponds to the "main" branch.
+            - For community datasets like "lhoestq/squad" that have their own git repository on the Datasets Hub, the default version "main" corresponds to the "main" branch.
               You can specify a different version that the default "main" by using a commit sha or a git tag of the dataset repository.
         use_auth_token (``str`` or ``bool``, optional): Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
             If True, will get token from `"~/.huggingface"`.

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -23,10 +23,10 @@ from datasets.iterable_dataset import IterableDataset
 from datasets.load import (
     CachedDatasetModuleFactory,
     CachedMetricModuleFactory,
-    CanonicalDatasetModuleFactory,
-    CanonicalMetricModuleFactory,
-    CommunityDatasetModuleFactoryWithoutScript,
-    CommunityDatasetModuleFactoryWithScript,
+    GithubDatasetModuleFactory,
+    GithubMetricModuleFactory,
+    HubDatasetModuleFactoryWithoutScript,
+    HubDatasetModuleFactoryWithScript,
     LocalDatasetModuleFactoryWithoutScript,
     LocalDatasetModuleFactoryWithScript,
     LocalMetricModuleFactory,
@@ -182,26 +182,26 @@ class ModuleFactoryTest(TestCase):
             hf_modules_cache=self.hf_modules_cache,
         )
 
-    def test_CanonicalDatasetModuleFactory(self):
+    def test_GithubDatasetModuleFactory(self):
         # "wmt_t2t" has additional imports (internal)
-        factory = CanonicalDatasetModuleFactory(
+        factory = GithubDatasetModuleFactory(
             "wmt_t2t", download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
         assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
 
-    def test_CanonicalMetricModuleFactory_with_internal_import(self):
+    def test_GithubMetricModuleFactory_with_internal_import(self):
         # "squad_v2" requires additional imports (internal)
-        factory = CanonicalMetricModuleFactory(
+        factory = GithubMetricModuleFactory(
             "squad_v2", download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-    def test_CanonicalMetricModuleFactory_with_external_import(self):
+    def test_GithubMetricModuleFactory_with_external_import(self):
         # "bleu" requires additional imports (external from github)
-        factory = CanonicalMetricModuleFactory(
+        factory = GithubMetricModuleFactory(
             "bleu", download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
         )
         module_factory_result = factory.get_module()
@@ -237,16 +237,16 @@ class ModuleFactoryTest(TestCase):
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-    def test_CommunityDatasetModuleFactoryWithoutScript(self):
-        factory = CommunityDatasetModuleFactoryWithoutScript(
+    def test_HubDatasetModuleFactoryWithoutScript(self):
+        factory = HubDatasetModuleFactoryWithoutScript(
             SAMPLE_DATASET_IDENTIFIER2, download_config=self.download_config
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
         assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
 
-    def test_CommunityDatasetModuleFactoryWithScript(self):
-        factory = CommunityDatasetModuleFactoryWithScript(
+    def test_HubDatasetModuleFactoryWithScript(self):
+        factory = HubDatasetModuleFactoryWithScript(
             SAMPLE_DATASET_IDENTIFIER,
             download_config=self.download_config,
             dynamic_modules_path=self.dynamic_modules_path,
@@ -363,7 +363,7 @@ class LoadTest(TestCase):
                 self.assertNotEqual(dataset_module_1.module_path, dataset_module_3.module_path)
                 self.assertIn("Using the latest cached version of the module", self._caplog.text)
 
-    def test_load_dataset_canonical(self):
+    def test_load_dataset_from_github(self):
         scripts_version = os.getenv("HF_SCRIPTS_VERSION", SCRIPTS_VERSION)
         with self.assertRaises(FileNotFoundError) as context:
             datasets.load_dataset("_dummy")


### PR DESCRIPTION
I updated the source code and the documentation to start removing the "canonical datasets" logic.

Indeed this makes the documentation confusing and we don't want this distinction anymore in the future. Ideally users should share their datasets on the Hub directly.

### Changes

- the documentation about dataset loading mentions the datasets on the Hub (no difference between canonical and community, since they all have their own repository now)
- the documentation about adding a dataset doesn't explain the technical differences between canonical and community anymore, and only presents how to add a community dataset. There is still a small section at the bottom that mentions the datasets that are still on GitHub and redirects to the `ADD_NEW_DATASET.md` guide on GitHub about how to contribute a dataset to the `datasets` library
- the code source doesn't mention "canonical" anymore anywhere. There is still a `GitHubDatasetModuleFactory` class that is left, but I updated the docstring to say that it will be eventually removed in favor of the `HubDatasetModuleFactory` classes that already exist

Would love to have your feedbacks on this !

cc @julien-c @thomwolf @SBrandeis 