### PR TITLE
Hotfix failing CI tests on Windows

### DIFF
--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -35,10 +35,7 @@ def with_staging_testing(func):
         ENDPOINT_STAGING,
     )
 
-    repository = patch(
-        "huggingface_hub.repository.ENDPOINT",
-        ENDPOINT_STAGING,
-    )
+    repository = patch("huggingface_hub.repository.ENDPOINT", ENDPOINT_STAGING, create=True)
 
     config = patch.multiple(
         "datasets.config",


### PR DESCRIPTION
This PR makes a hotfix for our CI Windows tests: https://app.circleci.com/pipelines/github/huggingface/datasets/11092/workflows/9cfdb1dd-0fec-4fe0-8122-5f533192ebdc/jobs/67414

Fix #4118

I guess this issue is related to this PR:
- huggingface/huggingface_hub#815