### PR TITLE
Fix Wikipedia version and re-add tests

### DIFF
--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -876,10 +876,13 @@ _BASE_URL_TMPL = "https://dumps.wikimedia.org/{lang}wiki/{date}/"
 _INFO_FILE = "dumpstatus.json"
 
 
+_VERSION = datasets.Version("2.0.0", "")
+
+
 class WikipediaConfig(datasets.BuilderConfig):
     """BuilderConfig for Wikipedia."""
 
-    def __init__(self, language=None, date=None, **kwargs):
+    def __init__(self, language=None, date=None, version=_VERSION, **kwargs):
         """BuilderConfig for Wikipedia.
 
         Args:
@@ -888,16 +891,16 @@ class WikipediaConfig(datasets.BuilderConfig):
             available dates can be found at https://dumps.wikimedia.org/enwiki/.
           **kwargs: keyword arguments forwarded to super.
         """
-        super(WikipediaConfig, self).__init__(
+        super().__init__(
             name=f"{date}.{language}",
             description=f"Wikipedia dataset for {language}, parsed from {date} dump.",
+            version=version,
             **kwargs,
         )
         self.date = date
         self.language = language
 
 
-_VERSION = datasets.Version("2.0.0", "")
 _DATE = "20220301"
 
 
@@ -908,7 +911,6 @@ class Wikipedia(datasets.BeamBasedBuilder):
     BUILDER_CONFIG_CLASS = WikipediaConfig
     BUILDER_CONFIGS = [
         WikipediaConfig(
-            version=_VERSION,
             language=lang,
             date=_DATE,
         )  # pylint:disable=g-complex-comprehension

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -12,12 +12,12 @@ from datasets.utils import cached_path
 
 
 DATASETS_ON_HF_GCP = [
-    # {"dataset": "wikipedia", "config_name": "20200501.en"},
-    # {"dataset": "wikipedia", "config_name": "20200501.it"},
-    # {"dataset": "wikipedia", "config_name": "20200501.fr"},
-    # {"dataset": "wikipedia", "config_name": "20200501.frr"},
-    # {"dataset": "wikipedia", "config_name": "20200501.simple"},
-    # {"dataset": "wikipedia", "config_name": "20200501.de"},
+    {"dataset": "wikipedia", "config_name": "20220301.de"},
+    {"dataset": "wikipedia", "config_name": "20220301.en"},
+    {"dataset": "wikipedia", "config_name": "20220301.fr"},
+    {"dataset": "wikipedia", "config_name": "20220301.frr"},
+    {"dataset": "wikipedia", "config_name": "20220301.it"},
+    {"dataset": "wikipedia", "config_name": "20220301.simple"},
     {"dataset": "snli", "config_name": "plain_text"},
     {"dataset": "eli5", "config_name": "LFQA_reddit"},
     {"dataset": "wiki40b", "config_name": "en"},


### PR DESCRIPTION
To keep backward compatibility when loading using "wikipedia" dataset ID (https://huggingface.co/datasets/wikipedia), we have created the pre-processed data for the same languages we were offering before, but with updated date "20220301":
- de
- en
- fr
- frr
- it
- simple

The next step will be to offer the pre-processed data many other languages, but when loading using "wikimedia/wikipedia": https://huggingface.co/datasets/wikimedia/wikipedia