### PR TITLE
Add tip on how to speed up loading with ImageFolder

### DIFF
--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -1,11 +1,11 @@
 # Process image data
 
-🤗 Datasets support loading and processing images with the [`datasets.Image`] feature. This guide will show you how to:
+🤗 Datasets support loading and processing images with the [`Image`] feature. This guide will show you how to:
 
 - Load an image dataset.
 - Load a generic image dataset with `ImageFolder`.
-- Use [`datasets.Dataset.map`] to quickly apply transforms to an entire dataset.
-- Add data augmentations to your images with [`datasets.Dataset.set_transform`].
+- Use [`~Dataset.map`] to quickly apply transforms to an entire dataset.
+- Add data augmentations to your images with [`Dataset.set_transform`].
 
 ## Image datasets
 
@@ -25,7 +25,7 @@ For example, load the [Food-101](https://huggingface.co/datasets/food101) datase
  'label': 6}
 ```
 
-The [`datasets.Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
+The [`Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
 
 ```py
 >>> from datasets import load_dataset, Image
@@ -37,7 +37,7 @@ The [`datasets.Image`] feature automatically decodes the data from the `image` c
 ![image_process_beignet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_beignet.png)
 
 
-To load an image from its path, use the [`datasets.Dataset.cast_column`] method. The [`datasets.Image`] feature will decode the data at the path to return an image object:
+To load an image from its path, use the [`~Dataset.cast_column`] method. The [`Image`] feature will decode the data at the path to return an image object:
 
 ```py
 >>> from datasets import load_dataset, Image
@@ -89,7 +89,7 @@ If the image files come from a trusted source, pass `ignore_verifications=True` 
 
 ## Map
 
-[`datasets.Dataset.map`] can apply transforms over an entire dataset and it also generates a cache file.
+[`~Dataset.map`] can apply transforms over an entire dataset and it also generates a cache file.
 
 Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
 
@@ -99,7 +99,7 @@ Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvisi
 ...     return examples
 ```
 
-Now [`datasets.Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
+Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
 
 ```py
 >>> dataset = dataset.map(transforms, remove_columns=["image"], batched=True)
@@ -108,14 +108,14 @@ Now [`datasets.Dataset.map`] the function over the entire dataset and set `batch
  'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
 ```
 
-This saves time because you don't have to execute the same transform twice. It is best to use [`datasets.Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
+This saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
 
-[`datasets.Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
+[`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
 
 - [`batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.batch_size) determines the number of examples that are processed in one call to the transform function.
 - [`writer_batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.writer_batch_size) determines the number of processed examples that are kept in memory before they are stored away.
 
-Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`datasets.Dataset.map`].
+Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`~Dataset.map`].
 
 ## Data augmentation
 
@@ -148,7 +148,7 @@ Create a function to apply the `ColorJitter` transform to an image:
 ...     return examples
 ```
 
-Then you can use the [`datasets.Dataset.set_transform`] function to apply the transform on-the-fly to consume less disk space. Use this function if you only need to access the examples once:
+Then you can use the [`~Dataset.set_transform`] function to apply the transform on-the-fly to consume less disk space. Use this function if you only need to access the examples once:
 
 ```py
 >>> dataset.set_transform(transforms)

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -83,7 +83,7 @@ Load remote datasets from their URLs with the `data_files` parameter:
 
 <Tip>
 
-If the image files come from a trusted source, pass `ignore_verifications=True` to [`datasets.load_dataset`] to skip checksum verification and speed up loading.
+If the image files come from a trusted source, pass `ignore_verifications=True` to [`load_dataset`] to skip checksum verification and speed up loading.
 
 </Tip>
 

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -1,11 +1,11 @@
 # Process image data
 
-🤗 Datasets support loading and processing images with the [`Image`] feature. This guide will show you how to:
+🤗 Datasets support loading and processing images with the [`datasets.Image`] feature. This guide will show you how to:
 
 - Load an image dataset.
 - Load a generic image dataset with `ImageFolder`.
-- Use [`~Dataset.map`] to quickly apply transforms to an entire dataset.
-- Add data augmentations to your images with [`Dataset.set_transform`].
+- Use [`datasets.Dataset.map`] to quickly apply transforms to an entire dataset.
+- Add data augmentations to your images with [`datasets.Dataset.set_transform`].
 
 ## Image datasets
 
@@ -25,7 +25,7 @@ For example, load the [Food-101](https://huggingface.co/datasets/food101) datase
  'label': 6}
 ```
 
-The [`Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
+The [`datasets.Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
 
 ```py
 >>> from datasets import load_dataset, Image
@@ -37,7 +37,7 @@ The [`Image`] feature automatically decodes the data from the `image` column to 
 ![image_process_beignet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_beignet.png)
 
 
-To load an image from its path, use the [`~Dataset.cast_column`] method. The [`Image`] feature will decode the data at the path to return an image object:
+To load an image from its path, use the [`datasets.Dataset.cast_column`] method. The [`datasets.Image`] feature will decode the data at the path to return an image object:
 
 ```py
 >>> from datasets import load_dataset, Image
@@ -81,9 +81,15 @@ Load remote datasets from their URLs with the `data_files` parameter:
 
 `ImageFolder` will create a `label` column, and the label name is based on the directory name.
 
+<Tip>
+
+If the image files come from a trusted source, pass `ignore_verifications=True` to [`datasets.load_dataset`] to skip checksum verification and speed up loading.
+
+</Tip>
+
 ## Map
 
-[`~Dataset.map`] can apply transforms over an entire dataset and it also generates a cache file.
+[`datasets.Dataset.map`] can apply transforms over an entire dataset and it also generates a cache file.
 
 Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
 
@@ -93,7 +99,7 @@ Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvisi
 ...     return examples
 ```
 
-Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
+Now [`datasets.Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
 
 ```py
 >>> dataset = dataset.map(transforms, remove_columns=["image"], batched=True)
@@ -102,14 +108,14 @@ Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`
  'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
 ```
 
-This saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
+This saves time because you don't have to execute the same transform twice. It is best to use [`datasets.Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
 
-[`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
+[`datasets.Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
 
 - [`batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.batch_size) determines the number of examples that are processed in one call to the transform function.
 - [`writer_batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.writer_batch_size) determines the number of processed examples that are kept in memory before they are stored away.
 
-Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`~Dataset.map`].
+Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`datasets.Dataset.map`].
 
 ## Data augmentation
 
@@ -142,7 +148,7 @@ Create a function to apply the `ColorJitter` transform to an image:
 ...     return examples
 ```
 
-Then you can use the [`~Dataset.set_transform`] function to apply the transform on-the-fly to consume less disk space. Use this function if you only need to access the examples once:
+Then you can use the [`datasets.Dataset.set_transform`] function to apply the transform on-the-fly to consume less disk space. Use this function if you only need to access the examples once:
 
 ```py
 >>> dataset.set_transform(transforms)


### PR DESCRIPTION
This PR does two things:
* adds a tip on how to speed up loading of a large number of files with ImageFolder (motivated by [this issue](https://github.com/huggingface/datasets/issues/3960))
* replaces the current references to the `Dataset` methods in the Image Processing doc with their fully qualified counterparts (to align it with the Audio Processing doc)

cc @stevhliu 