### PR TITLE
Support remote cache_dir

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -287,7 +287,7 @@ class DatasetBuilder:
             self.info.features = features
 
         # prepare data dirs
-        cache_dir_root = str(cache_dir) or config.HF_DATASETS_CACHE
+        cache_dir_root = str(cache_dir or config.HF_DATASETS_CACHE)
         path_join = posixpath.join if is_remote_url(cache_dir_root) else os.path.join
         self._cache_dir_root = (
             os.path.expanduser(cache_dir_root) if not is_remote_url(cache_dir_root) else cache_dir_root

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -286,7 +286,8 @@ class DatasetBuilder:
         if features is not None:
             self.info.features = features
 
-        # prepare data dirs
+        # Prepare data dirs:
+        # cache_dir can be a remote bucket on GCS or S3 (when using BeamBasedBuilder for distributed data processing)
         self._cache_dir_root = str(cache_dir or config.HF_DATASETS_CACHE)
         self._cache_dir_root = (
             self._cache_dir_root if is_remote_url(self._cache_dir_root) else os.path.expanduser(self._cache_dir_root)
@@ -593,6 +594,7 @@ class DatasetBuilder:
         is_local = not is_remote_url(self._cache_dir_root)
         if is_local:
             lock_path = os.path.join(self._cache_dir_root, self._cache_dir.replace(os.sep, "_") + ".lock")
+        # File locking only with local paths; no file locking on GCS or S3
         with FileLock(lock_path) if is_local else contextlib.nullcontext():
             if is_local:
                 data_exists = os.path.exists(self._cache_dir)

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -287,7 +287,7 @@ class DatasetBuilder:
             self.info.features = features
 
         # prepare data dirs
-        self._cache_dir_root = str(cache_dir) if cache_dir else config.HF_DATASETS_CACHE
+        self._cache_dir_root = str(cache_dir or config.HF_DATASETS_CACHE)
         self._cache_dir_root = (
             self._cache_dir_root if is_remote_url(self._cache_dir_root) else os.path.expanduser(self._cache_dir_root)
         )

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -287,7 +287,7 @@ class DatasetBuilder:
             self.info.features = features
 
         # prepare data dirs
-        cache_dir_root = cache_dir or config.HF_DATASETS_CACHE
+        cache_dir_root = str(cache_dir) or config.HF_DATASETS_CACHE
         path_join = posixpath.join if is_remote_url(cache_dir_root) else os.path.join
         self._cache_dir_root = (
             os.path.expanduser(cache_dir_root) if not is_remote_url(cache_dir_root) else cache_dir_root

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -287,13 +287,20 @@ class DatasetBuilder:
             self.info.features = features
 
         # prepare data dirs
-        cache_dir_root = str(cache_dir or config.HF_DATASETS_CACHE)
-        path_join = posixpath.join if is_remote_url(cache_dir_root) else os.path.join
+        self._cache_dir_root = str(cache_dir) if cache_dir else config.HF_DATASETS_CACHE
         self._cache_dir_root = (
-            os.path.expanduser(cache_dir_root) if not is_remote_url(cache_dir_root) else cache_dir_root
+            self._cache_dir_root if is_remote_url(self._cache_dir_root) else os.path.expanduser(self._cache_dir_root)
+        )
+        path_join = posixpath.join if is_remote_url(self._cache_dir_root) else os.path.join
+        self._cache_downloaded_dir = (
+            path_join(self._cache_dir_root, config.DOWNLOADED_DATASETS_DIR)
+            if cache_dir
+            else config.DOWNLOADED_DATASETS_PATH
         )
         self._cache_downloaded_dir = (
-            path_join(cache_dir, config.DOWNLOADED_DATASETS_DIR) if cache_dir else config.DOWNLOADED_DATASETS_PATH
+            self._cache_downloaded_dir
+            if is_remote_url(self._cache_downloaded_dir)
+            else os.path.expanduser(self._cache_downloaded_dir)
         )
         self._cache_dir = self._build_cache_dir()
         if not is_remote_url(self._cache_dir_root):

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -295,7 +295,7 @@ class DatasetBuilder:
         self._cache_downloaded_dir = (
             path_join(self._cache_dir_root, config.DOWNLOADED_DATASETS_DIR)
             if cache_dir
-            else config.DOWNLOADED_DATASETS_PATH
+            else str(config.DOWNLOADED_DATASETS_PATH)
         )
         self._cache_downloaded_dir = (
             self._cache_downloaded_dir

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -20,6 +20,7 @@ import contextlib
 import copy
 import inspect
 import os
+import posixpath
 import shutil
 import textwrap
 import urllib
@@ -286,24 +287,28 @@ class DatasetBuilder:
             self.info.features = features
 
         # prepare data dirs
-        self._cache_dir_root = os.path.expanduser(cache_dir or config.HF_DATASETS_CACHE)
+        cache_dir_root = cache_dir or config.HF_DATASETS_CACHE
+        path_join = posixpath.join if is_remote_url(cache_dir_root) else os.path.join
+        self._cache_dir_root = (
+            os.path.expanduser(cache_dir_root) if not is_remote_url(cache_dir_root) else cache_dir_root
+        )
         self._cache_downloaded_dir = (
-            os.path.join(cache_dir, config.DOWNLOADED_DATASETS_DIR) if cache_dir else config.DOWNLOADED_DATASETS_PATH
+            path_join(cache_dir, config.DOWNLOADED_DATASETS_DIR) if cache_dir else config.DOWNLOADED_DATASETS_PATH
         )
         self._cache_dir = self._build_cache_dir()
         if not is_remote_url(self._cache_dir_root):
             os.makedirs(self._cache_dir_root, exist_ok=True)
-        lock_path = os.path.join(self._cache_dir_root, self._cache_dir.replace(os.sep, "_") + ".lock")
-        with FileLock(lock_path):
-            if os.path.exists(self._cache_dir):  # check if data exist
-                if len(os.listdir(self._cache_dir)) > 0:
-                    logger.info("Overwrite dataset info from restored data version.")
-                    self.info = DatasetInfo.from_directory(self._cache_dir)
-                else:  # dir exists but no data, remove the empty dir as data aren't available anymore
-                    logger.warning(
-                        f"Old caching folder {self._cache_dir} for dataset {self.name} exists but not data were found. Removing it. "
-                    )
-                    os.rmdir(self._cache_dir)
+            lock_path = os.path.join(self._cache_dir_root, self._cache_dir.replace(os.sep, "_") + ".lock")
+            with FileLock(lock_path):
+                if os.path.exists(self._cache_dir):  # check if data exist
+                    if len(os.listdir(self._cache_dir)) > 0:
+                        logger.info("Overwrite dataset info from restored data version.")
+                        self.info = DatasetInfo.from_directory(self._cache_dir)
+                    else:  # dir exists but no data, remove the empty dir as data aren't available anymore
+                        logger.warning(
+                            f"Old caching folder {self._cache_dir} for dataset {self.name} exists but not data were found. Removing it. "
+                        )
+                        os.rmdir(self._cache_dir)
 
         # Set download manager
         self.dl_manager = None
@@ -438,7 +443,7 @@ class DatasetBuilder:
     def cache_dir(self):
         return self._cache_dir
 
-    def _relative_data_dir(self, with_version=True, with_hash=True) -> str:
+    def _relative_data_dir(self, with_version=True, with_hash=True, is_local=True) -> str:
         """Relative path of this dataset in cache_dir:
         Will be:
             self.name/self.config.version/self.hash/
@@ -450,19 +455,26 @@ class DatasetBuilder:
         builder_data_dir = self.name if namespace is None else f"{namespace}___{self.name}"
         builder_config = self.config
         hash = self.hash
+        path_join = os.path.join if is_local else posixpath.join
         if builder_config:
             # use the enriched name instead of the name to make it unique
-            builder_data_dir = os.path.join(builder_data_dir, self.config_id)
+            builder_data_dir = path_join(builder_data_dir, self.config_id)
         if with_version:
-            builder_data_dir = os.path.join(builder_data_dir, str(self.config.version))
+            builder_data_dir = path_join(builder_data_dir, str(self.config.version))
         if with_hash and hash and isinstance(hash, str):
-            builder_data_dir = os.path.join(builder_data_dir, hash)
+            builder_data_dir = path_join(builder_data_dir, hash)
         return builder_data_dir
 
     def _build_cache_dir(self):
         """Return the data directory for the current version."""
-        builder_data_dir = os.path.join(self._cache_dir_root, self._relative_data_dir(with_version=False))
-        version_data_dir = os.path.join(self._cache_dir_root, self._relative_data_dir(with_version=True))
+        is_local = not is_remote_url(self._cache_dir_root)
+        path_join = os.path.join if is_local else posixpath.join
+        builder_data_dir = path_join(
+            self._cache_dir_root, self._relative_data_dir(with_version=False, is_local=is_local)
+        )
+        version_data_dir = path_join(
+            self._cache_dir_root, self._relative_data_dir(with_version=True, is_local=is_local)
+        )
 
         def _other_versions_on_disk():
             """Returns previous versions on disk."""
@@ -479,16 +491,17 @@ class DatasetBuilder:
             return version_dirnames
 
         # Check and warn if other versions exist on disk
-        version_dirs = _other_versions_on_disk()
-        if version_dirs:
-            other_version = version_dirs[0][0]
-            if other_version != self.config.version:
-                warn_msg = (
-                    f"Found a different version {str(other_version)} of dataset {self.name} in "
-                    f"cache_dir {self._cache_dir_root}. Using currently defined version "
-                    f"{str(self.config.version)}."
-                )
-                logger.warning(warn_msg)
+        if not is_remote_url(builder_data_dir):
+            version_dirs = _other_versions_on_disk()
+            if version_dirs:
+                other_version = version_dirs[0][0]
+                if other_version != self.config.version:
+                    warn_msg = (
+                        f"Found a different version {str(other_version)} of dataset {self.name} in "
+                        f"cache_dir {self._cache_dir_root}. Using currently defined version "
+                        f"{str(self.config.version)}."
+                    )
+                    logger.warning(warn_msg)
 
         return version_data_dir
 
@@ -571,7 +584,7 @@ class DatasetBuilder:
 
         # Prevent parallel disk operations
         lock_path = os.path.join(self._cache_dir_root, self._cache_dir.replace(os.sep, "_") + ".lock")
-        with FileLock(lock_path):
+        with FileLock(lock_path) if not is_remote_url(self._cache_dir_root) else contextlib.nullcontext():
             data_exists = os.path.exists(self._cache_dir)
             if data_exists and download_mode == DownloadMode.REUSE_DATASET_IF_EXISTS:
                 logger.warning(f"Reusing dataset {self.name} ({self._cache_dir})")

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -20,6 +20,7 @@ import contextlib
 import copy
 import inspect
 import os
+import posixpath
 import shutil
 import textwrap
 import urllib
@@ -59,7 +60,7 @@ from .utils.py_utils import (
     size_str,
     temporary_assignment,
 )
-from .utils.streaming_download_manager import StreamingDownloadManager, xjoin
+from .utils.streaming_download_manager import StreamingDownloadManager
 
 
 logger = logging.get_logger(__name__)
@@ -286,11 +287,20 @@ class DatasetBuilder:
             self.info.features = features
 
         # prepare data dirs
-        self._cache_dir_root = os.path.expanduser(cache_dir or config.HF_DATASETS_CACHE)
+        self._cache_dir_root = str(cache_dir or config.HF_DATASETS_CACHE)
+        self._cache_dir_root = (
+            self._cache_dir_root if is_remote_url(self._cache_dir_root) else os.path.expanduser(self._cache_dir_root)
+        )
+        path_join = posixpath.join if is_remote_url(self._cache_dir_root) else os.path.join
         self._cache_downloaded_dir = (
-            xjoin(self._cache_dir_root, config.DOWNLOADED_DATASETS_DIR)
+            path_join(self._cache_dir_root, config.DOWNLOADED_DATASETS_DIR)
             if cache_dir
-            else config.DOWNLOADED_DATASETS_PATH
+            else str(config.DOWNLOADED_DATASETS_PATH)
+        )
+        self._cache_downloaded_dir = (
+            self._cache_downloaded_dir
+            if is_remote_url(self._cache_downloaded_dir)
+            else os.path.expanduser(self._cache_downloaded_dir)
         )
         self._cache_dir = self._build_cache_dir()
         if not is_remote_url(self._cache_dir_root):
@@ -440,7 +450,7 @@ class DatasetBuilder:
     def cache_dir(self):
         return self._cache_dir
 
-    def _relative_data_dir(self, with_version=True, with_hash=True) -> str:
+    def _relative_data_dir(self, with_version=True, with_hash=True, is_local=True) -> str:
         """Relative path of this dataset in cache_dir:
         Will be:
             self.name/self.config.version/self.hash/
@@ -452,19 +462,26 @@ class DatasetBuilder:
         builder_data_dir = self.name if namespace is None else f"{namespace}___{self.name}"
         builder_config = self.config
         hash = self.hash
+        path_join = os.path.join if is_local else posixpath.join
         if builder_config:
             # use the enriched name instead of the name to make it unique
-            builder_data_dir = xjoin(builder_data_dir, self.config_id)
+            builder_data_dir = path_join(builder_data_dir, self.config_id)
         if with_version:
-            builder_data_dir = xjoin(builder_data_dir, str(self.config.version))
+            builder_data_dir = path_join(builder_data_dir, str(self.config.version))
         if with_hash and hash and isinstance(hash, str):
-            builder_data_dir = xjoin(builder_data_dir, hash)
+            builder_data_dir = path_join(builder_data_dir, hash)
         return builder_data_dir
 
     def _build_cache_dir(self):
         """Return the data directory for the current version."""
-        builder_data_dir = xjoin(self._cache_dir_root, self._relative_data_dir(with_version=False))
-        version_data_dir = xjoin(self._cache_dir_root, self._relative_data_dir(with_version=True))
+        is_local = not is_remote_url(self._cache_dir_root)
+        path_join = os.path.join if is_local else posixpath.join
+        builder_data_dir = path_join(
+            self._cache_dir_root, self._relative_data_dir(with_version=False, is_local=is_local)
+        )
+        version_data_dir = path_join(
+            self._cache_dir_root, self._relative_data_dir(with_version=True, is_local=is_local)
+        )
 
         def _other_versions_on_disk():
             """Returns previous versions on disk."""


### PR DESCRIPTION
This PR implements complete support for remote `cache_dir`. Before, the support was just partial.

This is useful to create datasets using Apache Beam (parallel data processing) builder with `cache_dir` in a remote bucket, e.g., for Wikipedia dataset.