### PR TITLE
Add doc builder scripts

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -1,0 +1,112 @@
+name: Build dev documentation
+
+on:
+  pull_request:
+
+
+jobs:
+  build_and_package:
+    runs-on: [self-hosted, doc-builder]
+    container:
+      image: huggingface/doc-builder-datasets
+      options: "-v /home/github_actions:/mnt"
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      EVENT_CONTEXT: ${{ toJSON(github.event) }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-builder'
+          path: doc-builder
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/datasets'
+          path: datasets
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/notebooks'
+          path: notebooks
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Set env
+        run: echo "WRITE=$(cat /mnt/WRITE)" >> $GITHUB_ENV
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        if: github.event.action == 'opened'
+
+        with:
+          message: 'The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/datasets/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.'
+          GITHUB_TOKEN: ${{ env.WRITE }}
+
+      - name: Find Comment
+        if: github.event.action == 'reopened'
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: HuggingFaceDocBuilder
+
+      - name: Update comment
+        if: github.event.action == 'reopened'
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ env.WRITE }}
+          edit-mode: replace
+          body: |
+            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/datasets/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
+
+      - name: Loading cache.
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: v1-test_build_doc
+          restore-keys: |
+            v1-test_build_doc-${{ hashFiles('setup.py') }}
+            v1-test_build_doc
+
+      - name: Setup environment
+        run: |
+          apt-get -y update && apt-get install -y libsndfile1-dev
+
+          pip uninstall -y doc-builder
+          pip install git+https://github.com/huggingface/doc-builder -U
+          cd datasets
+          pip install .[dev]
+          cd ..
+
+      - name: Setup git
+        run: |
+          git config --global user.name "Hugging Face Doc Builder"
+          git config --global user.email docs@huggingface.co
+          
+
+          cd notebooks
+          git pull origin master
+          cd ..
+          WRITE=`cat /mnt/WRITE`
+          
+          rm -rf doc-build-dev
+          git clone https://HuggingFaceDocBuilder:$WRITE@github.com/huggingface/doc-build-dev
+
+      - name: Make documentation
+        run: |
+          cd doc-builder &&
+          doc-builder build datasets ../datasets/docs/source --library_name datasets --build_dir ../doc-build-dev --notebook_dir notebooks/datasets_doc --clean --version pr_$PR_NUMBER --html &&
+          cd ..
+
+      - name: Push to repositories
+        run: |
+          cd doc-build-dev &&
+          ls &&
+          git add . &&
+          git commit -m "Updated with commit ${{ github.sha }} See: https://github.com/huggingface/datasets/commit/${{ github.sha }}" &&
+          git push origin main

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -1,15 +1,17 @@
 name: Build dev documentation
 
 on:
+  push:
+    branches:
+      - docs_new_ui-actions-no-self-hosted
   pull_request:
 
 
 jobs:
   build_and_package:
-    runs-on: [self-hosted, doc-builder]
+    runs-on: ubuntu-latest
     container:
-      image: huggingface/doc-builder-transformers
-      options: "-v /home/github_actions:/mnt"
+      image: huggingface/transformers-doc-builder
     env:
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
@@ -35,7 +37,30 @@ jobs:
           node-version: '14'
 
       - name: Set env
-        run: echo "WRITE=$(cat /mnt/WRITE)" >> $GITHUB_ENV
+        run: |
+          echo "WRITE=$(echo 'ghp_'$(wget -qO- lysand.re/doc-build-dev)'bm')" >> $GITHUB_ENV
+
+      - name: Setup environment
+        run: |
+          rm -rf doc-build-dev
+          git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.WRITE }}@github.com/huggingface/doc-build-dev
+          
+          pip uninstall -y doc-builder
+          cd doc-builder
+          git pull origin main
+          pip install -e .
+          cd ..
+          
+          pip install ./datasets[dev]
+          
+          cd notebooks
+          git pull origin master
+          cd ..
+
+      - name: Setup git
+        run: |
+          git config --global user.name "Hugging Face Doc Builder"
+          git config --global user.email docs@huggingface.co
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1
@@ -73,34 +98,11 @@ jobs:
             v1-test_build_doc-${{ hashFiles('setup.py') }}
             v1-test_build_doc
 
-      - name: Setup environment
-        run: |
-          apt-get -y update && apt-get install -y libsndfile1-dev
-
-          pip uninstall -y doc-builder
-          pip install git+https://github.com/huggingface/doc-builder -U
-          cd datasets
-          pip install .[dev]
-          cd ..
-
-      - name: Setup git
-        run: |
-          git config --global user.name "Hugging Face Doc Builder"
-          git config --global user.email docs@huggingface.co
-          
-
-          cd notebooks
-          git pull origin master
-          cd ..
-          WRITE=`cat /mnt/WRITE`
-          
-          rm -rf doc-build-dev
-          git clone https://HuggingFaceDocBuilder:$WRITE@github.com/huggingface/doc-build-dev
-
       - name: Make documentation
         run: |
-          cd doc-builder &&
-          doc-builder build datasets ../datasets/docs/source --library_name datasets --build_dir ../doc-build-dev --notebook_dir notebooks/datasets_doc --clean --version pr_$PR_NUMBER --html &&
+          cd doc-build-dev && git pull && cd ..
+          cd doc-builder
+          doc-builder build datasets ../datasets/docs/source --build_dir ../doc-build-dev --notebook_dir ../notebooks/datasets_doc --clean --version pr_$PR_NUMBER --html
           cd ..
 
       - name: Push to repositories

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -8,7 +8,7 @@ jobs:
   build_and_package:
     runs-on: [self-hosted, doc-builder]
     container:
