### PR TITLE
Fix failing CI on Windows for sari and wiki_split metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ TESTS_REQUIRE = [
     "mauve-text",
     "rouge_score",
     "sacrebleu",
+    "sacremoses",
     "scikit-learn",
     "scipy",
     "sentencepiece",  # for bleurt

--- a/setup.py
+++ b/setup.py
@@ -146,14 +146,14 @@ TESTS_REQUIRE = [
     "zstandard",
     # metrics dependencies
     "bert_score>=0.3.6",
+    "jiwer",
+    "mauve-text",
     "rouge_score",
     "sacrebleu",
-    "scipy",
-    "seqeval",
     "scikit-learn",
-    "jiwer",
+    "scipy",
     "sentencepiece",  # for bleurt
-    "mauve-text",
+    "seqeval",
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",


### PR DESCRIPTION
This PR adds `sacremoses` as explicit tests dependency (required by sari and wiki_split metrics).

Before, this library was installed as a third-party dependency, but this is no longer the case for Windows.

Fix #4341.