### PR TITLE
Stream private zipped images

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -212,7 +212,7 @@ class DatasetBuilder:
         info: Optional[DatasetInfo] = None,
         features: Optional[Features] = None,
         use_auth_token: Optional[Union[bool, str]] = None,
-        namespace: Optional[str] = None,
+        repo_id: Optional[str] = None,
         data_files: Optional[Union[str, list, dict, DataFilesDict]] = None,
         data_dir: Optional[str] = None,
         **config_kwargs,
@@ -234,8 +234,9 @@ class DatasetBuilder:
                 It can be used to changed the :obj:`datasets.Features` description of a dataset for example.
             use_auth_token (:obj:`str` or :obj:`bool`, optional): Optional string or boolean to use as Bearer token
                 for remote files on the Datasets Hub. If True, will get token from ``"~/.huggingface"``.
-            namespace: `str`, used to separate builders with the same name but not coming from the same namespace.
-                For example to separate "squad" from "lhoestq/squad" (the builder name would be "lhoestq___squad").
+            repo_id: `str`, used to separate builders with the same name but not coming from the same namespace.
+                For example to separate repo_id "squad" from repo_id "lhoestq/squad".
+                In this case, the builder name would be "lhoestq___squad".
             data_files: for builders like "csv" or "json" that need the user to specify data files. They can be either
                 local or remote files. For convenience you can use a DataFilesDict.
             data_dir: `str`, for builders that require manual download. It must be the path to the local directory containing
@@ -248,7 +249,7 @@ class DatasetBuilder:
         self.hash: Optional[str] = hash
         self.base_path = base_path
         self.use_auth_token = use_auth_token
-        self.namespace = namespace
+        self.repo_id = repo_id
 
         if data_files is not None and not isinstance(data_files, DataFilesDict):
             data_files = DataFilesDict.from_local_or_remote(
@@ -418,11 +419,12 @@ class DatasetBuilder:
         """Relative path of this dataset in cache_dir:
         Will be:
             self.name/self.config.version/self.hash/
-        or if a namespace has been specified:
+        or if a repo_id with a namespace has been specified:
             self.namespace___self.name/self.config.version/self.hash/
         If any of these element is missing or if ``with_version=False`` the corresponding subfolders are dropped.
         """
-        builder_data_dir = self.name if self.namespace is None else f"{self.namespace}___{self.name}"
+        namespace = self.repo_id.split("/")[0] if self.repo_id and self.repo_id.count("/") > 0 else None
+        builder_data_dir = self.name if namespace is None else f"{namespace}___{self.name}"
         builder_config = self.config
         hash = self.hash
         if builder_config:
@@ -927,7 +929,10 @@ class DatasetBuilder:
         splits_generator,
     ) -> IterableDataset:
         ex_iterable = self._get_examples_iterable_for_split(splits_generator)
-        return IterableDataset(ex_iterable, info=self.info, split=splits_generator.name)
+        token_per_repo_id = {self.repo_id: self.use_auth_token} if self.repo_id else {}
+        return IterableDataset(
+            ex_iterable, info=self.info, split=splits_generator.name, token_per_repo_id=token_per_repo_id
+        )
 
     def _post_process(self, dataset: Dataset, resources_paths: Mapping[str, str]) -> Optional[Dataset]:
         """Run dataset transforms or add indexes"""

--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -197,5 +197,9 @@ def _interleave_iterable_datasets(
     if info is None:
         info = DatasetInfo.from_merge([d.info for d in datasets])
         info.features = None
+    # Get all the auth tokens per repository - in case the datasets come from different private repositories
+    token_per_repo_id = {
+        repo_id: token for dataset in datasets for repo_id, token in dataset._token_per_repo_id.items()
+    }
     # Return new daset
-    return iterable_dataset(ex_iterable=ex_iterable, info=info, split=split)
+    return iterable_dataset(ex_iterable=ex_iterable, info=info, split=split, token_per_repo_id=token_per_repo_id)

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -22,7 +22,7 @@ REPO_METRICS_URL = "https://raw.githubusercontent.com/huggingface/datasets/{revi
 
 # Hub
 HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
-HUB_DATASETS_URL = HF_ENDPOINT + "/datasets/{path}/resolve/{revision}/{name}"
+HUB_DATASETS_URL = HF_ENDPOINT + "/datasets/{repo_id}/resolve/{revision}/{path}"
 HUB_DEFAULT_VERSION = "main"
 
 PY_VERSION = version.parse(platform.python_version())

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -81,7 +81,7 @@ class Audio:
                 f"An audio sample should have one of 'path' or 'bytes' but they are missing or None in {value}."
             )
 