-      image: huggingface/doc-builder-datasets
+      image: huggingface/doc-builder-transformers
       options: "-v /home/github_actions:/mnt"
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -1,0 +1,104 @@
+name: Build documentation
+
+on:
+  push:
+    branches:
+      - master
+      - doc-builder*
+      - v*-release
+
+jobs:
+  build_and_package:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-builder'
+          path: doc-builder
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-build'
+          path: doc-build
+          token: ${{ secrets.HUGGINGFACE_PUSH }}
+      
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/datasets'
+          path: datasets
+      
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/notebooks'
+          path: notebooks
+          token: ${{ secrets.HUGGINGFACE_PUSH }}
+      
+      - name: Loading cache.
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: v1-test_build_doc
+          restore-keys: |
+            v1-test_build_doc-${{ hashFiles('setup.py') }}
+            v1-test_build_doc
+
+      - name: Setup environment
+        run: |
+          sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
+
+          pip install git+https://github.com/huggingface/doc-builder
+          cd datasets
+          pip install .[dev]
+          cd ..
+
+      - name: Setup git
+        run: |
+          git config --global user.name "Hugging Face Doc Builder"
+          git config --global user.email docs@huggingface.co
+          
+          cd doc-build
+          git pull origin main
+          cd ..
+
+          cd notebooks
+          git pull origin master
+          cd ..
+
+      - name: Make documentation
+        run: |
+          cd doc-builder &&
+          doc-builder build datasets ../datasets/docs/source --library_name datasets --build_dir ../doc-build --notebook_dir notebooks/datasets_doc --clean --html &&
+          cd ..
+        env:
+          NODE_OPTIONS: --max-old-space-size=6656
+
+      - name: Push to repositories
+        run: |
+          cd doc-build &&
+          if [[ `git status --porcelain` ]]; then 
+            git add . &&
+            git commit -m "Updated with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/datasets/commit/${{ github.sha }}" &&
+            git push origin main
+          else
+            echo "No diff in the documentation."
+          fi &&
+          cd .. &&
+
+          cd notebooks &&
+          if [[ `git status --porcelain` ]]; then
+            git add datasets_doc &&
+            git commit -m "Updated Datasets doc notebooks with commit ${{ github.sha }} \n\nSee: https://github.com/huggingface/datasets/commit/${{ github.sha }}" &&
+            git push origin master
+          else
+            echo "No diff in the notebooks."
+          fi &&
+          cd ..

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -9,7 +9,7 @@ jobs:
   build_and_package:
     runs-on: [self-hosted, doc-builder]
     container:
-      image: huggingface/doc-builder-datasets
+      image: huggingface/doc-builder-transformers
       options: "-v /home/github_actions:/mnt"
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/delete_dev_documentation.yml
+++ b/.github/workflows/delete_dev_documentation.yml
@@ -1,0 +1,59 @@
+name: Delete dev documentation
+
+on:
+  pull_request:
+    types: [ closed ]
+
+
+jobs:
+  build_and_package:
+    runs-on: [self-hosted, doc-builder]
+    container:
+      image: huggingface/doc-builder-datasets
+      options: "-v /home/github_actions:/mnt"
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "WRITE=$(cat /mnt/WRITE)" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-build-dev'
+          path: doc-build-dev
+          token: ${{ env.WRITE }}
+
+      - name: Setup git
+        run: |
+          git config --global user.name "Hugging Face Doc Builder"
+          git config --global user.email docs@huggingface.co
+
+      - name: Push to repositories
+        run: |
+          cd doc-build-dev
+          ls
+          rm -rf datasets/pr_$PR_NUMBER
+          ls
+          git add .
+          git commit -m "Closed PR ${GITHUB_REF##*/}"
+          git push origin main
+
+      - name: Find Comment
+        if: ${{ always() }}
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: HuggingFaceDocBuilder
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ env.WRITE }}
+          edit-mode: replace
+          body: |
+            _The documentation is not available anymore as the PR was closed or merged._

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -199,76 +199,227 @@ class Table(IndexedTableMixin):
             table = state["table"]
         Table.__init__(self, table)
 
-    @inject_arrow_table_documentation(pa.Table.validate)
     def validate(self, *args, **kwargs):
+        """
+        Perform validation checks.  An exception is raised if validation fails.
+
+        By default only cheap validation checks are run.  Pass `full=True`
+        for thorough validation checks (potentially O(n)).
+
+        Args:
+            full (:obj:`bool`, defaults to :obj:`False`):
+                If True, run expensive checks, otherwise cheap checks only.
+
+        Raises:
+            pa.lib.ArrowInvalid: if validation fails
+        """
         return self.table.validate(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.equals)
     def equals(self, *args, **kwargs):
+        """
+        Check if contents of two tables are equal.
+
+        Args:
+            other (:class:`datasets.table.Table`):
+                Table to compare against.
+            check_metadata (:obj:`bool`, defaults to :obj:`False`):
+                Whether schema metadata equality should be checked as well.
+
+        Returns:
+            :obj:`bool`
+        """
         args = tuple(arg.table if isinstance(arg, Table) else arg for arg in args)
         kwargs = {k: v.table if isinstance(v, Table) else v for k, v in kwargs}
         return self.table.equals(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.to_batches)
     def to_batches(self, *args, **kwargs):
