### PR TITLE
Increase max retries for GitHub datasets

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -499,7 +499,9 @@ class GithubDatasetModuleFactory(_DatasetModuleFactory):
     ):
         self.name = name
         self.revision = revision
-        self.download_config = download_config or DownloadConfig()
+        self.download_config = download_config.copy() if download_config else DownloadConfig()
+        if self.download_config.max_retries < 3:
+            self.download_config.max_retries = 3
         self.download_mode = download_mode
         self.dynamic_modules_path = dynamic_modules_path
         assert self.name.count("/") == 0


### PR DESCRIPTION
As GitHub recurrently raises connectivity issues, this PR increases the number of max retries to request GitHub datasets, as previously done for GitHub metrics:
- #4063

Note that this is a temporary solution, while we decide when and how to load GitHub datasets from the Hub:
- #4059

Fix #2048

Related to:
- #4051 
- #3210
- #2787 
- #2075
- #2036

CC: @lhoestq 