### PR TITLE
Extend support for streaming datasets that use xml.dom.minidom.parse

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -5,6 +5,7 @@ import posixpath
 import re
 import tarfile
 import time
+import xml.dom.minidom
 from asyncio import TimeoutError
 from io import BytesIO
 from itertools import chain
@@ -692,6 +693,25 @@ def xet_parse(source, parser=None, use_auth_token: Optional[Union[str, bool]] = 
     else:
         with xopen(source, "rb", use_auth_token=use_auth_token) as f:
             return ET.parse(f, parser=parser)
+
+
+def xxml_dom_minidom_parse(filename_or_file, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):
+    """Extend `xml.dom.minidom.parse` function to support remote files.
+
+    Args:
+        filename_or_file (`str` or file): File path or file object.
+        use_auth_token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
+            Hugging Face Hub for private remote files.
+        **kwargs (optional): Additional keyword arguments passed to `xml.dom.minidom.parse`.
+
+    Returns:
+        :obj:`xml.dom.minidom.Document`: Parsed document.
+    """
+    if hasattr(filename_or_file, "read"):
+        return xml.dom.minidom.parse(filename_or_file, **kwargs)
+    else:
+        with xopen(filename_or_file, "rb", use_auth_token=use_auth_token) as f:
+            return xml.dom.minidom.parse(f, **kwargs)
 
 
 class _IterableFromGenerator(Iterable):

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -29,6 +29,7 @@ from .download.streaming_download_manager import (
     xsplit,
     xsplitext,
     xwalk,
+    xxml_dom_minidom_parse,
 )
 from .utils.logging import get_logger
 from .utils.patching import patch_submodule
@@ -98,6 +99,9 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     patch_submodule(module, "pd.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
     patch_submodule(module, "pd.read_excel", xpandas_read_excel, attrs=["__version__"]).start()
     patch_submodule(module, "sio.loadmat", wrap_auth(xsio_loadmat), attrs=["__version__"]).start()
+    # xml.dom.minidom
+    if hasattr(module, "parse") and module.parse.__module__ == "xml.dom.minidom":
+        patch_submodule(module, "parse", wrap_auth(xxml_dom_minidom_parse)).start()
     # xml.etree.ElementTree
     for submodule in ["ElementTree", "ET"]:
         patch_submodule(module, f"{submodule}.parse", wrap_auth(xet_parse)).start()


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `xml.dom.minidom.parse`, by patching that function.

This PR adds support for streaming datasets like "Yaxin/SemEval2015".

Fix #4453.