### PR TITLE
Fix Faiss custom_index device

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -232,6 +232,9 @@ class FaissIndex(BaseIndex):
         """
         if string_factory is not None and custom_index is not None:
             raise ValueError("Please specify either `string_factory` or `custom_index` but not both.")
+        if device is not None and custom_index is not None:
+            raise ValueError("Cannot pass both 'custom_index' and 'device'. "
+                             "Pass 'custom_index' already transferred to the target device instead.")
         self.device = device
         self.string_factory = string_factory
         self.metric_type = metric_type

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -233,8 +233,10 @@ class FaissIndex(BaseIndex):
         if string_factory is not None and custom_index is not None:
             raise ValueError("Please specify either `string_factory` or `custom_index` but not both.")
         if device is not None and custom_index is not None:
-            raise ValueError("Cannot pass both 'custom_index' and 'device'. "
-                             "Pass 'custom_index' already transferred to the target device instead.")
+            raise ValueError(
+                "Cannot pass both 'custom_index' and 'device'. "
+                "Pass 'custom_index' already transferred to the target device instead."
+            )
         self.device = device
         self.string_factory = string_factory
         self.metric_type = metric_type


### PR DESCRIPTION
Currently, if both `custom_index` and `device` are passed to `FaissIndex`, `device` is silently ignored.

This PR fixes this by raising a ValueError if both arguments are passed.

Alternatively, the `custom_index` could be transferred to the target `device`.