### PR TITLE
Fix missing lz4 dependency for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ TESTS_REQUIRE = [
     "h5py",
     "langdetect",
     "lxml",
+    "lz4",
     "mwparserfromhell",
     "nltk",
     "openpyxl",


### PR DESCRIPTION
Currently, `lz4` is not defined as a dependency for tests. Therefore, all tests marked with `@require_lz4` are skipped.