### PR TITLE
Add default branch for doc building

### DIFF
--- a/docs/source/_config.py
+++ b/docs/source/_config.py
@@ -1,0 +1,1 @@
+default_branch_name = "master"


### PR DESCRIPTION
Since other libraries use `main` as their default branch and it's now the standard default, you have to specify a different name in the doc config if you're using `master` like datasets (`doc-builder` tries to guess it, but in the job, we have weird checkout of merge commits so it doesn't always manage to get it right).

This PR makes sure it will always use master for the dev doc (until you decide to switchto main)