### PR TITLE
Skip identical files in `push_to_hub` instead of overwriting

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3949,60 +3949,63 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             shards = shards_with_embedded_external_files(shards)
 
         files = api.list_repo_files(repo_id, repo_type="dataset", revision=branch, token=token)
-        files = [file for file in files if file.startswith("data/")]
+        data_files = [file for file in files if file.startswith("data/")]
 
-        def path_in_repo(_index):
-            return f"data/{split}-{_index:05d}-of-{num_shards:05d}.parquet"
-
-        # Only delete file shards that don't currently exist. Others will be overwritten if the content is different
-        # or will be left intact is the content is identical.
-        def should_delete_file(file_name):
-            file_to_overwrite = file_name in [path_in_repo(i) for i in range(num_shards)]
-            file_from_same_split = file_name.startswith(f"data/{split}-")
-
-            return file_from_same_split and not file_to_overwrite
-
-        file_shards_to_delete = [file for file in files if should_delete_file(file)]
-
-        def delete_file(file):
-            api.delete_file(file, repo_id=repo_id, token=token, repo_type="dataset", revision=branch)
-
-        if len(file_shards_to_delete):
-            for file in logging.tqdm(
-                file_shards_to_delete,
-                desc="Deleting unused files from dataset repository",
-                total=len(file_shards_to_delete),
-                disable=not logging.is_progress_bar_enabled(),
-            ):
-                delete_file(file)
+        def path_in_repo(_index, shard):
+            return f"data/{split}-{_index:05d}-of-{num_shards:05d}-{shard._fingerprint}.parquet"
 
         uploaded_size = 0
+        shards_path_in_repo = []
         for index, shard in logging.tqdm(
             enumerate(shards),
             desc="Pushing dataset shards to the dataset hub",
             total=num_shards,
             disable=not logging.is_progress_bar_enabled(),
         ):
