### PR TITLE
Add code examples to API docs

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -341,6 +341,17 @@ class TensorflowDatasetMixin:
 
         Returns:
             :class:`tf.data.Dataset`
+
+        Example:
+
+        ```py
+        >>> ds_train = ds["train"].to_tf_dataset(
+        ...    columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'],
+        ...    shuffle=True,
+        ...    batch_size=16,
+        ...    collate_fn=data_collator,
+        ... )
+        ```
         """
 
         if config.TF_AVAILABLE:
@@ -771,6 +782,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds = Dataset.from_pandas(df)
+        ```
         """
         if info is not None and features is not None and info.features != features:
             raise ValueError(
@@ -845,6 +862,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds = Dataset.from_csv('path/to/dataset.csv')
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.csv import CsvDatasetReader
@@ -876,6 +899,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds = Dataset.from_json('path/to/dataset.json')
         """
         # Dynamic import to avoid circular dependency
         from .io.json import JsonDatasetReader
@@ -915,6 +943,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds = Dataset.from_parquet('path/to/dataset.parquet')
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.parquet import ParquetDatasetReader
@@ -950,6 +984,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds = Dataset.from_text('path/to/dataset.txt')
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.text import TextDatasetReader
@@ -981,6 +1021,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 of the dataset directory where the dataset will be saved to.
             fs (:class:`~filesystems.S3FileSystem`, ``fsspec.spec.AbstractFileSystem``, optional, defaults ``None``):
                 Instance of the remote filesystem used to download the files from.
+
+        Example:
+
+        ```py
+        >>> saved_ds = ds.save_to_disk("path/to/dataset/directory")
+        ```
         """
         if self.list_indexes():
             raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
@@ -1086,6 +1132,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             :class:`Dataset` or :class:`DatasetDict`:
             - If `dataset_path` is a path of a dataset directory: the dataset requested.
             - If `dataset_path` is a path of a dataset dict directory: a ``datasets.DatasetDict`` with each split.
+
+        Example:
+
+        ```py
+        >>> ds = load_from_disk("path/to/dataset/directory")
+        ```
         """
         # copies file from filesystem if it is remote filesystem to local filesystem and modifies dataset_path to temp directory containing local copies
         fs = fsspec.filesystem("file") if fs is None else fs
@@ -1128,12 +1180,33 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @property
     def data(self) -> Table:
-        """The Apache Arrow table backing the dataset."""
+        """The Apache Arrow table backing the dataset.
+        
+        Example:
+
+        ```py
+        >>> ds.data
+        MemoryMappedTable
+        text: string
+        label: int64
+        ----
+        text: [["compassionately explores the seemingly irreconcilable situation between conservative christian parents and their estranged gay and lesbian children .","the soundtrack alone is worth the price of admission .","rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .","beneath the film's obvious determination to shock at any cost lies considerable skill and determination , backed by sheer nerve .","bielinsky is a filmmaker of impressive talent .","so beautifully acted and directed , it's clear that washington most certainly has a new career ahead of him if he so chooses .","a visual spectacle full of stunning images and effects .","a gentle and engrossing character study .","it's enough to watch huppert scheming , with her small , intelligent eyes as steady as any noir villain , and to enjoy the perfectly pitched web of tension that chabrol spins .","an engrossing portrait of uncompromising artists trying to create something original against the backdrop of a corporate music industry that only seems to care about the bottom line .",...,"ultimately , jane learns her place as a girl , softens up and loses some of the intensity that made her an interesting character to begin with .","ah-nuld's action hero days might be over .","it's clear why deuces wild , which was shot two years ago , has been gathering dust on mgm's shelf .","feels like nothing quite so much as a middle-aged moviemaker's attempt to surround himself with beautiful , half-naked women .","when the precise nature of matthew's predicament finally comes into sharp focus , the revelation fails to justify the build-up .","this picture is murder by numbers , and as easy to be bored by as your abc's , despite a few whopping shootouts .","hilarious musical comedy though stymied by accents thick as mud .","if you are into splatter movies , then you will probably have a reasonably good time with the salton sea .","a dull , simple-minded and stereotypical tale of drugs , death and mind-numbing indifference on the inner-city streets .","the feature-length stretch . . . strains the show's concept ."]]
+        label: [[1,1,1,1,1,1,1,1,1,1,...,0,0,0,0,0,0,0,0,0,0]]
+        ```
+        """
         return self._data
 
     @property
     def cache_files(self) -> List[dict]:
-        """The cache files containing the Apache Arrow table backing the dataset."""
+        """The cache files containing the Apache Arrow table backing the dataset.
+        
+        Example:
+
+        ```py
+        >>> ds.cache_files
+        [{'filename': '/root/.cache/huggingface/datasets/rotten_tomatoes_movie_review/default/1.0.0/40d411e45a6ce3484deed7cc15b82a53dad9a72aafd9f86f8f227134bec5ca46/rotten_tomatoes_movie_review-validation.arrow'}]
+        ```
+        """
         cache_files = list_table_cache_files(self._data)
         if self._indices is not None:
             cache_files += list_table_cache_files(self._indices)
@@ -1141,24 +1214,56 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @property
     def num_columns(self) -> int:
-        """Number of columns in the dataset."""
+        """Number of columns in the dataset.
+        
+        Example:
+
+        ```py
+        >>> ds.num_columns
+        2
+        ```
+        """
         return self._data.num_columns
 
     @property
     def num_rows(self) -> int:
-        """Number of rows in the dataset (same as :meth:`Dataset.__len__`)."""
+        """Number of rows in the dataset (same as :meth:`Dataset.__len__`).
+        
+        Example:
+
+        ```py
+        >>> ds.num_rows
+        1066
+        ```
+        """
         if self._indices is not None:
             return self._indices.num_rows
         return self._data.num_rows
 
     @property
     def column_names(self) -> List[str]:
-        """Names of the columns in the dataset."""
+        """Names of the columns in the dataset.
+        
+        Example:
+
+        ```py
+        >>> ds.column_names
+        ['text', 'label']
+        ```
+        """
         return self._data.column_names
 
     @property
     def shape(self) -> Tuple[int, int]:
-        """Shape of the dataset (number of columns, number of rows)."""
+        """Shape of the dataset (number of columns, number of rows).
+        
+        Example:
+
+        ```py
+        >>> ds.shape
+        (1066, 2)
+        ```
+        """
         if self._indices is not None:
             return (self._indices.num_rows, self._data.num_columns)
         return self._data.shape
@@ -1173,6 +1278,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :obj:`list`: List of unique elements in the given column.
+
+        Example:
+
+        ```py
+        >>> ds.unique('label')
+        [1, 0]
+        ```
         """
         if column not in self._data.column_names:
             raise ValueError(f"Column ({column}) not in table columns ({self._data.column_names}).")
@@ -1193,6 +1305,32 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Whether to include null values in the class labels. If True, the null values will be encoded as the `"None"` class label.
 
                 *New in version 1.14.2*
+
+        Example:
+
+        ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("winograd_wsc", "wsc285", split="test")
+        >>> ds.features
+        {'label': ClassLabel(num_classes=2, names=['0', '1'], id=None),
+        'options': Sequence(feature=Value(dtype='string', id=None), length=-1, id=None),
+        'pronoun': Value(dtype='string', id=None),
+        'pronoun_loc': Value(dtype='int32', id=None),
+        'quote': Value(dtype='string', id=None),
+        'quote_loc': Value(dtype='int32', id=None),
+        'source': Value(dtype='string', id=None),
+        'text': Value(dtype='string', id=None)}
+        >>> ds = ds.class_encode_column('pronoun')
+        >>> ds.features
+        {'label': ClassLabel(num_classes=2, names=['0', '1'], id=None),
+        'options': Sequence(feature=Value(dtype='string', id=None), length=-1, id=None),
+        'pronoun': ClassLabel(num_classes=12, names=['He', 'It', 'She', 'They', 'he', 'her', 'him', 'his', 'it', 'she', 'them', 'they'], id=None),
+        'pronoun_loc': Value(dtype='int32', id=None),
+        'quote': Value(dtype='string', id=None),
+        'quote_loc': Value(dtype='int32', id=None),
+        'source': Value(dtype='string', id=None),
+        'text': Value(dtype='string', id=None)}
+        ```
         """
         # Sanity checks
         if column not in self._data.column_names:
@@ -1250,6 +1388,24 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`: A copy of the dataset with flattened columns.
+
+        Example:
+
+        ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("squad", split="train")
+        >>> ds.features
+        {'answers': Sequence(feature={'text': Value(dtype='string', id=None), 'answer_start': Value(dtype='int32', id=None)}, length=-1, id=None),
+         'context': Value(dtype='string', id=None),
+         'id': Value(dtype='string', id=None),
+         'question': Value(dtype='string', id=None),
+         'title': Value(dtype='string', id=None)}
+        >>> ds.flatten()
+        Dataset({
+            features: ['id', 'title', 'context', 'question', 'answers.text', 'answers.answer_start'],
+            num_rows: 87599
+        })
+        ```
         """
         dataset = copy.deepcopy(self)
         for depth in range(1, max_depth):
@@ -1296,6 +1452,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`: A copy of the dataset with casted features.
+
+        Example:
+
+        ```py
+        >>> new_features = ds.features.copy()
+        >>> new_features['label'] = ClassLabel(names=['bad', 'good'])
+        >>> new_features['text'] = Value('large_string')
+        >>> ds = ds.cast(new_features)
+        {'label': ClassLabel(num_classes=2, names=['bad', 'good'], id=None),
+        'text': Value(dtype='large_string', id=None)}
+        ```
         """
         if sorted(features) != sorted(self._data.column_names):
             raise ValueError(
@@ -1332,6 +1499,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds = ds.cast_column('label', ClassLabel(names=['bad', 'good']))
+        ```
         """
         if hasattr(feature, "cast_storage"):
             dataset = copy.deepcopy(self)
@@ -1361,6 +1534,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`: A copy of the dataset object without the columns to remove.
+
+        Example:
+
+        ```py
+        >>> ds.remove_columns('label')
+        Dataset({
+            features: ['text'],
+            num_rows: 1066
+        })
+        ```
         """
         dataset = copy.deepcopy(self)
         if isinstance(column_names, str):
@@ -1396,6 +1579,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`: A copy of the dataset with a renamed column.
+
+        Example:
+
+        ```py
+        >>> ds.rename_column('label', 'label_new')
+        Dataset({
+            features: ['text', 'label_new'],
+            num_rows: 1066
+        })
+        ```
         """
         dataset = copy.deepcopy(self)
         if original_column_name not in dataset._data.column_names:
@@ -1443,6 +1636,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`: A copy of the dataset with renamed columns
+
+        Example:
+
+        ```py
+        >>> ds.rename_columns({'text': 'text_new', 'label': 'label_new'})
+        Dataset({
+            features: ['text_new', 'label_new'],
+            num_rows: 1066
+        })
+        ```
         """
         dataset = copy.deepcopy(self)
 
@@ -1484,7 +1687,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return dataset
 
     def __len__(self):
-        """Number of rows in the dataset."""
+        """Number of rows in the dataset.
+        
+        Example:
+
+        ```py
+        >>> ds.__len__
+        <bound method Dataset.__len__ of Dataset({
+            features: ['text', 'label'],
+            num_rows: 1066
+        })>
+        ```
+        """
         return self.num_rows
 
     def _iter(self, decoded: bool = True):
@@ -1573,6 +1787,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
             new formatted columns = (all columns - previously unformatted columns)
 
+        Example:
+
+        ```py
+        >>> ds.set_format(type='numpy', columns=['text', 'label'])
+        ```
         """
         format_kwargs.update(format_kwargs.pop("format_kwargs", {}))  # allow to use self.set_format(self.format)
 
@@ -1608,6 +1827,22 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """Reset __getitem__ return format to python objects and all columns.
 
         Same as ``self.set_format()``
+
+        Example:
+
+        ```py
+        >>> ds.format
+        {'columns': ['text', 'label', 'input_ids', 'token_type_ids', 'attention_mask'],
+         'format_kwargs': {},
+         'output_all_columns': False,
+         'type': 'tensorflow'}
+        >>> ds.reset_format()
+        >>> ds.format
+        {'columns': ['text', 'label', 'input_ids', 'token_type_ids', 'attention_mask'],
+         'format_kwargs': {},
+         'output_all_columns': False,
+         'type': None}
+        ```
         """
         self.set_format()
 
@@ -1629,6 +1864,23 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             output_all_columns (:obj:`bool`, default to False): keep un-formatted columns as well in the output (as python objects)
                 If set to True, then the other un-formatted columns are kept with the output of the transform.
 
+        Example:
+
+        ```py
+        >>> from transformers import BertTokenizer
+        >>> tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+        >>> def encode(batch):
+        ...     return tokenizer(batch['text'], padding=True, truncation=True, return_tensors='pt')
+        >>> ds.set_transform(encode)
+        >>> ds[0]
+        {'attention_mask': tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                 1, 1]),
+         'input_ids': tensor([  101, 29353,  2135, 15102,  1996,  9428, 20868,  2890,  8663,  6895,
+                 20470,  2571,  3663,  2090,  4603,  3017,  3008,  1998,  2037, 24211,
+                 5637,  1998, 11690,  2336,  1012,   102]),
+         'token_type_ids': tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                 0, 0])}
+        ```
         """
         self.set_format("custom", columns=columns, output_all_columns=output_all_columns, transform=transform)
 
@@ -1654,6 +1906,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 None means __getitem__ returns all columns (default)
             output_all_columns (:obj:`bool`, default to False): keep un-formatted columns as well in the output (as python objects)
             format_kwargs: keywords arguments passed to the convert function like `np.array`, `torch.tensor` or `tensorflow.ragged.constant`.
+
+        Example:
+
+        ```py
+        >>> ds = ds.with_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
+        >>> ds.format
+        {'columns': ['input_ids', 'token_type_ids', 'attention_mask', 'label'],
+         'format_kwargs': {},
+         'output_all_columns': False,
+         'type': 'tensorflow'}
+        ```
         """
         dataset = copy.deepcopy(self)
         dataset.set_format(type=type, columns=columns, output_all_columns=output_all_columns, **format_kwargs)
@@ -1680,6 +1943,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             output_all_columns (:obj:`bool`, default to False): keep un-formatted columns as well in the output (as python objects)
                 If set to True, then the other un-formatted columns are kept with the output of the transform.
 
+        Example:
+
+        ```py
+        >>> def transform(example):
+        ...     inputs = feature_extractor([x for x in example_batch['image']], return_tensors='pt')
+        ...     inputs['labels'] = example['labels]
+        ...     return inputs
+        >>> ds = ds.with_transform(transform)
         """
         dataset = copy.deepcopy(self)
         dataset.set_transform(transform=transform, columns=columns, output_all_columns=output_all_columns)
@@ -1773,6 +2044,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :obj:`int`: Number of removed files.
+
+        Example:
+
+        ```py
+        >>> ds.cleanup_cache_files()
+        2
+        ```
         """
         current_cache_files = [os.path.abspath(cache_file["filename"]) for cache_file in self.cache_files]
         if not current_cache_files:
@@ -1882,6 +2160,19 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             new_fingerprint (:obj:`str`, optional, default `None`): the new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments.
             desc (:obj:`str`, optional, defaults to `None`): Meaningful description to be displayed alongside with the progress bar while mapping examples.
+
+        Example:
+
+        ```py
+        >>> def add_prefix(example):
+        ...     example["text"] = "Hello " + example["text"]
+        ...     return example
+        >>> ds = ds.map(add_prefix)
+        >>> ds[0:3]["text"]
+        ['Hello compassionately explores the seemingly irreconcilable situation between conservative christian parents and their estranged gay and lesbian children .',
+         'Hello the soundtrack alone is worth the price of admission .',
+         'Hello rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .']
+        ```
         """
         if keep_in_memory and cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `cache_file_name` but not both.")
@@ -2444,6 +2735,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             new_fingerprint (:obj:`str`, optional): The new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments.
             desc (:obj:`str`, optional, defaults to `None`): Meaningful description to be displayed alongside with the progress bar while filtering examples.
+
+        Example:
+
+        ```py
+        >>> ds.filter(lambda x: x["label"] == 1)
+        Dataset({
+            features: ['text', 'label'],
+            num_rows: 533
+        })
+        ```
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(
@@ -2569,6 +2870,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Higher value makes the processing do fewer lookups, lower value consume less temporary memory while running `.map()`.
             new_fingerprint (:obj:`str`, optional, default `None`): the new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
+
+        Example:
+
+        ```py
+        >>> ds.select(range(4))
+        Dataset({
+            features: ['text', 'label'],
+            num_rows: 4
+        })
+        ```
         """
         if keep_in_memory and indices_cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `indices_cache_file_name` but not both.")
@@ -2676,6 +2987,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Higher value gives smaller cache files, lower value consume less temporary memory.
             new_fingerprint (:obj:`str`, optional, default `None`): the new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
+
+        Example:
+
+        ```py
+        >>> ds['label'][:10]
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        >>> sorted_ds = ds.sort('label', reverse=True)
+        >>> sorted_ds['label'][:10]
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        ```
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(
@@ -2754,6 +3075,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Higher value makes the processing do fewer lookups, lower value consume less temporary memory while running `.map()`.
             new_fingerprint (:obj:`str`, optional, default `None`): the new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
+
+        Example:
+
+        ```py
+        >>> ds['label'][:10]
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        >>> shuffled_ds = ds.shuffle(seed=42)
+        >>> shuffled_ds['label'][:10]
+        [1, 0, 1, 1, 0, 0, 0, 0, 0, 0]
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(
@@ -2854,6 +3184,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
             test_new_fingerprint (:obj:`str`, optional, defaults to `None`): the new fingerprint of the test set after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
+
+        Example:
+
+        ```py
+        >>> ds = ds.train_test_split(test_size=0.2, shuffle=True)
+        ```
         """
         from .dataset_dict import DatasetDict  # import here because of circular dependency
 
@@ -3033,6 +3369,21 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             writer_batch_size (:obj:`int`, default `1000`): Number of rows per write operation for the cache file writer.
                 This value is a good trade-off between memory usage during the processing, and processing speed.
                 Higher value makes the processing do fewer lookups, lower value consume less temporary memory while running `.map()`.
+
+        Example:
+
+        ```py
+        >>> ds
+        Dataset({
+            features: ['text', 'label'],
+            num_rows: 1066
+        })
+        >>> ds = ds.shard(num_shards=2, index=0)
+        Dataset({
+            features: ['text', 'label'],
+            num_rows: 533
+        })
+        ```
         """
         if not 0 <= index < num_shards:
             raise ValueError("index should be in [0, num_shards-1]")
@@ -3157,6 +3508,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             int: The number of characters or bytes written
+
+        Example:
+
+        ```py
+        >>> ds.to_csv("path/to/dataset/directory")
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.csv import CsvDatasetWriter
@@ -3174,6 +3531,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             `dict` or `Iterator[dict]`
+
+        Example:
+
+        ```py
+        >>> ds.to_dict()
+        ```
         """
         if not batched:
             return query_table(
@@ -3225,6 +3588,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             int: The number of characters or bytes written.
+
+        Example:
+
+        ```py
+        >>> ds.to_json("path/to/dataset/directory")
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.json import JsonDatasetWriter
@@ -3244,6 +3613,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             `pandas.DataFrame` or `Iterator[pandas.DataFrame]`
+
+        Example:
+
+        ```py
+        >>> ds.to_pandas()
+        ```
         """
         if not batched:
             return query_table(
@@ -3278,6 +3653,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             int: The number of characters or bytes written
+
+        Example:
+
+        ```py
+        >>> ds.to_parquet("path/to/dataset/directory")
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.parquet import ParquetDatasetWriter
@@ -3580,6 +3961,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> ds.add_column(name="more_text", column=new_column_data)
+        Dataset({
+            features: ['text', 'label', 'more_text'],
+            num_rows: 1066
+        })
+        ```
         """
         column_table = InMemoryTable.from_pydict({name: column})
         _check_column_names(self._data.column_names + column_table.column_names)
@@ -3799,6 +4190,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Returns:
             :class:`Dataset`
+
+        Example:
+
+        ```py
+        >>> new_review = {'label': 0, 'text': 'this movie is the absolute worst thing I have ever seen'}
+        >>> ds.add_item(new_review)
+        ```
         """
         item_table = InMemoryTable.from_pydict({k: [v] for k, v in item.items()})
         # We don't call _check_if_features_can_be_aligned here so this cast is "unsafe"
@@ -3899,6 +4297,12 @@ def concatenate_datasets(
             (horizontally).
 
             *New in version 1.6.0*
+
+    Example:
+
+    ```py
+    >>> ds3 = concatenate_datasets([ds1, ds2])
+    ```
     """
     # Ignore datasets with no rows
     if any(dset.num_rows > 0 for dset in dsets):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1464,8 +1464,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> from datasets import load_dataset, ClassLabel, Value
         >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.features
-        {'label': ClassLabel(num_classes=2, names=['bad', 'good'], id=None),
-         'text': Value(dtype='large_string', id=None)}
+        {'label': ClassLabel(num_classes=2, names=['neg', 'pos'], id=None),
+         'text': Value(dtype='string', id=None)}
         >>> new_features = ds.features.copy()
         >>> new_features['label'] = ClassLabel(names=['bad', 'good'])
         >>> new_features['text'] = Value('large_string')
@@ -1873,9 +1873,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
         >>> ds = ds.map(lambda x: tokenizer(x['text'], truncation=True, padding=True), batched=True)
-        >>> ds.set_format(type='numpy', columns=['text', 'label'])
+        >>> ds.set_format(type='numpy', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
         >>> ds.format
-        {'columns': ['text', 'label'],
+        {'columns': ['input_ids', 'token_type_ids', 'attention_mask', 'label'],
          'format_kwargs': {},
          'output_all_columns': False,
          'type': 'numpy'}
@@ -1960,12 +1960,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
         >>> ds = ds.map(lambda x: tokenizer(x['text'], truncation=True, padding=True), batched=True)
-        >>> ds.set_format(type='numpy', columns=['text', 'label'])
         >>> ds.format
-        {'columns': ['text', 'label'],
+        {'columns': ['text', 'label', 'input_ids', 'token_type_ids', 'attention_mask'],
          'format_kwargs': {},
          'output_all_columns': False,
-         'type': 'numpy'}
+         'type': None}
         >>> ds = ds.with_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
         >>> ds.format
         {'columns': ['input_ids', 'token_type_ids', 'attention_mask', 'label'],
@@ -2243,6 +2242,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ['Review: compassionately explores the seemingly irreconcilable situation between conservative christian parents and their estranged gay and lesbian children .',
          'Review: the soundtrack alone is worth the price of admission .',
          'Review: rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .']
+
+        # process a batch of examples
+        >>> ds = ds.map(lambda example: tokenizer(example["text"]), batched=True)
+        # set number of processors
+        >>> ds = ds.map(add_prefix, num_proc=4)
         ```
         """
         if keep_in_memory and cache_file_name is not None:
@@ -3067,7 +3071,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         ```py
         >>> from datasets import load_dataset
-        >>> ds = load_dataset("rotten_tomatoes", split="validation)
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds['label'][:10]
         [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         >>> sorted_ds = ds.sort('label')
@@ -3157,9 +3161,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         ```py
         >>> from datasets import load_dataset
-        >>> ds = load_dataset("rotten_tomatoes", split="validation)
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds['label'][:10]
         [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+        # set a seed
         >>> shuffled_ds = ds.shuffle(seed=42)
         >>> shuffled_ds['label'][:10]
         [1, 0, 1, 1, 0, 0, 0, 0, 0, 0]
@@ -3281,6 +3287,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 num_rows: 214
             })
         })
+
+        # set a seed
+        >>> ds = ds.train_test_split(test_size=0.2, seed=42)
         ```
         """
         from .dataset_dict import DatasetDict  # import here because of circular dependency
@@ -4060,7 +4069,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         ```py
         >>> from datasets import load_dataset
-        >>> ds = load_dataset("rotten_tomatoes), split="validation")
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> more_text = ds["text"]
         >>> ds.add_column(name="text_2", column=more_text)
         Dataset({

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1181,7 +1181,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @property
     def data(self) -> Table:
         """The Apache Arrow table backing the dataset.
-        
+
         Example:
 
         ```py
@@ -1199,7 +1199,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @property
     def cache_files(self) -> List[dict]:
         """The cache files containing the Apache Arrow table backing the dataset.
-        
+
         Example:
 
         ```py
@@ -1215,7 +1215,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @property
     def num_columns(self) -> int:
         """Number of columns in the dataset.
-        
+
         Example:
 
         ```py
@@ -1228,7 +1228,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @property
     def num_rows(self) -> int:
         """Number of rows in the dataset (same as :meth:`Dataset.__len__`).
-        
+
         Example:
 
         ```py
@@ -1243,7 +1243,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @property
     def column_names(self) -> List[str]:
         """Names of the columns in the dataset.
-        
+
         Example:
 
         ```py
@@ -1256,7 +1256,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @property
     def shape(self) -> Tuple[int, int]:
         """Shape of the dataset (number of columns, number of rows).
-        
+
         Example:
 
         ```py
@@ -1688,7 +1688,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     def __len__(self):
         """Number of rows in the dataset.
-        
+
         Example:
 
         ```py

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -904,6 +904,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         ```py
         >>> ds = Dataset.from_json('path/to/dataset.json')
+        ```
         """
         # Dynamic import to avoid circular dependency
         from .io.json import JsonDatasetReader
@@ -1185,6 +1186,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.data
         MemoryMappedTable
         text: string
@@ -1203,6 +1206,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.cache_files
         [{'filename': '/root/.cache/huggingface/datasets/rotten_tomatoes_movie_review/default/1.0.0/40d411e45a6ce3484deed7cc15b82a53dad9a72aafd9f86f8f227134bec5ca46/rotten_tomatoes_movie_review-validation.arrow'}]
         ```
@@ -1219,6 +1224,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.num_columns
         2
         ```
@@ -1232,6 +1239,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.num_rows
         1066
         ```
@@ -1247,6 +1256,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.column_names
         ['text', 'label']
         ```
@@ -1260,6 +1271,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.shape
         (1066, 2)
         ```
@@ -1282,6 +1295,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.unique('label')
         [1, 0]
         ```
@@ -1310,26 +1325,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         ```py
         >>> from datasets import load_dataset
-        >>> ds = load_dataset("winograd_wsc", "wsc285", split="test")
+        >>> ds = load_dataset("boolq", split="validation")
         >>> ds.features
-        {'label': ClassLabel(num_classes=2, names=['0', '1'], id=None),
-        'options': Sequence(feature=Value(dtype='string', id=None), length=-1, id=None),
-        'pronoun': Value(dtype='string', id=None),
-        'pronoun_loc': Value(dtype='int32', id=None),
-        'quote': Value(dtype='string', id=None),
-        'quote_loc': Value(dtype='int32', id=None),
-        'source': Value(dtype='string', id=None),
-        'text': Value(dtype='string', id=None)}
-        >>> ds = ds.class_encode_column('pronoun')
+        {'answer': Value(dtype='bool', id=None),
+         'passage': Value(dtype='string', id=None),
+         'question': Value(dtype='string', id=None)}
+        >>> ds = ds.class_encode_column('answer')
         >>> ds.features
-        {'label': ClassLabel(num_classes=2, names=['0', '1'], id=None),
-        'options': Sequence(feature=Value(dtype='string', id=None), length=-1, id=None),
-        'pronoun': ClassLabel(num_classes=12, names=['He', 'It', 'She', 'They', 'he', 'her', 'him', 'his', 'it', 'she', 'them', 'they'], id=None),
-        'pronoun_loc': Value(dtype='int32', id=None),
-        'quote': Value(dtype='string', id=None),
-        'quote_loc': Value(dtype='int32', id=None),
-        'source': Value(dtype='string', id=None),
-        'text': Value(dtype='string', id=None)}
+        {'answer': ClassLabel(num_classes=2, names=['False', 'True'], id=None),
+         'passage': Value(dtype='string', id=None),
+         'question': Value(dtype='string', id=None)}
         ```
         """
         # Sanity checks
@@ -1456,12 +1461,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset, ClassLabel, Value
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> ds.features
+        {'label': ClassLabel(num_classes=2, names=['bad', 'good'], id=None),
+         'text': Value(dtype='large_string', id=None)}
         >>> new_features = ds.features.copy()
         >>> new_features['label'] = ClassLabel(names=['bad', 'good'])
         >>> new_features['text'] = Value('large_string')
         >>> ds = ds.cast(new_features)
+        >>> ds.features
         {'label': ClassLabel(num_classes=2, names=['bad', 'good'], id=None),
-        'text': Value(dtype='large_string', id=None)}
+         'text': Value(dtype='large_string', id=None)}
         ```
         """
         if sorted(features) != sorted(self._data.column_names):
@@ -1503,7 +1514,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> ds.features
+        {'label': ClassLabel(num_classes=2, names=['neg', 'pos'], id=None),
+         'text': Value(dtype='string', id=None)}
         >>> ds = ds.cast_column('label', ClassLabel(names=['bad', 'good']))
+        >>> ds.features
+        {'label': ClassLabel(num_classes=2, names=['bad', 'good'], id=None),
+         'text': Value(dtype='string', id=None)}
         ```
         """
         if hasattr(feature, "cast_storage"):
@@ -1538,6 +1557,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.remove_columns('label')
         Dataset({
             features: ['text'],
@@ -1583,6 +1604,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.rename_column('label', 'label_new')
         Dataset({
             features: ['text', 'label_new'],
@@ -1640,6 +1663,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.rename_columns({'text': 'text_new', 'label': 'label_new'})
         Dataset({
             features: ['text_new', 'label_new'],
@@ -1692,6 +1717,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.__len__
         <bound method Dataset.__len__ of Dataset({
             features: ['text', 'label'],
@@ -1790,7 +1817,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoTokenizer
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+        >>> ds = ds.map(lambda x: tokenizer(x['text'], truncation=True, padding=True), batched=True)
         >>> ds.set_format(type='numpy', columns=['text', 'label'])
+        >>> ds.format
+        {'columns': ['input_ids', 'token_type_ids', 'attention_mask', 'label'],
+         'format_kwargs': {},
+         'output_all_columns': False,
+         'type': 'numpy'}
         ```
         """
         format_kwargs.update(format_kwargs.pop("format_kwargs", {}))  # allow to use self.set_format(self.format)
@@ -1831,11 +1868,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoTokenizer
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+        >>> ds = ds.map(lambda x: tokenizer(x['text'], truncation=True, padding=True), batched=True)
+        >>> ds.set_format(type='numpy', columns=['text', 'label'])
         >>> ds.format
-        {'columns': ['text', 'label', 'input_ids', 'token_type_ids', 'attention_mask'],
+        {'columns': ['text', 'label'],
          'format_kwargs': {},
          'output_all_columns': False,
-         'type': 'tensorflow'}
+         'type': 'numpy'}
         >>> ds.reset_format()
         >>> ds.format
         {'columns': ['text', 'label', 'input_ids', 'token_type_ids', 'attention_mask'],
@@ -1867,14 +1910,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
-        >>> from transformers import BertTokenizer
-        >>> tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoTokenizer
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
         >>> def encode(batch):
         ...     return tokenizer(batch['text'], padding=True, truncation=True, return_tensors='pt')
         >>> ds.set_transform(encode)
         >>> ds[0]
         {'attention_mask': tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                 1, 1]),
+         1, 1]),
          'input_ids': tensor([  101, 29353,  2135, 15102,  1996,  9428, 20868,  2890,  8663,  6895,
                  20470,  2571,  3663,  2090,  4603,  3017,  3008,  1998,  2037, 24211,
                  5637,  1998, 11690,  2336,  1012,   102]),
