### PR TITLE
Deprecate `shard_size` in `push_to_hub` in favor of `max_shard_size`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3530,8 +3530,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
                 (like `"5MB"`).
             shard_size (Optional :obj:`int`):
-                .. deprecated:: 2.1.1
-                    'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.
+                Deprecated: 'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.
             embed_external_files (:obj:`bool`, default ``True``):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -21,6 +21,7 @@ import json
 import os
 import shutil
 import tempfile
+import warnings
 import weakref
 from collections import Counter, UserDict
 from collections.abc import Mapping
@@ -89,7 +90,7 @@ from .utils import logging
 from .utils._hf_hub_fixes import create_repo
 from .utils.file_utils import _retry, estimate_dataset_size
 from .utils.info_utils import is_small_dataset
-from .utils.py_utils import temporary_assignment, unique_values
+from .utils.py_utils import convert_file_size_to_int, temporary_assignment, unique_values
 from .utils.streaming_download_manager import xgetsize
 from .utils.typing import PathLike
 
@@ -3293,7 +3294,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         private: Optional[bool] = False,
         token: Optional[str] = None,
         branch: Optional[str] = None,
-        shard_size: Optional[int] = 500 << 20,
+        max_shard_size: Union[int, str] = "500MB",
         embed_external_files: bool = True,
     ) -> Tuple[str, str, int, int]:
         """Pushes the dataset to the hub.
@@ -3316,9 +3317,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             branch (Optional :obj:`str`):
                 The git branch on which to push the dataset. This defaults to the default branch as specified
                 in your repository, which defaults to `"main"`.
-            shard_size (Optional :obj:`int`):
-                The size of the dataset shards to be uploaded to the hub. The dataset will be pushed in files
-                of the size specified here, in bytes. Defaults to a shard size of 500MB.
+            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+                The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
+                (like `"5MB"`).
             embed_external_files (:obj:`bool`, default ``True``):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:
@@ -3337,6 +3338,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> dataset.push_to_hub("<organization>/<dataset_id>", split="evaluation")
         ```
         """
+        max_shard_size = convert_file_size_to_int(max_shard_size)
+
         api = HfApi(endpoint=config.HF_ENDPOINT)
         token = token if token is not None else HfFolder.get_token()
 
@@ -3405,7 +3408,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if self._indices is not None:
             dataset_nbytes = dataset_nbytes * len(self._indices) / len(self.data)
 
-        num_shards = int(dataset_nbytes / shard_size) + 1
+        num_shards = int(dataset_nbytes / max_shard_size) + 1
         num_shards = max(num_shards, 1)
         shards = (self.shard(num_shards=num_shards, index=i, contiguous=True) for i in range(num_shards))
 
@@ -3499,7 +3502,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         private: Optional[bool] = False,
         token: Optional[str] = None,
         branch: Optional[str] = None,
-        shard_size: Optional[int] = 500 << 20,
+        max_shard_size: Optional[int] = "500MB",
+        shard_size: Optional[int] = "deprecated",
         embed_external_files: bool = True,
     ):
         """Pushes the dataset to the hub.
@@ -3522,9 +3526,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             branch (Optional :obj:`str`):
                 The git branch on which to push the dataset. This defaults to the default branch as specified
                 in your repository, which defaults to `"main"`.
+            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+                The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
+                (like `"5MB"`).
             shard_size (Optional :obj:`int`):
-                The size of the dataset shards to be uploaded to the hub. The dataset will be pushed in files
-                of the size specified here, in bytes. Defaults to a shard size of 500MB.
+                .. deprecated:: 2.1.1
+                    'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.
             embed_external_files (:obj:`bool`, default ``True``):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:
@@ -3537,13 +3544,20 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> dataset.push_to_hub("<organization>/<dataset_id>", split="evaluation")
         ```
         """
+        if shard_size != "deprecated":
+            warnings.warn(
+                "'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.",
+                FutureWarning,
+            )
+            max_shard_size = shard_size
+
         repo_id, split, uploaded_size, dataset_nbytes = self._push_parquet_shards_to_hub(
             repo_id=repo_id,
             split=split,
             private=private,
             token=token,
             branch=branch,
-            shard_size=shard_size,
+            max_shard_size=max_shard_size,
             embed_external_files=embed_external_files,
         )
         organization, dataset_name = repo_id.split("/")

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3317,7 +3317,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             branch (Optional :obj:`str`):
                 The git branch on which to push the dataset. This defaults to the default branch as specified
                 in your repository, which defaults to `"main"`.
-            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+            max_shard_size (`int` or `str`, *optional*, defaults to `"500MB"`):
                 The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
                 (like `"5MB"`).
             embed_external_files (:obj:`bool`, default ``True``):
@@ -3502,7 +3502,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         private: Optional[bool] = False,
         token: Optional[str] = None,
         branch: Optional[str] = None,
-        max_shard_size: Optional[int] = "500MB",
+        max_shard_size: Union[int, str] = "500MB",
         shard_size: Optional[int] = "deprecated",
         embed_external_files: bool = True,
     ):
@@ -3526,7 +3526,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             branch (Optional :obj:`str`):
                 The git branch on which to push the dataset. This defaults to the default branch as specified
                 in your repository, which defaults to `"main"`.
-            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+            max_shard_size (`int` or `str`, *optional*, defaults to `"500MB"`):
                 The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
                 (like `"5MB"`).
             shard_size (Optional :obj:`int`):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -851,7 +851,8 @@ class DatasetDict(dict):
         private: Optional[bool] = False,
         token: Optional[str] = None,
         branch: Optional[None] = None,
