### PR TITLE
Align IterableDataset.shuffle with Dataset.shuffle

### DIFF
--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -31,12 +31,12 @@ An [`datasets.IterableDataset`] is useful for iterative jobs like training a mod
 
 Like a regular [`datasets.Dataset`] object, you can also shuffle a [`datasets.IterableDataset`] with [`datasets.IterableDataset.shuffle`]. 
 
-The `buffer_size` argument controls the size of the buffer to randomly sample examples from. Let's say your dataset has one million examples, and you set the `buffer_size` to ten thousand. [`datasets.IterableDataset.shuffle`] will randomly select examples from the first ten thousand examples in the buffer. Selected examples in the buffer are replaced with new examples.
+The `buffer_size` argument controls the size of the buffer to randomly sample examples from. Let's say your dataset has one million examples, and you set the `buffer_size` to ten thousand. [`datasets.IterableDataset.shuffle`] will randomly select examples from the first ten thousand examples in the buffer. Selected examples in the buffer are replaced with new examples. By default, the buffer size is 1,000.
 
 ```py
 >>> from datasets import load_dataset
 >>> dataset = load_dataset('oscar', "unshuffled_deduplicated_en", split='train', streaming=True)
->>> shuffled_dataset = dataset.shuffle(buffer_size=10_000, seed=42)
+>>> shuffled_dataset = dataset.shuffle(seed=42, buffer_size=10_000)
 ```
 
 <Tip>

--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -189,7 +189,10 @@ def _interleave_iterable_datasets(
     if probabilities is None:
         ex_iterable = CyclingMultiSourcesExamplesIterable(ex_iterables)
     else:
-        ex_iterable = RandomlyCyclingMultiSourcesExamplesIterable(ex_iterables, seed=seed, probabilities=probabilities)
+        generator = np.random.default_rng(seed)
+        ex_iterable = RandomlyCyclingMultiSourcesExamplesIterable(
+            ex_iterables, generator=generator, probabilities=probabilities
+        )
     # Set new info - we reset the features
     if info is None:
         info = DatasetInfo.from_merge([d.info for d in datasets])

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -356,9 +356,9 @@ class IterableDataset(DatasetInfoMixin):
         if self._shuffling and self._epoch == 0:
             return self._shuffling.generator
         elif self._shuffling:
-            # Create effective seed using self._epoch (we substract in order to avoir overflow in long_scalars)
+            # Create effective seed using self._epoch (we subtract in order to avoir overflow in long_scalars)
             effective_seed = deepcopy(self._shuffling.generator).integers(0, 1 << 63) - self._epoch
-            effective_seed = 1 << 63 + effective seed if effective_seed < 0 else effective_seed
+            effective_seed = (1 << 63) + effective seed if effective_seed < 0 else effective_seed
             return np.random.default_rng(effective_seed)
         else:
             raise ValueError("This dataset is not shuffled")

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -261,7 +261,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
         yield from ex_iterator
 
     def shuffle_data_sources(self, seed: Optional[int]) -> "SkipExamplesIterable":
-        """Doesn't shuffle the wrapped examples iterable since it would skip exampels from other shards instead."""
+        """Doesn't shuffle the wrapped examples iterable since it would skip examples from other shards instead."""
         return self
 
     @property
@@ -442,7 +442,7 @@ class IterableDataset(DatasetInfoMixin):
             shuffling=copy.deepcopy(self._shuffling),
         )
 
