### PR TITLE
Fix CLI run_beam save_infos

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -506,7 +506,6 @@ class DatasetBuilder:
             download_config (:class:`DownloadConfig`, optional): specific download configuration parameters.
             download_mode (:class:`DownloadMode`, optional): select the download/generate mode - Default to ``REUSE_DATASET_IF_EXISTS``
             ignore_verifications (:obj:`bool`): Ignore the verifications of the downloaded/processed dataset information (checksums/size/splits/...)
-            save_infos (:obj:`bool`): Save the dataset information (checksums/size/splits/...)
             try_from_hf_gcs (:obj:`bool`): If True, it will try to download the already prepared dataset from the Hf google cloud storage
             dl_manager (:class:`DownloadManager`, optional): specific Download Manger to use
             base_path (:obj:`str`, optional): base path for relative paths that are used to download files. This can be a remote url.

--- a/src/datasets/commands/run_beam.py
+++ b/src/datasets/commands/run_beam.py
@@ -126,10 +126,11 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                 if not self._force_redownload
                 else DownloadMode.FORCE_REDOWNLOAD,
                 download_config=DownloadConfig(cache_dir=config.DOWNLOADED_DATASETS_PATH),
-                save_infos=self._save_infos,
                 ignore_verifications=self._ignore_verifications,
                 try_from_hf_gcs=False,
             )
+            if self._save_infos:
+                builder._save_infos()
 
         print("Apache beam run successful.")
 


### PR DESCRIPTION
Currently, it raises TypeError:
```
TypeError: _download_and_prepare() got an unexpected keyword argument 'save_infos'
```