### PR TITLE
Fix CLI test checksums

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -297,6 +297,9 @@ class DatasetBuilder:
         # Set download manager
         self.dl_manager = None
 
+        # Record infos even if verify_infos=False; used by datastes-cli test to generate dataset_infos.json
+        self._record_infos = False
+
     # Must be set for datasets that use 'data_dir' functionality - the ones
     # that require users to do additional steps to download the data
     # (this is usually due to some external regulations / rules).
@@ -518,7 +521,7 @@ class DatasetBuilder:
                 download_config=download_config,
                 data_dir=self.config.data_dir,
                 base_path=base_path,
-                record_checksums=verify_infos,
+                record_checksums=self._record_infos or verify_infos,
             )
         elif isinstance(dl_manager, MockDownloadManager):
             try_from_hf_gcs = False

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -297,7 +297,7 @@ class DatasetBuilder:
         # Set download manager
         self.dl_manager = None
 
-        # Record infos even if verify_infos=False; used by datastes-cli test to generate dataset_infos.json
+        # Record infos even if verify_infos=False; used by "datasets-cli test" to generate dataset_infos.json
         self._record_infos = False
 
     # Must be set for datasets that use 'data_dir' functionality - the ones

--- a/src/datasets/commands/test.py
+++ b/src/datasets/commands/test.py
@@ -153,6 +153,7 @@ class TestCommand(BaseDatasetsCLICommand):
 
         for j, builder in enumerate(get_builders()):
             print(f"Testing builder '{builder.config.name}' ({j + 1}/{n_builders})")
