### PR TITLE
Fix filesystem docstring

### DIFF
--- a/src/datasets/filesystems/s3filesystem.py
+++ b/src/datasets/filesystems/s3filesystem.py
@@ -5,10 +5,40 @@ import s3fs
 
 class S3FileSystem(s3fs.S3FileSystem):
     """
-    ``datasets.filesystems.S3FileSystem`` is a subclass of s3fs.S3FileSystem](https://s3fs.readthedocs.io/en/latest/api.html), which is a known
-    implementation of ``fsspec``. Filesystem Spec [FSSPEC](https://filesystem-spec.readthedocs.io/en/latest/?badge=latest) is a project to
-    unify various projects and classes to work with remote filesystems
-    and file-system-like abstractions using a standard pythonic interface.
+    `datasets.filesystems.S3FileSystem` is a subclass of [`s3fs.S3FileSystem`](https://s3fs.readthedocs.io/en/latest/api.html).
+
+    Users can use this class to access S3 as if it were a file system. It exposes a filesystem-like API (ls, cp, open, etc.) on top of S3 storage. Provide credentials either explicitly (`key=`, `secret=`) or with boto's credential methods. See botocore documentation for more information. If no credentials are availabe, use `anon=True`.
+
+    Args:
+        anon (`bool`, default to `False`): Whether to use anonymous connection (public buckets only). If False, uses the key/secret given, 
+            or boto's credential resolver (client_kwargs, environment, variables, config files, EC2 IAM server, in that order).
+        key (`str`): If not anonymous, use this access key ID, if specified.
+        secret (`str): If not anonymous, use this secret access key, if specified.
+        token (`str`): If not anonymous, use this security token, if specified.
+        use_ssl (`bool`, default to `True`): Whether to use SSL in connections to S3; may be faster without, but insecure. If `use_ssl` is 
+            also set in `client_kwargs`, the value set in `client_kwargs` will take priority.
+        s3_additional_kwargs (`Dict`): Parameters that are used when calling s3 api methods. Typically used for things 
+            like ServerSideEncryption.
+        client_kwargs (`Dict`): Parameters for the botocore client.
+        requester_pays (`bool`, default to `False`): If RequesterPays buckets are supported.
+        default_block_size (`int`): If given, the default block size value used for `open()`, if no specific value is given at all time. 
+            The built-in default is 5MB.
+        default_fill_cache (`bool`, default to `True`): Whether to use cache filling with open by default. Refer to `S3File.open`.
+        default_cache_type (`str`, default to `bytes`): If given, the default cache_type value used for `open()`. Set to `none` if no 
+            caching is desired. See fsspec's documentation for other available cache_type values. Default cache_type is `bytes`.
+        version_aware (`bool`, default to `False`): Whether to support bucket versioning. If enable this will require the user to have 
+            the necessary IAM permissions for dealing with versioned objects.
+        cache_regions (`bool`, default to `False`): Whether to cache bucket regions or not. Whenever a new bucket is used, it will 
+            first find out which region it belongs and then use the client for that region.
+        asynchronous (`bool`, default to `False`): Whether this instance is to be used from inside coroutines.
+        config_kwargs (`Dict`): Parameters passed to `botocore.client.Config`.
+        kwargs: other parameters for core session.
+        session: aiobotocore AioSession object to be used for all connections. This session will be used inplace of creating a new 
+            session inside S3FileSystem. For example: `aiobotocore.session.AioSession(profile='test_user')`.
+        skip_instance_cache: Control reuse of instances. Passed on to `fsspec`.
+        use_listings_cache: Control reuse of directory listings. Passed on to `fsspec`.
+        listings_expirty_time: Control reuse of directory listings. Passed on to `fsspec`.
+        max_paths: Control reuse of directory listings. Passed on to `fsspec`.
 
     Examples:
 
@@ -21,7 +51,7 @@ class S3FileSystem(s3fs.S3FileSystem):
     ['dataset_info.json.json','dataset.arrow','state.json']
     ```
 
-    Listing files from private s3 bucket using <code>aws_access_key_id</code> and <code>aws_secret_access_key</code>.
+    Listing files from private s3 bucket using `aws_access_key_id` and `aws_secret_access_key`.
 
     ```py
     >>> import datasets
@@ -30,55 +60,36 @@ class S3FileSystem(s3fs.S3FileSystem):
     ['dataset_info.json.json','dataset.arrow','state.json']
     ```
 
-    Using <code>S3Filesystem</code> with <code>botocore.session.Session</code> and custom <code>aws_profile</code>.
+    Using `S3Filesystem` with `botocore.session.Session` and custom `aws_profile`.
 
     ```py
     >>> import botocore
     >>> from datasets.filesystems import S3Filesystem
+
     >>> s3_session = botocore.session.Session(profile_name='my_profile_name')
-    >>>
     >>> s3 = S3FileSystem(session=s3_session)  # doctest: +SKIP
     ```
 
-    Loading dataset from s3 using <code>S3Filesystem</code> and <code>load_from_disk()</code>.
+    Loading dataset from s3 using `S3Filesystem` and `load_from_disk()`.
 
     ```py
     >>> from datasets import load_from_disk
     >>> from datasets.filesystems import S3Filesystem
-    >>>
+    
     >>> s3 = S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)  # doctest: +SKIP
-    >>>
     >>> dataset = load_from_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
-    >>>
     >>> print(len(dataset))
     25000
     ```
 
-    Saving dataset to s3 using <code>S3Filesystem<code/> and <code>dataset.save_to_disk()<code/>.
+    Saving dataset to s3 using `S3Filesystem` and `dataset.save_to_disk()`.
 
     ```py
     >>> from datasets import load_dataset
     >>> from datasets.filesystems import S3Filesystem
-    >>>
+    
     >>> dataset = load_dataset("imdb")
-    >>>
     >>> s3 = S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)  # doctest: +SKIP
-    >>>
     >>> dataset.save_to_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
     ```
     """
