### PR TITLE
Add `data_dir` to `data_files` resolution and misc improvements to HfFileSystem

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -302,7 +302,7 @@ def _resolve_single_pattern_in_dataset_repository(
 ) -> List[PurePath]:
     data_files_ignore = FILES_TO_IGNORE
     fs = HfFileSystem(repo_info=dataset_info)
-    glob_iter = [PurePath(filepath) for filepath in fs.glob(pattern) if fs.isfile(filepath)]
+    glob_iter = [PurePath(filepath) for filepath in fs.glob(PurePath(pattern).as_posix()) if fs.isfile(filepath)]
     matched_paths = [
         filepath
         for filepath in glob_iter

--- a/src/datasets/filesystems/hffilesystem.py
+++ b/src/datasets/filesystems/hffilesystem.py
@@ -1,4 +1,4 @@
-from pathlib import PurePath
+from pathlib import PurePosixPath
 from typing import Optional
 
 import fsspec
@@ -37,10 +37,20 @@ class HfFileSystem(AbstractFileSystem):
 
     def _get_dirs(self):
         if self.dir_cache is None:
-            self.dir_cache = {
-                hf_file.rfilename: {"name": hf_file.rfilename, "size": 0 or None, "type": "file"}  # TODO(QL): add size
-                for hf_file in self.repo_info.siblings
-            }
+            self.dir_cache = {}
+            for hf_file in self.repo_info.siblings:
+                # TODO(QL): add sizes
+                self.dir_cache[hf_file.rfilename] = {
+                    "name": hf_file.rfilename,
+                    "size": None,
+                    "type": "file",
+                }
+                self.dir_cache.update(
+                    {
+                        str(d): {"name": str(d), "size": None, "type": "directory"}
+                        for d in list(PurePosixPath(hf_file.rfilename).parents)[:-1]
+                    }
+                )
 
     def _open(
         self,
@@ -67,18 +77,13 @@ class HfFileSystem(AbstractFileSystem):
 
     def ls(self, path, detail=False, **kwargs):
         self._get_dirs()
-        path = PurePath(path.strip("/"))
+        path = PurePosixPath(path.strip("/"))
         paths = {}
         for p, f in self.dir_cache.items():
-            p = PurePath(p.strip("/"))
+            p = PurePosixPath(p.strip("/"))
             root = p.parent
             if root == path:
-                # file is in directory -> return file
                 paths[str(p)] = f
-            elif path in p.parents:
-                # file is in subdirectory -> return first intermediate directory
-                ppath = str(path / p.relative_to(path).parts[0])
-                paths[ppath] = {"name": ppath + "/", "size": 0, "type": "directory"}
         out = list(paths.values())
         if detail:
             return out

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -732,7 +732,7 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         download_mode: Optional[DownloadMode] = None,
     ):
         if data_files is None and data_dir is not None:
-            data_files = [os.path.join(data_dir, "*"), os.path.join(data_dir, "**/*")]
+            data_files = os.path.join(data_dir, "**")
 
         self.path = path
         self.name = Path(path).stem
@@ -781,7 +781,7 @@ class PackagedDatasetModuleFactory(_DatasetModuleFactory):
         download_mode: Optional[DownloadMode] = None,
     ):
         if data_files is None and data_dir is not None:
-            data_files = [os.path.join(data_dir, "*"), os.path.join(data_dir, "**/*")]
+            data_files = os.path.join(data_dir, "**")
 
         self.name = name
         self.data_files = data_files
@@ -817,7 +817,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         download_mode: Optional[DownloadMode] = None,
     ):
         if data_files is None and data_dir is not None:
