### PR TITLE
Fix description links in dataset cards

### DIFF
--- a/datasets/app_reviews/README.md
+++ b/datasets/app_reviews/README.md
@@ -50,11 +50,11 @@ pretty_name: AppReviews
 
 ## Dataset Description
 
-- **Homepage: [Home Page](https://github.com/sealuzh/user_quality)
-- **Repository: [Repo Link](https://github.com/sealuzh/user_quality)
-- **Paper: [Link](https://giograno.me/assets/pdf/workshop/wama17.pdf)
+- **Homepage:** [Home Page](https://github.com/sealuzh/user_quality)
+- **Repository:** [Repo Link](https://github.com/sealuzh/user_quality)
+- **Paper:** [Link](https://giograno.me/assets/pdf/workshop/wama17.pdf)
 - **Leaderboard:
-- **Point of Contact: [Darshan Gandhi](darshangandhi1151@gmail.com)
+- **Point of Contact:** [Darshan Gandhi](darshangandhi1151@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/big_patent/README.md
+++ b/datasets/big_patent/README.md
@@ -68,9 +68,9 @@ pretty_name: Big Patent
 
 ## Dataset Description
 
-- **Homepage:[Big Patent](https://evasharma.github.io/bigpatent/)**
+- **Homepage:** [Big Patent](https://evasharma.github.io/bigpatent/)
 - **Repository:**
-- **Paper:[BIGPATENT: A Large-Scale Dataset for Abstractive and Coherent Summarization](https://arxiv.org/abs/1906.03741)**
+- **Paper:** [BIGPATENT: A Large-Scale Dataset for Abstractive and Coherent Summarization](https://arxiv.org/abs/1906.03741)
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/bn_hate_speech/README.md
+++ b/datasets/bn_hate_speech/README.md
@@ -50,10 +50,10 @@ pretty_name: Bengali Hate Speech Dataset
 
 ## Dataset Description
 
-- **Homepage: [Bengali Hate Speech Dataset](https://github.com/rezacsedu/Bengali-Hate-Speech-Dataset)**
-- **Repository: [Bengali Hate Speech Dataset](https://github.com/rezacsedu/Bengali-Hate-Speech-Dataset)**
-- **Paper: [Classification Benchmarks for Under-resourced Bengali Language based on Multichannel Convolutional-LSTM Network](https://arxiv.org/abs/2004.07807)**
-- **Point of Contact: [Md. Rezaul Karim](rezaul.karim.fit@gmail.com)**
+- **Homepage:** [Bengali Hate Speech Dataset](https://github.com/rezacsedu/Bengali-Hate-Speech-Dataset)
+- **Repository:** [Bengali Hate Speech Dataset](https://github.com/rezacsedu/Bengali-Hate-Speech-Dataset)
+- **Paper:** [Classification Benchmarks for Under-resourced Bengali Language based on Multichannel Convolutional-LSTM Network](https://arxiv.org/abs/2004.07807)
+- **Point of Contact:** [Md. Rezaul Karim](rezaul.karim.fit@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/cats_vs_dogs/README.md
+++ b/datasets/cats_vs_dogs/README.md
@@ -49,10 +49,10 @@ task_ids: []
 ## Dataset Description
 
 - **Homepage:** [Cats vs Dogs Dataset](https://www.microsoft.com/en-us/download/details.aspx?id=54765)
-- **Repository:** N/A
+- **Repository:**
 - **Paper:** [Paper](https://www.microsoft.com/en-us/research/wp-content/uploads/2007/10/CCS2007.pdf)
-- **Leaderboard:** N/A
-- **Point of Contact:** N/A
+- **Leaderboard:**
+- **Point of Contact:**
 
 ### Dataset Summary
 

--- a/datasets/dengue_filipino/README.md
+++ b/datasets/dengue_filipino/README.md
@@ -50,11 +50,11 @@ pretty_name: Dengue Dataset in Filipino
 
 ## Dataset Description
 
-- **Homepage: [Dengue Dataset in Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Repository: [Dengue Dataset in Filipino repository](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Paper: [IEEE paper](https://ieeexplore.ieee.org/document/8459963)**
+- **Homepage:** [Dengue Dataset in Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Repository:** [Dengue Dataset in Filipino repository](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Paper:** [IEEE paper](https://ieeexplore.ieee.org/document/8459963)
 - **Leaderboard:**
-- **Point of Contact: [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)**
+- **Point of Contact:** [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)
 
 ### Dataset Summary
 

--- a/datasets/disaster_response_messages/README.md
+++ b/datasets/disaster_response_messages/README.md
@@ -56,11 +56,11 @@ pretty_name: Disaster Response Messages
 
 ## Dataset Description
 
-- **Homepage: [HomePage](https://appen.com/datasets/combined-disaster-response-data/)
-- **Repository: [Repo to Download the Dataset](https://datasets.appen.com/appen_datasets/disaster_response_data/disaster_response_messages_training.csv)
+- **Homepage:** [HomePage](https://appen.com/datasets/combined-disaster-response-data/)
+- **Repository:** [Repo to Download the Dataset](https://datasets.appen.com/appen_datasets/disaster_response_data/disaster_response_messages_training.csv)
 - **Paper:
 - **Leaderboard:
-- **Point of Contact:[Darshan Gandhi](darshangandhi1151@gmail.com)
+- **Point of Contact:** [Darshan Gandhi](darshangandhi1151@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/dutch_social/README.md
+++ b/datasets/dutch_social/README.md
@@ -51,11 +51,11 @@ pretty_name: Dutch Social Media Collection
 
 ## Dataset Description
 
-- **Homepage:[Dutch Social Media Collection](http://datasets.coronawhy.org/dataset.xhtml?persistentId=doi:10.5072/FK2/MTPTL7)**
-- **Repository: **
-- **Paper:*(in-progress)* https://doi.org/10.5072/FK2/MTPTL7**
+- **Homepage:** [Dutch Social Media Collection](http://datasets.coronawhy.org/dataset.xhtml?persistentId=doi:10.5072/FK2/MTPTL7)
+- **Repository:**
+- **Paper:** *(in-progress)* https://doi.org/10.5072/FK2/MTPTL7
 - **Leaderboard:**
-- **Point of Contact: [Aakash Gupta](mailto:aakashg80@gmail.com)**
+- **Point of Contact:** [Aakash Gupta](mailto:aakashg80@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/fake_news_english/README.md
+++ b/datasets/fake_news_english/README.md
@@ -48,11 +48,11 @@ pretty_name: Fake News English
   - [Contributions](#contributions)
 
 ## Dataset Description
-- **Homepage: https://dl.acm.org/doi/10.1145/3201064.3201100** 
-- **Repository: https://github.com/jgolbeck/fakenews/**
-- **Paper: https://doi.org/10.1145/3201064.3201100**
+- **Homepage:** https://dl.acm.org/doi/10.1145/3201064.3201100**
+- **Repository:** https://github.com/jgolbeck/fakenews/
+- **Paper:** https://doi.org/10.1145/3201064.3201100
 - **Leaderboard:**
-- **Point of Contact: Jennifer Golbeck (http://www.jengolbeck.com)**
+- **Point of Contact:** Jennifer Golbeck (http://www.jengolbeck.com)
 
 ### Dataset Summary
 This dataset contains URLs of news articles classified as either fake or satire. The articles classified as fake also have the URL of a rebutting article.

--- a/datasets/fake_news_filipino/README.md
+++ b/datasets/fake_news_filipino/README.md
@@ -49,11 +49,11 @@ pretty_name: Fake News Filipino
 
 ## Dataset Description
 
-- **Homepage: [Fake News Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Repository: [Fake News Filipino repository](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Paper: [LREC 2020 paper](http://www.lrec-conf.org/proceedings/lrec2020/index.html)**
+- **Homepage:** [Fake News Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Repository:** [Fake News Filipino repository](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Paper:** [LREC 2020 paper](http://www.lrec-conf.org/proceedings/lrec2020/index.html)
 - **Leaderboard:**
-- **Point of Contact:[Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)**
+- **Point of Contact:** [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)
 
 ### Dataset Summary
 

--- a/datasets/freebase_qa/README.md
+++ b/datasets/freebase_qa/README.md
@@ -49,10 +49,10 @@ pretty_name: FreebaseQA
 ## Dataset Description
  
 - **Homepage:**
-- **Repository: [FreebaseQA repository](https://github.com/kelvin-jiang/FreebaseQA)**
-- **Paper: [FreebaseQA ACL paper](https://www.aclweb.org/anthology/N19-1028.pdf)**
+- **Repository:** [FreebaseQA repository](https://github.com/kelvin-jiang/FreebaseQA)
+- **Paper:** [FreebaseQA ACL paper](https://www.aclweb.org/anthology/N19-1028.pdf)
 - **Leaderboard:**
-- **Point of Contact: [Kelvin Jiang](https://github.com/kelvin-jiang)**
+- **Point of Contact:** [Kelvin Jiang](https://github.com/kelvin-jiang)
  
 ### Dataset Summary
  

--- a/datasets/glucose/README.md
+++ b/datasets/glucose/README.md
@@ -53,7 +53,7 @@ pretty_name: GLUCOSE
 
 - **[Repository](https://github.com/TevenLeScao/glucose)**
 - **[Paper](https://arxiv.org/abs/2009.07758)**
-- **Point of Contact: [glucose@elementalcognition.com](mailto:glucose@elementalcognition.com)**
+- **Point of Contact:** [glucose@elementalcognition.com](mailto:glucose@elementalcognition.com)
 
 ### Dataset Summary
 

--- a/datasets/gnad10/README.md
+++ b/datasets/gnad10/README.md
@@ -49,9 +49,9 @@ pretty_name: 10k German News Articles Datasets
 
 ## Dataset Description
 
-- **Homepage: [10k German News Article Dataset](https://tblock.github.io/10kGNAD/)**
-- **Repository: [10k German News Article Dataset](https://github.com/tblock/10kGNAD)()**
-- **Point of Contact: [Steven Liu](stevhliu@gmail.com)**
+- **Homepage:** [10k German News Article Dataset](https://tblock.github.io/10kGNAD/)
+- **Repository:** [10k German News Article Dataset](https://github.com/tblock/10kGNAD)
+- **Point of Contact:** [Steven Liu](stevhliu@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/grail_qa/README.md
+++ b/datasets/grail_qa/README.md
@@ -49,9 +49,9 @@ pretty_name: Grail QA
 
 ## Dataset Description
 
-- **Homepage: [Grail QA](https://dki-lab.github.io/GrailQA/)**
+- **Homepage:** [Grail QA](https://dki-lab.github.io/GrailQA/)
 - **Repository:**
-- **Paper:[GrailQA paper (Gu et al. '20)](https://arxiv.org/abs/2011.07743)**
+- **Paper:** [GrailQA paper (Gu et al. '20)](https://arxiv.org/abs/2011.07743)
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/hate_speech_filipino/README.md
+++ b/datasets/hate_speech_filipino/README.md
@@ -49,11 +49,11 @@ pretty_name: Hate Speech in Filipino
 
 ## Dataset Description
 
-- **Homepage: [Hate Speech Dataset in Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Repository: [Hate Speech Dataset in Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Paper: [PCJ paper](https://pcj.csp.org.ph/index.php/pcj/issue/download/29/PCJ%20V14%20N1%20pp1-14%202019)**
+- **Homepage:** [Hate Speech Dataset in Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Repository:** [Hate Speech Dataset in Filipino homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Paper:** [PCJ paper](https://pcj.csp.org.ph/index.php/pcj/issue/download/29/PCJ%20V14%20N1%20pp1-14%202019)
 - **Leaderboard:**
-- **Point of Contact: [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)**
+- **Point of Contact:** [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)
 
 ### Dataset Summary
 Contains 10k tweets (training set) that are labeled as hate speech or non-hate speech. Released with 4,232 validation and 4,232 testing samples. Collected during the 2016 Philippine Presidential Elections.

--- a/datasets/hind_encorp/README.md
+++ b/datasets/hind_encorp/README.md
@@ -50,9 +50,9 @@ pretty_name: HindEnCorp
 
 ## Dataset Description
 
-- **Homepage:https://lindat.mff.cuni.cz/repository/xmlui/handle/11858/00-097C-0000-0023-625F-0**
-- **Repository:https://lindat.mff.cuni.cz/repository/xmlui/**
-- **Paper:http://www.lrec-conf.org/proceedings/lrec2014/pdf/835_Paper.pdf**
+- **Homepage:** https://lindat.mff.cuni.cz/repository/xmlui/handle/11858/00-097C-0000-0023-625F-0
+- **Repository:** https://lindat.mff.cuni.cz/repository/xmlui/
+- **Paper:** http://www.lrec-conf.org/proceedings/lrec2014/pdf/835_Paper.pdf
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/jigsaw_unintended_bias/README.md
+++ b/datasets/jigsaw_unintended_bias/README.md
@@ -50,11 +50,11 @@ task_ids:
 
 ## Dataset Description
 
-- **Homepage: https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification **
-- **Repository: N/A **
-- **Paper: N/A **
-- **Leaderboard: https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification/leaderboard **
-- **Point of Contact: N/A **
+- **Homepage:** https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification
+- **Repository:**
+- **Paper:**
+- **Leaderboard:** https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification/leaderboard
+- **Point of Contact:**
 
 ### Dataset Summary
 

--- a/datasets/kor_3i4k/README.md
+++ b/datasets/kor_3i4k/README.md
@@ -49,10 +49,10 @@ pretty_name: 3i4K
 
 ## Dataset Description
 
-- **Homepage: [3i4K](https://github.com/warnikchow/3i4k)**
-- **Repository: [3i4K](https://github.com/warnikchow/3i4k)**
-- **Paper: [Speech Intention Understanding in a Head-final Language: A Disambiguation Utilizing Intonation-dependency](https://arxiv.org/abs/1811.04231)**
-- **Point of Contact: [Won Ik Cho](wicho@hi.snu.ac.kr)**
+- **Homepage:** [3i4K](https://github.com/warnikchow/3i4k)
+- **Repository:** [3i4K](https://github.com/warnikchow/3i4k)
+- **Paper:** [Speech Intention Understanding in a Head-final Language: A Disambiguation Utilizing Intonation-dependency](https://arxiv.org/abs/1811.04231)
+- **Point of Contact:** [Won Ik Cho](wicho@hi.snu.ac.kr)
 
 ### Dataset Summary
 

--- a/datasets/kor_hate/README.md
+++ b/datasets/kor_hate/README.md
@@ -50,10 +50,10 @@ pretty_name: Korean HateSpeech Dataset
 
 ## Dataset Description
 
-- **Homepage: [Korean HateSpeech Dataset](https://github.com/kocohub/korean-hate-speech)**
-- **Repository: [Korean HateSpeech Dataset](https://github.com/kocohub/korean-hate-speech)**
-- **Paper: [BEEP! Korean Corpus of Online News Comments for Toxic Speech Detection](https://arxiv.org/abs/2005.12503)**
-- **Point of Contact: [Steven Liu](stevhliu@gmail.com)**
+- **Homepage:** [Korean HateSpeech Dataset](https://github.com/kocohub/korean-hate-speech)
+- **Repository:** [Korean HateSpeech Dataset](https://github.com/kocohub/korean-hate-speech)
+- **Paper:** [BEEP! Korean Corpus of Online News Comments for Toxic Speech Detection](https://arxiv.org/abs/2005.12503)
+- **Point of Contact:** [Steven Liu](stevhliu@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/kor_sae/README.md
+++ b/datasets/kor_sae/README.md
@@ -49,10 +49,10 @@ pretty_name: Structured Argument Extraction for Korean
 
 ## Dataset Description
 
-- **Homepage: [Structured Argument Extraction for Korean](https://github.com/warnikchow/sae4k)**
-- **Repository: [Structured Argument Extraction for Korean](https://github.com/warnikchow/sae4k)**
-- **Paper: [Machines Getting with the Program: Understanding Intent Arguments of Non-Canonical Directives](https://arxiv.org/abs/1912.00342)**
-- **Point of Contact: [Won Ik Cho](wicho@hi.snu.ac.kr)**
+- **Homepage:** [Structured Argument Extraction for Korean](https://github.com/warnikchow/sae4k)
+- **Repository:** [Structured Argument Extraction for Korean](https://github.com/warnikchow/sae4k)
+- **Paper:** [Machines Getting with the Program: Understanding Intent Arguments of Non-Canonical Directives](https://arxiv.org/abs/1912.00342)
+- **Point of Contact:** [Won Ik Cho](wicho@hi.snu.ac.kr)
 
 ### Dataset Summary
 

--- a/datasets/kor_sarcasm/README.md
+++ b/datasets/kor_sarcasm/README.md
@@ -49,9 +49,9 @@ pretty_name: Korean Sarcasm Detection
 
 ## Dataset Description
 
-- **Homepage: [Korean Sarcasm Detection](https://github.com/SpellOnYou/korean-sarcasm)**
-- **Repository: [Korean Sarcasm Detection](https://github.com/SpellOnYou/korean-sarcasm)**
-- **Point of Contact: [Dionne Kim](jiwon.kim.096@gmail.com)**
+- **Homepage:** [Korean Sarcasm Detection](https://github.com/SpellOnYou/korean-sarcasm)
+- **Repository:** [Korean Sarcasm Detection](https://github.com/SpellOnYou/korean-sarcasm)
+- **Point of Contact:** [Dionne Kim](jiwon.kim.096@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/mbpp/README.md
+++ b/datasets/mbpp/README.md
@@ -55,8 +55,8 @@ task_ids:
     - [Contributions](#contributions)
 
 ## Dataset Description
-- **Repository: https://github.com/google-research/google-research/tree/master/mbpp**
-- **Paper: [Program Synthesis with Large Language Models](https://arxiv.org/abs/2108.07732)**
+- **Repository:** https://github.com/google-research/google-research/tree/master/mbpp
+- **Paper:** [Program Synthesis with Large Language Models](https://arxiv.org/abs/2108.07732)
 
 ### Dataset Summary
 The benchmark consists of around 1,000 crowd-sourced Python programming problems, designed to be solvable by entry level programmers, covering programming fundamentals, standard library functionality, and so on. Each problem consists of a task description, code solution and 3 automated test cases. As described in the paper, a subset of the data has been hand-verified by us. 

--- a/datasets/mocha/README.md
+++ b/datasets/mocha/README.md
@@ -49,9 +49,9 @@ paperswithcode_id: mocha
 
 ## Dataset Description
 
-- **Homepage:[Mocha](https://allennlp.org/mocha)**
-- **Repository:[https://github.com/anthonywchen/MOCHA](https://github.com/anthonywchen/MOCHA)**
-- **Paper:[MOCHA: A Dataset for Training and Evaluating Generative Reading Comprehension Metrics](https://www.aclweb.org/anthology/2020.emnlp-main.528/)**
+- **Homepage:** [Mocha](https://allennlp.org/mocha)
+- **Repository:** [https://github.com/anthonywchen/MOCHA](https://github.com/anthonywchen/MOCHA)
+- **Paper:** [MOCHA: A Dataset for Training and Evaluating Generative Reading Comprehension Metrics](https://www.aclweb.org/anthology/2020.emnlp-main.528/)
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/msr_sqa/README.md
+++ b/datasets/msr_sqa/README.md
@@ -49,9 +49,9 @@ pretty_name: Microsoft Research Sequential Question Answering
 
 ## Dataset Description
 
-- **Homepage:[Microsoft Research Sequential Question Answering (SQA) Dataset](https://msropendata.com/datasets/b25190ed-0f59-47b1-9211-5962858142c2)**
+- **Homepage:** [Microsoft Research Sequential Question Answering (SQA) Dataset](https://msropendata.com/datasets/b25190ed-0f59-47b1-9211-5962858142c2)
 - **Repository:**
-- **Paper:[https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/acl17-dynsp.pdf](https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/acl17-dynsp.pdf)**
+- **Paper:** [https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/acl17-dynsp.pdf](https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/acl17-dynsp.pdf)
 - **Leaderboard:**
 - **Point of Contact:**
   - Scott Wen-tau Yih        scottyih@microsoft.com

--- a/datasets/myanmar_news/README.md
+++ b/datasets/myanmar_news/README.md
@@ -23,7 +23,7 @@ pretty_name: MyanmarNews
 
 ## Dataset Description
 
-- **Repository: ** https://github.com/ayehninnkhine/MyanmarNewsClassificationSystem
+- **Repository:** https://github.com/ayehninnkhine/MyanmarNewsClassificationSystem
 
 ### Dataset Summary
 

--- a/datasets/newsph/README.md
+++ b/datasets/newsph/README.md
@@ -53,7 +53,7 @@ pretty_name: NewsPH-NLI
 ## Dataset Description
 
 - **Homepage:** [Filipino Text Benchmarks](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
-- **Repository: **
+- **Repository:**
 - **Paper:** [Investigating the True Performance of Transformers in Low-Resource Languages: A Case Study in Automatic Corpus Creation](https://arxiv.org/abs/2010.11574)
 - **Leaderboard:**
 - **Point of Contact:** [Jan Christian Blaise Cruz](jan_christian_cruz@dlsu.edu.ph)

--- a/datasets/newsph_nli/README.md
+++ b/datasets/newsph_nli/README.md
@@ -49,11 +49,11 @@ pretty_name: NewsPH NLI
 
 ## Dataset Description
 
-- **Homepage: [NewsPH NLI homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Repository: [NewsPH NLI repository](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)**
-- **Paper: [Arxiv paper](https://arxiv.org/pdf/2010.11574.pdf)**
+- **Homepage:** [NewsPH NLI homepage](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Repository:** [NewsPH NLI repository](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
+- **Paper:** [Arxiv paper](https://arxiv.org/pdf/2010.11574.pdf)
 - **Leaderboard:**
-- **Point of Contact: [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)**
+- **Point of Contact:** [Jan Christian Cruz](mailto:jan_christian_cruz@dlsu.edu.ph)
 
 ### Dataset Summary
 

--- a/datasets/ohsumed/README.md
+++ b/datasets/ohsumed/README.md
@@ -49,11 +49,11 @@ paperswithcode_id: null
 
 ## Dataset Description
 
-- **Homepage: http://davis.wpi.edu/xmdv/datasets/ohsumed.html**
-- **Repository: https://trec.nist.gov/data/filtering/t9.filtering.tar.gz**
-- **Paper: https://link.springer.com/chapter/10.1007/978-1-4471-2099-5_20**
+- **Homepage:** http://davis.wpi.edu/xmdv/datasets/ohsumed.html
+- **Repository:** https://trec.nist.gov/data/filtering/t9.filtering.tar.gz
+- **Paper:** https://link.springer.com/chapter/10.1007/978-1-4471-2099-5_20
 - **Leaderboard:**
-- **Point of Contact: [William Hersh](mailto:hersh@OHSU.EDU) [Aakash Gupta](mailto:aakashg80@gmail.com)**
+- **Point of Contact:** [William Hersh](mailto:hersh@OHSU.EDU) [Aakash Gupta](mailto:aakashg80@gmail.com)
 
 ### Dataset Summary
 

--- a/datasets/opus_rf/README.md
+++ b/datasets/opus_rf/README.md
@@ -77,11 +77,11 @@ pretty_name: OpusRf
 
 ## Dataset Description
 
-- **Homepage: http://opus.nlpl.eu/RF.php**
-- **Repository: NA**
-- **Paper: http://www.lrec-conf.org/proceedings/lrec2012/pdf/463_Paper.pdf**
-- **Leaderboard: [More Information Needed]**
-- **Point of Contact: [More Information Needed]**
+- **Homepage:** http://opus.nlpl.eu/RF.php
+- **Repository:**
+- **Paper:** http://www.lrec-conf.org/proceedings/lrec2012/pdf/463_Paper.pdf
+- **Leaderboard:** [More Information Needed]
+- **Point of Contact:** [More Information Needed]
 
 ### Dataset Summary
 

--- a/datasets/sem_eval_2018_task_1/README.md
+++ b/datasets/sem_eval_2018_task_1/README.md
@@ -52,11 +52,11 @@ task_ids:
 
 ## Dataset Description
 
-- **Homepage: https://competitions.codalab.org/competitions/17751**
+- **Homepage:** https://competitions.codalab.org/competitions/17751
 - **Repository:**
-- **Paper: http://saifmohammad.com/WebDocs/semeval2018-task1.pdf**
+- **Paper:** http://saifmohammad.com/WebDocs/semeval2018-task1.pdf
 - **Leaderboard:**
-- **Point of Contact: https://www.saifmohammad.com/**
+- **Point of Contact:** https://www.saifmohammad.com/
 
 ### Dataset Summary
 

--- a/datasets/sent_comp/README.md
+++ b/datasets/sent_comp/README.md
@@ -49,9 +49,9 @@ pretty_name: Google Sentence Compression
 
 ## Dataset Description
 
-- **Homepage:[https://github.com/google-research-datasets/sentence-compression](https://github.com/google-research-datasets/sentence-compression)**
-- **Repository:[https://github.com/google-research-datasets/sentence-compression](https://github.com/google-research-datasets/sentence-compression)**
-- **Paper:[https://www.aclweb.org/anthology/D13-1155/](https://www.aclweb.org/anthology/D13-1155/)**
+- **Homepage:** [https://github.com/google-research-datasets/sentence-compression](https://github.com/google-research-datasets/sentence-compression)
+- **Repository:** [https://github.com/google-research-datasets/sentence-compression](https://github.com/google-research-datasets/sentence-compression)
+- **Paper:** [https://www.aclweb.org/anthology/D13-1155/](https://www.aclweb.org/anthology/D13-1155/)
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/swahili/README.md
+++ b/datasets/swahili/README.md
@@ -51,11 +51,11 @@ pretty_name: swahili
 
 ## Dataset Description
 
-- **Homepage: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7339006/**
-- **Repository: NA**
-- **Paper: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7339006/**
-- **Leaderboard: [More Information Needed]**
-- **Point of Contact: [More Information Needed]**
+- **Homepage:** https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7339006/
+- **Repository:**
+- **Paper:** https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7339006/
+- **Leaderboard:** [More Information Needed]
+- **Point of Contact:** [More Information Needed]
 
 ### Dataset Summary
 

--- a/datasets/swda/README.md
+++ b/datasets/swda/README.md
@@ -49,11 +49,11 @@ pretty_name: The Switchboard Dialog Act Corpus (SwDA)
 
 ## Dataset Description
 
-- **Homepage: [The Switchboard Dialog Act Corpus](http://compprag.christopherpotts.net/swda.html)**
-- **Repository: [NathanDuran/Switchboard-Corpus](https://github.com/cgpotts/swda)**
-- **Paper:[The Switchboard Dialog Act Corpus](http://compprag.christopherpotts.net/swda.html)**
+- **Homepage:** [The Switchboard Dialog Act Corpus](http://compprag.christopherpotts.net/swda.html)
+- **Repository:** [NathanDuran/Switchboard-Corpus](https://github.com/cgpotts/swda)
+- **Paper:** [The Switchboard Dialog Act Corpus](http://compprag.christopherpotts.net/swda.html)
 = **Leaderboard: [Dialogue act classification](https://github.com/sebastianruder/NLP-progress/blob/master/english/dialogue.md#dialogue-act-classification)**
-- **Point of Contact: [Christopher Potts](https://web.stanford.edu/~cgpotts/)**
+- **Point of Contact:** [Christopher Potts](https://web.stanford.edu/~cgpotts/)
 
 ### Dataset Summary
 

--- a/datasets/telugu_news/README.md
+++ b/datasets/telugu_news/README.md
@@ -54,8 +54,8 @@ pretty_name: TeluguNews
 
 ## Dataset Description
 
-- **Homepage: https://www.kaggle.com/sudalairajkumar/telugu-nlp?select=telugu_news
-- **Repository: https://github.com/AnushaMotamarri/Telugu-Newspaper-Article-Dataset
+- **Homepage:** https://www.kaggle.com/sudalairajkumar/telugu-nlp?select=telugu_news
+- **Repository:** https://github.com/AnushaMotamarri/Telugu-Newspaper-Article-Dataset
 
 
 ### Dataset Summary

--- a/datasets/tuple_ie/README.md
+++ b/datasets/tuple_ie/README.md
@@ -49,9 +49,9 @@ pretty_name: TupleInf Open IE
 
 ## Dataset Description
 
-- **Homepage: [Tuple IE Homepage](https://allenai.org/data/tuple-ie)**
+- **Homepage:** [Tuple IE Homepage](https://allenai.org/data/tuple-ie)
 - **Repository:**
-- **Paper: [Answering Complex Questions Using Open Information Extraction](https://www.semanticscholar.org/paper/Answering-Complex-Questions-Using-Open-Information-Khot-Sabharwal/0ff595f0645a3e25a2f37145768985b10ead0509)**
+- **Paper:** [Answering Complex Questions Using Open Information Extraction](https://www.semanticscholar.org/paper/Answering-Complex-Questions-Using-Open-Information-Khot-Sabharwal/0ff595f0645a3e25a2f37145768985b10ead0509)
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/wiki_movies/README.md
+++ b/datasets/wiki_movies/README.md
@@ -50,9 +50,9 @@ paperswithcode_id: wikimovies
 
 ## Dataset Description
 
-- **Homepage: [WikiMovies Homepage](https://research.fb.com/downloads/babi/)**
+- **Homepage:** [WikiMovies Homepage](https://research.fb.com/downloads/babi/)
 - **Repository:**
-- **Paper: [Key-Value Memory Networks for Directly Reading Documents](https://arxiv.org/pdf/1606.03126.pdf)**
+- **Paper:** [Key-Value Memory Networks for Directly Reading Documents](https://arxiv.org/pdf/1606.03126.pdf)
 - **Leaderboard:**
 - **Point of Contact:**
 

--- a/datasets/wikitext_tl39/README.md
+++ b/datasets/wikitext_tl39/README.md
@@ -53,7 +53,7 @@ pretty_name: WikiText-TL-39
 ## Dataset Description
 
 - **Homepage:** [Filipino Text Benchmarks](https://github.com/jcblaisecruz02/Filipino-Text-Benchmarks)
-- **Repository: **
+- **Repository:**
 - **Paper:** [Evaluating language model finetuning techniques for low-resource languages](https://arxiv.org/abs/1907.00409)
 - **Leaderboard:**
 - **Point of Contact:** Jan Christian Blaise Cruz (jan_christian_cruz@dlsu.edu.ph)

--- a/datasets/wongnai_reviews/README.md
+++ b/datasets/wongnai_reviews/README.md
@@ -23,7 +23,7 @@ pretty_name: WongnaiReviews
 
 ## Dataset Description
 
-- **Repository: ** https://github.com/wongnai/wongnai-corpus
+- **Repository:** https://github.com/wongnai/wongnai-corpus
 
 ### Dataset Summary
 


### PR DESCRIPTION
I noticed many links were not properly displayed (only text, no link) on the Hub because of wrong syntax, e.g.: https://huggingface.co/datasets/big_patent

This PR fixes all description links in dataset cards.