### PR TITLE
Remove a copy-paste sentence in dataset cards

### DIFF
--- a/datasets/adv_glue/README.md
+++ b/datasets/adv_glue/README.md
@@ -91,8 +91,6 @@ AdvGLUE deviates from the GLUE dataset, which has a base language of English.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/aeslc/README.md
+++ b/datasets/aeslc/README.md
@@ -59,8 +59,6 @@ There are two features:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/ag_news/README.md
+++ b/datasets/ag_news/README.md
@@ -84,8 +84,6 @@ in Neural Information Processing Systems 28 (NIPS 2015).
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/ai2_arc/README.md
+++ b/datasets/ai2_arc/README.md
@@ -75,8 +75,6 @@ A new dataset of 7,787 genuine grade-school level, multiple-choice science quest
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### ARC-Challenge

--- a/datasets/amazon_us_reviews/README.md
+++ b/datasets/amazon_us_reviews/README.md
@@ -74,8 +74,6 @@ Each Dataset contains the following columns :
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### Apparel_v1_00

--- a/datasets/anli/README.md
+++ b/datasets/anli/README.md
@@ -58,8 +58,6 @@ English
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/arcd/README.md
+++ b/datasets/arcd/README.md
@@ -71,8 +71,6 @@ pretty_name: ARCD
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/art/README.md
+++ b/datasets/art/README.md
@@ -55,7 +55,7 @@ the Abductive Natural Language Inference Dataset from AI2
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
+`
 
 ### Data Instances
 

--- a/datasets/aslg_pc12/README.md
+++ b/datasets/aslg_pc12/README.md
@@ -55,8 +55,6 @@ Synthetic English-ASL Gloss Parallel Corpus 2012
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/asnq/README.md
+++ b/datasets/asnq/README.md
@@ -68,8 +68,6 @@ https://research.google/pubs/pub47761/
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/billsum/README.md
+++ b/datasets/billsum/README.md
@@ -79,8 +79,6 @@ features for us bills. ca bills does not have.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/biomrc/README.md
+++ b/datasets/biomrc/README.md
@@ -55,8 +55,6 @@ We introduce BIOMRC, a large-scale cloze-style biomedical MRC dataset. Care was 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### biomrc_large_A

--- a/datasets/blended_skill_talk/README.md
+++ b/datasets/blended_skill_talk/README.md
@@ -55,8 +55,6 @@ A dataset of 7k conversations explicitly designed to exhibit multiple conversati
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/blimp/README.md
+++ b/datasets/blimp/README.md
@@ -75,8 +75,6 @@ expert-crafted grammars.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### adjunct_island

--- a/datasets/blog_authorship_corpus/README.md
+++ b/datasets/blog_authorship_corpus/README.md
@@ -84,8 +84,6 @@ The language of the dataset is English (`en`).
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### blog-authorship-corpus

--- a/datasets/bookcorpus/README.md
+++ b/datasets/bookcorpus/README.md
@@ -73,8 +73,6 @@ Books are a rich source of both fine-grained information, how a character, an ob
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/bookcorpusopen/README.md
+++ b/datasets/bookcorpusopen/README.md
@@ -74,8 +74,6 @@ This version of bookcorpus has 17868 dataset items (books). Each item contains t
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/boolq/README.md
+++ b/datasets/boolq/README.md
@@ -58,8 +58,6 @@ The text-pair classification setup is similar to existing natural language infer
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/break_data/README.md
+++ b/datasets/break_data/README.md
@@ -57,8 +57,6 @@ This repository contains the Break dataset along with information on the exact d
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### QDMR

--- a/datasets/cfq/README.md
+++ b/datasets/cfq/README.md
@@ -60,8 +60,6 @@ data = datasets.load_dataset('cfq/mcd1')
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### mcd1

--- a/datasets/civil_comments/README.md
+++ b/datasets/civil_comments/README.md
@@ -66,8 +66,6 @@ dataset is released under CC0, as is the underlying comment text.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/clue/README.md
+++ b/datasets/clue/README.md
@@ -55,8 +55,6 @@ evaluating, and analyzing Chinese language understanding systems.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### afqmc

--- a/datasets/cmrc2018/README.md
+++ b/datasets/cmrc2018/README.md
@@ -75,8 +75,6 @@ inference throughout the context.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/coarse_discourse/README.md
+++ b/datasets/coarse_discourse/README.md
@@ -53,8 +53,6 @@ dataset contains discourse annotation and relation on threads from reddit during
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/com_qa/README.md
+++ b/datasets/com_qa/README.md
@@ -64,8 +64,6 @@ temporal or measurable quantities, TIMEX3 and the International System of Units 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/common_gen/README.md
+++ b/datasets/common_gen/README.md
@@ -68,8 +68,6 @@ crowd-sourcing from AMT and existing caption corpora, consists of 30k concept-se
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/commonsense_qa/README.md
+++ b/datasets/commonsense_qa/README.md
@@ -58,8 +58,6 @@ CommonsenseQA is a new multiple-choice question answering dataset that requires 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/compguesswhat/README.md
+++ b/datasets/compguesswhat/README.md
@@ -55,8 +55,6 @@ pretty_name: CompGuessWhat?!
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### compguesswhat-original

--- a/datasets/conll2000/README.md
+++ b/datasets/conll2000/README.md
@@ -64,8 +64,6 @@ Sabine Buchholz from Tilburg University, The Netherlands.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### conll2000

--- a/datasets/conllpp/README.md
+++ b/datasets/conllpp/README.md
@@ -79,8 +79,6 @@ correction on the test set for example, is:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### conllpp

--- a/datasets/coqa/README.md
+++ b/datasets/coqa/README.md
@@ -55,8 +55,6 @@ CoQA: A Conversational Question Answering Challenge
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/cornell_movie_dialog/README.md
+++ b/datasets/cornell_movie_dialog/README.md
@@ -67,8 +67,6 @@ This corpus contains a large metadata-rich collection of fictional conversations
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/cos_e/README.md
+++ b/datasets/cos_e/README.md
@@ -57,8 +57,6 @@ inference in a novel Commonsense Auto-Generated Explanation (CAGE) framework.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### v1.0

--- a/datasets/cosmos_qa/README.md
+++ b/datasets/cosmos_qa/README.md
@@ -55,8 +55,6 @@ Cosmos QA is a large-scale dataset of 35.6K problems that require commonsense-ba
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/crd3/README.md
+++ b/datasets/crd3/README.md
@@ -77,8 +77,6 @@ The text in the dataset is in English, as spoken by actors on The Critical Role 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/crime_and_punish/README.md
+++ b/datasets/crime_and_punish/README.md
@@ -53,8 +53,6 @@ pretty_name: CrimeAndPunish
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### crime-and-punish

--- a/datasets/daily_dialog/README.md
+++ b/datasets/daily_dialog/README.md
@@ -77,8 +77,6 @@ benefit the research field of dialog systems.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/definite_pronoun_resolution/README.md
+++ b/datasets/definite_pronoun_resolution/README.md
@@ -63,8 +63,6 @@ more than once in the sentence, its first occurrence is the one to be resolved.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/discofuse/README.md
+++ b/datasets/discofuse/README.md
@@ -55,8 +55,6 @@ pretty_name: DiscoFuse
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### discofuse-sport

--- a/datasets/docred/README.md
+++ b/datasets/docred/README.md
@@ -73,8 +73,6 @@ Multiple entities in a document generally exhibit complex inter-sentence relatio
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/doqa/README.md
+++ b/datasets/doqa/README.md
@@ -65,8 +65,6 @@ DoQA enables the development and evaluation of conversational QA systems that he
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cooking

--- a/datasets/drop/README.md
+++ b/datasets/drop/README.md
@@ -77,8 +77,6 @@ question, perhaps to multiple input positions, and perform discrete operations o
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/emo/README.md
+++ b/datasets/emo/README.md
@@ -55,8 +55,6 @@ In this dataset, given a textual dialogue i.e. an utterance along with two previ
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### emo2019

--- a/datasets/emotion/README.md
+++ b/datasets/emotion/README.md
@@ -72,8 +72,6 @@ Emotion is a dataset of English Twitter messages with six basic emotions: anger,
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/empathetic_dialogues/README.md
+++ b/datasets/empathetic_dialogues/README.md
@@ -55,8 +55,6 @@ PyTorch original implementation of Towards Empathetic Open-domain Conversation M
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/eraser_multi_rc/README.md
+++ b/datasets/eraser_multi_rc/README.md
@@ -61,8 +61,6 @@ answers and a rationalte. Each example in this dataset has the following 5 parts
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/esnli/README.md
+++ b/datasets/esnli/README.md
@@ -57,8 +57,6 @@ relations.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/event2Mind/README.md
+++ b/datasets/event2Mind/README.md
@@ -55,8 +55,6 @@ In Event2Mind, we explore the task of understanding stereotypical intents and re
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/fever/README.md
+++ b/datasets/fever/README.md
@@ -78,8 +78,6 @@ The dataset is in English.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### v1.0

--- a/datasets/flores/README.md
+++ b/datasets/flores/README.md
@@ -83,8 +83,6 @@ Evaluation datasets for low-resource machine translation: Nepali-English and Sin
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### neen

--- a/datasets/fquad/README.md
+++ b/datasets/fquad/README.md
@@ -80,8 +80,6 @@ This dataset is exclusively in French, with context data from Wikipedia and ques
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/gap/README.md
+++ b/datasets/gap/README.md
@@ -58,8 +58,6 @@ applications.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/gem/README.md
+++ b/datasets/gem/README.md
@@ -382,8 +382,6 @@ Each example has one `target` per example in its training set, and a set of `ref
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### common_gen

