### PR TITLE
Support huggingface_hub 0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ REQUIRED_PKGS = [
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
-    "huggingface_hub>=0.1.0,<1.0.0",
+    "huggingface_hub>=0.5.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     "responses<0.19",

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ REQUIRED_PKGS = [
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
-    "huggingface_hub>=0.5.0,<1.0.0",
+    "huggingface-hub>=0.1.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     "responses<0.19",

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3359,20 +3359,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             organization = api.whoami(token)["name"]
             repo_id = f"{organization}/{dataset_name}"
 
-        try:
-            api.create_repo(
-                dataset_name,
-                token,
-                repo_type="dataset",
-                organization=organization,
-                private=private,
-            )
-        except HTTPError as err:
-            if err.response.status_code == 409:
-                if private is not None:
-                    logger.warning("The repository already exists: the `private` keyword argument will be ignored.")
-            else:
-                raise
+        api.create_repo(repo_id, token=token, repo_type="dataset", private=private, exist_ok=True)
 
         # Find decodable columns, because if there are any, we need to:
         # (1) adjust the dataset size computation (needed for sharding) to account for possible external files

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3352,12 +3352,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 f"The identifier should be in the format <repo_id> or <namespace>/<repo_id>. It is {identifier}, "
                 "which doesn't conform to either format."
             )
-        if len(identifier) == 2:
-            organization, dataset_name = identifier
-        else:
+        elif len(identifier) == 1:
             dataset_name = identifier[0]
-            organization = api.whoami(token)["name"]
-            repo_id = f"{organization}/{dataset_name}"
+            organization_or_username = api.whoami(token)["name"]
+            repo_id = f"{organization_or_username}/{dataset_name}"
 
         api.create_repo(repo_id, token=token, repo_type="dataset", private=private, exist_ok=True)
 

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -860,8 +860,8 @@ class DatasetDict(dict):
 
         Args:
             repo_id (:obj:`str`):
-                The ID of the repository to push to in the following format: `<user>/<dataset_name>` or
-                `<org>/<dataset_name>`. Also accepts `<dataset_name>`, which will default to the namespace
+                The ID of the repository to push to in the following format: ``<user>/<dataset_name>`` or
+                ``<org>/<dataset_name>``. Also accepts ``<dataset_name>``, which will default to the namespace
                 of the logged-in user.
             private (Optional :obj:`bool`):
                 Whether the dataset repository should be set to private or not. Only affects repository creation:

--- a/src/datasets/utils/_hf_hub_fixes.py
+++ b/src/datasets/utils/_hf_hub_fixes.py
@@ -8,13 +8,37 @@ from packaging import version
 def create_repo(
     hf_api: HfApi,
     name: str,
+    organization: str,
     token: Optional[str] = None,
-    organization: Optional[str] = None,
     private: Optional[bool] = None,
     repo_type: Optional[str] = None,
     exist_ok: Optional[bool] = False,
     space_sdk: Optional[str] = None,
 ) -> str:
+    """
+    The huggingface_hub.HfApi.create_repo parameters changed in 0.5.0 and some of them were deprecated.
+    This function checks the huggingface_hub version to call the right parameters.
+
+    Args:
+        hf_api (`huggingface_hub.HfApi`): Hub client
+        name (`str`): name of the repository (without the namespace)
+        organization (`str`): namespace for the repository: the username or organization name.
+        token (`str`, *optional*): user or organization token. Defaults to None.
+        private (`bool`, *optional*):
+            Whether the model repo should be private.
+        repo_type (`str`, *optional*):
+            Set to `"dataset"` or `"space"` if uploading to a dataset or
+            space, `None` or `"model"` if uploading to a model. Default is
+            `None`.
+        exist_ok (`bool`, *optional*, defaults to `False`):
+            If `True`, do not raise an error if repo already exists.
+        space_sdk (`str`, *optional*):
+            Choice of SDK to use if repo_type is "space". Can be
+            "streamlit", "gradio", or "static".
+
+    Returns:
+        `str`: URL to the newly created repo.
+    """
     if version.parse(huggingface_hub.__version__) < version.parse("0.5.0"):
         return hf_api.create_repo(
             name=name,

--- a/src/datasets/utils/_hf_hub_fixes.py
+++ b/src/datasets/utils/_hf_hub_fixes.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import huggingface_hub
+from huggingface_hub import HfApi
+from packaging import version
+
+
+def create_repo(
+    hf_api: HfApi,
+    name: str,
+    token: Optional[str] = None,
+    organization: Optional[str] = None,
+    private: Optional[bool] = None,
+    repo_type: Optional[str] = None,
+    exist_ok: Optional[bool] = False,
+    space_sdk: Optional[str] = None,
+) -> str:
+    if version.parse(huggingface_hub.__version__) < version.parse("0.5.0"):
+        return hf_api.create_repo(
+            name=name,
+            organization=organization,
+            token=token,
+            private=private,
+            repo_type=repo_type,
+            exist_ok=exist_ok,
+            space_sdk=space_sdk,
+        )
+    else:  # the `organization` parameter is deprecated in huggingface_hub>=0.5.0
+        return hf_api.create_repo(
+            repo_id=f"{organization}/{name}",
+            token=token,
+            private=private,
+            repo_type=repo_type,
+            exist_ok=exist_ok,
+            space_sdk=space_sdk,
+        )

--- a/src/datasets/utils/_hf_hub_fixes.py
+++ b/src/datasets/utils/_hf_hub_fixes.py
@@ -22,9 +22,9 @@ def create_repo(
     Args:
         hf_api (`huggingface_hub.HfApi`): Hub client
         name (`str`): name of the repository (without the namespace)
+        token (`str`, *optional*): user or organization token. Defaults to None.
         organization (`str`, *optional*): namespace for the repository: the username or organization name.
             By default it uses the namespace associated to the token used.
-        token (`str`, *optional*): user or organization token. Defaults to None.
         private (`bool`, *optional*):
             Whether the model repo should be private.
         repo_type (`str`, *optional*):

--- a/src/datasets/utils/_hf_hub_fixes.py
+++ b/src/datasets/utils/_hf_hub_fixes.py
@@ -59,3 +59,43 @@ def create_repo(
             exist_ok=exist_ok,
             space_sdk=space_sdk,
         )
+
+
+def delete_repo(
+    hf_api: HfApi,
+    name: str,
+    token: Optional[str] = None,
+    organization: Optional[str] = None,
+    repo_type: Optional[str] = None,
+) -> str:
+    """
+    The huggingface_hub.HfApi.delete_repo parameters changed in 0.5.0 and some of them were deprecated.
+    This function checks the huggingface_hub version to call the right parameters.
+
+    Args:
+        hf_api (`huggingface_hub.HfApi`): Hub client
+        name (`str`): name of the repository (without the namespace)
+        token (`str`, *optional*): user or organization token. Defaults to None.
+        organization (`str`, *optional*): namespace for the repository: the username or organization name.
+            By default it uses the namespace associated to the token used.
+        repo_type (`str`, *optional*):
+            Set to `"dataset"` or `"space"` if uploading to a dataset or
+            space, `None` or `"model"` if uploading to a model. Default is
+            `None`.
+
+    Returns:
+        `str`: URL to the newly created repo.
+    """
+    if version.parse(huggingface_hub.__version__) < version.parse("0.5.0"):
+        return hf_api.delete_repo(
+            name=name,
+            organization=organization,
+            token=token,
+            repo_type=repo_type,
+        )
+    else:  # the `organization` parameter is deprecated in huggingface_hub>=0.5.0
+        return hf_api.delete_repo(
+            repo_id=f"{organization}/{name}",
+            token=token,
+            repo_type=repo_type,
+        )

--- a/src/datasets/utils/_hf_hub_fixes.py
+++ b/src/datasets/utils/_hf_hub_fixes.py
@@ -8,8 +8,8 @@ from packaging import version
 def create_repo(
     hf_api: HfApi,
     name: str,
-    organization: str,
     token: Optional[str] = None,
+    organization: Optional[str] = None,
     private: Optional[bool] = None,
     repo_type: Optional[str] = None,
     exist_ok: Optional[bool] = False,
@@ -22,7 +22,8 @@ def create_repo(
     Args:
         hf_api (`huggingface_hub.HfApi`): Hub client
         name (`str`): name of the repository (without the namespace)
-        organization (`str`): namespace for the repository: the username or organization name.
+        organization (`str`, *optional*): namespace for the repository: the username or organization name.
+            By default it uses the namespace associated to the token used.
         token (`str`, *optional*): user or organization token. Defaults to None.
         private (`bool`, *optional*):
             Whether the model repo should be private.

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -14,6 +14,7 @@ from huggingface_hub.hf_api import HfFolder
 from packaging import version
 
 from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
+from datasets.utils._hf_hub_fixes import delete_repo
 from tests.utils import require_pil, require_sndfile
 
 
@@ -40,11 +41,8 @@ class TestPushToHub(TestCase):
     _api = HfApi(endpoint=ENDPOINT_STAGING)
 
     def cleanup_repo(self, ds_name):
-        if version.parse(huggingface_hub.__version__) < version.parse("0.5.0"):
-            organization, name = ds_name.split("/")
-            self._api.delete_repo(name, token=self._token, repo_type="dataset", organization=organization)
-        else:  # the `organization` parameter is deprecated in huggingface_hub>=0.5.0
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+        organization, name = ds_name.split("/")
+        delete_repo(hf_api=self._api, name=name, organization=organization, token=self._token, repo_type="dataset")
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -103,7 +103,7 @@ class TestPushToHub(TestCase):
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
             self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_dict_to_hub_private(self):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -123,7 +123,7 @@ class TestPushToHub(TestCase):
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
             self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_dict_to_hub(self):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -143,7 +143,7 @@ class TestPushToHub(TestCase):
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
             self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_dict_to_hub_multiple_files(self):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
@@ -171,7 +171,7 @@ class TestPushToHub(TestCase):
                 ],
             )
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_dict_to_hub_overwrite_files(self):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
@@ -221,7 +221,7 @@ class TestPushToHub(TestCase):
             self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
 
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
         # Push to hub two times, but the second time with fewer files.
         # Verify that the new files contain the correct dataset and that non-necessary files have been deleted.
@@ -263,7 +263,7 @@ class TestPushToHub(TestCase):
             self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
 
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_to_hub(self):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -283,7 +283,7 @@ class TestPushToHub(TestCase):
                 self.assertListEqual(list(local_ds.features.keys()), list(hub_ds.features.keys()))
                 self.assertDictEqual(local_ds.features, hub_ds.features)
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_to_hub_custom_features(self):
         features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})
@@ -299,7 +299,7 @@ class TestPushToHub(TestCase):
             self.assertDictEqual(ds.features, hub_ds.features)
             self.assertEqual(ds[:], hub_ds[:])
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     @require_sndfile
     def test_push_dataset_to_hub_custom_features_audio(self):
@@ -327,7 +327,7 @@ class TestPushToHub(TestCase):
                 self.assertTrue(bool(path) == (not embed_external_files))
                 self.assertTrue(bool(bytes_) == embed_external_files)
             finally:
-                self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+                self.cleanup_repo(ds_name)
 
     @require_pil
     def test_push_dataset_to_hub_custom_features_image(self):
@@ -352,7 +352,7 @@ class TestPushToHub(TestCase):
                 self.assertTrue(bool(path) == (not embed_external_files))
                 self.assertTrue(bool(bytes_) == embed_external_files)
             finally:
-                self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+                self.cleanup_repo(ds_name)
 
     def test_push_dataset_dict_to_hub_custom_features(self):
         features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})
