### PR TITLE
Add tags for task_ids:summarization-* and task_categories:summarization*

### DIFF
--- a/datasets/aeslc/README.md
+++ b/datasets/aeslc/README.md
@@ -3,6 +3,18 @@ languages:
 - en
 paperswithcode_id: aeslc
 pretty_name: AESLC
+task_categories:
+- text-classification
+arxiv: "1906.03497"
+task_ids:
+- "summarization"
+- "summarization-other-conversations-summarization"
+- "other-other-query-based-multi-document-summarization"
+- "summarization-other-aspect-based-summarization"
+- "summarization--other-headline-generation"
+task_categories:
+- "summarization"
+- "dialogue-system"
 ---
 
 # Dataset Card for "aeslc"

--- a/datasets/aeslc/README.md
+++ b/datasets/aeslc/README.md
@@ -6,7 +6,7 @@ pretty_name: AESLC
 task_categories:
 - summarization
 task_ids:
-- summarization--other-email-headline-generation
+- summarization-other-email-headline-generation
 - summarization-other-conversations-summarization
 - summarization-other-multi-document-summarization
 - summarization-other-aspect-based-summarization

--- a/datasets/aeslc/README.md
+++ b/datasets/aeslc/README.md
@@ -4,16 +4,12 @@ languages:
 paperswithcode_id: aeslc
 pretty_name: AESLC
 task_categories:
-- text-classification
+- summarization
 task_ids:
-- "summarization"
-- "summarization-other-conversations-summarization"
-- "other-other-query-based-multi-document-summarization"
-- "summarization-other-aspect-based-summarization"
-- "summarization--other-headline-generation"
-task_categories:
-- "summarization"
-- "dialogue-system"
+- summarization--other-email-headline-generation
+- summarization-other-conversations-summarization
+- summarization-other-multi-document-summarization
+- summarization-other-aspect-based-summarization
 ---
 
 # Dataset Card for "aeslc"

--- a/datasets/aeslc/README.md
+++ b/datasets/aeslc/README.md
@@ -5,7 +5,6 @@ paperswithcode_id: aeslc
 pretty_name: AESLC
 task_categories:
 - text-classification
-arxiv: "1906.03497"
 task_ids:
 - "summarization"
 - "summarization-other-conversations-summarization"


### PR DESCRIPTION
yaml header at top of README.md file was edited to add task tags because I couldn't find the existing tags in the json
separate Pull Request will modify dataset_infos.json to add these tags

The Enron dataset (dataset id aeslc) is only tagged with:

    arxiv:1906.03497'
    languages:en
    pretty_name:AESLC

Using the email subject_line field as a label or target variable it possible to create models for the following task_ids (in order of relevance):

    'task_ids:summarization'
    'task_ids:summarization-other-conversations-summarization'
    "task_ids:other-other-query-based-multi-document-summarization"
    'task_ids:summarization-other-aspect-based-summarization'
    'task_ids:summarization--other-headline-generation'

The subject might also be used for the task_category "task_categories:summarization"

E-mail chains might be used for the task category "task_categories:dialogue-system"