### PR TITLE
Add HF Speech Bench to Librispeech Dataset Card

### DIFF
--- a/datasets/librispeech_asr/README.md
+++ b/datasets/librispeech_asr/README.md
@@ -63,7 +63,7 @@ LibriSpeech is a corpus of approximately 1000 hours of 16kHz read English speech
 
 ### Supported Tasks and Leaderboards
 
-- `automatic-speech-recognition`, `audio-speaker-identification`: The dataset can be used to train a model for Automatic Speech Recognition (ASR). The model is presented with an audio file and asked to transcribe the audio file to written text. The most common evaluation metric is the word error rate (WER). The task has an active Hugging Face leaderboard which can be found at https://huggingface.co/spaces/huggingface/hf-speech-bench and ranks models based on their WER.
+- `automatic-speech-recognition`, `audio-speaker-identification`: The dataset can be used to train a model for Automatic Speech Recognition (ASR). The model is presented with an audio file and asked to transcribe the audio file to written text. The most common evaluation metric is the word error rate (WER). The task has an active Hugging Face leaderboard which can be found at https://huggingface.co/spaces/huggingface/hf-speech-bench. The leaderboard ranks models uploaded to the Hub based on their WER. An external leaderboard at https://paperswithcode.com/sota/speech-recognition-on-librispeech-test-clean ranks the latest models from research and academia.
 
 ### Languages
 

--- a/datasets/librispeech_asr/README.md
+++ b/datasets/librispeech_asr/README.md
@@ -54,7 +54,7 @@ task_ids:
 - **Homepage:** [LibriSpeech ASR corpus](http://www.openslr.org/12)
 - **Repository:** [Needs More Information]
 - **Paper:** [LibriSpeech: An ASR Corpus Based On Public Domain Audio Books](https://www.danielpovey.com/files/2015_icassp_librispeech.pdf)
-- **Leaderboard:** [Paperswithcode Leaderboard](https://paperswithcode.com/sota/speech-recognition-on-librispeech-test-other)
+- **Leaderboard:** [The 🤗 Speech Bench](https://huggingface.co/spaces/huggingface/hf-speech-bench)
 - **Point of Contact:** [Daniel Povey](mailto:dpovey@gmail.com)
 
 ### Dataset Summary
@@ -63,7 +63,7 @@ LibriSpeech is a corpus of approximately 1000 hours of 16kHz read English speech
 
 ### Supported Tasks and Leaderboards
 
-- `automatic-speech-recognition`, `audio-speaker-identification`: The dataset can be used to train a model for Automatic Speech Recognition (ASR). The model is presented with an audio file and asked to transcribe the audio file to written text. The most common evaluation metric is the word error rate (WER). The task has an active leaderboard which can be found at https://paperswithcode.com/sota/speech-recognition-on-librispeech-test-clean and ranks models based on their WER.
+- `automatic-speech-recognition`, `audio-speaker-identification`: The dataset can be used to train a model for Automatic Speech Recognition (ASR). The model is presented with an audio file and asked to transcribe the audio file to written text. The most common evaluation metric is the word error rate (WER). The task has an active Hugging Face leaderboard which can be found at https://huggingface.co/spaces/huggingface/hf-speech-bench and ranks models based on their WER.
 
 ### Languages
 


### PR DESCRIPTION
Adds the HF Speech Bench to Librispeech Dataset Card in place of the Papers With Code Leaderboard. Should improve usage and visibility of this leaderboard! Wondering whether this can also be done for [Common Voice 7](https://huggingface.co/datasets/mozilla-foundation/common_voice_7_0) and [8](https://huggingface.co/datasets/mozilla-foundation/common_voice_8_0) through someone with permissions? 

cc @patrickvonplaten: more leaderboard promotion!