### PR TITLE
Set builder name from module instead of class

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -248,7 +248,7 @@ class DatasetBuilder:
 
         """
         # DatasetBuilder name
-        self.name: str = camelcase_to_snakecase(self.__class__.__name__)
+        self.name: str = camelcase_to_snakecase(self.__module__.split(".")[-1])
         self.hash: Optional[str] = hash
         self.base_path = base_path
         self.use_auth_token = use_auth_token

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -65,9 +65,7 @@ class BeamBuilderTest(TestCase):
             builder.download_and_prepare()
             self.assertTrue(
                 os.path.exists(
-                    os.path.join(
-                        tmp_cache_dir, "dummy_beam_dataset", "default", "0.0.0", "dummy_beam_dataset-train.arrow"
-                    )
+                    os.path.join(tmp_cache_dir, builder.name, "default", "0.0.0", f"{builder.name}-train.arrow")
                 )
             )
             self.assertDictEqual(builder.info.features, datasets.Features({"content": datasets.Value("string")}))
@@ -79,9 +77,7 @@ class BeamBuilderTest(TestCase):
                 dset["train"][expected_num_examples - 1], get_test_dummy_examples()[expected_num_examples - 1][1]
             )
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_cache_dir, "dummy_beam_dataset", "default", "0.0.0", "dataset_info.json")
-                )
+                os.path.exists(os.path.join(tmp_cache_dir, builder.name, "default", "0.0.0", "dataset_info.json"))
             )
             del dset
 
@@ -99,9 +95,7 @@ class BeamBuilderTest(TestCase):
             builder.download_and_prepare()
             self.assertTrue(
                 os.path.exists(
-                    os.path.join(
-                        tmp_cache_dir, "nested_beam_dataset", "default", "0.0.0", "nested_beam_dataset-train.arrow"
-                    )
+                    os.path.join(tmp_cache_dir, builder.name, "default", "0.0.0", f"{builder.name}-train.arrow")
                 )
             )
             self.assertDictEqual(
@@ -115,8 +109,6 @@ class BeamBuilderTest(TestCase):
                 dset["train"][expected_num_examples - 1], get_test_nested_examples()[expected_num_examples - 1][1]
             )
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_cache_dir, "nested_beam_dataset", "default", "0.0.0", "dataset_info.json")
-                )
+                os.path.exists(os.path.join(tmp_cache_dir, builder.name, "default", "0.0.0", "dataset_info.json"))
             )
             del dset

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -123,42 +123,35 @@ class DummyBuilderWithManualDownload(DummyBuilderWithMultipleConfigs):
 
 
 def _run_concurrent_download_and_prepare(tmp_dir):
-    dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-    dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.REUSE_DATASET_IF_EXISTS)
-    return dummy_builder
+    builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+    builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.REUSE_DATASET_IF_EXISTS)
+    return builder
 
 
 class BuilderTest(TestCase):
     def test_download_and_prepare(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
-                )
+                os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", f"{builder.name}-train.arrow"))
             )
-            self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
-            self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
-            self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
-            )
+            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertEqual(builder.info.splits["train"].num_examples, 100)
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", "dataset_info.json")))
 
     def test_download_and_prepare_checksum_computation(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
-            self.assertTrue(all(v["checksum"] is not None for _, v in dummy_builder.info.download_checksums.items()))
-            dummy_builder_skip_checksum_computation = DummyBuilderSkipChecksumComputation(
-                cache_dir=tmp_dir, name="dummy"
-            )
-            dummy_builder_skip_checksum_computation.download_and_prepare(
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            self.assertTrue(all(v["checksum"] is not None for _, v in builder.info.download_checksums.items()))
+            builder_skip_checksum_computation = DummyBuilderSkipChecksumComputation(cache_dir=tmp_dir, name="dummy")
+            builder_skip_checksum_computation.download_and_prepare(
                 try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD
             )
             self.assertTrue(
                 all(
-                    v["checksum"] is None
-                    for _, v in dummy_builder_skip_checksum_computation.info.download_checksums.items()
+                    v["checksum"] is None for _, v in builder_skip_checksum_computation.info.download_checksums.items()
                 )
             )
 
@@ -170,21 +163,17 @@ class BuilderTest(TestCase):
                     pool.apply_async(_run_concurrent_download_and_prepare, kwds={"tmp_dir": tmp_dir})
                     for _ in range(processes)
                 ]
-                dummy_builders = [job.get() for job in jobs]
-                for dummy_builder in dummy_builders:
+                builders = [job.get() for job in jobs]
+                for builder in builders:
                     self.assertTrue(
                         os.path.exists(
-                            os.path.join(
-                                tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow"
-                            )
+                            os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", f"{builder.name}-train.arrow")
                         )
                     )
-                    self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
-                    self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
+                    self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+                    self.assertEqual(builder.info.splits["train"].num_examples, 100)
                     self.assertTrue(
-                        os.path.exists(
-                            os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json")
-                        )
+                        os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", "dataset_info.json"))
                     )
 
     def test_download_and_prepare_with_base_path(self):
@@ -192,34 +181,32 @@ class BuilderTest(TestCase):
             rel_path = "dummy1.data"
             abs_path = os.path.join(tmp_dir, "dummy2.data")
             # test relative path is missing
-            dummy_builder = DummyBuilderWithDownload(cache_dir=tmp_dir, name="dummy", rel_path=rel_path)
+            builder = DummyBuilderWithDownload(cache_dir=tmp_dir, name="dummy", rel_path=rel_path)
             with self.assertRaises(FileNotFoundError):
-                dummy_builder.download_and_prepare(
+                builder.download_and_prepare(
                     try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir
                 )
             # test absolute path is missing
-            dummy_builder = DummyBuilderWithDownload(cache_dir=tmp_dir, name="dummy", abs_path=abs_path)
+            builder = DummyBuilderWithDownload(cache_dir=tmp_dir, name="dummy", abs_path=abs_path)
             with self.assertRaises(FileNotFoundError):
-                dummy_builder.download_and_prepare(
+                builder.download_and_prepare(
                     try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir
                 )
             # test that they are both properly loaded when they exist
             open(os.path.join(tmp_dir, rel_path), "w")
             open(abs_path, "w")
-            dummy_builder = DummyBuilderWithDownload(
-                cache_dir=tmp_dir, name="dummy", rel_path=rel_path, abs_path=abs_path
-            )
-            dummy_builder.download_and_prepare(
+            builder = DummyBuilderWithDownload(cache_dir=tmp_dir, name="dummy", rel_path=rel_path, abs_path=abs_path)
+            builder.download_and_prepare(
                 try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir
             )
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
                         tmp_dir,
-                        dummy_builder.name,
+                        builder.name,
                         "dummy",
                         "0.0.0",
-                        f"{dummy_builder.name}-train.arrow",
+                        f"{builder.name}-train.arrow",
                     )
                 )
             )
@@ -235,34 +222,34 @@ class BuilderTest(TestCase):
             return {"tokenized_dataset": f"tokenized_dataset-{split}.arrow"}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder.info.post_processed = PostProcessedInfo(
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder.info.post_processed = PostProcessedInfo(
                 features=Features({"text": Value("string"), "tokens": [Value("string")]})
             )
-            dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
-            dummy_builder._post_processing_resources = types.MethodType(_post_processing_resources, dummy_builder)
-            os.makedirs(dummy_builder.cache_dir)
+            builder._post_process = types.MethodType(_post_process, builder)
+            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            os.makedirs(builder.cache_dir)
 
-            dummy_builder.info.splits = SplitDict()
-            dummy_builder.info.splits.add(SplitInfo("train", num_examples=10))
-            dummy_builder.info.splits.add(SplitInfo("test", num_examples=10))
+            builder.info.splits = SplitDict()
+            builder.info.splits.add(SplitInfo("train", num_examples=10))
+            builder.info.splits.add(SplitInfo("test", num_examples=10))
 
-            for split in dummy_builder.info.splits:
+            for split in builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{split}.arrow"),
+                    path=os.path.join(builder.cache_dir, f"{builder.name}-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
                     writer.finalize()
 
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"tokenized_dataset-{split}.arrow"),
+                    path=os.path.join(builder.cache_dir, f"tokenized_dataset-{split}.arrow"),
                     features=Features({"text": Value("string"), "tokens": [Value("string")]}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10, "tokens": [list("foo")] * 10})
                     writer.finalize()
 
-            dsets = dummy_builder.as_dataset()
+            dsets = builder.as_dataset()
             self.assertIsInstance(dsets, DatasetDict)
             self.assertListEqual(list(dsets.keys()), ["train", "test"])
             self.assertEqual(len(dsets["train"]), 10)
@@ -277,19 +264,19 @@ class BuilderTest(TestCase):
             self.assertListEqual(dsets["test"].column_names, ["text", "tokens"])
             del dsets
 
-            dset = dummy_builder.as_dataset("train")
+            dset = builder.as_dataset("train")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train")
             self.assertEqual(len(dset), 10)
             self.assertDictEqual(dset.features, Features({"text": Value("string"), "tokens": [Value("string")]}))
             self.assertListEqual(dset.column_names, ["text", "tokens"])
-            self.assertGreater(dummy_builder.info.post_processing_size, 0)
+            self.assertGreater(builder.info.post_processing_size, 0)
             self.assertGreater(
-                dummy_builder.info.post_processed.resources_checksums["train"]["tokenized_dataset"]["num_bytes"], 0
+                builder.info.post_processed.resources_checksums["train"]["tokenized_dataset"]["num_bytes"], 0
             )
             del dset
 
-            dset = dummy_builder.as_dataset("train+test[:30%]")
+            dset = builder.as_dataset("train+test[:30%]")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train+test[:30%]")
             self.assertEqual(len(dset), 13)
@@ -297,7 +284,7 @@ class BuilderTest(TestCase):
             self.assertListEqual(dset.column_names, ["text", "tokens"])
             del dset
 
-            dset = dummy_builder.as_dataset("all")
+            dset = builder.as_dataset("all")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train+test")
             self.assertEqual(len(dset), 20)
@@ -309,30 +296,30 @@ class BuilderTest(TestCase):
             return dataset.select([0, 1], keep_in_memory=True)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
-            os.makedirs(dummy_builder.cache_dir)
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder._post_process = types.MethodType(_post_process, builder)
+            os.makedirs(builder.cache_dir)
 
-            dummy_builder.info.splits = SplitDict()
-            dummy_builder.info.splits.add(SplitInfo("train", num_examples=10))
-            dummy_builder.info.splits.add(SplitInfo("test", num_examples=10))
+            builder.info.splits = SplitDict()
+            builder.info.splits.add(SplitInfo("train", num_examples=10))
+            builder.info.splits.add(SplitInfo("test", num_examples=10))
 
-            for split in dummy_builder.info.splits:
+            for split in builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{split}.arrow"),
+                    path=os.path.join(builder.cache_dir, f"{builder.name}-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
                     writer.finalize()
 
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"small_dataset-{split}.arrow"),
+                    path=os.path.join(builder.cache_dir, f"small_dataset-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 2})
                     writer.finalize()
 
-            dsets = dummy_builder.as_dataset()
+            dsets = builder.as_dataset()
             self.assertIsInstance(dsets, DatasetDict)
             self.assertListEqual(list(dsets.keys()), ["train", "test"])
             self.assertEqual(len(dsets["train"]), 2)
@@ -343,7 +330,7 @@ class BuilderTest(TestCase):
             self.assertListEqual(dsets["test"].column_names, ["text"])
             del dsets
 
-            dset = dummy_builder.as_dataset("train")
+            dset = builder.as_dataset("train")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train")
             self.assertEqual(len(dset), 2)
@@ -351,7 +338,7 @@ class BuilderTest(TestCase):
             self.assertListEqual(dset.column_names, ["text"])
             del dset
 
-            dset = dummy_builder.as_dataset("train+test[:30%]")
+            dset = builder.as_dataset("train+test[:30%]")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train+test[:30%]")
             self.assertEqual(len(dset), 2)
@@ -376,31 +363,31 @@ class BuilderTest(TestCase):
             return {"index": f"Flat-{split}.faiss"}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
-            dummy_builder._post_processing_resources = types.MethodType(_post_processing_resources, dummy_builder)
-            os.makedirs(dummy_builder.cache_dir)
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder._post_process = types.MethodType(_post_process, builder)
+            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            os.makedirs(builder.cache_dir)
 
-            dummy_builder.info.splits = SplitDict()
-            dummy_builder.info.splits.add(SplitInfo("train", num_examples=10))
-            dummy_builder.info.splits.add(SplitInfo("test", num_examples=10))
+            builder.info.splits = SplitDict()
+            builder.info.splits.add(SplitInfo("train", num_examples=10))
+            builder.info.splits.add(SplitInfo("test", num_examples=10))
 
-            for split in dummy_builder.info.splits:
+            for split in builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{split}.arrow"),
+                    path=os.path.join(builder.cache_dir, f"{builder.name}-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
                     writer.finalize()
 
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"small_dataset-{split}.arrow"),
+                    path=os.path.join(builder.cache_dir, f"small_dataset-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 2})
                     writer.finalize()
 
-            dsets = dummy_builder.as_dataset()
+            dsets = builder.as_dataset()
             self.assertIsInstance(dsets, DatasetDict)
             self.assertListEqual(list(dsets.keys()), ["train", "test"])
             self.assertEqual(len(dsets["train"]), 10)
@@ -411,11 +398,11 @@ class BuilderTest(TestCase):
             self.assertListEqual(dsets["test"].column_names, ["text"])
             self.assertListEqual(dsets["train"].list_indexes(), ["my_index"])
             self.assertListEqual(dsets["test"].list_indexes(), ["my_index"])
-            self.assertGreater(dummy_builder.info.post_processing_size, 0)
-            self.assertGreater(dummy_builder.info.post_processed.resources_checksums["train"]["index"]["num_bytes"], 0)
+            self.assertGreater(builder.info.post_processing_size, 0)
+            self.assertGreater(builder.info.post_processed.resources_checksums["train"]["index"]["num_bytes"], 0)
             del dsets
 
-            dset = dummy_builder.as_dataset("train")
+            dset = builder.as_dataset("train")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train")
             self.assertEqual(len(dset), 10)
@@ -424,7 +411,7 @@ class BuilderTest(TestCase):
             self.assertListEqual(dset.list_indexes(), ["my_index"])
             del dset
 
-            dset = dummy_builder.as_dataset("train+test[:30%]")
+            dset = builder.as_dataset("train+test[:30%]")
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train+test[:30%]")
             self.assertEqual(len(dset), 13)
@@ -444,46 +431,38 @@ class BuilderTest(TestCase):
             return {"tokenized_dataset": f"tokenized_dataset-{split}.arrow"}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder.info.post_processed = PostProcessedInfo(
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder.info.post_processed = PostProcessedInfo(
                 features=Features({"text": Value("string"), "tokens": [Value("string")]})
             )
-            dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
-            dummy_builder._post_processing_resources = types.MethodType(_post_processing_resources, dummy_builder)
-            dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            builder._post_process = types.MethodType(_post_process, builder)
+            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
-                )
+                os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", f"{builder.name}-train.arrow"))
             )
-            self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
+            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
             self.assertDictEqual(
-                dummy_builder.info.post_processed.features,
+                builder.info.post_processed.features,
                 Features({"text": Value("string"), "tokens": [Value("string")]}),
             )
-            self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
-            self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
-            )
+            self.assertEqual(builder.info.splits["train"].num_examples, 100)
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", "dataset_info.json")))
 
         def _post_process(self, dataset, resources_paths):
             return dataset.select([0, 1], keep_in_memory=True)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
-            dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder._post_process = types.MethodType(_post_process, builder)
+            builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
-                )
+                os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", f"{builder.name}-train.arrow"))
             )
-            self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
-            self.assertIsNone(dummy_builder.info.post_processed)
-            self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
-            self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
-            )
+            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertIsNone(builder.info.post_processed)
+            self.assertEqual(builder.info.splits["train"].num_examples, 100)
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", "dataset_info.json")))
 
         def _post_process(self, dataset, resources_paths):
             if os.path.exists(resources_paths["index"]):
@@ -500,81 +479,73 @@ class BuilderTest(TestCase):
             return {"index": f"Flat-{split}.faiss"}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
-            dummy_builder._post_processing_resources = types.MethodType(_post_processing_resources, dummy_builder)
-            dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder._post_process = types.MethodType(_post_process, builder)
+            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
-                )
+                os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", f"{builder.name}-train.arrow"))
             )
-            self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
-            self.assertIsNone(dummy_builder.info.post_processed)
-            self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
-            self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
-            )
+            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertIsNone(builder.info.post_processed)
+            self.assertEqual(builder.info.splits["train"].num_examples, 100)
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", "dataset_info.json")))
 
     def test_error_download_and_prepare(self):
         def _prepare_split(self, split_generator, **kwargs):
             raise ValueError()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder._prepare_split = types.MethodType(_prepare_split, dummy_builder)
+            builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
+            builder._prepare_split = types.MethodType(_prepare_split, builder)
             self.assertRaises(
                 ValueError,
-                dummy_builder.download_and_prepare,
+                builder.download_and_prepare,
                 try_from_hf_gcs=False,
                 download_mode=DownloadMode.FORCE_REDOWNLOAD,
             )
-            self.assertRaises(AssertionError, dummy_builder.as_dataset)
+            self.assertRaises(AssertionError, builder.as_dataset)
 
     def test_generator_based_download_and_prepare(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy")
-            dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy")
+            builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
                         tmp_dir,
-                        dummy_builder.name,
+                        builder.name,
                         "dummy",
                         "0.0.0",
-                        f"{dummy_builder.name}-train.arrow",
+                        f"{builder.name}-train.arrow",
                     )
                 )
             )
-            self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
-            self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
-            self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
-            )
+            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertEqual(builder.info.splits["train"].num_examples, 100)
+            self.assertTrue(os.path.exists(os.path.join(tmp_dir, builder.name, "dummy", "0.0.0", "dataset_info.json")))
 
         # Test that duplicated keys are ignored if ignore_verifications is True
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy")
+            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy")
             with patch("datasets.builder.ArrowWriter", side_effect=ArrowWriter) as mock_arrow_writer:
-                dummy_builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
+                builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
                 mock_arrow_writer.assert_called_once()
                 args, kwargs = mock_arrow_writer.call_args_list[0]
                 self.assertTrue(kwargs["check_duplicates"])
 
                 mock_arrow_writer.reset_mock()
 
-                dummy_builder.download_and_prepare(
-                    download_mode=DownloadMode.FORCE_REDOWNLOAD, ignore_verifications=True
-                )
+                builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD, ignore_verifications=True)
                 mock_arrow_writer.assert_called_once()
                 args, kwargs = mock_arrow_writer.call_args_list[0]
                 self.assertFalse(kwargs["check_duplicates"])
 
     def test_cache_dir_no_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_dir=None, data_files=None)
-            relative_cache_dir_parts = Path(dummy_builder._relative_data_dir()).parts
-            self.assertEqual(relative_cache_dir_parts, (dummy_builder.name, "dummy", "0.0.0"))
+            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_dir=None, data_files=None)
+            relative_cache_dir_parts = Path(builder._relative_data_dir()).parts
+            self.assertEqual(relative_cache_dir_parts, (builder.name, "dummy", "0.0.0"))
 
     def test_cache_dir_for_data_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -585,112 +556,110 @@ class BuilderTest(TestCase):
             with open(dummy_data2, "w", encoding="utf-8") as f:
                 f.writelines("foo bar\n")
 
-            dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data1)
+            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data1)
             other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data1)
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1])
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1}
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={Split.TRAIN: dummy_data1}
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1]}
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"test": dummy_data1}
             )
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data2)
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=[dummy_data2])
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1, dummy_data2]
             )
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
-            dummy_builder = DummyGeneratorBasedBuilder(
+            builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1, dummy_data2]
             )
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1, dummy_data2]
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files=[dummy_data2, dummy_data1]
             )
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
-            dummy_builder = DummyGeneratorBasedBuilder(
+            builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1, "test": dummy_data2}
             )
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1, "test": dummy_data2}
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1], "test": dummy_data2}
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"test": dummy_data2, "train": dummy_data1}
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1, "validation": dummy_data2}
             )
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1, dummy_data2], "test": dummy_data2}
             )
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
     def test_cache_dir_for_features(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             f1 = Features({"id": Value("int8")})
             f2 = Features({"id": Value("int32")})
-            dummy_builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, name="dummy", features=f1)
+            builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, name="dummy", features=f1)
             other_builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, name="dummy", features=f1)
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, name="dummy", features=f2)
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
     def test_cache_dir_for_config_kwargs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # create config on the fly
-            dummy_builder = DummyGeneratorBasedBuilderWithConfig(
-                cache_dir=tmp_dir, name="dummy", content="foo", times=2
-            )
+            builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, name="dummy", content="foo", times=2)
             other_builder = DummyGeneratorBasedBuilderWithConfig(
                 cache_dir=tmp_dir, name="dummy", times=2, content="foo"
             )
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
-            self.assertIn("content=foo", dummy_builder.cache_dir)
-            self.assertIn("times=2", dummy_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
+            self.assertIn("content=foo", builder.cache_dir)
+            self.assertIn("times=2", builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilderWithConfig(
                 cache_dir=tmp_dir, name="dummy", content="bar", times=2
             )
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, name="dummy", content="foo")
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             # overwrite an existing config
-            dummy_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="foo", times=2)
+            builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="foo", times=2)
             other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", times=2, content="foo")
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
-            self.assertIn("content=foo", dummy_builder.cache_dir)
-            self.assertIn("times=2", dummy_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
+            self.assertIn("content=foo", builder.cache_dir)
+            self.assertIn("times=2", builder.cache_dir)
             other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="bar", times=2)
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a", content="foo")
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
     def test_config_names(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -699,25 +668,25 @@ class BuilderTest(TestCase):
                 DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, data_files=None, data_dir=None)
             self.assertIn("Please pick one among the available configs", str(error_context.exception))
 
-            dummy_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a")
-            self.assertEqual(dummy_builder.config.name, "a")
+            builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="a")
+            self.assertEqual(builder.config.name, "a")
 
-            dummy_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="b")
-            self.assertEqual(dummy_builder.config.name, "b")
+            builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, name="b")
+            self.assertEqual(builder.config.name, "b")
 
             with self.assertRaises(ValueError):
                 DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir)
 
-            dummy_builder = DummyBuilderWithDefaultConfig(cache_dir=tmp_dir)
-            self.assertEqual(dummy_builder.config.name, "a")
+            builder = DummyBuilderWithDefaultConfig(cache_dir=tmp_dir)
+            self.assertEqual(builder.config.name, "a")
 
     def test_cache_dir_for_data_dir(self):
         with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as data_dir:
-            dummy_builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, name="a", data_dir=data_dir)
+            builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, name="a", data_dir=data_dir)
             other_builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, name="a", data_dir=data_dir)
-            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, name="a", data_dir=tmp_dir)
-            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
 
 @pytest.mark.parametrize(
@@ -731,23 +700,23 @@ class BuilderTest(TestCase):
 @pytest.mark.parametrize("in_memory", [False, True])
 def test_builder_as_dataset(split, expected_dataset_class, expected_dataset_length, in_memory, tmp_path):
     cache_dir = str(tmp_path)
-    dummy_builder = DummyBuilder(cache_dir=cache_dir, name="dummy")
-    os.makedirs(dummy_builder.cache_dir)
+    builder = DummyBuilder(cache_dir=cache_dir, name="dummy")
+    os.makedirs(builder.cache_dir)
 
-    dummy_builder.info.splits = SplitDict()
-    dummy_builder.info.splits.add(SplitInfo("train", num_examples=10))
-    dummy_builder.info.splits.add(SplitInfo("test", num_examples=10))
+    builder.info.splits = SplitDict()
+    builder.info.splits.add(SplitInfo("train", num_examples=10))
+    builder.info.splits.add(SplitInfo("test", num_examples=10))
 
-    for info_split in dummy_builder.info.splits:
+    for info_split in builder.info.splits:
         with ArrowWriter(
-            path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{info_split}.arrow"),
+            path=os.path.join(builder.cache_dir, f"{builder.name}-{info_split}.arrow"),
             features=Features({"text": Value("string")}),
         ) as writer:
             writer.write_batch({"text": ["foo"] * 10})
             writer.finalize()
 
     with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = dummy_builder.as_dataset(split=split, in_memory=in_memory)
+        dataset = builder.as_dataset(split=split, in_memory=in_memory)
     assert isinstance(dataset, expected_dataset_class)
     if isinstance(dataset, DatasetDict):
         assert list(dataset.keys()) == ["train", "test"]
@@ -768,10 +737,10 @@ def test_generator_based_builder_as_dataset(in_memory, tmp_path):
     cache_dir = tmp_path / "data"
     cache_dir.mkdir()
     cache_dir = str(cache_dir)
-    dummy_builder = DummyGeneratorBasedBuilder(cache_dir=cache_dir, name="dummy")
-    dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+    builder = DummyGeneratorBasedBuilder(cache_dir=cache_dir, name="dummy")
+    builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
     with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = dummy_builder.as_dataset("train", in_memory=in_memory)
+        dataset = builder.as_dataset("train", in_memory=in_memory)
     assert dataset.data.to_pydict() == {"text": ["foo"] * 100}
 
 
@@ -782,8 +751,8 @@ def test_custom_writer_batch_size(tmp_path, writer_batch_size, default_writer_ba
     cache_dir = str(tmp_path)
     if default_writer_batch_size:
         DummyGeneratorBasedBuilder.DEFAULT_WRITER_BATCH_SIZE = default_writer_batch_size
-    dummy_builder = DummyGeneratorBasedBuilder(cache_dir=cache_dir, name="dummy", writer_batch_size=writer_batch_size)
-    assert dummy_builder._writer_batch_size == (writer_batch_size or default_writer_batch_size)
-    dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
-    dataset = dummy_builder.as_dataset("train")
+    builder = DummyGeneratorBasedBuilder(cache_dir=cache_dir, name="dummy", writer_batch_size=writer_batch_size)
+    assert builder._writer_batch_size == (writer_batch_size or default_writer_batch_size)
+    builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
+    dataset = builder.as_dataset("train")
     assert len(dataset.data[0].chunks) == expected_chunks

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -134,12 +134,14 @@ class BuilderTest(TestCase):
             dummy_builder = DummyBuilder(cache_dir=tmp_dir, name="dummy")
             dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dummy_builder-train.arrow"))
+                os.path.exists(
+                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
+                )
             )
             self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
             self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dataset_info.json"))
+                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
             )
 
     def test_download_and_prepare_checksum_computation(self):
@@ -172,13 +174,17 @@ class BuilderTest(TestCase):
                 for dummy_builder in dummy_builders:
                     self.assertTrue(
                         os.path.exists(
-                            os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dummy_builder-train.arrow")
+                            os.path.join(
+                                tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow"
+                            )
                         )
                     )
                     self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
                     self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
                     self.assertTrue(
-                        os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dataset_info.json"))
+                        os.path.exists(
+                            os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json")
+                        )
                     )
 
     def test_download_and_prepare_with_base_path(self):
@@ -210,10 +216,10 @@ class BuilderTest(TestCase):
                 os.path.exists(
                     os.path.join(
                         tmp_dir,
-                        "dummy_builder_with_download",
+                        dummy_builder.name,
                         "dummy",
                         "0.0.0",
-                        "dummy_builder_with_download-train.arrow",
+                        f"{dummy_builder.name}-train.arrow",
                     )
                 )
             )
@@ -243,7 +249,7 @@ class BuilderTest(TestCase):
 
             for split in dummy_builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"dummy_builder-{split}.arrow"),
+                    path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
@@ -313,7 +319,7 @@ class BuilderTest(TestCase):
 
             for split in dummy_builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"dummy_builder-{split}.arrow"),
+                    path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
@@ -381,7 +387,7 @@ class BuilderTest(TestCase):
 
             for split in dummy_builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(dummy_builder.cache_dir, f"dummy_builder-{split}.arrow"),
+                    path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{split}.arrow"),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
@@ -446,7 +452,9 @@ class BuilderTest(TestCase):
             dummy_builder._post_processing_resources = types.MethodType(_post_processing_resources, dummy_builder)
             dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dummy_builder-train.arrow"))
+                os.path.exists(
+                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
+                )
             )
             self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
             self.assertDictEqual(
@@ -455,7 +463,7 @@ class BuilderTest(TestCase):
             )
             self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dataset_info.json"))
+                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
             )
 
         def _post_process(self, dataset, resources_paths):
@@ -466,13 +474,15 @@ class BuilderTest(TestCase):
             dummy_builder._post_process = types.MethodType(_post_process, dummy_builder)
             dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dummy_builder-train.arrow"))
+                os.path.exists(
+                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
+                )
             )
             self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
             self.assertIsNone(dummy_builder.info.post_processed)
             self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dataset_info.json"))
+                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
             )
 
         def _post_process(self, dataset, resources_paths):
@@ -495,13 +505,15 @@ class BuilderTest(TestCase):
             dummy_builder._post_processing_resources = types.MethodType(_post_processing_resources, dummy_builder)
             dummy_builder.download_and_prepare(try_from_hf_gcs=False, download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dummy_builder-train.arrow"))
+                os.path.exists(
+                    os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", f"{dummy_builder.name}-train.arrow")
+                )
             )
             self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
             self.assertIsNone(dummy_builder.info.post_processed)
             self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, "dummy_builder", "dummy", "0.0.0", "dataset_info.json"))
+                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
             )
 
     def test_error_download_and_prepare(self):
@@ -527,19 +539,17 @@ class BuilderTest(TestCase):
                 os.path.exists(
                     os.path.join(
                         tmp_dir,
-                        "dummy_generator_based_builder",
+                        dummy_builder.name,
                         "dummy",
                         "0.0.0",
-                        "dummy_generator_based_builder-train.arrow",
+                        f"{dummy_builder.name}-train.arrow",
                     )
                 )
             )
             self.assertDictEqual(dummy_builder.info.features, Features({"text": Value("string")}))
             self.assertEqual(dummy_builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(
-                    os.path.join(tmp_dir, "dummy_generator_based_builder", "dummy", "0.0.0", "dataset_info.json")
-                )
+                os.path.exists(os.path.join(tmp_dir, dummy_builder.name, "dummy", "0.0.0", "dataset_info.json"))
             )
 
         # Test that duplicated keys are ignored if ignore_verifications is True
@@ -564,7 +574,7 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_dir=None, data_files=None)
             relative_cache_dir_parts = Path(dummy_builder._relative_data_dir()).parts
-            self.assertEqual(relative_cache_dir_parts, ("dummy_generator_based_builder", "dummy", "0.0.0"))
+            self.assertEqual(relative_cache_dir_parts, (dummy_builder.name, "dummy", "0.0.0"))
 
     def test_cache_dir_for_data_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -730,7 +740,7 @@ def test_builder_as_dataset(split, expected_dataset_class, expected_dataset_leng
 
     for info_split in dummy_builder.info.splits:
         with ArrowWriter(
-            path=os.path.join(dummy_builder.cache_dir, f"dummy_builder-{info_split}.arrow"),
+            path=os.path.join(dummy_builder.cache_dir, f"{dummy_builder.name}-{info_split}.arrow"),
             features=Features({"text": Value("string")}),
         ) as writer:
             writer.write_batch({"text": ["foo"] * 10})


### PR DESCRIPTION
Now the builder name attribute is set from from the builder class name.

This PR sets the builder name attribute from the module name instead. Some motivating reasons:
- The dataset ID is relevant and unique among all datasets and this is directly related to the repository name, i.e., the name of the directory containing the dataset
- The name of the module (i.e. the file containing the loading loading script) is already relevant for loading: it must have the same name as its containing directory (related to the dataset ID), as we search for it using its directory name
- On the other hand, the name of the builder class is not relevant for loading: in our code, we just search for a class which is subclass of `DatasetBuilder` (independently of its name). We do not put any constraint on the naming of the builder class and indeed it can have a name completely different from its module/direcotry/dataset_id

IMO it makes more sense to align the caching directory name with the dataset_id/directory/module name instead of the builder class name.

Fix #4381.