### PR TITLE
Close parquet writer properly in `push_to_hub`

### DIFF
--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -99,4 +99,5 @@ class ParquetDatasetWriter:
             )
             writer.write_table(batch)
             written += batch.nbytes
+        writer.close()
         return written


### PR DESCRIPTION
We don’t call writer.close(), which causes https://github.com/huggingface/datasets/issues/4077. I can happen that we upload the file before the writer is garbage collected and writes the footer.

I fixed this by explicitly closing the parquet writer.

Close https://github.com/huggingface/datasets/issues/4077.