### PR TITLE
Add Mahalanobis distance metric

### DIFF
--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -21,10 +21,10 @@ import datasets
 _DESCRIPTION = """
 Compute the Mahalanobis Distance
 
-Mahalonobis distance is the distance between a point and a distribution. 
-And not between two distinct points. It is effectively a multivariate equivalent of the Euclidean distance. 
-It was introduced by Prof. P. C. Mahalanobis in 1936 
-and has been used in various statistical applications ever since 
+Mahalonobis distance is the distance between a point and a distribution.
+And not between two distinct points. It is effectively a multivariate equivalent of the Euclidean distance.
+It was introduced by Prof. P. C. Mahalanobis in 1936
+and has been used in various statistical applications ever since
 [source: https://www.machinelearningplus.com/statistics/mahalanobis-distance/]
 """
 

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -66,9 +66,6 @@ class Mahalanobis(datasets.Metric):
             features=datasets.Features(
                 {
                     "X": datasets.Sequence(datasets.Value("float", id="sequence"), id="X"),
-                    "reference_distribution": datasets.Sequence(
-                        datasets.Value("float", id="sequence"), id="reference_distribution"
-                    ),
                 }
             ),
         )

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -14,7 +14,9 @@
 """Mahalanobis metric."""
 
 import numpy as np
+
 import datasets
+
 
 _DESCRIPTION = """
 Compute the Mahalanobis Distance

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -48,9 +48,9 @@ Returns:
 Examples:
 
     >>> mahalanobis_metric = datasets.load_metric("mahalanobis")
-    >>> results = mahalanobis_metric.compute(references=[[0, 1], [1, 0]], predictions=[0, 1])
+    >>> results = mahalanobis_metric.compute(references=[[0, 1], [1, 0]], predictions=[[0, 1]])
     >>> print(results)
-    {'mahalanobis': np.array([0.5])}
+    {'mahalanobis': array([0.5])}
 """
 
 

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -65,7 +65,7 @@ class Mahalanobis(datasets.Metric):
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("float", id="sequence"),
+                    "predictions": datasets.Sequence(datasets.Value("float", id="sequence"), id="predictions"),
                     "references": datasets.Sequence(datasets.Value("float", id="sequence"), id="references"),
                 }
             ),

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -78,11 +78,14 @@ class Mahalanobis(datasets.Metric):
         references = np.array(references)
 
         # Assert that arrays are 2D
-        assert len(predictions.shape) == 2, "Expected `predictions` to be a 2D vector"
-        assert len(references.shape) == 2, "Expected `references` to be a 2D vector"
-        assert (
-            references.shape[0] > 1
-        ), "Expected `references` to be a 2D vector with more than one element in the first dimension"
+        if len(predictions.shape) != 2:
+            raise ValueError("Expected `predictions` to be a 2D vector")
+        if len(references.shape) != 2:
+            raise ValueError("Expected `references` to be a 2D vector")
+        if references.shape[0] < 2:
+            raise ValueError(
+                "Expected `references` to be a 2D vector with more than one element in the first dimension"
+            )
 
         # Get mahalanobis distance for each prediction
         predictions_minus_mu = predictions - np.mean(references)

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -16,7 +16,6 @@
 import numpy as np
 import datasets
 
-
 _DESCRIPTION = """
 Compute the Mahalanobis Distance
 
@@ -25,7 +24,6 @@ And not between two distinct points. It is effectively a multivariate equivalent
 It was introduced by Prof. P. C. Mahalanobis in 1936 
 and has been used in various statistical applications ever since [source: https://www.machinelearningplus.com/statistics/mahalanobis-distance/]
 """