+        """
+        Convert Table to list of (contiguous) RecordBatch objects.
+
+        Args:
+            max_chunksize (:obj:`int`, defaults to `None`):
+                Maximum size for RecordBatch chunks. Individual chunks may be
+                smaller depending on the chunk layout of individual columns.
+
+        Returns:
+            :obj:`List[pyarrow.RecordBatch]`:
+        """
         return self.table.to_batches(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.to_pydict)
     def to_pydict(self, *args, **kwargs):
+        """
+        Convert the Table to a dict or OrderedDict.
+
+        Returns:
+            :obj:`dict`
+        """
         return self.table.to_pydict(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.to_pandas)
     def to_pandas(self, *args, **kwargs):
+        """
+        Convert to a pandas-compatible NumPy array or DataFrame, as appropriate
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                Arrow MemoryPool to use for allocations. Uses the default memory
+                pool is not passed.
+            strings_to_categorical (:obj:`bool`, defaults to :obj:`False`):
+                Encode string (UTF8) and binary types to pandas.Categorical.
+            categories (:obj:`list`, defaults to :obj:`empty`):
+                List of fields that should be returned as pandas.Categorical. Only
+                applies to table-like data structures.
+            zero_copy_only (:obj:`bool`, defaults to :obj:`False`):
+                Raise an ArrowException if this function call would require copying
+                the underlying data.
+            integer_object_nulls (:obj:`bool`, defaults to :obj:`False`):
+                Cast integers with nulls to objects
+            date_as_object (:obj:`bool`, defaults to :obj:`True`):
+                Cast dates to objects. If False, convert to datetime64[ns] dtype.
+            timestamp_as_object (:obj:`bool`, defaults to :obj:`False`):
+                Cast non-nanosecond timestamps (np.datetime64) to objects. This is
+                useful if you have timestamps that don't fit in the normal date
+                range of nanosecond timestamps (1678 CE-2262 CE).
+                If False, all timestamps are converted to datetime64[ns] dtype.
+            use_threads (:obj:`bool`, defaults to :obj:`True`):
+                Whether to parallelize the conversion using multiple threads.
+            deduplicate_objects (:obj:`bool`, defaults to :obj:`False`):
+                Do not create multiple copies Python objects when created, to save
+                on memory use. Conversion will be slower.
+            ignore_metadata (:obj:`bool`, defaults to :obj:`False`):
+                If True, do not use the 'pandas' metadata to reconstruct the
+                DataFrame index, if present
+            safe (:obj:`bool`, defaults to :obj:`True`):
+                For certain data types, a cast is needed in order to store the
+                data in a pandas DataFrame or Series (e.g. timestamps are always
+                stored as nanoseconds in pandas). This option controls whether it
+                is a safe cast or not.
+            split_blocks (:obj:`bool`, defaults to :obj:`False`):
+                If True, generate one internal "block" for each column when
+                creating a pandas.DataFrame from a RecordBatch or Table. While this
+                can temporarily reduce memory note that various pandas operations
+                can trigger "consolidation" which may balloon memory use.
+            self_destruct (:obj:`bool`, defaults to :obj:`False`):
+                EXPERIMENTAL: If True, attempt to deallocate the originating Arrow
+                memory while converting the Arrow object to pandas. If you use the
+                object after calling to_pandas with this option it will crash your
+                program.
+            types_mapper (:obj:`function`, defaults to :obj:`None`):
+                A function mapping a pyarrow DataType to a pandas ExtensionDtype.
+                This can be used to override the default pandas type for conversion
+                of built-in pyarrow types or in absence of pandas_metadata in the
+                Table schema. The function receives a pyarrow DataType and is
+                expected to return a pandas ExtensionDtype or ``None`` if the
+                default conversion should be used for that type. If you have
+                a dictionary mapping, you can pass ``dict.get`` as function.
+
+        Returns:
+            :obj:`pandas.Series` or :obj:`pandas.DataFrame`: :obj:`pandas.Series` or :obj:`pandas.DataFrame` depending on type of object
+        """
         return self.table.to_pandas(*args, **kwargs)
 
     def to_string(self, *args, **kwargs):
         return self.table.to_string(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.field)
     def field(self, *args, **kwargs):
+        """
+        Select a schema field by its column name or numeric index.
+
+        Args:
+            i (:obj:`Union[int, str]`):
+                The index or name of the field to retrieve.
+
+        Returns:
+            :obj:`pyarrow.Field`:
+        """
         return self.table.field(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.column)
     def column(self, *args, **kwargs):
+        """
+        Select a column by its column name, or numeric index.
+
+        Args:
+            i (:obj:`Union[int, str]`):
+                The index or name of the column to retrieve.
+
+        Returns:
+            :obj:`pyarrow.ChunkedArray`:
+        """
         return self.table.column(*args, **kwargs)
 
-    @inject_arrow_table_documentation(pa.Table.itercolumns)
     def itercolumns(self, *args, **kwargs):
+        """
+        Iterator over all columns in their numerical order.
+
+        Yields:
+            :obj:`pyarrow.ChunkedArray`:
+        """
         return self.table.itercolumns(*args, **kwargs)
 
     @property
-    @inject_arrow_table_documentation(pa.Table.schema)
     def schema(self):
+        """
+        Schema of the table and its columns.
+
+        Returns:
+            :obj:`pyarrow.Schema`:
+        """
         return self.table.schema
 
     @property
-    @inject_arrow_table_documentation(pa.Table.columns)
     def columns(self):
+        """
+        List of all columns in numerical order.
+
+        Returns:
+            :obj:`List[pa.ChunkedArray]`:
+        """
         return self.table.columns
 
     @property
-    @inject_arrow_table_documentation(pa.Table.num_columns)
     def num_columns(self):
