### PR TITLE
Add `@transmit_format` in `flatten`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1427,6 +1427,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         return dset
 
+    @transmit_format
     @fingerprint_transform(inplace=False)
     def flatten(self, new_fingerprint: Optional[str] = None, max_depth=16) -> "Dataset":
         """Flatten the table.
@@ -1635,6 +1636,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return dataset
 
     @transmit_tasks
+    @transmit_format
     @fingerprint_transform(inplace=False)
     def rename_column(
         self, original_column_name: str, new_column_name: str, new_fingerprint: Optional[str] = None
@@ -1699,6 +1701,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return dataset
 
     @transmit_tasks
+    @transmit_format
     @fingerprint_transform(inplace=False)
     def rename_columns(self, column_mapping: Dict[str, str], new_fingerprint: Optional[str] = None) -> "Dataset":
         """

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1635,8 +1635,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         dataset._fingerprint = new_fingerprint
         return dataset
 
-    @transmit_tasks
-    @transmit_format
+    @transmit_tasks    
     @fingerprint_transform(inplace=False)
     def rename_column(
         self, original_column_name: str, new_column_name: str, new_fingerprint: Optional[str] = None
@@ -1685,6 +1684,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return [new_column_name if col == original_column_name else col for col in columns]
 
         new_column_names = rename(self._data.column_names)
+        # `transmit_format` doesn't handle column renaming, so update the format columns manually
+        if self._format_columns is not None:
+            dataset._format_columns = rename(self._format_columns)
+
         dataset._info.features = Features(
             {
                 new_column_name if col == original_column_name else col: feature
@@ -1698,7 +1701,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return dataset
 
     @transmit_tasks
-    @transmit_format
     @fingerprint_transform(inplace=False)
     def rename_columns(self, column_mapping: Dict[str, str], new_fingerprint: Optional[str] = None) -> "Dataset":
         """
@@ -1749,6 +1751,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return [column_mapping[col] if col in column_mapping else col for col in columns]
 
         new_column_names = rename(self._data.column_names)
+        # `transmit_format` doesn't handle column renaming, so update the format columns manually
+        if self._format_columns is not None:
+            dataset._format_columns = rename(self._format_columns)
+
         dataset._info.features = Features(
             {
                 column_mapping[col] if col in column_mapping else col: feature

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1635,7 +1635,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         dataset._fingerprint = new_fingerprint
         return dataset
 
-    @transmit_tasks 
+    @transmit_tasks
     @fingerprint_transform(inplace=False)
     def rename_column(
         self, original_column_name: str, new_column_name: str, new_fingerprint: Optional[str] = None

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1685,9 +1685,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return [new_column_name if col == original_column_name else col for col in columns]
 
         new_column_names = rename(self._data.column_names)
-        if self._format_columns is not None:
-            dataset._format_columns = rename(self._format_columns)
-
         dataset._info.features = Features(
             {
                 new_column_name if col == original_column_name else col: feature
@@ -1752,9 +1749,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return [column_mapping[col] if col in column_mapping else col for col in columns]
 
         new_column_names = rename(self._data.column_names)
-        if self._format_columns is not None:
-            dataset._format_columns = rename(self._format_columns)
-
         dataset._info.features = Features(
             {
                 column_mapping[col] if col in column_mapping else col: feature

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1684,7 +1684,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return [new_column_name if col == original_column_name else col for col in columns]
 
         new_column_names = rename(self._data.column_names)
-        # `transmit_format` doesn't handle column renaming, so update the format columns manually
         if self._format_columns is not None:
             dataset._format_columns = rename(self._format_columns)
 
@@ -1751,7 +1750,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return [column_mapping[col] if col in column_mapping else col for col in columns]
 
         new_column_names = rename(self._data.column_names)
-        # `transmit_format` doesn't handle column renaming, so update the format columns manually
         if self._format_columns is not None:
             dataset._format_columns = rename(self._format_columns)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1635,7 +1635,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         dataset._fingerprint = new_fingerprint
         return dataset
 
-    @transmit_tasks    
+    @transmit_tasks 
     @fingerprint_transform(inplace=False)
     def rename_column(
         self, original_column_name: str, new_column_name: str, new_fingerprint: Optional[str] = None

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -750,7 +750,7 @@ class BaseDatasetTest(TestCase):
             ) as dset:
                 with self._to(in_memory, tmp_dir, dset) as dset:
                     fingerprint = dset._fingerprint
-                    dset._format_columns = ["a.b.c", "foo"]
+                    dset._format_columns = ["a", "foo"]
                     with dset.flatten() as dset:
                         self.assertListEqual(sorted(dset.column_names), ["a.b.c", "foo"])
                         self.assertListEqual(sorted(dset.features.keys()), ["a.b.c", "foo"])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -750,9 +750,11 @@ class BaseDatasetTest(TestCase):
             ) as dset:
                 with self._to(in_memory, tmp_dir, dset) as dset:
                     fingerprint = dset._fingerprint
+                    dset._format_columns = ["a.b.c", "foo"]
                     with dset.flatten() as dset:
                         self.assertListEqual(sorted(dset.column_names), ["a.b.c", "foo"])
                         self.assertListEqual(sorted(dset.features.keys()), ["a.b.c", "foo"])
+                        self.assertListEqual(dset._format_columns, ["a.b.c", "foo"])
                         self.assertDictEqual(
                             dset.features, Features({"a.b.c": Sequence(Value("string")), "foo": Value("int64")})
                         )

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -46,6 +46,7 @@ class DatasetDictTest(TestCase):
             {"a": [{"b": {"c": ["text"]}}] * 10, "foo": [1] * 10},
             features=Features({"a": {"b": Sequence({"c": Value("string")})}, "foo": Value("int64")}),
         )
+        dset_split._format_columns = ["a.b.c", "foo"]
         dset = DatasetDict({"train": dset_split, "test": dset_split})
         dset = dset.flatten()
         self.assertDictEqual(dset.column_names, {"train": ["a.b.c", "foo"], "test": ["a.b.c", "foo"]})
@@ -53,6 +54,7 @@ class DatasetDictTest(TestCase):
         self.assertDictEqual(
             dset["train"].features, Features({"a.b.c": Sequence(Value("string")), "foo": Value("int64")})
         )
+        self.assertListEqual(dset["train"]._format_columns, ["a.b.c", "foo"])
         del dset
 
     def test_set_format_numpy(self):

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -46,7 +46,7 @@ class DatasetDictTest(TestCase):
             {"a": [{"b": {"c": ["text"]}}] * 10, "foo": [1] * 10},
             features=Features({"a": {"b": Sequence({"c": Value("string")})}, "foo": Value("int64")}),
         )
-        dset_split._format_columns = ["a.b.c", "foo"]
+        dset_split._format_columns = ["a", "foo"]
         dset = DatasetDict({"train": dset_split, "test": dset_split})
         dset = dset.flatten()
         self.assertDictEqual(dset.column_names, {"train": ["a.b.c", "foo"], "test": ["a.b.c", "foo"]})


### PR DESCRIPTION
As suggested by @mariosasko in https://github.com/huggingface/datasets/pull/4411, we should include the `@transmit_format` decorator to `flatten`, `rename_column`, and `rename_columns` so as to ensure that the value of `_format_columns` in an `ArrowDataset` is properly updated.

**Edit**: according to @mariosasko comment below, the decorator `@transmit_format` doesn't handle column renaming, so it's done manually for those instead.