### PR TITLE
Add packaged builder configs to the documentation

### DIFF
--- a/docs/source/package_reference/loading_methods.mdx
+++ b/docs/source/package_reference/loading_methods.mdx
@@ -4,6 +4,8 @@ Methods for listing and loading datasets and metrics:
 
 ## Datasets
 
+Methods for listing and loading datasets and metrics:
+
 [[autodoc]] datasets.list_datasets
 
 [[autodoc]] datasets.load_dataset
@@ -27,3 +29,38 @@ Methods for listing and loading datasets and metrics:
 [[autodoc]] datasets.load_metric
 
 [[autodoc]] datasets.inspect_metric
+
+## From files
+
+Configurations used to load data files.
+They are used when loading local files or a dataset repository:
+
+- local files: `load_dataset("parquet", data_dir="path/to/data/dir")`
+- dataset repository: `load_dataset("allenai/c4")`
+
+You can pass arguments to `load_dataset` to configure data loading.
+For example you can specify the `sep` parameter to define the [`~datasets.packaged_modules.csv.CsvConfig`] that is used to load the data:
+
+```python
+load_dataset("csv", data_dir="path/to/data/dir", sep="\t")
+```
+
+### Text
+
+[[autodoc]] datasets.packaged_modules.text.TextConfig
+
+### CSV
+
+[[autodoc]] datasets.packaged_modules.csv.CsvConfig
+
+### JSON
+
+[[autodoc]] datasets.packaged_modules.json.JsonConfig
+
+### Parquet
+
+[[autodoc]] datasets.packaged_modules.parquet.ParquetConfig
+
+### Images
+
+[[autodoc]] datasets.packaged_modules.imagefolder.ImageFolderConfig

--- a/docs/source/package_reference/loading_methods.mdx
+++ b/docs/source/package_reference/loading_methods.mdx
@@ -4,8 +4,6 @@ Methods for listing and loading datasets and metrics:
 
 ## Datasets
 
-Methods for listing and loading datasets and metrics:
-
 [[autodoc]] datasets.list_datasets
 
 [[autodoc]] datasets.load_dataset


### PR DESCRIPTION
Add the packaged builders configurations to the docs reference is useful to show the list of all parameters one can use when loading data in many formats: CSV, JSON, etc.