### PR TITLE
Add URL and ID fields to Wikipedia dataset

### DIFF
--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -405,6 +405,7 @@ class Wikipedia(datasets.BeamBasedBuilder):
             description=_DESCRIPTION,
             features=datasets.Features(
                 {
+                    "id": datasets.Value("string"),
                     "url": datasets.Value("string"),
                     "title": datasets.Value("string"),
                     "text": datasets.Value("string"),
@@ -510,7 +511,7 @@ class Wikipedia(datasets.BeamBasedBuilder):
 
             beam.metrics.Metrics.counter(language, "cleaned-examples").inc()
 
-            yield id_, {"url": url, "title": title, "text": text}
+            yield id_, {"id": id_, "url": url, "title": title, "text": text}
 
         return (
             pipeline


### PR DESCRIPTION
This PR adds the URL field, so that we conform to proper attribution, required by their license: provide credit to the authors by including a hyperlink (where possible) or URL to the page or pages you are re-using.

About the conversion from title to URL, I found that apart from replacing blanks with underscores, some other special character must also be percent-encoded (e.g. `"` to `%22`): https://meta.wikimedia.org/wiki/Help:URL

Therefore, I have finally used `urllib.parse.quote` function. This additionally percent-encodes non-ASCII characters, but Wikimedia docs say these are equivalent:
> For the other characters either the code or the character can be used in internal and external links, they are equivalent. The system does a conversion when needed.
> [[%C3%80_propos_de_M%C3%A9ta]]
> is rendered as [À_propos_de_Méta](https://meta.wikimedia.org/wiki/%C3%80_propos_de_M%C3%A9ta), almost like [À propos de Méta](https://meta.wikimedia.org/wiki/%C3%80_propos_de_M%C3%A9ta), which leads to this page on Meta with in the address bar the URL
> [http://meta.wikipedia.org/wiki/%C3%80_propos_de_M%C3%A9ta](https://meta.wikipedia.org/wiki/%C3%80_propos_de_M%C3%A9ta)
> while [http://meta.wikipedia.org/wiki/À_propos_de_Méta](https://meta.wikipedia.org/wiki/%C3%80_propos_de_M%C3%A9ta) leads to the same. 

Fix #3398.
CC: @geohci