### PR TITLE
Image process doc

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -29,6 +29,8 @@
     title: Process
   - local: audio_process
     title: Process audio data
+  - local: image_process
+    title: Process image data
   - local: stream
     title: Stream
   - local: share

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -124,4 +124,4 @@ Now you can visualize the results of the `ColorJitter` transform:
 >>> plt.imshow(img.permute(1, 2, 0))
 ```
 
-![image_process_jitter](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_dog.png)
+![image_process_jitter](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_jitter.png)

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -1,0 +1,127 @@
+# Process image data
+
+🤗 Datasets support loading and processing images with the [`~Image`] feature. This guide will show you how to:
+
+- Load an image dataset.
+- Load a generic image dataset with `ImageFolder`.
+- Add data augmentations to your images.
+- Use [`~Dataset.map`] to quickly apply your transforms to the entire dataset.
+
+## Image datasets
+
+The images in an image dataset are typically either a:
+
+- PIL `image`.
+- Path to an image file that you can load. 
+
+For example, load the [Food-101](https://huggingface.co/datasets/food101) dataset and take a look:
+
+```py
+>>> from datasets import load_dataset, Image
+
+>>> dataset = load_dataset("food101", split="train[100:]")
+>>> dataset[0]
+{'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x7FC45AB5C590>,
+ 'label': 6}
+```
+
+The [`~Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
+
+```py
+>>> from datasets import load_dataset, Image
+
+>>> dataset = load_dataset("food101", split="train[100:200]")
+>>> dataset[0]["image"]
+```
+
+![image_process_beignet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_beignet.png)
+
+
+To load an image from its path, use the [`~Dataset.cast_column`] method. The [`~Image`] feature will decode the data at the path to return an image object:
+
+```py
+>>> from datasets import load_dataset, Image
+
+>>> dataset = load_dataset("cats_vs_dogs").cast_column("image_file_path", Image())
+>>> dataset[0]["image_file_path"]
+```
+
+![image_process_dog](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_dog.png)
+
+<Tip>
+
+You can also access the path and bytes of an image file by setting `decode=False` when you load a dataset. In this case, you will need to cast the `image` column:
+
+`dataset = load_dataset("food101", split="train[100:]").cast_column('image', Image(decode=False))`
+
+</Tip>
+
+## ImageFolder
+
+You can also load your image dataset with our `ImageFolder` dataset builder without writing a custom dataloader. Your image dataset structure should look like this:
+
+```
+folder/dog/golden_retriever.png
+folder/dog/german_shepherd.png
+folder/dog/chihuahua.png
+
+folder/cat/maine_coon.png
+folder/cat/bengal.png
+folder/cat/birman.png
+```
+
+Then you can load your dataset by specifying `imagefolder` and the directory of your dataset in `data_dir`:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder")
+```
+
+Load remote datasets from their URLs with the `data_files` parameter:
+
+```py
+dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
+```
+
+## Data augmentation
+
+Adding data augmentations to a dataset is common to prevent overfitting and achieve better performance. You can use any library or package you want to apply the augmentations. This guide will use the transforms from [torchvision](https://pytorch.org/vision/stable/transforms.html).
+
+Add the [`ColorJitter`](https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.ColorJitter) transform to change the color properties of the image randomly:
+
+```py
+>>> from torchvision.transforms import Compose, ColorJitter, ToTensor
+
+>>> jitter = Compose(
+    [
+     ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.7),
+     ToTensor(),
+    ]
+)
+```
+
+Create a function to apply the `ColorJitter` transform to an image:
+
+```py
+>>> def transforms(examples):
+...     examples["pixel_values"] = [jitter(image.convert("RGB")) for image in examples["image"]]
+...     return examples
+```
+
+Use the [`~Dataset.set_transform`] function to apply the transformation on-the-fly. This is generally faster than [`~Dataset.map`] because it only prepares the data when it is used, instead of preparing it across the entire dataset ahead of time:
+
+```py
+>>> dataset.set_transform(transforms)
+```
+
+Now you can visualize the results of the `ColorJitter` transform:
+
+```py
+>>> import numpy as np
+>>> import matplotlib.pyplot as plt
+
+>>> img = dataset[0]["pixel_values"]
+>>> plt.imshow(img.permute(1, 2, 0))
+```
+
+![image_process_jitter](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_dog.png)

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -19,7 +19,7 @@ For example, load the [Food-101](https://huggingface.co/datasets/food101) datase
 ```py
 >>> from datasets import load_dataset, Image
 
