### PR TITLE
Fix builder docstring

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -192,6 +192,9 @@ class DatasetBuilder:
     dataset by defining a `datasets.BuilderConfig` subclass and accepting a
     config object (or name) on construction. Configurable datasets expose a
     pre-defined set of configurations in :meth:`datasets.DatasetBuilder.builder_configs`.
+
+    Args:
+        cache_dir (`str`): Directory to read/write data. Defaults to "~/datasets".
     """
 
     # Default version


### PR DESCRIPTION
Currently, the args of `DatasetBuilder` do not appear in the docs: https://huggingface.co/docs/datasets/package_reference/builder_classes#datasets.DatasetBuilder