### PR TITLE
Add Lahnda language tag

### DIFF
--- a/src/datasets/utils/resources/languages.json
+++ b/src/datasets/utils/resources/languages.json
@@ -559,6 +559,7 @@
     "lad": "Ladino",
     "lag": "Langi",
     "lag-TZ": "Langi (Tanzania)",
+    "lah": "Lahnda",
     "lb": "Luxembourgish",
     "lb-LU": "Luxembourgish (Luxembourg)",
     "lbe": "Lak",


### PR DESCRIPTION
This language is present in [Wikimedia's WIT](https://huggingface.co/datasets/wikimedia/wit_base) dataset.