### PR TITLE
Add remove_columns=True

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1847,7 +1847,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 - `function(batch: Union[Dict[List], List[Any]]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False` and `with_rank=False`
                 - `function(batch: Union[Dict[List], List[Any]], *extra_args) -> Union[Dict, Any]` if `batched=True` and `with_indices=True` and/or `with_rank=True` (one extra arg for each)
 
-                If no function is provided, default to identity function: ``lambda x: x``.
+                If no function is provided, default to identity function: ``lambda x: {}``.
             with_indices (:obj:`bool`, default `False`): Provide example indices to `function`. Note that in this case the
                 signature of `function` should be `def function(example, idx[, rank]): ...`.
             with_rank (:obj:`bool`, default `False`): Provide process rank to `function`. Note that in this case the
@@ -2122,7 +2122,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 - `function(example: Union[Dict, Any], *extra_args) -> Union[Dict, Any]` if `batched=False` and `with_indices=True` and/or `with_rank=True` (one extra arg for each)
                 - `function(batch: Union[Dict[List], List[Any]]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False` and `with_rank=False`
                 - `function(batch: Union[Dict[List], List[Any]], *extra_args) -> Union[Dict, Any]` if `batched=True` and `with_indices=True` and/or `with_rank=True` (one extra arg for each)
-                If no function is provided, default to identity function: lambda x: x
+                If no function is provided, default to identity function: ``lambda x: {}``
             with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
             with_rank (:obj:`bool`, default `False`): Provide process rank to `function`. Note that in this case the signature of `function` should be `def function(example[, idx], rank): ...`.
             input_columns (`Optional[List[str]]`, defaults to `None`): The columns to be passed into `function` as

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1904,7 +1904,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 return self
 
         if function is None:
-            function = lambda x: x  # noqa: E731
+            function = lambda x: None  # noqa: E731
 
         def decorate(f):
             """

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1847,7 +1847,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 - `function(batch: Union[Dict[List], List[Any]]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False` and `with_rank=False`
                 - `function(batch: Union[Dict[List], List[Any]], *extra_args) -> Union[Dict, Any]` if `batched=True` and `with_indices=True` and/or `with_rank=True` (one extra arg for each)
 
-                If no function is provided, default to identity function: ``lambda x: {}``.
+                If no function is provided, default to no-op function: ``lambda x: {}``, which doesn't add new columns.
             with_indices (:obj:`bool`, default `False`): Provide example indices to `function`. Note that in this case the
                 signature of `function` should be `def function(example, idx[, rank]): ...`.
             with_rank (:obj:`bool`, default `False`): Provide process rank to `function`. Note that in this case the

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2122,7 +2122,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 - `function(example: Union[Dict, Any], *extra_args) -> Union[Dict, Any]` if `batched=False` and `with_indices=True` and/or `with_rank=True` (one extra arg for each)
                 - `function(batch: Union[Dict[List], List[Any]]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False` and `with_rank=False`
                 - `function(batch: Union[Dict[List], List[Any]], *extra_args) -> Union[Dict, Any]` if `batched=True` and `with_indices=True` and/or `with_rank=True` (one extra arg for each)
-                If no function is provided, default to identity function: ``lambda x: {}``
+                If no function is provided, default to no-op function: ``lambda x: {}``, which doesn't add new columns.
             with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
             with_rank (:obj:`bool`, default `False`): Provide process rank to `function`. Note that in this case the signature of `function` should be `def function(example[, idx], rank): ...`.
             input_columns (`Optional[List[str]]`, defaults to `None`): The columns to be passed into `function` as

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1904,7 +1904,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 return self
 
         if function is None:
-            function = lambda x: None  # noqa: E731
+            function = lambda x: {}  # noqa: E731
 
         def decorate(f):
             """

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -380,7 +380,7 @@ class DatasetDict(dict):
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         drop_last_batch: bool = False,
-        remove_columns: Optional[Union[str, List[str]]] = None,
+        remove_columns: Optional[Union[bool, str, List[str]]] = None,
         keep_in_memory: bool = False,
         load_from_cache_file: bool = True,
         cache_file_names: Optional[Dict[str, Optional[str]]] = None,