-
 
 _CITATION = """\
 @article{de2000mahalanobis,
@@ -83,7 +81,8 @@ class Mahalanobis(datasets.Metric):
         # Assert that arrays are 2D
         assert len(predictions.shape) == 2, "Expected `predictions` to be a 2D vector"
         assert len(references.shape) == 2, "Expected `references` to be a 2D vector"
-        assert references.shape[0] > 1, "Expected `references` to be a 2D vector with more than one element in the first dimension"
+        assert references.shape[
+                   0] > 1, "Expected `references` to be a 2D vector with more than one element in the first dimension"
 
         # Get mahalanobis distance for each prediction
         predictions_minus_mu = predictions - np.mean(references)

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -64,9 +64,7 @@ class Mahalanobis(datasets.Metric):
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("float", id="sequence"),
-                    "references": datasets.Sequence(
-                        datasets.Value("float", id="sequence"), id="references"
-                    ),
+                    "references": datasets.Sequence(datasets.Value("float", id="sequence"), id="references"),
                 }
             ),
         )

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -1,0 +1,100 @@
+# Copyright 2021 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Mahalanobis metric."""
+
+import numpy as np
+import datasets
+
+
+_DESCRIPTION = """
+Compute the Mahalanobis Distance
+
+Mahalonobis distance is the distance between a point and a distribution. 
+And not between two distinct points. It is effectively a multivariate equivalent of the Euclidean distance. 
+It was introduced by Prof. P. C. Mahalanobis in 1936 
+and has been used in various statistical applications ever since [source: https://www.machinelearningplus.com/statistics/mahalanobis-distance/]
+"""
+
+
+_CITATION = """\
+@article{de2000mahalanobis,
+  title={The mahalanobis distance},
+  author={De Maesschalck, Roy and Jouan-Rimbaud, Delphine and Massart, D{\'e}sir{\'e} L},
+  journal={Chemometrics and intelligent laboratory systems},
+  volume={50},
+  number={1},
+  pages={1--18},
+  year={2000},
+  publisher={Elsevier}
+}
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions: Predicted labels, as returned by a model.
+    references: Ground truth labels.
+Returns:
+    matthews_correlation: Matthews correlation.
+Examples:
+
+    >>> mahalanobis_metric = datasets.load_metric("mahalanobis")
+    >>> results = mahalanobis_metric.compute(references=[[0, 1], [1, 0]], predictions=[0, 1])
+    >>> print(results)
+    {'mahalanobis': np.array([0.5])}
+"""
+
+
+@datasets.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class Mahalanobis(datasets.Metric):
+    def _info(self):
+        return datasets.MetricInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("float"),
+                    "references": datasets.Value("float"),
+                }
+            ),
+        )
+
+    def _compute(
+            self,
+            predictions,
+            references
+    ):
+
+        # convert to numpy arrays
+        predictions = np.array(predictions)
+        references = np.array(references)
+
+        # Assert that arrays are 2D
+        assert len(predictions.shape) == 2, "Expected `predictions` to be a 2D vector"
+        assert len(references.shape) == 2, "Expected `references` to be a 2D vector"
+        assert references.shape[0] > 1, "Expected `references` to be a 2D vector with more than one element in the first dimension"
+
+        # Get mahalanobis distance for each prediction
+        predictions_minus_mu = predictions - np.mean(references)
+        cov = np.cov(references.T)
+        try:
+            inv_covmat = np.linalg.inv(cov)
+        except np.linalg.LinAlgError:
+            inv_covmat = np.linalg.pinv(cov)
+        left_term = np.dot(predictions_minus_mu, inv_covmat)
+        mahal_dist = np.dot(left_term, predictions_minus_mu.T).diagonal()
+
+        return {
+            'mahalanobis': mahal_dist
+        }

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -22,7 +22,8 @@ Compute the Mahalanobis Distance
 Mahalonobis distance is the distance between a point and a distribution. 
 And not between two distinct points. It is effectively a multivariate equivalent of the Euclidean distance. 
 It was introduced by Prof. P. C. Mahalanobis in 1936 
-and has been used in various statistical applications ever since [source: https://www.machinelearningplus.com/statistics/mahalanobis-distance/]
+and has been used in various statistical applications ever since 
+[source: https://www.machinelearningplus.com/statistics/mahalanobis-distance/]
 """
 
 _CITATION = """\
@@ -62,17 +63,13 @@ class Mahalanobis(datasets.Metric):
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("float"),
-                    "references": datasets.Value("float"),
+                    "predictions": datasets.Value("float", id="sequence"),
+                    "references": datasets.Sequence(datasets.Value("float", id="sequence"), id="references")
                 }
             ),
         )
 
-    def _compute(
-            self,
-            predictions,
-            references
-    ):
+    def _compute(self, predictions, references):
 
         # convert to numpy arrays
         predictions = np.array(predictions)
@@ -81,8 +78,8 @@ class Mahalanobis(datasets.Metric):
         # Assert that arrays are 2D
         assert len(predictions.shape) == 2, "Expected `predictions` to be a 2D vector"
         assert len(references.shape) == 2, "Expected `references` to be a 2D vector"
-        assert references.shape[
-                   0] > 1, "Expected `references` to be a 2D vector with more than one element in the first dimension"
+        assert references.shape[0] > 1, \
+            "Expected `references` to be a 2D vector with more than one element in the first dimension"
 
         # Get mahalanobis distance for each prediction
         predictions_minus_mu = predictions - np.mean(references)

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -64,7 +64,9 @@ class Mahalanobis(datasets.Metric):
             features=datasets.Features(
                 {
                     "predictions": datasets.Value("float", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("float", id="sequence"), id="references")
+                    "references": datasets.Sequence(
+                        datasets.Value("float", id="sequence"), id="references"
+                    ),
                 }
             ),
         )
@@ -78,8 +80,9 @@ class Mahalanobis(datasets.Metric):
         # Assert that arrays are 2D
         assert len(predictions.shape) == 2, "Expected `predictions` to be a 2D vector"
         assert len(references.shape) == 2, "Expected `references` to be a 2D vector"
-        assert references.shape[0] > 1, \
-            "Expected `references` to be a 2D vector with more than one element in the first dimension"
+        assert (
+            references.shape[0] > 1
+        ), "Expected `references` to be a 2D vector with more than one element in the first dimension"
 
         # Get mahalanobis distance for each prediction
         predictions_minus_mu = predictions - np.mean(references)
@@ -91,6 +94,4 @@ class Mahalanobis(datasets.Metric):
         left_term = np.dot(predictions_minus_mu, inv_covmat)
         mahal_dist = np.dot(left_term, predictions_minus_mu.T).diagonal()
 
-        return {
-            'mahalanobis': mahal_dist
-        }
+        return {"mahalanobis": mahal_dist}

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -46,7 +46,7 @@ Args:
     predictions: Predicted labels, as returned by a model.
     references: Ground truth labels.
 Returns:
-    matthews_correlation: Matthews correlation.
+    mahalanobis: The Mahalonobis distance.
 Examples:
 
     >>> mahalanobis_metric = datasets.load_metric("mahalanobis")


### PR DESCRIPTION
Mahalanobis distance is a very useful metric to measure the distance from one datapoint X to a distribution P. 
In this PR I implement the metric in a simple way with the help of numpy only.

Similar to the [MAUVE implementation](https://github.com/huggingface/datasets/blob/master/metrics/mauve/mauve.py), we can make this metric accept texts as input and encode them with a featurize model, if that is desirable.