### PR TITLE
[WIP] Add TEDLIUM dataset

### DIFF
--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -84,20 +84,20 @@ The audio and transcriptions are in English, as per the TED talks at http://www.
 
 ### Data Instances
 ```
-{'audio': {'path': '/home/sanchitgandhi/cache/downloads/extracted/6e3655f9e735ae3c467deed1df788e0dabd671c1f3e2e386e30aa3b571bd9761/TEDLIUM_release1/train/stm/PaulaScher_2008P.stm', 
+{'audio': {'path': '/home/sanchitgandhi/cache/downloads/extracted/6e3655f9e735ae3c467deed1df788e0dabd671c1f3e2e386e30aa3b571bd9761/TEDLIUM_release1/train/sph/PaulaScher_2008P.sph', 
   'array': array([-0.00048828, -0.00018311, -0.00137329, ...,  0.00079346,
           0.00091553,  0.00085449], dtype=float32),
   'sampling_rate': 16000},
 'text': '{COUGH} but <sil> i was so {COUGH} utterly unqualified for(2) this project and {NOISE} so utterly ridiculous {SMACK} and ignored the brief {SMACK} <sil>', 
 'speaker_id': 'PaulaScher_2008P', 
 'gender': 'female', 
-'file': '/home/sanchitgandhi/cache/downloads/extracted/6e3655f9e735ae3c467deed1df788e0dabd671c1f3e2e386e30aa3b571bd9761/TEDLIUM_release1/train/stm/PaulaScher_2008P.stm', 
+'file': '/home/sanchitgandhi/cache/downloads/extracted/6e3655f9e735ae3c467deed1df788e0dabd671c1f3e2e386e30aa3b571bd9761/TEDLIUM_release1/train/sph/PaulaScher_2008P.sph', 
 'id': 'PaulaScher_2008P-1003.35-1011.16-<o,f0,female>'}
 ```
 ### Data Fields
 
 - audio: A dictionary containing the path to the downloaded audio file, the decoded audio array, and the sampling rate. Note that when accessing the audio column: `dataset[0]["audio"]` the audio file is automatically decoded and resampled to `dataset.features["audio"].sampling_rate`. Decoding and resampling of a large number of audio files might take a significant amount of time. Thus it is important to first query the sample index before the `"audio"` column, *i.e.* `dataset[0]["audio"]` should **always** be preferred over `dataset["audio"][0]`. 
-- file: A path to the downloaded audio file in .sth format.
+- file: A path to the downloaded audio file in .sph format.
 - text: the transcription of the audio file.
 - gender: the gender of the speaker. One of: male, female or N/A.
 - id: unique id of the data sample.
@@ -106,7 +106,7 @@ The audio and transcriptions are in English, as per the TED talks at http://www.
 ### Data Splits
 There are three releases for the TED-LIUM corpus, progressively increasing the number of transcribed speech training data from 118 hours (Release 1), to 207 hours (Release 2), to 452 hours (Release 3).
 
-Release 1 (default config):
+Release 1:
 - 774 audio talks and automatically aligned transcriptions.
 - Contains 118 hours of speech audio data.
 - Homepage: https://www.openslr.org/7/
@@ -126,6 +126,10 @@ Release 3:
 - Selected monolingual data for language modeling from WMT12 publicly available corpora: these files come from the TED-LIUM 2 release, but have been modified to produce a tokenization more relevant for English language.
 - Homepage: https://www.openslr.org/51/
 
+Release 3 contains two different corpus distributions:
+- The ‘legacy’ one, on which the dev and test datasets are the same as in TED-LIUM 2 (and TED-LIUM 1).
+- The ‘speaker adaptation’ one, specially designed for experiments on speaker adaptation.
+
 Each release is split into a training, validation and test set:
 
 | Split      | Release 1 | Release 2 | Release 3 |
@@ -139,13 +143,13 @@ Each release is split into a training, validation and test set:
 
 ### Curation Rationale
 
-TED-LIUM was built during [The International Workshop on Spoken Language Trans- lation (IWSLT) 2011 Evaluation Campaign](https://aclanthology.org/2011.iwslt-evaluation.1/), an annual workshop focused on the automatic translation of public talks and included tracks for speech recognition, speech translation, text translation, and system combination. The corpus was entered 
+TED-LIUM was built during [The International Workshop on Spoken Language Trans- lation (IWSLT) 2011 Evaluation Campaign](https://aclanthology.org/2011.iwslt-evaluation.1/), an annual workshop focused on the automatic translation of public talks and included tracks for speech recognition, speech translation, text translation, and system combination.
 
 ### Source Data
 
 #### Initial Data Collection and Normalization
 
-The data was obtained from publicly available TED talks at http://www.ted.com. Proper alignments between the speech and the transcribed text were generated using an in-house speaker segmentation and clustering tool (LIUM_SpkDiarization). Speech disfluencies (e.g. repetitions, hesitations, false starts) were treated in the following way: the repetitions were transcribed, the hesitations were mapped to a specific filler word and the false starts were not taken into account. For full details on the data collection and processing, refer to the [TED-LIUM paper](https://aclanthology.org/L12-1405/).
+The data was obtained from publicly available TED talks at http://www.ted.com. Proper alignments between the speech and the transcribed text were generated using an in-house speaker segmentation and clustering tool (_LIUM_SpkDiarization_). Speech disfluencies (e.g. repetitions, hesitations, false starts) were treated in the following way: repetitions were transcribed, hesitations mapped to a specific filler word, and false starts not taken into account. For full details on the data collection and processing, refer to the [TED-LIUM paper](https://aclanthology.org/L12-1405/).
 
 #### Who are the source language producers?
 

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -1,0 +1,152 @@
+annotations_creators:
+- expert-generated
+language_creators:
+- expert-generated
+languages:
+- en
+licenses:
+- cc-by-nc-nd-3-0
+multilinguality:
+- monolingual
+size_categories:
+- 10K<n<100K
+source_datasets:
+- original
+task_categories:
+- automatic-speech-recognition
+task_ids:
+- automatic-speech-recognition
+
+# Dataset Card for tedlium
+
+## Table of Contents
+- [Dataset Description](#dataset-description)
+  - [Dataset Summary](#dataset-summary)
+  - [Supported Tasks](#supported-tasks-and-leaderboards)
+  - [Languages](#languages)
+- [Dataset Structure](#dataset-structure)
+  - [Data Instances](#data-instances)
+  - [Data Fields](#data-instances)
+  - [Data Splits](#data-instances)
+- [Dataset Creation](#dataset-creation)
+  - [Curation Rationale](#curation-rationale)
+  - [Source Data](#source-data)
+  - [Annotations](#annotations)
+  - [Personal and Sensitive Information](#personal-and-sensitive-information)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+  - [Social Impact of Dataset](#social-impact-of-dataset)
+  - [Discussion of Biases](#discussion-of-biases)
+  - [Other Known Limitations](#other-known-limitations)
+- [Additional Information](#additional-information)
+  - [Dataset Curators](#dataset-curators)
+  - [Licensing Information](#licensing-information)
+  - [Citation Information](#citation-information)
+
+## Dataset Description
+
+- **Homepage:** [TED-LIUM homepage](https://www.openslr.org/7/)
+- **Repository:** [Needs More Information]
+- **Paper:** [TED-LIUM: an Automatic Speech Recognition dedicated corpus](https://aclanthology.org/L12-1405/)
+- **Leaderboard:** [Paperswithcode Leaderboard](https://paperswithcode.com/sota/speech-recognition-on-tedlium)
+- **Point of Contact:** [Sanchit Gandhi](mailto:sanchit@huggingface.co)
+
+### Dataset Summary
+
+The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. It contains about 118 hours of speech.
+
+### Supported Tasks and Leaderboards
+
+- `automatic-speech-recognition`: The dataset can be used to train a model for Automatic Speech Recognition (ASR). The model is presented with an audio file and asked to transcribe the audio file to written text. The most common evaluation metric is the word error rate (WER). The task has an active leaderboard which can be found at https://paperswithcode.com/sota/speech-recognition-on-tedlium that ranks models based on their WER.
+
+### Languages
+
+The audio and transcriptions are in English, as per the TED talks at http://www.ted.com.
+
+## Dataset Structure
+
+### Data Instances
+
+TODO
+
+### Data Fields
+
+- gender: an integer value corresponding to the gender of the speaker.
+- id: unique id of the data sample.
+- speaker_id: unique id of the speaker. The same speaker id can be found for multiple data samples.
+- speech: A dictionary containing the path to the downloaded audio file, the decoded audio array, and the sampling rate. Note that when accessing the audio column: `dataset[0]["audio"]` the audio file is automatically decoded and resampled to `dataset.features["audio"].sampling_rate`. Decoding and resampling of a large number of audio files might take a significant amount of time. Thus it is important to first query the sample index before the "audio" column, i.e. `dataset[0]["audio"]` should always be preferred over `dataset["audio"][0]`.
+- text: the transcription of the audio file.
+
+### Data Splits
+
+The data is split into a training, validation and test set.
+
+| Split      | Examples |
+|------------|----------|
+| Train      |   56,803 |
+| Validation |      591 |
+| Test       |    1,469 |
+
+
+## Dataset Creation
+
+### Curation Rationale
+
+TED-LIUM was built during [The International Workshop on Spoken Language Trans- lation (IWSLT) 2011 Evaluation Campaign](https://aclanthology.org/2011.iwslt-evaluation.1/), an annual workshop focused on the automatic translation of public talks and included tracks for speech recognition, speech translation, text translation, and system combination. The corpus was entered 
+
+### Source Data
+
+#### Initial Data Collection and Normalization
+
+The data was obtained from publicly availably TED talks at http://www.ted.com. Proper alignments between the speech and the transcribed text were generated using an in-house speaker segmentation and clustering tool (LIUM_SpkDiarization). Speech disfluencies (e.g. repetitions, hesitations, false starts) were treated in the following way: the repetitions were transcribed, the hesitations were mapped to a specific filler word and the false starts were not taken into account. For full details on the data collection and processing, refer to the [TED-LIUM paper](https://aclanthology.org/L12-1405/).
+
+#### Who are the source language producers?
+
+[Needs More Information]
+
+### Annotations
+
+#### Annotation process
+
+[Needs More Information]
+
+#### Who are the annotators?
+
+[Needs More Information]
+
+### Personal and Sensitive Information
+
+[Needs More Information]
+
+## Considerations for Using the Data
+
+### Social Impact of Dataset
+
+[Needs More Information]
+
+### Discussion of Biases
+
+[Needs More Information]
+
+### Other Known Limitations
+
+[Needs More Information]
+
+## Additional Information
+
+### Dataset Curators
+
+[Needs More Information]
+
+### Licensing Information
+
+Licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
+
+### Citation Information
+
+@inproceedings{rousseau2012tedlium,
+  title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
+  author={Rousseau, Anthony and Del{\'e}glise, Paul and Est{\`e}ve, Yannick},
+  booktitle={Conference on Language Resources and Evaluation (LREC)},
+  pages={125--129},
+  year={2012}
+}

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -195,6 +195,7 @@ Licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/license
 
 ### Citation Information
 
+Release 1:
 ```
 @inproceedings{rousseau2012tedlium,
   title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
@@ -202,5 +203,32 @@ Licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/license
   booktitle={Conference on Language Resources and Evaluation (LREC)},
   pages={125--129},
   year={2012}
+}
+```
+
+Release 2:
+```
+@inproceedings{rousseau2014enhancing,
+  title={Enhancing the TED-LIUM corpus with selected data for language modeling and more TED talks.},
+  author={Rousseau, Anthony and Del{\'e}glise, Paul and Esteve, Yannick and others},
+  booktitle={LREC},
+  pages={3935--3939},
+  year={2014}
+}
+```
+
+Release 3:
+```
+@inproceedings{hernandez2018ted,
+  author="Hernandez, Fran{\c{c}}ois
+  and Nguyen, Vincent
+  and Ghannay, Sahar
+  and Tomashenko, Natalia
+  and Est{\`e}ve, Yannick",
+  title="TED-LIUM 3: Twice as Much Data and Corpus Repartition for Experiments on Speaker Adaptation",
+  booktitle="Speech and Computer",
+  year="2018",
+  publisher="Springer International Publishing",
+  pages="198--208",
 }
 ```

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -68,26 +68,57 @@ The audio and transcriptions are in English, as per the TED talks at http://www.
 ## Dataset Structure
 
 ### Data Instances
-
-TODO
-
+```
+{'audio': {'path': '/home/sanchitgandhi/cache/downloads/extracted/6e3655f9e735ae3c467deed1df788e0dabd671c1f3e2e386e30aa3b571bd9761/TEDLIUM_release1/train/stm/PaulaScher_2008P.stm', 
+  'array': array([-0.00048828, -0.00018311, -0.00137329, ...,  0.00079346,
+          0.00091553,  0.00085449], dtype=float32),
+  'sampling_rate': 16000},
+'text': '{COUGH} but <sil> i was so {COUGH} utterly unqualified for(2) this project and {NOISE} so utterly ridiculous {SMACK} and ignored the brief {SMACK} <sil>', 
+'speaker_id': 'PaulaScher_2008P', 
+'gender': 'female', 
+'file': '/home/sanchitgandhi/cache/downloads/extracted/6e3655f9e735ae3c467deed1df788e0dabd671c1f3e2e386e30aa3b571bd9761/TEDLIUM_release1/train/stm/PaulaScher_2008P.stm', 
+'id': 'PaulaScher_2008P-1003.35-1011.16-<o,f0,female>'}
+```
 ### Data Fields
 
-- gender: an integer value corresponding to the gender of the speaker.
+- audio: A dictionary containing the path to the downloaded audio file, the decoded audio array, and the sampling rate. Note that when accessing the audio column: `dataset[0]["audio"]` the audio file is automatically decoded and resampled to `dataset.features["audio"].sampling_rate`. Decoding and resampling of a large number of audio files might take a significant amount of time. Thus it is important to first query the sample index before the `"audio"` column, *i.e.* `dataset[0]["audio"]` should **always** be preferred over `dataset["audio"][0]`. 
+- file: A path to the downloaded audio file in .sth format.
+- text: the transcription of the audio file.
+- gender: the gender of the speaker. One of: male, female or N/A.
 - id: unique id of the data sample.
 - speaker_id: unique id of the speaker. The same speaker id can be found for multiple data samples.
-- speech: A dictionary containing the path to the downloaded audio file, the decoded audio array, and the sampling rate. Note that when accessing the audio column: `dataset[0]["audio"]` the audio file is automatically decoded and resampled to `dataset.features["audio"].sampling_rate`. Decoding and resampling of a large number of audio files might take a significant amount of time. Thus it is important to first query the sample index before the "audio" column, i.e. `dataset[0]["audio"]` should always be preferred over `dataset["audio"][0]`.
-- text: the transcription of the audio file.
 
 ### Data Splits
+There are three releases for the TED-LIUM corpus, progressively increasing the number of transcribed speech training data from 118 hours (Release 1), to 207 hours (Release 2), to 452 hours (Release 3).
 
-The data is split into a training, validation and test set.
+Release 1 (default config) 2012:
+- 774 audio talks and automatically aligned transcriptions.
+- Contains 118 hours of speech audio data.
+- Homepage: https://www.openslr.org/7/
 
-| Split      | Examples |
-|------------|----------|
-| Train      |   56,803 |
-| Validation |      591 |
-| Test       |    1,469 |
+Release 2:
+- 1495 audio talks and automatically aligned transcriptions.
+- Contains 207 hours of speech audio data.
+- Dictionary with pronunciations (159848 entries).
+- Selected monolingual data for language modeling from WMT12 publicly available corpora.
+- Homepage: https://www.openslr.org/19/
+
+Release 3:
+
+- 2351 audio talks and automatically aligned transcriptions.
+- Contains 452 hours of speech audio data.
+- TED-LIUM 2 validation and test data: 19 TED talks with their corresponding manual transcriptions.
+- Dictionary with pronunciations (159848 entries), the same file as the one included in TED-LIUM 2.
+- Selected monolingual data for language modeling from WMT12 publicly available corpora: these files come from the TED-LIUM 2 release, but have been modified to produce a tokenization more relevant for English language.
+- Homepage: https://www.openslr.org/51/
+
+Each release is split into a training, validation and test set:
+
+| Split      | Release 1 | Release 2 | Release 3 |
+|------------|-----------|-----------|-----------|
+| Train      | 56,803    | 92,973    | 268,263   |
+| Validation | 591       | 591       | 591       |
+| Test       | 1,469     | 1,469     | 1,469     |
 
 
 ## Dataset Creation
@@ -100,11 +131,11 @@ TED-LIUM was built during [The International Workshop on Spoken Language Trans- 
 
 #### Initial Data Collection and Normalization
 
-The data was obtained from publicly availably TED talks at http://www.ted.com. Proper alignments between the speech and the transcribed text were generated using an in-house speaker segmentation and clustering tool (LIUM_SpkDiarization). Speech disfluencies (e.g. repetitions, hesitations, false starts) were treated in the following way: the repetitions were transcribed, the hesitations were mapped to a specific filler word and the false starts were not taken into account. For full details on the data collection and processing, refer to the [TED-LIUM paper](https://aclanthology.org/L12-1405/).
+The data was obtained from publicly available TED talks at http://www.ted.com. Proper alignments between the speech and the transcribed text were generated using an in-house speaker segmentation and clustering tool (LIUM_SpkDiarization). Speech disfluencies (e.g. repetitions, hesitations, false starts) were treated in the following way: the repetitions were transcribed, the hesitations were mapped to a specific filler word and the false starts were not taken into account. For full details on the data collection and processing, refer to the [TED-LIUM paper](https://aclanthology.org/L12-1405/).
 
 #### Who are the source language producers?
 
-[Needs More Information]
+TED Talks are influential videos from expert speakers on education, business, science, tech and creativity.
 
 ### Annotations
 

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -57,6 +57,22 @@ task_ids:
 
 The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. It contains about 118 hours of speech.
 
+
+### Example 
+
+```python
+from datasets import load_dataset
+
+tedlium = load_dataset("LIUM/minds14", "release1") # for Release 1
+
+# see structure
+print(tedlium)
+
+# load audio sample on the fly
+audio_input = tedlium["train"][0]["audio"]  # first decoded audio sample
+transcription = tedlium["train"][0]["text"]  # first transcription
+```
+
 ### Supported Tasks and Leaderboards
 
 - `automatic-speech-recognition`: The dataset can be used to train a model for Automatic Speech Recognition (ASR). The model is presented with an audio file and asked to transcribe the audio file to written text. The most common evaluation metric is the word error rate (WER). The task has an active leaderboard which can be found at https://paperswithcode.com/sota/speech-recognition-on-tedlium that ranks models based on their WER.
@@ -91,7 +107,7 @@ The audio and transcriptions are in English, as per the TED talks at http://www.
 ### Data Splits
 There are three releases for the TED-LIUM corpus, progressively increasing the number of transcribed speech training data from 118 hours (Release 1), to 207 hours (Release 2), to 452 hours (Release 3).
 
-Release 1 (default config) 2012:
+Release 1 (default config):
 - 774 audio talks and automatically aligned transcriptions.
 - Contains 118 hours of speech audio data.
 - Homepage: https://www.openslr.org/7/
@@ -104,7 +120,6 @@ Release 2:
 - Homepage: https://www.openslr.org/19/
 
 Release 3:
-
 - 2351 audio talks and automatically aligned transcriptions.
 - Contains 452 hours of speech audio data.
 - TED-LIUM 2 validation and test data: 19 TED talks with their corresponding manual transcriptions.

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -63,7 +63,7 @@ The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled 
 ```python
 from datasets import load_dataset
 
-tedlium = load_dataset("LIUM/minds14", "release1") # for Release 1
+tedlium = load_dataset("LIUM/tedlium", "release1") # for Release 1
 
 # see structure
 print(tedlium)
@@ -72,6 +72,8 @@ print(tedlium)
 audio_input = tedlium["train"][0]["audio"]  # first decoded audio sample
 transcription = tedlium["train"][0]["text"]  # first transcription
 ```
+
+Note that the processing of the TEDLIUM dataset requires pydub for audio segmentation. Instructions on how to download pydub can be found at https://github.com/jiaaro/pydub#installation. 
 
 ### Supported Tasks and Leaderboards
 

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -55,7 +55,7 @@ task_ids:
 
 ### Dataset Summary
 
-The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. It contains about 118 hours of speech.
+The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. The three releases of the corpus range from 118 to 452 hours of transcribed speech data.
 
 
 ### Example 
@@ -72,8 +72,6 @@ print(tedlium)
 audio_input = tedlium["train"][0]["audio"]  # first decoded audio sample
 transcription = tedlium["train"][0]["text"]  # first transcription
 ```
-
-Note that the processing of the TEDLIUM dataset requires pydub for audio segmentation. Instructions on how to download pydub can be found at https://github.com/jiaaro/pydub#installation. 
 
 ### Supported Tasks and Leaderboards
 
@@ -195,12 +193,11 @@ Licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/license
 ### Citation Information
 
 ```
-@inproceedings{panayotov2015librispeech,
-  title={Librispeech: an ASR corpus based on public domain audio books},
-  author={Panayotov, Vassil and Chen, Guoguo and Povey, Daniel and Khudanpur, Sanjeev},
-  booktitle={Acoustics, Speech and Signal Processing (ICASSP), 2015 IEEE International Conference on},
-  pages={5206--5210},
-  year={2015},
-  organization={IEEE}
+@inproceedings{rousseau2012tedlium,
+  title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
+  author={Rousseau, Anthony and Del{\'e}glise, Paul and Est{\`e}ve, Yannick},
+  booktitle={Conference on Language Resources and Evaluation (LREC)},
+  pages={125--129},
+  year={2012}
 }
 ```

--- a/datasets/tedlium/README.md
+++ b/datasets/tedlium/README.md
@@ -1,3 +1,5 @@
+---
+pretty_name: TED-LIUM
 annotations_creators:
 - expert-generated
 language_creators:
@@ -16,6 +18,7 @@ task_categories:
 - automatic-speech-recognition
 task_ids:
 - automatic-speech-recognition
+---
 
 # Dataset Card for tedlium
 
@@ -143,10 +146,13 @@ Licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/license
 
 ### Citation Information
 
-@inproceedings{rousseau2012tedlium,
-  title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
-  author={Rousseau, Anthony and Del{\'e}glise, Paul and Est{\`e}ve, Yannick},
-  booktitle={Conference on Language Resources and Evaluation (LREC)},
-  pages={125--129},
-  year={2012}
+```
+@inproceedings{panayotov2015librispeech,
+  title={Librispeech: an ASR corpus based on public domain audio books},
+  author={Panayotov, Vassil and Chen, Guoguo and Povey, Daniel and Khudanpur, Sanjeev},
+  booktitle={Acoustics, Speech and Signal Processing (ICASSP), 2015 IEEE International Conference on},
+  pages={5206--5210},
+  year={2015},
+  organization={IEEE}
 }
+```

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -20,12 +20,39 @@ import numpy as np
 
 
 import datasets
+from datasets.tasks import AutomaticSpeechRecognition
 
 from pydub import AudioSegment
 
+_LICENSE = "licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en)"
 
-# Find for instance the citation on arxiv or on the dataset repo/website
-_CITATION = """\
+class TedliumReleaseConfig(datasets.BuilderConfig):
+  """BuilderConfig for a release of the TED-LIUM dataset."""
+
+  def __init__(self, *, url, download_url, split_paths, citation, **kwargs):
+    super(TedliumReleaseConfig, self).__init__(
+        version=datasets.Version("1.0.1"), **kwargs)
+    self.url = url
+    self.download_url = download_url
+    # List of split, path pairs containing the relative path within the
+    # extracted tarball to the data for each split.
+    self.split_paths = split_paths
+    self.citation = citation
+
+
+def _make_builder_configs():
+  """Creates builder configs for all supported Tedlium dataset releases."""
+  release1 = TedliumReleaseConfig(
+      name="release1",
+      description="""\
+        The TED-LIUM corpus is English-language TED talks, with transcriptions,
+        sampled at 16kHz. It contains about 118 hours of speech.
+
+        This is the TED-LIUM corpus release 1,
+        licensed under Creative Commons BY-NC-ND 3.0
+        (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
+        """,
+      citation="""\
         @inproceedings{rousseau2012tedlium,
           title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
           author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
@@ -33,21 +60,105 @@ _CITATION = """\
           pages={125--129},
           year={2012}
         }
-        """
+        """,
+      url="https://www.openslr.org/7/",
+      download_url="http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
+      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release1",
+                                                   "train")),
+                   (datasets.Split.VALIDATION,
+                    os.path.join("TEDLIUM_release1", "dev")),
+                   (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test"))])
 
-_DESCRIPTION = """\
-        The TED-LIUM corpus is English-language TED talks, with transcriptions,
-        sampled at 16kHz. It contains about 118 hours of speech.
+  release2 = TedliumReleaseConfig(
+      name="release2",
+      description="""\
+        This is the TED-LIUM corpus release 2,
+        licensed under Creative Commons BY-NC-ND 3.0
+        (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
 
-        This is the TED-LIUM corpus release 1.
-        """
+        All talks and text are property of TED Conferences LLC.
 
-_HOMEPAGE = "https://www.openslr.org/7/"
+        The TED-LIUM corpus was made from audio talks and their transcriptions
+        available on the TED website. We have prepared and filtered these data
+        in order to train acoustic models to participate to the International
+        Workshop on Spoken Language Translation 2011 (the LIUM English/French
+        SLT system reached the first rank in the SLT task).
 
-_LICENSE = "licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en)"
+        Contains 1495 talks and transcripts.
+        """,
+      citation="""\
+        @inproceedings{rousseau2014tedlium2,
+          title={Enhancing the {TED-LIUM} Corpus with Selected Data for Language Modeling and More {TED} Talks},
+          author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
+          booktitle={Conference on Language Resources and Evaluation (LREC)},
+          year={2014}
+        }
+        """,
+      url="https://www.openslr.org/19/",
+      download_url="http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
+      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release2",
+                                                   "train")),
+                   (datasets.Split.VALIDATION,
+                    os.path.join("TEDLIUM_release2", "dev")),
+                   (datasets.Split.TEST, os.path.join("TEDLIUM_release2", "test"))])
 
-# The HuggingFace Datasets library doesn't host the datasets but only points to the original files.
-_URLS = {"release1" : "http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz"}
+  release3 = TedliumReleaseConfig(
+      name="release3",
+      description="""\
+        This is the TED-LIUM corpus release 3, licensed under Creative Commons
+        BY-NC-ND 3.0.
+
+        All talks and text are property of TED Conferences LLC.
+
+        This new TED-LIUM release was made through a collaboration between the
+        Ubiqus company and the LIUM (University of Le Mans, France)
+
+        Contents:
+
+        - 2351 audio talks in NIST sphere format (SPH), including talks from
+          TED-LIUM 2: be careful, same talks but not same audio files (only
+          these audio file must be used with the TED-LIUM 3 STM files)
+        - 452 hours of audio
+        - 2351 aligned automatic transcripts in STM format
+        - TEDLIUM 2 dev and test data: 19 TED talks in SPH format with
+          corresponding manual transcriptions (cf. 'legacy' distribution below).
+        - Dictionary with pronunciations (159848 entries), same file as the one
+          included in TED-LIUM 2
+        - Selected monolingual data for language modeling from WMT12 publicly
+          available corpora: these files come from the TED-LIUM 2 release, but
+          have been modified to get a tokenization more relevant for English
+          language
+
+        Two corpus distributions:
+        - the legacy one, on which the dev and test datasets are the same as in
+          TED-LIUM 2 (and TED-LIUM 1).
+        - the 'speaker adaptation' one, especially designed for experiments on
+          speaker adaptation.
+        """,
+      citation="""\
+        @inproceedings{hernandez2018tedlium3,
+          title={TED-LIUM 3: twice as much data and corpus repartition for experiments on speaker adaptation},
+          author={Hernandez, Fran{\\c{c}}ois and Nguyen, Vincent and Ghannay, Sahar and Tomashenko, Natalia and Est{\\`e}ve, Yannick},
+          booktitle={International Conference on Speech and Computer},
+          pages={198--208},
+          year={2018},
+          organization={Springer}
+        }
+        """,
+      url="https://www.openslr.org/51/",
+      download_url="http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
+      split_paths=[
+          (datasets.Split.VALIDATION,
+           os.path.join("TEDLIUM_release-3", "legacy", "dev")),
+          (datasets.Split.TEST, os.path.join("TEDLIUM_release-3", "legacy",
+                                         "test")),
+          # The legacy/train directory contains symlinks to "data",
+          # which are skipped by extraction (see above).
+          # Work around this by manually dereferencing the links here.
+          (datasets.Split.TRAIN, os.path.join("TEDLIUM_release-3", "data"))
+      ])
+
+  return [release1, release2, release3]
 
 
 class TedLium(datasets.GeneratorBasedBuilder):
@@ -55,16 +166,10 @@ class TedLium(datasets.GeneratorBasedBuilder):
 
     VERSION = datasets.Version("1.1.0")
 
-    BUILDER_CONFIGS = [
-        datasets.BuilderConfig(name="release1", version=VERSION, description="TEDLIUM first release"),
-    ]
-
-    DEFAULT_CONFIG_NAME = "release1"  # It's not mandatory to have a default configuration. Just use one if it make sense.
+    BUILDER_CONFIGS = _make_builder_configs()
 
     def _info(self):
-        # TODO: This method specifies the datasets.DatasetInfo object which contains informations and typings for the dataset
-        if self.config.name == "release1":  # This is the name of the configuration selected in BUILDER_CONFIGS above
-            features = datasets.Features({
+        features = datasets.Features({
                 "audio":
                     datasets.features.Audio(sampling_rate=16_000),
                 "text":
@@ -78,33 +183,20 @@ class TedLium(datasets.GeneratorBasedBuilder):
                     datasets.Value('string'),
             })
         return datasets.DatasetInfo(
-            # This is the description that will appear on the datasets page.
-            description=_DESCRIPTION,
-            # This defines the different columns of the dataset and their types
-            features=features,  # Here we define them above because they are different between the two configurations
-            # If there's a common (input, target) tuple from the features, uncomment supervised_keys line below and
-            # specify them. They'll be used if as_supervised=True in builder.as_dataset.
+            description=self.config.description,
+            features=features,
             supervised_keys=("audio", "text"),
-            # Homepage of the dataset for documentation
-            homepage=_HOMEPAGE,
-            # License for the dataset if available
+            homepage=self.config.url,
             license=_LICENSE,
-            # Citation for the dataset
-            citation=_CITATION,
+            citation=self.config.citation,
+            task_templates=[AutomaticSpeechRecognition(audio_column="audio", transcription_column="text")],
         )
 
     def _split_generators(self, dl_manager):
-        urls = _URLS[self.config.name]
-        data_dir = dl_manager.download_and_extract(urls)
-
-        split_paths = [(datasets.Split.TRAIN, os.path.join("TEDLIUM_release1",
-                                                           "train")),
-                       (datasets.Split.VALIDATION,
-                        os.path.join("TEDLIUM_release1", "dev")),
-                       (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test"))]
-
+        data_dir = dl_manager.download_and_extract(
+            self.config.download_url)
         splits = []
-        for split, path in split_paths:
+        for split, path in self.config.split_paths:
             kwargs = {"filepath": os.path.join(data_dir, path)}
             splits.append(datasets.SplitGenerator(name=split, gen_kwargs=kwargs))
         return splits

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -287,7 +287,7 @@ class TedLium(datasets.GeneratorBasedBuilder):
                                 speaker_file = fn
                                 audio_file = os.path.join(split_dir, speaker_file + ".sph")
                                 segment, sampling_rate = sf.read(audio_file, dtype=np.int16)
-                            samples = _extract_audio_segment(segment, int(channel), float(start), float(end))
+                            samples = _extract_audio_segment(segment, sampling_rate, float(start), float(end))
                             key = "-".join([speaker, start, end, label])
                             example = {
                                 "audio": {"path": audio_file, "array": samples, "sampling_rate": sampling_rate},
@@ -368,13 +368,12 @@ def _maybe_trim_suffix(transcript):
     return transcript
 
 
-def _extract_audio_segment(segment, channel, start_sec, end_sec):
+def _extract_audio_segment(segment, sampling_rate, start_sec, end_sec):
     """Extracts segment of audio samples (as an ndarray) from the given segment."""
     # The dataset only contains mono audio.
-    assert channel == 1
-    start_ms = int(start_sec * 1000)
-    end_ms = int(end_sec * 1000)
-    samples = segment[start_ms:end_ms]
+    start_sample = int(start_sec * sampling_rate)
+    end_sample = min(int(end_sec * sampling_rate), segment.shape[0])
+    samples = segment[start_sample:end_sample]
     return samples
 
 

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -27,16 +27,18 @@ import datasets
 from datasets.tasks import AutomaticSpeechRecognition
 
 
+_DL_URL = "https://huggingface.co/datasets/LIUM/tedlium/resolve/main/"
+
 _LICENSE = "licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en)"
 
 
 class TedliumReleaseConfig(datasets.BuilderConfig):
     """BuilderConfig for a release of the TED-LIUM dataset."""
 
-    def __init__(self, *, url, download_url, split_paths, citation, **kwargs):
+    def __init__(self, *, url, download_urls, split_paths, citation, **kwargs):
         super(TedliumReleaseConfig, self).__init__(version=datasets.Version("1.0.1"), **kwargs)
         self.url = url
-        self.download_url = download_url
+        self.download_urls = download_urls
         # List of split, path pairs containing the relative path within the
         # extracted tarball to the data for each split.
         self.split_paths = split_paths
@@ -65,11 +67,15 @@ def _make_builder_configs():
         }
         """,
         url="https://www.openslr.org/7/",
-        download_url="http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
+        download_urls={
+            "train": _DL_URL + os.path.join("TEDLIUM_release1", "train.tar.gz"),
+            "validation": _DL_URL + os.path.join("TEDLIUM_release1", "dev.tar.gz"),
+            "test": _DL_URL + os.path.join("TEDLIUM_release1", "test.tar.gz"),
+        },
         split_paths=[
-            (datasets.Split.TRAIN, os.path.join("TEDLIUM_release1", "train")),
-            (datasets.Split.VALIDATION, os.path.join("TEDLIUM_release1", "dev")),
-            (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test")),
+            (datasets.Split.TRAIN, "train"),
+            (datasets.Split.VALIDATION, "dev"),
+            (datasets.Split.TEST, "test"),
         ],
     )
 
@@ -99,11 +105,15 @@ def _make_builder_configs():
         }
         """,
         url="https://www.openslr.org/19/",
-        download_url="http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
+        download_urls={
+            "train": _DL_URL + os.path.join("TEDLIUM_release2", "train.tar.gz"),
+            "validation": _DL_URL + os.path.join("TEDLIUM_release2", "dev.tar.gz"),
+            "test": _DL_URL + os.path.join("TEDLIUM_release2", "test.tar.gz"),
+        },
         split_paths=[
-            (datasets.Split.TRAIN, os.path.join("TEDLIUM_release2", "train")),
-            (datasets.Split.VALIDATION, os.path.join("TEDLIUM_release2", "dev")),
-            (datasets.Split.TEST, os.path.join("TEDLIUM_release2", "test")),
+            (datasets.Split.TRAIN, "train"),
+            (datasets.Split.VALIDATION, "dev"),
+            (datasets.Split.TEST, "test"),
         ],
     )
 
@@ -111,7 +121,8 @@ def _make_builder_configs():
         name="release3",
         description="""\
         This is the TED-LIUM corpus release 3, licensed under Creative Commons
-        BY-NC-ND 3.0.
+        BY-NC-ND 3.0. This is the 'legacy' version of the corpus, in which the dev and test datasets are the same as in
+        TED-LIUM 2 (and TED-LIUM 1).
 
         All talks and text are property of TED Conferences LLC.
 
@@ -126,7 +137,7 @@ def _make_builder_configs():
         - 452 hours of audio
         - 2351 aligned automatic transcripts in STM format
         - TEDLIUM 2 dev and test data: 19 TED talks in SPH format with
-          corresponding manual transcriptions (cf. 'legacy' distribution below).
+          corresponding manual transcriptions.
         - Dictionary with pronunciations (159848 entries), same file as the one
           included in TED-LIUM 2
         - Selected monolingual data for language modeling from WMT12 publicly
@@ -134,11 +145,6 @@ def _make_builder_configs():
           have been modified to get a tokenization more relevant for English
           language
 
-        Two corpus distributions:
-        - the legacy one, on which the dev and test datasets are the same as in
-          TED-LIUM 2 (and TED-LIUM 1).
-        - the 'speaker adaptation' one, especially designed for experiments on
-          speaker adaptation.
         """,
         citation="""\
         @inproceedings{hernandez2018tedlium3,
@@ -151,18 +157,54 @@ def _make_builder_configs():
         }
         """,
         url="https://www.openslr.org/51/",
-        download_url="http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
+        download_urls={
+            "train": _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train.tar.gz"),
+            "validation": _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "dev.tar.gz"),
+            "test": _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "test.tar.gz"),
+        },
         split_paths=[
-            (datasets.Split.VALIDATION, os.path.join("TEDLIUM_release-3", "legacy", "dev")),
-            (datasets.Split.TEST, os.path.join("TEDLIUM_release-3", "legacy", "test")),
-            # The legacy/train directory contains symlinks to "data",
-            # which are skipped by extraction (see above).
-            # Work around this by manually dereferencing the links here.
-            (datasets.Split.TRAIN, os.path.join("TEDLIUM_release-3", "data")),
+            (datasets.Split.TRAIN, "train"),
+            (datasets.Split.VALIDATION, "dev"),
+            (datasets.Split.TEST, "test"),
         ],
     )
 
-    return [release1, release2, release3]
+    release3_speaker_adaptation = TedliumReleaseConfig(
+        name="release3-speaker-adaptation",
+        description="""\
+            This is the TED-LIUM corpus release 3, licensed under Creative Commons
+            BY-NC-ND 3.0. This is the 'speaker adaptation' version of the corpus, specially designed for experiments on
+            speaker adaptation.
+
+            All talks and text are property of TED Conferences LLC.
+
+            This new TED-LIUM release was made through a collaboration between the
+            Ubiqus company and the LIUM (University of Le Mans, France)
+            """,
+        citation="""\
+            @inproceedings{hernandez2018tedlium3,
+              title={TED-LIUM 3: twice as much data and corpus repartition for experiments on speaker adaptation},
+              author={Hernandez, Fran{\\c{c}}ois and Nguyen, Vincent and Ghannay, Sahar and Tomashenko, Natalia and Est{\\`e}ve, Yannick},
+              booktitle={International Conference on Speech and Computer},
+              pages={198--208},
+              year={2018},
+              organization={Springer}
+            }
+            """,
+        url="https://www.openslr.org/51/",
+        download_urls={
+            "train": _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train.tar.gz"),
+            "validation": _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "dev.tar.gz"),
+            "test": _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "test.tar.gz"),
+        },
+        split_paths=[
+            (datasets.Split.TRAIN, "train"),
+            (datasets.Split.VALIDATION, "dev"),
+            (datasets.Split.TEST, "test"),
+        ],
+    )
+
+    return [release1, release2, release3, release3_speaker_adaptation]
 
 
 class TedLium(datasets.GeneratorBasedBuilder):
@@ -194,21 +236,20 @@ class TedLium(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        archive_path = dl_manager.download(self.config.download_url)
+        archive_path = dl_manager.download(self.config.download_urls)
         # (Optional) In non-streaming mode, we can extract the archive locally to have actual local audio files:
         local_extracted_archive = dl_manager.extract(archive_path) if not dl_manager.is_streaming else {}
         splits = []
         for split, path in self.config.split_paths:
             kwargs = {
-                "filepath": dl_manager.iter_archive(archive_path),
-                "local_extracted_archive": local_extracted_archive,
-                "split": split,
+                "filepath": dl_manager.iter_archive(archive_path[split]),
+                "local_extracted_archive": local_extracted_archive.get(split),
                 "split_path": path,
             }
             splits.append(datasets.SplitGenerator(name=split, gen_kwargs=kwargs))
         return splits
 
-    def _generate_examples(self, filepath, local_extracted_archive, split, split_path):
+    def _generate_examples(self, filepath, local_extracted_archive, split_path):
         """Generate examples from a TED-LIUM stm file."""
         if local_extracted_archive:
             # The stm directory houses the speaker and transcription information in .stm format
@@ -244,38 +285,36 @@ class TedLium(datasets.GeneratorBasedBuilder):
                         yield key, example
 
         else:
-            key = 0
             audio_data = {}
             transcripts = defaultdict(list)
             for path, f in filepath:
-                if path.split("/")[1] == split:
-                    if path.endswith(".sph"):
-                        # get the speaker id
-                        fn = path.split("/")[-1].strip(".sph")
-                        # read the audio data from raw byte form and add key-value pair to dict
-                        audio_data[fn] = sf.read(BytesIO(f.read()), dtype=np.int16)
-                    elif path.endswith(".stm"):
-                        for line in f:
-                            if line:
-                                line = line.decode("utf-8").strip()
-                                fn, channel, speaker, start, end, label, transcript = line.split(" ", 6)
-                                transcript = _maybe_trim_suffix(transcript)
-                                audio_file = path.replace("stm", "sph")
-                                id_key = "-".join([speaker, start, end, label])
-                                # append metadata information to the dict of transcripts for the associated speaker
-                                transcripts[fn].append(
-                                    {
-                                        "text": transcript,
-                                        "speaker_id": speaker,
-                                        "gender": _parse_gender(label),
-                                        "file": audio_file,
-                                        "id": id_key,
-                                        "start": start,
-                                        "end": end,
-                                        "channel": channel,
-                                        "fn": fn,
-                                    }
-                                )
+                if path.endswith(".sph"):
+                    # get the speaker id
+                    fn = path.split("/")[-1].strip(".sph")
+                    # read the audio data from raw byte form and add key-value pair to dict
+                    audio_data[fn] = sf.read(BytesIO(f.read()), dtype=np.int16)
+                elif path.endswith(".stm"):
+                    for line in f:
+                        if line:
+                            line = line.decode("utf-8").strip()
+                            fn, channel, speaker, start, end, label, transcript = line.split(" ", 6)
+                            transcript = _maybe_trim_suffix(transcript)
+                            audio_file = path.replace("stm", "sph")
+                            key = "-".join([speaker, start, end, label])
+                            # append metadata information to the dict of transcripts for the associated speaker
+                            transcripts[fn].append(
+                                {
+                                    "text": transcript,
+                                    "speaker_id": speaker,
+                                    "gender": _parse_gender(label),
+                                    "file": audio_file,
+                                    "id": key,
+                                    "start": start,
+                                    "end": end,
+                                    "channel": channel,
+                                    "fn": fn,
+                                }
+                            )
 
                 if audio_data and audio_data.keys() == transcripts.keys():
                     for fn, speaker in transcripts.items():
@@ -288,6 +327,7 @@ class TedLium(datasets.GeneratorBasedBuilder):
                                 float(transcript["end"]),
                             )
                             audio = {"path": transcript["file"], "array": samples, "sampling_rate": sampling_rate}
+                            key = transcript["id"]
                             yield key, {
                                 "audio": audio,
                                 "text": transcript["text"],
@@ -296,7 +336,6 @@ class TedLium(datasets.GeneratorBasedBuilder):
                                 "file": transcript["file"],
                                 "id": transcript["id"],
                             }
-                            key += 1
                     audio_data = {}
                     transcripts = defaultdict(list)
 

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -238,8 +238,8 @@ def _maybe_trim_suffix(transcript):
     transcript = splits[0]
     if len(splits) > 1:
         suffix = splits[-1]
-    if not suffix.startswith("("):
-        transcript += " " + suffix
+        if not suffix.startswith("("):
+            transcript += " " + suffix
     return transcript
 
 

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -250,7 +250,6 @@ class TedLium(datasets.GeneratorBasedBuilder):
                 if path.split("/")[1] == split:
                     if path.endswith(".sph"):
                         fn = path.split("/")[-1].strip(".sph")
-                        import ipdb; ipdb.set_trace()
                         audio_data[fn] = f.read()
                     elif path.endswith(".stm"):
                         for line in f:

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -331,7 +331,7 @@ class TedLium(datasets.GeneratorBasedBuilder):
                                 segment, sampling_rate = audio_data[transcript["fn"]]
                                 samples = _extract_audio_segment(
                                     segment,
-                                    int(transcript["channel"]),
+                                    sampling_rate,
                                     float(transcript["start"]),
                                     float(transcript["end"]),
                                 )

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -106,7 +106,9 @@ def _make_builder_configs():
         """,
         url="https://www.openslr.org/19/",
         download_urls={
-            "train": [_DL_URL + os.path.join("TEDLIUM_release2", "train.tar.gz")],
+            "train": [_DL_URL + os.path.join("TEDLIUM_release2", "train_1.tar.gz"),
+                      _DL_URL + os.path.join("TEDLIUM_release2", "train_2.tar.gz"),
+                      _DL_URL + os.path.join("TEDLIUM_release2", "train_3.tar.gz")],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release2", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release2", "test.tar.gz")],
         },
@@ -198,7 +200,10 @@ def _make_builder_configs():
             """,
         url="https://www.openslr.org/51/",
         download_urls={
-            "train": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train.tar.gz")],
+            "train": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_1.tar.gz"),
+                      _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_2.tar.gz"),
+                      _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_3.tar.gz"),
+                      _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_4.tar.gz")],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "test.tar.gz")],
         },

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -203,7 +203,9 @@ class TedLium(datasets.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """Generate examples from a TED-LIUM stm file."""
+        # The stm directory houses the speaker and transcription information in .stm format
         stm_dir = os.path.join(filepath, "stm")
+        # The sph directory houses the audio files in .sph format
         sph_dir = os.path.join(filepath, "sph")
         stm_files = [os.path.join(stm_dir, f) for f in os.listdir(stm_dir) if f.endswith('.stm')]
         for file in stm_files:

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -1,0 +1,273 @@
+# coding=utf-8
+# Copyright 2022 The TensorFlow Datasets Authors and the HuggingFace Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TED-LIUM speech recognition dataset."""
+
+import os
+import re
+import numpy as np
+
+
+import datasets
+from datasets.tasks import AutomaticSpeechRecognition
+
+
+class TedliumReleaseConfig(datasets.BuilderConfig):
+  """BuilderConfig for a release of the TED-LIUM dataset."""
+
+  def __init__(self, *, url, download_url, split_paths, citation, **kwargs):
+    super(TedliumReleaseConfig, self).__init__(
+        version=datasets.Version("1.0.1"), **kwargs)
+    self.url = url
+    self.download_url = download_url
+    # List of split, path pairs containing the relative path within the
+    # extracted tarball to the data for each split.
+    self.split_paths = split_paths
+    self.citation = citation
+
+
+def _make_builder_configs():
+  """Creates builder configs for all supported Tedlium dataset releases."""
+  release1 = TedliumReleaseConfig(
+      name="release1",
+      description="""\
+        The TED-LIUM corpus is English-language TED talks, with transcriptions,
+        sampled at 16kHz. It contains about 118 hours of speech.
+
+        This is the TED-LIUM corpus release 1,
+        licensed under Creative Commons BY-NC-ND 3.0
+        (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
+        """,
+      citation="""\
+        @inproceedings{rousseau2012tedlium,
+          title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
+          author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
+          booktitle={Conference on Language Resources and Evaluation (LREC)},
+          pages={125--129},
+          year={2012}
+        }
+        """,
+      url="https://www.openslr.org/7/",
+      download_url="http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
+      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release1",
+                                                   "train")),
+                   (datasets.Split.VALIDATION,
+                    os.path.join("TEDLIUM_release1", "dev")),
+                   (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test"))])
+
+  release2 = TedliumReleaseConfig(
+      name="release2",
+      description="""\
+        This is the TED-LIUM corpus release 2,
+        licensed under Creative Commons BY-NC-ND 3.0
+        (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
+
+        All talks and text are property of TED Conferences LLC.
+
+        The TED-LIUM corpus was made from audio talks and their transcriptions
+        available on the TED website. We have prepared and filtered these data
+        in order to train acoustic models to participate to the International
+        Workshop on Spoken Language Translation 2011 (the LIUM English/French
+        SLT system reached the first rank in the SLT task).
+
+        Contains 1495 talks and transcripts.
+        """,
+      citation="""\
+        @inproceedings{rousseau2014tedlium2,
+          title={Enhancing the {TED-LIUM} Corpus with Selected Data for Language Modeling and More {TED} Talks},
+          author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
+          booktitle={Conference on Language Resources and Evaluation (LREC)},
+          year={2014}
+        }
+        """,
+      url="https://www.openslr.org/19/",
+      download_url="http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
+      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release2",
+                                                   "train")),
+                   (datasets.Split.VALIDATION,
+                    os.path.join("TEDLIUM_release2", "dev")),
+                   (datasets.Split.TEST, os.path.join("TEDLIUM_release2", "test"))])
+
+  release3 = TedliumReleaseConfig(
+      name="release3",
+      description="""\
+        This is the TED-LIUM corpus release 3, licensed under Creative Commons
+        BY-NC-ND 3.0.
+
+        All talks and text are property of TED Conferences LLC.
+
+        This new TED-LIUM release was made through a collaboration between the
+        Ubiqus company and the LIUM (University of Le Mans, France)
+
+        Contents:
+
+        - 2351 audio talks in NIST sphere format (SPH), including talks from
+          TED-LIUM 2: be careful, same talks but not same audio files (only
+          these audio file must be used with the TED-LIUM 3 STM files)
+        - 452 hours of audio
+        - 2351 aligned automatic transcripts in STM format
+        - TEDLIUM 2 dev and test data: 19 TED talks in SPH format with
+          corresponding manual transcriptions (cf. 'legacy' distribution below).
+        - Dictionary with pronunciations (159848 entries), same file as the one
+          included in TED-LIUM 2
+        - Selected monolingual data for language modeling from WMT12 publicly
+          available corpora: these files come from the TED-LIUM 2 release, but
+          have been modified to get a tokenization more relevant for English
+          language
+
+        Two corpus distributions:
+        - the legacy one, on which the dev and test datasets are the same as in
+          TED-LIUM 2 (and TED-LIUM 1).
+        - the 'speaker adaptation' one, especially designed for experiments on
+          speaker adaptation.
+        """,
+      citation="""\
+        @inproceedings{hernandez2018tedlium3,
+          title={TED-LIUM 3: twice as much data and corpus repartition for experiments on speaker adaptation},
+          author={Hernandez, Fran{\\c{c}}ois and Nguyen, Vincent and Ghannay, Sahar and Tomashenko, Natalia and Est{\\`e}ve, Yannick},
+          booktitle={International Conference on Speech and Computer},
+          pages={198--208},
+          year={2018},
+          organization={Springer}
+        }
+        """,
+      url="https://www.openslr.org/51/",
+      download_url="http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
+      split_paths=[
+          (datasets.Split.VALIDATION,
+           os.path.join("TEDLIUM_release-3", "legacy", "dev")),
+          (datasets.Split.TEST, os.path.join("TEDLIUM_release-3", "legacy",
+                                         "test")),
+          # The legacy/train directory contains symlinks to "data",
+          # which are skipped by extraction (see above).
+          # Work around this by manually dereferencing the links here.
+          (datasets.Split.TRAIN, os.path.join("TEDLIUM_release-3", "data"))
+      ])
+
+  return [release1, release2, release3]
+
+
+class Tedlium(datasets.BeamBasedBuilder):
+  """TED-LIUM speech recognition dataset."""
+
+  BUILDER_CONFIGS = _make_builder_configs()
+
+  def _info(self):
+    return datasets.DatasetInfo(
+        description="""
+        The TED-LIUM corpus is English-language TED talks, with transcriptions,
+        sampled at 16kHz. It contains about 118 hours of speech.
+        """,
+        features=datasets.Features({
+            "speech":
+                datasets.features.Audio(sampling_rate=16_000),
+            "text":
+                datasets.Value('string'),
+            "speaker_id":
+                datasets.Value('string'),
+            "gender":
+                datasets.features.ClassLabel(names=["unknown", "female", "male"]),
+            "id":
+                datasets.Value('string'),
+        }),
+        supervised_keys=("speech", "text"),
+        homepage=self.config.url,
+        citation=self.config.citation,
+        task_templates=[AutomaticSpeechRecognition(audio_column="speech", transcription_column="text")],
+    )
+
+  def _split_generators(self, dl_manager):
+    extracted_dir = dl_manager.download_and_extract(
+        self.config.download_url)
+    splits = []
+    for split, path in self.config.split_paths:
+      kwargs = {"directory": os.path.join(extracted_dir, path)}
+      splits.append(datasets.SplitGenerator(name=split, gen_kwargs=kwargs))
+    return splits
+
+  def _build_pcollection(self, pipeline, directory):
+    beam = datasets.lazy_imports.apache_beam
+    stm_files = datasets.Value('io').gfile.glob(os.path.join(directory, "stm", "*stm"))
+    return (pipeline
+            | beam.Create(stm_files)
+            | beam.FlatMap(_generate_examples_from_stm_file))
+
+
+def _generate_examples_from_stm_file(stm_path):
+  """Generate examples from a TED-LIUM stm file."""
+  stm_dir = os.path.dirname(stm_path)
+  sph_dir = os.path.join(os.path.dirname(stm_dir), "sph")
+  with open(stm_path) as f:
+    for line in f:
+      line = line.strip()
+      fn, channel, speaker, start, end, label, transcript = line.split(" ", 6)
+      transcript = _maybe_trim_suffix(transcript)
+
+      audio_file = "%s.sph" % fn
+      samples = _extract_audio_segment(
+          os.path.join(sph_dir, audio_file), int(channel), float(start),
+          float(end))
+
+      key = "-".join([speaker, start, end, label])
+      example = {
+          "speech": samples,
+          "text": transcript,
+          "speaker_id": speaker,
+          "gender": _parse_gender(label),
+          "id": key,
+      }
+      yield key, example
+
+
+def _maybe_trim_suffix(transcript):
+  # stm files for the TEDLIUM release 1 train split contain a key (enclosed in
+  # parens) at the end.
+  splits = transcript.rsplit(" ", 1)
+  transcript = splits[0]
+  if len(splits) > 1:
+    suffix = splits[-1]
+    if not suffix.startswith("("):
+      transcript += " " + suffix
+  return transcript
+
+
+def _parse_gender(label_str):
+  """Parse gender string from STM "<label>" field."""
+  gender = re.split(",|_", label_str)[-1][:-1]
+  # Fix inconsistencies in the data.
+  if not gender:
+    gender = -1  # Missing label.
+  elif gender == "<NA":  # In TEDLIUM release 3 training data.
+    gender = -1  # Missing label.
+  elif gender == "F":
+    gender = "female"
+  elif gender == "M":
+    gender = "male"
+  return gender
+
+
+def _extract_audio_segment(sph_path, channel, start_sec, end_sec):
+  """Extracts segment of audio samples (as an ndarray) from the given path."""
+  with open(sph_path, "rb") as f:
+    segment = datasets.lazy_imports.pydub.AudioSegment.from_file(
+        f, format="nistsphere")
+  # The dataset only contains mono audio.
+  assert segment.channels == 1
+  assert channel == 1
+  start_ms = int(start_sec * 1000)
+  end_ms = int(end_sec * 1000)
+  segment = segment[start_ms:end_ms]
+  samples = np.array(segment.get_array_of_samples())
+  return samples

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -222,7 +222,7 @@ class TedLium(datasets.GeneratorBasedBuilder):
 
                     key = "-".join([speaker, start, end, label])
                     example = {
-                        "audio": {"path": file, "bytes": samples},
+                        "audio": {"path": file, "array": samples, "sampling_rate": 16000},
                         "text": transcript,
                         "speaker_id": speaker,
                         "gender": _parse_gender(label),

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -1,5 +1,4 @@
-# coding=utf-8
-# Copyright 2022 The TensorFlow Datasets Authors and the HuggingFace Datasets Authors.
+# Copyright 2022 The HuggingFace Datasets Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,36 +20,13 @@ import numpy as np
 
 
 import datasets
-from datasets.tasks import AutomaticSpeechRecognition
+import tensorflow as tf
+
+import tensorflow_datasets.public_api as tfds
 
 
-class TedliumReleaseConfig(datasets.BuilderConfig):
-  """BuilderConfig for a release of the TED-LIUM dataset."""
-
-  def __init__(self, *, url, download_url, split_paths, citation, **kwargs):
-    super(TedliumReleaseConfig, self).__init__(
-        version=datasets.Version("1.0.1"), **kwargs)
-    self.url = url
-    self.download_url = download_url
-    # List of split, path pairs containing the relative path within the
-    # extracted tarball to the data for each split.
-    self.split_paths = split_paths
-    self.citation = citation
-
-
-def _make_builder_configs():
-  """Creates builder configs for all supported Tedlium dataset releases."""
-  release1 = TedliumReleaseConfig(
-      name="release1",
-      description="""\
-        The TED-LIUM corpus is English-language TED talks, with transcriptions,
-        sampled at 16kHz. It contains about 118 hours of speech.
-
-        This is the TED-LIUM corpus release 1,
-        licensed under Creative Commons BY-NC-ND 3.0
-        (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
-        """,
-      citation="""\
+# Find for instance the citation on arxiv or on the dataset repo/website
+_CITATION = """\
         @inproceedings{rousseau2012tedlium,
           title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
           author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
@@ -58,218 +34,150 @@ def _make_builder_configs():
           pages={125--129},
           year={2012}
         }
-        """,
-      url="https://www.openslr.org/7/",
-      download_url="http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
-      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release1",
-                                                   "train")),
-                   (datasets.Split.VALIDATION,
-                    os.path.join("TEDLIUM_release1", "dev")),
-                   (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test"))])
+        """
 
-  release2 = TedliumReleaseConfig(
-      name="release2",
-      description="""\
-        This is the TED-LIUM corpus release 2,
-        licensed under Creative Commons BY-NC-ND 3.0
-        (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
-
-        All talks and text are property of TED Conferences LLC.
-
-        The TED-LIUM corpus was made from audio talks and their transcriptions
-        available on the TED website. We have prepared and filtered these data
-        in order to train acoustic models to participate to the International
-        Workshop on Spoken Language Translation 2011 (the LIUM English/French
-        SLT system reached the first rank in the SLT task).
-
-        Contains 1495 talks and transcripts.
-        """,
-      citation="""\
-        @inproceedings{rousseau2014tedlium2,
-          title={Enhancing the {TED-LIUM} Corpus with Selected Data for Language Modeling and More {TED} Talks},
-          author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
-          booktitle={Conference on Language Resources and Evaluation (LREC)},
-          year={2014}
-        }
-        """,
-      url="https://www.openslr.org/19/",
-      download_url="http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
-      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release2",
-                                                   "train")),
-                   (datasets.Split.VALIDATION,
-                    os.path.join("TEDLIUM_release2", "dev")),
-                   (datasets.Split.TEST, os.path.join("TEDLIUM_release2", "test"))])
-
-  release3 = TedliumReleaseConfig(
-      name="release3",
-      description="""\
-        This is the TED-LIUM corpus release 3, licensed under Creative Commons
-        BY-NC-ND 3.0.
-
-        All talks and text are property of TED Conferences LLC.
-
-        This new TED-LIUM release was made through a collaboration between the
-        Ubiqus company and the LIUM (University of Le Mans, France)
-
-        Contents:
-
-        - 2351 audio talks in NIST sphere format (SPH), including talks from
-          TED-LIUM 2: be careful, same talks but not same audio files (only
-          these audio file must be used with the TED-LIUM 3 STM files)
-        - 452 hours of audio
-        - 2351 aligned automatic transcripts in STM format
-        - TEDLIUM 2 dev and test data: 19 TED talks in SPH format with
-          corresponding manual transcriptions (cf. 'legacy' distribution below).
-        - Dictionary with pronunciations (159848 entries), same file as the one
-          included in TED-LIUM 2
-        - Selected monolingual data for language modeling from WMT12 publicly
-          available corpora: these files come from the TED-LIUM 2 release, but
-          have been modified to get a tokenization more relevant for English
-          language
-
-        Two corpus distributions:
-        - the legacy one, on which the dev and test datasets are the same as in
-          TED-LIUM 2 (and TED-LIUM 1).
-        - the 'speaker adaptation' one, especially designed for experiments on
-          speaker adaptation.
-        """,
-      citation="""\
-        @inproceedings{hernandez2018tedlium3,
-          title={TED-LIUM 3: twice as much data and corpus repartition for experiments on speaker adaptation},
-          author={Hernandez, Fran{\\c{c}}ois and Nguyen, Vincent and Ghannay, Sahar and Tomashenko, Natalia and Est{\\`e}ve, Yannick},
-          booktitle={International Conference on Speech and Computer},
-          pages={198--208},
-          year={2018},
-          organization={Springer}
-        }
-        """,
-      url="https://www.openslr.org/51/",
-      download_url="http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
-      split_paths=[
-          (datasets.Split.VALIDATION,
-           os.path.join("TEDLIUM_release-3", "legacy", "dev")),
-          (datasets.Split.TEST, os.path.join("TEDLIUM_release-3", "legacy",
-                                         "test")),
-          # The legacy/train directory contains symlinks to "data",
-          # which are skipped by extraction (see above).
-          # Work around this by manually dereferencing the links here.
-          (datasets.Split.TRAIN, os.path.join("TEDLIUM_release-3", "data"))
-      ])
-
-  return [release1, release2, release3]
-
-
-class Tedlium(datasets.BeamBasedBuilder):
-  """TED-LIUM speech recognition dataset."""
-
-  BUILDER_CONFIGS = _make_builder_configs()
-
-  def _info(self):
-    return datasets.DatasetInfo(
-        description="""
+_DESCRIPTION = """\
         The TED-LIUM corpus is English-language TED talks, with transcriptions,
         sampled at 16kHz. It contains about 118 hours of speech.
-        """,
-        features=datasets.Features({
-            "speech":
-                datasets.features.Audio(sampling_rate=16_000),
-            "text":
-                datasets.Value('string'),
-            "speaker_id":
-                datasets.Value('string'),
-            "gender":
-                datasets.features.ClassLabel(names=["unknown", "female", "male"]),
-            "id":
-                datasets.Value('string'),
-        }),
-        supervised_keys=("speech", "text"),
-        homepage=self.config.url,
-        citation=self.config.citation,
-        task_templates=[AutomaticSpeechRecognition(audio_column="speech", transcription_column="text")],
-    )
 
-  def _split_generators(self, dl_manager):
-    extracted_dir = dl_manager.download_and_extract(
-        self.config.download_url)
-    splits = []
-    for split, path in self.config.split_paths:
-      kwargs = {"directory": os.path.join(extracted_dir, path)}
-      splits.append(datasets.SplitGenerator(name=split, gen_kwargs=kwargs))
-    return splits
+        This is the TED-LIUM corpus release 1.
+        """
 
-  def _build_pcollection(self, pipeline, directory):
-    import apache_beam as beam
-    stm_directory = os.path.join(directory, "stm")
-    stm_files = [os.path.join(stm_directory, f) for f in os.listdir(stm_directory) if f.endswith('.stm')]
-    return (pipeline
-            | beam.Create(stm_files)
-            | beam.FlatMap(_generate_examples_from_stm_file))
+_HOMEPAGE = "https://www.openslr.org/7/"
+
+_LICENSE = "licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en)"
+
+# The HuggingFace Datasets library doesn't host the datasets but only points to the original files.
+_URLS = {"release1" : "http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz"}
 
 
-def _generate_examples_from_stm_file(stm_path):
-  """Generate examples from a TED-LIUM stm file."""
-  stm_dir = os.path.dirname(stm_path)
-  sph_dir = os.path.join(os.path.dirname(stm_dir), "sph")
-  with open(stm_path) as f:
-    for line in f:
-      line = line.strip()
-      fn, channel, speaker, start, end, label, transcript = line.split(" ", 6)
-      transcript = _maybe_trim_suffix(transcript)
+class TedLium(datasets.GeneratorBasedBuilder):
+    """ The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. It contains about 118 hours of speech."""
 
-      audio_file = "%s.sph" % fn
-      samples = _extract_audio_segment(
-          os.path.join(sph_dir, audio_file), int(channel), float(start),
-          float(end))
+    VERSION = datasets.Version("1.1.0")
 
-      key = "-".join([speaker, start, end, label])
-      example = {
-          "speech": samples,
-          "text": transcript,
-          "speaker_id": speaker,
-          "gender": _parse_gender(label),
-          "id": key,
-      }
-      yield key, example
+    BUILDER_CONFIGS = [
+        datasets.BuilderConfig(name="release1", version=VERSION, description="TEDLIUM first release"),
+    ]
 
+    DEFAULT_CONFIG_NAME = "release1"  # It's not mandatory to have a default configuration. Just use one if it make sense.
+
+    def _info(self):
+        # TODO: This method specifies the datasets.DatasetInfo object which contains informations and typings for the dataset
+        if self.config.name == "release1":  # This is the name of the configuration selected in BUILDER_CONFIGS above
+            features = datasets.Features({
+                "speech":
+                    datasets.features.Audio(sampling_rate=16_000),
+                "text":
+                    datasets.Value('string'),
+                "speaker_id":
+                    datasets.Value('string'),
+                "gender":
+                    datasets.features.ClassLabel(names=["unknown", "female", "male"]),
+                "id":
+                    datasets.Value('string'),
+            })
+        return datasets.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            # This defines the different columns of the dataset and their types
+            features=features,  # Here we define them above because they are different between the two configurations
+            # If there's a common (input, target) tuple from the features, uncomment supervised_keys line below and
+            # specify them. They'll be used if as_supervised=True in builder.as_dataset.
+            supervised_keys=("speech", "text"),
+            # Homepage of the dataset for documentation
+            homepage=_HOMEPAGE,
+            # License for the dataset if available
+            license=_LICENSE,
+            # Citation for the dataset
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        # If several configurations are possible (listed in BUILDER_CONFIGS), the configuration selected by the user is in self.config.name
+
+        # dl_manager is a datasets.download.DownloadManager that can be used to download and extract URLS
+        # It can accept any type or nested list/dict and will give back the same structure with the url replaced with path to local files.
+        # By default the archives will be extracted and a path to a cached folder where they are extracted is returned instead of the archive
+        urls = _URLS[self.config.name]
+        data_dir = dl_manager.download_and_extract(urls)
+
+        split_paths = [(datasets.Split.TRAIN, os.path.join("TEDLIUM_release1",
+                                                           "train")),
+                       (datasets.Split.VALIDATION,
+                        os.path.join("TEDLIUM_release1", "dev")),
+                       (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test"))]
+
+        splits = []
+        for split, path in split_paths:
+            kwargs = {"filepath": os.path.join(data_dir, path)}
+            splits.append(datasets.SplitGenerator(name=split, gen_kwargs=kwargs))
+        return splits
+
+    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
+    def _generate_examples(self, filepath):
+        """Generate examples from a TED-LIUM stm file."""
+        stm_path = filepath  # (?)
+        stm_dir = os.path.dirname(stm_path)
+        sph_dir = os.path.join(os.path.dirname(stm_dir), "sph")
+        with open(stm_path) as f:
+            for line in f:
+                line = line.strip()
+                fn, channel, speaker, start, end, label, transcript = line.split(" ", 6)
+                transcript = _maybe_trim_suffix(transcript)
+
+                audio_file = "%s.sph" % fn
+                samples = _extract_audio_segment(
+                    os.path.join(sph_dir, audio_file), int(channel), float(start),
+                    float(end))
+
+                key = "-".join([speaker, start, end, label])
+                example = {
+                    "speech": samples,
+                    "text": transcript,
+                    "speaker_id": speaker,
+                    "gender": _parse_gender(label),
+                    "id": key,
+                }
+                yield key, example
 
 def _maybe_trim_suffix(transcript):
-  # stm files for the TEDLIUM release 1 train split contain a key (enclosed in
-  # parens) at the end.
-  splits = transcript.rsplit(" ", 1)
-  transcript = splits[0]
-  if len(splits) > 1:
-    suffix = splits[-1]
+    # stm files for the TEDLIUM release 1 train split contain a key (enclosed in
+    # parens) at the end.
+    splits = transcript.rsplit(" ", 1)
+    transcript = splits[0]
+    if len(splits) > 1:
+        suffix = splits[-1]
     if not suffix.startswith("("):
-      transcript += " " + suffix
-  return transcript
+        transcript += " " + suffix
+    return transcript
 
 
 def _parse_gender(label_str):
-  """Parse gender string from STM "<label>" field."""
-  gender = re.split(",|_", label_str)[-1][:-1]
-  # Fix inconsistencies in the data.
-  if not gender:
-    gender = -1  # Missing label.
-  elif gender == "<NA":  # In TEDLIUM release 3 training data.
-    gender = -1  # Missing label.
-  elif gender == "F":
-    gender = "female"
-  elif gender == "M":
-    gender = "male"
-  return gender
+    """Parse gender string from STM "<label>" field."""
+    gender = re.split(",|_", label_str)[-1][:-1]
+    # Fix inconsistencies in the data.
+    if not gender:
+        gender = -1  # Missing label.
+    elif gender == "<NA":  # In TEDLIUM release 3 training data.
+        gender = -1  # Missing label.
+    elif gender == "F":
+        gender = "female"
+    elif gender == "M":
+        gender = "male"
+    return gender
 
 
 def _extract_audio_segment(sph_path, channel, start_sec, end_sec):
-  """Extracts segment of audio samples (as an ndarray) from the given path."""
-  with open(sph_path, "rb") as f:
-    # need to fix this tfds import too
-    segment = datasets.lazy_imports.pydub.AudioSegment.from_file(
-        f, format="nistsphere")
-  # The dataset only contains mono audio.
-  assert segment.channels == 1
-  assert channel == 1
-  start_ms = int(start_sec * 1000)
-  end_ms = int(end_sec * 1000)
-  segment = segment[start_ms:end_ms]
-  samples = np.array(segment.get_array_of_samples())
-  return samples
+    """Extracts segment of audio samples (as an ndarray) from the given path."""
+    with tf.io.gfile.GFile(sph_path, "rb") as f:
+        segment = tfds.core.lazy_imports.pydub.AudioSegment.from_file(
+            f, format="nistsphere")
+    # The dataset only contains mono audio.
+    assert segment.channels == 1
+    assert channel == 1
+    start_ms = int(start_sec * 1000)
+    end_ms = int(end_sec * 1000)
+    segment = segment[start_ms:end_ms]
+    samples = np.array(segment.get_array_of_samples())
+    return samples

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -20,9 +20,8 @@ import numpy as np
 
 
 import datasets
-import tensorflow as tf
 
-import tensorflow_datasets.public_api as tfds
+from pydub import AudioSegment
 
 
 # Find for instance the citation on arxiv or on the dataset repo/website
@@ -114,10 +113,9 @@ class TedLium(datasets.GeneratorBasedBuilder):
             splits.append(datasets.SplitGenerator(name=split, gen_kwargs=kwargs))
         return splits
 
-    # method parameters are unpacked from `gen_kwargs` as given in `_split_generators`
     def _generate_examples(self, filepath):
         """Generate examples from a TED-LIUM stm file."""
-        stm_path = filepath  # (?)
+        stm_path = os.path.join(filepath, "stm")
         stm_dir = os.path.dirname(stm_path)
         sph_dir = os.path.join(os.path.dirname(stm_dir), "sph")
         with open(stm_path) as f:
@@ -170,9 +168,8 @@ def _parse_gender(label_str):
 
 def _extract_audio_segment(sph_path, channel, start_sec, end_sec):
     """Extracts segment of audio samples (as an ndarray) from the given path."""
-    with tf.io.gfile.GFile(sph_path, "rb") as f:
-        segment = tfds.core.lazy_imports.pydub.AudioSegment.from_file(
-            f, format="nistsphere")
+    with open(sph_path, "rb") as f:
+        segment = AudioSegment.from_file(f, format="nistsphere")
     # The dataset only contains mono audio.
     assert segment.channels == 1
     assert channel == 1

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -109,7 +109,6 @@ def _make_builder_configs():
             "train": [
                 _DL_URL + os.path.join("TEDLIUM_release2", "train_1.tar.gz"),
                 _DL_URL + os.path.join("TEDLIUM_release2", "train_2.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release2", "train_3.tar.gz"),
             ],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release2", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release2", "test.tar.gz")],
@@ -165,9 +164,6 @@ def _make_builder_configs():
             "train": [
                 _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_1.tar.gz"),
                 _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_2.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_3.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_4.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_5.tar.gz"),
             ],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release3", "legacy", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release3", "legacy", "test.tar.gz")],
@@ -206,9 +202,6 @@ def _make_builder_configs():
             "train": [
                 _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_1.tar.gz"),
                 _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_2.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_3.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_4.tar.gz"),
-                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_5.tar.gz"),
             ],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "test.tar.gz")],

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -106,9 +106,11 @@ def _make_builder_configs():
         """,
         url="https://www.openslr.org/19/",
         download_urls={
-            "train": [_DL_URL + os.path.join("TEDLIUM_release2", "train_1.tar.gz"),
-                      _DL_URL + os.path.join("TEDLIUM_release2", "train_2.tar.gz"),
-                      _DL_URL + os.path.join("TEDLIUM_release2", "train_3.tar.gz")],
+            "train": [
+                _DL_URL + os.path.join("TEDLIUM_release2", "train_1.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release2", "train_2.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release2", "train_3.tar.gz"),
+            ],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release2", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release2", "test.tar.gz")],
         },
@@ -165,6 +167,7 @@ def _make_builder_configs():
                 _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_2.tar.gz"),
                 _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_3.tar.gz"),
                 _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_4.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release3", "legacy", "train_5.tar.gz"),
             ],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release3", "legacy", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release3", "legacy", "test.tar.gz")],
@@ -200,10 +203,13 @@ def _make_builder_configs():
             """,
         url="https://www.openslr.org/51/",
         download_urls={
-            "train": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_1.tar.gz"),
-                      _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_2.tar.gz"),
-                      _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_3.tar.gz"),
-                      _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_4.tar.gz")],
+            "train": [
+                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_1.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_2.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_3.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_4.tar.gz"),
+                _DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "train_5.tar.gz"),
+            ],
             "validation": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "dev.tar.gz")],
             "test": [_DL_URL + os.path.join("TEDLIUM_release3", "speaker-adaptation", "test.tar.gz")],
         },
@@ -266,7 +272,6 @@ class TedLium(datasets.GeneratorBasedBuilder):
                 # The stm directory houses the speaker and transcription information in .stm format
                 split_dir = os.path.join(local_archive, split_path)
                 stm_files = [os.path.join(split_dir, f) for f in os.listdir(split_dir) if f.endswith(".stm")]
-                import ipdb; ipdb.set_trace()
                 for file in stm_files:
                     # the .sph speaker file almost always has the same file name as the .stm file
                     speaker_file = Path(file).stem

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -15,37 +15,37 @@
 """TED-LIUM speech recognition dataset."""
 
 import os
-from pathlib import Path
 import re
-import numpy as np
+from pathlib import Path
 
+import numpy as np
+from pydub import AudioSegment
 
 import datasets
 from datasets.tasks import AutomaticSpeechRecognition
 
-from pydub import AudioSegment
 
 _LICENSE = "licensed under Creative Commons BY-NC-ND 3.0 (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en)"
 
-class TedliumReleaseConfig(datasets.BuilderConfig):
-  """BuilderConfig for a release of the TED-LIUM dataset."""
 
-  def __init__(self, *, url, download_url, split_paths, citation, **kwargs):
-    super(TedliumReleaseConfig, self).__init__(
-        version=datasets.Version("1.0.1"), **kwargs)
-    self.url = url
-    self.download_url = download_url
-    # List of split, path pairs containing the relative path within the
-    # extracted tarball to the data for each split.
-    self.split_paths = split_paths
-    self.citation = citation
+class TedliumReleaseConfig(datasets.BuilderConfig):
+    """BuilderConfig for a release of the TED-LIUM dataset."""
+
+    def __init__(self, *, url, download_url, split_paths, citation, **kwargs):
+        super(TedliumReleaseConfig, self).__init__(version=datasets.Version("1.0.1"), **kwargs)
+        self.url = url
+        self.download_url = download_url
+        # List of split, path pairs containing the relative path within the
+        # extracted tarball to the data for each split.
+        self.split_paths = split_paths
+        self.citation = citation
 
 
 def _make_builder_configs():
-  """Creates builder configs for all supported Tedlium dataset releases."""
-  release1 = TedliumReleaseConfig(
-      name="release1",
-      description="""\
+    """Creates builder configs for all supported Tedlium dataset releases."""
+    release1 = TedliumReleaseConfig(
+        name="release1",
+        description="""\
         The TED-LIUM corpus is English-language TED talks, with transcriptions,
         sampled at 16kHz. It contains about 118 hours of speech.
 
@@ -53,7 +53,7 @@ def _make_builder_configs():
         licensed under Creative Commons BY-NC-ND 3.0
         (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
         """,
-      citation="""\
+        citation="""\
         @inproceedings{rousseau2012tedlium,
           title={TED-LIUM: an Automatic Speech Recognition dedicated corpus},
           author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
@@ -62,17 +62,18 @@ def _make_builder_configs():
           year={2012}
         }
         """,
-      url="https://www.openslr.org/7/",
-      download_url="http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
-      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release1",
-                                                   "train")),
-                   (datasets.Split.VALIDATION,
-                    os.path.join("TEDLIUM_release1", "dev")),
-                   (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test"))])
+        url="https://www.openslr.org/7/",
+        download_url="http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
+        split_paths=[
+            (datasets.Split.TRAIN, os.path.join("TEDLIUM_release1", "train")),
+            (datasets.Split.VALIDATION, os.path.join("TEDLIUM_release1", "dev")),
+            (datasets.Split.TEST, os.path.join("TEDLIUM_release1", "test")),
+        ],
+    )
 
-  release2 = TedliumReleaseConfig(
-      name="release2",
-      description="""\
+    release2 = TedliumReleaseConfig(
+        name="release2",
+        description="""\
         This is the TED-LIUM corpus release 2,
         licensed under Creative Commons BY-NC-ND 3.0
         (http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en).
@@ -87,7 +88,7 @@ def _make_builder_configs():
 
         Contains 1495 talks and transcripts.
         """,
-      citation="""\
+        citation="""\
         @inproceedings{rousseau2014tedlium2,
           title={Enhancing the {TED-LIUM} Corpus with Selected Data for Language Modeling and More {TED} Talks},
           author={Rousseau, Anthony and Del{\\'e}glise, Paul and Est{\\`e}ve, Yannick},
@@ -95,17 +96,18 @@ def _make_builder_configs():
           year={2014}
         }
         """,
-      url="https://www.openslr.org/19/",
-      download_url="http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
-      split_paths=[(datasets.Split.TRAIN, os.path.join("TEDLIUM_release2",
-                                                   "train")),
-                   (datasets.Split.VALIDATION,
-                    os.path.join("TEDLIUM_release2", "dev")),
-                   (datasets.Split.TEST, os.path.join("TEDLIUM_release2", "test"))])
+        url="https://www.openslr.org/19/",
+        download_url="http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
+        split_paths=[
+            (datasets.Split.TRAIN, os.path.join("TEDLIUM_release2", "train")),
+            (datasets.Split.VALIDATION, os.path.join("TEDLIUM_release2", "dev")),
+            (datasets.Split.TEST, os.path.join("TEDLIUM_release2", "test")),
+        ],
+    )
 
-  release3 = TedliumReleaseConfig(
-      name="release3",
-      description="""\
+    release3 = TedliumReleaseConfig(
+        name="release3",
+        description="""\
         This is the TED-LIUM corpus release 3, licensed under Creative Commons
         BY-NC-ND 3.0.
 
@@ -136,7 +138,7 @@ def _make_builder_configs():
         - the 'speaker adaptation' one, especially designed for experiments on
           speaker adaptation.
         """,
-      citation="""\
+        citation="""\
         @inproceedings{hernandez2018tedlium3,
           title={TED-LIUM 3: twice as much data and corpus repartition for experiments on speaker adaptation},
           author={Hernandez, Fran{\\c{c}}ois and Nguyen, Vincent and Ghannay, Sahar and Tomashenko, Natalia and Est{\\`e}ve, Yannick},
@@ -146,43 +148,39 @@ def _make_builder_configs():
           organization={Springer}
         }
         """,
-      url="https://www.openslr.org/51/",
-      download_url="http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
-      split_paths=[
-          (datasets.Split.VALIDATION,
-           os.path.join("TEDLIUM_release-3", "legacy", "dev")),
-          (datasets.Split.TEST, os.path.join("TEDLIUM_release-3", "legacy",
-                                         "test")),
-          # The legacy/train directory contains symlinks to "data",
-          # which are skipped by extraction (see above).
-          # Work around this by manually dereferencing the links here.
-          (datasets.Split.TRAIN, os.path.join("TEDLIUM_release-3", "data"))
-      ])
+        url="https://www.openslr.org/51/",
+        download_url="http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
+        split_paths=[
+            (datasets.Split.VALIDATION, os.path.join("TEDLIUM_release-3", "legacy", "dev")),
+            (datasets.Split.TEST, os.path.join("TEDLIUM_release-3", "legacy", "test")),
+            # The legacy/train directory contains symlinks to "data",
+            # which are skipped by extraction (see above).
+            # Work around this by manually dereferencing the links here.
+            (datasets.Split.TRAIN, os.path.join("TEDLIUM_release-3", "data")),
+        ],
+    )
 
-  return [release1, release2, release3]
+    return [release1, release2, release3]
 
 
 class TedLium(datasets.GeneratorBasedBuilder):
-    """ The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. It contains about 118 hours of speech."""
+    """The TED-LIUM corpus is English-language TED talks, with transcriptions, sampled at 16kHz. It contains about 118 hours of speech."""
 
     VERSION = datasets.Version("1.1.0")
 
     BUILDER_CONFIGS = _make_builder_configs()
 
     def _info(self):
-        features = datasets.Features({
-                "audio":
-                    datasets.features.Audio(sampling_rate=16_000),
-                "text":
-                    datasets.Value('string'),
-                "speaker_id":
-                    datasets.Value('string'),
-                "gender":
-                    datasets.features.ClassLabel(names=["unknown", "female", "male"]),
-                "file": datasets.Value('string'),
-                "id":
-                    datasets.Value('string'),
-            })
+        features = datasets.Features(
+            {
+                "audio": datasets.features.Audio(sampling_rate=16_000),
+                "text": datasets.Value("string"),
+                "speaker_id": datasets.Value("string"),
+                "gender": datasets.features.ClassLabel(names=["unknown", "female", "male"]),
+                "file": datasets.Value("string"),
+                "id": datasets.Value("string"),
+            }
+        )
         return datasets.DatasetInfo(
             description=self.config.description,
             features=features,
@@ -194,8 +192,7 @@ class TedLium(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        data_dir = dl_manager.download_and_extract(
-            self.config.download_url)
+        data_dir = dl_manager.download_and_extract(self.config.download_url)
         splits = []
         for split, path in self.config.split_paths:
             kwargs = {"filepath": os.path.join(data_dir, path)}

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -198,8 +198,9 @@ class Tedlium(datasets.BeamBasedBuilder):
     return splits
 
   def _build_pcollection(self, pipeline, directory):
-    beam = datasets.lazy_imports.apache_beam
-    stm_files = datasets.Value('io').gfile.glob(os.path.join(directory, "stm", "*stm"))
+    import apache_beam as beam
+    stm_directory = os.path.join(directory, "stm")
+    stm_files = [os.path.join(stm_directory, f) for f in os.listdir(stm_directory) if f.endswith('.stm')]
     return (pipeline
             | beam.Create(stm_files)
             | beam.FlatMap(_generate_examples_from_stm_file))
@@ -261,6 +262,7 @@ def _parse_gender(label_str):
 def _extract_audio_segment(sph_path, channel, start_sec, end_sec):
   """Extracts segment of audio samples (as an ndarray) from the given path."""
   with open(sph_path, "rb") as f:
+    # need to fix this tfds import too
     segment = datasets.lazy_imports.pydub.AudioSegment.from_file(
         f, format="nistsphere")
   # The dataset only contains mono audio.

--- a/datasets/tedlium/tedlium.py
+++ b/datasets/tedlium/tedlium.py
@@ -259,14 +259,13 @@ class TedLium(datasets.GeneratorBasedBuilder):
         if local_extracted_archive:
             for local_archive in local_extracted_archive:
                 # The stm directory houses the speaker and transcription information in .stm format
-                stm_dir = os.path.join(local_archive, split_path, "stm")
-                # The sph directory houses the audio files in .sph format
-                sph_dir = os.path.join(local_archive, split_path, "sph")
-                stm_files = [os.path.join(stm_dir, f) for f in os.listdir(stm_dir) if f.endswith(".stm")]
+                split_dir = os.path.join(local_archive, split_path)
+                stm_files = [os.path.join(split_dir, f) for f in os.listdir(split_dir) if f.endswith(".stm")]
+                import ipdb; ipdb.set_trace()
                 for file in stm_files:
                     # the .sph speaker file almost always has the same file name as the .stm file
                     speaker_file = Path(file).stem
-                    audio_file = os.path.join(sph_dir, speaker_file + ".sph")
+                    audio_file = os.path.join(split_dir, speaker_file + ".sph")
                     segment, sampling_rate = sf.read(audio_file, dtype=np.int16)
                     with open(file) as f:
                         for line in f:
@@ -276,7 +275,7 @@ class TedLium(datasets.GeneratorBasedBuilder):
                             if speaker_file != fn:
                                 # handle the case where the stm file does not have the same file name as the transcript
                                 speaker_file = fn
-                                audio_file = os.path.join(sph_dir, speaker_file + ".sph")
+                                audio_file = os.path.join(split_dir, speaker_file + ".sph")
                                 segment, sampling_rate = sf.read(audio_file, dtype=np.int16)
                             samples = _extract_audio_segment(segment, int(channel), float(start), float(end))
                             key = "-".join([speaker, start, end, label])

--- a/metrics/mse/README.md
+++ b/metrics/mse/README.md
@@ -1,0 +1,123 @@
+# Metric Card for MSE
+
+
+## Metric Description
+
+Mean Squared Error(MSE) represents the average of the squares of errors -- i.e. the average squared difference between the estimated values and the actual values.
+
+![image](https://user-images.githubusercontent.com/14205986/165999302-eba3702d-81e3-4363-9c0e-d3bfceb7ec5a.png)
+
+## How to Use
+
+At minimum, this metric requires predictions and references as inputs.
+
+```python
+>>> mse_metric = datasets.load_metric("mse")
+>>> predictions = [2.5, 0.0, 2, 8]
+>>> references = [3, -0.5, 2, 7]
+>>> results = mse_metric.compute(predictions=predictions, references=references)
+```
+
+### Inputs
+
+Mandatory inputs: 
+- `predictions`: numeric array-like of shape (`n_samples,`) or (`n_samples`, `n_outputs`), representing the estimated target values.
+- `references`: numeric array-like of shape (`n_samples,`) or (`n_samples`, `n_outputs`), representing the ground truth (correct) target values.
+
+Optional arguments:
+- `sample_weight`: numeric array-like of shape (`n_samples,`) representing sample weights. The default is `None`.
+- `multioutput`: `raw_values`, `uniform_average` or numeric array-like of shape (`n_outputs,`), which defines the aggregation of multiple output values. The default value is `uniform_average`.
+  - `raw_values` returns a full set of errors in case of multioutput input.
+  - `uniform_average` means that the errors of all outputs are averaged with uniform weight. 
+  - the array-like value defines weights used to average errors.
+- `squared` (`bool`): If `True` returns MSE value, if `False` returns RMSE (Root Mean Squared Error). The default value is `True`.
+        
+
+### Output Values
+This metric outputs a dictionary, containing the mean squared error score, which is of type:
+- `float`: if multioutput is `uniform_average` or an ndarray of weights, then the weighted average of all output errors is returned.
+- numeric array-like of shape (`n_outputs,`): if multioutput is `raw_values`, then the score is returned for each output separately. 
+
+Each MSE `float` value ranges from `0.0` to `1.0`, with the best value being `0.0`.
+
+Output Example(s):
+```python
+{'mse': 0.5}
+```
+
+If `multioutput="raw_values"`:
+```python
+{'mse': array([0.41666667, 1. ])}
+```
+
+#### Values from Popular Papers
+
+
+### Examples
+
+Example with the `uniform_average` config:
+```python
+>>> from datasets import load_metric
+>>> mse_metric = load_metric("mse")
+>>> predictions = [2.5, 0.0, 2, 8]
+>>> references = [3, -0.5, 2, 7]
+>>> results = mse_metric.compute(predictions=predictions, references=references)
+>>> print(results)
+{'mse': 0.375}
+```
+
+Example with `squared = True`, which returns the RMSE:
+```python
+>>> from datasets import load_metric
+>>> mse_metric = load_metric("mse")
+>>> predictions = [2.5, 0.0, 2, 8]
+>>> references = [3, -0.5, 2, 7]
+>>> rmse_result = mse_metric.compute(predictions=predictions, references=references, squared=False)
+>>> print(rmse_result)
+{'mse': 0.6123724356957945}
+```
+
+Example with multi-dimensional lists, and the `raw_values` config:
+```python
+>>> from datasets import load_metric
+>>> mse_metric = load_metric("mse", "multilist")
+>>> predictions = [[0.5, 1], [-1, 1], [7, -6]]
+>>> references = [[0, 2], [-1, 2], [8, -5]]
+>>> results = mse_metric.compute(predictions=predictions, references=references, multioutput='raw_values')
+>>> print(results) 
+{'mse': array([0.41666667, 1. ])}
+"""
+```
+
+## Limitations and Bias
+MSE has the disadvantage of heavily weighting outliers -- given that it squares them, this results in large errors weighing more heavily than small ones. It can be used alongside [MAE](https://huggingface.co/metrics/mae), which is complementary given that it does not square the errors. 
+
+## Citation(s)
+```bibtex
+@article{scikit-learn,
+  title={Scikit-learn: Machine Learning in {P}ython},
+  author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+  journal={Journal of Machine Learning Research},
+  volume={12},
+  pages={2825--2830},
+  year={2011}
+}
+```
+
+```bibtex
+@article{willmott2005advantages,
+  title={Advantages of the mean absolute error (MAE) over the root mean square error (RMSE) in assessing average model performance},
+  author={Willmott, Cort J and Matsuura, Kenji},
+  journal={Climate research},
+  volume={30},
+  number={1},
+  pages={79--82},
+  year={2005}
+}
+```
+
+## Further References
+- [Mean Squared Error - Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error)


### PR DESCRIPTION
Adds the TED-LIUM dataset https://www.tensorflow.org/datasets/catalog/tedlium#tedliumrelease3 

TODO:

- [x] Port `tedium.py` from TF datasets using `convert_dataset.sh` script
- [x] Make `load_dataset` work
- [ ] ~~Run `datasets-cli` command to generate `dataset_infos.json`~~
- [ ] ~~Create dummy data for continuous testing~~
- [ ] ~~Dummy data tests~~
- [ ] ~~Real data tests~~
- [ ] Create the metadata JSON
- [ ] Close PR and add directly to the Hub under LIUM org