@@ -1910,6 +1955,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoTokenizer
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+        >>> ds = ds.map(lambda x: tokenizer(x['text'], truncation=True, padding=True), batched=True)
+        >>> ds.set_format(type='numpy', columns=['text', 'label'])
+        >>> ds.format
+        {'columns': ['text', 'label'],
+         'format_kwargs': {},
+         'output_all_columns': False,
+         'type': 'numpy'}
         >>> ds = ds.with_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
         >>> ds.format
         {'columns': ['input_ids', 'token_type_ids', 'attention_mask', 'label'],
@@ -1946,11 +2002,22 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
-        >>> def transform(example):
-        ...     inputs = feature_extractor([x for x in example_batch['image']], return_tensors='pt')
-        ...     inputs['labels'] = example['labels]
-        ...     return inputs
-        >>> ds = ds.with_transform(transform)
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoTokenizer
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+        >>> def encode(example):
+        ...     return tokenizer(example["text"], padding=True, truncation=True, return_tensors='pt')
+        >>> ds = ds.with_transform(encode)
+        >>> ds[0]
+        {'attention_mask': tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+         1, 1, 1, 1, 1]),
+         'input_ids': tensor([  101, 18027, 16310, 16001,  1103,  9321,   178, 11604,  7235,  6617,
+                 1742,  2165,  2820,  1206,  6588, 22572, 12937,  1811,  2153,  1105,
+                 1147, 12890, 19587,  6463,  1105, 15026,  1482,   119,   102]),
+         'token_type_ids': tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                 0, 0, 0, 0, 0])}
+        ```
         """
         dataset = copy.deepcopy(self)
         dataset.set_transform(transform=transform, columns=columns, output_all_columns=output_all_columns)
@@ -2048,8 +2115,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.cleanup_cache_files()
-        2
+        10
         ```
         """
         current_cache_files = [os.path.abspath(cache_file["filename"]) for cache_file in self.cache_files]
@@ -2164,14 +2233,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> def add_prefix(example):
-        ...     example["text"] = "Hello " + example["text"]
+        ...     example["text"] = "Review: " + example["text"]
         ...     return example
         >>> ds = ds.map(add_prefix)
         >>> ds[0:3]["text"]
-        ['Hello compassionately explores the seemingly irreconcilable situation between conservative christian parents and their estranged gay and lesbian children .',
-         'Hello the soundtrack alone is worth the price of admission .',
-         'Hello rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .']
+        ['Review: compassionately explores the seemingly irreconcilable situation between conservative christian parents and their estranged gay and lesbian children .',
+         'Review: the soundtrack alone is worth the price of admission .',
+         'Review: rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .']
         ```
         """
         if keep_in_memory and cache_file_name is not None:
@@ -2739,6 +2810,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.filter(lambda x: x["label"] == 1)
         Dataset({
             features: ['text', 'label'],
@@ -2874,6 +2947,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds.select(range(4))
         Dataset({
             features: ['text', 'label'],
@@ -2991,9 +3066,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation)
         >>> ds['label'][:10]
         [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        >>> sorted_ds = ds.sort('label', reverse=True)
+        >>> sorted_ds = ds.sort('label')
         >>> sorted_ds['label'][:10]
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         ```
@@ -3079,11 +3156,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation)
         >>> ds['label'][:10]
         [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         >>> shuffled_ds = ds.shuffle(seed=42)
         >>> shuffled_ds['label'][:10]
         [1, 0, 1, 1, 0, 0, 0, 0, 0, 0]
+        ```
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(
@@ -3188,7 +3268,19 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds = ds.train_test_split(test_size=0.2, shuffle=True)
+        DatasetDict({
+            train: Dataset({
+                features: ['text', 'label'],
+                num_rows: 852
+            })
+            test: Dataset({
+                features: ['text', 'label'],
+                num_rows: 214
+            })
+        })
         ```
         """
         from .dataset_dict import DatasetDict  # import here because of circular dependency
@@ -3373,12 +3465,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> ds
         Dataset({
             features: ['text', 'label'],
             num_rows: 1066
         })
-        >>> ds = ds.shard(num_shards=2, index=0)
+        >>> ds.shard(num_shards=2, index=0)
         Dataset({
             features: ['text', 'label'],
             num_rows: 533
@@ -3965,9 +4059,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
-        >>> ds.add_column(name="more_text", column=new_column_data)
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes), split="validation")
+        >>> more_text = ds["text"]
+        >>> ds.add_column(name="text_2", column=more_text)
         Dataset({
-            features: ['text', 'label', 'more_text'],
+            features: ['text', 'label', 'text_2'],
             num_rows: 1066
         })
         ```
@@ -4194,8 +4291,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
         >>> new_review = {'label': 0, 'text': 'this movie is the absolute worst thing I have ever seen'}
-        >>> ds.add_item(new_review)
+        >>> ds = ds.add_item(new_review)
+        >>> ds[-1]
+        {'label': 0, 'text': 'this movie is the absolute worst thing I have ever seen'}
         ```
         """
         item_table = InMemoryTable.from_pydict({k: [v] for k, v in item.items()})

--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -185,6 +185,14 @@ class DatasetInfo:
         Args:
             dataset_info_dir (str): Destination directory.
             pretty_print (bool, default ``False``): If True, the JSON will be pretty-printed with the indent level of 4.
+
+        Example:
+
+        ```py
+        >>> from datasets import load_dataset
+        >>> ds = load_dataset("rotten_tomatoes", split="validation")
+        >>> ds.info.write_to_directory("/path/to/directory/")
+        ```
         """
         with open(os.path.join(dataset_info_dir, config.DATASET_INFO_FILENAME), "wb") as f:
             self._dump_info(f, pretty_print=pretty_print)
@@ -242,6 +250,13 @@ class DatasetInfo:
         Args:
             dataset_info_dir (`str`): The directory containing the metadata file. This
                 should be the root directory of a specific dataset version.
+
+        Example:
+
+        ```py
+        >>> from datasets import DatasetInfo
+        >>> ds_info = DatasetInfo.from_directory("/path/to/directory/")
+        ```
         """
         logger.info(f"Loading Dataset info from {dataset_info_dir}")
         if not dataset_info_dir:


### PR DESCRIPTION
This PR adds code examples for functions related to the base Datasets class to highlight usage. Most of the examples use the `rotten_tomatoes` dataset since it is nice and small. Several things I would appreciate feedback on:

- Do you think it is clearer to make every code example fully reproducible so when users copy the code they can actually run it and get an output? This seems quite repetitive - maybe even unnecessary - but it is definitely clearer. Personally, I think we might be able to get away with not including this since users probably want to try the function on their own dataset. For example:

   ```py
   >>> from datasets import load_dataset
   >>> ds = load_dataset("rotten_tomatoes", split="validation")
   >>> code example goes here
   ```

- Should we showcase a function with more than one parameter to highlight different use-cases (it's pretty basic right now, but I'd be happy to add more)?
- For the `class_encode_column` function, let me know if there is a simpler dataset with fewer columns (currently using `winograd_wsc`) so it is easier for users to see what changed.
- Where possible, I try to show the input before and the output after using a function like `flatten` for example. Do you think this is too much and just showing the usage (ie, `>>> ds.flatten()`) will be sufficient?

Thanks :)