### PR TITLE
Small fixes in ROC AUC docs

### DIFF
--- a/metrics/roc_auc/README.md
+++ b/metrics/roc_auc/README.md
@@ -1,13 +1,13 @@
-# Metric Card for RUC AOC
+# Metric Card for ROC AUC
 
 
 ## Metric Description
 This metric computes the area under the curve (AUC) for the Receiver Operating Characteristic Curve (ROC). The return values represent how well the model used is predicting the correct classes, based on the input data. A score of `0.5` means that the model is predicting exactly at chance, i.e. the model's predictions are correct at the same rate as if the predictions were being decided by the flip of a fair coin or the roll of a fair die. A score above `0.5` indicates that the model is doing better than chance, while a score below `0.5` indicates that the model is doing worse than chance.
 
 This metric has three separate use cases:
-    - **binary**: The case in which there are only two different label classes, and each example gets only one label. This is the default implementation.
-    - **multiclass**: The case in which there can be more than two different label classes, but each example still gets only one label.
-    - **multilabel**: The case in which there can be more than two different label classes, and each example can have more than one label.
+- **binary**: The case in which there are only two different label classes, and each example gets only one label. This is the default implementation.
+- **multiclass**: The case in which there can be more than two different label classes, but each example still gets only one label.
+- **multilabel**: The case in which there can be more than two different label classes, and each example can have more than one label.
 
 
 ## How to Use
@@ -39,9 +39,9 @@ See the [Examples Section Below](#examples_section) for more extensive examples.
     - binary: expects an array-like of shape (n_samples,)
     - multiclass: expects an array-like of shape (n_samples,)
     - multilabel: expects an array-like of shape (n_samples, n_classes)
-- **`prediction_scores`** (array-like of shape (n_samples,) or (n_samples, n_classes)): Ground truth labels. Expects different inputs based on use case:
+- **`prediction_scores`** (array-like of shape (n_samples,) or (n_samples, n_classes)): Model predictions. Expects different inputs based on use case:
     - binary: expects an array-like of shape (n_samples,)
-    - multiclass: expects an array-like of shape (n_samples,)
+    - multiclass: expects an array-like of shape (n_samples, n_classes). The probability estimates must sum to 1 across the possible classes.
     - multilabel: expects an array-like of shape (n_samples, n_classes)
 - **`average`** (`str`): Type of average, and is ignored in the binary use case. Defaults to `'macro'`. Options are:
     - `'micro'`: Calculates metrics globally by considering each element of the label indicator matrix as a label. Only works with the multilabel use case.

--- a/metrics/roc_auc/roc_auc.py
+++ b/metrics/roc_auc/roc_auc.py
@@ -33,9 +33,9 @@ Args:
     - binary: expects an array-like of shape (n_samples,)
     - multiclass: expects an array-like of shape (n_samples,)
     - multilabel: expects an array-like of shape (n_samples, n_classes)
-- prediction_scores (array-like of shape (n_samples,) or (n_samples, n_classes)): Ground truth labels. Expects different inputs based on use case:
+- prediction_scores (array-like of shape (n_samples,) or (n_samples, n_classes)): Model predictions. Expects different inputs based on use case:
     - binary: expects an array-like of shape (n_samples,)
-    - multiclass: expects an array-like of shape (n_samples,)
+    - multiclass: expects an array-like of shape (n_samples, n_classes)
     - multilabel: expects an array-like of shape (n_samples, n_classes)
 - average (`str`): Type of average, and is ignored in the binary use case. Defaults to 'macro'. Options are:
     - `'micro'`: Calculates metrics globally by considering each element of the label indicator matrix as a label. Only works with the multilabel use case.


### PR DESCRIPTION
The list of use cases did not render on GitHub with the prepended spacing.
Additionally, some typo's we're fixed.