@@ -411,9 +411,14 @@ class DatasetDict(dict):
                 `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
             drop_last_batch (:obj:`bool`, default `False`): Whether a last batch smaller than the batch_size should be
                 dropped instead of being processed by the function.
-            remove_columns (`Optional[Union[str, List[str]]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
+            remove_columns (`Optional[Union[bool,List[str]]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
+                Argument behaviour according to typing:
+                    - None: No column is removed.
+                    - bool: Flag determining whether all columns are removed or not. Columns from the output of `function` are preserved.
+                    - str: Single column removed. Columns from the output of `function` are preserved.
+                    - List[str]: List of columns removed. Columns from the output of `function` are preserved.
             keep_in_memory (`bool`, defaults to `False`): Keep the dataset in memory instead of writing it to a cache file.
             load_from_cache_file (`bool`, defaults to `True`): If a cache file storing the current computation from `function`
                 can be identified, use it instead of recomputing.
@@ -951,7 +956,7 @@ class IterableDatasetDict(dict):
         self,
         function: Optional[Callable] = None,
         with_indices: bool = False,
-        input_columns: Optional[Union[str, List[str]]] = None,
+        input_columns: Optional[Union[bool, str, List[str]]] = None,
         batched: bool = False,
         batch_size: int = 1000,
         remove_columns: Optional[Union[str, List[str]]] = None,
@@ -987,9 +992,15 @@ class IterableDatasetDict(dict):
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
             batched (:obj:`bool`, default `False`): Provide batch of examples to `function`.
             batch_size (:obj:`int`, optional, default ``1000``): Number of examples per batch provided to `function` if `batched=True`.
-            remove_columns (`Optional[List[str]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
+            remove_columns (`Optional[Union[bool,List[str]]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
+                Argument behaviour according to typing:
+                    - None: No column is removed.
+                    - bool: Flag determining whether all columns are removed or not. Columns from the output of `function` are preserved.
+                    - str: Single column removed. Columns from the output of `function` are preserved.
+                    - List[str]: List of columns removed. Columns from the output of `function` are preserved.
+
         """
         return IterableDatasetDict(
             {

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -986,7 +986,7 @@ class IterableDatasetDict(dict):
                 - `function(batch: Union[Dict[List], List[Any]]) -> dict` if `batched=True` and `with_indices=False`
                 - `function(batch: Union[Dict[List], List[Any]], indices: List[int]) -> dict` if `batched=True` and `with_indices=True`
 
-                If no function is provided, default to identity function: ``lambda x: {}``.
+                If no function is provided, default to no-op function: ``lambda x: {}``, which doesn't add new columns.
             with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
             input_columns (`Optional[Union[str, List[str]]]`, default `None`): The columns to be passed into `function`
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -986,7 +986,7 @@ class IterableDatasetDict(dict):
                 - `function(batch: Union[Dict[List], List[Any]]) -> dict` if `batched=True` and `with_indices=False`
                 - `function(batch: Union[Dict[List], List[Any]], indices: List[int]) -> dict` if `batched=True` and `with_indices=True`
 
-                If no function is provided, default to identity function: ``lambda x: x``.
+                If no function is provided, default to identity function: ``lambda x: {}``.
             with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
             input_columns (`Optional[Union[str, List[str]]]`, default `None`): The columns to be passed into `function`
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -216,7 +216,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         if c in transformed_batch:
                             del transformed_batch[c]
 
-                transformed_batch.update(processed_batch)
+                if self.remove_columns is False or self.remove_columns is None:
+                    transformed_batch = processed_batch
+                else:
+                    transformed_batch.update(processed_batch)
 
                 if transformed_batch:
                     first_col = next(iter(transformed_batch))
@@ -254,7 +257,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         if c in transformed_example:
                             del transformed_example[c]
 
-                transformed_example.update(processed_example)
+                if self.remove_columns is False or self.remove_columns is None:
+                    transformed_example = processed_example
+                else:
+                    transformed_example.update(processed_example)
 
                 yield key, transformed_example
                 current_idx += 1

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -579,7 +579,7 @@ class IterableDataset(DatasetInfoMixin):
                 - `function(batch: Union[Dict[List], List[Any]]) -> dict` if `batched=True` and `with_indices=False`
                 - `function(batch: Union[Dict[List], List[Any]], indices: List[int]) -> dict` if `batched=True` and `with_indices=True`
 
-                If no function is provided, default to identity function: ``lambda x: {}``.
+                If no function is provided, default to no-op function: ``lambda x: {}``, which doesn't add new columns.
             with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
             input_columns (`Optional[Union[str, List[str]]]`, default `None`): The columns to be passed into `function`
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -216,7 +216,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         if c in transformed_batch:
                             del transformed_batch[c]
 
-                if self.remove_columns is False or self.remove_columns is None:
+                if self.remove_columns is True:
                     transformed_batch = processed_batch
                 else:
                     transformed_batch.update(processed_batch)
@@ -257,7 +257,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         if c in transformed_example:
                             del transformed_example[c]
 
-                if self.remove_columns is False or self.remove_columns is None:
+                if self.remove_columns is True:
                     transformed_example = processed_example
                 else:
                     transformed_example.update(processed_example)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -579,7 +579,7 @@ class IterableDataset(DatasetInfoMixin):
                 - `function(batch: Union[Dict[List], List[Any]]) -> dict` if `batched=True` and `with_indices=False`
                 - `function(batch: Union[Dict[List], List[Any]], indices: List[int]) -> dict` if `batched=True` and `with_indices=True`
 
-                If no function is provided, default to identity function: ``lambda x: x``.
+                If no function is provided, default to identity function: ``lambda x: {}``.
             with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
             input_columns (`Optional[Union[str, List[str]]]`, default `None`): The columns to be passed into `function`
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -599,7 +599,7 @@ class IterableDataset(DatasetInfoMixin):
         if isinstance(remove_columns, str):
             remove_columns = [remove_columns]
         if function is None:
-            function = lambda x: None  # noqa: E731
+            function = lambda x: {}  # noqa: E731
         info = self._info.copy()
         info.features = None
         ex_iterable = MappedExamplesIterable(

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -599,7 +599,7 @@ class IterableDataset(DatasetInfoMixin):
         if isinstance(remove_columns, str):
             remove_columns = [remove_columns]
         if function is None:
-            function = lambda x: x  # noqa: E731
+            function = lambda x: None  # noqa: E731
         info = self._info.copy()
         info.features = None
         ex_iterable = MappedExamplesIterable(

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1352,6 +1352,18 @@ class BaseDatasetTest(TestCase):
                         with empty_dset.map(lambda x: {}, remove_columns=columns_names[0]) as mapped_dset:
                             self.assertListEqual(columns_names[1:], mapped_dset.column_names)
                             assert_arrow_metadata_are_synced_with_dataset_features(mapped_dset)
+                    # remove all input columns
+                    with dset.map(
+                        lambda x: {
+                            "filename": x["filename"],
+                            "id+1": x["id"] + 1,
+                        },  # `filename` is an old column, `id+1` is a new column
+                        remove_columns=True,
+                    ) as mapped_dset:
+                        self.assertDictEqual(
+                            mapped_dset.features, Features({"filename": Value("string"), "id+1": Value("int64")})
+                        )
+                        assert_arrow_metadata_are_synced_with_dataset_features(mapped_dset)
 
     def test_map_stateful_callable(self, in_memory):
         # be sure that the state of the map callable is unaffected

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -521,7 +521,7 @@ def test_iterable_dataset_map_batched(dataset: IterableDataset, generate_example
     assert next(iter(dataset)) == {"id+1": 1}
 
 
-def test_iterable_dataset_map_persist_with_remove_column(dataset: IterableDataset, generate_examples_fn):
+def test_iterable_dataset_map_persist_with_remove_column(dataset: IterableDataset):
     func = lambda x: {"id": [i + 1 for i in x["id"]]}  # noqa: E731
     batch_size = 3
     dataset = dataset.map(func, batched=True, batch_size=batch_size, remove_columns=True)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -527,7 +527,7 @@ def test_iterable_dataset_map_persist_with_remove_column(dataset: IterableDatase
     dataset = dataset.map(func, batched=True, batch_size=batch_size, remove_columns=True)
     assert isinstance(dataset._ex_iterable, MappedExamplesIterable)
     assert dataset._ex_iterable.function is func
-    assert dataset._ex_iterable.batch_size is False
+    assert dataset._ex_iterable.batch_size == batch_size
     assert next(iter(dataset)) == {"id": 1}
 
 

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -523,7 +523,8 @@ def test_iterable_dataset_map_batched(dataset: IterableDataset, generate_example
 
 def test_iterable_dataset_map_persist_with_remove_column(dataset: IterableDataset, generate_examples_fn):
     func = lambda x: {"id": [i + 1 for i in x["id"]]}  # noqa: E731
-    dataset = dataset.map(func, remove_columns=True)
+    batch_size = 3
+    dataset = dataset.map(func, batched=True, batch_size=batch_size, remove_columns=True)
     assert isinstance(dataset._ex_iterable, MappedExamplesIterable)
     assert dataset._ex_iterable.function is func
     assert dataset._ex_iterable.batch_size is False


### PR DESCRIPTION
This should fix all the issue we have with in place operations in mapping functions. This is crucial as where we do some weird things like:
```
def apply(batch):
    batch_size = len(batch["id"])
    batch["text"] = ["potato" for _ range(batch_size)]
    return {}

# Columns are: {"id": int}
dset.map(apply, batched=True, remove_columns="text") # crashes because `text` is not in the original columns
dset.map(apply, batched=True) # mapped datasets has `text` column
```

In this PR we suggest to have `remove_columns=True` so that we ignore the input completely, and just use the output to generate mapped dataset. This means that inplace operations won't have any effects anymore.