### PR TITLE
Fix dummy dataset generation script for handling nested types of _URLs

### DIFF
--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -161,8 +161,9 @@ class MockDownloadManager:
             dummy_data_dict[key] = value
 
         # make sure that values are unique
-        first_value = next(iter(dummy_data_dict.values()))
-        if isinstance(first_value, str) and len(set(dummy_data_dict.values())) < len(dummy_data_dict.values()):
+        if all([isinstance(i, str) for i in dummy_data_dict.values()]) and len(set(dummy_data_dict.values())) < len(
+            dummy_data_dict.values()
+        ):
             # append key to value to make its name unique
             dummy_data_dict = {key: value + key for key, value in dummy_data_dict.items()}
 


### PR DESCRIPTION
It seems that when user specify nested _URLs structures in their dataset script. An error will be raised when generating dummy dataset.

I think the types of all elements in `dummy_data_dict.values()` should be checked because they may have different types.

Linked to issue #4428 

PS: I am not sure whether my code fix this issue in a proper way.