### PR TITLE
Test that TensorFlow is not imported on startup

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,10 @@
+import sys
+
+from .utils import require_tf
+
+
+@require_tf
+def test_import_datasets_doesnt_import_tensorfow():
+    import datasets  # noqa
+
+    assert "tensorflow" not in sys.modules


### PR DESCRIPTION
TF takes some time to be imported, and also uses some GPU memory.

I just added a test to make sure that in the future it's never imported by default when
```python
import datasets
```
is called.

Right now this fails because `huggingface_hub` does import tensorflow