### PR TITLE
Create new sections for audio and vision in guides

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -50,10 +50,14 @@
       title: Beam Datasets
     title: "General usage"
   - sections:
+    - local: audio_load
+      title: Load audio data
     - local: audio_process
       title: Process audio data
     title: "Audio"
   - sections:
+    - local: image_load
+      title: Load image data
     - local: image_process
       title: Process image data
     title: "Vision"

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -61,6 +61,10 @@
     - local: image_process
       title: Process image data
     title: "Vision"
+  - sections:
+    - local: nlp_process
+      title: Process text data
+    title: "Text"
   title: "How-to guides"
 - sections:
   - local: about_arrow

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -23,38 +23,40 @@
 - sections:
   - local: how_to
     title: Overview
-  - local: loading
-    title: Load
-  - local: process
-    title: Process
-  - local: audio_process
-    title: Process audio data
-  - local: image_process
-    title: Process image data
-  - local: stream
-    title: Stream
-  - local: use_with_tensorflow
-    title: Use with TensorFlow
-  - local: use_with_pytorch
-    title: Use with PyTorch
-  - local: share
-    title: Share
-  - local: dataset_script
-    title: Create a dataset loading script
-  - local: dataset_card
-    title: Create a dataset card
-  - local: repository_structure
-    title: Structure your repository
-  - local: cache
-    title: Cache management
-  - local: filesystems
-    title: Cloud storage
-  - local: faiss_es
-    title: Search index
-  - local: how_to_metrics
-    title: Metrics
-  - local: beam
-    title: Beam Datasets
+  - sections:
+    - local: loading
+      title: Load
+    - local: process
+      title: Process
+    - local: stream
+      title: Stream
+    - local: share
+      title: Share
+    - local: dataset_script
+      title: Create a dataset loading script
+    - local: dataset_card
+      title: Create a dataset card
+    - local: repository_structure
+      title: Structure your repository
+    - local: cache
+      title: Cache management
+    - local: filesystems
+      title: Cloud storage
+    - local: faiss_es
+      title: Search index
+    - local: how_to_metrics
+      title: Metrics
+    - local: beam
+      title: Beam Datasets
+    title: "General usage"
+  - sections:
+    - local: audio_process
+      title: Process audio data
+    title: "Audio"
+  - sections:
+    - local: image_process
+      title: Process image data
+    title: "Vision"
   title: "How-to guides"
 - sections:
   - local: about_arrow

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -30,6 +30,10 @@
       title: Process
     - local: stream
       title: Stream
+    - local: use_with_tensorflow
+      title: Use with TensorFlow
+    - local: use_with_pytorch
+      title: Use with PyTorch
     - local: share
       title: Share
     - local: dataset_script

--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -1,0 +1,49 @@
+# Load audio data
+
+Audio datasets typically have an `audio` column which contains three important fields:
+
+* `array`: the decoded audio data represented as a 1-dimensional array.
+* `path`: the path to the downloaded audio file.
+* `sampling_rate`: the sampling rate of the audio data.
+
+When you load an audio dataset and call the `audio` column, the [`Audio`] feature automatically decodes and resamples the audio file:
+
+```py
+>>> from datasets import load_dataset, Audio
+
+>>> dataset = load_dataset("PolyAI/minds14", "en-US", split="train")
+>>> dataset[0]["audio"]
+{'array': array([ 0.        ,  0.00024414, -0.00024414, ..., -0.00024414,
+         0.        ,  0.        ], dtype=float32),
+ 'path': '/root/.cache/huggingface/datasets/downloads/extracted/f14948e0e84be638dd7943ac36518a4cf3324e8b7aa331c5ab11541518e9368c/en-US~JOINT_ACCOUNT/602ba55abb1e6d0fbce92065.wav',
+ 'sampling_rate': 8000}
+```
+
+<Tip warning={true}>
+
+Index into an audio dataset using the row index first and then the `audio` column - `dataset[0]["audio"]` - to avoid decoding and resampling all the audio files in the dataset. Otherwise, if you have a large dataset, this can be a slow and time-consuming process.
+
+</Tip>
+
+## Path
+
+The `path` is useful for loading your own dataset. Use the [`~Dataset.cast_column`] function to take a column of audio file paths, and decode it into `array`'s of the audio data with the [`Audio`] feature:
+
+```py
+>>> audio_dataset = audio_dataset.cast_column("paths_to_my_audio_files", Audio())
+```
+
+If you only want to load the underlying path to the audio dataset without decoding the audio file into an `array`, set `decode=False` in the [`Audio`] feature:
+
+```py
+>>> dataset = load_dataset("PolyAI/minds14", "en-US", split="train").cast_column('audio', Audio(decode=False))
+>>> dataset[0]
+{'audio': {'bytes': None,
+  'path': '/root/.cache/huggingface/datasets/downloads/extracted/f14948e0e84be638dd7943ac36518a4cf3324e8b7aa331c5ab11541518e9368c/en-US~JOINT_ACCOUNT/602ba55abb1e6d0fbce92065.wav'},
+ 'english_transcription': 'I would like to set up a joint account with my partner',
+ 'intent_class': 11,
+ 'lang_id': 4,
+ 'path': '/root/.cache/huggingface/datasets/downloads/extracted/f14948e0e84be638dd7943ac36518a4cf3324e8b7aa331c5ab11541518e9368c/en-US~JOINT_ACCOUNT/602ba55abb1e6d0fbce92065.wav',
+ 'transcription': 'I would like to set up a joint account with my partner'}
+```
+

--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -1,6 +1,6 @@
 # Load audio data
 
-Audio datasets typically have an `audio` column which contains three important fields:
+Audio datasets are loaded from the `audio` column, which contains three important fields:
 
 * `array`: the decoded audio data represented as a 1-dimensional array.
 * `path`: the path to the downloaded audio file.
@@ -21,13 +21,13 @@ When you load an audio dataset and call the `audio` column, the [`Audio`] featur
 
 <Tip warning={true}>
 
-Index into an audio dataset using the row index first and then the `audio` column - `dataset[0]["audio"]` - to avoid decoding and resampling all the audio files in the dataset. Otherwise, if you have a large dataset, this can be a slow and time-consuming process.
+Index into an audio dataset using the row index first and then the `audio` column - `dataset[0]["audio"]` - to avoid decoding and resampling all the audio files in the dataset. Otherwise, this can be a slow and time-consuming process if you have a large dataset.
 
 </Tip>
 
 ## Path
 
-The `path` is useful for loading your own dataset. Use the [`~Dataset.cast_column`] function to take a column of audio file paths, and decode it into `array`'s of the audio data with the [`Audio`] feature:
+The `path` is useful for loading your own dataset. Use the [`~Dataset.cast_column`] function to take a column of audio file paths, and decode it into `array`'s with the [`Audio`] feature:
 
 ```py
 >>> audio_dataset = audio_dataset.cast_column("paths_to_my_audio_files", Audio())

--- a/docs/source/audio_process.mdx
+++ b/docs/source/audio_process.mdx
@@ -1,9 +1,11 @@
 # Process audio data
 
-This guide shows audio specific methods for processing audio datasets. For guides on how to process datasets in general, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>. Learn how to:
+This guide shows specific methods for processing audio datasets. Learn how to:
 
 - Resample the sampling rate.
 - Use [`~Dataset.map`] with audio datasets.
+
+For a guide on processing any type of dataset, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>.
 
 ## Cast
 
@@ -33,27 +35,27 @@ Audio files are decoded and resampled on-the-fly, so the next time you access an
 
 ## Map
 
-The [`~Dataset.map`] function is useful for preprocessing your entire dataset at once. Depending on the type of model you're working with, you'll need to either load a [feature extractor](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoFeatureExtractor) or a [processor](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoProcessor).
+The [`~Dataset.map`] function helps preprocess your entire dataset at once. Depending on the type of model you're working with, you'll need to either load a [feature extractor](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoFeatureExtractor) or a [processor](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoProcessor).
 
-For pretrained speech recognition models, load a feature extractor and tokenizer and then combine them in a `processor`:
+- For pretrained speech recognition models, load a feature extractor and tokenizer and combine them in a `processor`:
 
-```py
->>> from transformers import AutoTokenizer, AutoFeatureExtractor, AutoProcessor
+    ```py
+    >>> from transformers import AutoTokenizer, AutoFeatureExtractor, AutoProcessor
 
->>> model_checkpoint = "facebook/wav2vec2-large-xlsr-53"
-# after defining a vocab.json file you can instantiate a tokenizer object:
->>> tokenizer = AutoTokenizer("./vocab.json", unk_token="[UNK]", pad_token="[PAD]", word_delimiter_token="|")
->>> feature_extractor = AutoFeatureExtractor.from_pretrained(model_checkpoint)
->>> processor = AutoProcessor.from_pretrained(feature_extractor=feature_extractor, tokenizer=tokenizer)
-```
+    >>> model_checkpoint = "facebook/wav2vec2-large-xlsr-53"
+    # after defining a vocab.json file you can instantiate a tokenizer object:
+    >>> tokenizer = AutoTokenizer("./vocab.json", unk_token="[UNK]", pad_token="[PAD]", word_delimiter_token="|")
+    >>> feature_extractor = AutoFeatureExtractor.from_pretrained(model_checkpoint)
+    >>> processor = AutoProcessor.from_pretrained(feature_extractor=feature_extractor, tokenizer=tokenizer)
+    ```
 
-For fine-tuned speech recognition models, you only need to load a `processor`:
+- For fine-tuned speech recognition models, you only need to load a `processor`:
 
-```py
->>> from transformers import AutoProcessor
+    ```py
+    >>> from transformers import AutoProcessor
 
->>> processor = AutoProcessor.from_pretrained("facebook/wav2vec2-base-960h")
-```
+    >>> processor = AutoProcessor.from_pretrained("facebook/wav2vec2-base-960h")
+    ```
 
 When you use [`~Dataset.map`] with your preprocessing function, include the `audio` column to ensure you're actually resampling the audio data:
 

--- a/docs/source/audio_process.mdx
+++ b/docs/source/audio_process.mdx
@@ -1,93 +1,29 @@
 # Process audio data
 
-🤗 Datasets supports an [`Audio`] feature, enabling users to load and process raw audio files for training. This guide will show you how to:
+This guide shows audio specific methods for processing audio datasets. For guides on how to process datasets in general, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>. Learn how to:
 
-- Load your own custom audio dataset.
-- Resample audio files.
-- Use [`Dataset.map`] with audio files.
+- Resample the sampling rate.
+- Use [`~Dataset.map`] with audio datasets.
 
-## Installation
+## Cast
 
-The [`Audio`] feature should be installed as an extra dependency in 🤗 Datasets. Install the [`Audio`] feature (and its dependencies) with pip:
-
-```bash
-pip install datasets[audio]
-```
-
-<Tip warning={true}>
-
-On Linux, non-Python dependency on `libsndfile` package must be installed manually, using your distribution package manager, for example:
-
-```bash
-sudo apt-get install libsndfile1
-```
-
-</Tip>
-
-To support loading audio datasets containing MP3 files, users should additionally install [torchaudio](https://pytorch.org/audio/stable/index.html), so that audio data is handled with high performance.
-
-```bash
-pip install torchaudio
-```
-
-<Tip warning={true}>
-
-torchaudio's `sox_io` [backend](https://pytorch.org/audio/stable/backend.html#) supports decoding `mp3` files. Unfortunately, the `sox_io` backend is only available on Linux/macOS, and is not supported by Windows.
-
-</Tip>
-
-Then you can load an audio dataset the same way you would load a text dataset. For example, load the [Common Voice](https://huggingface.co/datasets/common_voice) dataset with the Turkish configuration:
+The [`~Dataset.cast_column`] function is used to cast a column to another feature to be decoded. When you use this function with the [`Audio`] feature, you can resample the sampling rate:
 
 ```py
->>> from datasets import load_dataset, load_metric, Audio
->>> common_voice = load_dataset("common_voice", "tr", split="train")
+>>> from datasets import load_dataset, Audio
+
+>>> dataset = load_dataset("PolyAI/minds14", "en-US", split="train")
+>>> dataset = dataset.cast_column("audio", Audio(sampling_rate=16000))
 ```
 
-## Audio datasets
-
-Audio datasets commonly have an `audio` and `path` or `file` column.
-
-`audio` is the actual audio file that is loaded and resampled on-the-fly upon calling it.
+Audio files are decoded and resampled on-the-fly, so the next time you access an example, the audio file is resampled to 16kHz:
 
 ```py