--- a/datasets/germeval_14/README.md
+++ b/datasets/germeval_14/README.md
@@ -53,8 +53,6 @@ The GermEval 2014 NER Shared Task builds on a new dataset with German Named Enti
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### germeval_14

--- a/datasets/glue/README.md
+++ b/datasets/glue/README.md
@@ -166,8 +166,6 @@ The language data in GLUE is in English (BCP-47 `en`)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### ax

--- a/datasets/guardian_authorship/README.md
+++ b/datasets/guardian_authorship/README.md
@@ -68,8 +68,6 @@ IMPORTANT: train+validation+test[:60%] will generate the wrong splits becasue th
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cross_genre_1

--- a/datasets/hans/README.md
+++ b/datasets/hans/README.md
@@ -71,8 +71,6 @@ The HANS dataset is an NLI evaluation set that tests specific hypotheses about i
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/hansards/README.md
+++ b/datasets/hansards/README.md
@@ -73,8 +73,6 @@ from the DARPA TIDES program.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### house

--- a/datasets/hellaswag/README.md
+++ b/datasets/hellaswag/README.md
@@ -53,8 +53,6 @@ pretty_name: HellaSwag
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/hotpot_qa/README.md
+++ b/datasets/hotpot_qa/README.md
@@ -55,8 +55,6 @@ HotpotQA is a new dataset with 113k  Wikipedia-based question-answer  pairs with
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### distractor