@@ -369,7 +369,7 @@ class TestPushToHub(TestCase):
             self.assertListEqual(list(local_ds["test"].features.keys()), list(hub_ds["test"].features.keys()))
             self.assertDictEqual(local_ds["test"].features, hub_ds["test"].features)
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_to_hub_custom_splits(self):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -383,7 +383,7 @@ class TestPushToHub(TestCase):
             self.assertListEqual(list(ds.features.keys()), list(hub_ds["random"].features.keys()))
             self.assertDictEqual(ds.features, hub_ds["random"].features)
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     def test_push_dataset_dict_to_hub_custom_splits(self):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -399,7 +399,7 @@ class TestPushToHub(TestCase):
             self.assertListEqual(list(local_ds["random"].features.keys()), list(hub_ds["random"].features.keys()))
             self.assertDictEqual(local_ds["random"].features, hub_ds["random"].features)
         finally:
-            self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+            self.cleanup_repo(ds_name)
 
     @unittest.skip("This test cannot pass until iterable datasets have push to hub")
     def test_push_streaming_dataset_dict_to_hub(self):
@@ -418,4 +418,4 @@ class TestPushToHub(TestCase):
                 self.assertListEqual(list(local_ds["train"].features.keys()), list(hub_ds["train"].features.keys()))
                 self.assertDictEqual(local_ds["train"].features, hub_ds["train"].features)
             finally:
-                self._api.delete_repo(ds_name, token=self._token, repo_type="dataset")
+                self.cleanup_repo(ds_name)


### PR DESCRIPTION
Following https://github.com/huggingface/datasets/issues/4105

`huggingface_hub` deprecated some parameters in `HfApi` in 0.5. This PR updates all the calls to HfApi to remove all the deprecations, <s>and I set the `hugginface_hub` requirement to `>=0.5.0`</s>

cc @adrinjalali @LysandreJik 