### PR TITLE
Retry HfApi call when 504 error inside push_to_hub

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -97,7 +97,7 @@ from .table import (
 )
 from .tasks import TaskTemplate
 from .utils import logging
-from .utils.file_utils import estimate_dataset_size
+from .utils.file_utils import _retry, estimate_dataset_size
 from .utils.info_utils import is_small_dataset
 from .utils.py_utils import temporary_assignment, unique_values
 from .utils.streaming_download_manager import xgetsize
@@ -3484,14 +3484,20 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             buffer = BytesIO()
             shard.to_parquet(buffer)
             uploaded_size += buffer.tell()
-            api.upload_file(
-                path_or_fileobj=buffer.getvalue(),
-                path_in_repo=path_in_repo(index),
-                repo_id=repo_id,
-                token=token,
-                repo_type="dataset",
-                revision=branch,
-                identical_ok=True,
+            _retry(
+                api.upload_file,
+                func_kwargs=dict(
+                    path_or_fileobj=buffer.getvalue(),
+                    path_in_repo=path_in_repo(index),
+                    repo_id=repo_id,
+                    token=token,
+                    repo_type="dataset",
+                    revision=branch,
+                    identical_ok=True,
+                ),
+                exceptions=HTTPError,
+                status_codes=[504],
+                max_retries=2,
             )
         return repo_id, split, uploaded_size, dataset_nbytes
 

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from functools import partial
 from hashlib import sha256
 from pathlib import Path
-from typing import Dict, Optional, TypeVar, Union
+from typing import Dict, Optional, Type, TypeVar, Union
 from urllib.parse import urljoin, urlparse
 
 import numpy as np
@@ -365,6 +365,31 @@ def _raise_if_offline_mode_is_enabled(msg: Optional[str] = None):
         raise OfflineModeIsEnabled(
             "Offline mode is enabled." if msg is None else "Offline mode is enabled. " + str(msg)
         )
+
+
+def _retry(
+    func,
+    func_args: Optional[tuple] = None,
+    func_kwargs: Optional[dict] = None,
+    exceptions: Type[requests.exceptions.RequestException] = requests.exceptions.RequestException,
+    status_codes: Optional[list[int]] = None,
+    max_retries: int = 0,
+    base_wait_time: float = 0.5,
+    max_wait_time: float = 2,
+):
+    func_args = func_args or ()
+    func_kwargs = func_kwargs or {}
+    retry = 0
+    while True:
+        try:
+            return func(*func_args, **func_kwargs)
+        except exceptions as err:
+            if retry >= max_retries or (status_codes and err.response.status_code not in status_codes):
+                raise err
+            else:
+                sleep_time = min(max_wait_time, base_wait_time * 2**retry)  # Exponential backoff
+                time.sleep(sleep_time)
+                retry += 1
 
 
 def _request_with_retry(


### PR DESCRIPTION
Ass suggested by @lhoestq in #3872, this PR:
- Implements a retry function
- Retries HfApi call when 504 error. To be agreed:
  - max_retries = 2 (at 0.5 and 1 seconds)

Fix #3872.