### PR TITLE
Fix SQuAD v2 metric docs on `references` format

### DIFF
--- a/metrics/squad_v2/README.md
+++ b/metrics/squad_v2/README.md
@@ -18,7 +18,7 @@ The metric takes two files or two lists - one representing model predictions and
 
 *References*: List of question-answers dictionaries with the following key-value pairs:
 * `'id'`: id of the question-answer pair (see above),
-* `'answers'`: a list of Dict {'text': text of the answer as a string}
+* `'answers'`: a Dict {'text': list of string answers}
 *  `'no_answer_threshold'`: the probability threshold to decide that a question has no answer.
 
 ```python

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -57,7 +57,7 @@ Args:
         - the probability that the question has no answer
     references: List of question-answers dictionaries with the following key-values:
             - 'id': id of the question-answer pair (see above),
-            - 'answers': a list of Dict {'text': text of the answer as a string}
+            - 'answers': a Dict {'text': list of string answers}
     no_answer_threshold: float
         Probability threshold to decide that a question has no answer.
 Returns:


### PR DESCRIPTION
`references` it's not a list of dictionaries but a dictionary that has a list in its values.