### PR TITLE
Enable label alignment for token classification datasets

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4408,7 +4408,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise ValueError(f"Column ({label_column}) not in table columns ({self._data.column_names}).")
 
         label_feature = self.features[label_column]
-        if not (isinstance(label_feature, ClassLabel) or (isinstance(label_feature, Sequence) and isinstance(label_feature.feature, ClassLabel))):
+        if not (
+            isinstance(label_feature, ClassLabel)
+            or (isinstance(label_feature, Sequence) and isinstance(label_feature.feature, ClassLabel))
+        ):
             raise ValueError(
                 f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} or {Sequence.__name__} column, and column {label_feature} is of type {type(label_feature).__name__}."
             )
@@ -4422,8 +4425,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             label_feature.int2str if isinstance(label_feature, ClassLabel) else label_feature.feature.int2str
         )
 
-        def process_label_ids(batch):
         if isinstance(label_feature, ClassLabel):
+
             def process_label_ids(batch):
                 dset_label_names = [
                     int2str_function(label_id).lower() if label_id is not None else None
@@ -4433,7 +4436,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     label2id[label_name] if label_name is not None else None for label_name in dset_label_names
                 ]
                 return batch
+
         else:
+
             def process_label_ids(batch):
                 dset_label_names = [
                     [int2str_function(label_id).lower() if label_id is not None else None for label_id in seq]

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4413,7 +4413,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             or (isinstance(label_feature, Sequence) and isinstance(label_feature.feature, ClassLabel))
         ):
             raise ValueError(
-                f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} or {Sequence.__name__} column, and column {label_feature} is of type {type(label_feature).__name__}."
+                f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} column or {Sequence.__name__} column with the inner type {ClassLabel.__name__}, and column {label_feature} is of type {type(label_feature).__name__}."
             )
 
         # Sort input mapping by ID value to ensure the label names are aligned

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4423,10 +4423,23 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         )
 
         def process_label_ids(batch):
-            dset_label_names = [
-                [int2str_function(label_id).lower() for label_id in seq] for seq in batch[label_column]
-            ]
-            batch[label_column] = [[label2id[label_name] for label_name in seq] for seq in dset_label_names]
+            if isinstance(label_feature, ClassLabel):
+                dset_label_names = [
+                    int2str_function(label_id).lower() if label_id is not None else None
+                    for label_id in batch[label_column]
+                ]
+                batch[label_column] = [
+                    label2id[label_name] if label_name is not None else None for label_name in dset_label_names
+                ]
+            else:
+                dset_label_names = [
+                    [int2str_function(label_id).lower() if label_id is not None else None for label_id in seq]
+                    for seq in batch[label_column]
+                ]
+                batch[label_column] = [
+                    [label2id[label_name] if label_name is not None else None for label_name in seq]
+                    for seq in dset_label_names
+                ]
             return batch
 
         features = self.features.copy()

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4408,30 +4408,33 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise ValueError(f"Column ({label_column}) not in table columns ({self._data.column_names}).")
 
         label_feature = self.features[label_column]
-        # if not isinstance(label_feature, ClassLabel):
-        #     raise ValueError(
-        #         f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} column, and column {label_feature} is {type(label_feature).__name__}."
-        #     )
+        if not (isinstance(label_feature, ClassLabel) or isinstance(label_feature, Sequence)):
+            raise ValueError(
+                f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} or {Sequence.__name__} column, and column {label_feature} is of type {type(label_feature).__name__}."
+            )
 
         # Sort input mapping by ID value to ensure the label names are aligned
         label2id = dict(sorted(label2id.items(), key=lambda item: item[1]))
         label_names = list(label2id.keys())
         # Some label mappings use uppercase label names so we lowercase them during alignment
         label2id = {k.lower(): v for k, v in label2id.items()}
-        int2str_function = label_feature.int2str if isinstance(label_feature, ClassLabel) else label_feature.feature.int2str
+        int2str_function = (
+            label_feature.int2str if isinstance(label_feature, ClassLabel) else label_feature.feature.int2str
+        )
 
         def process_label_ids(batch):
-            dset_label_names = []
-            for seq in batch[label_column]:
-                dset_label_names.append([int2str_function(label_id).lower() for label_id in seq])
-            outputs = []
-            for seq in dset_label_names:
-                outputs.append([label2id[label_name] for label_name in seq])
-            batch[label_column] = outputs
+            dset_label_names = [
+                [int2str_function(label_id).lower() for label_id in seq] for seq in batch[label_column]
+            ]
+            batch[label_column] = [[label2id[label_name] for label_name in seq] for seq in dset_label_names]
             return batch
 
         features = self.features.copy()
-        features[label_column] = ClassLabel(num_classes=len(label_names), names=label_names) if isinstance(label_feature, ClassLabel) else Sequence(ClassLabel(num_classes=len(label_names), names=label_names))
+        features[label_column] = (
+            ClassLabel(num_classes=len(label_names), names=label_names)
+            if isinstance(label_feature, ClassLabel)
+            else Sequence(ClassLabel(num_classes=len(label_names), names=label_names))
+        )
         return self.map(process_label_ids, features=features, batched=True, desc="Aligning the labels")
 
 


### PR DESCRIPTION
This PR extends the `Dataset.align_labels_with_mapping()` method to support alignment of label mappings between datasets and models for token classification (e.g. NER).

Example of usage:

```python
from datasets import load_dataset

ner_ds = load_dataset("conll2003", split="train")
# returns [3, 0, 7, 0, 0, 0, 7, 0, 0]
ner_ds[0]["ner_tags"]
# hypothetical model mapping with O <--> B-LOC
label2id = {
    "B-LOC": "0",
    "B-MISC": "7",
    "B-ORG": "3",
    "B-PER": "1",
    "I-LOC": "6",
    "I-MISC": "8",
    "I-ORG": "4",
    "I-PER": "2",
    "O": "5"
  }
ner_aligned_ds = ner_ds.align_labels_with_mapping(label2id, "ner_tags")
# returns [3, 5, 7, 5, 5, 5, 7, 5, 5]
ner_aligned_ds[0]["ner_tags"]
```

Context: we need this in AutoTrain to automatically align datasets / models during evaluation. cc @abhishekkrthakur 