-
-    _re_params = re.compile(r"(Parameters\s*---+\n*(((?!\n\n\s).)*)\n\n)\s", re.DOTALL)
-
-    S3FileSystem_doc = s3fs.S3FileSystem.__doc__.split("Examples")[0]
-    S3FileSystem_doc_params = _re_params.search(S3FileSystem_doc).group(1)
-    S3FileSystem_doc = _re_params.sub("", S3FileSystem_doc)
-    __doc__ = f"""
-{S3FileSystem_doc}.
-
-{__doc__}
-
-{S3FileSystem_doc_params}
-    """
-
-    pass

--- a/src/datasets/filesystems/s3filesystem.py
+++ b/src/datasets/filesystems/s3filesystem.py
@@ -1,5 +1,3 @@
-import re
-
 import s3fs
 
 
@@ -17,24 +15,24 @@ class S3FileSystem(s3fs.S3FileSystem):
         token (`str`): If not anonymous, use this security token, if specified.
         use_ssl (`bool`, default to `True`): Whether to use SSL in connections to S3; may be faster without, but insecure. If `use_ssl` is
             also set in `client_kwargs`, the value set in `client_kwargs` will take priority.
-        s3_additional_kwargs (`Dict`): Parameters that are used when calling s3 api methods. Typically used for things
+        s3_additional_kwargs (`dict`): Parameters that are used when calling S3 API methods. Typically used for things
             like ServerSideEncryption.
-        client_kwargs (`Dict`): Parameters for the botocore client.
-        requester_pays (`bool`, default to `False`): If RequesterPays buckets are supported.
+        client_kwargs (`dict`): Parameters for the botocore client.
+        requester_pays (`bool`, default to `False`): Whether RequesterPays buckets are supported.
         default_block_size (`int`): If given, the default block size value used for `open()`, if no specific value is given at all time.
             The built-in default is 5MB.
         default_fill_cache (`bool`, default to `True`): Whether to use cache filling with open by default. Refer to `S3File.open`.
         default_cache_type (`str`, default to `bytes`): If given, the default cache_type value used for `open()`. Set to `none` if no
-            caching is desired. See fsspec's documentation for other available cache_type values. Default cache_type is `bytes`.
+            caching is desired. See fsspec's documentation for other available cache_type values.
         version_aware (`bool`, default to `False`): Whether to support bucket versioning. If enable this will require the user to have
             the necessary IAM permissions for dealing with versioned objects.
-        cache_regions (`bool`, default to `False`): Whether to cache bucket regions or not. Whenever a new bucket is used, it will
-            first find out which region it belongs and then use the client for that region.
+        cache_regions (`bool`, default to `False`): Whether to cache bucket regions. Whenever a new bucket is used, it will
+            first find out which region it belongs to and then use the client for that region.
         asynchronous (`bool`, default to `False`): Whether this instance is to be used from inside coroutines.
-        config_kwargs (`Dict`): Parameters passed to `botocore.client.Config`.
-        kwargs: other parameters for core session.
-        session: aiobotocore AioSession object to be used for all connections. This session will be used inplace of creating a new
-            session inside S3FileSystem. For example: `aiobotocore.session.AioSession(profile='test_user')`.
+        config_kwargs (`dict`): Parameters passed to `botocore.client.Config`.
+        kwargs: Other parameters for core session.
+        session (`aiobotocore.session.AioSession`): Session to be used for all connections. This session will be used inplace of creating
+            a new session inside S3FileSystem. For example: `aiobotocore.session.AioSession(profile='test_user')`.
         skip_instance_cache (`bool`): Control reuse of instances. Passed on to `fsspec`.
         use_listings_cache (`bool`): Control reuse of directory listings. Passed on to `fsspec`.
         listings_expiry_time (`int` or `float`): Control reuse of directory listings. Passed on to `fsspec`.
