### PR TITLE
Fix push_to_hub with null images

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3401,7 +3401,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 nonlocal extra_nbytes
                 if isinstance(feature, (Audio, Image)):
                     for x in array.to_pylist():
-                        if x["bytes"] is None and x["path"] is not None:
+                        if x is not None and x["bytes"] is None and x["path"] is not None:
                             size = xgetsize(x["path"])
                             extra_nbytes += size
                     extra_nbytes -= array.field("path").nbytes

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -161,7 +161,7 @@ class Audio:
             return bytes_
 
         bytes_array = pa.array(
-            [path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"] for x in storage.to_pylist()],
+            [(path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None for x in storage.to_pylist()],
             type=pa.binary(),
         )
         path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -161,7 +161,10 @@ class Audio:
             return bytes_
 
         bytes_array = pa.array(
-            [(path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None for x in storage.to_pylist()],
+            [
+                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                for x in storage.to_pylist()
+            ],
             type=pa.binary(),
         )
         path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -182,7 +182,7 @@ class Image:
             return bytes_
 
         bytes_array = pa.array(
-            [path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"] for x in storage.to_pylist()],
+            [(path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None for x in storage.to_pylist()],
             type=pa.binary(),
         )
         path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -182,7 +182,10 @@ class Image:
             return bytes_
 
         bytes_array = pa.array(
-            [(path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None for x in storage.to_pylist()],
+            [
+                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                for x in storage.to_pylist()
+            ],
             type=pa.binary(),
         )
         path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -325,7 +325,7 @@ class TestPushToHub(TestCase):
     @require_sndfile
     def test_push_dataset_to_hub_custom_features_audio(self):
         audio_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_audio_44100.wav")
-        data = {"x": [audio_path], "y": [0]}
+        data = {"x": [audio_path, None], "y": [0, -1]}
         features = Features({"x": Audio(), "y": Value("int32")})
         ds = Dataset.from_dict(data, features=features)
 
@@ -339,6 +339,9 @@ class TestPushToHub(TestCase):
                 self.assertListEqual(list(ds.features.keys()), list(hub_ds.features.keys()))
                 self.assertDictEqual(ds.features, hub_ds.features)
                 np.testing.assert_equal(ds[0]["x"]["array"], hub_ds[0]["x"]["array"])
+                self.assertEqual(
+                    ds[1], hub_ds[1]
+                )  # don't test hub_ds[0] since audio decoding might be slightly different
                 hub_ds = hub_ds.cast_column("x", Audio(decode=False))
                 elem = hub_ds[0]["x"]
                 path, bytes_ = elem["path"], elem["bytes"]
@@ -352,7 +355,7 @@ class TestPushToHub(TestCase):
     @require_pil
     def test_push_dataset_to_hub_custom_features_image(self):
         image_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg")
-        data = {"x": [image_path], "y": [0]}
+        data = {"x": [image_path, None], "y": [0, -1]}
         features = Features({"x": Image(), "y": Value("int32")})
         ds = Dataset.from_dict(data, features=features)
 


### PR DESCRIPTION
This code currently raises an error because of the null image:
```python
import datasets

dataset_dict = { 'name': ['image001.jpg', 'image002.jpg'], 'image': ['cat.jpg', None] }
features = datasets.Features({
    'name': datasets.Value('string'),
    'image': datasets.Image(),
})
dataset = datasets.Dataset.from_dict(dataset_dict, features)
dataset.push_to_hub("username/dataset") # this line produces an error: 'NoneType' object is not subscriptable
```
I fixed this in this PR

TODO:
- [x] add a test