### PR TITLE
Update minimal PyArrow version warning

### DIFF
--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -23,9 +23,9 @@ import pyarrow
 from packaging import version
 
 
-if version.parse(pyarrow.__version__).major < 5:
+if version.parse(pyarrow.__version__).major < 6:
     raise ImportWarning(
-        "To use `datasets`, the module `pyarrow>=5.0.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
+        "To use `datasets`, the module `pyarrow>=6.0.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."
     )
 


### PR DESCRIPTION
Update the minimal PyArrow version warning (should've been part of #4250). 