### PR TITLE
Fix main classes reference in docs

### DIFF
--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -141,8 +141,6 @@ It also has dataset transform methods like map or filter, to process all the spl
     - from_text
     - prepare_for_task
 
-<a id='package_reference_features'></a>
-
 ## IterableDataset
 
 The base class [`datasets.IterableDataset`] implements an iterable Dataset backed by python generators.

--- a/src/datasets/features/translation.py
+++ b/src/datasets/features/translation.py
@@ -19,19 +19,21 @@ class Translation:
     Output: A dictionary mapping string language codes to translations as `Text`
         features.
 
-    Example::
+    Example:
 
-        # At construction time:
+    ```python
+    >>> # At construction time:
 
-        datasets.features.Translation(languages=['en', 'fr', 'de'])
+    >>> datasets.features.Translation(languages=['en', 'fr', 'de'])
 
-        # During data generation:
+    >>> # During data generation:
 
-        yield {
-                'en': 'the cat',
-                'fr': 'le chat',
-                'de': 'die katze'
-        }
+    >>> yield {
+    >>>     'en': 'the cat',
+    >>>     'fr': 'le chat',
+    >>>     'de': 'die katze'
+    >>> }
+    ```
     """
 
     languages: List[str]
@@ -66,26 +68,28 @@ class TranslationVariableLanguages:
         translation: variable-length 1D tf.Tensor of tf.string plain text
             translations, sorted to align with language codes.
 
-    Example::
+    Example:
 
-        # At construction time:
+    ```python
+    >>> # At construction time:
 
-        datasets.features.Translation(languages=['en', 'fr', 'de'])
+    >>> datasets.features.Translation(languages=['en', 'fr', 'de'])
 
-        # During data generation:
+    >>> # During data generation:
 
-        yield {
-                'en': 'the cat',
-                'fr': ['le chat', 'la chatte,']
-                'de': 'die katze'
-        }
+    >>> yield {
+    >>>     'en': 'the cat',
+    >>>     'fr': ['le chat', 'la chatte,']
+    >>>     'de': 'die katze'
+    >>> }
 
-        # Tensor returned :
+    >>> # Tensor returned :
 
-        {
-                'language': ['en', 'de', 'fr', 'fr'],
-                'translation': ['the cat', 'die katze', 'la chatte', 'le chat'],
-        }
+    >>> {
+    >>>     'language': ['en', 'de', 'fr', 'fr'],
+    >>>     'translation': ['the cat', 'die katze', 'la chatte', 'le chat'],
+    >>> }
+    ```
     """
 
     languages: Optional[List] = None


### PR DESCRIPTION
Currently the section index (on the page's right side) of the [main classes reference](https://huggingface.co/docs/datasets/master/en/package_reference/main_classes) incorrectly displays `Tensor returned:`, this PR fixes this issue by wrapping code examples in this page with markdown code block.

There are other examples in datasets library having this issue.