### PR TITLE
Fix patching module that doesn't exist

### DIFF
--- a/src/datasets/utils/patching.py
+++ b/src/datasets/utils/patching.py
@@ -53,7 +53,10 @@ class patch_submodule:
         # in this case we need to patch "os" and "os.path"
 
         for i in range(len(submodules)):
-            submodule = import_module(".".join(submodules[: i + 1]))
+            try:
+                submodule = import_module(".".join(submodules[: i + 1]))
+            except ModuleNotFoundError:
+                continue
             # We iterate over all the globals in self.obj in case we find "os" or "os.path"
             for attr in self.obj.__dir__():
                 obj_attr = getattr(self.obj, attr)
@@ -79,7 +82,10 @@ class patch_submodule:
         # itself if it was imported as "from os.path import join".
 
         if submodules:  # if it's an attribute of a submodule like "os.path.join"
-            attr_value = getattr(import_module(".".join(submodules)), target_attr)
+            try:
+                attr_value = getattr(import_module(".".join(submodules)), target_attr)
+            except (AttributeError, ModuleNotFoundError):
+                return
             # We iterate over all the globals in self.obj in case we find "os.path.join"
             for attr in self.obj.__dir__():
                 # We don't check for the name of the global, but rather if its value *is* "os.path.join".

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -142,3 +142,11 @@ def test_patch_submodule_successive():
     assert _test_patching.os.path.join is original_join
     assert _test_patching.os.path.dirname is original_dirname
     assert _test_patching.os.rename is original_rename
+
+
+def test_patch_submodule_doesnt_exist():
+    mock = "__test_patch_submodule_doesnt_exist_mock__"
+    with patch_submodule(_test_patching, "__module_that_doesn_exist__.__attribute_that_doesn_exist__", mock):
+        pass
+    with patch_submodule(_test_patching, "os.__attribute_that_doesn_exist__", mock):
+        pass


### PR DESCRIPTION
Reported in https://github.com/huggingface/huggingface_hub/runs/6894703718?check_suite_focus=true

When trying to patch `scipy.io.loadmat`:

```python
ModuleNotFoundError: No module named 'scipy'
```

Instead it shouldn't raise an error and do nothing

Fix https://github.com/huggingface/datasets/issues/4494