### PR TITLE
Document cases for github datasets

### DIFF
--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -134,10 +134,10 @@ The distinction between a Hub dataset and a dataset from GitHub only comes from 
 
 The code of these datasets are reviewed by the Hugging Face team, and they require test data in order to be regularly tested.
 
-In some cases in makes more sense to open a PR on github:
+In some cases it makes more sense to open a PR on GitHub:
 
 - when you need the dataset to be reviewed
 - when you need long-term maintenance from the Hugging Face team
-- when there’s no clear org name / namespace that you can put the dataset under
+- when there's no clear org name / namespace that you can put the dataset under
 
 For more info, please take a look at the documentation on [How to add a new dataset in the huggingface/datasets repository](https://github.com/huggingface/datasets/blob/master/ADD_NEW_DATASET.md).

--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -134,4 +134,10 @@ The distinction between a Hub dataset and a dataset from GitHub only comes from 
 
 The code of these datasets are reviewed by the Hugging Face team, and they require test data in order to be regularly tested.
 
+In some cases in makes more sense to open a PR on github:
+
+- when you need the dataset to be reviewed
+- when you need long-term maintenance from the Hugging Face team
+- when there’s no clear org name / namespace that you can put the dataset under
+
 For more info, please take a look at the documentation on [How to add a new dataset in the huggingface/datasets repository](https://github.com/huggingface/datasets/blob/master/ADD_NEW_DATASET.md).


### PR DESCRIPTION
In general we recommend adding the new dataset under a username or organization in the Hugging Face Hub at [hf.co/datasets](hf.co/datasets), but users can still add a dataset on github in some cases.

I added a paragraph in the documentation to explain in which cases it can make more sense to open a PR on github:

- when you need the dataset to be reviewed
- when you need long-term maintenance from the HF team
- when there’s no clear org name / namespace that you can put the dataset under