### PR TITLE
Fix timestamp conversion from Pandas to Python datetime in streaming mode

### DIFF
--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -482,6 +482,26 @@ class CastToPythonObjectsTest(TestCase):
         casted_obj = cast_to_python_objects(obj)
         self.assertDictEqual(casted_obj, expected_obj)
 
+    def test_cast_to_python_objects_pandas_timestamp(self):
+        obj = pd.Timestamp(2020, 1, 1)
+        expected_obj = obj.to_pydatetime()
+        casted_obj = cast_to_python_objects(obj)
+        self.assertEqual(casted_obj, expected_obj)
+        casted_obj = cast_to_python_objects(pd.Series([obj]))
+        self.assertListEqual(casted_obj, [expected_obj])
+        casted_obj = cast_to_python_objects(pd.DataFrame({"a": [obj]}))
+        self.assertDictEqual(casted_obj, {"a": [expected_obj]})
+
+    def test_cast_to_python_objects_pandas_timedelta(self):
+        obj = pd.Timedelta(seconds=1)
+        expected_obj = obj.to_pytimedelta()
+        casted_obj = cast_to_python_objects(obj)
+        self.assertEqual(casted_obj, expected_obj)
+        casted_obj = cast_to_python_objects(pd.Series([obj]))
+        self.assertListEqual(casted_obj, [expected_obj])
+        casted_obj = cast_to_python_objects(pd.DataFrame({"a": [obj]}))
+        self.assertDictEqual(casted_obj, {"a": [expected_obj]})
+
     @require_torch
     def test_cast_to_python_objects_torch(self):
         import torch

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from itertools import chain, islice
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from datasets import load_dataset
@@ -699,6 +700,21 @@ def test_iterable_dataset_features(features):
     else:
         expected = [x for _, x in ex_iterable]
     assert list(dataset) == expected
+
+
+def test_iterable_dataset_features_cast_to_python():
+    ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"timestamp": pd.Timestamp(2020, 1, 1), "array": np.ones(5), "n": 1}
+    )
+    features = Features(
+        {
+            "id": Value("int64"),
+            "timestamp": Value("timestamp[us]"),
+            "array": [Value("int64")],
+        }
+    )
+    dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features))
+    assert list(dataset) == [{"timestamp": pd.Timestamp(2020, 1, 1).to_pydatetime(), "array": [1] * 5, "id": 0}]
 
 
 @require_torch


### PR DESCRIPTION
Arrow accepts both pd.Timestamp and datetime.datetime objects to create timestamp arrays.
However a timestamp array is always converted to datetime.datetime objects.

This created an inconsistency between streaming in non-streaming. e.g. the `ett` dataset outputs datetime.datetime objects in non-streaming but pd.timestamp in streaming.

I fixed this by always converting pd.Timestamp to datetime.datetime during the example encoding step.
I fixed the same issue for pd.Timedelta as well. Finally I added an extra step of conversion for Series and DataFrame to take this into account in case such data are passed as Series or DataFrame.

Fix https://github.com/huggingface/datasets/issues/4533
Related to https://github.com/huggingface/datasets-server/issues/397