### PR TITLE
Mark Google Drive tests as slow

### DIFF
--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -32,7 +32,7 @@ from datasets.utils.streaming_download_manager import (
     xsplitext,
 )
 
-from .utils import require_lz4, require_zstandard
+from .utils import require_lz4, require_zstandard, slow
 
 
 TEST_URL = "https://huggingface.co/datasets/lhoestq/test/raw/main/some_text.txt"
@@ -628,10 +628,20 @@ def test_streaming_dl_manager_extract_all_supported_single_file_compression_type
         ("https://github.com/user/repo/blob/master/data/morph_train.tsv?raw=true", None),
         ("https://repo.org/bitstream/handle/20.500.12185/346/annotated_corpus.zip?sequence=3&isAllowed=y", "zip"),
         ("https://zenodo.org/record/2787612/files/SICK.zip?download=1", "zip"),
+    ],
+)
+def test_streaming_dl_manager_get_extraction_protocol_gg_drive(urlpath, expected_protocol):
+    assert _get_extraction_protocol(urlpath) == expected_protocol
+
+
+@pytest.mark.parametrize(
+    "urlpath, expected_protocol",
+    [
         (TEST_GG_DRIVE_GZIPPED_URL, "gzip"),
         (TEST_GG_DRIVE_ZIPPED_URL, "zip"),
     ],
 )
+@slow  # otherwise it spams google drive and the CI gets banned
 def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol):
     assert _get_extraction_protocol(urlpath) == expected_protocol
 
@@ -649,23 +659,27 @@ def test_streaming_dl_manager_get_extraction_protocol_throws(urlpath):
     _get_extraction_protocol(urlpath)
 
 
+@slow  # otherwise it spams google drive and the CI gets banned
 def test_streaming_gg_drive():
     with xopen(TEST_GG_DRIVE_URL) as f:
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
+@slow  # otherwise it spams google drive and the CI gets banned
 def test_streaming_gg_drive_no_extract():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_URL)
     with xopen(urlpath) as f:
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
+@slow  # otherwise it spams google drive and the CI gets banned
 def test_streaming_gg_drive_gzipped():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_GZIPPED_URL)
     with xopen(urlpath) as f:
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
+@slow  # otherwise it spams google drive and the CI gets banned
 def test_streaming_gg_drive_zipped():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_ZIPPED_URL)
     all_files = list(xglob(xjoin(urlpath, "*")))


### PR DESCRIPTION
These tests make the CI spam the Google Drive API, the CI now gets banned by Google Drive very often.

I think we can just skip these tests from the CI for now.

In the future we could have a CI job that runs only once a day or once a week for such cases

cc @albertvillanova @mariosasko @severo 

![image](https://user-images.githubusercontent.com/42851186/159283608-fdeca1ac-b57f-4fa3-bf09-6fa5361c494f.png)
