### PR TITLE
[CI] fixing seqeval install in ci by pinning setuptools-scm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
             - run: pip install --upgrade pip
             - run: python -m venv venv
             - run: source venv/bin/activate
+            - run: echo "installing pinned version of setuptools-scm to fix seqeval installation on 3.6" && pip install "setuptools-scm==6.4.2"
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
@@ -31,6 +32,7 @@ jobs:
             - run: pip install --upgrade pip
             - run: python -m venv venv
             - run: source venv/bin/activate
+            - run: echo "installing pinned version of setuptools-scm to fix seqeval installation on 3.6" && pip install "setuptools-scm==6.4.2"
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==6.0.0

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ TESTS_REQUIRE = [
     "openpyxl",
     "py7zr",
     "tldextract",
-    "zstandard==0.17.0",  # pin for https://github.com/huggingface/datasets/issues/4544
+    "zstandard",
     "bigbench @ https://storage.googleapis.com/public_research_data/bigbench/bigbench-0.0.1.tar.gz",
     "sentencepiece",  # bigbench requires t5 which requires seqio which requires sentencepiece
     "sacremoses",
@@ -158,6 +158,7 @@ TESTS_REQUIRE = [
     "scipy",
     "sentencepiece",  # for bleurt
     "seqeval",
+    "setuptools-scm>=7.0.2",  # for seqeval, see https://github.com/huggingface/datasets/issues/4544
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ TESTS_REQUIRE = [
     "scipy",
     "sentencepiece",  # for bleurt
     "seqeval",
-    "setuptools-scm>=7.0.2",  # for seqeval, see https://github.com/huggingface/datasets/issues/4544
+    "setuptools-scm==6.4.2",  # for seqeval, see https://github.com/huggingface/datasets/issues/4544
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ TESTS_REQUIRE = [
     "openpyxl",
     "py7zr",
     "tldextract",
-    "zstandard",
+    "zstandard==0.17.0",  # pin for https://github.com/huggingface/datasets/issues/4544
     "bigbench @ https://storage.googleapis.com/public_research_data/bigbench/bigbench-0.0.1.tar.gz",
     "sentencepiece",  # bigbench requires t5 which requires seqio which requires sentencepiece
     "sacremoses",

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,6 @@ TESTS_REQUIRE = [
     "scikit-learn",
     "scipy",
     "sentencepiece",  # for bleurt
-    "setuptools-scm==6.4.2",  # for seqeval, see https://github.com/huggingface/datasets/issues/4544
     "seqeval",
     # to speed up pip backtracking
     "toml>=0.10.1",

--- a/setup.py
+++ b/setup.py
@@ -157,8 +157,8 @@ TESTS_REQUIRE = [
     "scikit-learn",
     "scipy",
     "sentencepiece",  # for bleurt
-    "seqeval",
     "setuptools-scm==6.4.2",  # for seqeval, see https://github.com/huggingface/datasets/issues/4544
+    "seqeval",
     # to speed up pip backtracking
     "toml>=0.10.1",
     "requests_file>=1.5.1",


### PR DESCRIPTION
The latest setuptools-scm version supported on 3.6 is 6.4.2. However for some reason circleci has version 7, which doesn't work.

I fixed this by pinning the version of setuptools-scm in the circleci job

Fix https://github.com/huggingface/datasets/issues/4544