@@ -42,7 +40,7 @@ class S3FileSystem(s3fs.S3FileSystem):
 
     Examples:
 
-    Listing files from public s3 bucket.
+    Listing files from public S3 bucket.
 
     ```py
     >>> import datasets
@@ -51,7 +49,7 @@ class S3FileSystem(s3fs.S3FileSystem):
     ['dataset_info.json.json','dataset.arrow','state.json']
     ```
 
-    Listing files from private s3 bucket using `aws_access_key_id` and `aws_secret_access_key`.
+    Listing files from private S3 bucket using `aws_access_key_id` and `aws_secret_access_key`.
 
     ```py
     >>> import datasets
@@ -70,19 +68,19 @@ class S3FileSystem(s3fs.S3FileSystem):
     >>> s3 = S3FileSystem(session=s3_session)  # doctest: +SKIP
     ```
 
-    Loading dataset from s3 using `S3Filesystem` and `load_from_disk()`.
+    Loading dataset from S3 using `S3Filesystem` and [`load_from_disk`].
 
     ```py
     >>> from datasets import load_from_disk
     >>> from datasets.filesystems import S3Filesystem
 
     >>> s3 = S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)  # doctest: +SKIP
-    >>> dataset = load_from_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
+    >>> dataset = load_from_disk('s3://my-private-datasets/imdb/train', fs=s3)  # doctest: +SKIP
     >>> print(len(dataset))
     25000
     ```
 
