### PR TITLE
Add YAML tags to Dataset Card rotten tomatoes

### DIFF
--- a/datasets/rotten_tomatoes/README.md
+++ b/datasets/rotten_tomatoes/README.md
@@ -1,8 +1,26 @@
 ---
-pretty_name: RottenTomatoes - Movie Review Data
+pretty_name: RottenTomatoes - MR Movie Review Data
+annotations_creators:
+- crowdsourced
+language_creators:
+- crowdsourced
 languages:
 - en
-paperswithcode_id: null
+licenses:
+- unknown
+multilinguality:
+- monolingual
+task_categories:
+- text-classification
+task_ids:
+- sentiment-classification
+paperswithcode_id:
+- mr
+size_categories:
+- 1K<n<10K
+source_datasets:
+- original
+paperswithcode_id: mr
 ---
 
 # Dataset Card for "rotten_tomatoes"
@@ -35,7 +53,7 @@ paperswithcode_id: null
 
 - **Homepage:** [http://www.cs.cornell.edu/people/pabo/movie-review-data/](http://www.cs.cornell.edu/people/pabo/movie-review-data/)
 - **Repository:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
-- **Paper:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+- **Paper:** [https://arxiv.org/abs/cs/0506075](https://arxiv.org/abs/cs/0506075)
 - **Point of Contact:** [More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
 - **Size of downloaded dataset files:** 0.47 MB
 - **Size of the generated dataset:** 1.28 MB
@@ -74,7 +92,7 @@ An example of 'validation' looks as follows.
 ```
 {
     "label": 1,
-    "text": "Sometimes the days and nights just drag on-- it's the morning that make me feel alive. And I have one thing to thank for that: pancakes."
+    "text": "Sometimes the days and nights just drag on -- it 's the morning that make me feel alive . And I have one thing to thank for that : pancakes . "
 }
 ```
 

--- a/datasets/rotten_tomatoes/README.md
+++ b/datasets/rotten_tomatoes/README.md
@@ -14,8 +14,7 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id:
-- mr
+paperswithcode_id: mr
 size_categories:
 - 1K<n<10K
 source_datasets:

--- a/datasets/rotten_tomatoes/README.md
+++ b/datasets/rotten_tomatoes/README.md
@@ -20,7 +20,6 @@ size_categories:
 - 1K<n<10K
 source_datasets:
 - original
-paperswithcode_id: mr
 ---
 
 # Dataset Card for "rotten_tomatoes"


### PR DESCRIPTION
The dataset card for the rotten tomatoes / MR movie review dataset had some missing YAML tags. Hopefully, this also improves the visibility of this dataset now that paperswithcode and huggingface link to eachother.