->>> common_voice[0]["audio"]
-{'array': array([ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
-    -8.8930130e-05, -3.8027763e-05, -2.9146671e-05], dtype=float32),
-'path': '/root/.cache/huggingface/datasets/downloads/extracted/05be0c29807a73c9b099873d2f5975dae6d05e9f7d577458a2466ecb9a2b0c6b/cv-corpus-6.1-2020-12-11/tr/clips/common_voice_tr_21921195.mp3',
-'sampling_rate': 48000}
-```
-
-When you access an audio file, it is automatically decoded and resampled. Generally, you should query an audio file like: `common_voice[0]["audio"]`. If you query an audio file with `common_voice["audio"][0]` instead, **all** the audio files in your dataset will be decoded and resampled. This process can take a long time if you have a large dataset.
-
-`path` or `file` is an absolute path to an audio file.
-
-```py
->>> common_voice[0]["path"]
-/root/.cache/huggingface/datasets/downloads/extracted/05be0c29807a73c9b099873d2f5975dae6d05e9f7d577458a2466ecb9a2b0c6b/cv-corpus-6.1-2020-12-11/tr/clips/common_voice_tr_21921195.mp3
-```
-
-The `path` is useful if you want to load your own audio dataset. In this case, provide a column of audio file paths to [`Dataset.cast_column`]:
-
-```py
->>> my_audio_dataset = my_audio_dataset.cast_column("paths_to_my_audio_files", Audio())
-```
-
-## Resample
-
-Some models expect the audio data to have a certain sampling rate due to how the model was pretrained. For example, the [XLSR-Wav2Vec2](https://huggingface.co/facebook/wav2vec2-large-xlsr-53) model expects the input to have a sampling rate of 16kHz, but an audio file from the Common Voice dataset has a sampling rate of 48kHz. You can use [`Dataset.cast_column`] to downsample the sampling rate to 16kHz:
-
-```py
->>> common_voice = common_voice.cast_column("audio", Audio(sampling_rate=16_000))
-```
-
-The next time you load the audio file, the [`Audio`] feature will load and resample it to 16kHz:
-
-```py
->>> common_voice_train[0]["audio"]
-{'array': array([ 0.0000000e+00,  0.0000000e+00,  0.0000000e+00, ...,
--7.4556941e-05, -1.4621433e-05, -5.7861507e-05], dtype=float32),
-'path': '/root/.cache/huggingface/datasets/downloads/extracted/05be0c29807a73c9b099873d2f5975dae6d05e9f7d577458a2466ecb9a2b0c6b/cv-corpus-6.1-2020-12-11/tr/clips/common_voice_tr_21921195.mp3',
-'sampling_rate': 16000}
+>>> dataset[0]["audio"]
+{'array': array([ 2.3443763e-05,  2.1729663e-04,  2.2145823e-04, ...,
+         3.8356509e-05, -7.3497440e-06, -2.1754686e-05], dtype=float32),
+ 'path': '/root/.cache/huggingface/datasets/downloads/extracted/f14948e0e84be638dd7943ac36518a4cf3324e8b7aa331c5ab11541518e9368c/en-US~JOINT_ACCOUNT/602ba55abb1e6d0fbce92065.wav',
+ 'sampling_rate': 16000}
 ```
 
 <div class="flex justify-center">
@@ -97,31 +33,29 @@ The next time you load the audio file, the [`Audio`] feature will load and resam
 
 ## Map
 
-Just like text datasets, you can apply a preprocessing function over an entire dataset with [`Dataset.map`], which is useful for preprocessing all of your audio data at once. Start with a [speech recognition model](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=downloads) of your choice, and load a `processor` object that contains:
+The [`~Dataset.map`] function is useful for preprocessing your entire dataset at once. Depending on the type of model you're working with, you'll need to either load a [feature extractor](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoFeatureExtractor) or a [processor](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoProcessor).
 
-1. A feature extractor to convert the speech signal to the model's input format. Every speech recognition model on the 🤗 [Hub](https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=downloads) contains a predefined feature extractor that can be easily loaded with `AutoFeatureExtractor.from_pretrained(...)`.
-
-2. A tokenizer to convert the model's output format to text. Fine-tuned speech recognition models, such as [facebook/wav2vec2-base-960h](https://huggingface.co/facebook/wav2vec2-base-960h), contain a predefined tokenizer that can be easily loaded with `AutoTokenizer.from_pretrained(...)`.
-
-   For pretrained speech recognition models, such as [facebook/wav2vec2-large-xlsr-53](https://huggingface.co/facebook/wav2vec2-large-xlsr-53), a tokenizer needs to be created from the target text as explained [here](https://huggingface.co/blog/fine-tune-wav2vec2-english). The following example demonstrates how to load a feature extractor, tokenizer and processor for a pretrained speech recognition model:
+For pretrained speech recognition models, load a feature extractor and tokenizer and then combine them in a `processor`:
 
 ```py
->>> from transformers import AutoTokenizer, AutoFeatureExtractor, Wav2Vec2Processor
+>>> from transformers import AutoTokenizer, AutoFeatureExtractor, AutoProcessor
+
 >>> model_checkpoint = "facebook/wav2vec2-large-xlsr-53"
->>> # after defining a vocab.json file you can instantiate a tokenizer object:
+# after defining a vocab.json file you can instantiate a tokenizer object:
 >>> tokenizer = AutoTokenizer("./vocab.json", unk_token="[UNK]", pad_token="[PAD]", word_delimiter_token="|")
 >>> feature_extractor = AutoFeatureExtractor.from_pretrained(model_checkpoint)
->>> processor = Wav2Vec2Processor.from_pretrained(feature_extractor=feature_extractor, tokenizer=tokenizer)
+>>> processor = AutoProcessor.from_pretrained(feature_extractor=feature_extractor, tokenizer=tokenizer)
 ```
 
-For fine-tuned speech recognition models, you can simply load a predefined `processor` object with:
+For fine-tuned speech recognition models, you only need to load a `processor`:
 
 ```py
->>> from transformers import Wav2Vec2Processor
->>> processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base-960h")
+>>> from transformers import AutoProcessor
+
+>>> processor = AutoProcessor.from_pretrained("facebook/wav2vec2-base-960h")
 ```
 
-Make sure to include the `audio` key in your preprocessing function when you call [`Dataset.map`] so that you are actually resampling the audio data:
+When you use [`~Dataset.map`] with your preprocessing function, include the `audio` column to ensure you're actually resampling the audio data:
 
 ```py
 >>> def prepare_dataset(batch):
@@ -131,5 +65,5 @@ Make sure to include the `audio` key in your preprocessing function when you cal
 ...     with processor.as_target_processor():
 ...         batch["labels"] = processor(batch["sentence"]).input_ids
 ...     return batch
->>> common_voice_train = common_voice_train.map(prepare_dataset, remove_columns=common_voice_train.column_names)
+>>> dataset = dataset.map(prepare_dataset, remove_columns=dataset.column_names)
 ```

--- a/docs/source/how_to.md
+++ b/docs/source/how_to.md
@@ -16,13 +16,13 @@ The guides cover four key areas of 🤗 Datasets:
     <span class="bg-pink-200 text-pink-900 dark:bg-pink-500 px-1 rounded font-bold">General usage</span>: Functions for general dataset loading and processing. The functions shown in this section are applicable across all dataset modalities.
 </div>
 <div>
-    <span class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold">Audio</span>: Functions for loading, processing, and sharing audio datasets.
+    <span class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold">Audio</span>: How to load, process, and share audio datasets.
 </div>
 <div>
-    <span class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold">Vision</span>: Functions for loading, processing, and sharing image datasets.
+    <span class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold">Vision</span>: How to load, process, and share image datasets.
 </div>
 <div>
-    <span class="bg-blue-200 text-blue-900 dark:bg-blue-500 px-1 rounded font-bold">NLP</span>: Functions for loading, processing, and sharing NLP datasets.
+    <span class="bg-blue-200 text-blue-900 dark:bg-blue-500 px-1 rounded font-bold">NLP</span>: How to load, process, and share NLP datasets.
 </div>
 
 If you have any questions about 🤗 Datasets, feel free to join and ask the community on our [forum](https://discuss.huggingface.co/c/datasets/10).

--- a/docs/source/how_to.md
+++ b/docs/source/how_to.md
@@ -1,8 +1,8 @@
 # Overview
 
-The how-to guides demonstrate how to complete a specific task with your dataset. The guides offer a more comprehensive overview of all the tools 🤗 Datasets offers and how to use them. This will help you tackle some of the messier real-world datasets out there.
+The how-to guides offer a more comprehensive overview of all the tools 🤗 Datasets offers and how to use them. This will help you tackle some of the messier real-world datasets, where you may need to manipulate the dataset structure or content to get it ready for training.
 
-The guides assume you are familiar and comfortable with the 🤗 Datasets basics. We recommend new users check out our [tutorial](./tutorial) first.
+The guides assume you are familiar and comfortable with the 🤗 Datasets basics. We recommend newer users check out our [tutorials](tutorial) first.
 
 <Tip>
 

--- a/docs/source/how_to.md
+++ b/docs/source/how_to.md
@@ -1,25 +1,28 @@
 # Overview
 
-Our how-to guides will show you how to complete a specific task. These guides are intended to help you apply your knowledge of 🤗 Datasets to real-world problems you may encounter. Want to flatten a column or load a dataset from a local file? We got you covered! You should already be familiar and comfortable with the 🤗 Datasets basics, and if you aren't, we recommend reading our [tutorial](./tutorial) first.
+The how-to guides demonstrate how to complete a specific task with your dataset. The guides offer a more comprehensive overview of all the tools 🤗 Datasets offers and how to use them. This will help you tackle some of the messier real-world datasets out there.
 
-The how-to guides will cover eight key areas of 🤗 Datasets:
+The guides assume you are familiar and comfortable with the 🤗 Datasets basics. We recommend new users check out our [tutorial](./tutorial) first.
 
-* How to load a dataset from other data sources.
+<Tip>
 
-* How to process a dataset.
+Interested in learning more? Take a look at [Chapter 5](https://huggingface.co/course/chapter5/1?fw=pt) of the Hugging Face course!
 
-* How to use a dataset with your favorite ML/DL framework.
+</Tip>
 
-* How to stream large datasets.
+The guides cover four key areas of 🤗 Datasets:
 
-* How to upload and share a dataset.
+<div>
+    <span class="bg-pink-200 text-pink-900 dark:bg-pink-500 px-1 rounded font-bold">General usage</span>: Functions for general dataset loading and processing. The functions shown in this section are applicable across all dataset modalities.
+</div>
+<div>
+    <span class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold">Audio</span>: Functions for loading, processing, and sharing audio datasets.
+</div>
+<div>
+    <span class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold">Vision</span>: Functions for loading, processing, and sharing image datasets.
+</div>
+<div>
+    <span class="bg-blue-200 text-blue-900 dark:bg-blue-500 px-1 rounded font-bold">NLP</span>: Functions for loading, processing, and sharing NLP datasets.
+</div>
 
-* How to create a dataset loading script.
-
-* How to create a dataset card.
-
-* How to compute metrics.
-
-* How to manage the cache.
-
-You can also find guides on how to process massive datasets with Beam, how to integrate with cloud storage providers, and how to add an index to search your dataset.
+If you have any questions about 🤗 Datasets, feel free to join and ask the community on our [forum](https://discuss.huggingface.co/c/datasets/10).

--- a/docs/source/how_to_metrics.mdx
+++ b/docs/source/how_to_metrics.mdx
@@ -1,5 +1,11 @@
 # Metrics
 
+<Tip warning={true}>
+
+Metrics will soon be deprecated in 🤗 Datasets. To learn more about how to use metrics, take a look at our newest library 🤗 [Evaluate](https://huggingface.co/docs/evaluate/index)! In addition to metrics, we've also added more tools for evaluating models and datasets.
+
+</Tip>
+
 Metrics are important for evaluating a model's predictions. In the tutorial, you learned how to compute a metric over an entire evaluation set. You have also seen how to load a metric. 
 
 This guide will show you how to:

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -1,0 +1,121 @@
+# Load image data
+
+Image datasets typically have a `image` column which contains a PIL object. When you load an image dataset and call the `image` column, the [`Image`] feature automatically decodes the PIL object into an image:
+
+```py
+>>> from datasets import load_dataset, Image
+
+>>> dataset = load_dataset("beans", split="train")
+>>> dataset[0]["image"]
+```
+
+<Tip warning={true}>
+
+Index into an image dataset using the row index first and then the `image` column - `dataset[0]["image"]` - to avoid decoding and resampling all the image objects in the dataset. Otherwise, if you have a large dataset, this can be a slow and time-consuming process.
+
+</Tip>
+
+## Path
+
+The path is useful for loading your own dataset. Use the [`~Dataset.cast_column`] function to accept a column of image file paths, and decode it into a PIL image with the [`Image`] feature:
+```py
+>>> from datasets import load_dataset, Image
+
+>>> dataset = Dataset.from_dict({"image": ["path/to/image_1", "path/to/image_2", ..., "path/to/image_n"]}).cast_column("image", Image())
+>>> dataset[0]["image"]
+<PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E6D7160>]
+```
+
+If you only want to load the underlying path to the image dataset without decoding the image object, set `decode=False` in the [`Image`] feature:
+
+```py
+>>> dataset = load_dataset("beans", split="train").cast_column("image", Image(decode=False))
+>>> dataset[0]["image"]
+{'bytes': None,
+ 'path': '/root/.cache/huggingface/datasets/downloads/extracted/b0a21163f78769a2cf11f58dfc767fb458fc7cea5c05dccc0144a2c0f0bc1292/train/bean_rust/bean_rust_train.29.jpg'}
+```
+
+## ImageFolder
+
+You can also load your image dataset with a `ImageFolder` dataset builder. The `ImageFolder` does not require writing a custom dataloader. Your image dataset structure should look like this:
+
+```
+folder/train/dog/golden_retriever.png
+folder/train/dog/german_shepherd.png
+folder/train/dog/chihuahua.png
+
+folder/train/cat/maine_coon.png
+folder/train/cat/bengal.png
+folder/train/cat/birman.png
+```
+
+Load your dataset by specifying `imagefolder` and the directory of your dataset in `data_dir`:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder")
+>>> dataset["train"][0]["image"]
+<PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E6D7160>]
+```
+
+Load remote datasets from their URLs with the `data_files` parameter:
+
+```py
+>>> dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
+```
+
+`ImageFolder` creates a `label` column, and the label name is based on the directory name. To ignore the `label` column, set `drop_labels=False` as defined in [`~datasets.packaged_modules.imagefolder.ImageFolderConfig`].
+
+## ImageFolder with metadata
+
+Metadata associated with your dataset can also be loaded. Make sure your dataset has a `metadata.jsonl` file:
+
+```
+folder/train/metadata.jsonl
+folder/train/0001.png
+folder/train/0002.png
+folder/train/0003.png
+```
+
+Link the metadata in `metadata.jsonl` file to the images using the `file_path` parameter:
+
+```py
+>>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder", file_path="/path/to/folder/train/metadata.jsonl", split="train")
+```
+
+### Image captioning
+
+Image captioning datasets have text describing an image. An example `metadata.jsonl` may look like:
+
+```jsonl
+{"file_name": "0001.png", "text": "This is a golden retriever playing with a ball"}
+{"file_name": "0002.png", "text": "A german shepherd"}
+{"file_name": "0003.png", "text": "One chihuahua"}
+```
+
+Load the dataset with `ImageFolder`, and it will create a `text` column for the image captions:
+
+```py
+>>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder", split="train")
+>>> dataset[0]["text"]
+"This is a golden retriever playing with a ball"
+```
+
+### Object detection
+
+Object detection datasets have bounding boxes and categories identifying objects in an image. An example `metadata.jsonl` may look like:
+
+```jsonl
+{"file_name": "0001.png", "objects": {"bbox": [[302.0, 109.0, 73.0, 52.0]], "categories": [0]}}
+{"file_name": "0002.png", "objects": {"bbox": [[810.0, 100.0, 57.0, 28.0]], "categories": [1]}}
+{"file_name": "0003.png", "objects": {"bbox": [[160.0, 31.0, 248.0, 616.0], [741.0, 68.0, 202.0, 401.0]], "categories": [2, 2]}}
+```
+
+Load the dataset with `ImageFolder`, and it will create a `objects` column with the bounding boxes and the categories:
+
+```py
+>>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder", split="train")
+>>> dataset[0]["objects"]
+{"bbox": [[302.0, 109.0, 73.0, 52.0]], "categories": [0]}
+```

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -1,6 +1,6 @@
 # Load image data
 
