### PR TITLE
Add redirect to dataset script in the repo structure page

### DIFF
--- a/docs/source/dataset_script.mdx
+++ b/docs/source/dataset_script.mdx
@@ -2,6 +2,8 @@
 
 Write a dataset script to load and share your own datasets. It is a Python file that defines the different configurations and splits of your dataset, as well as how to download and process the data.
 
+The script can download data files from any website, or from the same dataset repository.
+
 Any dataset script, for example `my_dataset.py`, can be placed in a folder or a repository named `my_dataset` and be loaded with:
 
 ```py

--- a/docs/source/repository_structure.mdx
+++ b/docs/source/repository_structure.mdx
@@ -5,7 +5,7 @@ To host and share your dataset, you can create a dataset repository on the Huggi
 This guide will show you how to structure your dataset repository when you upload it.
 A dataset with a supported structure can be loaded automatically with [`~datasets.load_dataset`], and it will have a preview on its dataset page on the Hub.
 
-Note that you can also include a [python script](dataset_script.html) to define your dataset, for more flexibility.
+Note that you can also include a [python script](dataset_script) to define your dataset, for more flexibility.
 
 <Tip>
 
@@ -17,7 +17,7 @@ The following examples use CSV files, but you can use any supported format (text
 
 The simplest dataset structure has two files: *train.csv* and *test.csv*.
 
-Your repository will also contain a *README.md* file, the [dataset card](dataset_card.html) displayed on your dataset page.
+Your repository will also contain a *README.md* file, the [dataset card](dataset_card) displayed on your dataset page.
 
 ```
 my_dataset_repository/

--- a/docs/source/repository_structure.mdx
+++ b/docs/source/repository_structure.mdx
@@ -5,6 +5,8 @@ To host and share your dataset, you can create a dataset repository on the Huggi
 This guide will show you how to structure your dataset repository when you upload it.
 A dataset with a supported structure can be loaded automatically with [`~datasets.load_dataset`], and it will have a preview on its dataset page on the Hub.
 
+Note that you can also include a [python script](dataset_script.html) to define your dataset, for more flexibility.
+
 <Tip>
 
 The following examples use CSV files, but you can use any supported format (text, JSON, JSON Lines, CSV, Parquet).


### PR DESCRIPTION
Following https://github.com/huggingface/hub-docs/pull/146 I added a redirection to the dataset scripts documentation in the repository structure page.