### PR TITLE
Add API code examples for loading methods

### DIFF
--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -47,6 +47,13 @@ def list_datasets(with_community_datasets=True, with_details=False):
     Args:
         with_community_datasets (:obj:`bool`, optional, default ``True``): Include the community provided datasets.
         with_details (:obj:`bool`, optional, default ``False``): Return the full details on the datasets instead of only the short name.
+
+    Example:
+
+    ```py
+    >>> from datasets import list_datasets
+    >>> list_datasets()
+    ```
     """
     datasets = huggingface_hub.list_datasets(full=with_details)
     if not with_community_datasets:
@@ -62,6 +69,13 @@ def list_metrics(with_community_metrics=True, with_details=False):
     Args:
         with_community_metrics (:obj:`bool`, optional, default ``True``): Include the community provided metrics.
         with_details (:obj:`bool`, optional, default ``False``): Return the full details on the metrics instead of only the short name.
+
+    Example:
+
+    ```py
+    >>> from datasets import list_metrics
+    >>> list_metrics()
+    ```
     """
     metrics = huggingface_hub.list_metrics()
     if not with_community_metrics:
@@ -151,6 +165,13 @@ def get_dataset_infos(
         use_auth_token (``str`` or :obj:`bool`, optional): Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
             If True, will get token from `"~/.huggingface"`.
         config_kwargs: optional attributes for builder class which will override the attributes if supplied.
+
+    Example:
+
+    ```py
+    >>> from datasets import get_dataset_infos
+    >>> get_dataset_infos('rotten_tomatoes')
+    ```
     """
     config_names = get_dataset_config_names(
         path=path,
@@ -209,6 +230,25 @@ def get_dataset_config_names(
         data_files (:obj:`Union[Dict, List, str]`, optional): Defining the data_files of the dataset configuration.
         download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied,
             for example ``use_auth_token``
+
+    Example:
+
+    ```py
+    >>> from datasets import get_dataset_config_names
+    >>> get_dataset_config_names("glue")
+    ['cola',
+     'sst2',
+     'mrpc',
+     'qqp',
+     'stsb',
+     'mnli',
+     'mnli_mismatched',
+     'mnli_matched',
+     'qnli',
+     'rte',
+     'wnli',
+     'ax']
+    ```
     """
     dataset_module = dataset_module_factory(
         path,
@@ -319,6 +359,13 @@ def get_dataset_split_names(
             If True, will get token from `"~/.huggingface"`.
         config_kwargs: optional attributes for builder class which will override the attributes if supplied.
 
+    Example:
+
+    ```py
+    >>> from datasets import get_dataset_split_names
+    >>> get_dataset_split_names('rotten_tomatoes')
+    ['train', 'validation', 'test']
+    ```
     """
     info = get_dataset_config_info(
         path,

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -53,6 +53,14 @@ def list_datasets(with_community_datasets=True, with_details=False):
     ```py
     >>> from datasets import list_datasets
     >>> list_datasets()
+    ['acronym_identification',
+     'ade_corpus_v2',
+     'adversarial_qa',
+     'aeslc',
+     'afrikaans_ner_corpus',
+     'ag_news',
+     ...
+    ]
     ```
     """
     datasets = huggingface_hub.list_datasets(full=with_details)
@@ -75,6 +83,14 @@ def list_metrics(with_community_metrics=True, with_details=False):
     ```py
     >>> from datasets import list_metrics
     >>> list_metrics()
+    ['accuracy',
+     'bertscore',
+     'bleu',
+     'bleurt',
+     'cer',
+     'chrf',
+     ...
+    ]
     ```
     """
     metrics = huggingface_hub.list_metrics()
@@ -171,6 +187,7 @@ def get_dataset_infos(
     ```py
     >>> from datasets import get_dataset_infos
     >>> get_dataset_infos('rotten_tomatoes')
+    {'default': DatasetInfo(description="Movie Review Dataset.\nThis is a dataset of containing 5,331 positive and 5,331 negative processed\nsentences from Rotten Tomatoes movie reviews...), ...}
     ```
     """
     config_names = get_dataset_config_names(

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1431,6 +1431,13 @@ def load_metric(
 
     Returns:
         `datasets.Metric`
+
+    Example:
+
+    ```py
+    >>> from datasets import load_metric
+    >>> accuracy = load_metric('accuracy')
+    ```
     """
     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
     metric_module = metric_module_factory(
@@ -1522,6 +1529,15 @@ def load_dataset_builder(
     Returns:
         :class:`DatasetBuilder`
 
+    Example:
+
+    ```py
+    >>> from datasets import load_dataset_builder
+    >>> ds_builder = load_dataset_builder('rotten_tomatoes')
+    >>> ds_builder.info.features
+    {'label': ClassLabel(num_classes=2, names=['neg', 'pos'], id=None),
+     'text': Value(dtype='string', id=None)}
+    ```
     """
     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
     if use_auth_token is not None:
@@ -1690,6 +1706,48 @@ def load_dataset(
         - if `split` is not None: the dataset requested,
         - if `split` is None, a ``datasets.streaming.IterableDatasetDict`` with each split.
 
+    Example:
+
+    Load a dataset from the Hugging Face Hub:
+
+    ```py
+    >>> from datasets import load_dataset
+    >>> ds = load_dataset('rotten_tomatoes', split='train')
+
+    # Map data files to splits
+    >>> data_files = {'train': 'train.csv', 'test': 'test.csv'}
+    >>> ds = load_dataset('namespace/your_dataset_name', data_files=data_files)
+    ```
+
+    Load a local dataset:
+
+    ```py
+    # Load a CSV file
+    >>> from datasets import load_dataset
+    >>> ds = load_dataset('csv', data_files='my_dataset.csv')
+
+    # Load a JSON file
+    >>> from datasets import load_dataset
+    >>> ds = load_dataset('json', data_files='my_dataset.json')
+
+    # Load from a local loading script
+    >>> from datasets import load_dataset
+    >>> ds = load_dataset('path/to/local/loading_script/loading_script.py', split='train')
+    ```
+
+    Load an [`IterableDataset`]:
+
+    ```py
+    >>> from datasets import load_dataset
+    >>> ds = load_dataset('rotten_tomatoes', split='train', streaming=True)
+    ```
+
+    Load an image dataset with the `ImageFolder` dataset builder:
+
+    ```py
+    >>> from datasets import load_dataset
+    >>> ds = load_dataset('imagefolder', data_dir='/path/to/images', split='train')
+    ```
     """
     if Path(path, config.DATASET_STATE_JSON_FILENAME).exists():
         raise ValueError(
@@ -1770,6 +1828,13 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
         :class:`Dataset` or :class:`DatasetDict`:
         - If `dataset_path` is a path of a dataset directory: the dataset requested.
         - If `dataset_path` is a path of a dataset dict directory: a ``datasets.DatasetDict`` with each split.
+
+    Example:
+
+    ```py
+    >>> from datasets import load_from_disk
+    >>> ds = load_from_disk('path/to/dataset/directory')
+    ```
     """
     # gets filesystem from dataset, either s3:// or file:// and adjusted dataset_path
     if is_remote_filesystem(fs):

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1437,6 +1437,8 @@ def load_metric(
     ```py
     >>> from datasets import load_metric
     >>> accuracy = load_metric('accuracy')
+    >>> accuracy.compute(references=[1, 0], predictions=[1, 1])
+    {'accuracy': 0.5}
     ```
     """
     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
@@ -1724,18 +1726,18 @@ def load_dataset(
     ```py
     # Load a CSV file
     >>> from datasets import load_dataset
-    >>> ds = load_dataset('csv', data_files='my_dataset.csv')
+    >>> ds = load_dataset('csv', data_files='path/to/local/my_dataset.csv')
 
     # Load a JSON file
     >>> from datasets import load_dataset
-    >>> ds = load_dataset('json', data_files='my_dataset.json')
+    >>> ds = load_dataset('json', data_files='path/to/local/my_dataset.json')
 
     # Load from a local loading script
     >>> from datasets import load_dataset
     >>> ds = load_dataset('path/to/local/loading_script/loading_script.py', split='train')
     ```
 
-    Load an [`IterableDataset`]:
+    Load an [`~datasets.IterableDataset`]:
 
     ```py
     >>> from datasets import load_dataset


### PR DESCRIPTION
This PR adds API code examples for loading methods, let me know if I've missed any important parameters we should showcase :)

I was a bit confused about `inspect_dataset` and `inspect_metric`. The `path` parameter says it will accept a dataset identifier from the Hub. But when I try the identifier `rotten_tomatoes`, it gives me:

```py
from datasets import inspect_dataset
inspect_dataset('rotten_tomatoes', local_path='/content/rotten_tomatoes')

FileNotFoundError: Couldn't find a dataset script at /content/rotten_tomatoes/rotten_tomatoes.py or any data file in the same directory.
```

Does the user need to have an existing copy of `rotten_tomatoes.py` on their local drive (in which case, it seems like the same option as the first option in `path`)?