### PR TITLE
Refactor column mappings for question answering datasets

### DIFF
--- a/datasets/cuad/README.md
+++ b/datasets/cuad/README.md
@@ -30,8 +30,9 @@ train-eval-index:
   col_mapping:
     question: question
     context: context
-    answers__text: answers.text
-    answers__answer_start: answers.answer_start
+    answers:
+      text: text
+      answer_start: answer_start
   metrics:
     - type: cuad
       name: CUAD

--- a/datasets/cuad/README.md
+++ b/datasets/cuad/README.md
@@ -30,8 +30,8 @@ train-eval-index:
   col_mapping:
     question: question
     context: context
-    answers_text: answers.text
-    answers_start: answers.answer_start
+    answers__text: answers.text
+    answers__answer_start: answers.answer_start
   metrics:
     - type: cuad
       name: CUAD

--- a/datasets/squad/README.md
+++ b/datasets/squad/README.md
@@ -30,8 +30,8 @@ train-eval-index:
   col_mapping:
     question: question
     context: context
-    answers_text: answers.text
-    answers_start: answers.answer_start
+    answers__text: answers.text
+    answers__answer_start: answers.answer_start
   metrics:
     - type: squad
       name: SQuAD

--- a/datasets/squad/README.md
+++ b/datasets/squad/README.md
@@ -30,8 +30,9 @@ train-eval-index:
   col_mapping:
     question: question
     context: context
-    answers__text: answers.text
-    answers__answer_start: answers.answer_start
+    answers:
+      text: text
+      answer_start: answer_start
   metrics:
     - type: squad
       name: SQuAD
@@ -40,28 +41,36 @@ train-eval-index:
 # Dataset Card for "squad"
 
 ## Table of Contents
