### PR TITLE
Fix double dots in data files

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -122,8 +122,9 @@ def _resolve_single_pattern_locally(
     matched_paths = [
         Path(filepath).resolve()
         for filepath in glob_iter
-        if filepath.name not in data_files_ignore and not any(part.startswith((".", "__")) for part in filepath.parts)
-    ]
+        if filepath.name not in data_files_ignore
+        and not any(part.startswith((".", "__")) and set(part) != {"."} for part in filepath.parts)
+    ]  # ignore .ipynb and __pycache__, but keep /../
     if allowed_extensions is not None:
         out = [
             filepath
@@ -307,8 +308,9 @@ def _resolve_single_pattern_in_dataset_repository(
     matched_paths = [
         filepath
         for filepath in glob_iter
-        if filepath.name not in data_files_ignore and not any(part.startswith((".", "__")) for part in filepath.parts)
-    ]
+        if filepath.name not in data_files_ignore
+        and not any(part.startswith((".", "__")) and set(part) != {"."} for part in filepath.parts)
+    ]  # ignore .ipynb and __pycache__, but keep /../
     if allowed_extensions is not None:
         out = [
             filepath

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -152,6 +152,12 @@ def test_resolve_patterns_locally_or_by_urls_with_absolute_path(tmp_path, comple
     assert len(resolved_data_files) == 1
 
 
+def test_resolve_patterns_locally_or_by_urls_with_double_dots(tmp_path, complex_data_dir):
+    path_with_double_dots = os.path.join(complex_data_dir, "data", "subdir", "..", "train.txt")
+    resolved_data_files = resolve_patterns_locally_or_by_urls(str(tmp_path / "blabla"), [path_with_double_dots])
+    assert len(resolved_data_files) == 1
+
+
 @pytest.mark.parametrize("pattern,size,extensions", [("**", 4, ["txt"]), ("**", 4, None), ("**", 0, ["blablabla"])])
 def test_resolve_patterns_locally_or_by_urls_with_extensions(complex_data_dir, pattern, size, extensions):
     if size > 0:


### PR DESCRIPTION
As mentioned in https://github.com/huggingface/transformers/pull/17715 `data_files` can't find a file if the path contains double dots `/../`. This has been introduced in https://github.com/huggingface/datasets/pull/4412, by trying to ignore hidden files and directories (i.e. if they start with a dot)

I fixed this and added a test

cc @sgugger @ydshieh 