### PR TITLE
Fix WMT dataset loading issue and docs update

### DIFF
--- a/datasets/wmt14/README.md
+++ b/datasets/wmt14/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt14/wmt_utils.py
+++ b/datasets/wmt14/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/datasets/wmt15/README.md
+++ b/datasets/wmt15/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt15/wmt_utils.py
+++ b/datasets/wmt15/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/datasets/wmt16/README.md
+++ b/datasets/wmt16/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt16/wmt_utils.py
+++ b/datasets/wmt16/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/datasets/wmt17/README.md
+++ b/datasets/wmt17/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt17/wmt_utils.py
+++ b/datasets/wmt17/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/datasets/wmt18/README.md
+++ b/datasets/wmt18/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt18/wmt_utils.py
+++ b/datasets/wmt18/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/datasets/wmt19/README.md
+++ b/datasets/wmt19/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt19/wmt_utils.py
+++ b/datasets/wmt19/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/datasets/wmt_t2t/README.md
+++ b/datasets/wmt_t2t/README.md
@@ -46,22 +46,31 @@ task_ids: []
 
 ### Dataset Summary
 
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 ### Supported Tasks and Leaderboards

--- a/datasets/wmt_t2t/wmt_utils.py
+++ b/datasets/wmt_t2t/wmt_utils.py
@@ -25,7 +25,6 @@ import itertools
 import os
 import re
 import xml.etree.cElementTree as ElementTree
-from abc import ABC, abstractmethod
 
 import datasets
 
@@ -34,22 +33,31 @@ logger = datasets.logging.get_logger(__name__)
 
 
 _DESCRIPTION = """\
-Translate dataset based on the data from statmt.org.
+Translation dataset based on the data from statmt.org.
 
-Versions exists for the different years using a combination of multiple data
-sources. The base `wmt_translate` allows you to create your own config to choose
-your own data/language pair by creating a custom `datasets.translate.wmt.WmtConfig`.
+Versions exist for different years using a combination of data
+sources. The base `wmt` allows you to create a custom dataset by choosing
+your own data/language pair. This can be done as follows:
 
 ```
-config = datasets.wmt.WmtConfig(
-    version="0.0.1",
+from datasets import inspect_dataset, load_dataset_builder
+
+inspect_dataset("<insert the dataset name", "path/to/scripts")
+builder = load_dataset_builder(
+    "path/to/scripts/wmt_utils.py",
     language_pair=("fr", "de"),
     subsets={
         datasets.Split.TRAIN: ["commoncrawl_frde"],
         datasets.Split.VALIDATION: ["euelections_dev2019"],
     },
 )
-builder = datasets.builder("wmt_translate", config=config)
+
+# Standard version
+builder.download_and_prepare()
+ds = builder.as_dataset()
+
+# Streamable version
+ds = builder.as_streaming_dataset()
 ```
 
 """
@@ -662,20 +670,15 @@ class WmtConfig(datasets.BuilderConfig):
         # +++++++++++++++++++++
 
 
-class Wmt(ABC, datasets.GeneratorBasedBuilder):
+class Wmt(datasets.GeneratorBasedBuilder):
     """WMT translation dataset."""
 
+    BUILDER_CONFIG_CLASS = WmtConfig
+
     def __init__(self, *args, **kwargs):
-        if type(self) == Wmt and "config" not in kwargs:  # pylint: disable=unidiomatic-typecheck
-            raise ValueError(
-                "The raw `wmt_translate` can only be instantiated with the config "
-                "kwargs. You may want to use one of the `wmtYY_translate` "
-                "implementation instead to get the WMT dataset for a specific year."
-            )
         super(Wmt, self).__init__(*args, **kwargs)
 
     @property
-    @abstractmethod
     def _subsets(self):
         """Subsets that make up each split of the dataset."""
         raise NotImplementedError("This is a abstract method")
@@ -685,7 +688,8 @@ class Wmt(ABC, datasets.GeneratorBasedBuilder):
         """Subsets that make up each split of the dataset for the language pair."""
         source, target = self.config.language_pair
         filtered_subsets = {}
-        for split, ss_names in self._subsets.items():
+        subsets = self._subsets if self.config.subsets is None else self.config.subsets
+        for split, ss_names in subsets.items():
             filtered_subsets[split] = []
             for ss_name in ss_names:
                 dataset = DATASET_MAP[ss_name]

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -111,11 +111,13 @@ def import_main_class(module_path, dataset=True) -> Optional[Union[Type[DatasetB
     # Find the main class in our imported module
     module_main_cls = None
     for name, obj in module.__dict__.items():
-        if isinstance(obj, type) and issubclass(obj, main_cls_type):
+        if inspect.isclass(obj) and issubclass(obj, main_cls_type):
             if inspect.isabstract(obj):
                 continue
             module_main_cls = obj
-            break
+            obj_module = inspect.getmodule(obj)
+            if obj_module is not None and module == obj_module:
+                break
 
     return module_main_cls
 


### PR DESCRIPTION
This PR is a fix for #4354 

Changes are made for `wmt14`, `wmt15`, `wmt16`, `wmt17`, `wmt18`, `wmt19` and `wmt_t2t`. And READMEs are updated for the corresponding datasets.

As I am on a M1 Mac, I am not able to create a virtual `dev` environment using `pip install -e ".[dev]"`. Issue is with `tensorflow-text` not supported on M1s and there is no supporting repo by Apple or Google. So, if I was needed to perform local testing, I am not able to do that.

Let me know, if any additional changes are required.

Thanks