-    def shuffle(self, buffer_size, seed=None) -> "IterableDataset":
+    def shuffle(self, seed=None, buffer_size: int = 1000) -> "IterableDataset":
         """
         Randomly shuffles the elements of this dataset.
 
@@ -460,8 +460,8 @@ class IterableDataset(DatasetInfoMixin):
         then the order of the shards is kept unchanged.
 
         Args:
-            buffer_size (:obj:`int`): size of the buffer.
             seed (:obj:`int`, optional, default None): random seed that will be used to create the distribution.
+            buffer_size (:obj:`int`, default 1000): size of the buffer.
         """
         shuffling = ShufflingConfig(seed=seed)
         return iterable_dataset(

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -358,7 +358,7 @@ class IterableDataset(DatasetInfoMixin):
         elif self._shuffling:
             # Create effective seed using self._epoch (we subtract in order to avoir overflow in long_scalars)
             effective_seed = deepcopy(self._shuffling.generator).integers(0, 1 << 63) - self._epoch
-            effective_seed = (1 << 63) + effective seed if effective_seed < 0 else effective_seed
+            effective_seed = (1 << 63) + effective_seed if effective_seed < 0 else effective_seed
             return np.random.default_rng(effective_seed)
         else:
             raise ValueError("This dataset is not shuffled")

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -358,6 +358,7 @@ class IterableDataset(DatasetInfoMixin):
         elif self._shuffling:
             # Create effective seed using self._epoch (we substract in order to avoir overflow in long_scalars)
             effective_seed = deepcopy(self._shuffling.generator).integers(0, 1 << 63) - self._epoch
+            effective_seed = 1 << 63 + effective seed if effective_seed < 0 else effective_seed
             return np.random.default_rng(effective_seed)
         else:
             raise ValueError("This dataset is not shuffled")

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1,4 +1,5 @@
 import copy
+from copy import deepcopy
 from dataclasses import dataclass
 from itertools import cycle, islice, repeat
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
@@ -46,7 +47,7 @@ class _BaseExamplesIterable:
         """An examples iterable should yield tuples (example_key, example) of type (int/str, dict)"""
         raise NotImplementedError()
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "_BaseExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "_BaseExamplesIterable":
         """
         Either shuffle the shards/sources of the dataset, or propagate the shuffling to the underlying iterable.
         If the order of the shards must stay fixed (when using .skip or .take for example), then this method returns self.
@@ -58,22 +59,21 @@ class _BaseExamplesIterable:
         raise NotImplementedError()
 
 
-def _shuffle_kwargs(seed: Optional[int], kwargs: dict) -> dict:
-    shuffled_kwargs = {}
-    if seed is None:
-        # We use the current NumPy's seed
-        _, seed, pos, *_ = np.random.get_state()
-        seed: int = seed[pos] if pos < 624 else seed[0]
-        _ = np.random.random()  # do 1 step of rng
-    for key, value in sorted(kwargs.items()):
+def _shuffle_kwargs(rng: np.random.Generator, kwargs: dict) -> dict:
+    # We must shuffle all the lists, and lists of the same size must have the same shuffling.
+    # This way entangled lists of (shard, shard_metadata) are still in the right order.
+
+    # First, let's generate the shuffled indices per list size
+    list_sizes = set(len(value) for value in kwargs.values() if isinstance(value, list))
+    indices_per_size = {}
+    for size in list_sizes:
+        indices_per_size[size] = list(range(size))
+        rng.shuffle(indices_per_size[size])
+    # Now let's copy the kwargs and shuffle the lists based on their sizes
+    shuffled_kwargs = dict(kwargs)
+    for key, value in shuffled_kwargs.items():
         if isinstance(value, list):
-            value = list(value)
-            # We use the same seed for all the lists that have the same length
-            # This way entangled lists of (shard, shard_metadata) are still in the right order
-            np.random.default_rng(seed + len(value)).shuffle(value)
-            shuffled_kwargs[key] = value
-        else:
-            shuffled_kwargs[key] = value
+            shuffled_kwargs[key] = [value[i] for i in indices_per_size[len(value)]]
     return shuffled_kwargs
 
 
@@ -85,8 +85,8 @@ class ExamplesIterable(_BaseExamplesIterable):
     def __iter__(self):
         yield from self.generate_examples_fn(**self.kwargs)
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "ExamplesIterable":
-        return ShardShuffledExamplesIterable(self.generate_examples_fn, self.kwargs, seed)
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "ExamplesIterable":
+        return ShardShuffledExamplesIterable(self.generate_examples_fn, self.kwargs, generator)
 
     @property
     def n_shards(self) -> int:
@@ -95,13 +95,14 @@ class ExamplesIterable(_BaseExamplesIterable):
 
 
 class ShardShuffledExamplesIterable(ExamplesIterable):
-    def __init__(self, generate_examples_fn: Callable, kwargs: dict, seed: Optional[int]):
+    def __init__(self, generate_examples_fn: Callable, kwargs: dict, generator: np.random.Generator):
         super().__init__(generate_examples_fn, kwargs)
-        self.seed = seed
+        self.generator = deepcopy(generator)
 
     def __iter__(self):
         """Shuffle the kwargs order to shuffle shards"""
-        kwargs_with_shuffled_shards = _shuffle_kwargs(self.seed, self.kwargs)
+        rng = deepcopy(self.generator)
+        kwargs_with_shuffled_shards = _shuffle_kwargs(rng, self.kwargs)
         yield from self.generate_examples_fn(**kwargs_with_shuffled_shards)
 
 
@@ -119,9 +120,9 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
             except StopIteration:  # if we ran out of examples on this iterator, break the main for loop
                 break
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "CyclingMultiSourcesExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "CyclingMultiSourcesExamplesIterable":
         """Shuffle each underlying examples iterable."""
-        ex_iterables = [ex_iterable.shuffle_data_sources(seed) for ex_iterable in self.ex_iterables]
+        ex_iterables = [ex_iterable.shuffle_data_sources(generator) for ex_iterable in self.ex_iterables]
         return CyclingMultiSourcesExamplesIterable(ex_iterables)
 
     @property
@@ -130,9 +131,9 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
 
 
 class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIterable):
-    def __init__(self, ex_iterables, seed: Optional[int] = None, probabilities: Optional[List[float]] = None):
+    def __init__(self, ex_iterables, generator: np.random.Generator, probabilities: Optional[List[float]] = None):
         super().__init__(ex_iterables)
-        self.seed = seed
+        self.generator = deepcopy(generator)
         self.probabilities = probabilities
 
     @staticmethod
@@ -151,7 +152,7 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
                 yield from (int(i) for i in rng.choice(num_sources, size=random_batch_size, p=p))
 
     def __iter__(self):
-        rng = np.random.default_rng(self.seed)
+        rng = deepcopy(self.generator)
         iterators = [iter(ex_iterable) for ex_iterable in self.ex_iterables]
         # this is an infinite iterator that randomly samples the index of the source to pick examples from
         indices_iterator = self._iter_random_indices(rng, len(iterators), p=self.probabilities)
@@ -161,10 +162,12 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
             except StopIteration:  # if we ran out of examples on this iterator, break the main for loop
                 break
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "RandomlyCyclingMultiSourcesExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "RandomlyCyclingMultiSourcesExamplesIterable":
         """Shuffle the data sources of each wrapped examples iterable."""
-        ex_iterables = [ex_iterable.shuffle_data_sources(seed) for ex_iterable in self.ex_iterables]
-        return RandomlyCyclingMultiSourcesExamplesIterable(ex_iterables, seed=seed, probabilities=self.probabilities)
+        ex_iterables = [ex_iterable.shuffle_data_sources(generator) for ex_iterable in self.ex_iterables]
+        return RandomlyCyclingMultiSourcesExamplesIterable(
+            ex_iterables, generator=generator, probabilities=self.probabilities
+        )
 
 
 class MappedExamplesIterable(_BaseExamplesIterable):
@@ -196,10 +199,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 # If not batched, apply the transform and yield the example directly
                 yield key, self.function(example)
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "MappedExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "MappedExamplesIterable":
         """Shuffle the wrapped examples iterable."""
         return MappedExamplesIterable(
-            self.ex_iterable.shuffle_data_sources(seed),
+            self.ex_iterable.shuffle_data_sources(generator),
             function=self.function,
             batched=self.batched,
             batch_size=self.batch_size,
@@ -211,10 +214,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
 
 
 class BufferShuffledExamplesIterable(_BaseExamplesIterable):
-    def __init__(self, ex_iterable: _BaseExamplesIterable, buffer_size: int, seed: Optional[int]):
+    def __init__(self, ex_iterable: _BaseExamplesIterable, buffer_size: int, generator: np.random.Generator):
         self.ex_iterable = ex_iterable
         self.buffer_size = buffer_size
-        self.seed = seed
+        self.generator = generator
 
     @staticmethod
     def _iter_random_indices(rng: np.random.Generator, buffer_size: int, random_batch_size=1000) -> Iterator[int]:
@@ -223,7 +226,7 @@ class BufferShuffledExamplesIterable(_BaseExamplesIterable):
 
     def __iter__(self):
         buffer_size = self.buffer_size
-        rng = np.random.default_rng(self.seed)
+        rng = deepcopy(self.generator)
         indices_iterator = self._iter_random_indices(rng, buffer_size)
         # this is the shuffle buffer that we keep in memory
         mem_buffer = []
@@ -238,10 +241,10 @@ class BufferShuffledExamplesIterable(_BaseExamplesIterable):
         rng.shuffle(mem_buffer)
         yield from mem_buffer
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "BufferShuffledExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "BufferShuffledExamplesIterable":
         """Shuffle the wrapped examples iterable as well as the shuffling buffer."""
         return BufferShuffledExamplesIterable(
-            self.ex_iterable.shuffle_data_sources(seed), buffer_size=self.buffer_size, seed=seed
+            self.ex_iterable.shuffle_data_sources(generator), buffer_size=self.buffer_size, generator=generator
         )
 
     @property
@@ -260,7 +263,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
             pass
         yield from ex_iterator
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "SkipExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "SkipExamplesIterable":
         """Doesn't shuffle the wrapped examples iterable since it would skip examples from other shards instead."""
         return self
 
@@ -277,7 +280,7 @@ class TakeExamplesIterable(_BaseExamplesIterable):
     def __iter__(self):
         yield from islice(self.ex_iterable, self.n)
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "TakeExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "TakeExamplesIterable":
         """Doesn't shuffle the wrapped examples iterable since it would take examples from other shards instead."""
         return self
 
@@ -299,10 +302,10 @@ class TypedExamplesIterable(_BaseExamplesIterable):
             decoded_example = self.features.decode_example(encoded_example)
             yield key, decoded_example
 
-    def shuffle_data_sources(self, seed: Optional[int]) -> "TypedExamplesIterable":
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "TypedExamplesIterable":
         """Shuffle the wrapped examples iterable."""
         return TypedExamplesIterable(
-            self.ex_iterable.shuffle_data_sources(seed),
+            self.ex_iterable.shuffle_data_sources(generator),
             features=self.features,
         )
 
@@ -324,7 +327,7 @@ def _generate_examples_from_tables_wrapper(generate_tables_fn):
 
 @dataclass
 class ShufflingConfig:
-    seed: Optional[int] = None
+    generator: np.random.Generator
 
 
 class IterableDataset(DatasetInfoMixin):
@@ -349,12 +352,15 @@ class IterableDataset(DatasetInfoMixin):
     def _head(self, n=5):
         return _examples_to_batch([x for key, x in islice(self._iter(), n)])
 
-    @property
-    def _effective_seed(self):
-        if self._shuffling:
-            return self._shuffling.seed + self._epoch if self._shuffling.seed is not None else None
+    def _effective_generator(self):
+        if self._shuffling and self._epoch == 0:
+            return self._shuffling.generator
+        elif self._shuffling:
+            # Create effective seed using self._epoch (we substract in order to avoir overflow in long_scalars)
+            effective_seed = deepcopy(self._shuffling.generator).integers(0, 1 << 63) - self._epoch
+            return np.random.default_rng(effective_seed)
         else:
-            return None
+            raise ValueError("This dataset is not shuffled")
 
     @property
     def n_shards(self) -> int:
@@ -362,7 +368,7 @@ class IterableDataset(DatasetInfoMixin):
 
     def _iter(self):
         if self._shuffling:
-            ex_iterable = self._ex_iterable.shuffle_data_sources(self._effective_seed)
+            ex_iterable = self._ex_iterable.shuffle_data_sources(self._effective_generator())
         else:
             ex_iterable = self._ex_iterable
         yield from ex_iterable
@@ -442,7 +448,9 @@ class IterableDataset(DatasetInfoMixin):
             shuffling=copy.deepcopy(self._shuffling),
         )
 
