### PR TITLE
Properly raise FileNotFound even if the dataset is private

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4073,7 +4073,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         if token is None:
             raise OSError(
-                "You need to provide a `token` or be logged in to Hugging Face with " "`huggingface-cli login`."
+                "You need to provide a `token` or be logged in to Hugging Face with `huggingface-cli login`."
             )
 
         if split is None:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1149,6 +1149,7 @@ def dataset_module_factory(
                         (
                             OfflineModeIsEnabled,
                             requests.exceptions.ConnectTimeout,
+                            requests.exceptions.ConnectionError,
                         ),
                     ):
                         raise ConnectionError(f"Couldn't reach '{path}' on the Hub ({type(e).__name__})")

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1161,7 +1161,7 @@ def dataset_module_factory(
                         msg = msg + f" at revision '{revision}'" if revision else msg
                         raise FileNotFoundError(
                             msg
-                            + ". If the repo is private, make sure you are authenticated with ``use_auth_token=True`` after logging in with ``huggingface-cli login```."
+                            + ". If the repo is private, make sure you are authenticated with `use_auth_token=True` after logging in with `huggingface-cli login`."
                         )
                     else:
                         raise e

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -509,7 +509,7 @@ def get_from_cache(
                 logger.info(f"Couldn't get ETag version for url {url}")
             elif response.status_code == 401 and config.HF_ENDPOINT in url and use_auth_token is None:
                 raise ConnectionError(
-                    f"Unauthorized for URL {url}. Please use the parameter ``use_auth_token=True`` after logging in with ``huggingface-cli login``"
+                    f"Unauthorized for URL {url}. Please use the parameter `use_auth_token=True` after logging in with `huggingface-cli login`"
                 )
         except (OSError, requests.exceptions.Timeout) as e:
             # not connected

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -781,9 +781,6 @@ def test_loading_from_the_datasets_hub_with_use_auth_token():
         mock_head.assert_called()
 
 
-@pytest.mark.skipif(
-    os.name == "nt", reason="skip on windows because of SSL issues with moon-staging.huggingface.co:443"
-)
 def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_data):
     with pytest.raises(FileNotFoundError):
         load_dataset(hf_private_dataset_repo_txt_data, streaming=True)
@@ -791,9 +788,6 @@ def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_da
     assert next(iter(ds)) is not None
 
 
-@pytest.mark.skipif(
-    os.name == "nt", reason="skip on windows because of SSL issues with moon-staging.huggingface.co:443"
-)
 def test_load_streaming_private_dataset_with_zipped_data(hf_token, hf_private_dataset_repo_zipped_txt_data):
     with pytest.raises(FileNotFoundError):
         load_dataset(hf_private_dataset_repo_zipped_txt_data, streaming=True)


### PR DESCRIPTION
`tests/test_load.py::test_load_streaming_private_dataset` was failing because the hub now returns 401 when getting the HfApi.dataset_info of a dataset without authentication. `load_dataset` was raising ConnectionError, while it should be FileNoteFoundError since it first checks for local files before checking the Hub.

Moreover when use_auth_token is not set (default is False), we should not pass `token=None` to HfApi.dataset_info, or it will use the local token by default - instead it should use no token. It's currently not possible to ask for no token to be used, so as a workaround I simply set token="no-token"