### PR TITLE
Add single dataset citations for TweetEval

### DIFF
--- a/datasets/tweet_eval/README.md
+++ b/datasets/tweet_eval/README.md
@@ -464,6 +464,90 @@ year={2020}
 }
 ```
 
+If you use any of the TweetEval datasets, please cite their original publications:
+
+#### Emotion Recognition:
+```
+@inproceedings{mohammad2018semeval,
+  title={Semeval-2018 task 1: Affect in tweets},
+  author={Mohammad, Saif and Bravo-Marquez, Felipe and Salameh, Mohammad and Kiritchenko, Svetlana},
+  booktitle={Proceedings of the 12th international workshop on semantic evaluation},
+  pages={1--17},
+  year={2018}
+}
+
+```
+#### Emoji Prediction:
+```
+@inproceedings{barbieri2018semeval,
+  title={Semeval 2018 task 2: Multilingual emoji prediction},
+  author={Barbieri, Francesco and Camacho-Collados, Jose and Ronzano, Francesco and Espinosa-Anke, Luis and 
+    Ballesteros, Miguel and Basile, Valerio and Patti, Viviana and Saggion, Horacio},
+  booktitle={Proceedings of The 12th International Workshop on Semantic Evaluation},
+  pages={24--33},
+  year={2018}
+}
+```
+
+#### Irony Detection:
+```
+@inproceedings{van2018semeval,
+  title={Semeval-2018 task 3: Irony detection in english tweets},
+  author={Van Hee, Cynthia and Lefever, Els and Hoste, V{\'e}ronique},
+  booktitle={Proceedings of The 12th International Workshop on Semantic Evaluation},
+  pages={39--50},
+  year={2018}
+}
+```
+
+#### Hate Speech Detection:
+```
+@inproceedings{basile-etal-2019-semeval,
+    title = "{S}em{E}val-2019 Task 5: Multilingual Detection of Hate Speech Against Immigrants and Women in {T}witter",
+    author = "Basile, Valerio  and Bosco, Cristina  and Fersini, Elisabetta  and Nozza, Debora and Patti, Viviana and
+      Rangel Pardo, Francisco Manuel  and Rosso, Paolo  and Sanguinetti, Manuela",
+    booktitle = "Proceedings of the 13th International Workshop on Semantic Evaluation",
+    year = "2019",
+    address = "Minneapolis, Minnesota, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/S19-2007",
+    doi = "10.18653/v1/S19-2007",
+    pages = "54--63"
+}
+```
+#### Offensive Language Identification:
+```
+@inproceedings{zampieri2019semeval,
+  title={SemEval-2019 Task 6: Identifying and Categorizing Offensive Language in Social Media (OffensEval)},
+  author={Zampieri, Marcos and Malmasi, Shervin and Nakov, Preslav and Rosenthal, Sara and Farra, Noura and Kumar, Ritesh},
+  booktitle={Proceedings of the 13th International Workshop on Semantic Evaluation},
+  pages={75--86},
+  year={2019}
+}
+```
+
+#### Sentiment Analysis:
+```
+@inproceedings{rosenthal2017semeval,
+  title={SemEval-2017 task 4: Sentiment analysis in Twitter},
+  author={Rosenthal, Sara and Farra, Noura and Nakov, Preslav},
+  booktitle={Proceedings of the 11th international workshop on semantic evaluation (SemEval-2017)},
+  pages={502--518},
+  year={2017}
+}
+```
+
+#### Stance Detection:
+```
+@inproceedings{mohammad2016semeval,
+  title={Semeval-2016 task 6: Detecting stance in tweets},
+  author={Mohammad, Saif and Kiritchenko, Svetlana and Sobhani, Parinaz and Zhu, Xiaodan and Cherry, Colin},
+  booktitle={Proceedings of the 10th International Workshop on Semantic Evaluation (SemEval-2016)},
+  pages={31--41},
+  year={2016}
+}
+```
+
 ### Contributions
 
 Thanks to [@gchhablani](https://github.com/gchhablani) and [@abhishekkrthakur](https://github.com/abhishekkrthakur) for adding this dataset.

--- a/datasets/tweet_eval/README.md
+++ b/datasets/tweet_eval/README.md
@@ -1,5 +1,6 @@
 ---
-annotations_creators: []
+annotations_creators:
+- found
 language_creators:
 - found
 languages:


### PR DESCRIPTION
This PR adds single data citations as per request of the original creators of the TweetEval dataset.

This is a recent email from the creator:

> Could I ask you a favor? Would you be able to add at the end of the README the citations of the single datasets as well? You can just copy our readme maybe? https://github.com/cardiffnlp/tweeteval#citing-tweeteval
(just to be sure that the creator of the single datasets also get credits when tweeteval is used)

Please let me know if this looks okay or if any changes are needed.

Thanks,
Gunjan
