### PR TITLE
Fix/start token mask issue and update documentation

### DIFF
--- a/metrics/perplexity/README.md
+++ b/metrics/perplexity/README.md
@@ -23,15 +23,16 @@ results = perplexity.compute(input_texts=input_texts, model_id='gpt2')
 ### Inputs
 - **model_id** (str): model used for calculating Perplexity. NOTE: Perplexity can only be calculated for causal language models.
     - This includes models such as gpt2, causal variations of bert, causal versions of t5, and more (the full list can be found in the AutoModelForCausalLM documentation here: https://huggingface.co/docs/transformers/master/en/model_doc/auto#transformers.AutoModelForCausalLM )
-- **input_texts** (list of str): input text, each separate text snippet is one list entry. Perplexity returned will be an average of the perplexity for each list entry.
-- **stride** (int): stride size, defaults to 512
+- **input_texts** (list of str): input text, each separate text snippet is one list entry.
+- **batch_size** (int): the batch size to run texts through the model. Defaults to 16.
+- **add_start_token** (bool): whether to add the start token to the texts, so the perplexity can include the probability of the first word. Defaults to True.
 - **device** (str): device to run on, defaults to 'cuda' when available
 
 ### Output Values
-This metric outputs a dictionary with one value: the average perplexity score for the text input in the list.
+This metric outputs a dictionary with the perplexity scores for the text input in the list, and the average perplexity.
 
 ```
-{'perplexity': 117.9}
+{'perplexities': [8.182524681091309, 33.42122268676758, 27.012239456176758], 'mean_perplexity': 22.871995608011883}
 ```
 
 This metric's range is 0 and up. A lower score is better.
@@ -45,27 +46,34 @@ Calculating perplexity on input_texts defined here:
 perplexity = datasets.load_metric("perplexity")
 input_texts = ["lorem ipsum", "Happy Birthday!", "Bienvenue"]
 results = perplexity.compute(model_id='gpt2',
-                              input_texts=input_texts,
-                              stride=1)
-round(results["perplexity"], 1)
->>> 78.2
+                             add_start_token=False,
+                             input_texts=input_texts)
+print(list(results.keys()))
+>>>['perplexities', 'mean_perplexity']
+print(round(results["mean_perplexity"], 2))
+>>>78.22
+print(round(results["perplexities"][0], 2))
+>>>11.11
 ```
 Calculating perplexity on input_texts loaded in from a dataset:
 ```python
 perplexity = datasets.load_metric("perplexity")
 input_texts = datasets.load_dataset("wikitext",
-                                     "wikitext-2-raw-v1",
-                                     split="test")["text"][:10]
-
+                                    "wikitext-2-raw-v1",
+                                    split="test")["text"][:50]
+input_texts = [s for s in input_texts if s!='']
 results = perplexity.compute(model_id='gpt2',
-                              input_texts=input_texts,
-                              stride=256)
-round(results["perplexity"], 1)
->>> 117.9
+                             input_texts=input_texts)
+print(list(results.keys()))
+>>>['perplexities', 'mean_perplexity']
+print(round(results["mean_perplexity"], 2))
+>>>60.35
+print(round(results["perplexities"][0], 2))
+>>>81.12
 ```
 
 ## Limitations and Bias
-Note that the output value is based heavily on what text the model was trained on. This means that perplexity scores are not comparable between models or datasets. 
+Note that the output value is based heavily on what text the model was trained on. This means that perplexity scores are not comparable between models or datasets.
 
 
 ## Citation

--- a/metrics/perplexity/README.md
+++ b/metrics/perplexity/README.md
@@ -30,6 +30,7 @@ results = perplexity.compute(input_texts=input_texts, model_id='gpt2')
 
 ### Output Values
 This metric outputs a dictionary with the perplexity scores for the text input in the list, and the average perplexity.
+If one of the input texts is longer than the max input length of the model, then it is truncated to the max length for the perplexity computation.
 
 ```
 {'perplexities': [8.182524681091309, 33.42122268676758, 27.012239456176758], 'mean_perplexity': 22.871995608011883}

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -50,7 +50,9 @@ Args:
     device (str): device to run on, defaults to 'cuda' when available
 Returns:
     perplexity: dictionary containing the perplexity scores for the texts
-        in the input list, as well as the mean perplexity.
+        in the input list, as well as the mean perplexity. If one of the input texts is
+        longer than the max input length of the model, then it is truncated to the
+        max length for the perplexity computation.
 Examples:
     Example 1:
         >>> perplexity = datasets.load_metric("perplexity")

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -161,6 +161,7 @@ class Perplexity(datasets.Metric):
             end_index = min(start_index + batch_size, len(encoded_texts))
             encoded_batch = encoded_texts[start_index:end_index]
             attn_mask = attn_masks[start_index:end_index]
+
             if add_start_token:
                 bos_tokens_tensor = torch.tensor([[tokenizer.bos_token_id]] * encoded_batch.size(dim=0)).to(device)
                 encoded_batch = torch.cat([bos_tokens_tensor, encoded_batch], dim=1)


### PR DESCRIPTION
This pr fixes a couple bugs:

1) the perplexity was calculated with a 0 in the attention mask for the start token, which was causing high perplexity scores that were not correct
2) the documentation was not updated