-    Saving dataset to s3 using `S3Filesystem` and `dataset.save_to_disk()`.
+    Saving dataset to S3 using `S3Filesystem` and [`Dataset.save_to_disk`].
 
     ```py
     >>> from datasets import load_dataset
@@ -90,6 +88,6 @@ class S3FileSystem(s3fs.S3FileSystem):
 
     >>> dataset = load_dataset("imdb")
     >>> s3 = S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)  # doctest: +SKIP
-    >>> dataset.save_to_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
+    >>> dataset.save_to_disk('s3://my-private-datasets/imdb/train', fs=s3)  # doctest: +SKIP
     ```
     """

--- a/src/datasets/filesystems/s3filesystem.py
+++ b/src/datasets/filesystems/s3filesystem.py
@@ -13,7 +13,7 @@ class S3FileSystem(s3fs.S3FileSystem):
         anon (`bool`, default to `False`): Whether to use anonymous connection (public buckets only). If False, uses the key/secret given,
             or boto's credential resolver (client_kwargs, environment, variables, config files, EC2 IAM server, in that order).
         key (`str`): If not anonymous, use this access key ID, if specified.
-        secret (`str): If not anonymous, use this secret access key, if specified.
+        secret (`str`): If not anonymous, use this secret access key, if specified.
         token (`str`): If not anonymous, use this security token, if specified.
         use_ssl (`bool`, default to `True`): Whether to use SSL in connections to S3; may be faster without, but insecure. If `use_ssl` is
             also set in `client_kwargs`, the value set in `client_kwargs` will take priority.

--- a/src/datasets/filesystems/s3filesystem.py
+++ b/src/datasets/filesystems/s3filesystem.py
@@ -35,10 +35,10 @@ class S3FileSystem(s3fs.S3FileSystem):
         kwargs: other parameters for core session.
         session: aiobotocore AioSession object to be used for all connections. This session will be used inplace of creating a new
             session inside S3FileSystem. For example: `aiobotocore.session.AioSession(profile='test_user')`.
-        skip_instance_cache: Control reuse of instances. Passed on to `fsspec`.
-        use_listings_cache: Control reuse of directory listings. Passed on to `fsspec`.
-        listings_expirty_time: Control reuse of directory listings. Passed on to `fsspec`.
-        max_paths: Control reuse of directory listings. Passed on to `fsspec`.
+        skip_instance_cache (`bool`): Control reuse of instances. Passed on to `fsspec`.
+        use_listings_cache (`bool`): Control reuse of directory listings. Passed on to `fsspec`.
+        listings_expiry_time (`int` or `float`): Control reuse of directory listings. Passed on to `fsspec`.
+        max_paths (`int`): Control reuse of directory listings. Passed on to `fsspec`.
 
     Examples:
 

--- a/src/datasets/filesystems/s3filesystem.py
+++ b/src/datasets/filesystems/s3filesystem.py
@@ -10,30 +10,30 @@ class S3FileSystem(s3fs.S3FileSystem):
     Users can use this class to access S3 as if it were a file system. It exposes a filesystem-like API (ls, cp, open, etc.) on top of S3 storage. Provide credentials either explicitly (`key=`, `secret=`) or with boto's credential methods. See botocore documentation for more information. If no credentials are availabe, use `anon=True`.
 
     Args:
-        anon (`bool`, default to `False`): Whether to use anonymous connection (public buckets only). If False, uses the key/secret given, 
+        anon (`bool`, default to `False`): Whether to use anonymous connection (public buckets only). If False, uses the key/secret given,
             or boto's credential resolver (client_kwargs, environment, variables, config files, EC2 IAM server, in that order).
         key (`str`): If not anonymous, use this access key ID, if specified.
         secret (`str): If not anonymous, use this secret access key, if specified.
         token (`str`): If not anonymous, use this security token, if specified.
-        use_ssl (`bool`, default to `True`): Whether to use SSL in connections to S3; may be faster without, but insecure. If `use_ssl` is 
+        use_ssl (`bool`, default to `True`): Whether to use SSL in connections to S3; may be faster without, but insecure. If `use_ssl` is
             also set in `client_kwargs`, the value set in `client_kwargs` will take priority.
-        s3_additional_kwargs (`Dict`): Parameters that are used when calling s3 api methods. Typically used for things 
+        s3_additional_kwargs (`Dict`): Parameters that are used when calling s3 api methods. Typically used for things
             like ServerSideEncryption.
         client_kwargs (`Dict`): Parameters for the botocore client.
         requester_pays (`bool`, default to `False`): If RequesterPays buckets are supported.
-        default_block_size (`int`): If given, the default block size value used for `open()`, if no specific value is given at all time. 
+        default_block_size (`int`): If given, the default block size value used for `open()`, if no specific value is given at all time.
             The built-in default is 5MB.
         default_fill_cache (`bool`, default to `True`): Whether to use cache filling with open by default. Refer to `S3File.open`.
-        default_cache_type (`str`, default to `bytes`): If given, the default cache_type value used for `open()`. Set to `none` if no 
+        default_cache_type (`str`, default to `bytes`): If given, the default cache_type value used for `open()`. Set to `none` if no
             caching is desired. See fsspec's documentation for other available cache_type values. Default cache_type is `bytes`.
-        version_aware (`bool`, default to `False`): Whether to support bucket versioning. If enable this will require the user to have 
+        version_aware (`bool`, default to `False`): Whether to support bucket versioning. If enable this will require the user to have
             the necessary IAM permissions for dealing with versioned objects.
-        cache_regions (`bool`, default to `False`): Whether to cache bucket regions or not. Whenever a new bucket is used, it will 
+        cache_regions (`bool`, default to `False`): Whether to cache bucket regions or not. Whenever a new bucket is used, it will
             first find out which region it belongs and then use the client for that region.
         asynchronous (`bool`, default to `False`): Whether this instance is to be used from inside coroutines.
         config_kwargs (`Dict`): Parameters passed to `botocore.client.Config`.
         kwargs: other parameters for core session.
-        session: aiobotocore AioSession object to be used for all connections. This session will be used inplace of creating a new 
+        session: aiobotocore AioSession object to be used for all connections. This session will be used inplace of creating a new
             session inside S3FileSystem. For example: `aiobotocore.session.AioSession(profile='test_user')`.
         skip_instance_cache: Control reuse of instances. Passed on to `fsspec`.
         use_listings_cache: Control reuse of directory listings. Passed on to `fsspec`.
@@ -75,7 +75,7 @@ class S3FileSystem(s3fs.S3FileSystem):
     ```py
     >>> from datasets import load_from_disk
     >>> from datasets.filesystems import S3Filesystem
-    
+
     >>> s3 = S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)  # doctest: +SKIP
     >>> dataset = load_from_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP
     >>> print(len(dataset))
@@ -87,7 +87,7 @@ class S3FileSystem(s3fs.S3FileSystem):
     ```py
     >>> from datasets import load_dataset
     >>> from datasets.filesystems import S3Filesystem
-    
+
     >>> dataset = load_dataset("imdb")
     >>> s3 = S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)  # doctest: +SKIP
     >>> dataset.save_to_disk('s3://my-private-datasets/imdb/train',fs=s3)  # doctest: +SKIP


### PR DESCRIPTION
This PR untangles the `S3FileSystem` docstring so the [parameters](https://huggingface.co/docs/datasets/master/en/package_reference/main_classes#parameters) are properly displayed.