-    def decode_example(self, value: dict) -> dict:
+    def decode_example(self, value: dict, token_per_repo_id=None) -> dict:
         """Decode example audio file into audio data.
 
         Args:
@@ -105,12 +105,14 @@ class Audio:
             if file:
                 array, sampling_rate = self._decode_non_mp3_file_like(file, "opus")
             else:
-                array, sampling_rate = self._decode_non_mp3_path_like(path, "opus")
+                array, sampling_rate = self._decode_non_mp3_path_like(
+                    path, "opus", token_per_repo_id=token_per_repo_id
+                )
         else:
             if file:
                 array, sampling_rate = self._decode_non_mp3_file_like(file)
             else:
-                array, sampling_rate = self._decode_non_mp3_path_like(path)
+                array, sampling_rate = self._decode_non_mp3_path_like(path, token_per_repo_id=token_per_repo_id)
         return {"path": path, "array": array, "sampling_rate": sampling_rate}
 
     def flatten(self) -> Union["FeatureType", Dict[str, "FeatureType"]]:
@@ -186,12 +188,13 @@ class Audio:
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
         return array_cast(storage, self.pa_type)
 
-    def _decode_non_mp3_path_like(self, path, format=None):
+    def _decode_non_mp3_path_like(self, path, format=None, token_per_repo_id=None):
         try:
             import librosa
         except ImportError as err:
             raise ImportError("To support decoding audio files, please install 'librosa'.") from err
 
+        token_per_repo_id = token_per_repo_id or {}
         if format == "opus":
             import soundfile
 
@@ -200,8 +203,14 @@ class Audio:
                     "Decoding .opus files requires 'libsndfile'>=1.0.30, "
                     + "it can be installed via conda: `conda install -c conda-forge libsndfile>=1.0.30`"
                 )
+        source_url = path.split("::")[-1]
+        try:
+            repo_id = string_to_dict(source_url, config.HUB_DATASETS_URL)["repo_id"]
+            use_auth_token = token_per_repo_id[repo_id]
+        except (ValueError, KeyError):
+            use_auth_token = None
 
-        with xopen(path, "rb") as f:
+        with xopen(path, "rb", use_auth_token=use_auth_token) as f:
             array, sampling_rate = librosa.load(f, sr=self.sampling_rate, mono=self.mono)
         return array, sampling_rate
 

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union
 import pyarrow as pa
 from packaging import version
 
+from .. import config
 from ..table import array_cast
-from ..utils.py_utils import no_op_if_value_is_null
+from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
 from ..utils.streaming_download_manager import xopen
 
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1054,7 +1054,7 @@ def encode_nested_example(schema, obj):
     return obj
 
 
-def decode_nested_example(schema, obj):
+def decode_nested_example(schema, obj, token_per_repo_id=None):
     """Decode a nested example.
     This is used since some features (in particular Audio and Image) have some logic during decoding.
 
@@ -1084,7 +1084,8 @@ def decode_nested_example(schema, obj):
             return decode_nested_example([schema.feature], obj)
     # Object with special decoding:
     elif isinstance(schema, (Audio, Image)):
-        return schema.decode_example(obj) if obj is not None else None
+        # we pass the token to read and decode files from private repositories in streaming mode
+        return schema.decode_example(obj, token_per_repo_id=token_per_repo_id) if obj is not None else None
     return obj
 
 
@@ -1373,7 +1374,7 @@ class Features(dict):
             encoded_batch[key] = [encode_nested_example(self[key], obj) for obj in column]
         return encoded_batch
 
