### PR TITLE
Re-add download_manager module in utils

### DIFF
--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -69,12 +69,19 @@ from .splits import (
 )
 from .tasks import *
 from .utils import *
-from .utils import download_manager as _deprecated_download_manager
 from .utils import logging
 
 
 # deprecated modules
+from datasets import utils as _utils  # isort:skip
+from datasets.utils import download_manager as _deprecated_download_manager  # isort:skip
 
 
+_utils.DownloadConfig = DownloadConfig
+_utils.DownloadManager = DownloadManager
+_utils.DownloadMode = DownloadMode
+_deprecated_download_manager.DownloadConfig = DownloadConfig
 _deprecated_download_manager.DownloadMode = DownloadMode
 _deprecated_download_manager.DownloadManager = DownloadManager
+
+del _utils, _deprecated_download_manager

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -69,4 +69,12 @@ from .splits import (
 )
 from .tasks import *
 from .utils import *
+from .utils import download_manager as _deprecated_download_manager
 from .utils import logging
+
+
+# deprecated modules
+
+
+_deprecated_download_manager.DownloadMode = DownloadMode
+_deprecated_download_manager.DownloadManager = DownloadManager

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -1,0 +1,4 @@
+# deprecated, please use daatsets.download.download_manager
+
+DownloadMode = None
+DownloadManager = None

--- a/src/datasets/utils/download_manager.py
+++ b/src/datasets/utils/download_manager.py
@@ -1,4 +1,1 @@
 # deprecated, please use daatsets.download.download_manager
-
-DownloadMode = None
-DownloadManager = None


### PR DESCRIPTION
https://github.com/huggingface/datasets/pull/4384 moved `datasets.utils.download_manager` to `datasets.download.download_manager`

This breaks `evaluate` which imports `DownloadMode` from `datasets.utils.download_manager` 

This PR re-adds `datasets.utils.download_manager` without circular imports.

We could also show a message that says that accessing it is deprecated, but I think we can do this in a subsequent PR, and just focus on doing a patch release for now