### PR TITLE
Pin responses to fix CI for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ REQUIRED_PKGS = [
     "huggingface_hub>=0.1.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
+    "responses<0.19",
 ]
 
 AUDIO_REQUIRE = [


### PR DESCRIPTION
Temporarily fix CI for Windows by pinning `responses`. 

See: https://app.circleci.com/pipelines/github/huggingface/datasets/10292/workflows/83de4a55-bff7-43ec-96f7-0c335af5c050/jobs/63355

Fix: #3839