### PR TITLE
Close `PIL.Image` file handler in `Image.decode_example`

### DIFF
--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -108,6 +108,7 @@ class Image:
             else:
                 if is_local_path(path):
                     image = PIL.Image.open(path)
+                    image.load()
                 else:
                     with xopen(path, "rb") as f:
                         bytes_ = BytesIO(f.read())

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -108,13 +108,13 @@ class Image:
             else:
                 if is_local_path(path):
                     image = PIL.Image.open(path)
-                    image.load()
                 else:
                     with xopen(path, "rb") as f:
                         bytes_ = BytesIO(f.read())
                     image = PIL.Image.open(bytes_)
         else:
             image = PIL.Image.open(BytesIO(bytes_))
+        image.load()
         return image
 
     def flatten(self) -> Union["FeatureType", Dict[str, "FeatureType"]]:

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -114,7 +114,7 @@ class Image:
                     image = PIL.Image.open(bytes_)
         else:
             image = PIL.Image.open(BytesIO(bytes_))
-        image.load()
+        image.load()  # to avoid "Too many open files" errors
         return image
 
     def flatten(self) -> Union["FeatureType", Dict[str, "FeatureType"]]:


### PR DESCRIPTION
Closes the file handler of the PIL image object in `Image.decode_example` to avoid the `Too many open files` error.

To pass [the image equality checks](https://app.circleci.com/pipelines/github/huggingface/datasets/10774/workflows/d56670e6-16bb-4c64-b601-a152c5acf5ed/jobs/65825) in CI, `Image.decode_example` calls `image.load()` regardless of how the image object is created (not only for the `PIL.Image.open(local_path)` case). This is needed because `load()` sets the `readonly` attribute of a `PIL.Image` object to 0 (it's 1 after `PIL.Image.open(file_like)`), and in the older PIL versions (only fixed on main), that attribute is considered in `PIL.Image.__eq__`. More info can be found here: https://github.com/python-pillow/Pillow/issues/5926.

Fix #3985 