-            buffer = BytesIO()
-            shard.to_parquet(buffer)
-            uploaded_size += buffer.tell()
-            _retry(
-                api.upload_file,
-                func_kwargs=dict(
-                    path_or_fileobj=buffer.getvalue(),
-                    path_in_repo=path_in_repo(index),
-                    repo_id=repo_id,
-                    token=token,
-                    repo_type="dataset",
-                    revision=branch,
-                    identical_ok=True,
-                ),
-                exceptions=HTTPError,
-                status_codes=[504],
-                base_wait_time=2.0,
-                max_retries=5,
-                max_wait_time=20.0,
-            )
+            shard_path_in_repo = path_in_repo(index, shard)
+            # Upload a shard only if it doesn't already exist in the repository
+            if shard_path_in_repo not in data_files:
+                buffer = BytesIO()
+                shard.to_parquet(buffer)
+                uploaded_size += buffer.tell()
+                _retry(
+                    api.upload_file,
+                    func_kwargs=dict(
+                        path_or_fileobj=buffer.getvalue(),
+                        path_in_repo=shard_path_in_repo,
+                        repo_id=repo_id,
+                        token=token,
+                        repo_type="dataset",
+                        revision=branch,
+                        identical_ok=False,
+                    ),
+                    exceptions=HTTPError,
+                    status_codes=[504],
+                    base_wait_time=2.0,
+                    max_retries=5,
+                    max_wait_time=20.0,
+                )
+            shards_path_in_repo.append(shard_path_in_repo)
+
+        # Cleanup to remove unused files
+        data_files_to_delete = [
+            data_file
+            for data_file in data_files
+            if data_file.startswith(f"data/{split}-") and data_file not in shards_path_in_repo
+        ]
+
+        def delete_file(file):
+            api.delete_file(file, repo_id=repo_id, token=token, repo_type="dataset", revision=branch)
+
+        if len(data_files_to_delete):
+            for data_file in logging.tqdm(
+                data_files_to_delete,
+                desc="Deleting unused files from dataset repository",
+                total=len(data_files_to_delete),
+                disable=not logging.is_progress_bar_enabled(),
+            ):
+                delete_file(data_file)
+
         return repo_id, split, uploaded_size, dataset_nbytes
 
     def push_to_hub(

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -24,7 +24,7 @@ class Url(str):
     pass
 
 
-SPLIT_PATTERN_SHARDED = "data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].*"
+SPLIT_PATTERN_SHARDED = "data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"
 
 DEFAULT_PATTERNS_SPLIT_IN_FILENAME = {
     str(Split.TRAIN): ["**train*"],

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -38,10 +38,6 @@ def with_staging_testing(func):
 class TestPushToHub(TestCase):
     _api = HfApi(endpoint=ENDPOINT_STAGING)
 
-    def cleanup_repo(self, ds_name):
-        organization, name = ds_name.split("/")
-        delete_repo(hf_api=self._api, name=name, organization=organization, token=self._token, repo_type="dataset")
-
     def assertFilesMatch(self, files, expected_files):
         data_files = [f[: f.rindex("-")] for f in files if f.startswith("data/")]
         expected_data_files = [f[: f.rindex("-")] for f in expected_files if f.startswith("data/")]
@@ -49,6 +45,10 @@ class TestPushToHub(TestCase):
         non_expected_data_files = [f for f in expected_files if not f.startswith("data/")]
         self.assertEqual(non_data_files, non_expected_data_files)
         self.assertEqual(data_files, expected_data_files)
+
+    def cleanup_repo(self, ds_name):
+        organization, name = ds_name.split("/")
+        delete_repo(hf_api=self._api, name=name, organization=organization, token=self._token, repo_type="dataset")
 
     @classmethod
     def setUpClass(cls):
@@ -86,7 +86,7 @@ class TestPushToHub(TestCase):
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
             self.assertFilesMatch(
-                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+                files, [".gitattributes", "data/train-00000-of-00001-<FINGERPRINT>.parquet", "dataset_infos.json"]
             )
         finally:
             self.cleanup_repo(ds_name)
@@ -108,7 +108,7 @@ class TestPushToHub(TestCase):
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
             self.assertFilesMatch(
-                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+                files, [".gitattributes", "data/train-00000-of-00001-<FINGERPRINT>.parquet", "dataset_infos.json"]
             )
         finally:
             self.cleanup_repo(ds_name)
@@ -144,7 +144,7 @@ class TestPushToHub(TestCase):
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
             self.assertFilesMatch(
-                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+                files, [".gitattributes", "data/train-00000-of-00001-<FINGERPRINT>.parquet", "dataset_infos.json"]
             )
         finally:
             self.cleanup_repo(ds_name)
@@ -166,7 +166,7 @@ class TestPushToHub(TestCase):
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
             self.assertFilesMatch(
-                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+                files, [".gitattributes", "data/train-00000-of-00001-<FINGERPRINT>.parquet", "dataset_infos.json"]
             )
         finally:
             self.cleanup_repo(ds_name)
@@ -191,8 +191,8 @@ class TestPushToHub(TestCase):
                 files,
                 [
                     ".gitattributes",
-                    "data/train-00000-of-00002-<fingerprint>.parquet",
-                    "data/train-00001-of-00002-<fingerprint>.parquet",
+                    "data/train-00000-of-00002-<FINGERPRINT>.parquet",
+                    "data/train-00001-of-00002-<FINGERPRINT>.parquet",
                     "dataset_infos.json",
                 ],
             )
@@ -234,9 +234,9 @@ class TestPushToHub(TestCase):
                 files,
                 [
                     ".gitattributes",
-                    "data/random-00000-of-00001-<fingerprint>.parquet",
-                    "data/train-00000-of-00002-<fingerprint>.parquet",
-                    "data/train-00001-of-00002-<fingerprint>.parquet",
+                    "data/random-00000-of-00001-<FINGERPRINT>.parquet",
+                    "data/train-00000-of-00002-<FINGERPRINT>.parquet",
+                    "data/train-00001-of-00002-<FINGERPRINT>.parquet",
                     "datafile.txt",
                     "dataset_infos.json",
                 ],
@@ -280,8 +280,8 @@ class TestPushToHub(TestCase):
                 files,
                 [
                     ".gitattributes",
-                    "data/random-00000-of-00001-<fingerprint>.parquet",
-                    "data/train-00000-of-00001-<fingerprint>.parquet",
+                    "data/random-00000-of-00001-<FINGERPRINT>.parquet",
+                    "data/train-00000-of-00001-<FINGERPRINT>.parquet",
                     "datafile.txt",
                     "dataset_infos.json",
                 ],
@@ -416,6 +416,34 @@ class TestPushToHub(TestCase):
             self.assertListEqual(ds.column_names, hub_ds["random"].column_names)
             self.assertListEqual(list(ds.features.keys()), list(hub_ds["random"].features.keys()))
             self.assertDictEqual(ds.features, hub_ds["random"].features)
+        finally:
+            self.cleanup_repo(ds_name)
+
+    def test_push_to_dataset_skip_identical_files(self):
+        ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
+        ds_name = f"{USER}/test-{int(time.time() * 10e3)}"
+        try:
+            with patch("datasets.arrow_dataset.HfApi.upload_file", side_effect=self._api.upload_file) as mock_hf_api:
+                # Initial push
+                ds.push_to_hub(ds_name, token=self._token, max_shard_size="1KB")
+                call_count_old = mock_hf_api.call_count
+                mock_hf_api.reset_mock()
+
+                # Remove a data file
+                files = self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token)
+                data_files = [f for f in files if f.startswith("data/")]
+                self.assertGreater(len(data_files), 1)
+                self._api.delete_file(data_files[0], repo_id=ds_name, repo_type="dataset", token=self._token)
+
+                # "Resume" push - push missing files
+                ds.push_to_hub(ds_name, token=self._token, max_shard_size="1KB")
+                call_count_new = mock_hf_api.call_count
+                self.assertGreater(call_count_old, call_count_new)
+
+            hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+            self.assertListEqual(ds.column_names, hub_ds.column_names)
+            self.assertListEqual(list(ds.features.keys()), list(hub_ds.features.keys()))
+            self.assertDictEqual(ds.features, hub_ds.features)
         finally:
             self.cleanup_repo(ds_name)
 

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -42,6 +42,14 @@ class TestPushToHub(TestCase):
         organization, name = ds_name.split("/")
         delete_repo(hf_api=self._api, name=name, organization=organization, token=self._token, repo_type="dataset")
 
