### PR TITLE
Support passing config_kwargs to CLI run_beam

### DIFF
--- a/src/datasets/commands/datasets_cli.py
+++ b/src/datasets/commands/datasets_cli.py
@@ -9,6 +9,10 @@ from datasets.commands.test import TestCommand
 from datasets.utils.logging import set_verbosity_info
 
 
+def parse_unknown_args(unknown_args):
+    return {key.lstrip("-"): value for key, value in zip(unknown_args[::2], unknown_args[1::2])}
+
+
 def main():
     parser = ArgumentParser("HuggingFace Datasets CLI tool", usage="datasets-cli <command> [<args>]")
     commands_parser = parser.add_subparsers(help="datasets-cli command helpers")
@@ -21,15 +25,15 @@ def main():
     RunBeamCommand.register_subcommand(commands_parser)
     DummyDataCommand.register_subcommand(commands_parser)
 
-    # Let's go
-    args = parser.parse_args()
-
+    # Parse args
+    args, unknown_args = parser.parse_known_args()
     if not hasattr(args, "func"):
         parser.print_help()
         exit(1)
+    kwargs = parse_unknown_args(unknown_args)
 
     # Run
-    service = args.func(args)
+    service = args.func(args, **kwargs)
     service.run()
 
 

--- a/src/datasets/commands/datasets_cli.py
+++ b/src/datasets/commands/datasets_cli.py
@@ -14,7 +14,9 @@ def parse_unknown_args(unknown_args):
 
 
 def main():
-    parser = ArgumentParser("HuggingFace Datasets CLI tool", usage="datasets-cli <command> [<args>]")
+    parser = ArgumentParser(
+        "HuggingFace Datasets CLI tool", usage="datasets-cli <command> [<args>]", allow_abbrev=False
+    )
     commands_parser = parser.add_subparsers(help="datasets-cli command helpers")
     set_verbosity_info()
 

--- a/src/datasets/commands/run_beam.py
+++ b/src/datasets/commands/run_beam.py
@@ -11,7 +11,7 @@ from datasets.load import dataset_module_factory, import_main_class
 from datasets.utils.download_manager import DownloadConfig, DownloadMode
 
 
-def run_beam_command_factory(args):
+def run_beam_command_factory(args, **kwargs):
     return RunBeamCommand(
         args.dataset,
         args.name,
@@ -22,6 +22,7 @@ def run_beam_command_factory(args):
         args.save_infos,
         args.ignore_verifications,
         args.force_redownload,
+        **kwargs
     )
 
 
@@ -68,6 +69,7 @@ class RunBeamCommand(BaseDatasetsCLICommand):
         save_infos: bool,
         ignore_verifications: bool,
         force_redownload: bool,
+        **config_kwargs,
     ):
         self._dataset = dataset
         self._name = name
@@ -78,6 +80,7 @@ class RunBeamCommand(BaseDatasetsCLICommand):
         self._save_infos = save_infos
         self._ignore_verifications = ignore_verifications
         self._force_redownload = force_redownload
+        self._config_kwargs = config_kwargs
 
     def run(self):
         import apache_beam as beam
@@ -115,6 +118,7 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                     beam_options=beam_options,
                     cache_dir=self._cache_dir,
                     base_path=dataset_module.builder_kwargs.get("base_path"),
+                    **self._config_kwargs
                 )
             )
 

--- a/src/datasets/commands/run_beam.py
+++ b/src/datasets/commands/run_beam.py
@@ -22,7 +22,7 @@ def run_beam_command_factory(args, **kwargs):
         args.save_infos,
         args.ignore_verifications,
         args.force_redownload,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -118,7 +118,7 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                     beam_options=beam_options,
                     cache_dir=self._cache_dir,
                     base_path=dataset_module.builder_kwargs.get("base_path"),
-                    **self._config_kwargs
+                    **self._config_kwargs,
                 )
             )
 


### PR DESCRIPTION
This PR supports passing `config_kwargs` to CLI run_beam, so that for example for "wikipedia" dataset, we can pass:
```
--date 20220501 --language ca
```