### PR TITLE
[FR] improve language tag for PIAF dataset

### DIFF
--- a/datasets/piaf/README.md
+++ b/datasets/piaf/README.md
@@ -5,6 +5,7 @@ language_creators:
 - crowdsourced
 languages:
 - fr-FR
+- fr
 licenses:
 - mit
 multilinguality:


### PR DESCRIPTION
Hi, 

As pointed out by @lhoestq in this discussion (https://huggingface.co/datasets/asi/wikitext_fr/discussions/1), it is not yet possible to edit datasets outside of a namespace with the Hub PR feature and that you have to go through GitHub.

This modification should allow better referencing since only the xx language tags are currently taken into account and not the xx-xx.