### PR TITLE
Simplify Common Voice code

### DIFF
--- a/datasets/common_voice/common_voice.py
+++ b/datasets/common_voice/common_voice.py
@@ -659,135 +659,84 @@ class CommonVoice(datasets.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
-        streaming = dl_manager.is_streaming
         archive_path = dl_manager.download(_DATA_URL.format(self.config.name))
-        if streaming:
-            # Here we use iter_archive in streaming mode because dl_manager.download_and_extract
-            # doesn't work to stream TAR archives (we have to stream the files in the archive one by one).
-            #
-            # The iter_archive method returns an iterable of (path_within_archive, file_obj) for every
-            # file in the TAR archive.
-            #
-            archive_iterator = dl_manager.iter_archive(archive_path)
-            # we locate the data using the path within the archive
-            path_to_data = "/".join(["cv-corpus-6.1-2020-12-11", self.config.name])
-            path_to_clips = "/".join([path_to_data, "clips"])
-            metadata_filepaths = {
-                split: "/".join([path_to_data, f"{split}.tsv"])
-                for split in ["train", "test", "dev", "other", "validated", "invalidated"]
-            }
-        else:
-            # In non-streaming we can extract the archive locally as usual
-            extracted_dir = dl_manager.extract(archive_path)
-            archive_iterator = None
-            # we locate the data using the local path
-            path_to_data = os.path.join(extracted_dir, "cv-corpus-6.1-2020-12-11", self.config.name)
-            path_to_clips = os.path.join(path_to_data, "clips")
-            metadata_filepaths = {
-                split: os.path.join(path_to_data, f"{split}.tsv")
-                for split in ["train", "test", "dev", "other", "validated", "invalidated"]
-            }
+        # Here we use iter_archive because dl_manager.download_and_extract
+        # doesn't work to stream TAR archives in streaming mode.
+        # (we have to stream the files in the archive one by one)
+        #
+        # The iter_archive method returns an iterable of (path_within_archive, file_obj) for every
+        # file in the TAR archive.
+        #
+        archive_iterator = dl_manager.iter_archive(archive_path)
+        # we locate the data using the path within the archive
+        path_to_data = "/".join(["cv-corpus-6.1-2020-12-11", self.config.name])
+        path_to_clips = "/".join([path_to_data, "clips"])
+        metadata_filepaths = {
+            split: "/".join([path_to_data, f"{split}.tsv"])
+            for split in ["train", "test", "dev", "other", "validated", "invalidated"]
+        }
+        # in streaming mode, the archive is not extracted locally
+        local_extracted_archive = dl_manager.extract(archive_path) if not dl_manager.is_streaming else None
 
         return [
             datasets.SplitGenerator(
                 name=datasets.Split.TRAIN,
                 gen_kwargs={
-                    "streaming": streaming,
+                    "local_extracted_archive": local_extracted_archive,
                     "archive_iterator": archive_iterator,
-                    "filepath": metadata_filepaths["train"],
+                    "metadata_filepath": metadata_filepaths["train"],
                     "path_to_clips": path_to_clips,
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.TEST,
                 gen_kwargs={
-                    "streaming": streaming,
+                    "local_extracted_archive": local_extracted_archive,
                     "archive_iterator": archive_iterator,
-                    "filepath": metadata_filepaths["test"],
+                    "metadata_filepath": metadata_filepaths["test"],
                     "path_to_clips": path_to_clips,
                 },
             ),
             datasets.SplitGenerator(
                 name=datasets.Split.VALIDATION,
                 gen_kwargs={
-                    "streaming": streaming,
+                    "local_extracted_archive": local_extracted_archive,
                     "archive_iterator": archive_iterator,
-                    "filepath": metadata_filepaths["dev"],
+                    "metadata_filepath": metadata_filepaths["dev"],
                     "path_to_clips": path_to_clips,
                 },
             ),
             datasets.SplitGenerator(
                 name="other",
                 gen_kwargs={
-                    "streaming": streaming,
+                    "local_extracted_archive": local_extracted_archive,
                     "archive_iterator": archive_iterator,
-                    "filepath": metadata_filepaths["other"],
+                    "metadata_filepath": metadata_filepaths["other"],
                     "path_to_clips": path_to_clips,
                 },
             ),
             datasets.SplitGenerator(
                 name="validated",
                 gen_kwargs={
-                    "streaming": streaming,
+                    "local_extracted_archive": local_extracted_archive,
                     "archive_iterator": archive_iterator,
-                    "filepath": metadata_filepaths["validated"],
+                    "metadata_filepath": metadata_filepaths["validated"],
                     "path_to_clips": path_to_clips,
                 },
             ),
             datasets.SplitGenerator(
                 name="invalidated",
                 gen_kwargs={
-                    "streaming": streaming,
+                    "local_extracted_archive": local_extracted_archive,
                     "archive_iterator": archive_iterator,
-                    "filepath": metadata_filepaths["invalidated"],
+                    "metadata_filepath": metadata_filepaths["invalidated"],
                     "path_to_clips": path_to_clips,
                 },
             ),
         ]
 
-    def _generate_examples(self, streaming, archive_iterator, filepath, path_to_clips):
+    def _generate_examples(self, local_extracted_archive, archive_iterator, metadata_filepath, path_to_clips):
         """Yields examples."""
-        if streaming:
-            yield from self._generate_examples_streaming(archive_iterator, filepath, path_to_clips)
-        else:
-            yield from self._generate_examples_non_streaming(filepath, path_to_clips)
-
-    def _generate_examples_non_streaming(self, filepath, path_to_clips):
-
-        data_fields = list(self._info().features.keys())
-
-        # audio is not a header of the csv files
-        data_fields.remove("audio")
-        path_idx = data_fields.index("path")
-
-        with open(filepath, encoding="utf-8") as f:
-            lines = f.readlines()
-            headline = lines[0]
-
-            column_names = headline.strip().split("\t")
-            assert (
-                column_names == data_fields
-            ), f"The file should have {data_fields} as column names, but has {column_names}"
-
-            for id_, line in enumerate(lines[1:]):
-                field_values = line.strip().split("\t")
-
-                # set absolute path for mp3 audio file
-                field_values[path_idx] = os.path.join(path_to_clips, field_values[path_idx])
-
-                # if data is incomplete, fill with empty values
-                if len(field_values) < len(data_fields):
-                    field_values += (len(data_fields) - len(field_values)) * ["''"]
-
-                result = {key: value for key, value in zip(data_fields, field_values)}
-
-                # set audio feature
-                result["audio"] = field_values[path_idx]
-
-                yield id_, result
-
-    def _generate_examples_streaming(self, archive_iterator, filepath, path_to_clips):
-        """Yields examples in streaming mode."""
         data_fields = list(self._info().features.keys())
 
         # audio is not a header of the csv files
@@ -797,7 +746,7 @@ class CommonVoice(datasets.GeneratorBasedBuilder):
         all_field_values = {}
         metadata_found = False
         for path, f in archive_iterator:
-            if path == filepath:
+            if path == metadata_filepath:
                 metadata_found = True
                 lines = f.readlines()
                 headline = lines[0].decode("utf-8")
@@ -826,7 +775,7 @@ class CommonVoice(datasets.GeneratorBasedBuilder):
 
                     # set audio feature
                     result["audio"] = {"path": path, "bytes": f.read()}
-                    # set path to None since the path doesn't exist locally in streaming mode
-                    result["path"] = None
+                    # set path to None if the path doesn't exist locally in streaming mode
+                    result["path"] = os.path.join(local_extracted_archive, path) if local_extracted_archive else None
 
                     yield path, result


### PR DESCRIPTION
In #3736 we introduced one method to generate examples when streaming, that is different from the one when not streaming.

In this PR I propose a new implementation which is simpler: it only has one function, based on `iter_archive`. And you still have access to local audio files when loading the dataset in non-streaming mode.

cc @patrickvonplaten @polinaeterna @anton-l @albertvillanova since this will become the template for many audio datasets to come.

This change can also trivially be applied to the other audio datasets that already exist. Using this line, you can get access to local files in non-streaming mode:
```python
local_extracted_archive = dl_manager.extract(archive_path) if not dl_manager.is_streaming else None
```