-    def shuffle(self, seed=None, buffer_size: int = 1000) -> "IterableDataset":
+    def shuffle(
+        self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000
+    ) -> "IterableDataset":
         """
         Randomly shuffles the elements of this dataset.
 
@@ -460,14 +468,21 @@ class IterableDataset(DatasetInfoMixin):
         then the order of the shards is kept unchanged.
 
         Args:
-            seed (:obj:`int`, optional, default None): random seed that will be used to create the distribution.
+            seed (:obj:`int`, optional, default None): random seed that will be used to shuffle the dataset.
+                It is used to sample from the shuffle buffe and als oto shuffle the data shards.
+            generator (:obj:`numpy.random.Generator`, optional): Numpy random Generator to use to compute the permutation of the dataset rows.
+                If ``generator=None`` (default), uses np.random.default_rng (the default BitGenerator (PCG64) of NumPy).
             buffer_size (:obj:`int`, default 1000): size of the buffer.
         """
-        shuffling = ShufflingConfig(seed=seed)
+        if generator is None:
+            generator = np.random.default_rng(seed)
+        else:
+            generator = deepcopy(generator)
+        shuffling = ShufflingConfig(generator=generator)
         return iterable_dataset(
-            ex_iterable=BufferShuffledExamplesIterable(self._ex_iterable, buffer_size, seed=seed).shuffle_data_sources(
-                seed=seed
-            ),
+            ex_iterable=BufferShuffledExamplesIterable(
+                self._ex_iterable, buffer_size=buffer_size, generator=generator
+            ).shuffle_data_sources(generator),
             info=copy.deepcopy(self._info),
             split=self._split,
             format_type=self._format_type,

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from itertools import chain, islice
 
 import numpy as np
@@ -22,7 +23,7 @@ from datasets.iterable_dataset import (
     iterable_dataset,
 )
 
-from .utils import require_torch
+from .utils import is_rng_equal, require_torch
 
 
 DEFAULT_N_EXAMPLES = 20
@@ -73,7 +74,7 @@ def test_examples_iterable_with_kwargs(generate_examples_fn):
 
 def test_examples_iterable_shuffle_data_sources(generate_examples_fn):
     ex_iterable = ExamplesIterable(generate_examples_fn, {"filepaths": ["0.txt", "1.txt"]})
-    ex_iterable = ex_iterable.shuffle_data_sources(40)
+    ex_iterable = ex_iterable.shuffle_data_sources(np.random.default_rng(40))
     expected = list(generate_examples_fn(filepaths=["1.txt", "0.txt"]))  # shuffle the filepaths
     assert list(ex_iterable) == expected
 
@@ -90,7 +91,7 @@ def test_examples_iterable_shuffle_shards_and_metadata():
             "all_metadata": [{"id": str(i)} for i in range(100)],
         },
     )