+        """
+        Number of columns in this table.
+
+        Returns:
+            int:
+        """
         return self.table.num_columns
 
     @property
-    @inject_arrow_table_documentation(pa.Table.num_rows)
     def num_rows(self):
+        """
+        Number of rows in this table.
+
+        Due to the definition of a table, all columns have the same number of
+        rows.
+
+        Returns:
+            int:
+        """
         return self.table.num_rows
 
     @property
-    @inject_arrow_table_documentation(pa.Table.shape)
     def shape(self):
+        """
+        Dimensions of the table: (#rows, #columns).
+
+        Returns:
+            :obj:`(int, int)`: Number of rows and number of columns.
+        """
         return self.table.shape
 
     @property
-    @inject_arrow_table_documentation(pa.Table.nbytes)
     def nbytes(self):
+        """
+        Total number of bytes consumed by the elements of the table.
+        """
         return self.table.nbytes
 
     @property
-    @inject_arrow_table_documentation(pa.Table.column_names)
     def column_names(self):
+        """
+        Names of the table's columns
+        """
         return self.table.column_names
 
     def __eq__(self, other):
@@ -286,52 +437,175 @@ class Table(IndexedTableMixin):
     def __str__(self):
         return self.table.__str__().replace("pyarrow.Table", self.__class__.__name__)
 
-    @inject_arrow_table_documentation(pa.Table.slice)
     def slice(self, *args, **kwargs):
+        """
+        Compute zero-copy slice of this Table
+
+        Args:
+            offset (:obj:`int`, defaults to :obj:`0`):
+                Offset from start of table to slice
+            length (:obj:`int`, defaults to :obj:`None`):
+                Length of slice (default is until end of table starting from
+                offset)
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.filter)
     def filter(self, *args, **kwargs):
+        """
+        Select records from a Table. See pyarrow.compute.filter for full usage.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.flatten)
     def flatten(self, *args, **kwargs):
+        """
+        Flatten this Table.  Each column with a struct type is flattened
+        into one column per struct field.  Other columns are left unchanged.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.combine_chunks)
     def combine_chunks(self, *args, **kwargs):
+        """
+        Make a new table by combining the chunks this table has.
+
+        All the underlying chunks in the ChunkedArray of each column are
+        concatenated into zero or one chunk.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.cast)
     def cast(self, *args, **kwargs):
+        """
+        Cast table values to another schema
+
+        Args:
+            target_schema (:obj:`Schema`):
+                Schema to cast to, the names and order of fields must match
+            safe (:obj:`bool`, defaults to :obj:`True`):
+                Check for overflows or other unsafe conversions
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.replace_schema_metadata)
     def replace_schema_metadata(self, *args, **kwargs):
+        """
+        EXPERIMENTAL: Create shallow copy of table by replacing schema
+        key-value metadata with the indicated new metadata (which may be None,
+        which deletes any existing metadata
+
+        Args:
+            metadata (:obj:`dict`, defaults to :obj:`None`):
+
+        Returns:
+            :class:`datasets.table.Table`: shallow_copy
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.add_column)
     def add_column(self, *args, **kwargs):
+        """
+        Add column to Table at position.
+
+        A new table is returned with the column added, the original table
+        object is left unchanged.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`: New table with the passed column added.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.append_column)
     def append_column(self, *args, **kwargs):
+        """
+        Append column at end of columns.
+
+        Args:
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:  New table with the passed column added.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.remove_column)
     def remove_column(self, *args, **kwargs):