-            data_files = [os.path.join(data_dir, "*"), os.path.join(data_dir, "**/*")]
+            data_files = os.path.join(data_dir, "**")
 
         self.name = name
         self.revision = revision

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1524,8 +1524,8 @@ def load_dataset_builder(
 
 
         name (:obj:`str`, optional): Defining the name of the dataset configuration.
-        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration. If `data_files` is not specified for the generic builders (csv, text etc.) or the Hub datasets,
-            it's equal to passing `os.path.join(data_dir, **)` as `data_files` to reference all the files inside a directory.
+        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration. If specified for the generic builders (csv, text etc.) or the Hub datasets and `data_files` is None,
+            the behavior is equal to passing `os.path.join(data_dir, **)` as `data_files` to reference all the files in a directory.
         data_files (:obj:`str` or :obj:`Sequence` or :obj:`Mapping`, optional): Path(s) to source data file(s).
         cache_dir (:obj:`str`, optional): Directory to read/write data. Defaults to "~/.cache/huggingface/datasets".
         features (:class:`Features`, optional): Set the features type to use for this dataset.
@@ -1676,8 +1676,8 @@ def load_dataset(
               e.g. ``glue``, ``squad``, ``'username/dataset_name'``, a dataset repository on the HF hub containing a dataset script `'dataset_name.py'`.
 
         name (:obj:`str`, optional): Defining the name of the dataset configuration.
-        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration. If `data_files` is not specified for the generic builders (csv, text etc.) or the Hub datasets,
-            it's equal to passing `os.path.join(data_dir, **)` as `data_files` to reference all the files inside a directory.
+        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration. If specified for the generic builders (csv, text etc.) or the Hub datasets and `data_files` is None,
+            the behavior is equal to passing `os.path.join(data_dir, **)` as `data_files` to reference all the files in a directory.
         data_files (:obj:`str` or :obj:`Sequence` or :obj:`Mapping`, optional): Path(s) to source data file(s).
         split (:class:`Split` or :obj:`str`): Which split of the data to load.
             If None, will return a `dict` with all splits (typically `datasets.Split.TRAIN` and `datasets.Split.TEST`).

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1105,6 +1105,8 @@ def dataset_module_factory(
         dynamic_modules_path (Optional str, defaults to HF_MODULES_CACHE / "datasets_modules", i.e. ~/.cache/huggingface/modules/datasets_modules):
             Optional path to the directory in which the dynamic modules are saved. It must have been initialized with :obj:`init_dynamic_modules`.
             By default the datasets and metrics are stored inside the `datasets_modules` module.
+        data_dir (:obj:`str`, optional): Directory with the data files. Used only if `data_files` is not specified,
+            in which case it's equal to passing `os.path.join(data_dir, "**")` as `data_files`.
         data_files (:obj:`Union[Dict, List, str]`, optional): Defining the data_files of the dataset configuration.
         script_version:
             .. deprecated:: 1.13
@@ -1522,7 +1524,8 @@ def load_dataset_builder(
 
 
         name (:obj:`str`, optional): Defining the name of the dataset configuration.
-        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration.
+        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration. If `data_files` is not specified for the generic builders (csv, text etc.) or the Hub datasets,
+            it's equal to passing `os.path.join(data_dir, **)` as `data_files` to reference all the files inside a directory.
         data_files (:obj:`str` or :obj:`Sequence` or :obj:`Mapping`, optional): Path(s) to source data file(s).
         cache_dir (:obj:`str`, optional): Directory to read/write data. Defaults to "~/.cache/huggingface/datasets".
         features (:class:`Features`, optional): Set the features type to use for this dataset.
@@ -1673,7 +1676,8 @@ def load_dataset(
               e.g. ``glue``, ``squad``, ``'username/dataset_name'``, a dataset repository on the HF hub containing a dataset script `'dataset_name.py'`.
 
         name (:obj:`str`, optional): Defining the name of the dataset configuration.
-        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration.
+        data_dir (:obj:`str`, optional): Defining the data_dir of the dataset configuration. If `data_files` is not specified for the generic builders (csv, text etc.) or the Hub datasets,
+            it's equal to passing `os.path.join(data_dir, **)` as `data_files` to reference all the files inside a directory.
         data_files (:obj:`str` or :obj:`Sequence` or :obj:`Mapping`, optional): Path(s) to source data file(s).
         split (:class:`Split` or :obj:`str`): Which split of the data to load.
             If None, will return a `dict` with all splits (typically `datasets.Split.TRAIN` and `datasets.Split.TEST`).

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -727,9 +727,13 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
     def __init__(
         self,
         path: str,
+        data_dir: Optional[str] = None,
         data_files: Optional[Union[str, List, Dict]] = None,
         download_mode: Optional[DownloadMode] = None,
     ):
+        if data_files is None and data_dir is not None:
+            data_files = [os.path.join(data_dir, "*"), os.path.join(data_dir, "**/*")]
+
         self.path = path
         self.name = Path(path).stem
         self.data_files = data_files
@@ -771,10 +775,14 @@ class PackagedDatasetModuleFactory(_DatasetModuleFactory):
     def __init__(
         self,
         name: str,
+        data_dir: Optional[str] = None,
         data_files: Optional[Union[str, List, Dict]] = None,
         download_config: Optional[DownloadConfig] = None,
         download_mode: Optional[DownloadMode] = None,
     ):
+        if data_files is None and data_dir is not None:
+            data_files = [os.path.join(data_dir, "*"), os.path.join(data_dir, "**/*")]
+
         self.name = name
         self.data_files = data_files
         self.downnload_config = download_config
@@ -803,10 +811,14 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         self,
         name: str,
         revision: Optional[Union[str, Version]] = None,
+        data_dir: Optional[str] = None,
         data_files: Optional[Union[str, List, Dict]] = None,
         download_config: Optional[DownloadConfig] = None,
         download_mode: Optional[DownloadMode] = None,
     ):
+        if data_files is None and data_dir is not None:
+            data_files = [os.path.join(data_dir, "*"), os.path.join(data_dir, "**/*")]
+
         self.name = name
         self.revision = revision
         self.data_files = data_files
@@ -1048,6 +1060,7 @@ def dataset_module_factory(
     download_mode: Optional[DownloadMode] = None,
     force_local_path: Optional[str] = None,
     dynamic_modules_path: Optional[str] = None,
+    data_dir: Optional[str] = None,
     data_files: Optional[Union[Dict, List, str, DataFilesDict]] = None,
     **download_kwargs,
 ) -> DatasetModule:
@@ -1135,7 +1148,11 @@ def dataset_module_factory(
     # Try packaged
     if path in _PACKAGED_DATASETS_MODULES:
         return PackagedDatasetModuleFactory(
-            path, data_files=data_files, download_config=download_config, download_mode=download_mode
+            path,
+            data_dir=data_dir,
+            data_files=data_files,
+            download_config=download_config,
+            download_mode=download_mode,
         ).get_module()
     # Try locally
     elif path.endswith(filename):
@@ -1151,7 +1168,7 @@ def dataset_module_factory(
         ).get_module()
     elif os.path.isdir(path):
         return LocalDatasetModuleFactoryWithoutScript(
-            path, data_files=data_files, download_mode=download_mode
+            path, data_dir=data_dir, data_files=data_files, download_mode=download_mode
         ).get_module()
     # Try remotely
     elif is_relative_path(path) and path.count("/") <= 1 and not force_local_path:
@@ -1206,6 +1223,7 @@ def dataset_module_factory(
                     return HubDatasetModuleFactoryWithoutScript(
                         path,
                         revision=revision,
+                        data_dir=data_dir,
                         data_files=data_files,
                         download_config=download_config,
                         download_mode=download_mode,
@@ -1535,7 +1553,12 @@ def load_dataset_builder(
         download_config = download_config.copy() if download_config else DownloadConfig()
         download_config.use_auth_token = use_auth_token
     dataset_module = dataset_module_factory(
-        path, revision=revision, download_config=download_config, download_mode=download_mode, data_files=data_files
+        path,
+        revision=revision,
+        download_config=download_config,
+        download_mode=download_mode,
+        data_dir=data_dir,
+        data_files=data_files,
     )
 
     # Get dataset builder class from the processing script

--- a/tests/hub_fixtures.py
+++ b/tests/hub_fixtures.py
@@ -37,7 +37,7 @@ def hf_private_dataset_repo_txt_data_(hf_api: HfApi, hf_token, text_file):
     hf_api.upload_file(
         token=hf_token,
         path_or_fileobj=str(text_file),
-        path_in_repo="data.txt",
+        path_in_repo="data/text_data.txt",
         repo_id=repo_id,
         repo_type="dataset",
     )

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -89,6 +89,8 @@ def test_fs_isfile(protocol, zip_jsonl_path, jsonl_gz_path):
 def test_hf_filesystem(hf_token, hf_api, hf_private_dataset_repo_txt_data, text_file):
     repo_info = hf_api.dataset_info(hf_private_dataset_repo_txt_data, token=hf_token)
     hffs = HfFileSystem(repo_info=repo_info, token=hf_token)
-    assert sorted(hffs.glob("*")) == [".gitattributes", "data.txt"]
+    assert sorted(hffs.glob("*")) == [".gitattributes", "data"]
+    assert hffs.isdir("data")
+    assert hffs.isfile(".gitattributes") and hffs.isfile("data/text_data.txt")
     with open(text_file) as f:
-        assert hffs.open("data.txt", "r").read() == f.read()
+        assert hffs.open("data/text_data.txt", "r").read() == f.read()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -259,7 +259,7 @@ class ModuleFactoryTest(TestCase):
     def test_HubDatasetModuleFactoryWithoutScript_with_data_dir(self):
         data_dir = "data2"
         factory = HubDatasetModuleFactoryWithoutScript(
-            SAMPLE_DATASET_IDENTIFIER3, data_dir="data2", download_config=self.download_config
+            SAMPLE_DATASET_IDENTIFIER3, data_dir=data_dir, download_config=self.download_config
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -14,6 +14,7 @@ import requests
 
 import datasets
 from datasets import SCRIPTS_VERSION, config, load_dataset, load_from_disk
+from datasets import data_files
 from datasets.arrow_dataset import Dataset
 from datasets.builder import DatasetBuilder
 from datasets.data_files import DataFilesDict
@@ -236,6 +237,14 @@ class ModuleFactoryTest(TestCase):
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
+
+        factory = PackagedDatasetModuleFactory(
+            "json", data_dir=self._data_dir, download_config=self.download_config
+        )
+        module_factory_result = factory.get_module()
+        assert module_factory_result.builder_kwargs["data_files"] is not None
+        for data_file in module_factory_result.builder_kwargs["data_files"]:
+            assert data_file.
 
     def test_HubDatasetModuleFactoryWithoutScript(self):
         factory = HubDatasetModuleFactoryWithoutScript(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -13,7 +13,7 @@ import pytest
 import requests
 
 import datasets
-from datasets import SCRIPTS_VERSION, config, data_files, load_dataset, load_from_disk
+from datasets import SCRIPTS_VERSION, config, load_dataset, load_from_disk
 from datasets.arrow_dataset import Dataset
 from datasets.builder import DatasetBuilder
 from datasets.data_files import DataFilesDict

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -13,8 +13,7 @@ import pytest
 import requests
 
 import datasets
-from datasets import SCRIPTS_VERSION, config, load_dataset, load_from_disk
-from datasets import data_files
+from datasets import SCRIPTS_VERSION, config, data_files, load_dataset, load_from_disk
 from datasets.arrow_dataset import Dataset
 from datasets.builder import DatasetBuilder
 from datasets.data_files import DataFilesDict
@@ -238,13 +237,14 @@ class ModuleFactoryTest(TestCase):
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-        factory = PackagedDatasetModuleFactory(
-            "json", data_dir=self._data_dir, download_config=self.download_config
-        )
+    def test_PackagedDatasetModuleFactory_with_data_dir(self):
+        factory = PackagedDatasetModuleFactory("json", data_dir=self._data_dir, download_config=self.download_config)
         module_factory_result = factory.get_module()
-        assert module_factory_result.builder_kwargs["data_files"] is not None
-        for data_file in module_factory_result.builder_kwargs["data_files"]:
-            assert data_file.
+        assert (
+            module_factory_result.builder_kwargs["data_files"] is not None
+            and len(module_factory_result.builder_kwargs["data_files"]["train"]) > 0
+        )
+        assert Path(module_factory_result.builder_kwargs["data_files"]["train"][0]).parent.samefile(self._data_dir)
 
     def test_HubDatasetModuleFactoryWithoutScript(self):
         factory = HubDatasetModuleFactoryWithoutScript(


### PR DESCRIPTION
As discussed in https://github.com/huggingface/datasets/pull/2830#issuecomment-1048989764, this PR adds a QOL improvement to easily reference the files inside a directory in `load_dataset` using the `data_dir` param (very handy for ImageFolder because it avoids globbing, but also useful for the other loaders). Additionally, it fixes the issue with `HfFileSystem.isdir`, which would previously always return `False`, and aligns the path-handling logic in `HfFileSystem` with `fsspec.GitHubFileSystem`.