### PR TITLE
Fix cast to null

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1749,6 +1749,8 @@ def array_cast(array: pa.Array, pa_type: pa.DataType, allow_number_to_str=True):
             raise TypeError(
                 f"Couldn't cast array of type {array.type} to {pa_type} since allow_number_to_str is set to {allow_number_to_str}"
             )
+        if pa.types.is_null(pa_type) and not pa.types.is_null(array.type):
+            raise TypeError(f"Couldn't cast array of type {array.type} to {pa_type}")
         return array.cast(pa_type)
     raise TypeError(f"Couldn't cast array of type\n{array.type}\nto\n{pa_type}")
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1044,4 +1044,4 @@ def test_cast_array_to_features_to_null_type():
     # different type
     arr = pa.array([[None, 1]])
     with pytest.raises(TypeError):
-        cast_array_to_feature(arr, Sequence(Value("null")), allow_number_to_str=False)
+        cast_array_to_feature(arr, Sequence(Value("null")))

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1034,3 +1034,14 @@ def test_cast_array_to_features_nested_with_null_values():
     assert casted_array.to_pylist() == [
         {"foo": [[], [0]]}
     ]  # empty list because of https://github.com/huggingface/datasets/issues/3676
+
+
+def test_cast_array_to_features_to_null_type():
+    # same type
+    arr = pa.array([[None, None]])
+    assert cast_array_to_feature(arr, Sequence(Value("null"))).type == pa.list_(pa.null())
+
+    # different type
+    arr = pa.array([[None, 1]])
+    with pytest.raises(TypeError):
+        cast_array_to_feature(arr, Sequence(Value("null")), allow_number_to_str=False)


### PR DESCRIPTION
It currently fails with `ArrowNotImplementedError` instead of `TypeError` when one tries to cast integer to null type.

Because if this, type inference breaks when one replaces null values with integers in `map` (it first tries to cast to the previous type before inferring the new type).

Fix https://github.com/huggingface/datasets/issues/4483