-    def decode_example(self, example: dict):
+    def decode_example(self, example: dict, token_per_repo_id=None):
         """Decode example with custom feature decoding.
 
         Args:
@@ -1384,7 +1385,7 @@ class Features(dict):
         """
 
         return {
-            column_name: decode_nested_example(feature, value)
+            column_name: decode_nested_example(feature, value, token_per_repo_id=token_per_repo_id)
             if self._column_requires_decoding[column_name]
             else value
             for column_name, (feature, value) in zip_dict(

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -459,6 +459,7 @@ class IterableDataset(DatasetInfoMixin):
         split: Optional[NamedSplit] = None,
         format_type: Optional[str] = None,
         shuffling: Optional[ShufflingConfig] = None,
+        token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None,
     ):
         info = info.copy() if info is not None else DatasetInfo()
         DatasetInfoMixin.__init__(self, info=info, split=split)
@@ -467,6 +468,7 @@ class IterableDataset(DatasetInfoMixin):
         self._format_type = format_type
         self._shuffling = shuffling
         self._epoch = 0
+        self._token_per_repo_id = token_per_repo_id or {}
 
     def _head(self, n=5):
         return _examples_to_batch([x for key, x in islice(self._iter(), n)])
@@ -499,7 +501,10 @@ class IterableDataset(DatasetInfoMixin):
                 # we encode the example for ClassLabel feature types for example
                 encoded_example = self.features.encode_example(example)
                 # Decode example for Audio feature, e.g.
-                decoded_example = self.features.decode_example(encoded_example)
+                # the auth token is required to acecss and decode files from private repositories
+                decoded_example = self.features.decode_example(
+                    encoded_example, token_per_repo_id=self._token_per_repo_id
+                )
                 yield decoded_example
             else:
                 yield example
@@ -527,6 +532,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def map(
@@ -597,6 +603,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def filter(
@@ -649,6 +656,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def shuffle(
@@ -690,6 +698,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=shuffling,
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def set_epoch(self, epoch: int):
@@ -709,6 +718,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def take(self, n) -> "IterableDataset":
@@ -725,6 +735,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def add_column(self, name: str, column: Union[list, np.array]) -> "IterableDataset":
@@ -836,6 +847,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
     def cast(
@@ -867,6 +879,7 @@ class IterableDataset(DatasetInfoMixin):
             split=self._split,
             format_type=self._format_type,
             shuffling=copy.deepcopy(self._shuffling),
+            token_per_repo_id=self._token_per_repo_id,
         )
 
 
@@ -876,6 +889,7 @@ def iterable_dataset(
     split: Optional[NamedSplit] = None,
     format_type: Optional[str] = None,
     shuffling: Optional[ShufflingConfig] = None,
+    token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None,
 ):
     if format_type is not None and format_type == "torch":
         import torch
@@ -892,4 +906,5 @@ def iterable_dataset(
         split=split,
         format_type=format_type,
         shuffling=shuffling,
+        token_per_repo_id=token_per_repo_id,
     )

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -106,9 +106,9 @@ def hf_github_url(path: str, name: str, dataset=True, revision: Optional[str] = 
         return config.REPO_METRICS_URL.format(revision=revision, path=path, name=name)
 
 
-def hf_hub_url(path: str, name: str, revision: Optional[str] = None) -> str:
+def hf_hub_url(repo_id: str, path: str, revision: Optional[str] = None) -> str:
     revision = revision or config.HUB_DEFAULT_VERSION
-    return config.HUB_DATASETS_URL.format(path=path, name=name, revision=revision)
+    return config.HUB_DATASETS_URL.format(repo_id=repo_id, path=path, revision=revision)
 
 
 def url_or_path_join(base_name: str, *pathnames: str) -> str:

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -105,6 +105,8 @@ def string_to_dict(string: str, pattern: str) -> Dict[str, str]:
     regex = re.sub(r"{(.+?)}", r"(?P<_\1>.+)", pattern)
     values = list(re.search(regex, string).groups())
     keys = re.findall(r"{(.+?)}", pattern)
+    if len(values) != len(keys):
+        return ValueError(f"Pattern {pattern} doesn't match {string}")
     _dict = dict(zip(keys, values))
     return _dict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -467,3 +467,19 @@ def text_path_with_unicode_new_lines(tmp_path_factory):
     with open(path, "w", encoding="utf-8") as f:
         f.write(text)
     return path
+
+
+@pytest.fixture(scope="session")
+def image_path():
+    return os.path.join(os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg")
+
+
+@pytest.fixture(scope="session")
+def zip_image_path(image_path, tmp_path_factory):
+    import zipfile
+
+    path = tmp_path_factory.mktemp("data") / "dataset.img.zip"
+    with zipfile.ZipFile(path, "w") as f:
+        f.write(image_path, arcname=os.path.basename(image_path))
+        f.write(image_path, arcname=os.path.basename(image_path).replace(".jpg", "2.jpg"))
+    return path

--- a/tests/hub_fixtures.py
+++ b/tests/hub_fixtures.py
@@ -11,7 +11,7 @@ FULL_NAME = "Dummy User"
 PASS = "__DUMMY_TRANSFORMERS_PASS__"
 
 ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
-ENDPOINT_STAGING_DATASETS_URL = ENDPOINT_STAGING + "/datasets/{path}/resolve/{revision}/{name}"
+ENDPOINT_STAGING_DATASETS_URL = ENDPOINT_STAGING + "/datasets/{repo_id}/resolve/{revision}/{path}"
 
 
 @pytest.fixture(scope="session")
@@ -79,3 +79,29 @@ def hf_private_dataset_repo_zipped_txt_data(hf_private_dataset_repo_zipped_txt_d
     with patch("datasets.config.HF_ENDPOINT", ENDPOINT_STAGING):
         with patch("datasets.config.HUB_DATASETS_URL", ENDPOINT_STAGING_DATASETS_URL):
             yield hf_private_dataset_repo_zipped_txt_data_
+
+
+@pytest.fixture(scope="session")
+def hf_private_dataset_repo_zipped_img_data_(hf_api: HfApi, hf_token, zip_image_path):
+    repo_name = f"repo_zipped_img_data-{int(time.time() * 10e3)}"
+    hf_api.create_repo(token=hf_token, name=repo_name, repo_type="dataset", private=True)
+    repo_id = f"{USER}/{repo_name}"
+    hf_api.upload_file(
+        token=hf_token,
+        path_or_fileobj=str(zip_image_path),
+        path_in_repo="data.zip",
+        repo_id=repo_id,
+        repo_type="dataset",
+    )
+    yield repo_id
+    try:
+        hf_api.delete_repo(token=hf_token, name=repo_name, repo_type="dataset")
+    except (requests.exceptions.HTTPError, ValueError):  # catch http error and token invalid error
+        pass
+
+
+@pytest.fixture()
+def hf_private_dataset_repo_zipped_img_data(hf_private_dataset_repo_zipped_img_data_):
+    with patch("datasets.config.HF_ENDPOINT", ENDPOINT_STAGING):
+        with patch("datasets.config.HUB_DATASETS_URL", ENDPOINT_STAGING_DATASETS_URL):
+            yield hf_private_dataset_repo_zipped_img_data_

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -40,6 +40,7 @@ from .utils import (
     assert_arrow_memory_doesnt_increase,
     assert_arrow_memory_increases,
     offline,
+    require_pil,
     set_current_working_directory_to_temp_dir,
 )
 
@@ -599,6 +600,17 @@ def test_load_dataset_streaming_csv(path_extension, streaming, csv_path, bz2_csv
     assert isinstance(ds, IterableDataset if streaming else Dataset)
     ds_item = next(iter(ds))
     assert ds_item == {"col_1": "0", "col_2": 0, "col_3": 0.0}
+
+
+@require_pil
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_dataset_private_zipped_images(hf_private_dataset_repo_zipped_img_data, hf_token, streaming):
+    ds = load_dataset(
+        hf_private_dataset_repo_zipped_img_data, split="train", streaming=streaming, use_auth_token=hf_token
+    )
+    assert isinstance(ds, IterableDataset if streaming else Dataset)
+    ds_items = list(ds)
+    assert len(ds_items) == 2
 
 
 @pytest.mark.parametrize("streaming", [False, True])

--- a/tests/test_packaged_modules.py
+++ b/tests/test_packaged_modules.py
@@ -55,11 +55,6 @@ def text_file(tmp_path):
     return str(filename)
 
 
-@pytest.fixture
-def image_file():
-    return os.path.join(os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg")
-
-
 def test_csv_generate_tables_raises_error_with_malformed_csv(csv_file, malformed_csv_file, caplog):
     csv = Csv()
     generator = csv._generate_tables([csv_file, malformed_csv_file])
@@ -85,9 +80,9 @@ def test_text_linebreaks(text_file, keep_linebreaks):
 
 
 @pytest.mark.parametrize("drop_labels", [True, False])
-def test_imagefolder_drop_labels(image_file, drop_labels):
+def test_imagefolder_drop_labels(image_path, drop_labels):
     imagefolder = ImageFolder(drop_labels=drop_labels)
-    generator = imagefolder._generate_examples([(image_file, image_file)])
+    generator = imagefolder._generate_examples([(image_path, image_path)])
     if not drop_labels:
         assert all(example.keys() == {"image", "label"} for _, example in generator)
     else:

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -29,7 +29,7 @@ def with_staging_testing(func):
     config = patch.multiple(
         "datasets.config",
         HF_ENDPOINT=ENDPOINT_STAGING,
-        HUB_DATASETS_URL=ENDPOINT_STAGING + "/datasets/{path}/resolve/{revision}/{name}",
+        HUB_DATASETS_URL=ENDPOINT_STAGING + "/datasets/{repo_id}/resolve/{revision}/{path}",
     )
     return config(func)
 


### PR DESCRIPTION
As mentioned in https://github.com/huggingface/datasets/issues/4139 it's currently not possible to stream private zipped images from the Hub.

This is because `Image.decode_example` does not handle authentication. Indeed decoding requires to access and download the file from the private repository.

In this PR I added authentication to `Image.decode_example` via a `token_per_repo_id` optional argument. I first wanted to just pass `use_auth_token` but a single `Image` instance can be responsible of decoding images from a combination several datasets together (from `interleave_datasets` for example). Therefore I just used a dictionary `repo_id` -> `token` instead.