### PR TITLE
Updated annotations for nli_tr dataset

### DIFF
--- a/datasets/nli_tr/README.md
+++ b/datasets/nli_tr/README.md
@@ -1,4 +1,31 @@
 ---
+annotations_creators:
+- expert-generated
+language_creators:
+- machine-generated
+languages:
+- tr
+licenses:
+  snli_tr:
+  - cc-by-4.0
+  multinli_tr:
+  - cc-by-3.0
+  - cc-by-sa-3.0-at
+  - mit
+  - other-Open Portion of the American National Corpus
+multilinguality:
+- monolingual
+size_categories:
+- 100K<n<1M
+source_datasets:
+- extended|snli
+- extended|multi_nli
+task_categories:
+- text-classification
+- text-scoring
+task_ids:
+- natural-language-inference
+- semantic-similarity-scoring
 paperswithcode_id: nli-tr
 pretty_name: Natural Language Inference in Turkish
 ---


### PR DESCRIPTION
This PR adds annotation tags for `nli_tr` dataset so that the dataset can be searchable wrt. relevant query parameters.

The annotations in this PR are based on the existing annotations of `snli` and `multi_nli` datasets as `nli_tr` is a machine-generated extension of those datasets.

This PR is intended only for updating the annotation labels but a followup PR will focus on updating the missing sections in the `README.md` as well.

Thanks for all your time to review it.