### PR TITLE
Use a constant for the articles regex in SQuAD v2

### DIFF
--- a/metrics/squad_v2/evaluate.py
+++ b/metrics/squad_v2/evaluate.py
@@ -16,6 +16,8 @@ import sys
 import numpy as np
 
 
+ARTICLES_REGEX = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+
 OPTS = None
 
 
@@ -59,8 +61,7 @@ def normalize_answer(s):
     """Lower text and remove punctuation, articles and extra whitespace."""
 
     def remove_articles(text):
-        regex = re.compile(r"\b(a|an|the)\b", re.UNICODE)
-        return re.sub(regex, " ", text)
+        return re.sub(ARTICLES_REGEX, " ", text)
 
     def white_space_fix(text):
         return " ".join(text.split())

--- a/metrics/squad_v2/evaluate.py
+++ b/metrics/squad_v2/evaluate.py
@@ -61,7 +61,7 @@ def normalize_answer(s):
     """Lower text and remove punctuation, articles and extra whitespace."""
 
     def remove_articles(text):
-        return re.sub(ARTICLES_REGEX, " ", text)
+        return ARTICLES_REGEX.sub(" ", text)
 
     def white_space_fix(text):
         return " ".join(text.split())


### PR DESCRIPTION
The main reason for doing this is to be able to change the articles list if using another language, for example. It's not the most elegant solution but at least it makes the metric more extensible with no drawbacks.

BTW, what could be the best way to make this more generic (i.e., SQuAD in other languages)? Maybe receive a regex as an optional param, with the current value as the default? Similarly for SQuAD v1 (can't they re-use code?).