### PR TITLE
Fix None issue with Sequence of dict

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -984,6 +984,8 @@ def encode_nested_example(schema, obj):
                     return [encode_nested_example(sub_schema, o) for o in obj]
             return list(obj)
     elif isinstance(schema, Sequence):
+        if obj is None:
+            return None
         # We allow to reverse list of dict => dict of list for compatiblity with tfds
         if isinstance(schema.feature, dict):
             # dict of list to fill
@@ -995,16 +997,12 @@ def encode_nested_example(schema, obj):
                 return list_dict
             else:
                 # obj is a single dict
-                if obj is None:
-                    return None
                 for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
                     list_dict[k] = [encode_nested_example(sub_schema, o) for o in sub_objs]
                 return list_dict
         # schema.feature is not a dict
         if isinstance(obj, str):  # don't interpret a string as a list
             raise ValueError(f"Got a string but expected a list instead: '{obj}'")
-        if obj is None:
-            return None
         else:
             if len(obj) > 0:
                 for first_elmt in obj:

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -995,6 +995,8 @@ def encode_nested_example(schema, obj):
                 return list_dict
             else:
                 # obj is a single dict
+                if obj is None:
+                    return None
                 for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
                     list_dict[k] = [encode_nested_example(sub_schema, o) for o in sub_objs]
                 return list_dict

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -289,8 +289,9 @@ def test_class_label_to_and_from_dict(class_label_arg, tmp_path_factory):
     assert generated_class_label == class_label
 
 
-def test_encode_nested_example_sequence_with_none():
-    schema = Sequence(Value("int32"))
+@pytest.mark.parametrize("inner_type", [Value("int32"), {"subcolumn": Value("int32")}])
+def test_encode_nested_example_sequence_with_none(inner_type):
+    schema = Sequence(inner_type)
     obj = None
     result = encode_nested_example(schema, obj)
     assert result is None


### PR DESCRIPTION
`Features.encode_example` currently fails if it contains a sequence if dict like `Sequence({"subcolumn": Value("int32")})` and if `None` is passed instead of the dict.

```python
  File "/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/features/features.py", line 1310, in encode_example
    return encode_nested_example(self, example)
  File "/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/features/features.py", line 973, in encode_nested_example
    return {k: encode_nested_example(sub_schema, sub_obj) for k, (sub_schema, sub_obj) in zip_dict(schema, obj)}
  File "/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/features/features.py", line 973, in <dictcomp>
    return {k: encode_nested_example(sub_schema, sub_obj) for k, (sub_schema, sub_obj) in zip_dict(schema, obj)}
  File "/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/features/features.py", line 998, in encode_nested_example
    for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
  File "/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/utils/py_utils.py", line 207, in zip_dict
    yield key, tuple(d[key] for d in dicts)
  File "/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/utils/py_utils.py", line 207, in <genexpr>
    yield key, tuple(d[key] for d in dicts)
TypeError: 'NoneType' object is not subscriptable
```

I fixed this issue and updated the tests (this case was missing in the tests)