### PR TITLE
Handle Nones in PyArrow struct

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             - run: pip install pyarrow --upgrade
             - run: HF_SCRIPTS_VERSION=master HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
-    run_dataset_script_tests_pyarrow_3:
+    run_dataset_script_tests_pyarrow_5:
         working_directory: ~/datasets
         docker:
             - image: cimg/python:3.6
@@ -33,7 +33,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
-            - run: pip install pyarrow==3.0.0
+            - run: pip install pyarrow==5.0.0
             - run: HF_SCRIPTS_VERSION=master HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_latest_WIN:
@@ -57,7 +57,7 @@ jobs:
                 $env:HF_SCRIPTS_VERSION="master"
                 python -m pytest -n 2 --dist loadfile -sv ./tests/
 
-    run_dataset_script_tests_pyarrow_3_WIN:
+    run_dataset_script_tests_pyarrow_5_WIN:
         working_directory: ~/datasets
         executor:
             name: win/default
@@ -72,7 +72,7 @@ jobs:
                 conda activate py37
                 pip install .[tests]
                 pip install -r additional-tests-requirements.txt --no-deps
-                pip install pyarrow==3.0.0
+                pip install pyarrow==5.0.0
             - run: |
                 conda activate py37
                 $env:HF_SCRIPTS_VERSION="master"
@@ -126,8 +126,8 @@ workflows:
         jobs:
             - check_code_quality
             - run_dataset_script_tests_pyarrow_latest
-            - run_dataset_script_tests_pyarrow_3
+            - run_dataset_script_tests_pyarrow_5
             - run_dataset_script_tests_pyarrow_latest_WIN
-            - run_dataset_script_tests_pyarrow_3_WIN
+            - run_dataset_script_tests_pyarrow_5_WIN
             - build_doc
             - deploy_doc: *workflow_filters

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - python
     - pip
     - numpy >=1.17
-    - pyarrow >=3.0.0
+    - pyarrow >=5.0.0
     - python-xxhash
     - dill
     - pandas
@@ -32,7 +32,7 @@ requirements:
     - python
     - pip
     - numpy >=1.17
-    - pyarrow >=3.0.0
+    - pyarrow >=5.0.0
     - python-xxhash
     - dill
     - pandas

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -16,8 +16,8 @@ jobs:
           pip install setuptools wheel
           pip install -e .[benchmarks]
 
-          # pyarrow==3.0.0
-          pip install pyarrow==3.0.0
+          # pyarrow==5.0.0
+          pip install pyarrow==5.0.0
 
           dvc repro --force
 
@@ -26,7 +26,7 @@ jobs:
 
           python ./benchmarks/format.py report.json report.md
 