+    def assertFilesMatch(self, files, expected_files):
+        data_files = [f[: f.rindex("-")] for f in files if f.startswith("data/")]
+        expected_data_files = [f[: f.rindex("-")] for f in expected_files if f.startswith("data/")]
+        non_data_files = [f for f in files if not f.startswith("data/")]
+        non_expected_data_files = [f for f in expected_files if not f.startswith("data/")]
+        self.assertEqual(non_data_files, non_expected_data_files)
+        self.assertEqual(data_files, expected_data_files)
+
     @classmethod
     def setUpClass(cls):
         """
@@ -77,7 +85,9 @@ class TestPushToHub(TestCase):
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
-            self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
+            self.assertFilesMatch(
+                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+            )
         finally:
             self.cleanup_repo(ds_name)
 
@@ -97,7 +107,9 @@ class TestPushToHub(TestCase):
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
-            self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
+            self.assertFilesMatch(
+                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+            )
         finally:
             self.cleanup_repo(ds_name)
 
@@ -131,7 +143,9 @@ class TestPushToHub(TestCase):
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
+            self.assertFilesMatch(
+                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+            )
         finally:
             self.cleanup_repo(ds_name)
 
@@ -151,7 +165,9 @@ class TestPushToHub(TestCase):
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            self.assertListEqual(files, [".gitattributes", "data/train-00000-of-00001.parquet", "dataset_infos.json"])
+            self.assertFilesMatch(
+                files, [".gitattributes", "data/train-00000-of-00001-<fingerprint>.parquet", "dataset_infos.json"]
+            )
         finally:
             self.cleanup_repo(ds_name)
 
@@ -171,12 +187,12 @@ class TestPushToHub(TestCase):
 
             # Ensure that there are two files on the repository that have the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            self.assertListEqual(
+            self.assertFilesMatch(
                 files,
                 [
                     ".gitattributes",
-                    "data/train-00000-of-00002.parquet",
-                    "data/train-00001-of-00002.parquet",
+                    "data/train-00000-of-00002-<fingerprint>.parquet",
+                    "data/train-00001-of-00002-<fingerprint>.parquet",
                     "dataset_infos.json",
                 ],
             )
@@ -214,13 +230,13 @@ class TestPushToHub(TestCase):
 
             # Ensure that there are two files on the repository that have the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            self.assertListEqual(
+            self.assertFilesMatch(
                 files,
                 [
                     ".gitattributes",
-                    "data/random-00000-of-00001.parquet",
-                    "data/train-00000-of-00002.parquet",
-                    "data/train-00001-of-00002.parquet",
+                    "data/random-00000-of-00001-<fingerprint>.parquet",
+                    "data/train-00000-of-00002-<fingerprint>.parquet",
+                    "data/train-00001-of-00002-<fingerprint>.parquet",
                     "datafile.txt",
                     "dataset_infos.json",
                 ],
@@ -260,12 +276,12 @@ class TestPushToHub(TestCase):
 
             # Ensure that there are two files on the repository that have the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            self.assertListEqual(
+            self.assertFilesMatch(
                 files,
                 [
                     ".gitattributes",
-                    "data/random-00000-of-00001.parquet",
-                    "data/train-00000-of-00001.parquet",
+                    "data/random-00000-of-00001-<fingerprint>.parquet",
+                    "data/train-00000-of-00001-<fingerprint>.parquet",
                     "datafile.txt",
                     "dataset_infos.json",
                 ],


### PR DESCRIPTION
Skip identical files instead of overwriting them to save bandwidth and circumvent (user-side/server-side) errors, which can arise when working with large datasets due to long-lasting HTTP connections, by repeating calls to `push_to_hub` to resume an upload.

To be able to check if an upload can be resumed, this PR modifies the shard naming scheme from:
```
data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9].parquet
```
to:
```
data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]-<SHARD_FINGERPRINT>.parquet
```
cc @LysandreJik 