### PR TITLE
Increase max retries for GitHub metrics

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -581,6 +581,7 @@ class GithubMetricModuleFactory(_MetricModuleFactory):
         self.name = name
         self.revision = revision
         self.download_config = download_config or DownloadConfig()
+        self.download_config.max_retries = 3
         self.download_mode = download_mode
         self.dynamic_modules_path = dynamic_modules_path
         assert self.name.count("/") == 0

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -580,8 +580,9 @@ class GithubMetricModuleFactory(_MetricModuleFactory):
     ):
         self.name = name
         self.revision = revision
-        self.download_config = download_config or DownloadConfig()
-        self.download_config.max_retries = 3
+        self.download_config = download_config.copy() or DownloadConfig()
+        if self.download_config.max_retries < 3:
+            self.download_config.max_retries = 3
         self.download_mode = download_mode
         self.dynamic_modules_path = dynamic_modules_path
         assert self.name.count("/") == 0


### PR DESCRIPTION
As GitHub recurrently raises connectivity issues, this PR increases the number of max retries to request GitHub metrics.

Related to:
- #3134

Also related to:
- #4059