-          echo "<details>\n<summary>Show benchmarks</summary>\n\nPyArrow==3.0.0\n" > final_report.md
+          echo "<details>\n<summary>Show benchmarks</summary>\n\nPyArrow==5.0.0\n" > final_report.md
           cat report.md >> final_report.md
 
           # pyarrow

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,8 @@ REQUIRED_PKGS = [
     # We use numpy>=1.17 to have np.random.Generator (Dataset shuffling)
     "numpy>=1.17",
     # Backend and serialization.
-    # Minimum 3.0.0 to support mix of struct and list types in parquet, and batch iterators of parquet data
-    # pyarrow 4.0.0 introduced segfault bug, see: https://github.com/huggingface/datasets/pull/2268
-    "pyarrow>=3.0.0,!=4.0.0",
+    # Minimum 5.0.0 to support mix of struct and list types in parquet, and batch iterators of parquet data, masks in StructArray
+    "pyarrow>=5.0.0",
     # For smart caching dataset processing
     "dill",
     # For performance gains with apache arrow

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -24,9 +24,9 @@ from packaging import version as _version
 from pyarrow import total_allocated_bytes
 
 
-if _version.parse(pyarrow.__version__).major < 3:
+if _version.parse(pyarrow.__version__).major < 5:
     raise ImportWarning(
-        "To use `datasets`, the module `pyarrow>=3.0.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
+        "To use `datasets`, the module `pyarrow>=5.0.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."
     )
 

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -184,9 +184,7 @@ class TypedSequence:
             elif isinstance(data, list) and data and isinstance(first_non_null_value(data)[1], np.ndarray):
                 out = list_of_np_array_to_pyarrow_listarray(data)
             else:
-                casted_data = cast_to_python_objects(data, only_1d_for_numpy=True)
-                mask = np.array([value is None for value in casted_data])
-                out = pa.array(casted_data, mask=mask)
+                out = pa.array(cast_to_python_objects(data, only_1d_for_numpy=True))
             # use smaller integer precisions if possible
             if self.trying_int_optimization:
                 if pa.types.is_int64(out.type):
@@ -211,9 +209,7 @@ class TypedSequence:
                     elif isinstance(data, list) and data and any(isinstance(value, np.ndarray) for value in data):
                         return list_of_np_array_to_pyarrow_listarray(data)
                     else:
-                        casted_data = cast_to_python_objects(data, only_1d_for_numpy=True)
-                        mask = np.array([value is None for value in casted_data])
-                        return pa.array(casted_data, mask=mask)
+                        return pa.array(cast_to_python_objects(data, only_1d_for_numpy=True))
                 except pa.lib.ArrowInvalid as e:
                     if "overflow" in str(e):
                         raise OverflowError(

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -185,7 +185,7 @@ class TypedSequence:
                 out = list_of_np_array_to_pyarrow_listarray(data)
             else:
                 casted_data = cast_to_python_objects(data, only_1d_for_numpy=True)
-                mask = np.array(casted_data, dtype=np.object) == None  # noqa: E711
+                mask = np.array([value is None for value in casted_data])
                 out = pa.array(casted_data, mask=mask)
             # use smaller integer precisions if possible
             if self.trying_int_optimization:
@@ -212,7 +212,7 @@ class TypedSequence:
                         return list_of_np_array_to_pyarrow_listarray(data)
                     else:
                         casted_data = cast_to_python_objects(data, only_1d_for_numpy=True)
-                        mask = np.array(casted_data, dtype=np.object) == None  # noqa: E711
+                        mask = np.array([value is None for value in casted_data])
                         return pa.array(casted_data, mask=mask)
                 except pa.lib.ArrowInvalid as e:
                     if "overflow" in str(e):

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -127,7 +127,7 @@ class Audio:
         """
         if pa.types.is_string(storage.type):
             bytes_array = pa.array([None] * len(storage), type=pa.binary())
-            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"])
+            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
         elif pa.types.is_struct(storage.type) and storage.type.get_all_field_indices("array"):
             storage = pa.array([Audio().encode_example(x) if x is not None else None for x in storage.to_pylist()])
         elif pa.types.is_struct(storage.type):
@@ -139,7 +139,7 @@ class Audio:
                 path_array = storage.field("path")
             else:
                 path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"])
+            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
 
     def embed_storage(self, storage: pa.StructArray, drop_paths: bool = True) -> pa.StructArray:
@@ -165,7 +165,7 @@ class Audio:
             type=pa.binary(),
         )
         path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")
-        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"])
+        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
         return array_cast(storage, self.pa_type)
 
     def _decode_non_mp3_path_like(self, path, format=None):

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -138,7 +138,7 @@ class Image:
 
         if pa.types.is_string(storage.type):
             bytes_array = pa.array([None] * len(storage), type=pa.binary())
-            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"])
+            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
         elif pa.types.is_struct(storage.type):
             if storage.type.get_field_index("bytes") >= 0:
                 bytes_array = storage.field("bytes")
@@ -148,7 +148,7 @@ class Image:
                 path_array = storage.field("path")
             else:
                 path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"])
+            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         elif pa.types.is_list(storage.type):
             bytes_array = pa.array(
                 [
@@ -158,7 +158,9 @@ class Image:
                 type=pa.binary(),
             )
             path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"])
+            storage = pa.StructArray.from_arrays(
+                [bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null()
+            )
         return array_cast(storage, self.pa_type)
 
     def embed_storage(self, storage: pa.StructArray, drop_paths: bool = True) -> pa.StructArray:
@@ -184,7 +186,7 @@ class Image:
             type=pa.binary(),
         )
         path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")
-        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"])
+        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
         return array_cast(storage, self.pa_type)
 
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, TypeVar, Unio
 
 import numpy as np
 import pyarrow as pa
-import pyarrow.compute as pc
-from packaging import version
 
 from . import config
 from .utils.logging import get_logger
@@ -19,8 +17,6 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
-
-IS_PYARROW_AT_LEAST_4 = config.PYARROW_VERSION.major >= 4
 
 
 def inject_arrow_table_documentation(arrow_table_method):
@@ -922,31 +918,6 @@ def _wrap_for_chunked_arrays(func):
     return wrapper
 
 
-def _sanitize_sliced_list_arrays_for_cast(func):
-    """Sanitize pyarrow.ListArray objects for pyarrow.Array.cast in case they are sliced list arrays"""
-
-    @_wrap_for_chunked_arrays
-    def _sanitize(array: pa.ListArray) -> pa.ListArray:
-        """Return the same pyarrow.ListArray but with array.offset == 0 for compatibility with cast for pyarrow 3"""
-        if array.offset == 0:
-            return array
-        elif len(array) == 0:
-            return array.values.slice(0, 0)
-        else:
-            values_offset = array.offsets[0]  # the relevant values start at this index
-            new_values = array.values.slice(values_offset.as_py())  # get the values to start at the right position
-            new_offsets = pc.subtract(array.offsets, values_offset)  # update the offsets accordingly
-            return pa.ListArray.from_arrays(new_offsets, new_values)
-
-    def wrapper(array, *args, **kwargs):
-        if pa.types.is_list(array.type) and config.PYARROW_VERSION < version.parse("4.0.0"):
-            array = _sanitize(array)
-        return func(array, *args, **kwargs)
-
-    return wrapper
-
-
-@_sanitize_sliced_list_arrays_for_cast
 @_wrap_for_chunked_arrays
 def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
     """Improved version of pa.Array.cast
@@ -1019,7 +990,6 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
     raise TypeError(f"Couldn't cast array of type\n{array.type}\nto\n{pa_type}")
 
 
-@_sanitize_sliced_list_arrays_for_cast
 @_wrap_for_chunked_arrays
 def cast_array_to_feature(array: pa.Array, feature: "FeatureType", allow_number_to_str=True):
     """Cast an array to the arrow type that corresponds to the requested feature type.

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -234,6 +234,40 @@ def test_dataset_with_audio_feature_tar_mp3(tar_mp3_path):
 
 
 @require_sndfile
+def test_dataset_with_audio_feature_with_none():
+    data = {"audio": [None]}
+    features = Features({"audio": Audio()})
+    dset = Dataset.from_dict(data, features=features)
+    item = dset[0]
+    assert item.keys() == {"audio"}
+    assert item["audio"] is None
+    batch = dset[:1]
+    assert len(batch) == 1
+    assert batch.keys() == {"audio"}
+    assert isinstance(batch["audio"], list) and all(item is None for item in batch["audio"])
+    column = dset["audio"]
+    assert len(column) == 1
+    assert isinstance(column, list) and all(item is None for item in column)
+
+    # nested tests
+
+    data = {"audio": [[None]]}
+    features = Features({"audio": Sequence(Audio())})
+    dset = Dataset.from_dict(data, features=features)
+    item = dset[0]
+    assert item.keys() == {"audio"}
+    assert all(i is None for i in item["audio"])
+
+    data = {"nested": [{"audio": None}]}
+    features = Features({"nested": {"audio": Audio()}})
+    dset = Dataset.from_dict(data, features=features)
+    item = dset[0]
+    assert item.keys() == {"nested"}
+    assert item["nested"].keys() == {"audio"}
+    assert item["nested"]["audio"] is None
+
+
+@require_sndfile
 def test_resampling_at_loading_dataset_with_audio_feature(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_44100.wav")
     data = {"audio": [audio_path]}

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -222,6 +222,40 @@ def test_dataset_with_image_feature_tar_jpg(tar_jpg_path):
 
 
 @require_pil
+def test_dataset_with_image_feature_with_none():
+    data = {"image": [None]}
+    features = Features({"image": Image()})
+    dset = Dataset.from_dict(data, features=features)
+    item = dset[0]
+    assert item.keys() == {"image"}
+    assert item["image"] is None
+    batch = dset[:1]
+    assert len(batch) == 1
+    assert batch.keys() == {"image"}
+    assert isinstance(batch["image"], list) and all(item is None for item in batch["image"])
+    column = dset["image"]
+    assert len(column) == 1
+    assert isinstance(column, list) and all(item is None for item in column)
+
+    # nested tests
+
+    data = {"images": [[None]]}
+    features = Features({"images": Sequence(Image())})
+    dset = Dataset.from_dict(data, features=features)
+    item = dset[0]
+    assert item.keys() == {"images"}
+    assert all(i is None for i in item["images"])
+
+    data = {"nested": [{"image": None}]}
+    features = Features({"nested": {"image": Image()}})
+    dset = Dataset.from_dict(data, features=features)
+    item = dset[0]
+    assert item.keys() == {"nested"}
+    assert item["nested"].keys() == {"image"}
+    assert item["nested"]["image"] is None
+
+
+@require_pil
 @pytest.mark.parametrize(
     "build_data",
     [


### PR DESCRIPTION
This PR fixes an issue introduced by #3575 where `None` values stored in PyArrow arrays/structs would get ignored by `cast_storage` or by the `pa.array(cast_to_python_objects(..))` pattern. To fix the former, it also bumps the minimal PyArrow version to v5.0.0 to use the `mask` param in `pa.SturctArray`. 

