### PR TITLE
Catch pull error when mirroring

### DIFF
--- a/.github/hub/update_hub_repositories.py
+++ b/.github/hub/update_hub_repositories.py
@@ -149,7 +149,11 @@ class update_main:
         logs.append(repo.git.reset("--hard"))
         logs.append(repo.git.clean("-f", "-d"))
         logs.append(repo.git.checkout(CANONICAL_DATASET_REPO_MAIN_BRANCH))
-        logs.append(repo.remote().pull())
+        try:
+            logs.append(repo.remote().pull())
+        except Exception as e:
+            logs.append("pull failed !")
+            logs.append(repr(e))
         # Copy the changes and commit
         distutils.dir_util.copy_tree(
             str(src_canonical_dataset_path(datasets_lib_path, dataset_name)), str(canonical_dataset_path(dataset_name))


### PR DESCRIPTION
Catch pull errors when mirroring so that the script continues to update the other datasets.

The error will still be printed at the end of the job. In this case the job also fails, and asks to manually update the datasets that failed.