### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/datasets/qa4mre/qa4mre.py
+++ b/datasets/qa4mre/qa4mre.py
@@ -140,7 +140,7 @@ class Qa4mreConfig(datasets.BuilderConfig):
             raise ValueError("Incorrect track. Track should be one of the following: ", PATHS[year]["_TRACKS"])
 
         if track.lower() != "main" and language.upper() != "EN":
-            logger.warn("Only English documents available for pilot " "tracks. Setting English by default.")
+            logger.warning("Only English documents available for pilot " "tracks. Setting English by default.")
             language = "EN"
 
         if track.lower() == "main" and language.upper() not in PATHS[year]["_LANGUAGES_MAIN"]:


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444
