### PR TITLE
Fix flatten of Sequence feature type

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1457,7 +1457,12 @@ class Features(dict):
                     del flattened[column_name]
                 elif isinstance(subfeature, Sequence) and isinstance(subfeature.feature, dict):
                     no_change = False
-                    flattened.update({f"{column_name}.{k}": Sequence(v) for k, v in subfeature.feature.items()})
+                    flattened.update(
+                        {
+                            f"{column_name}.{k}": Sequence(v) if not isinstance(v, dict) else [v]
+                            for k, v in subfeature.feature.items()
+                        }
+                    )
                     del flattened[column_name]
             self = flattened
             if no_change:

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -226,6 +226,13 @@ class FeaturesTest(TestCase):
         assert flattened_features == {"foo.bar1": Value("int32"), "foo.bar2.foobar": Value("string")}
         assert features == _features, "calling flatten shouldn't alter the current features"
 
+    def test_flatten_with_sequence(self):
+        features = Features({"foo": Sequence({"bar": {"my_value": Value("int32")}})})
+        _features = features.copy()
+        flattened_features = features.flatten()
+        assert flattened_features == {"foo.bar": [{"my_value": Value("int32")}]}
+        assert features == _features, "calling flatten shouldn't alter the current features"
+
 
 def test_classlabel_init(tmp_path_factory):
     names = ["negative", "positive"]


### PR DESCRIPTION
The `Sequence` features type is not correctly flattened if it contains a dictionary. This PR fixes this, and I added a test case for this.

Close https://github.com/huggingface/datasets/issues/3795