### PR TITLE
[CI] Fix upstream hub test url

### DIFF
--- a/tests/hub_fixtures.py
+++ b/tests/hub_fixtures.py
@@ -8,7 +8,7 @@ from huggingface_hub.hf_api import HfApi, HfFolder
 
 USER = "__DUMMY_TRANSFORMERS_USER__"
 FULL_NAME = "Dummy User"
-TOKEN = "hf_94wBhPGp6KrrTH3KDchhKpRxZwd6dmHWLL"
+TOKEN = "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"
 
 ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
 ENDPOINT_STAGING_DATASETS_URL = ENDPOINT_STAGING + "/datasets/{repo_id}/resolve/{revision}/{path}"

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -14,7 +14,7 @@ from huggingface_hub.hf_api import HfFolder
 
 from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
 from datasets.utils._hf_hub_fixes import delete_repo
-from tests.hub_fixtures import ENDPOINT_STAGING, USER, TOKEN
+from tests.hub_fixtures import ENDPOINT_STAGING, TOKEN, USER
 from tests.utils import require_pil, require_sndfile
 
 

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -14,16 +14,12 @@ from huggingface_hub.hf_api import HfFolder
 
 from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
 from datasets.utils._hf_hub_fixes import delete_repo
-from tests.hub_fixtures import TOKEN
+from tests.hub_fixtures import ENDPOINT_STAGING, USER, TOKEN
 from tests.utils import require_pil, require_sndfile
 
 
 REPO_NAME = f"repo-{int(time.time() * 10e3)}"
-ENDPOINT_STAGING = "https://moon-staging.huggingface.co"
 
-# Should create a __DUMMY_DATASETS_USER__ :)
-USER = "__DUMMY_TRANSFORMERS_USER__"
-PASS = "__DUMMY_TRANSFORMERS_PASS__"
 TOKEN_PATH_STAGING = expanduser("~/.huggingface/staging_token")
 
 


### PR DESCRIPTION
Some tests were still using moon-stagign instead of hub-ci.

I also updated the token to use one dedicated to `datasets`