### PR TITLE
Replace `assertEqual` with `assertTupleEqual` in unit tests for verbosity

### DIFF
--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -176,7 +176,7 @@ class ArrayXDTest(unittest.TestCase):
         self.assertIsInstance(matrix_column, list)
         self.assertIsInstance(matrix_column[0], list)
         self.assertIsInstance(matrix_column[0][0], list)
-        self.assertEqual(np.array(matrix_column).shape, (2, *shape_2))
+        self.assertTupleEqual(np.array(matrix_column).shape, (2, *shape_2))
 
         matrix_field_of_first_example = dataset[0]["matrix"]
         self.assertIsInstance(matrix_field_of_first_example, list)
@@ -188,20 +188,20 @@ class ArrayXDTest(unittest.TestCase):
         self.assertIsInstance(matrix_field_of_first_two_examples, list)
         self.assertIsInstance(matrix_field_of_first_two_examples[0], list)
         self.assertIsInstance(matrix_field_of_first_two_examples[0][0], list)
-        self.assertEqual(np.array(matrix_field_of_first_two_examples).shape, (2, *shape_2))
+        self.assertTupleEqual(np.array(matrix_field_of_first_two_examples).shape, (2, *shape_2))
 
         with dataset.formatted_as("numpy"):
-            self.assertEqual(dataset["matrix"].shape, (2, *shape_2))
+            self.assertTupleEqual(dataset["matrix"].shape, (2, *shape_2))
             self.assertEqual(dataset[0]["matrix"].shape, shape_2)
-            self.assertEqual(dataset[:2]["matrix"].shape, (2, *shape_2))
+            self.assertTupleEqual(dataset[:2]["matrix"].shape, (2, *shape_2))
 
         with dataset.formatted_as("pandas"):
             self.assertIsInstance(dataset["matrix"], pd.Series)
             self.assertIsInstance(dataset[0]["matrix"], pd.Series)
             self.assertIsInstance(dataset[:2]["matrix"], pd.Series)
-            self.assertEqual(dataset["matrix"].to_numpy().shape, (2, *shape_2))
-            self.assertEqual(dataset[0]["matrix"].to_numpy().shape, (1, *shape_2))
-            self.assertEqual(dataset[:2]["matrix"].to_numpy().shape, (2, *shape_2))
+            self.assertTupleEqual(dataset["matrix"].to_numpy().shape, (2, *shape_2))
+            self.assertTupleEqual(dataset[0]["matrix"].to_numpy().shape, (1, *shape_2))
+            self.assertTupleEqual(dataset[:2]["matrix"].to_numpy().shape, (2, *shape_2))
 
     def test_write(self, array_feature, shape_1, shape_2):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -268,7 +268,7 @@ class ArrayXDDynamicTest(unittest.TestCase):
 
         for first_dim, single_arr in zip(first_dim_list, pylist):
             self.assertIsInstance(single_arr, np.ndarray)
-            self.assertEqual(single_arr.shape, (first_dim, *fixed_shape))
+            self.assertTupleEqual(single_arr.shape, (first_dim, *fixed_shape))
 
     def test_iter_dataset(self):
         fixed_shape = (2, 2)
@@ -278,7 +278,7 @@ class ArrayXDDynamicTest(unittest.TestCase):
         for first_dim, ds_row in zip(first_dim_list, dataset):
             single_arr = ds_row["image"]
             self.assertIsInstance(single_arr, np.ndarray)
-            self.assertEqual(single_arr.shape, (first_dim, *fixed_shape))
+            self.assertTupleEqual(single_arr.shape, (first_dim, *fixed_shape))
 
     def test_to_pandas_fail(self):
         fixed_shape = (2, 2)
@@ -298,7 +298,7 @@ class ArrayXDDynamicTest(unittest.TestCase):
         for first_dim, ds_row in zip(first_dim_list, dataset):
             single_arr = ds_row["image"]
             self.assertIsInstance(single_arr, np.ndarray)
-            self.assertEqual(single_arr.shape, (first_dim * 2, *fixed_shape))
+            self.assertTupleEqual(single_arr.shape, (first_dim * 2, *fixed_shape))
 
 
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -576,7 +576,7 @@ class BaseDatasetTest(TestCase):
             dset1, dset2, dset3 = self._to(in_memory, tmp_dir, dset1, dset2, dset3)
 
             with concatenate_datasets([dset1, dset2, dset3]) as dset_concat:
-                self.assertEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
+                self.assertTupleEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
                 self.assertEqual(len(dset_concat), len(dset1) + len(dset2) + len(dset3))
                 self.assertListEqual(dset_concat["id"], [0, 1, 2, 3, 4, 5, 6, 7])
                 self.assertEqual(len(dset_concat.cache_files), 0 if in_memory else 3)
@@ -618,7 +618,7 @@ class BaseDatasetTest(TestCase):
             dset1, dset2, dset3 = dset1.select([2, 1, 0]), dset2.select([2, 1, 0]), dset3
 
             with concatenate_datasets([dset3, dset2, dset1]) as dset_concat:
-                self.assertEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 3))
+                self.assertTupleEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 3))
                 self.assertEqual(len(dset_concat), len(dset1) + len(dset2) + len(dset3))
                 self.assertListEqual(dset_concat["id"], [6, 7, 8, 5, 4, 3, 2, 1, 0])
                 # in_memory = False:
