### PR TITLE
Fix CLI run_beam namespace

### DIFF
--- a/src/datasets/commands/run_beam.py
+++ b/src/datasets/commands/run_beam.py
@@ -105,7 +105,6 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                         beam_options=beam_options,
                         cache_dir=self._cache_dir,
                         base_path=dataset_module.builder_kwargs.get("base_path"),
-                        namespace=dataset_module.builder_kwargs.get("namespace"),
                     )
                 )
         else:
@@ -116,7 +115,6 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                     beam_options=beam_options,
                     cache_dir=self._cache_dir,
                     base_path=dataset_module.builder_kwargs.get("base_path"),
-                    namespace=dataset_module.builder_kwargs.get("namespace"),
                 )
             )
 


### PR DESCRIPTION
Currently, it raises TypeError:
```
TypeError: __init__() got an unexpected keyword argument 'namespace'
```