### PR TITLE
[Doc] Don't use v for version tags on GitHub

### DIFF
--- a/docs/source/_config.py
+++ b/docs/source/_config.py
@@ -1,1 +1,2 @@
 default_branch_name = "master"
+version_prefix = ""


### PR DESCRIPTION
This removes the `v` automatically used by `doc-builder` for versions.