### PR TITLE
[Common Voice] Make sure bytes are correctly deleted if `path` exists

### DIFF
--- a/datasets/common_voice/common_voice.py
+++ b/datasets/common_voice/common_voice.py
@@ -792,8 +792,9 @@ class CommonVoice(datasets.GeneratorBasedBuilder):
                     result = {key: value for key, value in zip(data_fields, field_values)}
 
                     # set audio feature
+                    path = os.path.join(local_extracted_archive, path) if local_extracted_archive else path
                     result["audio"] = {"path": path, "bytes": f.read()}
                     # set path to None if the audio file doesn't exist locally (i.e. in streaming mode)
-                    result["path"] = os.path.join(local_extracted_archive, path) if local_extracted_archive else None
+                    result["path"] = path if local_extracted_archive else None
 
                     yield path, result


### PR DESCRIPTION
`path` should be set to local path inside audio feature if exist so that bytes can correctly be deleted.