-    ex_iterable = ex_iterable.shuffle_data_sources(42)
+    ex_iterable = ex_iterable.shuffle_data_sources(np.random.default_rng(42))
     out = list(ex_iterable)
     filepaths_ids = [x["filepath"].split(".")[0] for _, x in out]
     metadata_ids = [x["metadata"]["id"] for _, x in out]
@@ -100,7 +101,11 @@ def test_examples_iterable_shuffle_shards_and_metadata():
 @pytest.mark.parametrize("seed", [42, 1337, 101010, 123456])
 def test_buffer_shuffled_examples_iterable(generate_examples_fn, seed):
     n, buffer_size = 100, 30
-    rng = np.random.default_rng(seed)
+    generator = np.random.default_rng(seed)
+    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
+    ex_iterable = BufferShuffledExamplesIterable(base_ex_iterable, buffer_size=buffer_size, generator=generator)
+
+    rng = deepcopy(generator)
     expected_indices_used_for_shuffling = list(
         islice(BufferShuffledExamplesIterable._iter_random_indices(rng, buffer_size=buffer_size), n - buffer_size)
     )
@@ -108,9 +113,6 @@ def test_buffer_shuffled_examples_iterable(generate_examples_fn, seed):
     assert all(0 <= index_to_pick < buffer_size for index_to_pick in expected_indices_used_for_shuffling)
     # it should be random indices
     assert expected_indices_used_for_shuffling != list(range(buffer_size))
