### PR TITLE
Error of writing with different schema, due to nonpreservation of nullability

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1102,6 +1102,21 @@ def cast_table_to_features(table: pa.Table, features: "Features"):
     arrays = [cast_array_to_feature(table[name], feature) for name, feature in features.items()]
     return pa.Table.from_arrays(arrays, schema=features.arrow_schema)
 
+def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
+    """Cast an table to the arrow schema. Different from `cast_table_to_features`, this method can preserve nullability.
+
+    Args:
+        table (pa.Table): PyArrow table to cast
+        features (Features): target features.
+
+    Returns:
+        pa.Table: the casted table
+    """
+    from .features import Features
+    
+    features = Features.from_arrow_schema(schema)
+    arrays = [cast_array_to_feature(table[name], feature) for name, feature in features.items()]
+    return pa.Table.from_arrays(arrays, schema=schema)
 
 def table_cast(table: pa.Table, schema: pa.Schema):
     """Improved version of pa.Table.cast
@@ -1116,9 +1131,7 @@ def table_cast(table: pa.Table, schema: pa.Schema):
         pa.Table: the casted table
     """
     if table.schema != schema:
-        from .features import Features
-
-        return cast_table_to_features(table, Features.from_arrow_schema(schema))
+        return cast_table_to_schema(table, schema)
     elif table.schema.metadata != schema.metadata:
         return table.replace_schema_metadata(schema.metadata)
     else:

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1104,7 +1104,7 @@ def cast_table_to_features(table: pa.Table, features: "Features"):
 
 
 def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
-    """Cast an table to the arrow schema. Different from `cast_table_to_features`, this method can preserve nullability.
+    """Cast a table to the arrow schema. Different from `cast_table_to_features`, this method can preserve nullability.
 
     Args:
         table (pa.Table): PyArrow table to cast

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -988,8 +988,7 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
         if pa.types.is_fixed_size_list(pa_type):
             if pa_type.list_size * len(array) == len(array.values):
                 return pa.FixedSizeListArray.from_arrays(
-                    _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str),
-                    pa_type.list_size,
+                    _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str), pa_type.list_size,
                 )
         elif pa.types.is_list(pa_type):
             return pa.ListArray.from_arrays(
@@ -998,8 +997,7 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
     elif pa.types.is_fixed_size_list(array.type):
         if pa.types.is_fixed_size_list(pa_type):
             return pa.FixedSizeListArray.from_arrays(
-                _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str),
-                pa_type.list_size,
+                _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str), pa_type.list_size,
             )
         elif pa.types.is_list(pa_type):
             offsets_arr = pa.array(range(len(array) + 1), pa.int32())
@@ -1102,6 +1100,7 @@ def cast_table_to_features(table: pa.Table, features: "Features"):
     arrays = [cast_array_to_feature(table[name], feature) for name, feature in features.items()]
     return pa.Table.from_arrays(arrays, schema=features.arrow_schema)
 
+
 def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
     """Cast an table to the arrow schema. Different from `cast_table_to_features`, this method can preserve nullability.
 
@@ -1113,10 +1112,11 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
         pa.Table: the casted table
     """
     from .features import Features
-    
+
     features = Features.from_arrow_schema(schema)
     arrays = [cast_array_to_feature(table[name], feature) for name, feature in features.items()]
     return pa.Table.from_arrays(arrays, schema=schema)
+
 
 def table_cast(table: pa.Table, schema: pa.Schema):
     """Improved version of pa.Table.cast

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1116,6 +1116,8 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
     from .features import Features
 
     features = Features.from_arrow_schema(schema)
+    if sorted(table.column_names) != sorted(features):
+        raise ValueError(f"Couldn't cast\n{table.schema}\nto\n{features}\nbecause column names don't match")
     arrays = [cast_array_to_feature(table[name], feature) for name, feature in features.items()]
     return pa.Table.from_arrays(arrays, schema=schema)
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -988,7 +988,8 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
         if pa.types.is_fixed_size_list(pa_type):
             if pa_type.list_size * len(array) == len(array.values):
                 return pa.FixedSizeListArray.from_arrays(
-                    _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str), pa_type.list_size,
+                    _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str),
+                    pa_type.list_size,
                 )
         elif pa.types.is_list(pa_type):
             return pa.ListArray.from_arrays(
@@ -997,7 +998,8 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
     elif pa.types.is_fixed_size_list(array.type):
         if pa.types.is_fixed_size_list(pa_type):
             return pa.FixedSizeListArray.from_arrays(
-                _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str), pa_type.list_size,
+                _c(array.values, pa_type.value_type, allow_number_to_str=allow_number_to_str),
+                pa_type.list_size,
             )
         elif pa.types.is_list(pa_type):
             offsets_arr = pa.array(range(len(array) + 1), pa.int32())


### PR DESCRIPTION
## 1. Case
```
dataset.map(
  batched=True,
  disable_nullable=True,
)
```
will get the following error at here https://github.com/huggingface/datasets/blob/c9967f55626931f8059dc416526c791444cdfdf7/src/datasets/arrow_writer.py#L516

`pyarrow.lib.ArrowInvalid: Tried to write record batch with different schema`

## 2. Debugging
### 2.1 tracing
During `_map_single`, the following are called
https://github.com/huggingface/datasets/blob/c9967f55626931f8059dc416526c791444cdfdf7/src/datasets/arrow_dataset.py#L2523
https://github.com/huggingface/datasets/blob/c9967f55626931f8059dc416526c791444cdfdf7/src/datasets/arrow_writer.py#L511
### 2.2. Observation
The problem is, even after `table_cast`, `pa_table.schema != self._schema`
`pa_table.schema` (before/after `table_cast`)
```
input_ids: list<item: int32>
  child 0, item: int32
```
`self._schema`
```
input_ids: list<item: int32> not null
  child 0, item: int32
```
### 2.3. Reason
https://github.com/huggingface/datasets/blob/c9967f55626931f8059dc416526c791444cdfdf7/src/datasets/table.py#L1121
Here we lose nullability stored in `schema` because it seems that `Features` is always nullable and don't store nullability.
https://github.com/huggingface/datasets/blob/c9967f55626931f8059dc416526c791444cdfdf7/src/datasets/table.py#L1103
So, casting to schema from such `Features` loses nullability, and eventually causes error of writing with different schema

## 3. Solution
1. Let `Features` stores nullability.
2. Directly cast table with original schema but not schema from converted `Features`. (this PR)
3. Don't `cast_table` when `write_table`