-- [Dataset Description](#dataset-description)
-  - [Dataset Summary](#dataset-summary)
-  - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
-  - [Languages](#languages)
-- [Dataset Structure](#dataset-structure)
-  - [Data Instances](#data-instances)
-  - [Data Fields](#data-fields)
-  - [Data Splits](#data-splits)
-- [Dataset Creation](#dataset-creation)
-  - [Curation Rationale](#curation-rationale)
-  - [Source Data](#source-data)
-  - [Annotations](#annotations)
-  - [Personal and Sensitive Information](#personal-and-sensitive-information)
-- [Considerations for Using the Data](#considerations-for-using-the-data)
-  - [Social Impact of Dataset](#social-impact-of-dataset)
-  - [Discussion of Biases](#discussion-of-biases)
-  - [Other Known Limitations](#other-known-limitations)
-- [Additional Information](#additional-information)
-  - [Dataset Curators](#dataset-curators)
-  - [Licensing Information](#licensing-information)
-  - [Citation Information](#citation-information)
-  - [Contributions](#contributions)
+- [Dataset Card for "squad"](#dataset-card-for-squad)
+  - [Table of Contents](#table-of-contents)
+  - [Dataset Description](#dataset-description)
+    - [Dataset Summary](#dataset-summary)
+    - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
+    - [Languages](#languages)
+  - [Dataset Structure](#dataset-structure)
+    - [Data Instances](#data-instances)
+      - [plain_text](#plain_text)
+    - [Data Fields](#data-fields)
+      - [plain_text](#plain_text-1)
+    - [Data Splits](#data-splits)
+  - [Dataset Creation](#dataset-creation)
+    - [Curation Rationale](#curation-rationale)
+    - [Source Data](#source-data)
+      - [Initial Data Collection and Normalization](#initial-data-collection-and-normalization)
+      - [Who are the source language producers?](#who-are-the-source-language-producers)
+    - [Annotations](#annotations)
+      - [Annotation process](#annotation-process)
+      - [Who are the annotators?](#who-are-the-annotators)
+    - [Personal and Sensitive Information](#personal-and-sensitive-information)
+  - [Considerations for Using the Data](#considerations-for-using-the-data)
+    - [Social Impact of Dataset](#social-impact-of-dataset)
+    - [Discussion of Biases](#discussion-of-biases)
+    - [Other Known Limitations](#other-known-limitations)
+  - [Additional Information](#additional-information)
+    - [Dataset Curators](#dataset-curators)
+    - [Licensing Information](#licensing-information)
+    - [Citation Information](#citation-information)
+    - [Contributions](#contributions)
 
 ## Dataset Description
 

--- a/datasets/squad_v2/README.md
+++ b/datasets/squad_v2/README.md
@@ -30,8 +30,9 @@ train-eval-index:
   col_mapping:
     question: question
     context: context
-    answers__text: answers.text
-    answers__answer_start: answers.answer_start
+    answers:
+      text: text
+      answer_start: answer_start
   metrics:
   - type: squad_v2
     name: SQuAD v2

--- a/datasets/squad_v2/README.md
+++ b/datasets/squad_v2/README.md
@@ -30,8 +30,8 @@ train-eval-index:
   col_mapping:
     question: question
     context: context
-    answers_text: answers.text
-    answers_start: answers.answer_start
+    answers__text: answers.text
+    answers__answer_start: answers.answer_start
   metrics:
   - type: squad_v2
     name: SQuAD v2
@@ -40,28 +40,36 @@ train-eval-index:
 # Dataset Card for "squad_v2"
 
 ## Table of Contents
-- [Dataset Description](#dataset-description)
-  - [Dataset Summary](#dataset-summary)
-  - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
-  - [Languages](#languages)
-- [Dataset Structure](#dataset-structure)
-  - [Data Instances](#data-instances)
-  - [Data Fields](#data-fields)
-  - [Data Splits](#data-splits)
-- [Dataset Creation](#dataset-creation)
-  - [Curation Rationale](#curation-rationale)
-  - [Source Data](#source-data)
-  - [Annotations](#annotations)
-  - [Personal and Sensitive Information](#personal-and-sensitive-information)
-- [Considerations for Using the Data](#considerations-for-using-the-data)
-  - [Social Impact of Dataset](#social-impact-of-dataset)
-  - [Discussion of Biases](#discussion-of-biases)
-  - [Other Known Limitations](#other-known-limitations)
-- [Additional Information](#additional-information)
-  - [Dataset Curators](#dataset-curators)
-  - [Licensing Information](#licensing-information)
-  - [Citation Information](#citation-information)
-  - [Contributions](#contributions)
+- [Dataset Card for "squad_v2"](#dataset-card-for-squad_v2)
+  - [Table of Contents](#table-of-contents)
+  - [Dataset Description](#dataset-description)
+    - [Dataset Summary](#dataset-summary)
+    - [Supported Tasks and Leaderboards](#supported-tasks-and-leaderboards)
+    - [Languages](#languages)
+  - [Dataset Structure](#dataset-structure)
+    - [Data Instances](#data-instances)
+      - [squad_v2](#squad_v2)
+    - [Data Fields](#data-fields)
+      - [squad_v2](#squad_v2-1)
+    - [Data Splits](#data-splits)
+  - [Dataset Creation](#dataset-creation)
+    - [Curation Rationale](#curation-rationale)
+    - [Source Data](#source-data)
+      - [Initial Data Collection and Normalization](#initial-data-collection-and-normalization)
+      - [Who are the source language producers?](#who-are-the-source-language-producers)
+    - [Annotations](#annotations)
+      - [Annotation process](#annotation-process)
+      - [Who are the annotators?](#who-are-the-annotators)
+    - [Personal and Sensitive Information](#personal-and-sensitive-information)
+  - [Considerations for Using the Data](#considerations-for-using-the-data)
+    - [Social Impact of Dataset](#social-impact-of-dataset)
+    - [Discussion of Biases](#discussion-of-biases)
+    - [Other Known Limitations](#other-known-limitations)
+  - [Additional Information](#additional-information)
+    - [Dataset Curators](#dataset-curators)
+    - [Licensing Information](#licensing-information)
+    - [Citation Information](#citation-information)
+    - [Contributions](#contributions)
 
 ## Dataset Description
 


### PR DESCRIPTION
This PR tweaks the keys in the metadata that are used to define the column mapping for question answering datasets. This is needed in order to faithfully reconstruct column names like `answers.text` and `answers.answer_start` from the keys in AutoTrain.

As observed in https://github.com/huggingface/datasets/pull/4367 we cannot use periods `.` in the keys of the YAML tags, so a decision was made to use a flat mapping with underscores. For QA datasets, however, it's handy to be able to reconstruct the nesting -- hence this PR.

cc @sashavor 