### PR TITLE
Fix iter_archive getting reset

### DIFF
--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -21,7 +21,7 @@ import os
 import tarfile
 from datetime import datetime
 from functools import partial
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union
 
 from .. import config, utils
 from .deprecation_utils import DeprecatedEnum
@@ -73,6 +73,72 @@ class GenerateMode(DeprecatedEnum):
     @property
     def help_message(self):
         return "Use 'DownloadMode' instead."
+
+
+class _IterableFromGenerator(Iterable):
+    """Utility class to create an iterable from a generator function, in order to reset the generator when needed."""
+
+    def __init__(self, generator: Callable, *args, **kwargs):
+        self.generator = generator
+        self.args = args
+        self.kwargs = kwargs
+
+    def __iter__(self):
+        yield from self.generator(*self.args, **self.kwargs)
+
+
+class ArchiveIterable(_IterableFromGenerator):
+    """An iterable of (path, fileobj) from a TAR archive, used by `iter_archive`"""
+
+    @classmethod
+    def _iter_from_fileobj(cls, f) -> Generator[Tuple, None, None]:
+        stream = tarfile.open(fileobj=f, mode="r|*")
+        for tarinfo in stream:
+            file_path = tarinfo.name
+            if not tarinfo.isreg():
+                continue
+            if file_path is None:
+                continue
+            if os.path.basename(file_path).startswith(".") or os.path.basename(file_path).startswith("__"):
+                # skipping hidden files
+                continue
+            file_obj = stream.extractfile(tarinfo)
+            yield file_path, file_obj
+            stream.members = []
+        del stream
+
+    @classmethod
+    def _iter_from_path(cls, urlpath: str) -> Generator[Tuple, None, None]:
+        with open(urlpath, "rb") as f:
+            yield from cls._iter_from_fileobj(f)
+
+    @classmethod
+    def from_buf(cls, fileobj) -> "ArchiveIterable":
+        return cls(cls._iter_from_fileobj, fileobj)
+
+    @classmethod
+    def from_path(cls, urlpath_or_buf) -> "ArchiveIterable":
+        return cls(cls._iter_from_path, urlpath_or_buf)
+
+
+class FilesIterable(_IterableFromGenerator):
+    """An iterable of paths from a list of directories or files"""
+
+    @classmethod
+    def _iter_from_paths(cls, urlpaths: Union[str, List[str]]) -> Generator[str, None, None]:
+        if not isinstance(urlpaths, list):
+            urlpaths = [urlpaths]
+        for urlpath in urlpaths:
+            if os.path.isfile(urlpath):
+                yield urlpath
+            else:
+                for dirpath, _, filenames in os.walk(urlpath):
+                    for filename in filenames:
+                        yield os.path.join(dirpath, filename)
+
+    @classmethod
+    def from_paths(cls, urlpaths) -> "FilesIterable":
+        return cls(cls._iter_from_paths, urlpaths)
 
 
 class DownloadManager:
@@ -255,27 +321,10 @@ class DownloadManager:
                 File object is opened in binary mode.
         """
 
-        def _iter_archive(f):
-            stream = tarfile.open(fileobj=f, mode="r|*")
-            for tarinfo in stream:
-                file_path = tarinfo.name
-                if not tarinfo.isreg():
-                    continue
-                if file_path is None:
-                    continue
-                if os.path.basename(file_path).startswith(".") or os.path.basename(file_path).startswith("__"):
-                    # skipping hidden files
-                    continue
-                file_obj = stream.extractfile(tarinfo)
-                yield file_path, file_obj
-                stream.members = []
-            del stream
-
         if hasattr(path_or_buf, "read"):
-            yield from _iter_archive(path_or_buf)
+            return ArchiveIterable.from_buf(path_or_buf)
         else:
-            with open(path_or_buf, "rb") as f:
-                yield from _iter_archive(f)
+            return ArchiveIterable.from_path(path_or_buf)
 
     def iter_files(self, paths: Union[str, List[str]]):
         """Iterate over file paths.
@@ -286,15 +335,7 @@ class DownloadManager:
         Yields:
             str: File path.
         """
-        if not isinstance(paths, list):
-            paths = [paths]
-        for path in paths:
-            if os.path.isfile(path):
-                yield path
-            else:
-                for dirpath, _, filenames in os.walk(path):
-                    for filename in filenames:
-                        yield os.path.join(dirpath, filename)
+        return FilesIterable.from_paths(paths)
 
     def extract(self, path_or_paths, num_proc=None):
         """Extract given path(s).


### PR DESCRIPTION
The `DownloadManager.iter_archive` method currently returns an iterator - which is  **empty** once you iter over it once. This means you can't pass the same archive iterator to several splits.

To fix that, I changed the ouput of `DownloadManager.iter_archive` to be an iterable that you can iterate over several times, instead of a one-time-use iterator.

The `StreamingDownloadManager.iter_archive` already returns an appropriate iterable, and the code added in this PR are inspired from the one in `streaming_download_manager.py`