-        shard_size: Optional[int] = 500 << 20,
+        max_shard_size: Union[int, str] = "500MB",
+        shard_size: Optional[int] = "deprecated",
         embed_external_files: bool = True,
     ):
         """Pushes the ``DatasetDict`` to the hub.
@@ -873,7 +874,7 @@ class DatasetDict(dict):
                 if no token is passed and the user is not logged-in.
             branch (Optional :obj:`str`):
                 The git branch on which to push the dataset.
-            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+            max_shard_size (`int` or `str`, *optional*, defaults to `"500MB"`):
                 The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
                 (like `"5MB"`).
             shard_size (Optional :obj:`int`):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -3,6 +3,7 @@ import copy
 import json
 import os
 import re
+import warnings
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -872,9 +873,12 @@ class DatasetDict(dict):
                 if no token is passed and the user is not logged-in.
             branch (Optional :obj:`str`):
                 The git branch on which to push the dataset.
+            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+                The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
+                (like `"5MB"`).
             shard_size (Optional :obj:`int`):
-                The size of the dataset shards to be uploaded to the hub. The dataset will be pushed in files
-                of the size specified here, in bytes.
+                .. deprecated:: 2.1.1
+                    'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.
             embed_external_files (:obj:`bool`, default ``True``):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:
@@ -887,6 +891,13 @@ class DatasetDict(dict):
         >>> dataset_dict.push_to_hub("<organization>/<dataset_id>")
         ```
         """
+        if shard_size != "deprecated":
+            warnings.warn(
+                "'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.",
+                FutureWarning,
+            )
+            max_shard_size = shard_size
+
         self._check_values_type()
         total_uploaded_size = 0
         total_dataset_nbytes = 0
@@ -902,7 +913,7 @@ class DatasetDict(dict):
                 private=private,
                 token=token,
                 branch=branch,
-                shard_size=shard_size,
+                max_shard_size=max_shard_size,
                 embed_external_files=embed_external_files,
             )
             total_uploaded_size += uploaded_size

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -878,8 +878,7 @@ class DatasetDict(dict):
                 The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
                 (like `"500MB"` or `"1GB"`).
             shard_size (Optional :obj:`int`):
-                .. deprecated:: 2.1.1
-                    'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.
+                Deprecated: 'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.
             embed_external_files (:obj:`bool`, default ``True``):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -876,7 +876,7 @@ class DatasetDict(dict):
                 The git branch on which to push the dataset.
             max_shard_size (`int` or `str`, *optional*, defaults to `"500MB"`):
                 The maximum size of the dataset shards to be uploaded to the hub. If expressed as a string, needs to be digits followed by a unit
-                (like `"5MB"`).
+                (like `"500MB"` or `"1GB"`).
             shard_size (Optional :obj:`int`):
                 .. deprecated:: 2.1.1
                     'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -91,7 +91,7 @@ def convert_file_size_to_int(size: Union[int, str]) -> int:
 
     Example:
     ```py
-    >>> convert_file_size_to_int("1MIB")
+    >>> convert_file_size_to_int("1MiB")
     1048576
     ```
     """

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -82,6 +82,36 @@ def size_str(size_in_bytes):
     return f"{int(size_in_bytes)} bytes"
 
 
+def convert_file_size_to_int(size: Union[int, str]) -> int:
+    """
+    Converts a size expressed as a string with digits an unit (like `"5MB"`) to an integer (in bytes).
+
+    Args:
+        size (`int` or `str`): The size to convert. Will be directly returned if an `int`.
+
+    Example:
+    ```py
+    >>> convert_file_size_to_int("1MIB")
+    1048576
+    ```
+    """
+    if isinstance(size, int):
+        return size
+    if size.upper().endswith("GIB"):
+        return int(size[:-3]) * (2**30)
+    if size.upper().endswith("MIB"):
+        return int(size[:-3]) * (2**20)
+    if size.upper().endswith("KIB"):
+        return int(size[:-3]) * (2**10)
+    if size.upper().endswith("GB"):
+        return int(size[:-2]) * (10**9)
+    if size.upper().endswith("MB"):
+        return int(size[:-2]) * (10**6)
+    if size.upper().endswith("KB"):
+        return int(size[:-2]) * (10**3)
+    raise ValueError("`size` is not in a valid format. Use an integer followed by the unit, e.g., '5GB'.")
+
+
 def string_to_dict(string: str, pattern: str) -> Dict[str, str]:
     """Un-format a string using a python f-string pattern.
     From https://stackoverflow.com/a/36838374

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -104,7 +104,12 @@ def convert_file_size_to_int(size: Union[int, str]) -> int:
     if size.upper().endswith("KIB"):
         return int(size[:-3]) * (2**10)
     if size.upper().endswith("GB"):
-        return int(size[:-2]) * (10**9)
+        if size.endswith("Gb"):
+            # gigabits
+            return int(size[:-2]) * (10**9 >> 3)
+        else:
+            # gigabytes
+            return int(size[:-2]) * (10**9)
     if size.upper().endswith("MB"):
         return int(size[:-2]) * (10**6)
     if size.upper().endswith("KB"):

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -148,7 +148,7 @@ class TestPushToHub(TestCase):
 
         ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
         try:
-            local_ds.push_to_hub(ds_name, token=self._token, shard_size=500 << 5)
+            local_ds.push_to_hub(ds_name, token=self._token, max_shard_size="16KB")
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             self.assertDictEqual(local_ds.column_names, hub_ds.column_names)


### PR DESCRIPTION
This PR adds a `max_shard_size` param to `push_to_hub` and deprecates `shard_size` in favor of this new param to have a more descriptive name (a shard has at most the `shard_size` bytes in `push_to_hub`) for the param and to align the API with [Transformers](https://github.com/huggingface/transformers/blob/ff06b177917384137af2d9585697d2d76c40cdfc/src/transformers/modeling_utils.py#L1350).
