### PR TITLE
Remove links in docs to old dataset viewer

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -6,7 +6,7 @@
 
 Load a dataset in a single line of code, and use our powerful data processing methods to quickly get your dataset ready for training in a deep learning model. Backed by the Apache Arrow format, process large datasets with zero-copy reads without any memory constraints for optimal speed and efficiency. We also feature a deep integration with the [Hugging Face Hub](https://huggingface.co/datasets), allowing you to easily load and share a dataset with the wider NLP community. There are currently over 2658 datasets, and more than 34 metrics available. 
 
-Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), or take an in-depth look inside a dataset with the live [Datasets Viewer](https://huggingface.co/datasets/viewer/).
+Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), and take an in-depth look inside of it with the live viewer.
 
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">

--- a/docs/source/load_hub.mdx
+++ b/docs/source/load_hub.mdx
@@ -1,6 +1,6 @@
 # Hugging Face Hub
 
-Now that you are all setup, the first step is to load a dataset. The easiest way to load a dataset is from the [Hugging Face Hub](https://huggingface.co/datasets). There are already over 900 datasets in over 100 languages on the Hub. Choose from a wide category of datasets to use for NLP tasks like question answering, summarization, machine translation, and language modeling. For a more in-depth look inside a dataset, use the live [Datasets Viewer](https://huggingface.co/datasets/viewer/).
+Now that you are all setup, the first step is to load a dataset. The easiest way to load a dataset is from the [Hugging Face Hub](https://huggingface.co/datasets). There are already over 6000 datasets in over 100 languages on the Hub. Choose from a wide category of datasets to use for NLP tasks like question answering, summarization, machine translation, and language modeling.
 
 ## Load a dataset
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -18,7 +18,7 @@ pip install datasets
 
 ## Load the dataset and model
 
-Begin by loading the [Microsoft Research Paraphrase Corpus (MRPC)](https://huggingface.co/datasets/viewer/?dataset=glue&config=mrpc) training dataset from the [General Language Understanding Evaluation (GLUE) benchmark](https://huggingface.co/datasets/glue). MRPC is a corpus of human annotated sentence pairs used to train a model to determine whether sentence pairs are semantically equivalent.
+Begin by loading the [Microsoft Research Paraphrase Corpus (MRPC)](https://huggingface.co/datasets/glue/viewer/mrpc) training dataset from the [General Language Understanding Evaluation (GLUE) benchmark](https://huggingface.co/datasets/glue). MRPC is a corpus of human annotated sentence pairs used to train a model to determine whether sentence pairs are semantically equivalent.
 
 ```py
 >>> from datasets import load_dataset


### PR DESCRIPTION
Remove the links in the docs to the no longer maintained dataset viewer.