### PR TITLE
Avoid recursion error in map if example is returned as dict value

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1926,8 +1926,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         def decorate(f):
             """
-            Decorate the mapped function, so that its first argument is wrapped with a LazyDict to be used internally
-            but a standard dictionary is returned at the end of the mapping.
+            Decorate the mapped function, so that its first argument is wrapped with a LazyDict to be used internally.
             """
 
             @wraps(f)
@@ -1937,9 +1936,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     Example(item, features=self.features) if not batched else Batch(item, features=self.features)
                 )
                 # Use the LazyDict internally, while mapping the function
-                result = f(decorated_item, *args, **kwargs)
-                # Return a standard dict
-                return result.data if isinstance(result, LazyDict) else result
+                return f(decorated_item, *args, **kwargs)
 
             return decorated
 
@@ -2271,8 +2268,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 if input_num_examples != processed_inputs_num_examples:
                     raise NumExamplesMismatchError()
             if isinstance(inputs, dict) and isinstance(processed_inputs, Mapping):
-                inputs.update(processed_inputs)
-                return inputs
+                return {**inputs, **processed_inputs}
             else:
                 return processed_inputs
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1936,6 +1936,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 decorated_item = (
                     Example(item, features=self.features) if not batched else Batch(item, features=self.features)
                 )
+                # Use the LazyDict internally, while mapping the function
                 result = f(decorated_item, *args, **kwargs)
                 # Return a standard dict
                 return result.data if isinstance(result, LazyDict) else result

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1926,7 +1926,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         def decorate(f):
             """
-            Decorate the mapped function, so that its first argument is wrapped with a LazyDict to be used internally.
+            Decorate the mapped function, so that its first argument is wrapped with a LazyDict to be used internally
+            but a standard dictionary is returned at the end of the mapping.
             """
 
             @wraps(f)
@@ -1935,8 +1936,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 decorated_item = (
                     Example(item, features=self.features) if not batched else Batch(item, features=self.features)
                 )
-                # Use the LazyDict internally, while mapping the function
-                return f(decorated_item, *args, **kwargs)
+                result = f(decorated_item, *args, **kwargs)
+                # Return a standard dict
+                return result.data if isinstance(result, LazyDict) else result
 
             return decorated
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -339,7 +339,6 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
     elif isinstance(obj, pd.DataFrame):
         return obj.to_dict("list"), True
     elif isinstance(obj, Mapping):
-        obj = obj.data if isinstance(obj, UserDict) else obj
         has_changed = not isinstance(obj, dict)
         output = {}
         for k, v in obj.items():

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -337,7 +337,7 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         return obj.values.tolist(), True
     elif isinstance(obj, pd.DataFrame):
         return obj.to_dict("list"), True
-    elif isinstance(obj, Mapping):
+    elif isinstance(obj, Mapping):  # check for dict-like to handle nested LazyDict objects
         has_changed = not isinstance(obj, dict)
         output = {}
         for k, v in obj.items():

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -18,7 +18,6 @@ import copy
 import json
 import re
 import sys
-from collections import UserDict
 from collections.abc import Iterable, Mapping
 from dataclasses import InitVar, _asdict_inner, dataclass, field, fields
 from functools import reduce, wraps

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -18,7 +18,8 @@ import copy
 import json
 import re
 import sys
-from collections.abc import Iterable
+from collections import UserDict
+from collections.abc import Iterable, Mapping
 from dataclasses import InitVar, _asdict_inner, dataclass, field, fields
 from functools import reduce, wraps
 from operator import mul
@@ -337,9 +338,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         return obj.values.tolist(), True
     elif isinstance(obj, pd.DataFrame):
         return obj.to_dict("list"), True
-    elif isinstance(obj, dict):
+    elif isinstance(obj, Mapping):
+        obj = obj.data if isinstance(obj, UserDict) else obj
+        has_changed = not isinstance(obj, dict)
         output = {}
-        has_changed = False
         for k, v in obj.items():
             casted_v, has_changed_v = _cast_to_python_objects(
                 v, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1166,6 +1166,13 @@ class BaseDatasetTest(TestCase):
                         with dset.map(lambda example: {"otherfield": {"append_x": example["field"] + "x"}}) as dset:
                             self.assertEqual(dset[0], {"field": "a", "otherfield": {"append_x": "ax"}})
 
+    def test_map_return_example_as_dict_value(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with Dataset.from_dict({"en": ["aa", "bb"], "fr": ["cc", "dd"]}) as dset:
+                with self._to(in_memory, tmp_dir, dset) as dset:
+                    with dset.map(lambda example: {"translation": example}) as dset:
+                        self.assertEqual(dset[0], {"en": "aa", "fr": "cc", "translation": {"en": "aa", "fr": "cc"}})
+
     def test_map_fn_kwargs(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with Dataset.from_dict({"id": range(10)}) as dset:


### PR DESCRIPTION
I noticed this bug while answering [this question](https://discuss.huggingface.co/t/correct-way-to-create-a-dataset-from-a-csv-file/15686/11?u=mariosasko). 

This code replicates the bug:
```python
from datasets import Dataset
dset = Dataset.from_dict({"en": ["aa", "bb"], "fr": ["cc", "dd"]})
dset.map(lambda ex: {"translation": ex})
```
and this is the fix for it (before this PR):
```python
from datasets import Dataset
dset = Dataset.from_dict({"en": ["aa", "bb"], "fr": ["cc", "dd"]})
dset.map(lambda ex: {"translation": dict(ex)})
```

Internally, this can be fixed by merging two dicts via dict unpacking (instead of `dict.update) `in `Dataset.map`, which avoids creating recursive dictionaries.

P.S. `{**a, **b}` is slightly more performant than `a.update(b)` in my bencmarks.