### PR TITLE
Fix text loader to split only on universal newlines

### DIFF
--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from io import StringIO
 from typing import Optional
 
 import pyarrow as pa
@@ -52,7 +53,8 @@ class Text(datasets.ArrowBasedBuilder):
     def _generate_tables(self, files):
         schema = pa.schema(self.config.features.type if self.config.features is not None else {"text": pa.string()})
         for file_idx, file in enumerate(files):
-            with open(file, "rb") as f:
+            # open in text mode, by default translates universal newlines ("\n", "\r\n" and "\r") into "\n"
+            with open(file, encoding=self.config.encoding) as f:
                 if self.config.sample_by == "line":
                     batch_idx = 0
                     while True:
@@ -60,9 +62,10 @@ class Text(datasets.ArrowBasedBuilder):
                         if not batch:
                             break
                         batch += f.readline()  # finish current line
-                        # bytes.splitlines splits only on universal newlines: "\n", "\r\n" and "\r"
-                        batch = batch.splitlines(keepends=self.config.keep_linebreaks)
-                        batch = [line.decode(encoding=self.config.encoding) for line in batch]
+                        # StringIO.readlines, by default splits only on "\n" (and keeps line breaks)
+                        batch = StringIO(batch).readlines()
+                        if not self.config.keep_linebreaks:
+                            batch = [line.rstrip("\n") for line in batch]
                         pa_table = pa.Table.from_arrays([pa.array(batch)], schema=schema)
                         # Uncomment for debugging (will print the Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
@@ -73,7 +76,7 @@ class Text(datasets.ArrowBasedBuilder):
                     batch_idx = 0
                     batch = ""
                     while True:
-                        batch += f.read(self.config.chunksize).decode(encoding=self.config.encoding)
+                        batch += f.read(self.config.chunksize)
                         if not batch:
                             break
                         batch += f.readline()  # finish current line
@@ -88,6 +91,6 @@ class Text(datasets.ArrowBasedBuilder):
                         batch_idx += 1
                         batch = batch[-1]
                 elif self.config.sample_by == "document":
-                    text = f.read().decode(encoding=self.config.encoding)
+                    text = f.read()
                     pa_table = pa.Table.from_arrays([pa.array([text])], schema=schema)
                     yield file_idx, pa_table

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,6 +464,6 @@ def zip_text_with_dir_path(text_path, text2_path, tmp_path_factory):
 def text_path_with_unicode_new_lines(tmp_path_factory):
     text = "\n".join(["First", "Second\u2029with Unicode new line", "Third"])
     path = str(tmp_path_factory.mktemp("data") / "dataset_with_unicode_new_lines.txt")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(text)
     return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -458,3 +458,12 @@ def zip_text_with_dir_path(text_path, text2_path, tmp_path_factory):
         f.write(text_path, arcname=os.path.join("main_dir", os.path.basename(text_path)))
         f.write(text2_path, arcname=os.path.join("main_dir", os.path.basename(text2_path)))
     return path
+
+
+@pytest.fixture(scope="session")
+def text_path_with_unicode_new_lines(tmp_path_factory):
+    text = "\n".join(["First", "Second\u2029with Unicode new line", "Third"])
+    path = str(tmp_path_factory.mktemp("data") / "dataset_with_unicode_new_lines.txt")
+    with open(path, "w") as f:
+        f.write(text)
+    return path

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -651,6 +651,12 @@ def test_load_dataset_zip_text(data_file, streaming, zip_text_path, zip_text_wit
         assert ds_item == {"text": "0"}
 
 
+def test_load_dataset_text_with_unicode_new_lines(text_path_with_unicode_new_lines):
+    data_files = str(text_path_with_unicode_new_lines)
+    ds = load_dataset("text", split="train", data_files=data_files)
+    assert ds.num_rows == 3
+
+
 def test_loading_from_the_datasets_hub():
     with tempfile.TemporaryDirectory() as tmp_dir:
         dataset = load_dataset(SAMPLE_DATASET_IDENTIFIER, cache_dir=tmp_dir)

--- a/tests/test_packaged_modules.py
+++ b/tests/test_packaged_modules.py
@@ -50,7 +50,7 @@ def text_file(tmp_path):
         Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         """
     )
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(data)
     return str(filename)
 
@@ -76,9 +76,9 @@ def test_csv_generate_tables_raises_error_with_malformed_csv(csv_file, malformed
 
 @pytest.mark.parametrize("keep_linebreaks", [True, False])
 def test_text_linebreaks(text_file, keep_linebreaks):
-    with open(text_file) as f:
+    with open(text_file, encoding="utf-8") as f:
         expected_content = f.read().splitlines(keepends=keep_linebreaks)
-    text = Text(keep_linebreaks=keep_linebreaks)
+    text = Text(keep_linebreaks=keep_linebreaks, encoding="utf-8")
     generator = text._generate_tables([text_file])
     generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()["text"]
     assert generated_content == expected_content


### PR DESCRIPTION
Currently, `text` loader breaks on a superset of universal newlines, which also contains Unicode line boundaries. See: https://docs.python.org/3/library/stdtypes.html#str.splitlines

However, the expected behavior is to get the lines splitted only on universal newlines: "\n", "\r\n" and "\r".

See: oscar-corpus/corpus#18

Fix #3729.