->>> dataset = load_dataset("food101", split="train[100:]")
+>>> dataset = load_dataset("food101", split="train[:100]")
 >>> dataset[0]
 {'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x7FC45AB5C590>,
  'label': 6}
@@ -42,8 +42,8 @@ To load an image from its path, use the [`~Dataset.cast_column`] method. The [`I
 ```py
 >>> from datasets import load_dataset, Image
 
->>> dataset = Dataset.from_dict({"image_file_path": ["path/to/image_1", "path/to/image_2", ..., "path/to/image_n"]}).cast_column("image_file_path", Image())
->>> dataset[0]["image_file_path"]
+>>> dataset = Dataset.from_dict({"image": ["path/to/image_1", "path/to/image_2", ..., "path/to/image_n"]}).cast_column("image", Image())
+>>> dataset[0]["image"]
 ```
 
 You can also access the path and bytes of an image file by setting `decode=False` when you load a dataset. In this case, you will need to cast the `image` column:
@@ -79,9 +79,47 @@ Load remote datasets from their URLs with the `data_files` parameter:
 >>> dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
 ```
 
+`ImageFolder` will create a `label` column, and the label name is based on the directory name.
+
+## Map
+
+[`~Dataset.map`] can apply transforms over an entire dataset and it also generates a cache file.
+
+Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
+
+```py
+>>> def transforms(examples):
+...     examples["pixel_values"] = [image.convert("RGB").resize((100,100)) for image in examples["image"]]
+...     return examples
+```
+
+Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
+
+```py
+>>> dataset = dataset.map(transforms, remove_columns=["image"], batched=True)
+>>> dataset[0]
+{'label': 6,
+ 'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
+```
+
+This saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
+
+[`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
+
+- [`batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.batch_size) determines the number of examples that are processed in one call to the transform function.
+- [`writer_batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.writer_batch_size) determines the number of processed examples that are kept in memory before they are stored away.
+
+Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`~Dataset.map`].
+
 ## Data augmentation
 
 Adding data augmentations to a dataset is common to prevent overfitting and achieve better performance. You can use any library or package you want to apply the augmentations. This guide will use the transforms from [torchvision](https://pytorch.org/vision/stable/transforms.html).
+
+<Tip>
+
+Feel free to use other data augmentation libraries like [Albumentations](https://albumentations.ai/docs/). 🤗 Datasets can apply any custom function and transforms to an entire dataset!
+
+</Tip>
 
 Add the [`ColorJitter`](https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.ColorJitter) transform to change the color properties of the image randomly:
 
@@ -121,34 +159,3 @@ Now visualize the results of the `ColorJitter` transform:
 ```
 
 ![image_process_jitter](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_jitter.png)
-
-## Map
-
-[`~Dataset.map`] can also apply transforms over an entire dataset and it also generates a cache file.
-
-Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
-
-```py
->>> def transforms(examples):
-...     examples["pixel_values"] = [image.convert("RGB").resize((100,100)) for image in examples["image"]]
-...     return examples
-```
-
-Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
-
-```py
->>> dataset = dataset.map(transforms, batched=True)
->>> dataset[0]
-{'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x7F058237BCD0>,
- 'label': 6,
- 'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
-```
-
-This saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
-
-[`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
-
-- [`batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.batch_size) determines the number of examples that are processed in one call to the transform function.
-- [`writer_batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.writer_batch_size) determines the number of processed examples that are kept in memory before they are stored away.
-
-Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`~Dataset.map`].

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -89,10 +89,10 @@ Add the [`ColorJitter`](https://pytorch.org/vision/stable/transforms.html#torchv
 >>> from torchvision.transforms import Compose, ColorJitter, ToTensor
 
 >>> jitter = Compose(
-... [
-...  ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.7),
-...  ToTensor(),
-...  ]
+...     [
+...          ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.7),
+...          ToTensor(),
+...     ]
 ... )
 ```
 
@@ -129,11 +129,8 @@ Now visualize the results of the `ColorJitter` transform:
 Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
 
 ```py
->>> from torchvision.transforms import Resize
-
->>> resize = Resize([100,100])
 >>> def transforms(examples):
-...     examples["pixel_values"] = [resize(image.convert("RGB")) for image in examples["image"]]
+...     examples["pixel_values"] = [image.convert("RGB").resize((100,100)) for image in examples["image"]]
 ...     return examples
 ```
 

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -1,11 +1,11 @@
 # Process image data
 
-🤗 Datasets support loading and processing images with the [`~Image`] feature. This guide will show you how to:
+🤗 Datasets support loading and processing images with the [`Image`] feature. This guide will show you how to:
 
 - Load an image dataset.
 - Load a generic image dataset with `ImageFolder`.
-- Add data augmentations to your images.
-- Use [`~Dataset.map`] to quickly apply your transforms to the entire dataset.
+- Add data augmentations to your images with [`Dataset.set_transform`].
+- Use [`~Dataset.map`] to quickly apply transforms to an entire dataset.
 
 ## Image datasets
 
@@ -25,7 +25,7 @@ For example, load the [Food-101](https://huggingface.co/datasets/food101) datase
  'label': 6}
 ```
 
-The [`~Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
+The [`Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
 
 ```py
 >>> from datasets import load_dataset, Image
@@ -37,28 +37,24 @@ The [`~Image`] feature automatically decodes the data from the `image` column to
 ![image_process_beignet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_beignet.png)
 
 
-To load an image from its path, use the [`~Dataset.cast_column`] method. The [`~Image`] feature will decode the data at the path to return an image object:
+To load an image from its path, use the [`~Dataset.cast_column`] method. The [`Image`] feature will decode the data at the path to return an image object:
 
 ```py
 >>> from datasets import load_dataset, Image
 
->>> dataset = load_dataset("cats_vs_dogs").cast_column("image_file_path", Image())
+>>> dataset = Dataset.from_dict({"image_file_path": ["path/to/image_1", "path/to/image_2", ..., "path/to/image_n"]}).cast_column("image_file_path", Image())
 >>> dataset[0]["image_file_path"]
 ```
 
-![image_process_dog](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_dog.png)
-
-<Tip>
-
 You can also access the path and bytes of an image file by setting `decode=False` when you load a dataset. In this case, you will need to cast the `image` column:
 
-`dataset = load_dataset("food101", split="train[100:]").cast_column('image', Image(decode=False))`
-
-</Tip>
+```py
+>>> dataset = load_dataset("food101", split="train[100:]").cast_column('image', Image(decode=False))
+```
 
 ## ImageFolder
 
-You can also load your image dataset with our `ImageFolder` dataset builder without writing a custom dataloader. Your image dataset structure should look like this:
+You can also load your image dataset with a `ImageFolder` dataset builder without writing a custom dataloader. Your image dataset structure should look like this:
 
 ```
 folder/dog/golden_retriever.png
@@ -80,7 +76,7 @@ Then you can load your dataset by specifying `imagefolder` and the directory of 
 Load remote datasets from their URLs with the `data_files` parameter:
 
 ```py
-dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
+>>> dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
 ```
 
 ## Data augmentation
@@ -93,11 +89,11 @@ Add the [`ColorJitter`](https://pytorch.org/vision/stable/transforms.html#torchv
 >>> from torchvision.transforms import Compose, ColorJitter, ToTensor
 
 >>> jitter = Compose(
-    [
-     ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.7),
-     ToTensor(),
-    ]
-)
+... [
+...  ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.7),
+...  ToTensor(),
+...  ]
+... )
 ```
 
 Create a function to apply the `ColorJitter` transform to an image:
@@ -108,13 +104,13 @@ Create a function to apply the `ColorJitter` transform to an image:
 ...     return examples
 ```
 
-Use the [`~Dataset.set_transform`] function to apply the transformation on-the-fly. This is generally faster than [`~Dataset.map`] because it only prepares the data when it is used, instead of preparing it across the entire dataset ahead of time:
+Then you can use the [`~Dataset.set_transform`] function to apply the transformation on-the-fly to consume less disk space. You should use [`~Dataset.set_transform`] if you only need to access the examples once:
 
 ```py
 >>> dataset.set_transform(transforms)
 ```
 
-Now you can visualize the results of the `ColorJitter` transform:
+Now visualize the results of the `ColorJitter` transform:
 
 ```py
 >>> import numpy as np
@@ -125,3 +121,13 @@ Now you can visualize the results of the `ColorJitter` transform:
 ```
 
 ![image_process_jitter](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_jitter.png)
+
+## Map
+
+[`~Dataset.map`] can also apply transforms over an entire dataset. When you use [`~Dataset.map`] to apply transforms, it generates a cache file. This saves time because you don't have to execute the same transform twice. You should use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations that are executed for each epoch, like data augmentations.
+
+To apply the same `ColorJitter` transform from above with [`~Dataset.map`], you need to set `batched=True`:
+
+```py
+>>> processed_food = dataset.map(transforms, batched=True)
+```

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -49,7 +49,7 @@ To load an image from its path, use the [`~Dataset.cast_column`] method. The [`I
 You can also access the path and bytes of an image file by setting `decode=False` when you load a dataset. In this case, you will need to cast the `image` column:
 
 ```py
->>> dataset = load_dataset("food101", split="train[100:]").cast_column('image', Image(decode=False))
+>>> dataset = load_dataset("food101", split="train[:100]").cast_column('image', Image(decode=False))
 ```
 
 ## ImageFolder

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -12,7 +12,7 @@
 The images in an image dataset are typically either a:
 
 - PIL `image`.
-- Path to an image file that you can load. 
+- Path to an image file you can load. 
 
 For example, load the [Food-101](https://huggingface.co/datasets/food101) dataset and take a look:
 
@@ -66,7 +66,7 @@ folder/cat/bengal.png
 folder/cat/birman.png
 ```
 
-Then you can load your dataset by specifying `imagefolder` and the directory of your dataset in `data_dir`:
+Then load your dataset by specifying `imagefolder` and the directory of your dataset in `data_dir`:
 
 ```py
 >>> from datasets import load_dataset
@@ -104,7 +104,7 @@ Create a function to apply the `ColorJitter` transform to an image:
 ...     return examples
 ```
 
-Then you can use the [`~Dataset.set_transform`] function to apply the transformation on-the-fly to consume less disk space. You should use [`~Dataset.set_transform`] if you only need to access the examples once:
+Then you can use the [`~Dataset.set_transform`] function to apply the transform on-the-fly to consume less disk space. Use this function if you only need to access the examples once:
 
 ```py
 >>> dataset.set_transform(transforms)
@@ -124,10 +124,34 @@ Now visualize the results of the `ColorJitter` transform:
 
 ## Map
 
-[`~Dataset.map`] can also apply transforms over an entire dataset. When you use [`~Dataset.map`] to apply transforms, it generates a cache file. This saves time because you don't have to execute the same transform twice. You should use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations that are executed for each epoch, like data augmentations.
+[`~Dataset.map`] can also apply transforms over an entire dataset and it also generates a cache file.
 
-To apply the same `ColorJitter` transform from above with [`~Dataset.map`], you need to set `batched=True`:
+Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
 
 ```py
->>> processed_food = dataset.map(transforms, batched=True)
+>>> from torchvision.transforms import Resize
+
+>>> resize = Resize([100,100])
+>>> def transforms(examples):
+...     examples["pixel_values"] = [resize(image.convert("RGB")) for image in examples["image"]]
+...     return examples
 ```
+
+Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
+
+```py
+>>> dataset = dataset.map(transforms, batched=True)
+>>> dataset[0]
+{'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x7F058237BCD0>,
+ 'label': 6,
+ 'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
+```
+
+This saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
+
+[`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
+
+- [`batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.batch_size) determines the number of examples that are processed in one call to the transform function.
+- [`writer_batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.writer_batch_size) determines the number of processed examples that are kept in memory before they are stored away.
+
+Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`~Dataset.map`].

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -4,8 +4,8 @@
 
 - Load an image dataset.
 - Load a generic image dataset with `ImageFolder`.
-- Add data augmentations to your images with [`Dataset.set_transform`].
 - Use [`~Dataset.map`] to quickly apply transforms to an entire dataset.
+- Add data augmentations to your images with [`Dataset.set_transform`].
 
 ## Image datasets
 

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -73,6 +73,12 @@ Specify a custom split with the `split` parameter:
 
 🤗 Datasets can be loaded from local files stored on your computer, and also from remote files. The datasets are most likely stored as a `csv`, `json`, `txt` or `parquet` file. The [`datasets.load_dataset`] method is able to load each of these file types.
 
+<Tip>
+
+Curious about how to load datasets for vision? Check out the image loading guide [here](./image_process)!
+
+</Tip>
+
 ### CSV
 
 🤗 Datasets can read a dataset made up of one or several CSV files:
@@ -177,38 +183,6 @@ To load remote parquet files via HTTP, you can pass the URLs:
 >>> data_files = {"train": base_url + "wikipedia-train.parquet"}
 >>> wiki = load_dataset("parquet", data_files=data_files, split="train")
 ```
-
-### Image folders
-
-🤗 Datasets can also load generic image folders.
-
-The folder structure should look like this:
-
-```
-   data/dog/xxx.png
-   data/dog/xxy.png
-   data/dog/xxz.png
-
-   data/cat/123.png
-   data/cat/nsdf3.png
-   data/cat/asd932_.png
-```
-
-To load an `imagefolder` dataset, simply pass the root path of the image folder to the `data_dir` kwarg of [`datasets.load_dataset`], which is a shorthand syntax for `data_files=os.path.join(data_dir, **)`.
-
-```py
->>> from datasets import load_dataset
->>> dataset = load_dataset("imagefolder", data_dir="/path/to/data")
-```
-
-To load remote image folders via HTTP, you can pass the URLs:
-
-```py
->>> dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
-```
-
-The resulting dataset will include an `image` feature, which is a [`PIL.Image`] loaded from the image file, and the corresponding `label` inferred from the directory structure.
-
 
 ## In-memory data
 


### PR DESCRIPTION
This PR is a first draft of how to process image data. It adds:

- Load an image dataset with `image` and `path` (adds tip about `decode=False` param to access the path and bytes, thanks to @mariosasko).
- Load an image using the `ImageFolder` builder. I know there is an [example](https://huggingface.co/docs/datasets/master/en/loading#image-folders) of this already, but I also wanted to add it here so users don't miss it. This doc seems important for centralizing all of the image-related things so far. Datasets has grown so quickly 🚀  now that I think maybe splitting up the How-to guides by modality may be better since working with vision/audio data is slightly different from what users have seen up until now. This way we can continue to scale the docs to better accommodate vision/audio things.
- Add a data augmentation with `set_transform`. There is only 1 example here so far, but we can certainly add more. 

Todo:
- [x] Couldn't figure out why my augmentation function works with `set_transform` but not `map` 🥲. Working with @mariosasko on this!