--- a/datasets/hyperpartisan_news_detection/README.md
+++ b/datasets/hyperpartisan_news_detection/README.md
@@ -60,8 +60,6 @@ There are 2 parts:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### byarticle

--- a/datasets/imdb/README.md
+++ b/datasets/imdb/README.md
@@ -72,8 +72,6 @@ This is a dataset for binary sentiment classification containing substantially m
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/indic_glue/README.md
+++ b/datasets/indic_glue/README.md
@@ -71,8 +71,6 @@ Indian languages by AI4Bharat.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### actsa-sc.te

--- a/datasets/iwslt2017/README.md
+++ b/datasets/iwslt2017/README.md
@@ -57,8 +57,6 @@ For each language pair, training and development sets are available through the 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### iwslt2017-ar-en

--- a/datasets/jeopardy/README.md
+++ b/datasets/jeopardy/README.md
@@ -67,8 +67,6 @@ Note: Tiebreaker questions do happen but they're very rare (like once every 20 y
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/kilt_wikipedia/README.md
+++ b/datasets/kilt_wikipedia/README.md
@@ -53,8 +53,6 @@ KILT-Wikipedia: Wikipedia pre-processed for KILT.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### 2019-08-01

--- a/datasets/kor_nli/README.md
+++ b/datasets/kor_nli/README.md
@@ -53,8 +53,6 @@ pretty_name: KorNLI
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### multi_nli

