### PR TITLE
Make DuplicateKeysError more user friendly [For Issue #2556]

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -457,7 +457,7 @@ class ArrowWriter:
         for hash, key in self.hkey_record:
             if hash in tmp_record:
                 duplicate_key_indices = [
-                    str(index) for index, (duplicate_hash, _) in enumerate(self.hkey_record) if duplicate_hash == hash
+                    str( self._num_examples + index) for index, (duplicate_hash, _) in enumerate(self.hkey_record) if duplicate_hash == hash
                 ]
 
                 raise DuplicatedKeysError(key, duplicate_key_indices)

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -454,9 +454,13 @@ class ArrowWriter:
     def check_duplicate_keys(self):
         """Raises error if duplicates found in a batch"""
         tmp_record = set()
-        for hash, key in self.hkey_record:
+        for hkey_index, (hash, key) in enumerate(self.hkey_record):
             if hash in tmp_record:
-                raise DuplicatedKeysError(key)
+                duplicate_key_indices = [
+                    str(index) for index, (duplicate_hash, _) in enumerate(self.hkey_record) if duplicate_hash == hash
+                ]
+
+                raise DuplicatedKeysError(key, hkey_index, duplicate_key_indices)
             else:
                 tmp_record.add(hash)
 

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -457,7 +457,9 @@ class ArrowWriter:
         for hash, key in self.hkey_record:
             if hash in tmp_record:
                 duplicate_key_indices = [
-                    str( self._num_examples + index) for index, (duplicate_hash, _) in enumerate(self.hkey_record) if duplicate_hash == hash
+                    str(self._num_examples + index)
+                    for index, (duplicate_hash, _) in enumerate(self.hkey_record)
+                    if duplicate_hash == hash
                 ]
 
                 raise DuplicatedKeysError(key, duplicate_key_indices)

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -454,13 +454,13 @@ class ArrowWriter:
     def check_duplicate_keys(self):
         """Raises error if duplicates found in a batch"""
         tmp_record = set()
-        for hkey_index, (hash, key) in enumerate(self.hkey_record):
+        for hash, key in self.hkey_record:
             if hash in tmp_record:
                 duplicate_key_indices = [
                     str(index) for index, (duplicate_hash, _) in enumerate(self.hkey_record) if duplicate_hash == hash
                 ]
 
-                raise DuplicatedKeysError(key, hkey_index, duplicate_key_indices)
+                raise DuplicatedKeysError(key, duplicate_key_indices)
             else:
                 tmp_record.add(hash)
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -801,7 +801,7 @@ class DatasetBuilder:
                 ) from None
             # If check_duplicates is set to True , then except DuplicatedKeysError
             except DuplicatedKeysError as e:
-                e.args = ( e.args[0] + f"datasets/{self.name}/{self.name}.py" ,)
+                e.args = (e.args[0] + f"datasets/{self.name}/{self.name}.py",)
                 raise (e) from None
             dl_manager.manage_extracted_files()
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -49,6 +49,7 @@ from .features import Features
 from .fingerprint import Hasher
 from .info import DatasetInfo, DatasetInfosDict, PostProcessedInfo
 from .iterable_dataset import ExamplesIterable, IterableDataset, _generate_examples_from_tables_wrapper
+from .keyhash import DuplicatedKeysError
 from .naming import camelcase_to_snakecase
 from .splits import Split, SplitDict, SplitGenerator
 from .streaming import extend_dataset_builder_for_streaming
@@ -798,7 +799,10 @@ class DatasetBuilder:
                     + "\nOriginal error:\n"
                     + str(e)
                 ) from None
-
+            # If check_duplicates is set to True , then except DuplicatedKeysError
+            except DuplicatedKeysError as e:
+                e.args = (e.args[0].replace("<Path to Dataset>", f"datasets/{self.name}/{self.name}.py"),)
+                raise (e) from None
             dl_manager.manage_extracted_files()
 
         if verify_infos:

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -801,7 +801,7 @@ class DatasetBuilder:
                 ) from None
             # If check_duplicates is set to True , then except DuplicatedKeysError
             except DuplicatedKeysError as e:
-                e.args = (e.args[0].replace("<Path to Dataset>", f"datasets/{self.name}/{self.name}.py"),)
+                e.args = ( e.args[0] + f"datasets/{self.name}/{self.name}.py" ,)
                 raise (e) from None
             dl_manager.manage_extracted_files()
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -801,8 +801,11 @@ class DatasetBuilder:
                 ) from None
             # If check_duplicates is set to True , then except DuplicatedKeysError
             except DuplicatedKeysError as e:
-                e.args = (e.args[0] + f"datasets/{self.name}/{self.name}.py",)
-                raise (e) from None
+                raise DuplicatedKeysError(
+                    e.key,
+                    e.duplicate_key_indices,
+                    fix_msg=f"To avoid duplicate keys, please fix the dataset script {self.name}.py",
+                ) from None
             dl_manager.manage_extracted_files()
 
         if verify_infos:

--- a/src/datasets/keyhash.py
+++ b/src/datasets/keyhash.py
@@ -71,9 +71,9 @@ class DuplicatedKeysError(Exception):
     """Raise an error when duplicate key found."""
 
     def __init__(self, key, duplicate_key_indices):
-        self.prefix = f"Found multiple examples generated with the same key"
+        self.prefix = "Found multiple examples generated with the same key"
         self.err_msg = f"\nThe following examples {', '.join(duplicate_key_indices)} have the key {key}"