@@ -633,7 +633,7 @@ class BaseDatasetTest(TestCase):
             dset2 = dset2.rename_columns({"id": "id2"})
             dset3 = dset3.rename_columns({"id": "id3"})
             with concatenate_datasets([dset1, dset2, dset3], axis=1) as dset_concat:
-                self.assertEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 3))
+                self.assertTupleEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 3))
                 self.assertEqual(len(dset_concat), len(dset1))
                 self.assertListEqual(dset_concat["id1"], [2, 1, 0])
                 self.assertListEqual(dset_concat["id2"], [5, 4, 3])
@@ -678,7 +678,7 @@ class BaseDatasetTest(TestCase):
             )
 
             with concatenate_datasets([dset3, dset2, dset1]) as dset_concat:
-                self.assertEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
+                self.assertTupleEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
                 self.assertEqual(len(dset_concat), len(dset1) + len(dset2) + len(dset3))
                 self.assertListEqual(dset_concat["id"], [7, 6, 5, 4, 3, 2, 1, 0])
                 # in_memory = False:
@@ -733,7 +733,7 @@ class BaseDatasetTest(TestCase):
                 if not in_memory:
                     dset_concat._data.table = Unpicklable()
                 with pickle.loads(pickle.dumps(dset_concat)) as dset_concat:
-                    self.assertEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
+                    self.assertTupleEqual((len(dset1), len(dset2), len(dset3)), (3, 3, 2))
                     self.assertEqual(len(dset_concat), len(dset1) + len(dset2) + len(dset3))
                     self.assertListEqual(dset_concat["id"], [7, 6, 5, 4, 3, 2, 1, 0])
                     # in_memory = True: 1 cache file for dset3
@@ -2169,8 +2169,8 @@ class BaseDatasetTest(TestCase):
                 self.assertIsInstance(dset[0][col], (tf.Tensor, tf.RaggedTensor))
                 self.assertIsInstance(dset[:2][col], (tf.Tensor, tf.RaggedTensor))
                 self.assertIsInstance(dset[col], (tf.Tensor, tf.RaggedTensor))
-            self.assertEqual(tuple(dset[:2]["vec"].shape), (2, 3))
-            self.assertEqual(tuple(dset["vec"][:2].shape), (2, 3))
+            self.assertTupleEqual(tuple(dset[:2]["vec"].shape), (2, 3))
+            self.assertTupleEqual(tuple(dset["vec"][:2].shape), (2, 3))
 
             dset.set_format("numpy")
             self.assertIsNotNone(dset[0])
@@ -2181,8 +2181,8 @@ class BaseDatasetTest(TestCase):
             self.assertIsInstance(dset[0]["vec"], np.ndarray)
             self.assertIsInstance(dset[:2]["vec"], np.ndarray)
             self.assertIsInstance(dset["vec"], np.ndarray)
-            self.assertEqual(dset[:2]["vec"].shape, (2, 3))
-            self.assertEqual(dset["vec"][:2].shape, (2, 3))
+            self.assertTupleEqual(dset[:2]["vec"].shape, (2, 3))
+            self.assertTupleEqual(dset["vec"][:2].shape, (2, 3))
 
             dset.set_format("torch", columns=["vec"])
             self.assertIsNotNone(dset[0])
@@ -2191,8 +2191,8 @@ class BaseDatasetTest(TestCase):
             self.assertIsInstance(dset[0]["vec"], torch.Tensor)
             self.assertIsInstance(dset[:2]["vec"], torch.Tensor)
             self.assertIsInstance(dset["vec"][:2], torch.Tensor)
-            self.assertEqual(dset[:2]["vec"].shape, (2, 3))
-            self.assertEqual(dset["vec"][:2].shape, (2, 3))
+            self.assertTupleEqual(dset[:2]["vec"].shape, (2, 3))
+            self.assertTupleEqual(dset["vec"][:2].shape, (2, 3))
 
     @require_tf
     @require_torch
@@ -2236,8 +2236,8 @@ class BaseDatasetTest(TestCase):
             self.assertIsInstance(dset[:2]["vec"], np.ndarray)
             self.assertIsInstance(dset["vec"], np.ndarray)
             # array is flat for ragged vectors in numpy
-            self.assertEqual(dset[:2]["vec"].shape, (2,))
-            self.assertEqual(dset["vec"][:2].shape, (2,))
+            self.assertTupleEqual(dset[:2]["vec"].shape, (2,))
+            self.assertTupleEqual(dset["vec"][:2].shape, (2,))
 
             dset.set_format("torch", columns=["vec"])
             self.assertIsNotNone(dset[0])

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -565,7 +565,7 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_dir=None, data_files=None)
             relative_cache_dir_parts = Path(builder._relative_data_dir()).parts
-            self.assertEqual(relative_cache_dir_parts, (builder.name, "default", "0.0.0"))
+            self.assertTupleEqual(relative_cache_dir_parts, (builder.name, "default", "0.0.0"))
 
     def test_cache_dir_for_data_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
As detailed in #4419 and as suggested by @mariosasko, we could replace the `assertEqual` assertions with `assertTupleEqual` when the assertion is between Tuples, in order to make the tests more verbose.