--- a/datasets/lc_quad/README.md
+++ b/datasets/lc_quad/README.md
@@ -55,8 +55,6 @@ LC-QuAD 2.0 is a Large Question Answering dataset with 30,000 pairs of question 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/librispeech_lm/README.md
+++ b/datasets/librispeech_lm/README.md
@@ -53,8 +53,6 @@ Language modeling resources to be used in conjunction with the LibriSpeech ASR c
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/lince/README.md
+++ b/datasets/lince/README.md
@@ -55,8 +55,6 @@ NLP systems on code-switching tasks.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### lid_hineng

--- a/datasets/math_dataset/README.md
+++ b/datasets/math_dataset/README.md
@@ -69,8 +69,6 @@ train_examples, val_examples = datasets.load_dataset(
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### algebra__linear_1d

--- a/datasets/math_qa/README.md
+++ b/datasets/math_qa/README.md
@@ -55,8 +55,6 @@ Our dataset is gathered by using a new representation language to annotate over 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/matinf/README.md
+++ b/datasets/matinf/README.md
@@ -58,8 +58,6 @@ merits held by MATINF.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### age_classification

--- a/datasets/mlqa/README.md
+++ b/datasets/mlqa/README.md
@@ -58,8 +58,6 @@ paperswithcode_id: mlqa
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### mlqa-translate-test.ar

--- a/datasets/mlsum/README.md
+++ b/datasets/mlsum/README.md
@@ -93,8 +93,6 @@ These highlight existing biases which motivate the use of a multi-lingual datase
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### de

--- a/datasets/movie_rationales/README.md
+++ b/datasets/movie_rationales/README.md
@@ -56,8 +56,6 @@ reviews.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/ms_marco/README.md
+++ b/datasets/ms_marco/README.md
@@ -72,8 +72,6 @@ version v1.1
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### v1.1

--- a/datasets/multi_news/README.md
+++ b/datasets/multi_news/README.md
@@ -79,8 +79,6 @@ There are two features:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/multi_nli_mismatch/README.md
+++ b/datasets/multi_nli_mismatch/README.md
@@ -81,8 +81,6 @@ basis for the shared task of the RepEval 2017 Workshop at EMNLP in Copenhagen.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/mwsc/README.md
+++ b/datasets/mwsc/README.md
@@ -56,8 +56,6 @@ This modified Winograd Schema Challenge (MWSC) ensures that scores are neither i
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/natural_questions/README.md
+++ b/datasets/natural_questions/README.md
@@ -75,8 +75,6 @@ NQ to be a more realistic and challenging task than prior QA datasets.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/newsgroup/README.md
+++ b/datasets/newsgroup/README.md
@@ -60,8 +60,6 @@ does not include cross-posts and includes only the "From" and "Subject" headers.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### 18828_alt.atheism

--- a/datasets/newsroom/README.md
+++ b/datasets/newsroom/README.md
@@ -90,8 +90,6 @@ English (`en`).
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/nli_tr/README.md
+++ b/datasets/nli_tr/README.md
@@ -80,8 +80,6 @@ The Natural Language Inference in Turkish (NLI-TR) is a set of two large scale d
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### multinli_tr

--- a/datasets/openbookqa/README.md
+++ b/datasets/openbookqa/README.md
@@ -77,8 +77,6 @@ a subject.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### additional

--- a/datasets/openwebtext/README.md
+++ b/datasets/openwebtext/README.md
@@ -73,8 +73,6 @@ An open-source replication of the WebText dataset from OpenAI.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/opinosis/README.md
+++ b/datasets/opinosis/README.md
@@ -56,8 +56,6 @@ Topics and opinions are obtained from Tripadvisor, Edmunds.com and Amazon.com.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/para_crawl/README.md
+++ b/datasets/para_crawl/README.md
@@ -93,8 +93,6 @@ Web-Scale Parallel Corpora for Official European Languages.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### enbg

--- a/datasets/pg19/README.md
+++ b/datasets/pg19/README.md
@@ -64,8 +64,6 @@ One could use this dataset for benchmarking long-range language models, or use i
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/piaf/README.md
+++ b/datasets/piaf/README.md
@@ -72,8 +72,6 @@ Piaf is a reading comprehension dataset. This version, published in February 202
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/polyglot_ner/README.md
+++ b/datasets/polyglot_ner/README.md
@@ -116,8 +116,6 @@ corresponding to a different language. For example, "es" includes only spanish e
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### ar

--- a/datasets/qa4mre/README.md
+++ b/datasets/qa4mre/README.md
@@ -58,8 +58,6 @@ alzheimers data, and the other on entrance exams data.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### 2011.main.DE

--- a/datasets/qa_zre/README.md
+++ b/datasets/qa_zre/README.md
@@ -71,8 +71,6 @@ A dataset reducing relation extraction to simple reading comprehension questions
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/qangaroo/README.md
+++ b/datasets/qangaroo/README.md
@@ -61,8 +61,6 @@ The two QAngaroo datasets provide a training and evaluation resource for such me
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### masked_medhop

--- a/datasets/qanta/README.md
+++ b/datasets/qanta/README.md
@@ -55,8 +55,6 @@ The Qanta dataset is a question answering dataset based on the academic trivia g
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### mode=first,char_skip=25

--- a/datasets/qasc/README.md
+++ b/datasets/qasc/README.md
@@ -56,8 +56,6 @@ questions about grade school science (8,134 train, 926 dev, 920 test), and comes
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/quail/README.md
+++ b/datasets/quail/README.md
@@ -55,8 +55,6 @@ QuAIL is a  reading comprehension dataset. QuAIL contains 15K multi-choice quest
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### quail

--- a/datasets/quarel/README.md
+++ b/datasets/quarel/README.md
@@ -55,8 +55,6 @@ QuaRel is a crowdsourced dataset of 2771 multiple-choice story questions, includ
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/quartz/README.md
+++ b/datasets/quartz/README.md
@@ -60,8 +60,6 @@ The dataset is split into train (2696), dev (384) and test (784). A background s
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/quora/README.md
+++ b/datasets/quora/README.md
@@ -55,8 +55,6 @@ The Quora dataset is composed of question pairs, and the task is to determine if
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/quoref/README.md
+++ b/datasets/quoref/README.md
@@ -57,8 +57,6 @@ coreferences before selecting the appropriate span(s) in the paragraphs for answ
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/race/README.md
+++ b/datasets/race/README.md
@@ -57,8 +57,6 @@ The dataset can be served as the training and test sets for machine comprehensio
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### all

--- a/datasets/reddit/README.md
+++ b/datasets/reddit/README.md
@@ -85,8 +85,6 @@ English
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/reddit_tifu/README.md
+++ b/datasets/reddit_tifu/README.md
@@ -82,8 +82,6 @@ Features includes:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### long

--- a/datasets/reuters21578/README.md
+++ b/datasets/reuters21578/README.md
@@ -56,8 +56,6 @@ categorization research. It is collected from the Reuters financial newswire ser
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### ModApte

--- a/datasets/rotten_tomatoes/README.md
+++ b/datasets/rotten_tomatoes/README.md
@@ -76,8 +76,6 @@ ACL, 2005.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/saudinewsnet/README.md
+++ b/datasets/saudinewsnet/README.md
@@ -90,8 +90,6 @@ The dataset currently contains **31,030** Arabic articles (with a total number o
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/scan/README.md
+++ b/datasets/scan/README.md
@@ -102,8 +102,6 @@ data = datasets.load_dataset('scan/length')
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### addprim_jump

--- a/datasets/scicite/README.md
+++ b/datasets/scicite/README.md
@@ -70,8 +70,6 @@ Method, Background, Result
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/scientific_papers/README.md
+++ b/datasets/scientific_papers/README.md
@@ -61,8 +61,6 @@ Both "arxiv" and "pubmed" have two features:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### arxiv

--- a/datasets/scifact/README.md
+++ b/datasets/scifact/README.md
@@ -55,8 +55,6 @@ SciFact, a dataset of 1.4K expert-written scientific claims paired with evidence
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### claims

--- a/datasets/sciq/README.md
+++ b/datasets/sciq/README.md
@@ -55,8 +55,6 @@ The SciQ dataset contains 13,679 crowdsourced science exam questions about Physi
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/scitail/README.md
+++ b/datasets/scitail/README.md
@@ -60,8 +60,6 @@ with neutral label
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### dgem_format

--- a/datasets/search_qa/README.md
+++ b/datasets/search_qa/README.md
@@ -61,8 +61,6 @@ Following this approach, we built SearchQA, which consists of more than 140k que
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### raw_jeopardy

--- a/datasets/sem_eval_2010_task_8/README.md
+++ b/datasets/sem_eval_2010_task_8/README.md
@@ -57,8 +57,6 @@ and to provide a standard testbed for future research.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/sentiment140/README.md
+++ b/datasets/sentiment140/README.md
@@ -56,8 +56,6 @@ sentiment classification. For more detailed information please refer to the pape
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### sentiment140

--- a/datasets/social_bias_frames/README.md
+++ b/datasets/social_bias_frames/README.md
@@ -79,8 +79,6 @@ The language in SBIC is predominantly white-aligned English (78%, using a lexica
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 Each instance contains a post that may contain an offensive statement and annotated information concerning the nature of the offensive implication as well as the demographics of the annotator and origin of the post. See the [Social Bias Frames dataset viewer](https://huggingface.co/datasets/viewer/?dataset=social_bias_frames) to explore more examples. 

--- a/datasets/social_i_qa/README.md
+++ b/datasets/social_i_qa/README.md
@@ -55,8 +55,6 @@ We introduce Social IQa: Social Interaction QA, a new question-answering benchma
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/sogou_news/README.md
+++ b/datasets/sogou_news/README.md
@@ -56,8 +56,6 @@ URL http://sports.sohu.com is categorized as a sport class.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/squad/README.md
+++ b/datasets/squad/README.md
@@ -72,8 +72,6 @@ Stanford Question Answering Dataset (SQuAD) is a reading comprehension dataset, 
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/squad_es/README.md
+++ b/datasets/squad_es/README.md
@@ -53,8 +53,6 @@ automatic translation of the Stanford Question Answering Dataset (SQuAD) v2 into
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### v1.1.0

--- a/datasets/squad_it/README.md
+++ b/datasets/squad_it/README.md
@@ -75,8 +75,6 @@ into Italian. It represents a large-scale dataset for open question answering pr
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/squad_v1_pt/README.md
+++ b/datasets/squad_v1_pt/README.md
@@ -72,8 +72,6 @@ Portuguese translation of the SQuAD dataset. The translation was performed autom
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/squad_v2/README.md
+++ b/datasets/squad_v2/README.md
@@ -74,8 +74,6 @@ combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable questio
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### squad_v2

--- a/datasets/squadshifts/README.md
+++ b/datasets/squadshifts/README.md
@@ -56,8 +56,6 @@ Times articles, Reddit comments, and Amazon product reviews. Each dataset was ge
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### amazon

--- a/datasets/style_change_detection/README.md
+++ b/datasets/style_change_detection/README.md
@@ -55,8 +55,6 @@ Access to the dataset needs to be requested from zenodo.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### narrow

--- a/datasets/super_glue/README.md
+++ b/datasets/super_glue/README.md
@@ -62,8 +62,6 @@ Wikipedia article containing the answer. Following the original work, we evaluat
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### axb

--- a/datasets/ted_hrlr/README.md
+++ b/datasets/ted_hrlr/README.md
@@ -54,8 +54,6 @@ where one is high resource and the other is low resource.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### az_to_en

--- a/datasets/ted_multi/README.md
+++ b/datasets/ted_multi/README.md
@@ -55,8 +55,6 @@ incomplete translations will be filtered out.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text

--- a/datasets/tiny_shakespeare/README.md
+++ b/datasets/tiny_shakespeare/README.md
@@ -68,8 +68,6 @@ d = d.batch(batch_size)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/trec/README.md
+++ b/datasets/trec/README.md
@@ -57,8 +57,6 @@ Data are collected from four sources: 4,500 English questions published by USC (
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/trivia_qa/README.md
+++ b/datasets/trivia_qa/README.md
@@ -81,8 +81,6 @@ English.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### rc

--- a/datasets/tydiqa/README.md
+++ b/datasets/tydiqa/README.md
@@ -87,8 +87,6 @@ the use of translation (unlike MLQA and XQuAD).
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### primary_task

--- a/datasets/ubuntu_dialogs_corpus/README.md
+++ b/datasets/ubuntu_dialogs_corpus/README.md
@@ -55,8 +55,6 @@ Ubuntu Dialogue Corpus, a dataset containing almost 1 million multi-turn dialogu
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### train

--- a/datasets/web_of_science/README.md
+++ b/datasets/web_of_science/README.md
@@ -79,8 +79,6 @@ Web of Science Dataset WOS-5736
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### WOS11967

--- a/datasets/web_questions/README.md
+++ b/datasets/web_questions/README.md
@@ -58,8 +58,6 @@ The questions are popular ones asked on the web (at least in 2013).
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/wiki40b/README.md
+++ b/datasets/wiki40b/README.md
@@ -60,8 +60,6 @@ that removes non-content sections and structured objects.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### en

--- a/datasets/wiki_dpr/README.md
+++ b/datasets/wiki_dpr/README.md
@@ -81,8 +81,6 @@ The wikipedia dump is the one from Dec. 20, 2018.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 Each instance contains a paragraph of at most 100 words, as well as the title of the wikipedia page it comes from, and the DPR embedding (a 768-d vector).

--- a/datasets/wiki_qa/README.md
+++ b/datasets/wiki_qa/README.md
@@ -55,8 +55,6 @@ Wiki Question Answering corpus from Microsoft
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/wiki_split/README.md
+++ b/datasets/wiki_split/README.md
@@ -57,8 +57,6 @@ the dataset contains some inherent noise, it can serve as valuable training data
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/wikipedia/README.md
+++ b/datasets/wikipedia/README.md
@@ -714,8 +714,6 @@ You can find the list of languages [here](https://meta.wikimedia.org/wiki/List_o
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 An example looks as follows:

--- a/datasets/wikisql/README.md
+++ b/datasets/wikisql/README.md
@@ -55,8 +55,6 @@ A large crowd-sourced dataset for developing natural language interfaces for rel
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/wikitext/README.md
+++ b/datasets/wikitext/README.md
@@ -80,8 +80,6 @@ that can take advantage of long term dependencies.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### wikitext-103-raw-v1

--- a/datasets/winogrande/README.md
+++ b/datasets/winogrande/README.md
@@ -58,8 +58,6 @@ commonsense reasoning.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### winogrande_debiased

--- a/datasets/wiqa/README.md
+++ b/datasets/wiqa/README.md
@@ -56,8 +56,6 @@ The dataset is split into 29808 train questions, 6894 dev questions and 3003 tes
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/wmt14/README.md
+++ b/datasets/wmt14/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cs-en

--- a/datasets/wmt15/README.md
+++ b/datasets/wmt15/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cs-en

--- a/datasets/wmt16/README.md
+++ b/datasets/wmt16/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cs-en

--- a/datasets/wmt17/README.md
+++ b/datasets/wmt17/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cs-en

--- a/datasets/wmt18/README.md
+++ b/datasets/wmt18/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cs-en

--- a/datasets/wmt19/README.md
+++ b/datasets/wmt19/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### cs-en

--- a/datasets/wmt_t2t/README.md
+++ b/datasets/wmt_t2t/README.md
@@ -74,8 +74,6 @@ builder = datasets.builder("wmt_translate", config=config)
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### de-en

--- a/datasets/x_stance/README.md
+++ b/datasets/x_stance/README.md
@@ -55,8 +55,6 @@ It can be used to train and evaluate stance detection systems.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/xcopa/README.md
+++ b/datasets/xcopa/README.md
@@ -97,8 +97,6 @@ Xcopa language et
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### et

--- a/datasets/xnli/README.md
+++ b/datasets/xnli/README.md
@@ -59,8 +59,6 @@ labels).
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### all_languages

--- a/datasets/xquad/README.md
+++ b/datasets/xquad/README.md
@@ -85,8 +85,6 @@ across 11 languages.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### xquad.ar

--- a/datasets/xsum/README.md
+++ b/datasets/xsum/README.md
@@ -64,8 +64,6 @@ There are three features:
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### default

--- a/datasets/xtreme/README.md
+++ b/datasets/xtreme/README.md
@@ -532,8 +532,6 @@ Niger-Congo languages Swahili and Yoruba, spoken in Africa.
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### MLQA.ar.ar

--- a/datasets/yelp_polarity/README.md
+++ b/datasets/yelp_polarity/README.md
@@ -83,8 +83,6 @@ that is "
 
 ## Dataset Structure
 
-We show detailed information for up to 5 configurations of the dataset.
-
 ### Data Instances
 
 #### plain_text


### PR DESCRIPTION
Remove the following copy-paste sentence from dataset cards:
```
We show detailed information for up to 5 configurations of the dataset.
```