-        self.suffix = "\nPlease fix the dataset script at <Path to Dataset> to avoid duplicate keys"
+        self.suffix = "\nTo avoid duplicate keys, please fix the dataset script at "
         super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
 
 

--- a/src/datasets/keyhash.py
+++ b/src/datasets/keyhash.py
@@ -70,11 +70,17 @@ class InvalidKeyError(Exception):
 class DuplicatedKeysError(Exception):
     """Raise an error when duplicate key found."""
 
-    def __init__(self, key):
-        self.prefix = "FAILURE TO GENERATE DATASET !"
-        self.err_msg = f"\nFound duplicate Key: {key}"
-        self.suffix = "\nKeys should be unique and deterministic in nature"
-        super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
+    def __init__(self, key, index=None, duplicate_key_indices=None):
+        if index and duplicate_key_indices:
+            self.prefix = f"Found multiple examples with duplicate key: {key}"
+            self.err_msg = f"\nThe following examples {' ,'.join(duplicate_key_indices)} have the same key {key} "
+            self.suffix = "\nPlease fix the dataset script at <Path to Dataset>"
+            super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
+        else:
+            self.prefix = "FAILURE TO GENERATE DATASET !"
+            self.err_msg = f"\nFound duplicate Key: {key}"
+            self.suffix = "\nKeys should be unique and deterministic in nature"
+            super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
 
 
 class KeyHasher:

--- a/src/datasets/keyhash.py
+++ b/src/datasets/keyhash.py
@@ -70,8 +70,8 @@ class InvalidKeyError(Exception):
 class DuplicatedKeysError(Exception):
     """Raise an error when duplicate key found."""
 
-    def __init__(self, key, index=None, duplicate_key_indices=None):
-        if index and duplicate_key_indices:
+    def __init__(self, key, duplicate_key_indices=None):
+        if duplicate_key_indices:
             self.prefix = f"Found multiple examples with duplicate key: {key}"
             self.err_msg = f"\nThe following examples {' ,'.join(duplicate_key_indices)} have the same key {key} "
             self.suffix = "\nPlease fix the dataset script at <Path to Dataset>"

--- a/src/datasets/keyhash.py
+++ b/src/datasets/keyhash.py
@@ -70,10 +70,16 @@ class InvalidKeyError(Exception):
 class DuplicatedKeysError(Exception):
     """Raise an error when duplicate key found."""
 
-    def __init__(self, key, duplicate_key_indices):
+    def __init__(self, key, duplicate_key_indices, fix_msg=""):
+        self.key = key
+        self.duplicate_key_indices = duplicate_key_indices
+        self.fix_msg = fix_msg
         self.prefix = "Found multiple examples generated with the same key"
-        self.err_msg = f"\nThe following examples {', '.join(duplicate_key_indices)} have the key {key}"
-        self.suffix = "\nTo avoid duplicate keys, please fix the dataset script at "
+        if len(duplicate_key_indices) <= 20:
+            self.err_msg = f"\nThe examples at index {', '.join(duplicate_key_indices)} have the key {key}"
+        else:
+            self.err_msg = f"\nThe examples at index {', '.join(duplicate_key_indices[:20])}... ({len(duplicate_key_indices) - 20} more) have the key {key}"
+        self.suffix = "\n" + fix_msg if fix_msg else ""
         super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
 
 

--- a/src/datasets/keyhash.py
+++ b/src/datasets/keyhash.py
@@ -70,17 +70,11 @@ class InvalidKeyError(Exception):
 class DuplicatedKeysError(Exception):
     """Raise an error when duplicate key found."""
 
-    def __init__(self, key, duplicate_key_indices=None):
-        if duplicate_key_indices:
-            self.prefix = f"Found multiple examples with duplicate key: {key}"
-            self.err_msg = f"\nThe following examples {' ,'.join(duplicate_key_indices)} have the same key {key} "
-            self.suffix = "\nPlease fix the dataset script at <Path to Dataset>"
-            super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
-        else:
-            self.prefix = "FAILURE TO GENERATE DATASET !"
-            self.err_msg = f"\nFound duplicate Key: {key}"
-            self.suffix = "\nKeys should be unique and deterministic in nature"
-            super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
+    def __init__(self, key, duplicate_key_indices):
+        self.prefix = f"Found multiple examples generated with the same key"
+        self.err_msg = f"\nThe following examples {', '.join(duplicate_key_indices)} have the key {key}"
+        self.suffix = "\nPlease fix the dataset script at <Path to Dataset> to avoid duplicate keys"
+        super().__init__(f"{self.prefix}{self.err_msg}{self.suffix}")
 
 
 class KeyHasher:


### PR DESCRIPTION
# What does this PR do?

## Summary

*DuplicateKeysError error does not provide any information regarding the examples which have the same the key.*

*This information is very helpful for debugging the dataset generator script.*

## Additions
-

## Changes
- Changed `DuplicateKeysError Class` in `src/datasets/keyhash.py` to add current index and duplicate_key_indices to error message.
- Changed `check_duplicate_keys` function in `src/datasets/arrow_writer.py` to find indices of examples with duplicate hash if duplicate keys are found.

## Deletions
-

## To do  : 
- [x] Find way to find and print path `<Path to Dataset>` in Error message 

## Issues Addressed : 

Fixes #2556  