### PR TITLE
Fixes FrugalScore

### DIFF
--- a/metrics/frugalscore/frugalscore.py
+++ b/metrics/frugalscore/frugalscore.py
@@ -101,12 +101,15 @@ class FRUGALSCORE(datasets.Metric):
             no_cuda=(device == "cpu"),
             log_level="warning",
         )
-        dataset = {"sentence1": predictions, "sentence2": references}
+        dataset = {"sentence1": references, "sentence2": predictions}
         raw_datasets = datasets.Dataset.from_dict(dataset)
 
         def tokenize_function(data):
             return self.tokenizer(
-                data["sentence1"], data["sentence2"], max_length=max_length, truncation=True, padding=True
+                data["sentence1"],
+                data["sentence2"],
+                max_length=max_length,
+                truncation=True,
             )
 
         tokenized_datasets = raw_datasets.map(tokenize_function, batched=True)


### PR DESCRIPTION
There are two minor modifications in this PR:
1) `predictions` and `references` are swapped. Basically Frugalscore is commutative, however some tiny differences can occur if we swap the references and the predictions. I decided to swap them just to obtain the exact results as reported in the paper.
2) I switched to dynamic padding that was was used in the training, forcing the padding to `max_length`  introduces errors for some reason that I ignore.

@lhoestq 