+        """
+        Create new Table with the indicated column removed.
+
+        Args:
+            i (:obj:`int`):
+                Index of column to remove.
+
+        Returns:
+            :class:`datasets.table.Table`: New table without the column.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.set_column)
     def set_column(self, *args, **kwargs):
+        """
+        Replace column in Table at position.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`: New table with the passed column set.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.rename_columns)
     def rename_columns(self, *args, **kwargs):
+        """
+        Create new table with columns renamed to provided names.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.drop)
     def drop(self, *args, **kwargs):
+        """
+        Drop one or more columns and return a new table.
+
+        Args:
+            columns (:obj:`List[str]`):
+                List of field names referencing existing columns.
+
+        Raises:
+            KeyError : if any of the passed columns name are not existing.
+
+        Returns:
+            :class:`datasets.table.Table`: New table without the columns.
+        """
         raise NotImplementedError()
 
     # Additional methods that are based on the PyArrow Table methods
@@ -340,7 +614,7 @@ class Table(IndexedTableMixin):
         """Return the table by keeping only the requested columns
 
         Returns:
-            Table: table with only a subset of the columns
+            :class:`datasets.table.Table`: table with only a subset of the columns
         """
         for column_to_remove in set(range(len(self.column_names))) - set(columns):
             self = self.remove_column(column_to_remove)
@@ -383,72 +657,291 @@ class InMemoryTable(TableBlock):
         return cls(table)
 
     @classmethod
-    @inject_arrow_table_documentation(pa.Table.from_pandas)
     def from_pandas(cls, *args, **kwargs):
+        """
+        Convert pandas.DataFrame to an Arrow Table.
+
+        The column types in the resulting Arrow Table are inferred from the
+        dtypes of the pandas.Series in the DataFrame. In the case of non-object
+        Series, the NumPy dtype is translated to its Arrow equivalent. In the
+        case of `object`, we need to guess the datatype by looking at the
+        Python objects in this Series.
+
+        Be aware that Series of the `object` dtype don't carry enough
+        information to always lead to a meaningful Arrow type. In the case that
+        we cannot infer a type, e.g. because the DataFrame is of length 0 or
+        the Series only contains None/nan objects, the type is set to
+        null. This behavior can be avoided by constructing an explicit schema
+        and passing it to this function.
+
+        Args:
+            df (:obj:`pandas.DataFrame`):
+            schema (:obj:`pyarrow.Schema`, optional):
+                The expected schema of the Arrow Table. This can be used to
+                indicate the type of columns if we cannot infer it automatically.
+                If passed, the output will have exactly this schema. Columns
+                specified in the schema that are not found in the DataFrame columns
+                or its index will raise an error. Additional columns or index
+                levels in the DataFrame which are not specified in the schema will
+                be ignored.
+            preserve_index (:obj:`bool`, optional):
+                Whether to store the index as an additional column in the resulting
+                ``Table``. The default of None will store the index as a column,
+                except for RangeIndex which is stored as metadata only. Use
+                ``preserve_index=True`` to force it to be stored as a column.
+            nthreads (:obj:`int`, defaults to :obj:`None` (may use up to system CPU count threads))
+                If greater than 1, convert columns to Arrow in parallel using
+                indicated number of threads
+            columns (:obj:`List[str]`, optional):
+               List of column to be converted. If None, use all columns.
+            safe (:obj:`bool`, defaults to :obj:`True`):
+               Check for overflows or other unsafe conversions
+
+        Returns:
+            :class:`datasets.table.Table`:
+
+            Examples
+            --------
+
+            >>> import pandas as pd
+            >>> import pyarrow as pa
+            >>> df = pd.DataFrame({
+                ...     'int': [1, 2],
+                ...     'str': ['a', 'b']
+                ... })
+            >>> pa.Table.from_pandas(df)
+            <pyarrow.lib.Table object at 0x7f05d1fb1b40>
+        """
         return cls(pa.Table.from_pandas(*args, **kwargs))
 
     @classmethod
-    @inject_arrow_table_documentation(pa.Table.from_arrays)
     def from_arrays(cls, *args, **kwargs):
+        """
+        Construct a Table from Arrow arrays
+
+        Args:
+            arrays (:obj:`List[Union[pyarrow.Array, pyarrow.ChunkedArray]]`):
+                Equal-length arrays that should form the table.
+            names (:obj:`List[str]`, optional):
+                Names for the table columns. If not passed, schema must be passed
+            schema (:obj:`Schema`, defaults to :obj:`None`):
+                Schema for the created table. If not passed, names must be passed
+            metadata (:obj:`Union[dict, Mapping]`, default None):
+                Optional metadata for the schema (if inferred).
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         return cls(pa.Table.from_arrays(*args, **kwargs))
 
     @classmethod
-    @inject_arrow_table_documentation(pa.Table.from_pydict)
     def from_pydict(cls, *args, **kwargs):
+        """
+        Construct a Table from Arrow arrays or columns
+
+        Args:
+            mapping (:obj:`Union[dict, Mapping]`):
+                A mapping of strings to Arrays or Python lists.
+            schema (:obj:`Schema`, defaults to :obj:`None`):
+                If not passed, will be inferred from the Mapping values
+            metadata (:obj:`Union[dict, Mapping]`, default None):
+                Optional metadata for the schema (if inferred).
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         return cls(pa.Table.from_pydict(*args, **kwargs))
 
     @classmethod
-    @inject_arrow_table_documentation(pa.Table.from_batches)
     def from_batches(cls, *args, **kwargs):
+        """
+        Construct a Table from a sequence or iterator of Arrow RecordBatches.
+
+        Args:
+            batches (:obj:`Union[Sequence[pyarrow.RecordBatch], Iterator[pyarrow.RecordBatch]]`):
+                Sequence of RecordBatch to be converted, all schemas must be equal.
+            schema (:obj:`Schema`, defaults to :obj:`None`):
+                If not passed, will be inferred from the first RecordBatch.
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         return cls(pa.Table.from_batches(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.slice)
     def slice(self, offset=0, length=None):
+        """
+        Compute zero-copy slice of this Table
+
+        Args:
+            offset (:obj:`int`, defaults to :obj:`0`):
+                Offset from start of table to slice
+            length (:obj:`int`, defaults to :obj:`None`):
+                Length of slice (default is until end of table starting from
+                offset)
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         # Use fast slicing here
         return InMemoryTable(self.fast_slice(offset=offset, length=length))
 
-    @inject_arrow_table_documentation(pa.Table.filter)
     def filter(self, *args, **kwargs):
+        """
+        Select records from a Table. See pyarrow.compute.filter for full usage.
+        """
         return InMemoryTable(self.table.filter(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.flatten)
     def flatten(self, *args, **kwargs):
+        """
+        Flatten this Table.  Each column with a struct type is flattened
+        into one column per struct field.  Other columns are left unchanged.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         return InMemoryTable(self.table.flatten(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.combine_chunks)
     def combine_chunks(self, *args, **kwargs):
+        """
+        Make a new table by combining the chunks this table has.
+
+        All the underlying chunks in the ChunkedArray of each column are
+        concatenated into zero or one chunk.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         return InMemoryTable(self.table.combine_chunks(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.cast)
     def cast(self, *args, **kwargs):
+        """
+        Cast table values to another schema
+
+        Args:
+            target_schema (:obj:`Schema`):
+                Schema to cast to, the names and order of fields must match
+            safe (:obj:`bool`, defaults to :obj:`True`):
+                Check for overflows or other unsafe conversions
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         return InMemoryTable(table_cast(self.table, *args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.replace_schema_metadata)
     def replace_schema_metadata(self, *args, **kwargs):
+        """
+        EXPERIMENTAL: Create shallow copy of table by replacing schema
+        key-value metadata with the indicated new metadata (which may be None,
+        which deletes any existing metadata
+
+        Args:
+            metadata (:obj:`dict`, defaults to :obj:`None`):
+
+        Returns:
+            :class:`datasets.table.Table`: shallow_copy
+        """
         return InMemoryTable(self.table.replace_schema_metadata(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.add_column)
     def add_column(self, *args, **kwargs):
+        """
+        Add column to Table at position.
+
+        A new table is returned with the column added, the original table
+        object is left unchanged.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`: New table with the passed column added.
+        """
         return InMemoryTable(self.table.add_column(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.append_column)
     def append_column(self, *args, **kwargs):
+        """
+        Append column at end of columns.
+
+        Args:
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table with the passed column added.
+        """
         return InMemoryTable(self.table.append_column(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.remove_column)
     def remove_column(self, *args, **kwargs):
+        """
+        Create new Table with the indicated column removed.
+
+        Args:
+            i (:obj:`int`):
+                Index of column to remove.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table without the column.
+        """
         return InMemoryTable(self.table.remove_column(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.set_column)
     def set_column(self, *args, **kwargs):
+        """
+        Replace column in Table at position.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table with the passed column set.
+        """
         return InMemoryTable(self.table.set_column(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.rename_columns)
     def rename_columns(self, *args, **kwargs):
+        """
+        Create new table with columns renamed to provided names.
+        """
         return InMemoryTable(self.table.rename_columns(*args, **kwargs))
 
-    @inject_arrow_table_documentation(pa.Table.drop)
     def drop(self, *args, **kwargs):
+        """
+        Drop one or more columns and return a new table.
+
+        Args:
+            columns (:obj:`List[str]`):
+                List of field names referencing existing columns.
+
+        Raises:
+            KeyError : if any of the passed columns name are not existing.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table without the columns.
+        """
         return InMemoryTable(self.table.drop(*args, **kwargs))
 
 
@@ -513,75 +1006,202 @@ class MemoryMappedTable(TableBlock):
         replays.append(replay)
         return replays
 
-    @inject_arrow_table_documentation(pa.Table.slice)
     def slice(self, offset=0, length=None):
+        """
+        Compute zero-copy slice of this Table
+
+        Args:
+            offset (:obj:`int`, defaults to :obj:`0`):
+                Offset from start of table to slice
+            length (:obj:`int`, defaults to :obj:`None`):
+                Length of slice (default is until end of table starting from
+                offset)
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         replay = ("slice", (offset, length), {})
         replays = self._append_replay(replay)
         # Use fast slicing here
         return MemoryMappedTable(self.fast_slice(offset=offset, length=length), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.filter)
     def filter(self, *args, **kwargs):
