### PR TITLE
Skip checksum computation if `ignore_verifications` is `True`

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -518,6 +518,7 @@ class DatasetBuilder:
                 download_config=download_config,
                 data_dir=self.config.data_dir,
                 base_path=base_path,
+                record_checksums=verify_infos,
             )
         elif isinstance(dl_manager, MockDownloadManager):
             try_from_hf_gcs = False
@@ -808,7 +809,7 @@ class DatasetBuilder:
                 ds = post_processed
                 recorded_checksums = {}
                 for resource_name, resource_path in resources_paths.items():
-                    size_checksum = get_size_checksum_dict(resource_path)
+                    size_checksum = get_size_checksum_dict(resource_path, record_checksum=verify_infos)
                     recorded_checksums[resource_name] = size_checksum
                 if verify_infos:
                     if self.info.post_processed is None or self.info.post_processed.resources_checksums is None:

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -84,6 +84,7 @@ class DownloadManager:
         data_dir: Optional[str] = None,
         download_config: Optional[DownloadConfig] = None,
         base_path: Optional[str] = None,
+        record_checksums: bool = True,
     ):
         """Download manager constructor.
 
@@ -95,12 +96,14 @@ class DownloadManager:
                 download options
             base_path: `str`, base path that is used when relative paths are used to
                 download files. This can be a remote url.
+            record_checksums: `bool`, whether to record checksums of downloaded files.
         """
         self._dataset_name = dataset_name
         self._data_dir = data_dir
         self._base_path = base_path or os.path.abspath(".")
+        self._record_checksums = record_checksums
         # To record what is being used: {url: {num_bytes: int, checksum: str}}
-        self._recorded_sizes_checksums: Dict[str, Dict[str, Union[int, str]]] = {}
+        self._recorded_sizes_checksums: Dict[str, Dict[str, Optional[Union[int, str]]]] = {}
         self.download_config = download_config or DownloadConfig()
         self.downloaded_paths = {}
         self.extracted_paths = {}
@@ -145,7 +148,9 @@ class DownloadManager:
         """Record size/checksum of downloaded files."""
         for url, path in zip(url_or_urls.flatten(), downloaded_path_or_paths.flatten()):
             # call str to support PathLike objects
-            self._recorded_sizes_checksums[str(url)] = get_size_checksum_dict(path)
+            self._recorded_sizes_checksums[str(url)] = get_size_checksum_dict(
+                path, record_checksum=self._record_checksums
+            )
 
     def download_custom(self, url_or_urls, custom_download):
         """

--- a/src/datasets/utils/info_utils.py
+++ b/src/datasets/utils/info_utils.py
@@ -75,13 +75,17 @@ def verify_splits(expected_splits: Optional[dict], recorded_splits: dict):
     logger.info("All the splits matched successfully.")
 
 
-def get_size_checksum_dict(path: str) -> dict:
+def get_size_checksum_dict(path: str, record_checksum: bool = True) -> dict:
     """Compute the file size and the sha256 checksum of a file"""
-    m = sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            m.update(chunk)
-    return {"num_bytes": os.path.getsize(path), "checksum": m.hexdigest()}
+    if record_checksum:
+        m = sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                m.update(chunk)
+            checksum = m.hexdigest()
+    else:
+        checksum = None
+    return {"num_bytes": os.path.getsize(path), "checksum": checksum}
 
 
 def is_small_dataset(dataset_size):


### PR DESCRIPTION
This will speed up the loading of the datasets where the number of data files is large (can easily happen with `imagefoler`, for instance)