### PR TITLE
Update Google Cloud Storage documentation and add Azure Blob Storage example

### DIFF
--- a/docs/source/filesystems.mdx
+++ b/docs/source/filesystems.mdx
@@ -38,28 +38,6 @@ Access a private S3 bucket by entering your `aws_access_key_id` and `aws_secret_
 ['dataset_info.json.json','dataset.arrow','state.json']
 ```
 
-### Google Cloud Storage
-
-Other filesystem implementations, like Google Cloud Storage, are used similarly:
-
-1. Install the Google Cloud Storage implementation:
-
-```
->>> conda install -c conda-forge gcsfs
-# or install with pip
->>> pip install gcsfs
-```
-
-2. Load your dataset:
-
-```py
->>> import gcsfs
->>> gcs = gcsfs.GCSFileSystem(project='my-google-project') 
-
->>> # saves encoded_dataset to your s3 bucket
->>> encoded_dataset.save_to_disk('gcs://my-private-datasets/imdb/train', fs=gcs)
-```
-
 ## Saving datasets
 
 After you have processed your dataset, you can save it to S3 with [`Dataset.save_to_disk`]:
@@ -131,4 +109,45 @@ Load with `botocore.session.Session` and custom AWS profile:
 
 >>> print(len(dataset))
 >>> # 25000
+```
+
+---
+
+## Other filesystems
+
+### Google Cloud Storage
+
+Other filesystem implementations, like Google Cloud Storage, are used similarly:
+
+1. Install the Google Cloud Storage implementation:
+
+```
+>>> conda install -c conda-forge gcsfs
+# or install with pip
+>>> pip install gcsfs
+```
+
+2. Save your dataset:
+
+```py
+>>> import gcsfs
+
+>>> # create GCSFileSystem instance using default gcloud credentials with project
+>>> gcs = gcsfs.GCSFileSystem(project='my-google-project')
+
+>>> # saves dataset to your gcs bucket
+>>> dataset.save_to_disk('gcs://my-private-datasets/imdb/train', fs=gcs)
+```
+
+3. Load your dataset:
+
+```py
+>>> import gcsfs
+>>> from datasets import load_from_disk
+
+>>> # create GCSFileSystem instance using default gcloud credentials with project
+>>> gcs = gcsfs.GCSFileSystem(project='my-google-project')
+
+>>> # loads dataset from your gcs bucket
+>>> dataset = load_from_disk('gcs://my-private-datasets/imdb/train', fs=gcs)
 ```

--- a/docs/source/filesystems.mdx
+++ b/docs/source/filesystems.mdx
@@ -151,3 +151,40 @@ Other filesystem implementations, like Google Cloud Storage, are used similarly:
 >>> # loads dataset from your gcs bucket
 >>> dataset = load_from_disk('gcs://my-private-datasets/imdb/train', fs=gcs)
 ```
+
+### Azure Blob Storage
+
+Other filesystem implementations, like Azure Blob Storage, are used similarly:
+
+1. Install the Azure Blob Storage implementation:
+
+```
+>>> conda install -c conda-forge adlfs
+# or install with pip
+>>> pip install adlfs
+```
+
+2. Load your dataset:
+
+```py
+>>> import adlfs
+
+>>> # create AzureBlobFileSystem instance with account_name and account_key
+>>> abfs = adlfs.AzureBlobFileSystem(account_name="XXXX", account_key="XXXX")
+
+>>> # saves dataset to your azure container
+>>> dataset.save_to_disk('abfs://my-private-datasets/imdb/train', fs=abfs)
+```
+
+3. Load your dataset:
+
+```py
+>>> import adlfs
+>>> from datasets import load_from_disk
+
+>>> # create AzureBlobFileSystem instance with account_name and account_key
+>>> abfs = adlfs.AzureBlobFileSystem(account_name="XXXX", account_key="XXXX")
+
+>>> # loads dataset from your azure container
+>>> dataset = load_from_disk('abfs://my-private-datasets/imdb/train', fs=abfs)
+```

--- a/docs/source/filesystems.mdx
+++ b/docs/source/filesystems.mdx
@@ -6,8 +6,7 @@
 |----------------------|---------------------------------------------------------------|
 | Amazon S3            | [s3fs](https://s3fs.readthedocs.io/en/latest/)                |
 | Google Cloud Storage | [gcsfs](https://gcsfs.readthedocs.io/en/latest/)              |
-| Azure DataLake       | [adl](https://github.com/dask/adlfs)                          |
-| Azure Blob           | [abfs](https://github.com/dask/adlfs)                         |
+| Azure Blob/DataLake  | [adlfs](https://github.com/fsspec/adlfs)                      |
 | Dropbox              | [dropboxdrivefs](https://github.com/MarineChap/dropboxdrivefs)|
 | Google Drive         | [gdrivefs](https://github.com/intake/gdrivefs)                |
 


### PR DESCRIPTION
While I was going through the 🤗 Datasets documentation of the Cloud storage filesystems at https://huggingface.co/docs/datasets/filesystems, I realized that the Google Cloud Storage documentation could be improved e.g. bullet point says "Load your dataset" when the actual call was to "Save your dataset", in-line code comment was mentioning "s3 bucket" instead of "gcs bucket", and some more in-line comments could be included.

Also, I think that mixing Google Cloud Storage documentation with AWS S3's one was a little bit confusing, so I moved all those to the end of the document under an h2 tab named "Other filesystems", with an h3 for "Google Cloud Storage".

Besides that, I was currently working with Azure Blob Storage and found out that the URL to [adlfs](https://github.com/fsspec/adlfs) was common for both filesystems Azure Blob Storage and Azure DataLake Storage, as well as the URL, which was updated even though the redirect was working fine, so I decided to group those under the same row in the column of supported filesystems.

And took also the change to add a small documentation entry as for Google Cloud Storage but for Azure Blob Storage, as I assume that AWS S3, GCP Cloud Storage, and Azure Blob Storage, are the most used cloud storage providers.

Let me know if you're OK with these changes, or whether you want me to roll back some of those! :hugs: