### PR TITLE
Add to docs how to load from local script

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -5,6 +5,7 @@ You have already seen how to load a dataset from the Hugging Face Hub. But datas
 This guide will show you how to load a dataset from:
 
 - The Hub without a dataset loading script
+- Local loading script
 - Local files
 - In-memory data
 - Offline
@@ -67,6 +68,18 @@ Specify a custom split with the `split` parameter:
 ```py
 >>> data_files = {"validation": "en/c4-validation.*.json.gz"}
 >>> c4_validation = load_dataset("allenai/c4", data_files=data_files, split="validation")
+```
+
+## Local loading script
+
+You may have a 🤗 Datasets loading script locally on your computer. You can load this dataset by passing to [`load_dataset`] one of the following paths:
+
+- The local path to the loading script file
+- The local path to the directory containing the loading script file (only if the script file has the same name as the directory)
+
+```py
+>>> dataset = load_dataset("path/to/local/loading_script/loading_script.py", split="train")
+>>> dataset = load_dataset("path/to/local/loading_script", split="train")  # equivalently because the file has the same name as the directory
 ```
 
 ## Local and remote files

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -74,12 +74,12 @@ Specify a custom split with the `split` parameter:
 
 You may have a 🤗 Datasets loading script locally on your computer. You can load this dataset by passing to [`load_dataset`] one of the following paths:
 
-- The local path to the loading script file
-- The local path to the directory containing the loading script file (only if the script file has the same name as the directory)
+- The local path to the loading script file.
+- The local path to the directory containing the loading script file (only if the script file has the same name as the directory).
 
 ```py
 >>> dataset = load_dataset("path/to/local/loading_script/loading_script.py", split="train")
->>> dataset = load_dataset("path/to/local/loading_script", split="train")  # equivalently because the file has the same name as the directory
+>>> dataset = load_dataset("path/to/local/loading_script", split="train")  # equivalent because the file has the same name as the directory
 ```
 
 ## Local and remote files


### PR DESCRIPTION
This option was missing from the docs guide (it was only explained in the docstring of `load_dataset`). Although this is an infrequent use case, there might be some users interested in it.

Related to #4192

CC: @stevhliu 