-
-    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = BufferShuffledExamplesIterable(base_ex_iterable, buffer_size=buffer_size, seed=seed)
 
     # The final order of examples is the result of a shuffle buffer.
     all_examples = list(generate_examples_fn(n=n))
@@ -144,14 +146,15 @@ def test_cycling_multi_sources_examples_iterable(generate_examples_fn):
 @pytest.mark.parametrize("probabilities", [None, (0.5, 0.5), (0.9, 0.1)])
 def test_randomly_cycling_multi_sources_examples_iterable(generate_examples_fn, probabilities):
     seed = 42
+    generator = np.random.default_rng(seed)
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"text": "foo"})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"text": "bar"})
     ex_iterable = RandomlyCyclingMultiSourcesExamplesIterable(
-        [ex_iterable1, ex_iterable2], seed=seed, probabilities=probabilities
+        [ex_iterable1, ex_iterable2], generator=generator, probabilities=probabilities
     )
 
     # The source used randomly changes at each example. It stops when one of the iterators is empty.
-    rng = np.random.default_rng(seed)
+    rng = deepcopy(generator)
     iterators = (generate_examples_fn(text="foo"), generate_examples_fn(text="bar"))
     indices_iterator = RandomlyCyclingMultiSourcesExamplesIterable._iter_random_indices(
         rng, len(iterators), p=probabilities
@@ -216,7 +219,9 @@ def test_skip_examples_iterable(generate_examples_fn):
     skip_ex_iterable = SkipExamplesIterable(base_ex_iterable, n=count)
     expected = list(generate_examples_fn(n=total))[count:]
     assert list(skip_ex_iterable) == expected
-    assert skip_ex_iterable.shuffle_data_sources(42) is skip_ex_iterable, "skip examples makes the shards order fixed"
+    assert (
+        skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable
+    ), "skip examples makes the shards order fixed"
 
 
 def test_take_examples_iterable(generate_examples_fn):
@@ -225,7 +230,9 @@ def test_take_examples_iterable(generate_examples_fn):
     take_ex_iterable = TakeExamplesIterable(base_ex_iterable, n=count)
     expected = list(generate_examples_fn(n=total))[:count]
     assert list(take_ex_iterable) == expected
-    assert take_ex_iterable.shuffle_data_sources(42) is take_ex_iterable, "skip examples makes the shards order fixed"
+    assert (
+        take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable
+    ), "skip examples makes the shards order fixed"
 
 
 ############################
@@ -282,12 +289,17 @@ def test_iterable_dataset_set_epoch(dataset: IterableDataset):
 def test_iterable_dataset_set_epoch_of_shuffled_dataset(dataset: IterableDataset, seed, epoch):
     buffer_size = 10
     shuffled_dataset = dataset.shuffle(seed, buffer_size=buffer_size)
+    base_generator = shuffled_dataset._shuffling.generator
     if epoch is not None:
         shuffled_dataset.set_epoch(epoch)
-    if seed is None:
-        assert shuffled_dataset._effective_seed is None
+    effective_generator = shuffled_dataset._effective_generator()
+    assert effective_generator is not None
+    if epoch is None or epoch == 0:
+        assert is_rng_equal(base_generator, shuffled_dataset._effective_generator())
     else:
-        assert shuffled_dataset._effective_seed == seed + (epoch if epoch is not None else 0)
+        assert not is_rng_equal(base_generator, shuffled_dataset._effective_generator())
+        effective_seed = deepcopy(base_generator).integers(0, 1 << 63) - epoch
+        assert is_rng_equal(np.random.default_rng(effective_seed), shuffled_dataset._effective_generator())
 
 
 def test_iterable_dataset_map(dataset: IterableDataset, generate_examples_fn):
@@ -333,16 +345,18 @@ def test_iterable_dataset_map_complex_features(dataset: IterableDataset, generat
 @pytest.mark.parametrize("epoch", [None, 0, 1])
 def test_iterable_dataset_shuffle(dataset: IterableDataset, generate_examples_fn, seed, epoch):
     buffer_size = 3
+    dataset = deepcopy(dataset)
     dataset._ex_iterable.kwargs["filepaths"] = ["0.txt", "1.txt"]
     dataset = dataset.shuffle(seed, buffer_size=buffer_size)
     assert isinstance(dataset._shuffling, ShufflingConfig)
-    assert dataset._shuffling.seed == seed
+    assert isinstance(dataset._shuffling.generator, np.random.Generator)
+    assert is_rng_equal(dataset._shuffling.generator, np.random.default_rng(seed))
     # Effective seed is sum of seed and epoch
-    if epoch is None:
+    if epoch is None or epoch == 0:
         effective_seed = seed
     else:
         dataset.set_epoch(epoch)
-        effective_seed = seed + epoch
+        effective_seed = np.random.default_rng(seed).integers(0, 1 << 63) - epoch
     # Shuffling adds a shuffle buffer
     expected_first_example_index = next(
         iter(BufferShuffledExamplesIterable._iter_random_indices(np.random.default_rng(effective_seed), buffer_size))
@@ -351,7 +365,7 @@ def test_iterable_dataset_shuffle(dataset: IterableDataset, generate_examples_fn
     # It also shuffles the underlying examples iterable
     expected_ex_iterable = ExamplesIterable(
         generate_examples_fn, {"filepaths": ["0.txt", "1.txt"]}
-    ).shuffle_data_sources(effective_seed)
+    ).shuffle_data_sources(np.random.default_rng(effective_seed))
     assert isinstance(dataset._ex_iterable.ex_iterable, ExamplesIterable)
     assert next(iter(dataset)) == list(islice(expected_ex_iterable, expected_first_example_index + 1))[-1][1]
 
@@ -419,7 +433,7 @@ def test_iterable_dataset_shuffle_after_skip_or_take(generate_examples_fn, metho
     ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n, "filepaths": [f"{i}.txt" for i in range(n_shards)]})
     dataset = IterableDataset(ex_iterable)
     dataset = dataset.skip(n) if method == "skip" else dataset.take(count)
-    shuffled_dataset = dataset.shuffle(seed, DEFAULT_N_EXAMPLES)
+    shuffled_dataset = dataset.shuffle(seed, buffer_size=DEFAULT_N_EXAMPLES)
     # shuffling a skip/take dataset should keep the same examples and don't shuffle the shards
     key = lambda x: f"{x['filepath']}_{x['id']}"  # noqa: E731
     assert sorted(dataset, key=key) == sorted(shuffled_dataset, key=key)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -281,7 +281,7 @@ def test_iterable_dataset_set_epoch(dataset: IterableDataset):
 @pytest.mark.parametrize("epoch", [None, 0, 1, 10])
 def test_iterable_dataset_set_epoch_of_shuffled_dataset(dataset: IterableDataset, seed, epoch):
     buffer_size = 10
-    shuffled_dataset = dataset.shuffle(buffer_size, seed=seed)
+    shuffled_dataset = dataset.shuffle(seed, buffer_size=buffer_size)
     if epoch is not None:
         shuffled_dataset.set_epoch(epoch)
     if seed is None:
@@ -334,7 +334,7 @@ def test_iterable_dataset_map_complex_features(dataset: IterableDataset, generat
 def test_iterable_dataset_shuffle(dataset: IterableDataset, generate_examples_fn, seed, epoch):
     buffer_size = 3
     dataset._ex_iterable.kwargs["filepaths"] = ["0.txt", "1.txt"]
-    dataset = dataset.shuffle(buffer_size, seed=seed)
+    dataset = dataset.shuffle(seed, buffer_size=buffer_size)
     assert isinstance(dataset._shuffling, ShufflingConfig)
     assert dataset._shuffling.seed == seed
     # Effective seed is sum of seed and epoch
@@ -419,7 +419,7 @@ def test_iterable_dataset_shuffle_after_skip_or_take(generate_examples_fn, metho
     ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n, "filepaths": [f"{i}.txt" for i in range(n_shards)]})
     dataset = IterableDataset(ex_iterable)
     dataset = dataset.skip(n) if method == "skip" else dataset.take(count)
-    shuffled_dataset = dataset.shuffle(DEFAULT_N_EXAMPLES, seed=seed)
+    shuffled_dataset = dataset.shuffle(seed, DEFAULT_N_EXAMPLES)
     # shuffling a skip/take dataset should keep the same examples and don't shuffle the shards
     key = lambda x: f"{x['filepath']}_{x['id']}"  # noqa: E731
     assert sorted(dataset, key=key) == sorted(shuffled_dataset, key=key)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
+from copy import deepcopy
 from ctypes.util import find_library
 from distutils.util import strtobool
 from enum import Enum
@@ -412,3 +413,7 @@ def assert_arrow_memory_doesnt_increase():
     previous_allocated_memory = pa.total_allocated_bytes()
     yield
     assert pa.total_allocated_bytes() - previous_allocated_memory <= 0, "Arrow memory wasn't expected to increase."
+
+
+def is_rng_equal(rng1, rng2):
+    return deepcopy(rng1).integers(0, 100, 10).tolist() == deepcopy(rng2).integers(0, 100, 10).tolist()


### PR DESCRIPTION
From #3444 , Dataset.shuffle can have the same API than IterableDataset.shuffle (i.e. in streaming mode).

Currently you can pass an optional seed to both if you want, BUT currently IterableDataset.shuffle always requires a buffer_size, used for approximate shuffling. I propose using a reasonable default value (maybe 1000) instead.

In this PR, I set the default `buffer_size` value to 1,000, and I reorder the `IterableDataset.shuffle` arguments to match `Dataset.shuffle`, i.e. making `seed` the first argument.