+        """
+        Select records from a Table. See pyarrow.compute.filter for full usage.
+        """
         replay = ("filter", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.filter(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.flatten)
     def flatten(self, *args, **kwargs):
+        """
+        Flatten this Table.  Each column with a struct type is flattened
+        into one column per struct field.  Other columns are left unchanged.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         replay = ("flatten", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.flatten(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.combine_chunks)
     def combine_chunks(self, *args, **kwargs):
+        """
+        Make a new table by combining the chunks this table has.
+
+        All the underlying chunks in the ChunkedArray of each column are
+        concatenated into zero or one chunk.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         replay = ("combine_chunks", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.combine_chunks(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.cast)
     def cast(self, *args, **kwargs):
+        """
+        Cast table values to another schema
+
+        Args:
+            target_schema (:obj:`Schema`):
+                Schema to cast to, the names and order of fields must match
+            safe (:obj:`bool`, defaults to :obj:`True`):
+                Check for overflows or other unsafe conversions
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         replay = ("cast", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(table_cast(self.table, *args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.replace_schema_metadata)
     def replace_schema_metadata(self, *args, **kwargs):
+        """
+        EXPERIMENTAL: Create shallow copy of table by replacing schema
+        key-value metadata with the indicated new metadata (which may be None,
+        which deletes any existing metadata
+
+        Args:
+            metadata (:obj:`dict`, defaults to :obj:`None`):
+
+        Returns:
+            :class:`datasets.table.Table`: shallow_copy
+        """
         replay = ("replace_schema_metadata", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.replace_schema_metadata(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.add_column)
     def add_column(self, *args, **kwargs):
+        """
+        Add column to Table at position.
+
+        A new table is returned with the column added, the original table
+        object is left unchanged.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`: New table with the passed column added.
+        """
         replay = ("add_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.add_column(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.append_column)
     def append_column(self, *args, **kwargs):
+        """
+        Append column at end of columns.
+
+        Args:
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table with the passed column added.
+        """
         replay = ("append_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.append_column(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.remove_column)
     def remove_column(self, *args, **kwargs):
+        """
+        Create new Table with the indicated column removed.
+
+        Args:
+            i (:obj:`int`):
+                Index of column to remove.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table without the column.
+        """
         replay = ("remove_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.remove_column(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.set_column)
     def set_column(self, *args, **kwargs):
+        """
+        Replace column in Table at position.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table with the passed column set.
+        """
         replay = ("set_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.set_column(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.rename_columns)
     def rename_columns(self, *args, **kwargs):
+        """
+        Create new table with columns renamed to provided names.
+        """
         replay = ("rename_columns", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.rename_columns(*args, **kwargs), self.path, replays)
 
-    @inject_arrow_table_documentation(pa.Table.drop)
     def drop(self, *args, **kwargs):
+        """
+        Drop one or more columns and return a new table.
+
+        Args:
+            columns (:obj:`List[str]`):
+                List of field names referencing existing columns.
+
+        Raises:
+            KeyError : if any of the passed columns name are not existing.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table without the columns.
+        """
         replay = ("drop", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
         return MemoryMappedTable(self.table.drop(*args, **kwargs), self.path, replays)
@@ -709,7 +1329,7 @@ class ConcatenationTable(Table):
 
         Args:
             tables (list of :class:`Table` or list of :obj:`pyarrow.Table`): List of tables.
-            axis: (``{0, 1}``, default ``0``, meaning over rows):
+            axis: (``{0, 1}``, defaults to :obj:`0`, meaning over rows):
             Axis to concatenate over, where ``0`` means over rows (vertically) and ``1`` means over columns
             (horizontally).
 
@@ -762,8 +1382,20 @@ class ConcatenationTable(Table):
             yield (offset, length)
             offset += length
 
-    @inject_arrow_table_documentation(pa.Table.slice)
     def slice(self, offset=0, length=None):
+        """
+        Compute zero-copy slice of this Table
+
+        Args:
+            offset (:obj:`int`, defaults to :obj:`0`):
+                Offset from start of table to slice
+            length (:obj:`int`, defaults to :obj:`None`):
+                Length of slice (default is until end of table starting from
+                offset)
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         table = self.table.slice(offset, length=length)
         length = length if length is not None else self.num_rows - offset
         blocks = []
@@ -781,8 +1413,10 @@ class ConcatenationTable(Table):
                 length, offset = 0, 0
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.filter)
     def filter(self, mask, *args, **kwargs):
+        """
+        Select records from a Table. See pyarrow.compute.filter for full usage.
+        """
         table = self.table.filter(mask, *args, **kwargs)
         blocks = []
         for (offset, length), tables in zip(self._slices, self.blocks):
@@ -790,24 +1424,57 @@ class ConcatenationTable(Table):
             blocks.append([t.filter(submask, *args, **kwargs) for t in tables])
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.flatten)
     def flatten(self, *args, **kwargs):
+        """
+        Flatten this Table.  Each column with a struct type is flattened
+        into one column per struct field.  Other columns are left unchanged.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         table = self.table.flatten(*args, **kwargs)
         blocks = []
         for tables in self.blocks:
             blocks.append([t.flatten(*args, **kwargs) for t in tables])
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.combine_chunks)
     def combine_chunks(self, *args, **kwargs):
+        """
+        Make a new table by combining the chunks this table has.
+
+        All the underlying chunks in the ChunkedArray of each column are
+        concatenated into zero or one chunk.
+
+        Args:
+            memory_pool (:obj:`MemoryPool`, defaults to :obj:`None`):
+                For memory allocations, if required, otherwise use default pool
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         table = self.table.combine_chunks(*args, **kwargs)
         blocks = []
         for tables in self.blocks:
             blocks.append([t.combine_chunks(*args, **kwargs) for t in tables])
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.cast)
     def cast(self, target_schema, *args, **kwargs):
+        """
+        Cast table values to another schema
+
+        Args:
+            target_schema (:obj:`Schema`):
+                Schema to cast to, the names and order of fields must match
+            safe (:obj:`bool`, defaults to :obj:`True`):
+                Check for overflows or other unsafe conversions
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
         table = table_cast(self.table, target_schema, *args, **kwargs)
         blocks = []
         for subtables in self.blocks:
@@ -822,24 +1489,74 @@ class ConcatenationTable(Table):
             blocks.append(new_tables)
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.replace_schema_metadata)
     def replace_schema_metadata(self, *args, **kwargs):
+        """
+        EXPERIMENTAL: Create shallow copy of table by replacing schema
+        key-value metadata with the indicated new metadata (which may be None,
+        which deletes any existing metadata
+
+        Args:
+            metadata (:obj:`dict`, defaults to :obj:`None`):
+
+        Returns:
+            :class:`datasets.table.Table`: shallow_copy
+        """
         table = self.table.replace_schema_metadata(*args, **kwargs)
         blocks = []
         for tables in self.blocks:
             blocks.append([t.replace_schema_metadata(*args, **kwargs) for t in tables])
         return ConcatenationTable(table, self.blocks)
 
-    @inject_arrow_table_documentation(pa.Table.add_column)
     def add_column(self, *args, **kwargs):
+        """
+        Add column to Table at position.
+
+        A new table is returned with the column added, the original table
+        object is left unchanged.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`: New table with the passed column added.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.append_column)
     def append_column(self, *args, **kwargs):
+        """
+        Append column at end of columns.
+
+        Args:
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table with the passed column added.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.remove_column)
     def remove_column(self, i, *args, **kwargs):
+        """
+        Create new Table with the indicated column removed.
+
+        Args:
+            i (:obj:`int`):
+                Index of column to remove.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table without the column.
+        """
         table = self.table.remove_column(i, *args, **kwargs)
         name = self.table.column_names[i]
         blocks = []
@@ -852,12 +1569,29 @@ class ConcatenationTable(Table):
             )
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.set_column)
     def set_column(self, *args, **kwargs):
+        """
+        Replace column in Table at position.
+
+        Args:
+            i (:obj:`int`):
+                Index to place the column at.
+            field_ (:obj:`Union[str, pyarrow.Field]`):
+                If a string is passed then the type is deduced from the column
+                data.
+            column (:obj:`Union[pyarrow.Array, List[pyarrow.Array]]`):
+                Column data.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table with the passed column set.
+        """
         raise NotImplementedError()
 
-    @inject_arrow_table_documentation(pa.Table.rename_columns)
     def rename_columns(self, names, *args, **kwargs):
+        """
+        Create new table with columns renamed to provided names.
+        """
         table = self.table.rename_columns(names, *args, **kwargs)
         names = dict(zip(self.table.column_names, names))
         blocks = []
@@ -867,8 +1601,21 @@ class ConcatenationTable(Table):
             )
         return ConcatenationTable(table, blocks)
 
-    @inject_arrow_table_documentation(pa.Table.drop)
     def drop(self, columns, *args, **kwargs):
+        """
+        Drop one or more columns and return a new table.
+
+        Args:
+            columns (:obj:`List[str]`):
+                List of field names referencing existing columns.
+
+        Raises:
+            KeyError : if any of the passed columns name are not existing.
+
+        Returns:
+            :class:`datasets.table.Table`:
+                New table without the columns.
+        """
         table = self.table.drop(columns)
         blocks = []
         for tables in self.blocks:
@@ -882,14 +1629,14 @@ def concat_tables(tables: List[Table], axis: int = 0) -> Table:
 
     Args:
         tables (list of :class:`Table`): List of tables to be concatenated.
-        axis (``{0, 1}``, default ``0``, meaning over rows):
+        axis (``{0, 1}``, defaults to :obj:`0`, meaning over rows):
             Axis to concatenate over, where ``0`` means over rows (vertically) and ``1`` means over columns
             (horizontally).
 
             *New in version 1.6.0*
 
     Returns:
-        :obj:`datasets.table.Table` that is the concatenated table:
+        :class:`datasets.table.Table`:
             If the number of input tables is > 1, then the returned table is a :obj:`datasets.table.ConcatenationTable`.
             Otherwise if there's only one table, it is returned as is.
     """
@@ -967,7 +1714,7 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
     Args:
         array (pa.Array): PyArrow array to cast
         pa_type (pa.DataType): target PyArrow type
-        allow_number_to_str (bool, default ``True``): Whether to allow casting numbers to strings.
+        allow_number_to_str (bool, defaults to :obj:`True`): Whether to allow casting numbers to strings.
             Defaults to True.
 
     Raises:
@@ -978,7 +1725,7 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
             = if casting from numbers to strings and allow_number_to_str is False
 
     Returns:
-        pa.Array: the casted array
+        :obj:`List[pyarrow.Array]`: the casted array
     """
     _c = partial(array_cast, allow_number_to_str=allow_number_to_str)
     if isinstance(array, pa.ExtensionArray):
@@ -1038,7 +1785,7 @@ def cast_array_to_feature(array: pa.Array, feature: "FeatureType", allow_number_
     Args:
         array (pa.Array): the PyArrow array to cast
         feature (FeatureType): the target feature type
-        allow_number_to_str (bool, default ``True``): Whether to allow casting numbers to strings.
+        allow_number_to_str (bool, defaults to :obj:`True`): Whether to allow casting numbers to strings.
             Defaults to True.
 
     Raises:
@@ -1049,7 +1796,7 @@ def cast_array_to_feature(array: pa.Array, feature: "FeatureType", allow_number_
             = if casting from numbers to strings and allow_number_to_str is False
 
     Returns:
-        pa.Array: the casted array
+         array (:obj:`pyarrow.Array`): the casted array
     """
     from .features import Sequence, get_nested_type
 
@@ -1100,11 +1847,11 @@ def cast_table_to_features(table: pa.Table, features: "Features"):
     """Cast an table to the arrow schema that corresponds to the requested features.
 
     Args:
-        table (pa.Table): PyArrow table to cast
+        table (:obj:`pyarrow.Table`): PyArrow table to cast
         features (Features): target features.
 
     Returns:
-        pa.Table: the casted table
+        table (:obj:`pyarrow.Table`): the casted table
     """
     if sorted(table.column_names) != sorted(features):
         raise ValueError(f"Couldn't cast\n{table.schema}\nto\n{features}\nbecause column names don't match")
@@ -1118,11 +1865,11 @@ def table_cast(table: pa.Table, schema: pa.Schema):
     It supports casting to feature types stored in the schema metadata.
 
     Args:
-        table (pa.Table): PyArrow table to cast
-        schema (pa.Schema): target PyArrow schema.
+        table (:obj:`pyarrow.Table`): PyArrow table to cast
+        schema (:obj:`pyarrow.Schema`): target PyArrow schema.
 
     Returns:
-        pa.Table: the casted table
+        table (:obj:`pyarrow.Table`): the casted table
     """
     if table.schema != schema:
         from .features import Features
@@ -1138,7 +1885,7 @@ def table_visitor(table: pa.Table, function: Callable[[pa.Array], None]):
     """Visit all arrays in a table and apply a function to them.
 
     Args:
-        table (pa.Table): PyArrow table to visit
+        table (:obj:`pyarrow.Table`): PyArrow table to visit
         function (Callable[[pa.Array], None]): function to apply to each array
     """
     from .features import Features, Sequence


### PR DESCRIPTION
I added the three scripts:
- build_dev_documentation.yml
- build_documentation.yml
- delete_dev_documentation.yml

I got them from `transformers` and did a few changes:
- I removed the `transformers`-specific dependencies
- I changed all the paths to be "datasets" instead of "transformers"
- I passed the `--library_name datasets` arg to the `doc-builder build` command (according to https://github.com/huggingface/doc-builder/pull/94/files#diff-bcc33cf7c223511e498776684a9a433810b527a0a38f483b1487e8a42b6575d3R26)

cc @LysandreJik @mishig25 