-Image datasets typically have a `image` column which contains a PIL object. When you load an image dataset and call the `image` column, the [`Image`] feature automatically decodes the PIL object into an image:
+Image datasets are loaded from the `image` column, which contains a PIL object. When you load an image dataset and call the `image` column, the [`Image`] feature automatically decodes the PIL object into an image:
 
 ```py
 >>> from datasets import load_dataset, Image
@@ -11,13 +11,13 @@ Image datasets typically have a `image` column which contains a PIL object. When
 
 <Tip warning={true}>
 
-Index into an image dataset using the row index first and then the `image` column - `dataset[0]["image"]` - to avoid decoding and resampling all the image objects in the dataset. Otherwise, if you have a large dataset, this can be a slow and time-consuming process.
+Index into an image dataset using the row index first and then the `image` column - `dataset[0]["image"]` - to avoid decoding and resampling all the image objects in the dataset. Otherwise, this can be a slow and time-consuming process if you have a large dataset.
 
 </Tip>
 
 ## Path
 
-The path is useful for loading your own dataset. Use the [`~Dataset.cast_column`] function to accept a column of image file paths, and decode it into a PIL image with the [`Image`] feature:
+You can load a dataset from the image path. Use the [`~Dataset.cast_column`] function to accept a column of image file paths, and decode it into a PIL image with the [`Image`] feature:
 ```py
 >>> from datasets import load_dataset, Image
 
@@ -37,7 +37,7 @@ If you only want to load the underlying path to the image dataset without decodi
 
 ## ImageFolder
 
-You can also load your image dataset with a `ImageFolder` dataset builder. The `ImageFolder` does not require writing a custom dataloader. Your image dataset structure should look like this:
+You can also load a dataset with a `ImageFolder` dataset builder. It does not require writing a custom dataloader, making it useful for quickly loading a dataset for certain vision tasks. Your image dataset structure should look like this:
 
 ```
 folder/train/dog/golden_retriever.png
@@ -69,7 +69,7 @@ Load remote datasets from their URLs with the `data_files` parameter:
 
 ## ImageFolder with metadata
 
-Metadata associated with your dataset can also be loaded. Make sure your dataset has a `metadata.jsonl` file:
+Metadata associated with your dataset can also be loaded, extending the utility of `ImageFolder` to additional vision tasks like image captioning and object detection. Make sure your dataset has a `metadata.jsonl` file:
 
 ```
 folder/train/metadata.jsonl

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -1,15 +1,17 @@
 # Process image data
 
-This guide shows image specific methods for processing image datasets. For guides on how to process datasets in general, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>. Learn how to:
+This guide shows specific methods for processing image datasets. Learn how to:
 
 - Use [`~Dataset.map`] with image dataset.
 - Apply data augmentations to your dataset with [`~Dataset.set_transform`].
+
+For a guide on processing any type of dataset, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>.
 
 ## Map
 
 The [`~Dataset.map`] function can apply transforms over an entire dataset.
 
-Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
+For example, create a basic [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
 
 ```py
 >>> def transforms(examples):
@@ -17,7 +19,7 @@ Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvisi
 ...     return examples
 ```
 
-Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
+Now use the [`~Dataset.map`] function to resize the entire dataset, and set `batched=True` to speed up the process by accepting batches of examples. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
 
 ```py
 >>> dataset = dataset.map(transforms, remove_columns=["image"], batched=True)
@@ -26,7 +28,7 @@ Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`
  'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
 ```
 
-The cache file saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
+The cache file saves time because you don't have to execute the same transform twice. The [`~Dataset.map`] function is best for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
 
 [`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
 
@@ -37,7 +39,7 @@ Both parameter values default to 1000, which can be expensive if you are storing
 
 ## Data augmentation
 
-🤗 Datasets can apply data augmentations from any library or package you use to your dataset. This guide will use the transforms from [torchvision](https://pytorch.org/vision/stable/transforms.html).
+🤗 Datasets can apply data augmentations from any library or package to your dataset. This guide will use the transforms from [torchvision](https://pytorch.org/vision/stable/transforms.html).
 
 <Tip>
 
@@ -45,7 +47,7 @@ Feel free to use other data augmentation libraries like [Albumentations](https:/
 
 </Tip>
 
-Add the [`ColorJitter`](https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.ColorJitter) transform to change the color properties of the image randomly:
+As an example, try to apply a [`ColorJitter`](https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.ColorJitter) transform to change the color properties of the image randomly:
 
 ```py
 >>> from torchvision.transforms import Compose, ColorJitter, ToTensor
@@ -72,7 +74,7 @@ Use the [`~Dataset.set_transform`] function to apply the transform on-the-fly wh
 >>> dataset.set_transform(transforms)
 ```
 
-Take a look at the transformed image by indexing into the `pixel_values`:
+Now you can take a look at the augmented image by indexing into the `pixel_values`:
 
 ```py
 >>> import numpy as np

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -1,152 +1,13 @@
 # Process image data
 
-🤗 Datasets support loading and processing images with the [`Image`] feature. This guide will show you how to:
+This guide shows image specific methods for processing image datasets. For guides on how to process datasets in general, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>. Learn how to:
 
-- Load an image dataset.
-- Load a generic image dataset with `ImageFolder`.
-- Use [`Dataset.map`] to quickly apply transforms to an entire dataset.
-- Add data augmentations to your images with [`Dataset.set_transform`].
-
-## Installation
-
-The [`Image`] feature should be installed as an extra dependency in 🤗 Datasets. Install the [`Image`] feature (and its dependencies) with pip:
-
-```bash
-pip install datasets[vision]
-```
-
-## Image datasets
-
-The images in an image dataset are typically either a:
-
-- PIL `image`.
-- Path to an image file you can load. 
-
-For example, load the [Food-101](https://huggingface.co/datasets/food101) dataset and take a look:
-
-```py
->>> from datasets import load_dataset, Image
-
->>> dataset = load_dataset("food101", split="train[:100]")
->>> dataset[0]
-{'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x7FC45AB5C590>,
- 'label': 6}
-```
-
-The [`Image`] feature automatically decodes the data from the `image` column to return an image object. Now try and call the `image` column to see what the image is:
-
-```py
->>> from datasets import load_dataset, Image
-
->>> dataset = load_dataset("food101", split="train[100:200]")
->>> dataset[0]["image"]
-<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x16289FBE0>
-```
-
-![image_process_beignet](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_beignet.png)
-
-
-To load an image from its path, use the [`Dataset.cast_column`] method. The [`Image`] feature will decode the data at the path to return an image object:
-
-```py
->>> from datasets import load_dataset, Image
-
->>> dataset = Dataset.from_dict({"image": ["path/to/image_1", "path/to/image_2", ..., "path/to/image_n"]}).cast_column("image", Image())
->>> dataset[0]["image"]
-<PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E6D7160>]
-```
-
-You can also access the path and bytes of an image file by setting `decode=False` when you load a dataset. In this case, you will need to cast the `image` column:
-
-```py
->>> dataset = load_dataset("food101", split="train[:100]").cast_column('image', Image(decode=False))
-```
-
-## ImageFolder
-
-You can also load your image dataset with a `ImageFolder` dataset builder without writing a custom dataloader. Your image dataset structure should look like this:
-
-```
-folder/train/dog/golden_retriever.png
-folder/train/dog/german_shepherd.png
-folder/train/dog/chihuahua.png
-
-folder/train/cat/maine_coon.png
-folder/train/cat/bengal.png
-folder/train/cat/birman.png
-```
-
-Then load your dataset by specifying `imagefolder` and the directory of your dataset in `data_dir`:
-
-```py
->>> from datasets import load_dataset
->>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder")
->>> dataset["train"][0]["image"]
-<PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E6D7160>]
-```
-
-Load remote datasets from their URLs with the `data_files` parameter:
-
-```py
->>> dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_3367a.zip", split="train")
-```
-
-`ImageFolder` will create a `label` column, and the label name is based on the directory name.
-
-You can pass `drop_labels=False` to ignore the `label` column, as defined in [`~datasets.packaged_modules.imagefolder.ImageFolderConfig`].
-
-## ImageFolder with metadata
-
-If your image dataset comes with metadata, they will be also loaded. First, make sure your dataset has a `metadata.jsonl`:
-
-```
-folder/train/metadata.jsonl
-folder/train/0001.png
-folder/train/0002.png
-folder/train/0003.png
-```
-
-You can link the metadata in `metadata.jsonl` file to the images using the "file_path" field.
-
-### Image captioning
-
-Here is an example of `metadata.jsonl` for image captioning:
-
-```jsonl
-{"file_name": "0001.png", "text": "This is a golden retriever playing with a ball"}
-{"file_name": "0002.png", "text": "A german shepherd"}
-{"file_name": "0003.png", "text": "One chihuahua"}
-```
-
-`ImageFolder` will create a `text` column for the image captions:
-
-```py
->>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder", split="train")
->>> dataset[0]["text"]
-This is a golden retriever playing with a ball
-```
-
-### Object detection
-
-Here is an example of `metadata.jsonl` for object detection:
-
-```jsonl
-{"file_name": "0001.png", "objects": {"bbox": [[302.0, 109.0, 73.0, 52.0]], "categories": [0]}}
-{"file_name": "0002.png", "objects": {"bbox": [[810.0, 100.0, 57.0, 28.0]], "categories": [1]}}
-{"file_name": "0003.png", "objects": {"bbox": [[160.0, 31.0, 248.0, 616.0], [741.0, 68.0, 202.0, 401.0]], "categories": [2, 2]}}
-```
-
-`ImageFolder` will create a `objects` column with the bounding boxes and the categories:
-
-```py
->>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder", split="train")
->>> dataset[0]["objects"]
-{"bbox": [[302.0, 109.0, 73.0, 52.0]], "categories": [0]}
-```
+- Use [`~Dataset.map`] with image dataset.
+- Apply data augmentations to your dataset with [`~Dataset.set_transform`].
 
 ## Map
 
-[`Dataset.map`] can apply transforms over an entire dataset and it also generates a cache file.
+The [`~Dataset.map`] function can apply transforms over an entire dataset.
 
 Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) function:
 
@@ -156,7 +17,7 @@ Create a simple [`Resize`](https://pytorch.org/vision/stable/generated/torchvisi
 ...     return examples
 ```
 
-Now [`Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
+Now [`~Dataset.map`] the function over the entire dataset and set `batched=True`. The transform returns `pixel_values` as a cacheable `PIL.Image` object:
 
 ```py
 >>> dataset = dataset.map(transforms, remove_columns=["image"], batched=True)
@@ -165,22 +26,22 @@ Now [`Dataset.map`] the function over the entire dataset and set `batched=True`.
  'pixel_values': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=100x100 at 0x7F058237BB10>}
 ```
 
-This saves time because you don't have to execute the same transform twice. It is best to use [`Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
+The cache file saves time because you don't have to execute the same transform twice. It is best to use [`~Dataset.map`] for operations you only run once per training - like resizing an image - instead of using it for operations executed for each epoch, like data augmentations.
 
-[`Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
+[`~Dataset.map`] takes up some memory, but you can reduce its memory requirements with the following parameters:
 
 - [`batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.batch_size) determines the number of examples that are processed in one call to the transform function.
 - [`writer_batch_size`](./package_reference/main_classes#datasets.DatasetDict.map.writer_batch_size) determines the number of processed examples that are kept in memory before they are stored away.
 
-Both parameter values default to 1000, which can be expensive if you are storing images. Lower the value to use less memory when calling [`Dataset.map`].
+Both parameter values default to 1000, which can be expensive if you are storing images. Lower these values to use less memory when you use [`~Dataset.map`].
 
 ## Data augmentation
 
-Adding data augmentations to a dataset is common to prevent overfitting and achieve better performance. You can use any library or package you want to apply the augmentations. This guide will use the transforms from [torchvision](https://pytorch.org/vision/stable/transforms.html).
+🤗 Datasets can apply data augmentations from any library or package you use to your dataset. This guide will use the transforms from [torchvision](https://pytorch.org/vision/stable/transforms.html).
 
 <Tip>
 
-Feel free to use other data augmentation libraries like [Albumentations](https://albumentations.ai/docs/). 🤗 Datasets can apply any custom function and transforms to an entire dataset!
+Feel free to use other data augmentation libraries like [Albumentations](https://albumentations.ai/docs/), [Kornia](https://kornia.readthedocs.io/en/latest/), and [imgaug](https://imgaug.readthedocs.io/en/latest/).
 
 </Tip>
 
@@ -205,13 +66,13 @@ Create a function to apply the `ColorJitter` transform to an image:
 ...     return examples
 ```
 
-Then you can use the [`Dataset.set_transform`] function to apply the transform on-the-fly to consume less disk space. Use this function if you only need to access the examples once:
+Use the [`~Dataset.set_transform`] function to apply the transform on-the-fly which consumes less disk space. This function is useful if you only need to access the examples once:
 
 ```py
 >>> dataset.set_transform(transforms)
 ```
 
-Now visualize the results of the `ColorJitter` transform:
+Take a look at the transformed image by indexing into the `pixel_values`:
 
 ```py
 >>> import numpy as np
@@ -221,4 +82,7 @@ Now visualize the results of the `ColorJitter` transform:
 >>> plt.imshow(img.permute(1, 2, 0))
 ```
 
-![image_process_jitter](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_jitter.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_jitter.png">
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/image_process_jitter.png"/>
+</div>

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -1,6 +1,6 @@
 # Load
 
-You have already seen how to load a dataset from the Hugging Face Hub. But datasets are stored in a variety of places, and sometimes you won't find the one you want on the Hub. A dataset can be on disk on your local machine, in a Github repository, and in in-memory data structures like Python dictionaries and Pandas DataFrames. Wherever your dataset may be stored, 🤗 Datasets provides a way for you to load and use it for training.
+Datasets are stored in various places; a dataset can be on your local machine's disk, in a Github repository, and in in-memory data structures like Python dictionaries and Pandas DataFrames. Wherever a dataset is stored, 🤗 Datasets can help you load it.
 
 This guide will show you how to load a dataset from:
 
@@ -11,39 +11,37 @@ This guide will show you how to load a dataset from:
 - Offline
 - A specific slice of a split
 
-For more information specific to loading audio datasets, take a look at the <a class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold" href="./audio_load">load audio data</a> guide. If you're working with image datasets, you can check out the <a class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold" href="./image_load">load image data</a> guide.
+For more details specific to loading audio datasets, take a look at the <a class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold" href="./audio_load">load audio data</a> guide. If you're working with image datasets, check out the <a class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold" href="./image_load">load image data</a> guide.
 
 <a id='load-from-the-hub'></a>
 
 ## Hugging Face Hub
 
-In the tutorial, you learned how to load a dataset from the Hub. This method relies on a dataset loading script that downloads and builds the dataset. However, you can also load a dataset from any dataset repository on the Hub **without** a loading script! 
+Datasets are loaded from a dataset loading script that downloads and generates the dataset. However, you can also load a dataset from any dataset repository on the Hub **without** a loading script! Begin by [creating a dataset repository](share#create-the-repository) and upload your data files. Now you can use the [`load_dataset`] function to load the dataset. 
 
-First, create a dataset repository and upload your data files. Then you can use [`load_dataset`] like you learned in the tutorial. For example, load the files from this [demo repository](https://huggingface.co/datasets/lhoestq/demo1) by providing the repository namespace and dataset name:
+For example, try loading the files from this [demo repository](https://huggingface.co/datasets/lhoestq/demo1) by providing the repository namespace and dataset name. This dataset repository contains CSV files, and the code below loads the dataset from the CSV files:
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset('lhoestq/demo1')
+>>> dataset = load_dataset("lhoestq/demo1")
 ```
 
-This dataset repository contains CSV files, and this code loads all the data from the CSV files.
-
-Some datasets may have more than one version, based on Git tags, branches or commits. Use the `revision` flag to specify which dataset version you want to load:
+Some datasets may have more than one version, based on Git tags, branches or commits. Use the `revision` parameter to specify the dataset version you want to load:
 
 ```py
 >>> dataset = load_dataset(
->>>   "lhoestq/custom_squad",
->>>   revision="main"  # tag name, or branch name, or commit hash
->>> )
+...   "lhoestq/custom_squad",
+...   revision="main"  # tag name, or branch name, or commit hash
+... )
 ```
 
 <Tip>
 
-Refer to the [Upload](./upload_dataset) guide for more instructions on how to create a dataset repository on the Hub, and how to upload your data files.
+Refer to the [Upload a dataset to the Hub](./upload_dataset) tutorial for more details on how to create a dataset repository on the Hub, and how to upload your data files.
 
 </Tip>
 
-If the dataset doesn't have a dataset loading script, then by default, all the data will be loaded in the `train` split. Use the `data_files` parameter to map data files to splits like `train`, `validation` and `test`:
+A dataset without a loading script will by default load all the data into the `train` split. Use the `data_files` parameter to map data files to splits like `train`, `validation` and `test`:
 
 ```py
 >>> data_files = {"train": "train.csv", "test": "test.csv"}
@@ -52,18 +50,18 @@ If the dataset doesn't have a dataset loading script, then by default, all the d
 
 <Tip warning={true}>
 
-If you don't specify which data files to use, `load_dataset` will return all the data files. This can take a long time if you are loading a large dataset like C4, which is approximately 13TB of data.
+If you don't specify which data files to use, [`load_dataset`] will return all the data files. This can take a long time if you are loading a large dataset like C4, which is approximately 13TB of data.
 
 </Tip>
 
-You can also load a specific subset of the files with the `data_files` parameter. The example below loads files from the [C4 dataset](https://huggingface.co/datasets/allenai/c4):
+You can also load a specific subset of the files with the `data_files` parameter. The example below only loads a single file from the [C4 dataset](https://huggingface.co/datasets/allenai/c4/tree/main/en):
 
 ```py
 >>> from datasets import load_dataset
->>> c4_subset = load_dataset('allenai/c4', data_files='en/c4-train.0000*-of-01024.json.gz')
+>>> c4_subset = load_dataset("allenai/c4", data_files="en/c4-train.0000*-of-01024.json.gz")
 ```
 
-Specify a custom split with the `split` parameter:
+The `split` parameter can also map a data file to a specific split:
 
 ```py
 >>> data_files = {"validation": "en/c4-validation.*.json.gz"}
@@ -72,7 +70,7 @@ Specify a custom split with the `split` parameter:
 
 ## Local loading script
 
-You may have a 🤗 Datasets loading script locally on your computer. You can load this dataset by passing to [`load_dataset`] one of the following paths:
+You may have a 🤗 Datasets loading script locally on your computer. In this case, load the dataset by passing one of the following paths to [`load_dataset`]:
 
 - The local path to the loading script file.
 - The local path to the directory containing the loading script file (only if the script file has the same name as the directory).
@@ -84,13 +82,7 @@ You may have a 🤗 Datasets loading script locally on your computer. You can lo
 
 ## Local and remote files
 
-🤗 Datasets can be loaded from local files stored on your computer, and also from remote files. The datasets are most likely stored as a `csv`, `json`, `txt` or `parquet` file. The [`load_dataset`] method is able to load each of these file types.
-
-<Tip>
-
-Curious about how to load datasets for vision? Check out the image loading guide [here](./image_process)!
-
-</Tip>
+Datasets can be loaded from local files stored on your computer, and also from remote files. The datasets are most likely stored as a `csv`, `json`, `txt` or `parquet` file. The [`load_dataset`] function is able to load each of these file types.
 
 ### CSV
 
@@ -98,22 +90,22 @@ Curious about how to load datasets for vision? Check out the image loading guide
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset('csv', data_files='my_file.csv')
+>>> dataset = load_dataset("csv", data_files="my_file.csv")
 ```
 
 If you have more than one CSV file:
 
 ```py
->>> dataset = load_dataset('csv', data_files=['my_file_1.csv', 'my_file_2.csv', 'my_file_3.csv'])
+>>> dataset = load_dataset("csv", data_files=["my_file_1.csv", "my_file_2.csv", "my_file_3.csv"])
 ```
 
 You can also map the training and test splits to specific CSV files:
 
 ```py
->>> dataset = load_dataset('csv', data_files={'train': ['my_train_file_1.csv', 'my_train_file_2.csv'], 'test': 'my_test_file.csv'})
+>>> dataset = load_dataset("csv", data_files={"train": ["my_train_file_1.csv", "my_train_file_2.csv"], "test": "my_test_file.csv"})
 ```
 
-To load remote CSV files via HTTP, you can pass the URLs:
+To load remote CSV files via HTTP, pass the URLs instead:
 
 ```py
 >>> base_url = "https://huggingface.co/datasets/lhoestq/demo1/resolve/main/data/"
@@ -134,12 +126,12 @@ JSON files are loaded directly with [`load_dataset`] as shown below:
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset('json', data_files='my_file.json')
+>>> dataset = load_dataset("json", data_files="my_file.json")
 ```
 
-JSON files can have diverse formats, but we think the most efficient format is to have multiple JSON objects; each line represents an individual row of data. For example:
+JSON files have diverse formats, but we think the most efficient format is to have multiple JSON objects; each line represents an individual row of data. For example:
 
-```py
+```json
 {"a": 1, "b": 2.0, "c": "foo", "d": false}
 {"a": 4, "b": -5.5, "c": null, "d": true}
 ```
@@ -148,19 +140,19 @@ Another JSON format you may encounter is a nested field, in which case you will 
 
 ```py
 {"version": "0.1.0",
-    "data": [{"a": 1, "b": 2.0, "c": "foo", "d": false},
-            {"a": 4, "b": -5.5, "c": null, "d": true}]
+ "data": [{"a": 1, "b": 2.0, "c": "foo", "d": false},
+          {"a": 4, "b": -5.5, "c": null, "d": true}]
 }
 
 >>> from datasets import load_dataset
->>> dataset = load_dataset('json', data_files='my_file.json', field='data')
+>>> dataset = load_dataset("json", data_files="my_file.json", field="data")
 ```
 
-To load remote JSON files via HTTP, you can pass the URLs:
+To load remote JSON files via HTTP, pass the URLs instead:
 
 ```py
 >>> base_url = "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
->>> dataset = load_dataset('json', data_files={'train': base_url + 'train-v1.1.json', 'validation': base_url + 'dev-v1.1.json'}, field="data")
+>>> dataset = load_dataset("json", data_files={"train": base_url + "train-v1.1.json", "validation": base_url + "dev-v1.1.json"}, field="data")
 ```
 
 While these are the most common JSON formats, you will see other datasets that are formatted differently. 🤗 Datasets recognizes these other formats, and will fallback accordingly on the Python JSON loading methods to handle them.
@@ -171,25 +163,27 @@ Text files are one of the most common file types for storing a dataset. 🤗 Dat
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset('text', data_files={'train': ['my_text_1.txt', 'my_text_2.txt'], 'test': 'my_test_file.txt'})
+>>> dataset = load_dataset("text", data_files={"train": ["my_text_1.txt", "my_text_2.txt"], "test": "my_test_file.txt"})
 ```
 
-To load remote TXT files via HTTP, you can pass the URLs:
+To load remote text files via HTTP, pass the URLs instead:
 
 ```py
->>> dataset = load_dataset('text', data_files='https://huggingface.co/datasets/lhoestq/test/resolve/main/some_text.txt')
+>>> dataset = load_dataset("text", data_files="https://huggingface.co/datasets/lhoestq/test/resolve/main/some_text.txt")
 ```
 
 ### Parquet
 
-Parquet files are stored in a columnar format unlike row-based files like CSV. Large datasets may be stored in a Parquet file because it is more efficient, and faster at returning your query. Load a Parquet file as shown in the following example:
+Parquet files are stored in a columnar format unlike row-based files like CSV. Large datasets may be stored in a Parquet file because it is more efficient, and faster at returning your query. 
+
+To load a Parquet file:
 
 ```py
 >>> from datasets import load_dataset
 >>> dataset = load_dataset("parquet", data_files={'train': 'train.parquet', 'test': 'test.parquet'})
 ```
 
-To load remote parquet files via HTTP, you can pass the URLs:
+To load remote Parquet files via HTTP, pass the URLs instead:
 
 ```py
 >>> base_url = "https://storage.googleapis.com/huggingface-nlp/cache/datasets/wikipedia/20200501.en/1.0.0/"
@@ -203,7 +197,7 @@ To load remote parquet files via HTTP, you can pass the URLs:
 
 ### Python dictionary
 
-Load Python dictionaries with [`Dataset.from_dict`]:
+Load Python dictionaries with [`~Dataset.from_dict`]:
 
 ```py
 >>> from datasets import Dataset
@@ -213,7 +207,7 @@ Load Python dictionaries with [`Dataset.from_dict`]:
 
 ### Pandas DataFrame
 
-Load Pandas DataFrames with [`Dataset.from_pandas`]:
+Load Pandas DataFrames with [`~Dataset.from_pandas`]:
 
 ```py
 >>> from datasets import Dataset
@@ -224,7 +218,7 @@ Load Pandas DataFrames with [`Dataset.from_pandas`]:
 
 <Tip warning={true}>
 
-An object data type in [pandas.Series](https://pandas.pydata.org/docs/reference/api/pandas.Series.html) doesn't always carry enough information for Arrow to automatically infer a data type. For example, if a DataFrame is of length 0 or the Series only contains None/nan objects, the type is set to null. Avoid potential errors by constructing an explicit schema with [`Features`] using the `from_dict` or `from_pandas` methods. See the [troubleshoot](./loading#specify-features) for more details on how to explicitly specify your own features.
+An object data type in [pandas.Series](https://pandas.pydata.org/docs/reference/api/pandas.Series.html) doesn't always carry enough information for Arrow to automatically infer a data type. For example, if a DataFrame is of length `0` or the Series only contains `None/NaN` objects, the type is set to `null`. Avoid potential errors by constructing an explicit schema with [`Features`] using the `from_dict` or `from_pandas` methods. See the [troubleshoot](./loading#specify-features) for more details on how to explicitly specify your own features.
 
 </Tip>
 
@@ -236,93 +230,93 @@ If you know you won't have internet access, you can run 🤗 Datasets in full of
 
 ## Slice splits
 
-For even greater control over how to load a split, you can choose to only load specific slices of a split. There are two options for slicing a split: using strings or [`ReadInstruction`]. Strings are more compact and readable for simple cases, while [`ReadInstruction`] is easier to use with variable slicing parameters.
+For more granular loading, you can load specific slices of a split. There are two options for slicing a split: using strings or the [`ReadInstruction`] API. Strings are more compact and readable for simple cases, while [`ReadInstruction`] is easier to use with variable slicing parameters.
 
-Concatenate the `train` and `test` split by:
+Concatenate a `train` and `test` split by:
 
 ```py
->>> train_test_ds = datasets.load_dataset('bookcorpus', split='train+test')
+>>> train_test_ds = datasets.load_dataset("bookcorpus", split="train+test")
 ===STRINGAPI-READINSTRUCTION-SPLIT===
->>> ri = datasets.ReadInstruction('train') + datasets.ReadInstruction('test')
->>> train_test_ds = datasets.load_dataset('bookcorpus', split=ri)
+>>> ri = datasets.ReadInstruction("train") + datasets.ReadInstruction("test")
+>>> train_test_ds = datasets.load_dataset("bookcorpus", split=ri)
 ```
 
 Select specific rows of the `train` split:
 
 ```py
->>> train_10_20_ds = datasets.load_dataset('bookcorpus', split='train[10:20]')
+>>> train_10_20_ds = datasets.load_dataset("bookcorpus", split="train[10:20]")
 ===STRINGAPI-READINSTRUCTION-SPLIT===
->>> train_10_20_ds = datasets.load_dataset('bookcorpus', split=datasets.ReadInstruction('train', from_=10, to=20, unit='abs'))
+>>> train_10_20_ds = datasets.load_dataset("bookcorpu"', split=datasets.ReadInstruction("train", from_=10, to=20, unit="abs"))
 ```
 
-Or select a percentage of the split with:
+Or select a percentage of a split with:
 
 ```py
->>> train_10pct_ds = datasets.load_dataset('bookcorpus', split='train[:10%]')
+>>> train_10pct_ds = datasets.load_dataset("bookcorpus", split="train[:10%]")
 ===STRINGAPI-READINSTRUCTION-SPLIT===
->>> train_10_20_ds = datasets.load_dataset('bookcorpus', split=datasets.ReadInstruction('train', to=10, unit='%'))
+>>> train_10_20_ds = datasets.load_dataset("bookcorpus", split=datasets.ReadInstruction("train", to=10, unit="%"))
 ```
 
 You can even select a combination of percentages from each split:
 
 ```py
->>> train_10_80pct_ds = datasets.load_dataset('bookcorpus', split='train[:10%]+train[-80%:]')
+>>> train_10_80pct_ds = datasets.load_dataset("bookcorpus", split="tr"in[:10%]+train[-80%:]")
 ===STRINGAPI-READINSTRUCTION-SPLIT===
->>> ri = (datasets.ReadInstruction('train', to=10, unit='%') + datasets.ReadInstruction('train', from_=-80, unit='%'))
->>> train_10_80pct_ds = datasets.load_dataset('bookcorpus', split=ri)
+>>> ri = (datasets.ReadInstruction("train", to=10, unit="%") + datasets.ReadInstruction("train", from_=-80, unit="%"))
+>>> train_10_80pct_ds = datasets.load_dataset("bookcorpus", split=ri)
 ```
 
-Finally, create cross-validated dataset splits by:
+Finally, create cross-validated splits by:
 
 ```py
->>> # 10-fold cross-validation (see also next section on rounding behavior):
->>> # The validation datasets are each going to be 10%:
->>> # [0%:10%], [10%:20%], ..., [90%:100%].
->>> # And the training datasets are each going to be the complementary 90%:
->>> # [10%:100%] (for a corresponding validation set of [0%:10%]),
->>> # [0%:10%] + [20%:100%] (for a validation set of [10%:20%]), ...,
->>> # [0%:90%] (for a validation set of [90%:100%]).
->>> vals_ds = datasets.load_dataset('bookcorpus', split=[f'train[{k}%:{k+10}%]' for k in range(0, 100, 10)])
->>> trains_ds = datasets.load_dataset('bookcorpus', split=[f'train[:{k}%]+train[{k+10}%:]' for k in range(0, 100, 10)])
+# 10-fold cross-validation (see also next section on rounding behavior):
+# The validation datasets are each going to be 10%:
+# [0%:10%], [10%:20%], ..., [90%:100%].
+# And the training datasets are each going to be the complementary 90%:
+# [10%:100%] (for a corresponding validation set of [0%:10%]),
+# [0%:10%] + [20%:100%] (for a validation set of [10%:20%]), ...,
+# [0%:90%] (for a validation set of [90%:100%]).
+>>> vals_ds = datasets.load_dataset("bookcorpus", split=[f"train[{k}%:{k+10}%]" for k in range(0, 100, 10)])
+>>> trains_ds = datasets.load_dataset("bookcorpus", split=[f"train[:{k}%]+train[{k+10}%:]" for k in range(0, 100, 10)])
 ===STRINGAPI-READINSTRUCTION-SPLIT===
->>> # 10-fold cross-validation (see also next section on rounding behavior):
->>> # The validation datasets are each going to be 10%:
->>> # [0%:10%], [10%:20%], ..., [90%:100%].
->>> # And the training datasets are each going to be the complementary 90%:
->>> # [10%:100%] (for a corresponding validation set of [0%:10%]),
->>> # [0%:10%] + [20%:100%] (for a validation set of [10%:20%]), ...,
->>> # [0%:90%] (for a validation set of [90%:100%]).
->>> vals_ds = datasets.load_dataset('bookcorpus', [datasets.ReadInstruction('train', from_=k, to=k+10, unit='%') for k in range(0, 100, 10)])
->>> trains_ds = datasets.load_dataset('bookcorpus', [(datasets.ReadInstruction('train', to=k, unit='%') + datasets.ReadInstruction('train', from_=k+10, unit='%')) for k in range(0, 100, 10)])
+# 10-fold cross-validation (see also next section on rounding behavior):
+# The validation datasets are each going to be 10%:
+# [0%:10%], [10%:20%], ..., [90%:100%].
+# And the training datasets are each going to be the complementary 90%:
+# [10%:100%] (for a corresponding validation set of [0%:10%]),
+# [0%:10%] + [20%:100%] (for a validation set of [10%:20%]), ...,
+# [0%:90%] (for a validation set of [90%:100%]).
+>>> vals_ds = datasets.load_dataset("bookcorpus", [datasets.ReadInstruction("train", from_=k, to=k+10, unit="%") for k in range(0, 100, 10)])
+>>> trains_ds = datasets.load_dataset("bookcorpus", [(datasets.ReadInstruction("train", to=k, unit="%") + datasets.ReadInstruction("train", from_=k+10, unit="%")) for k in range(0, 100, 10)])
 ```
 
 ### Percent slicing and rounding
 
-For datasets where the requested slice boundaries do not divide evenly by 100, the default behavior is to round the boundaries to the nearest integer. As a result, some slices may contain more examples than others as shown in the following example:
+For datasets where the requested slice boundaries do not divide evenly by 100, the default behavior is to round the boundaries to the nearest integer. As a result, some slices may contain more examples than others as shown below:
 
 ```py
-# Assuming *train* split contains 999 records.
+# Assuming train split contains 999 records.
 # 19 records, from 500 (included) to 519 (excluded).
->>> train_50_52_ds = datasets.load_dataset('bookcorpus', split='train[50%:52%]')
+>>> train_50_52_ds = datasets.load_dataset("bookcorpus", split="train[50%:52%]")
 # 20 records, from 519 (included) to 539 (excluded).
->>> train_52_54_ds = datasets.load_dataset('bookcorpus', split='train[52%:54%]')
+>>> train_52_54_ds = datasets.load_dataset("bookcorpus", split="train[52%:54%]")
 ```
 
-If you want equal sized splits, use `pct1_dropremainder` rounding instead. This will treat the specified percentage boundaries as multiples of 1%. 
+If you want equal sized splits, use `pct1_dropremainder` rounding instead. This treats the specified percentage boundaries as multiples of 1%. 
 
 ```py
 # 18 records, from 450 (included) to 468 (excluded).
->>> train_50_52pct1_ds = datasets.load_dataset('bookcorpus', split=datasets.ReadInstruction( 'train', from_=50, to=52, unit='%', rounding='pct1_dropremainder'))
+>>> train_50_52pct1_ds = datasets.load_dataset("bookcorpus", split=datasets.ReadInstruction("train", from_=50, to=52, unit="%", rounding="pct1_dropremainder"))
 # 18 records, from 468 (included) to 486 (excluded).
->>> train_52_54pct1_ds = datasets.load_dataset('bookcorpus', split=datasets.ReadInstruction('train',from_=52, to=54, unit='%', rounding='pct1_dropremainder'))
+>>> train_52_54pct1_ds = datasets.load_dataset("bookcorpus", split=datasets.ReadInstruction("train",from_=52, to=54, unit="%", rounding="pct1_dropremainder"))
 # Or equivalently:
->>> train_50_52pct1_ds = datasets.load_dataset('bookcorpus', split='train[50%:52%](pct1_dropremainder)')
->>> train_52_54pct1_ds = datasets.load_dataset('bookcorpus', split='train[52%:54%](pct1_dropremainder)')
+>>> train_50_52pct1_ds = datasets.load_dataset("bookcorpus", split="train[50%:52%](pct1_dropremainder)")
+>>> train_52_54pct1_ds = datasets.load_dataset("bookcorpus", split="train[52%:54%](pct1_dropremainder)")
 ```
 
 <Tip warning={true}>
 
-Using `pct1_dropremainder` rounding may truncate the last examples in a dataset if the number of examples in your dataset don't divide evenly by 100.
+`pct1_dropremainder` rounding may truncate the last examples in a dataset if the number of examples in your dataset don't divide evenly by 100.
 
 </Tip>
 
@@ -330,11 +324,11 @@ Using `pct1_dropremainder` rounding may truncate the last examples in a dataset 
 
 ## Troubleshooting
 
-Sometimes, you may get unexpected results when you load a dataset. In this section, you will learn how to solve two common issues you may encounter when you load a dataset: manually download a dataset, and specify features of a dataset.
+Sometimes, you may get unexpected results when you load a dataset. Two of the most common issues you may encounter are manually downloading a dataset, and specifying features of a dataset.
 
 ### Manual download
 
-Certain datasets require you to manually download the dataset files due to licensing incompatibility, or if the files are hidden behind a login page. This will cause [`load_dataset`] to throw an `AssertionError`. But 🤗 Datasets provides detailed instructions for downloading the missing files. After you have downloaded the files, use the `data_dir` argument to specify the path to the files you just downloaded.
+Certain datasets require you to manually download the dataset files due to licensing incompatibility, or if the files are hidden behind a login page. This causes [`load_dataset`] to throw an `AssertionError`. But 🤗 Datasets provides detailed instructions for downloading the missing files. After you have downloaded the files, use the `data_dir` argument to specify the path to the files you just downloaded.
 
 For example, if you try to download a configuration from the [MATINF](https://huggingface.co/datasets/matinf) dataset:
 
@@ -349,16 +343,16 @@ Manual data can be loaded with `datasets.load_dataset(matinf, data_dir='<path/to
 
 ### Specify features
 
-When you create a dataset from local files, the [`Features`] are automatically inferred by [Apache Arrow](https://arrow.apache.org/docs/). However, the features of the dataset may not always align with your expectations or you may want to define the features yourself. 
+When you create a dataset from local files, the [`Features`] are automatically inferred by [Apache Arrow](https://arrow.apache.org/docs/). However, the features of the dataset may not always align with your expectations or you may want to define the features yourself. The following example shows how you can add custom labels with the [`ClassLabel`] feature. 
 
-The following example shows how you can add custom labels with [`ClassLabel`]. First, define your own labels using the [`Features`] class:
+Start by defining your own labels with the [`Features`] class:
 
 ```py
 >>> class_names = ["sadness", "joy", "love", "anger", "fear", "surprise"]
 >>> emotion_features = Features({'text': Value('string'), 'label': ClassLabel(names=class_names)})
 ```
 
-Next, specify the `features` argument in [`load_dataset`] with the features you just created:
+Next, specify the `features` parameter in [`load_dataset`] with the features you just created:
 
 ```py
 >>> dataset = load_dataset('csv', data_files=file_dict, delimiter=';', column_names=['text', 'label'], features=emotion_features)
@@ -412,7 +406,7 @@ It is possible for a metric to have different configurations. The configurations
 
 ### Distributed setup
 
-When you work in a distributed or parallel processing environment, loading and computing a metric can be tricky because these processes are executed in parallel on separate subsets of the data. 🤗 Datasets supports distributed usage with a few additional arguments when you load a metric.
+When working in a distributed or parallel processing environment, loading and computing a metric can be tricky because these processes are executed in parallel on separate subsets of the data. 🤗 Datasets supports distributed usage with a few additional arguments when you load a metric.
 
 For example, imagine you are training and evaluating on eight parallel processes. Here's how you would load a metric in this distributed setting:
 

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -11,7 +11,7 @@ This guide will show you how to load a dataset from:
 - Offline
 - A specific slice of a split
 
-You will also learn how to troubleshoot common errors, and how to load specific configurations of a metric.
+For more information specific to loading audio datasets, take a look at the <a class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold" href="./audio_load">load audio data</a> guide. If you're working with image datasets, you can check out the <a class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold" href="./image_load">load image data</a> guide.
 
 <a id='load-from-the-hub'></a>
 
@@ -373,6 +373,12 @@ Now when you look at your dataset features, you can see it uses the custom label
 ```
 
 ## Metrics
+
+<Tip warning={true}>
+
+Metrics will soon be deprecated in 🤗 Datasets. To learn more about how to use metrics, take a look at our newest library 🤗 Evaluate! In addition to metrics, we've also added more tools for evaluating models and datasets.
+
+</Tip>
 
 When the metric you want to use is not supported by 🤗 Datasets, you can write and use your own metric script. Load your metric by providing the path to your local metric loading script:
 

--- a/docs/source/nlp_process.mdx
+++ b/docs/source/nlp_process.mdx
@@ -1,0 +1,57 @@
+# Process text data
+
+This guide shows specific methods for processing text datasets. Learn how to:
+
+- Tokenize a dataset with [`~Dataset.map`].
+- Align dataset labels with label ids for NLI datasets.
+
+For a guide on processing any type of dataset, take a look at the <a class="bg-pink-200 dark:bg-pink-500 px-1 rounded font-bold underline decoration-pink-900 text-pink-900 dark:bg-pink-500" href="./process">general process guide</a>.
+
+## Map
+
+The [`~Dataset.map`] function supports processing batches of examples at once which speeds up tokenization.
+
+Load a tokenizer from 🤗 [Transformers](https://huggingface.co/transformers/):
+
+```py
+>>> from transformers import AutoTokenizer
+
+>>> tokenizer = AutoTokenizer.from_pretrained('bert-base-cased')
+```
+
+Set the `batched` parameter to `True` in the [`~Dataset.map`] function to apply the tokenizer to batches of examples:
+
+```py
+>>> dataset = dataset.map(lambda examples: tokenizer(examples["text"]), batched=True)
+>>> dataset[0]
+{'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .', 
+ 'label': 1, 
+ 'input_ids': [101, 1996, 2600, 2003, 16036, 2000, 2022, 1996, 7398, 2301, 1005, 1055, 2047, 1000, 16608, 1000, 1998, 2008, 2002, 1005, 1055, 2183, 2000, 2191, 1037, 17624, 2130, 3618, 2084, 7779, 29058, 8625, 13327, 1010, 3744, 1011, 18856, 19513, 3158, 5477, 4168, 2030, 7112, 16562, 2140, 1012, 102], 
+ 'token_type_ids': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
+ 'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]}
+```
+
+## Align
+
+The [`~Dataset.align_labels_with_mapping`] function aligns a dataset label id with the label name. Not all 🤗 Transformers models follow the prescribed label mapping of the original dataset, especially for NLI datasets. For example, the [MNLI](https://huggingface.co/datasets/glue) dataset uses the following label mapping:
+
+```py
+>>> label2id = {'entailment': 0, 'neutral': 1, 'contradiction': 2}
+```
+
+To align the dataset label mapping with the mapping used by a model, create a dictionary of the label name and id to align on:
+
+```py
+>>> label2id = {"contradiction": 0, "neutral": 1, "entailment": 2}
+```
+
+Pass the dictionary of the label mappings to the [`~Dataset.align_labels_with_mapping`] function, and the column to align on:
+
+```py
+>>> from datasets import load_dataset
+
+>>> mnli = load_dataset("glue", "mnli", split="train")
+>>> mnli_aligned = mnli.align_labels_with_mapping(label2id, "label")
+```
+
+You can also use this function to assign a custom mapping of labels to ids.

--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -1,6 +1,6 @@
 # Process
 
-🤗 Datasets provides many tools for modifying the structure and content of a dataset. You can rearrange the order of rows or extract nested fields into their own columns. For more powerful processing applications, you can even alter the contents of a dataset by applying a function to the entire dataset to generate new rows and columns. These processing methods provide a lot of control and flexibility to mold your dataset into the desired shape and size with the appropriate features.
+🤗 Datasets provides many tools for modifying the structure and content of a dataset. These tools are important for tidying up a dataset, creating additional columns, converting between features and formats, and much more.
 
 This guide will show you how to:
 
@@ -11,54 +11,54 @@ This guide will show you how to:
 - Apply a custom formatting transform.
 - Save and export processed datasets.
 
-For more information specific to loading audio datasets, take a look at the <a class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold" href="./audio_process">process audio data</a> guide. If you're working with image datasets, you can check out the <a class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold" href="./image_process">process image data</a> guide.
+For more details specific to processing audio datasets, take a look at the <a class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold" href="./audio_process">process audio data</a> guide. If you're working with image datasets, check out the <a class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold" href="./image_process">process image data</a> guide. Text specific processing is covered in the <a class="bg-blue-200 text-blue-900 dark:bg-blue-500 px-1 rounded font-bold" href="./nlp_process">process text data</a> guide.
 
-Load the MRPC dataset from the GLUE benchmark to follow along with our examples:
+The examples use the MRPC dataset, but feel free to load any dataset of your choice and following along!
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset('glue', 'mrpc', split='train')
+>>> dataset = load_dataset("glue", "mrpc", split="train")
 ```
 
 <Tip warning={true}>
 
-All the processing methods in this guide return a new [`Dataset`]. Modification is not done in-place. Be careful about overriding your previous dataset!
+All processing methods in this guide return a new [`Dataset`] object. Modification is not done in-place. Be careful about overriding your previous dataset!
 
 </Tip>
 
 ## Sort, shuffle, select, split, and shard
 
-There are several methods for rearranging the structure of a dataset. These methods are useful for selecting only the rows you want, creating train and test splits, and sharding very large datasets into smaller chunks.
+There are several functions for rearranging the structure of a dataset. These functions are useful for selecting only the rows you want, creating train and test splits, and sharding very large datasets into smaller chunks.
 
 ### Sort
 
-Use [`Dataset.sort`] to sort a columns values according to their numerical values. The provided column must be NumPy compatible.
+Use [`~Dataset.sort`] to sort column values according to their numerical values. The provided column must be NumPy compatible.
 
 ```py
->>> dataset['label'][:10]
+>>> dataset["label"][:10]
 [1, 0, 1, 0, 1, 1, 0, 1, 0, 0]
->>> sorted_dataset = dataset.sort('label')
->>> sorted_dataset['label'][:10]
+>>> sorted_dataset = dataset.sort("label")
+>>> sorted_dataset["label"][:10]
 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
->>> sorted_dataset['label'][-10:]
+>>> sorted_dataset["label"][-10:]
 [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 ```
 
 ### Shuffle
 
-The [`Dataset.shuffle`] method randomly rearranges the values of a column. You can specify the `generator` argument in this method to use a different `numpy.random.Generator` if you want more control over the algorithm used to shuffle the dataset.
+The [`~Dataset.shuffle`] function randomly rearranges the column values. You can specify the `generator` parameter in this function to use a different `numpy.random.Generator` if you want more control over the algorithm used to shuffle the dataset.
 
 ```py
 >>> shuffled_dataset = sorted_dataset.shuffle(seed=42)
->>> shuffled_dataset['label'][:10]
+>>> shuffled_dataset["label"][:10]
 [1, 1, 1, 0, 1, 1, 1, 1, 1, 0]
 ```
 
 ### Select and Filter
 
-There are two options for filtering rows in a dataset: [`Dataset.select`] and [`Dataset.filter`].
+There are two options for filtering rows in a dataset: [`~Dataset.select`] and [`~Dataset.filter`].
 
-- [`Dataset.select`] returns rows according to a list of indices:
+- [`~Dataset.select`] returns rows according to a list of indices:
 
 ```py
 >>> small_dataset = dataset.select([0, 10, 20, 30, 40, 50])
@@ -66,13 +66,13 @@ There are two options for filtering rows in a dataset: [`Dataset.select`] and [`
 6
 ```
 
-- [`Dataset.filter`] returns rows that match a specified condition:
+- [`~Dataset.filter`] returns rows that match a specified condition:
 
 ```py
->>> start_with_ar = dataset.filter(lambda example: example['sentence1'].startswith('Ar'))
+>>> start_with_ar = dataset.filter(lambda example: example["sentence1"].startswith("Ar"))
 >>> len(start_with_ar)
 6
->>> start_with_ar['sentence1']
+>>> start_with_ar["sentence1"]
 ['Around 0335 GMT , Tab shares were up 19 cents , or 4.4 % , at A $ 4.56 , having earlier set a record high of A $ 4.57 .',
 'Arison said Mann may have been one of the pioneers of the world music movement and he had a deep love of Brazilian music .',
 'Arts helped coach the youth on an eighth-grade football team at Lombardi Middle School in Green Bay .',
@@ -82,7 +82,7 @@ There are two options for filtering rows in a dataset: [`Dataset.select`] and [`
 ]
 ```
 
-[`Dataset.filter`] can also filter by indices if you set `with_indices=True`:
+[`~Dataset.filter`] can also filter by indices if you set `with_indices=True`:
 
 ```py
 >>> even_dataset = dataset.filter(lambda example, idx: idx % 2 == 0, with_indices=True)
@@ -94,7 +94,7 @@ There are two options for filtering rows in a dataset: [`Dataset.select`] and [`
 
 ### Split
 
-[`Dataset.train_test_split`] creates train and test splits, if your dataset doesn't already have them. This allows you to adjust the relative proportions or absolute number of samples in each split. In the example below, use the `test_size` argument to create a test split that is 10% of the original dataset:
+The [`~Dataset.train_test_split`] function creates train and test splits, if your dataset doesn't already have them. This allows you to adjust the relative proportions or absolute number of samples in each split. In the example below, use the `test_size` parameter to create a test split that is 10% of the original dataset:
 
 ```py
 >>> dataset.train_test_split(test_size=0.1)
@@ -108,13 +108,13 @@ The splits are shuffled by default, but you can set `shuffle=False` to prevent s
 
 ### Shard
 
-🤗 Datasets supports sharding to divide a very large dataset into a predefined number of chunks. Specify the `num_shards` argument in [`Dataset.shard`] to determine the number of shards to split the dataset into. You will also need to provide the shard you want to return with the `index` argument.
+🤗 Datasets supports sharding to divide a very large dataset into a predefined number of chunks. Specify the `num_shards` parameter in [`~Dataset.shard`] to determine the number of shards to split the dataset into. You'll also need to provide the shard you want to return with the `index` parameter.
 
 For example, the [imdb](https://huggingface.co/datasets/imdb) dataset has 25000 examples:
 
 ```py
 >>> from datasets import load_dataset
->>> datasets = load_dataset('imdb', split='train')
+>>> datasets = load_dataset("imdb", split="train")
 >>> print(dataset)
 Dataset({
     features: ['text', 'label'],
@@ -122,7 +122,7 @@ Dataset({
 })
 ```
 
-After you shard the dataset into four chunks, the first shard only has 6250 examples:
+After sharding the dataset into four chunks, the first shard only has 6250 examples:
 
 ```py
 >>> dataset.shard(num_shards=4, index=0)
@@ -136,13 +136,13 @@ Dataset({
 
 ## Rename, remove, cast, and flatten
 
-The following methods allow you to modify the columns of a dataset. These methods are useful for renaming or removing columns, changing columns to a new set of features, and flattening nested column structures.
+The following functions allow you to modify the columns of a dataset. These functions are useful for renaming or removing columns, changing columns to a new set of features, and flattening nested column structures.
 
 ### Rename
 
-Use [`Dataset.rename_column`] when you need to rename a column in your dataset. Features associated with the original column are actually moved under the new column name, instead of just replacing the original column in-place.
+Use [`~Dataset.rename_column`] when you need to rename a column in your dataset. Features associated with the original column are actually moved under the new column name, instead of just replacing the original column in-place.
 
-Provide [`Dataset.rename_column`] with the name of the original column, and the new column name:
+Provide [`~Dataset.rename_column`] with the name of the original column, and the new column name:
 
 ```py
 >>> dataset
@@ -161,7 +161,7 @@ Dataset({
 
 ### Remove
 
-When you need to remove one or more columns, give [`Dataset.remove_columns`] the name of the column to remove. Remove more than one column by providing a list of column names:
+When you need to remove one or more columns, provide the name of the column to remove to the [`~Dataset.remove_columns`] function. Remove more than one column by providing a list of column names:
 
 ```py
 >>> dataset = dataset.remove_columns("label")
@@ -170,7 +170,7 @@ Dataset({
     features: ['sentence1', 'sentence2', 'idx'],
     num_rows: 3668
 })
->>> dataset = dataset.remove_columns(['sentence1', 'sentence2'])
+>>> dataset = dataset.remove_columns(["sentence1", "sentence2"])
 >>> dataset
 Dataset({
     features: ['idx'],
@@ -180,7 +180,7 @@ Dataset({
 
 ### Cast
 
-[`Dataset.cast`] changes the feature type of one or more columns. This method takes your new `Features` as its argument. The following sample code shows how to change the feature types of `ClassLabel` and `Value`:
+The [`~Dataset.cast`] function transforms the feature type of one or more columns. This function accepts your new [`Features`] as its argument. The example below demonstrates how to change the [`ClassLabel`] and [`Value`] features:
 
 ```py
 >>> dataset.features
@@ -191,8 +191,8 @@ Dataset({
 
 >>> from datasets import ClassLabel, Value
 >>> new_features = dataset.features.copy()
->>> new_features["label"] = ClassLabel(names=['negative', 'positive'])
->>> new_features["idx"] = Value('int64')
+>>> new_features["label"] = ClassLabel(names=["negative", "positive"])
+>>> new_features["idx"] = Value("int64")
 >>> dataset = dataset.cast(new_features)
 >>> dataset.features
 {'sentence1': Value(dtype='string', id=None),
@@ -203,11 +203,11 @@ Dataset({
 
 <Tip>
 
-Casting only works if the original feature type and new feature type are compatible. For example, you can cast a column with the feature type `Value('int32')` to `Value('bool')` if the original column only contains ones and zeros.
+Casting only works if the original feature type and new feature type are compatible. For example, you can cast a column with the feature type `Value("int32")` to `Value("bool")` if the original column only contains ones and zeros.
 
 </Tip>
 
-Use [`Dataset.cast_column`] to change the feature type of just one column. Pass the column name and its new feature type as arguments:
+Use the [`~Dataset.cast_column`] function to change the feature type of a single column. Pass the column name and its new feature type as arguments:
 
 ```py
 >>> dataset.features
@@ -220,11 +220,11 @@ Use [`Dataset.cast_column`] to change the feature type of just one column. Pass 
 
 ### Flatten
 
-Sometimes a column can be a nested structure of several types. Use [`Dataset.flatten`] to extract the subfields into their own separate columns. Take a look at the nested structure below from the SQuAD dataset:
+Sometimes a column can be a nested structure of several types. Use the [`~Dataset.flatten`] function to extract the subfields into their own separate columns. Take a look at the nested structure below from the SQuAD dataset:
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset('squad', split='train')
+>>> dataset = load_dataset("squad", split="train")
 >>> dataset.features
 {'answers': Sequence(feature={'text': Value(dtype='string', id=None), 'answer_start': Value(dtype='int32', id=None)}, length=-1, id=None),
 'context': Value(dtype='string', id=None),
@@ -233,7 +233,7 @@ Sometimes a column can be a nested structure of several types. Use [`Dataset.fla
 'title': Value(dtype='string', id=None)}
 ```
 
-The `answers` field contains two subfields: `text` and `answer_start`. Flatten them with [`Dataset.flatten`]:
+The `answers` field contains two subfields: `text` and `answer_start`. Flatten them with the [`~Dataset.flatten`] function:
 
 ```py
 >>> flat_dataset = dataset.flatten()
@@ -246,48 +246,25 @@ Dataset({
 
 Notice how the subfields are now their own independent columns: `answers.text` and `answers.answer_start`.
 
-## Align
-
-The [`Dataset.align_labels_with_mapping`] function aligns a dataset label id with the label name. Not all 🤗 Transformers models follow the prescribed label mapping of the original dataset, especially for NLI dataset labels. For example, the [MNLI](https://huggingface.co/datasets/glue) dataset uses the following label mapping:
-
-```py
->>> label2id = {'entailment': 0, 'neutral': 1, 'contradiction': 2}
-```
-
-To align the dataset label mapping with the mapping used by a model, create a dictionary of the label name and id to align on:
-
-```py
->>> label2id = {"contradiction": 0, "neutral": 1, "entailment": 2}
-```
-
-Pass the dictionary of the label mappings to the [`Dataset.align_labels_with_mapping`] function, and the column to align on:
-
-```py
->>> from datasets import load_dataset
-
->>> mnli = load_dataset("glue", "mnli", split="train")
->>> mnli_aligned = mnli.align_labels_with_mapping(label2id, "label")
-```
-
-You can also use this function to assign a custom mapping of labels to ids.
-
 ## Map
 
-Some of the more powerful applications of 🤗 Datasets come from using [`Dataset.map`]. The primary purpose of [`Dataset.map`] is to speed up processing functions. It allows you to apply a processing function to each example in a dataset, independently or in batches. This function can even create new rows and columns.
+Some of the more powerful applications of 🤗 Datasets come from using the [`~Dataset.map`] function. The primary purpose of [`~Dataset.map`] is to speed up processing functions. It allows you to apply a processing function to each example in a dataset, independently or in batches. This function can even create new rows and columns.
 
-In the following example, you will prefix each `sentence1` value in the dataset with `'My sentence: '`. First, create a function that adds `'My sentence: '` to the beginning of each sentence. The function needs to accept and output a `dict`:
+In the following example, prefix each `sentence1` value in the dataset with `'My sentence: '`. 
+
+Start by creating a function that adds `'My sentence: '` to the beginning of each sentence. The function needs to accept and output a `dict`:
 
 ```py
 >>> def add_prefix(example):
-...     example['sentence1'] = 'My sentence: ' + example['sentence1']
+...     example["sentence1"] = 'My sentence: '' + example["sentence1"]
 ...     return example
 ```
 
-Next, apply this function to the dataset with [`Dataset.map`]:
+Now use [`~Dataset.map`] to apply the `add_prefix` function to the entire dataset:
 
 ```py
 >>> updated_dataset = small_dataset.map(add_prefix)
->>> updated_dataset['sentence1'][:5]
+>>> updated_dataset["sentence1"][:5]
 ['My sentence: Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .',
 "My sentence: Yucaipa owned Dominick 's before selling the chain to Safeway in 1998 for $ 2.5 billion .",
 'My sentence: They had published an advertisement on the Internet on June 10 , offering the cargo for sale , he added .',
@@ -295,27 +272,27 @@ Next, apply this function to the dataset with [`Dataset.map`]:
 ]
 ```
 
-Let's take a look at another example, except this time, you will remove a column with [`Dataset.map`]. When you remove a column, it is only removed after the example has been provided to the mapped function. This allows the mapped function to use the content of the columns before they are removed.
+Let's take a look at another example, except this time, you'll remove a column with [`~Dataset.map`]. When you remove a column, it is only removed after the example has been provided to the mapped function. This allows the mapped function to use the content of the columns before they are removed.
 
-Specify the column to remove with the `remove_columns` argument in [`Dataset.map`]:
+Specify the column to remove with the `remove_columns` parameter in [`~Dataset.map`]:
 
 ```py
->>> updated_dataset = dataset.map(lambda example: {'new_sentence': example['sentence1']}, remove_columns=['sentence1'])
+>>> updated_dataset = dataset.map(lambda example: {"new_sentence": example["sentence1"]}, remove_columns=["sentence1"])
 >>> updated_dataset.column_names
 ['sentence2', 'label', 'idx', 'new_sentence']
 ```
 
 <Tip>
 
-🤗 Datasets also has a [`Dataset.remove_columns`] method that is functionally identical, but faster, because it doesn't copy the data of the remaining columns.
+🤗 Datasets also has a [`~Dataset.remove_columns`] function which is faster because it doesn't copy the data of the remaining columns.
 
 </Tip>
 
-You can also use [`Dataset.map`] with indices if you set `with_indices=True`. The example below adds the index to the beginning of each sentence:
+You can also use [`~Dataset.map`] with indices if you set `with_indices=True`. The example below adds the index to the beginning of each sentence:
 
 ```py
->>> updated_dataset = dataset.map(lambda example, idx: {'sentence2': f'{idx}: ' + example['sentence2']}, with_indices=True)
->>> updated_dataset['sentence2'][:5]
+>>> updated_dataset = dataset.map(lambda example, idx: {"sentence2": f"{idx}: " + example["sentence2"]}, with_indices=True)
+>>> updated_dataset["sentence2"][:5]
 ['0: Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .',
  "1: Yucaipa bought Dominick 's in 1995 for $ 693 million and sold it to Safeway for $ 1.8 billion in 1998 .",
  "2: On June 10 , the ship 's owners had published an advertisement on the Internet , offering the explosives for sale .",
@@ -324,8 +301,7 @@ You can also use [`Dataset.map`] with indices if you set `with_indices=True`. Th
 ]
 ```
 
-You can also use [`Dataset.map`] with the rank of the process if you set `with_rank=True`. This is analogous to `with_indices`. The `rank` argument in the mapped function goes after the `index` one if it is already present. The main use-case for it is to parallelize your computation across several GPUs. This requires setting `multiprocess.set_start_method("spawn")`, without which you will receive a CUDA error: `RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method`.
-
+The [`~Dataset.map`] also works with the rank of the process if you set `with_rank=True`. This is analogous to the `with_indices` parameter. The `with_rank` parameter in the mapped function goes after the `index` one if it is already present. 
 
 ```py
 >>> from multiprocess import set_start_method
@@ -342,65 +318,41 @@ You can also use [`Dataset.map`] with the rank of the process if you set `with_r
 >>> updated_dataset = dataset.map(gpu_computation, with_rank=True)
 ```
 
+The main use-case for rank is to parallelize computation across several GPUs. This requires setting `multiprocess.set_start_method("spawn")`. If you don't you'll receive the following CUDA error: 
+
+```bash
+RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method.
+```
+
 ### Multiprocessing
 
-Multiprocessing can significantly speed up processing by parallelizing the processes on your CPU. Set the `num_proc` argument in [`Dataset.map`] to set the number of processes to use:
+Multiprocessing significantly speeds up processing by parallelizing processes on the CPU. Set the `num_proc` parameter in [`~Dataset.map`] to set the number of processes to use:
 
 ```py
->>> updated_dataset = dataset.map(lambda example, idx: {'sentence2': f'{idx}: ' + example['sentence2']}, num_proc=4)
+>>> updated_dataset = dataset.map(lambda example, idx: {"sentence2": f"{idx}: " + example["sentence2"]}, num_proc=4)
 ```
 
 ### Batch processing
 
-[`Dataset.map`] also supports working with batches of examples. Operate on batches by setting `batched=True`. The default batch size is 1000, but you can adjust it with the `batch_size` argument. This opens the door to many interesting applications such as tokenization, splitting long sentences into shorter chunks, and data augmentation.
-
-#### Tokenization
-
-One of the most obvious use-cases for batch processing is tokenization, which accepts batches of inputs.
-
-First, load the tokenizer from the BERT model:
-
-```py
->>> from transformers import BertTokenizerFast
->>> tokenizer = BertTokenizerFast.from_pretrained('bert-base-cased')
-```
-
-Apply the tokenizer to batches of the `sentence1` field:
-
-```py
->>> encoded_dataset = dataset.map(lambda examples: tokenizer(examples['sentence1']), batched=True)
->>> encoded_dataset.column_names
-['sentence1', 'sentence2', 'label', 'idx', 'input_ids', 'token_type_ids', 'attention_mask']
->>> encoded_dataset[0]
-{'sentence1': 'Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .',
-'sentence2': 'Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .',
-'label': 1,
-'idx': 0,
-'input_ids': [  101,  7277,  2180,  5303,  4806,  1117,  1711,   117,  2292, 1119,  1270,   107,  1103,  7737,   107,   117,  1104,  9938, 4267, 12223, 21811,  1117,  2554,   119,   102],
-'token_type_ids': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-}
-```
-
-Now you have three new columns, `input_ids`, `token_type_ids`, `attention_mask`, that contain the encoded version of the `sentence1` field.
+The [`~Dataset.map`] function also supports working with batches of examples. Operate on batches by setting `batched=True`. The default batch size is 1000, but you can adjust it with the `batch_size` parameter. Batch processing enables interesting applications such as splitting long sentences into shorter chunks and data augmentation.
 
 #### Split long examples
 
-When your examples are too long, you may want to split them into several smaller snippets. Begin by creating a function that:
+When examples are too long, you may want to split them into several smaller chunks. Begin by creating a function that:
 
-1. Splits the `sentence1` field into snippets of 50 characters.
+1. Splits the `sentence1` field into chunks of 50 characters.
 
-2. Stacks all the snippets together to create the new dataset.
+2. Stacks all the chunks together to create the new dataset.
 
 ```py
 >>> def chunk_examples(examples):
 ...     chunks = []
-...     for sentence in examples['sentence1']:
+...     for sentence in examples["sentence1"]:
 ...         chunks += [sentence[i:i + 50] for i in range(0, len(sentence), 50)]
-...     return {'chunks': chunks}
+...     return {"chunks": chunks}
 ```
 
-Apply the function with [`Dataset.map`]:
+Apply the function with [`~Dataset.map`]:
 
 ```py
 >>> chunked_dataset = dataset.map(chunk_examples, batched=True, remove_columns=dataset.column_names)
@@ -431,15 +383,15 @@ Dataset(schema: {'chunks': 'string'}, num_rows: 10470)
 
 #### Data augmentation
 
-With batch processing, you can even augment your dataset with additional examples. In the following example, you will generate additional words for a masked token in a sentence.
+Another application is data augmentation. The following example generates additional words for a masked token in a sentence.
 
-Load the [RoBERTA](https://huggingface.co/roberta-base) model for use in the 🤗 Transformer [FillMaskPipeline](https://huggingface.co/transformers/main_classes/pipelines#transformers.FillMaskPipeline):
+Load and use the [RoBERTA](https://huggingface.co/roberta-base) model in 🤗 Transformer's [FillMaskPipeline](https://huggingface.co/transformers/main_classes/pipelines#transformers.FillMaskPipeline):
 
 ```py
 >>> from random import randint
 >>> from transformers import pipeline
 
->>> fillmask = pipeline('fill-mask', model='roberta-base')
+>>> fillmask = pipeline("fill-mask", model="roberta-base")
 >>> mask_token = fillmask.tokenizer.mask_token
 >>> smaller_dataset = dataset.filter(lambda e, i: i<100, with_indices=True)
 ```
@@ -449,22 +401,22 @@ Create a function to randomly select a word to mask in the sentence. The functio
 ```py
 >>> def augment_data(examples):
 ...     outputs = []
-...     for sentence in examples['sentence1']:
+...     for sentence in examples["sentence1"]:
 ...         words = sentence.split(' ')
 ...         K = randint(1, len(words)-1)
 ...         masked_sentence = " ".join(words[:K]  + [mask_token] + words[K+1:])
 ...         predictions = fillmask(masked_sentence)
-...         augmented_sequences = [predictions[i]['sequence'] for i in range(3)]
+...         augmented_sequences = [predictions[i]["sequence"] for i in range(3)]
 ...         outputs += [sentence] + augmented_sequences
 ...
-...     return {'data': outputs}
+...     return {"data": outputs}
 ```
 
-Use [`Dataset.map`] to apply the function over the whole dataset:
+Use [`~Dataset.map`] to apply the function over the whole dataset:
 
 ```py
 >>> augmented_dataset = smaller_dataset.map(augment_data, batched=True, remove_columns=dataset.column_names, batch_size=8)
->>> augmented_dataset[:9]['data']
+>>> augmented_dataset[:9]["data"]
 ['Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .',
  'Amrozi accused his brother, whom he called " the witness ", of deliberately withholding his evidence.',
  'Amrozi accused his brother, whom he called " the witness ", of deliberately suppressing his evidence.',
@@ -476,18 +428,18 @@ Use [`Dataset.map`] to apply the function over the whole dataset:
 ]
 ```
 
-For each original sentence, RoBERTA augmented a random word with three alternatives. In the first sentence, the word `distorting` is augmented with `withholding`, `suppressing`, and `destroying`.
+For each original sentence, RoBERTA augmented a random word with three alternatives. In the first sentence, the word `distorting` is supplemented by `withholding`, `suppressing`, and `destroying`.
 
 ### Process multiple splits
 
-Many datasets have splits that you can process simultaneously with [`DatasetDict.map`]. For example, tokenize the `sentence1` field in the train and test split by:
+Many datasets have splits that can be processed simultaneously with [`DatasetDict.map`]. For example, tokenize the `sentence1` field in the train and test split by:
 
 ```py
 >>> from datasets import load_dataset
 
 # load all the splits
 >>> dataset = load_dataset('glue', 'mrpc')
->>> encoded_dataset = dataset.map(lambda examples: tokenizer(examples['sentence1']), batched=True)
+>>> encoded_dataset = dataset.map(lambda examples: tokenizer(examples["sentence1"]), batched=True)
 >>> encoded_dataset["train"][0]
 {'sentence1': 'Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .',
 'sentence2': 'Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .',
@@ -501,7 +453,7 @@ Many datasets have splits that you can process simultaneously with [`DatasetDict
 
 ### Distributed usage
 
-When you use [`Dataset.map`] in a distributed setting, you should also use [torch.distributed.barrier](https://pytorch.org/docs/stable/distributed?highlight=barrier#torch.distributed.barrier). This ensures the main process performs the mapping, while the other processes load the results, thereby avoiding duplicate work.
+When you use [`~Dataset.map`] in a distributed setting, you should also use [torch.distributed.barrier](https://pytorch.org/docs/stable/distributed?highlight=barrier#torch.distributed.barrier). This ensures the main process performs the mapping, while the other processes load the results, thereby avoiding duplicate work.
 
 The following example shows how you can use `torch.distributed.barrier` to synchronize the processes:
 
@@ -539,11 +491,11 @@ Separate datasets can be concatenated if they share the same column types. Conca
 
 <Tip>
 
-You can also mix several datasets together by taking alternating examples from each one to create a new dataset. This is known as interleaving, and you can use it with [`interleave_datasets`]. Both [`interleave_datasets`] and [`concatenate_datasets`] will work with regular [`Dataset`] and [`IterableDataset`] objects. Refer to the [Stream](./stream#interleave) section for an example of how it's used.
+You can also mix several datasets together by taking alternating examples from each one to create a new dataset. This is known as *interleaving*, which is enabled by the [`interleave_datasets`] function. Both [`interleave_datasets`] and [`concatenate_datasets`] work with regular [`Dataset`] and [`IterableDataset`] objects. Refer to the [Stream](./stream#interleave) guide for an example of how to interleave datasets.
 
 </Tip>
 
-You can also concatenate two datasets horizontally (axis=1) as long as they have the same number of rows:
+You can also concatenate two datasets horizontally by setting `axis=1` as long as the datasets have the same number of rows:
 
 ```py
 >>> from datasets import Dataset
@@ -609,7 +561,7 @@ In this case, the tokenization is applied only when the examples are accessed.
 
 ## Save
 
-Once you are done processing your dataset, you can save and reuse it later with [`Dataset.save_to_disk`].
+Once you are done processing your dataset, you can save and reuse it later with [`~Dataset.save_to_disk`].
 
 Save your dataset by providing the path to the directory you wish to save it to:
 
@@ -617,7 +569,7 @@ Save your dataset by providing the path to the directory you wish to save it to:
 >>> encoded_dataset.save_to_disk("path/of/my/dataset/directory")
 ```
 
-When you want to use your dataset again, use [`load_from_disk`] to reload it:
+Use the [`load_from_disk`] function to reload the dataset:
 
 ```py
 >>> from datasets import load_from_disk
@@ -626,13 +578,13 @@ When you want to use your dataset again, use [`load_from_disk`] to reload it:
 
 <Tip>
 
-Want to save your dataset to a cloud storage provider? Read our [Cloud Storage](./filesystems) guide on how to save your dataset to AWS or Google Cloud Storage!
+Want to save your dataset to a cloud storage provider? Read our [Cloud Storage](./filesystems) guide to learn how to save your dataset to AWS or Google Cloud Storage.
 
 </Tip>
 
 ## Export
 
-🤗 Datasets supports exporting as well, so you can work with your dataset in other applications. The following table shows currently supported file formats you can export to:
+🤗 Datasets supports exporting as well so you can work with your dataset in other applications. The following table shows currently supported file formats you can export to:
 
 | File type               | Export method                                                  |
 |-------------------------|----------------------------------------------------------------|

--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -11,6 +11,8 @@ This guide will show you how to:
 - Apply a custom formatting transform.
 - Save and export processed datasets.
 
+For more information specific to loading audio datasets, take a look at the <a class="bg-yellow-200 text-yellow-900 dark:bg-yellow-500 px-1 rounded font-bold" href="./audio_process">process audio data</a> guide. If you're working with image datasets, you can check out the <a class="bg-green-200 text-green-900 dark:bg-green-500 px-1 rounded font-bold" href="./image_process">process image data</a> guide.
+
 Load the MRPC dataset from the GLUE benchmark to follow along with our examples:
 
 ```py

--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -505,36 +505,32 @@ You can also concatenate two datasets horizontally by setting `axis=1` as long a
 
 ## Format
 
-Set a dataset to a TensorFlow compatible format with [`Dataset.set_format`]. Specify `type=tensorflow` and the columns that should be formatted:
+The [`~Dataset.set_format`] function changes the format of a column to be compatible with some common data formats. Specify the output you'd like in the `type` parameter and the columns you want to format. Formatting is applied on-the-fly.
+
+For example, create PyTorch tensors by setting `type="torch"`:
 
 ```py
->>> import tensorflow as tf
->>> dataset.set_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
+>>> import torch
+>>> dataset.set_format(type="torch", columns=["input_ids", "token_type_ids", "attention_mask", "label"])
 ```
 
-Then you can wrap the dataset with `tf.data.Dataset`. This method gives you more control over how to create a [TensorFlow Dataset](https://www.tensorflow.org/api_docs/python/tf/data/Dataset). In the example below, the dataset is created `from_tensor_slices`:
+The [`~Dataset.with_format`] function also changes the format of a column, except it returns a new [`Dataset`] object:
 
 ```py
->>> tfdataset = tf.data.Dataset.from_tensor_slices((features, dataset["label"])).batch(32)
-```
-
-[`Dataset.with_format`] provides an alternative method to set the format. This method will return a new [`Dataset`] object with your specified format:
-
-```py
->>> dataset = dataset.with_format(type='tensorflow', columns=['input_ids', 'token_type_ids', 'attention_mask', 'label'])
+>>> dataset = dataset.with_format(type="torch", columns=["input_ids", "token_type_ids", "attention_mask", "label"])
 ```
 
 <Tip>
 
-🤗 Datasets also provides support for other common data formats such as NumPy, PyTorch, Pandas, and JAX.
+🤗 Datasets also provides support for other common data formats such as NumPy, Pandas, and JAX. Check out the [Using Datasets with TensorFlow](https://huggingface.co/docs/datasets/master/en/use_with_tensorflow#using-totfdataset) guide for more details on how to efficiently create a TensorFlow dataset.
 
 </Tip>
 
-Use [`Dataset.reset_format`] if you need to reset the dataset to the original format:
+If you need to reset the dataset to its original format, use the [`~Dataset.reset_format`] function:
 
 ```py
 >>> dataset.format
-{'type': 'tensorflow', 'format_kwargs': {}, 'columns': ['label'], 'output_all_columns': False}
+{'type': 'torch', 'format_kwargs': {}, 'columns': ['label'], 'output_all_columns': False}
 >>> dataset.reset_format()
 >>> dataset.format
 {'type': 'python', 'format_kwargs': {}, 'columns': ['idx', 'label', 'sentence1', 'sentence2'], 'output_all_columns': False}
@@ -542,22 +538,18 @@ Use [`Dataset.reset_format`] if you need to reset the dataset to the original fo
 
 ### Format transform
 
-[`Dataset.set_transform`] allows you to apply a custom formatting transform on-the-fly. This will replace any previously specified format. For example, you can use this method to tokenize and pad tokens on-the-fly:
+The [`~Dataset.set_transform`] function applies a custom formatting transform on-the-fly. This function replaces any previously specified format. For example, you can use this function to tokenize and pad tokens on-the-fly. Tokenization is only applied when examples are accessed:
 
 ```py
->>> from transformers import BertTokenizer
->>> tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+>>> from transformers import AutoTokenizer
+
+>>> tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
 >>> def encode(batch):
 ...     return tokenizer(batch["sentence1"], padding="longest", truncation=True, max_length=512, return_tensors="pt")
 >>> dataset.set_transform(encode)
 >>> dataset.format
 {'type': 'custom', 'format_kwargs': {'transform': <function __main__.encode(batch)>}, 'columns': ['idx', 'label', 'sentence1', 'sentence2'], 'output_all_columns': False}
->>> dataset[:2]
-{'input_ids': tensor([[  101,  2572,  3217, ... 102]]), 'token_type_ids': tensor([[0, 0, 0, ... 0]]), 'attention_mask': tensor([[1, 1, 1, ... 1]])}
 ```
-
-In this case, the tokenization is applied only when the examples are accessed.
-
 
 ## Save
 
@@ -573,7 +565,7 @@ Use the [`load_from_disk`] function to reload the dataset:
 
 ```py
 >>> from datasets import load_from_disk
->>> reloaded_encoded_dataset = load_from_disk("path/of/my/dataset/directory")
+>>> reloaded_dataset = load_from_disk("path/of/my/dataset/directory")
 ```
 
 <Tip>


### PR DESCRIPTION
This PR creates separate sections in the guides for audio, vision, text, and general usage so it is easier for users to find loading, processing, or sharing guides specific to the dataset type they're working with. It'll also allow us to scale the docs to additional dataset types - like time series, tabular, etc. - while keeping our docs information architecture. 

Some other changes include:

- Experimented with decorating text with some CSS to highlight guides specific to each modality. Hopefully, it'll be easier for users to find and realize that these different docs exist!
- Added deprecation warning for Metrics and redirect to Evaluate.
- Updated `set_format` section to recommend using the new `to_tf_dataset` function if you need to convert to a TensorFlow dataset.
- Reorganized `toctree` to nest general usage, audio, vision, and text sections under the how-to guides.
- A quick review and edit to the Load and Process docs for clarity.