### PR TITLE
Fix never ending GH Action to build documentation

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -536,9 +536,10 @@ class DatasetBuilder:
         Example:
 
         ```py
-        >>> from datasets import download_and_prepare
+        >>> from datasets import load_dataset_builder
         >>> builder = load_dataset_builder('rotten_tomatoes')
         >>> ds = builder.download_and_prepare()
+        ```
         """
         download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
         verify_infos = not ignore_verifications

--- a/src/datasets/utils/__init__.py
+++ b/src/datasets/utils/__init__.py
@@ -23,9 +23,11 @@ __all__ = [
     "disable_progress_bar",
     "enable_progress_bar",
     "is_progress_bar_enabled",
+    "StreamingDownloadManager",
     "Version",
 ]
 
 from .download_manager import DownloadConfig, DownloadManager, DownloadMode
 from .logging import disable_progress_bar, enable_progress_bar, is_progress_bar_enabled
+from .streaming_download_manager import StreamingDownloadManager
 from .version import Version


### PR DESCRIPTION
There was an unclosed code block introduced by:
- #4313 

https://github.com/huggingface/datasets/pull/4313/files#diff-f933ce41f71c6c0d1ce658e27de62cbe0b45d777e9e68056dd012ac3eb9324f7R538 

This causes the "Make documentation" step in the "Build documentation" workflow to never finish.
- I think this issue should also be addressed in the `doc-builder` lib.


Fix #4346.