### PR TITLE
Fix 401 error for unauthticated requests to non-existing repos

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1247,6 +1247,10 @@ def dataset_module_factory(
                     elif "404" in str(e):
                         msg = f"Dataset '{path}' doesn't exist on the Hub"
                         raise FileNotFoundError(msg + f" at revision '{revision}'" if revision else msg)
+                    elif "401" in str(e):
+                        msg = f"Dataset '{path}' doesn't exist on the Hub"
+                        msg = msg + f" at revision '{revision}'" if revision else msg
+                        raise FileNotFoundError(msg + ". If the repo is private, make sure you are authenticated.")
                     else:
                         raise e
                 if filename in [sibling.rfilename for sibling in dataset_info.siblings]:


### PR DESCRIPTION
The hub now returns 401 instead of 404 for unauthenticated requests to non-existing repos.
This PR add support for the 401 error and fixes the CI fails on `master`