### PR TITLE
Add `batch_size` parameter when calling `add_faiss_index` and `add_faiss_index_from_external_arrays`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1119,7 +1119,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Get json serializable dataset info
         dataset_info = asdict(dataset._info)
 
-        # Save dataset + indices + state + info
+        # Save dataset + state + info
         fs.makedirs(dataset_path, exist_ok=True)
         with fs.open(Path(dataset_path, config.DATASET_ARROW_FILENAME).as_posix(), "wb") as dataset_file:
             with ArrowWriter(stream=dataset_file) as writer:

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -447,6 +447,7 @@ class IndexableMixin:
         string_factory: Optional[str] = None,
         metric_type: Optional[int] = None,
         custom_index: Optional["faiss.Index"] = None,
+        batch_size: Optional[int] = 1000,
         train_size: Optional[int] = None,
         faiss_verbose: bool = False,
     ):
@@ -465,6 +466,7 @@ class IndexableMixin:
             string_factory (Optional :obj:`str`): This is passed to the index factory of Faiss to create the index. Default index class is IndexFlatIP.
             metric_type (Optional :obj:`int`): Type of metric. Ex: `faiss.METRIC_INNER_PRODUCT` or `faiss.METRIC_L2`.
             custom_index (Optional :obj:`faiss.Index`): Custom Faiss index that you already have instantiated and configured for your needs.
+            batch_size (Optional :obj:`int`): Size of the batch to use while adding vectors to the FaissIndex. Default value is 1000.
             train_size (Optional :obj:`int`): If the index needs a training step, specifies how many vectors will be used to train the index.
             faiss_verbose (:obj:`bool`, defaults to False): Enable the verbosity of the Faiss index.
         """
@@ -472,7 +474,7 @@ class IndexableMixin:
         faiss_index = FaissIndex(
             device=device, string_factory=string_factory, metric_type=metric_type, custom_index=custom_index
         )
-        faiss_index.add_vectors(self, column=column, train_size=train_size, faiss_verbose=faiss_verbose)
+        faiss_index.add_vectors(self, column=column, batch_size=batch_size, train_size=train_size, faiss_verbose=faiss_verbose)
         self._indexes[index_name] = faiss_index
 
     def add_faiss_index_from_external_arrays(
@@ -483,6 +485,7 @@ class IndexableMixin:
         string_factory: Optional[str] = None,
         metric_type: Optional[int] = None,
         custom_index: Optional["faiss.Index"] = None,
+        batch_size: Optional[int] = 1000,
         train_size: Optional[int] = None,
         faiss_verbose: bool = False,
     ):
@@ -501,13 +504,14 @@ class IndexableMixin:
             string_factory (Optional :obj:`str`): This is passed to the index factory of Faiss to create the index. Default index class is IndexFlatIP.
             metric_type (Optional :obj:`int`): Type of metric. Ex: `faiss.METRIC_INNER_PRODUCT` or `faiss.METRIC_L2`.
             custom_index (Optional :obj:`faiss.Index`): Custom Faiss index that you already have instantiated and configured for your needs.
+            batch_size (Optional :obj:`int`): Size of the batch to use while adding vectors to the FaissIndex. Default value is 1000.
             train_size (Optional :obj:`int`): If the index needs a training step, specifies how many vectors will be used to train the index.
             faiss_verbose (:obj:`bool`, defaults to False): Enable the verbosity of the Faiss index.
         """
         faiss_index = FaissIndex(
             device=device, string_factory=string_factory, metric_type=metric_type, custom_index=custom_index
         )
-        faiss_index.add_vectors(external_arrays, column=None, train_size=train_size, faiss_verbose=faiss_verbose)
+        faiss_index.add_vectors(external_arrays, column=None, batch_size=batch_size, train_size=train_size, faiss_verbose=faiss_verbose)
         self._indexes[index_name] = faiss_index
 
     def save_faiss_index(self, index_name: str, file: Union[str, PurePath]):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -25,7 +25,7 @@ class IndexableDatasetTest(TestCase):
         dset = dset.map(
             lambda ex, i: {"vecs": i * np.ones(5, dtype=np.float32)}, with_indices=True, keep_in_memory=True
         )
-        dset = dset.add_faiss_index("vecs", metric_type=faiss.METRIC_INNER_PRODUCT)
+        dset = dset.add_faiss_index("vecs", batch_size=100, metric_type=faiss.METRIC_INNER_PRODUCT)
         scores, examples = dset.get_nearest_examples("vecs", np.ones(5, dtype=np.float32))
         self.assertEqual(examples["filename"][0], "my_name-train_29")
         dset.drop_index("vecs")
@@ -37,6 +37,7 @@ class IndexableDatasetTest(TestCase):
         dset.add_faiss_index_from_external_arrays(
             external_arrays=np.ones((30, 5)) * np.arange(30).reshape(-1, 1),
             index_name="vecs",
+            batch_size=100,
             metric_type=faiss.METRIC_INNER_PRODUCT,
         )
         scores, examples = dset.get_nearest_examples("vecs", np.ones(5, dtype=np.float32))


### PR DESCRIPTION
Currently, even though the `batch_size` when adding vectors to the FAISS index can be tweaked in `FaissIndex.add_vectors()`, the function `ArrowDataset.add_faiss_index` doesn't have either the parameter `batch_size` to be propagated to the nested `FaissIndex.add_vectors` function or `*args, **kwargs`, so on, this PR adds the `batch_size` parameter to both `ArrowDataset.add_faiss_index` and `ArrowDataset.add_faiss_index_from_external_arrays`.

This is useful so as to tweak the `batch_size` according to the VM specifications.