### PR TITLE
Update for the rename doc-builder -> hf-doc-utils

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_package:
     runs-on: ubuntu-latest
     container:
-      image: huggingface/transformers-hf-doc-utils
+      image: huggingface/transformers-doc-builder
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_package:
     runs-on: ubuntu-latest
     container:
-      image: huggingface/transformers-doc-builder
+      image: huggingface/transformers-hf-doc-utils
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: 'huggingface/doc-builder'
-          path: doc-builder
+          repository: 'huggingface/hf-doc-utils'
+          path: hf-doc-utils
 
       - uses: actions/checkout@v2
         with:
@@ -41,8 +41,8 @@ jobs:
           rm -rf doc-build-dev
           git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.WRITE }}@github.com/huggingface/doc-build-dev
           
-          pip uninstall -y doc-builder
-          cd doc-builder
+          pip uninstall -y hf-doc-utils
+          cd hf-doc-utils
           git pull origin main
           pip install -e .
           cd ..
@@ -95,8 +95,8 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6656
         run: |
           cd doc-build-dev && git pull
-          cd ../doc-builder
-          doc-builder build datasets ../datasets/docs/source --build_dir ../doc-build-dev --clean --version pr_$PR_NUMBER --html
+          cd ../hf-doc-utils
+          hf-doc-utils build datasets ../datasets/docs/source --build_dir ../doc-build-dev --clean --version pr_$PR_NUMBER --html
 
       - name: Push to repositories
         run: |

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: 'huggingface/doc-builder'
-          path: doc-builder
+          repository: 'huggingface/hf-doc-utils'
+          path: hf-doc-utils
 
       - uses: actions/checkout@v2
         with:
@@ -45,7 +45,7 @@ jobs:
         run: |
           sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev
 
-          pip install git+https://github.com/huggingface/doc-builder
+          pip install git+https://github.com/huggingface/hf-doc-utils
           cd datasets
           pip install .[dev]
           cd ..
@@ -61,8 +61,8 @@ jobs:
 
       - name: Make documentation
         run: |
-          cd doc-builder &&
-          doc-builder build datasets ../datasets/docs/source --build_dir ../doc-build --clean --html &&
+          cd hf-doc-utils &&
+          hf-doc-utils build datasets ../datasets/docs/source --build_dir ../doc-build --clean --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ pip install -e ".[docs]"
 Then you need to install our special tool that builds the documentation:
 
 ```bash
-pip install git+https://github.com/huggingface/doc-builder
+pip install git+https://github.com/huggingface/hf-doc-utils
 ```
 
 ---
@@ -39,11 +39,11 @@ check how they look like before committing for instance). You don't have to comm
 
 ## Building the documentation
 
-Once you have setup the `doc-builder` and additional packages, you can generate the documentation by typing th
+Once you have setup the `hf-doc-utils` and additional packages, you can generate the documentation by typing th
 following command:
 
 ```bash
-doc-builder build transformers docs/source/ --build_dir ~/tmp/test-build
+hf-doc-utils build datasets docs/source/ --build_dir ~/tmp/test-build
 ```
 
 You can adapt the `--build_dir` to set any temporary folder that you prefer. This command will create it and generate


### PR DESCRIPTION
This PR adapts the job to the upcoming change of name of `doc-builder`.