### PR TITLE
Tidy up license metadata for google_wellformed_query, newspop, sick

### DIFF
--- a/datasets/google_wellformed_query/README.md
+++ b/datasets/google_wellformed_query/README.md
@@ -14,7 +14,7 @@ source_datasets:
 size_categories:
 - 10K<n<100K
 licenses:
-- CC-BY-SA-4.0
+- cc-by-sa-4.0
 paperswithcode_id: null
 pretty_name: GoogleWellformedQuery
 ---

--- a/datasets/newspop/README.md
+++ b/datasets/newspop/README.md
@@ -6,7 +6,7 @@ language_creators:
 languages:
 - en
 licenses:
-- cc-by-4
+- cc-by-4.0
 multilinguality:
 - monolingual
 size_categories:

--- a/datasets/sick/README.md
+++ b/datasets/sick/README.md
@@ -6,7 +6,7 @@ language_creators:
 languages:
 - en
 licenses:
-- CC-BY-NC-SA-3.0
+- cc-by-nc-sa-3.0
 multilinguality:
 - monolingual
 size_categories:


### PR DESCRIPTION
Amend three licenses on datasets to fit naming convention (lower case, cc licenses include sub-version number). I think that's it - everything else on datasets looks great & super-searchable now!