### PR TITLE
Remove unused multiprocessing args from test CLI

### DIFF
--- a/src/datasets/commands/test.py
+++ b/src/datasets/commands/test.py
@@ -27,8 +27,6 @@ def test_command_factory(args):
         args.ignore_verifications,
         args.force_redownload,
         args.clear_cache,
-        args.proc_rank,
-        args.num_proc,
     )
 
 
@@ -60,18 +58,6 @@ class TestCommand(BaseDatasetsCLICommand):
             action="store_true",
             help="Remove downloaded files and cached datasets after each config test",
         )
-        test_parser.add_argument(
-            "--proc_rank",
-            type=int,
-            default=0,
-            help="Rank of the current process for multiprocessing testing.",
-        )
-        test_parser.add_argument(
-            "--num_proc",
-            type=int,
-            default=1,
-            help="Number of processes to use for multiprocessing testing",
-        )
         test_parser.add_argument("dataset", type=str, help="Name of the dataset to download")
         test_parser.set_defaults(func=test_command_factory)
 
@@ -86,8 +72,6 @@ class TestCommand(BaseDatasetsCLICommand):
         ignore_verifications: bool,
         force_redownload: bool,
         clear_cache: bool,
-        proc_rank: int,
-        num_proc: int,
     ):
         self._dataset = dataset
         self._name = name
@@ -98,8 +82,6 @@ class TestCommand(BaseDatasetsCLICommand):
         self._ignore_verifications = ignore_verifications
         self._force_redownload = force_redownload
         self._clear_cache = clear_cache
-        self._proc_rank = proc_rank
-        self._num_proc = num_proc
         if clear_cache and not cache_dir:
             print(
                 "When --clear_cache is used, specifying a cache directory is mandatory.\n"
@@ -118,38 +100,31 @@ class TestCommand(BaseDatasetsCLICommand):
         path, name = self._dataset, self._name
         module = dataset_module_factory(path)
         builder_cls = import_main_class(module.module_path)
-
-        if self._all_configs and len(builder_cls.BUILDER_CONFIGS) > 0:
-            n_builders = len(builder_cls.BUILDER_CONFIGS) // self._num_proc
-            n_builders += (len(builder_cls.BUILDER_CONFIGS) % self._num_proc) > self._proc_rank
-        else:
-            n_builders = 1 if self._proc_rank == 0 else 0
+        n_builders = len(builder_cls.BUILDER_CONFIGS) if self._all_configs and builder_cls.BUILDER_CONFIGS else 1
 
         def get_builders() -> Generator[DatasetBuilder, None, None]:
-            if self._all_configs and len(builder_cls.BUILDER_CONFIGS) > 0:
+            if self._all_configs and builder_cls.BUILDER_CONFIGS:
                 for i, config in enumerate(builder_cls.BUILDER_CONFIGS):
-                    if i % self._num_proc == self._proc_rank:
-                        if "name" in module.builder_kwargs:
-                            yield builder_cls(
-                                cache_dir=self._cache_dir,
-                                data_dir=self._data_dir,
-                                **module.builder_kwargs,
-                            )
-                        else:
-                            yield builder_cls(
-                                name=config.name,
-                                cache_dir=self._cache_dir,
-                                data_dir=self._data_dir,
-                                **module.builder_kwargs,
-                            )
-            else:
-                if self._proc_rank == 0:
                     if "name" in module.builder_kwargs:
-                        yield builder_cls(cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs)
+                        yield builder_cls(
+                            cache_dir=self._cache_dir,
+                            data_dir=self._data_dir,
+                            **module.builder_kwargs,
+                        )
                     else:
                         yield builder_cls(
-                            name=name, cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs
+                            name=config.name,
+                            cache_dir=self._cache_dir,
+                            data_dir=self._data_dir,
+                            **module.builder_kwargs,
                         )
+            else:
+                if "name" in module.builder_kwargs:
+                    yield builder_cls(cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs)
+                else:
+                    yield builder_cls(
+                        name=name, cache_dir=self._cache_dir, data_dir=self._data_dir, **module.builder_kwargs
+                    )
 
         for j, builder in enumerate(get_builders()):
             print(f"Testing builder '{builder.config.name}' ({j + 1}/{n_builders})")

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -22,10 +22,8 @@ if config.PY_VERSION >= version.parse("3.7"):
             "ignore_verifications",
             "force_redownload",
             "clear_cache",
-            "proc_rank",
-            "num_proc",
         ],
-        defaults=[None, None, None, False, False, False, False, False, 0, 1],
+        defaults=[None, None, None, False, False, False, False, False],
     )
 else:
 
@@ -40,8 +38,6 @@ else:
         ignore_verifications: bool = False
         force_redownload: bool = False
         clear_cache: bool = False
-        proc_rank: int = 0
-        num_proc: int = 1
 
         def __iter__(self):
             return iter(self.__dict__.values())


### PR DESCRIPTION
Multiprocessing is not used in the test CLI.