+            builder._record_infos = True
             builder.download_and_prepare(
                 download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS
                 if not self._force_redownload

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,17 +1,6 @@
 import pytest
 
 
-@pytest.fixture
-def data_dir(tmp_path):
-    data_dir = tmp_path / "data_dir"
-    data_dir.mkdir()
-    with open(data_dir / "train.txt", "w") as f:
-        f.write("foo\n" * 10)
-    with open(data_dir / "test.txt", "w") as f:
-        f.write("bar\n" * 10)
-    return str(data_dir)
-
-
 DATASET_LOADING_SCRIPT_NAME = "__dummy_dataset1__"
 
 DATASET_LOADING_SCRIPT_CODE = """

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,0 +1,85 @@
+import pytest
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    with open(data_dir / "train.txt", "w") as f:
+        f.write("foo\n" * 10)
+    with open(data_dir / "test.txt", "w") as f:
+        f.write("bar\n" * 10)
+    return str(data_dir)
+
+
+DATASET_LOADING_SCRIPT_NAME = "__dummy_dataset1__"
+
+DATASET_LOADING_SCRIPT_CODE = """
+import json
+import os
+
+import datasets
+
+
+REPO_URL = "https://huggingface.co/datasets/albertvillanova/tests-raw-jsonl/resolve/main/"
+URLS = {"train": REPO_URL + "wikiann-bn-train.jsonl", "validation": REPO_URL + "wikiann-bn-validation.jsonl"}
+
+
+class __DummyDataset1__(datasets.GeneratorBasedBuilder):
+
+    def _info(self):
+        features = datasets.Features(
+            {
+                "tokens": datasets.Sequence(datasets.Value("string")),
+                "ner_tags": datasets.Sequence(
+                    datasets.features.ClassLabel(
+                        names=[
+                            "O",
+                            "B-PER",
+                            "I-PER",
+                            "B-ORG",
+                            "I-ORG",
+                            "B-LOC",
+                            "I-LOC",
+                        ]
+                    )
+                ),
+                "langs": datasets.Sequence(datasets.Value("string")),
+                "spans": datasets.Sequence(datasets.Value("string")),
+            }
+        )
+        return datasets.DatasetInfo(features=features)
+
+    def _split_generators(self, dl_manager):
+        dl_path = dl_manager.download(URLS)
+        return [
+            datasets.SplitGenerator(datasets.Split.TRAIN, gen_kwargs={"filepath": dl_path["train"]}),
+            datasets.SplitGenerator(datasets.Split.VALIDATION, gen_kwargs={"filepath": dl_path["validation"]}),
+        ]
+
+    def _generate_examples(self, filepath):
+        with open(filepath, "r", encoding="utf-8") as f:
+            for i, line in enumerate(f):
+                yield i, json.loads(line)
+"""
+
+
+@pytest.fixture
+def dataset_loading_script_name():
+    return DATASET_LOADING_SCRIPT_NAME
+
+
+@pytest.fixture
+def dataset_loading_script_code():
+    return DATASET_LOADING_SCRIPT_CODE
+
+
+@pytest.fixture
+def dataset_loading_script_dir(dataset_loading_script_name, dataset_loading_script_code, tmp_path):
+    script_name = dataset_loading_script_name
+    script_dir = tmp_path / script_name
+    script_dir.mkdir()
+    script_path = script_dir / f"{script_name}.py"
+    with open(script_path, "w") as f:
+        f.write(dataset_loading_script_code)
+    return str(script_dir)

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -55,7 +55,7 @@ def test_test_command(dataset_loading_script_dir):
     assert os.path.exists(dataset_infos_path)
     with open(dataset_infos_path, encoding="utf-8") as f:
         dataset_infos = json.load(f)
-    assert dataset_infos == {
+    expected_dataset_infos = {
         "default": {
             "description": "",
             "citation": "",
@@ -128,3 +128,44 @@ def test_test_command(dataset_loading_script_dir):
             "size_in_bytes": 6530717,
         }
     }
+    assert dataset_infos.keys() == expected_dataset_infos.keys()
+    assert dataset_infos["default"].keys() == expected_dataset_infos["default"].keys()
+    for key in dataset_infos["default"].keys():
+        if key in [
+            "description",
+            "citation",
+            "homepage",
+            "license",
+            "features",
+            "post_processed",
+            "supervised_keys",
+            "task_templates",
+            "builder_name",
+            "config_name",
+            "version",
+            "download_checksums",
+            "download_size",
+            "post_processing_size",
+        ]:
+            assert dataset_infos["default"][key] == expected_dataset_infos["default"][key]
+        elif key in ["dataset_size", "size_in_bytes"]:
+            assert round(dataset_infos["default"][key] / 10**5) == round(
+                expected_dataset_infos["default"][key] / 10**5
+            )
+        elif key == "splits":
+            assert dataset_infos["default"]["splits"].keys() == expected_dataset_infos["default"]["splits"].keys()
+            for split in dataset_infos["default"]["splits"].keys():
+                assert (
+                    dataset_infos["default"]["splits"][split].keys()
+                    == expected_dataset_infos["default"]["splits"][split].keys()
+                )
+                for subkey in dataset_infos["default"]["splits"][split].keys():
+                    if subkey == "num_bytes":
+                        assert round(dataset_infos["default"]["splits"][split][subkey] / 10**2) == round(
+                            expected_dataset_infos["default"]["splits"][split][subkey] / 10**2
+                        )
+                    else:
+                        assert (
+                            dataset_infos["default"]["splits"][split][subkey]
+                            == expected_dataset_infos["default"]["splits"][split][subkey]
+                        )

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -1,0 +1,108 @@
+import json
+import os
+from collections import namedtuple
+
+from datasets import config
+from datasets.commands.test import TestCommand
+
+
+TestCommandArgs = namedtuple(
+    "TestCommandArgs",
+    [
+        "dataset",
+        "name",
+        "cache_dir",
+        "data_dir",
+        "all_configs",
+        "save_infos",
+        "ignore_verifications",
+        "force_redownload",
+        "clear_cache",
+        "proc_rank",
+        "num_proc",
+    ],
+    defaults=[None, None, None, False, False, False, False, False, 0, 1],
+)
+
+
+def test_test_command(dataset_loading_script_dir, data_dir):
+    args = TestCommandArgs(dataset=dataset_loading_script_dir, data_dir=data_dir, all_configs=True, save_infos=True)
+    test_command = TestCommand(*args)
+    test_command.run()
+    dataset_infos_path = os.path.join(dataset_loading_script_dir, config.DATASETDICT_INFOS_FILENAME)
+    assert os.path.exists(dataset_infos_path)
+    with open(dataset_infos_path, encoding="utf-8") as f:
+        dataset_infos = json.load(f)
+    assert dataset_infos == {
+        "default": {
+            "description": "",
+            "citation": "",
+            "homepage": "",
+            "license": "",
+            "features": {
+                "tokens": {
+                    "feature": {"dtype": "string", "id": None, "_type": "Value"},
+                    "length": -1,
+                    "id": None,
+                    "_type": "Sequence",
+                },
+                "ner_tags": {
+                    "feature": {
+                        "num_classes": 7,
+                        "names": ["O", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC"],
+                        "id": None,
+                        "_type": "ClassLabel",
+                    },
+                    "length": -1,
+                    "id": None,
+                    "_type": "Sequence",
+                },
+                "langs": {
+                    "feature": {"dtype": "string", "id": None, "_type": "Value"},
+                    "length": -1,
+                    "id": None,
+                    "_type": "Sequence",
+                },
+                "spans": {
+                    "feature": {"dtype": "string", "id": None, "_type": "Value"},
+                    "length": -1,
+                    "id": None,
+                    "_type": "Sequence",
+                },
+            },
+            "post_processed": None,
+            "supervised_keys": None,
+            "task_templates": None,
+            "builder_name": "__dummy_dataset1__",
+            "config_name": "default",
+            "version": {"version_str": "0.0.0", "description": None, "major": 0, "minor": 0, "patch": 0},
+            "splits": {
+                "train": {
+                    "name": "train",
+                    "num_bytes": 2351591,
+                    "num_examples": 10000,
+                    "dataset_name": "__dummy_dataset1__",
+                },
+                "validation": {
+                    "name": "validation",
+                    "num_bytes": 238446,
+                    "num_examples": 1000,
+                    "dataset_name": "__dummy_dataset1__",
+                },
+            },
+            "download_checksums": {
+                "https://huggingface.co/datasets/albertvillanova/tests-raw-jsonl/resolve/main/wikiann-bn-train.jsonl": {
+                    "num_bytes": 3578339,
+                    "checksum": "6fbe6dbdcb3c9c3a98b0ab4d56b1c8b73baab9293d603064a5ab5230ab4f366b",
+                },
+                "https://huggingface.co/datasets/albertvillanova/tests-raw-jsonl/resolve/main/wikiann-bn-validation.jsonl": {
+                    "num_bytes": 362341,
+                    "checksum": "2ddd0c090a8ccb721d7aa8477ed7323750683822c247015d5cfab1af1c8c8b3f",
+                },
+            },
+            "download_size": 3940680,
+            "post_processing_size": None,
+            "dataset_size": 2590037,
+            "size_in_bytes": 6530717,
+        }
+    }

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -1,28 +1,50 @@
 import json
 import os
 from collections import namedtuple
+from dataclasses import dataclass
+
+from packaging import version
 
 from datasets import config
 from datasets.commands.test import TestCommand
 
 
-TestCommandArgs = namedtuple(
-    "TestCommandArgs",
-    [
-        "dataset",
-        "name",
-        "cache_dir",
-        "data_dir",
-        "all_configs",
-        "save_infos",
-        "ignore_verifications",
-        "force_redownload",
-        "clear_cache",
-        "proc_rank",
-        "num_proc",
-    ],
-    defaults=[None, None, None, False, False, False, False, False, 0, 1],
-)
+if config.PY_VERSION >= version.parse("3.7"):
+    TestCommandArgs = namedtuple(
+        "TestCommandArgs",
+        [
+            "dataset",
+            "name",
+            "cache_dir",
+            "data_dir",
+            "all_configs",
+            "save_infos",
+            "ignore_verifications",
+            "force_redownload",
+            "clear_cache",
+            "proc_rank",
+            "num_proc",
+        ],
+        defaults=[None, None, None, False, False, False, False, False, 0, 1],
+    )
+else:
+
+    @dataclass
+    class TestCommandArgs:
+        dataset: str
+        name: str = None
+        cache_dir: str = None
+        data_dir: str = None
+        all_configs: bool = False
+        save_infos: bool = False
+        ignore_verifications: bool = False
+        force_redownload: bool = False
+        clear_cache: bool = False
+        proc_rank: int = 0
+        num_proc: int = 1
+
+        def __iter__(self):
+            return iter(self.__dict__.values())
 
 
 def test_test_command(dataset_loading_script_dir):

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -25,8 +25,8 @@ TestCommandArgs = namedtuple(
 )
 
 
-def test_test_command(dataset_loading_script_dir, data_dir):
-    args = TestCommandArgs(dataset=dataset_loading_script_dir, data_dir=data_dir, all_configs=True, save_infos=True)
+def test_test_command(dataset_loading_script_dir):
+    args = TestCommandArgs(dataset=dataset_loading_script_dir, all_configs=True, save_infos=True)
     test_command = TestCommand(*args)
     test_command.run()
     dataset_infos_path = os.path.join(dataset_loading_script_dir, config.DATASETDICT_INFOS_FILENAME)


### PR DESCRIPTION
Previous PR:
- #3796 

introduced a side effect: `datasets-cli test` generates `dataset_infos.json` with `None` checksum values.

See:
- #3805 

This PR introduces a way for `datasets-cli test` to force to record infos, even if `verify_infos=False`

Close #3848.

CC: @craffel 