### PR TITLE
Tell users to upload on the hub directly

### DIFF
--- a/ADD_NEW_DATASET.md
+++ b/ADD_NEW_DATASET.md
@@ -11,7 +11,7 @@ You can share your dataset on https://huggingface.co/datasets directly using you
 
 Datasets used to be hosted in this GitHub repository, but all datasets have now been migrated to the Hugging Face Hub.
 The legacy GitHub datasets were added originally on the GitHub repository and therefore don't have a namespace: "squad", "glue", etc. unlike the other datasets that are named "username/dataset_name" or "org/dataset_name".
-Those datasets are still maintained, and if you'd like to edit them, please open a Pull Request on the huggingface/datasets repository.
+Those datasets are still maintained on GitHub, and if you'd like to edit them, please open a Pull Request on the huggingface/datasets repository.
 
 Sharing your dataset to the Hub is the recommended way of adding a dataset.
 

--- a/ADD_NEW_DATASET.md
+++ b/ADD_NEW_DATASET.md
@@ -1,6 +1,27 @@
 # How to add one (or several) new datasets to 🤗 Datasets
 
-## Start by preparing your environment
+ADD DATASETS DIRECTLY ON THE 🤗 HUGGING FACE HUB !
+
+You can share your dataset on https://huggingface.co/datasets directly using your account, see the documentation:
+
+* [Create a dataset and upload files](https://huggingface.co/docs/datasets/upload_dataset)
+* [Advanced guide using dataset scripts](https://huggingface.co/docs/datasets/share)
+
+## What about the datasets scripts in this GitHub repository then ?
+
+Datasets used to be hosted in this GitHub repository, but all datasets have now been migrated to the Hugging Face Hub.
+The legacy GitHub datasets were added originally on the GitHub repository and therefore don't have a namespace: "squad", "glue", etc. unlike the other datasets that are named "username/dataset_name" or "org/dataset_name".
+Those datasets are still maintained, and if you'd like to edit them, please open a Pull Request on the huggingface/datasets repository.
+
+Sharing your dataset to the Hub is the recommended way of adding a dataset.
+
+In some rare cases it makes more sense to open a PR on GitHub. For example when you are not the author of the dataset and there is no clear organization / namespace that you can put the dataset under.
+
+The following presents how to open a Pull Request on GitHub to add a new dataset to this repository.
+
+## Add a new dataset to this repository (legacy)
+
+### Start by preparing your environment
 
 1. Fork the [repository](https://github.com/huggingface/datasets) by clicking on the 'Fork' button on the repository's page.
 This creates a copy of the code under your GitHub user account.
@@ -29,9 +50,9 @@ This creates a copy of the code under your GitHub user account.
 
 Now you are ready, each time you want to add a new dataset, follow the steps in the following section:
 
-## Adding a new dataset
+### Adding a new dataset
 
-### Understand the structure of the dataset
+#### Understand the structure of the dataset
 
 1. Find a short-name for the dataset:
 
@@ -82,7 +103,7 @@ You are now ready to start the process of adding the dataset. We will create the
 		Don't spend too much time completing the dataset card, just copy what you find when exploring the dataset documentation. If you can't find all the information it's ok. You can always spend more time completing the dataset card while we are reviewing your PR (see below) and the dataset card will be open for everybody to complete them afterwards. If you don't know what to write in a section, just leave the `[More Information Needed]` text.
 
 
-### Write the loading/processing code
+#### Write the loading/processing code
 
 Now let's get coding :-)
 
@@ -155,7 +176,7 @@ datasets-cli test datasets/<your-dataset-folder> --save_infos --all_configs --da
 ```
 To have the configs use the path from `--data_dir` when generating them.
 
-### Automatically add code metadata
+#### Automatically add code metadata
 
 Now that your dataset script runs and create a dataset with the format you expected, you can add the JSON metadata and test data.
 
@@ -222,7 +243,7 @@ Note: You can use the CLI tool from the root of the repository with the followin
 python src/datasets/commands/datasets_cli.py <command>
 ```
 
-### Open a Pull Request on the main HuggingFace repo and share your work!!
+#### Open a Pull Request on the main HuggingFace repo and share your work!!
 
 Here are the step to open the Pull-Request on the main repo.
 
@@ -291,7 +312,7 @@ Congratulation you have open a PR to add a new dataset 🙏
 
 **Important note:** In order to merge your Pull Request the maintainers will require you to tag and add a dataset card. Here is now how to do this last step:
 
-### Tag the dataset and write the dataset card
+#### Tag the dataset and write the dataset card
 
 Each dataset is provided with a dataset card.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,79 +86,22 @@ If you would like to work on any of the open Issues:
 
 ## How to add a dataset
 
-A [more complete guide](https://github.com/huggingface/datasets/blob/master/ADD_NEW_DATASET.md) to adding a dataset was written for our December 2020 `datasets` sprint, we recommend reading through it before you start the process. Here is a summary of the steps described there:
+You can share your dataset on https://huggingface.co/datasets directly using your account, see the documentation:
 
-1. Make sure you followed steps 1-4 of the section [*How to contribute to datasets?*](#how-to-contribute-to-datasets).
-
-2. Create your dataset folder under `datasets/<your_dataset_name>` and create your dataset script under `datasets/<your_dataset_name>/<your_dataset_name>.py`. You can check out other dataset scripts under `datasets` for some inspiration. Note on naming: the dataset class should be camel case, while the dataset name is its snake case equivalent (ex: `class BookCorpus(datasets.GeneratorBasedBuilder)` for the dataset `book_corpus`).
-
-3. **Make sure you run all of the following commands from the root of your `datasets` git clone.** To check that your dataset works correctly and to create its `dataset_infos.json` file run the command:
-
-	```bash
-	datasets-cli test datasets/<your-dataset-folder> --save_infos --all_configs
-	```
-
-4. If the command was succesful, you should now create some dummy data. Use the following command to get in-detail instructions on how to create the dummy data:
-
-	```bash
-	datasets-cli dummy_data datasets/<your-dataset-folder>
-	```
-
-	There is a tool that automatically generates dummy data for you. At the moment it supports data files in the following format: txt, csv, tsv, jsonl, json, xml.
-	If the extensions of the raw data files of your dataset are in this list, then you can automatically generate your dummy data with:
-
-	```bash
-	datasets-cli dummy_data datasets/<your-dataset-folder> --auto_generate
-	```
-
-5. Now test that both the real data and the dummy data work correctly using the following commands:
-
-	*For the real data*:
-	```bash
-	RUN_SLOW=1 pytest tests/test_dataset_common.py::LocalDatasetTest::test_load_real_dataset_<your-dataset-name>
-	```
-	and
-
-	*For the dummy data*:
-	```bash
-	RUN_SLOW=1 pytest tests/test_dataset_common.py::LocalDatasetTest::test_load_dataset_all_configs_<your-dataset-name>
-	```
-
-6. Finally, take some time to document your dataset for other users. Each dataset should be accompanied by a `README.md` dataset card in its directory which describes the data and contains tags representing languages and tasks supported to be easily discoverable. You can find information on how to fill out the card either manually or by using our [web app](https://huggingface.co/datasets/card-creator/) in the following [guide](https://github.com/huggingface/datasets/blob/master/templates/README_guide.md).
-
-7. If all tests pass, your dataset works correctly. Awesome! You can now follow steps 6, 7 and 8 of the section [*How to contribute to 🤗 Datasets?*](#how-to-contribute-to-Datasets). If you experience problems with the dummy data tests, you might want to take a look at the section *Help for dummy data tests* below.
-
-
-
-### Help for dummy data tests
-
-Follow these steps in case the dummy data test keeps failing:
-
-- Verify that all filenames are spelled correctly. Rerun the command
-	```bash
-	datasets-cli dummy_data datasets/<your-dataset-folder>
-	```
-	and make sure you follow the exact instructions provided by the command of step 5).
-
-- Your datascript might require a difficult dummy data structure. In this case make sure you fully understand the data folder logit created by the function `_split_generators(...)` and expected by the function `_generate_examples(...)` of your dataset script. Also take a look at `tests/README.md` which lists different possible cases of how the dummy data should be created.
-
-- If the dummy data tests still fail, open a PR in the repo anyways and make a remark in the description that you need help creating the dummy data.
-
-If you're looking for more details about dataset scripts creation, please refer to the [documentation](https://huggingface.co/docs/datasets/master/dataset_script).
-
-Note: You can use the CLI tool from the root of the repository with the following command:
-```bash
-python src/datasets/commands/datasets_cli.py <command>
-```
+* [Create a dataset and upload files](https://huggingface.co/docs/datasets/upload_dataset)
+* [Advanced guide using dataset scripts](https://huggingface.co/docs/datasets/share)
 
 ## How to contribute to the dataset cards
 
 Improving the documentation of datasets is an ever increasing effort and we invite users to contribute by sharing their insights with the community in the `README.md` dataset cards provided for each dataset.
 
-If you see that a dataset card is missing information that you are in a position to provide (as an author of the dataset or as an experienced user), the best thing you can do is to open a Pull Request with the updated `README.md` file. We provide:
-- a [template](https://github.com/huggingface/datasets/blob/master/templates/README.md)
-- a [guide](https://github.com/huggingface/datasets/blob/master/templates/README_guide.md) describing what information should go into each of the paragraphs
-- and if you need inspiration, we recommend looking through a [completed example](https://github.com/huggingface/datasets/blob/master/datasets/eli5/README.md)
+If you see that a dataset card is missing information that you are in a position to provide (as an author of the dataset or as an experienced user), the best thing you can do is to open a Pull Request on the Hugging Face Hub. To to do, go to the "Files and versions" tab of the dataset page and edit the `README.md` file. We provide:
+
+* a [template](https://github.com/huggingface/datasets/blob/master/templates/README.md)
+* a [guide](https://github.com/huggingface/datasets/blob/master/templates/README_guide.md) describing what information should go into each of the paragraphs
+* and if you need inspiration, we recommend looking through a [completed example](https://github.com/huggingface/datasets/blob/master/datasets/eli5/README.md)
+
+Note that datasets that are outside of a namespace (`squad`, `imagenet-1k`, etc.) are maintained on GitHub. In this case you have to open a Pull request on GitHub to edit the file at `datasets/<dataset-name>/README.md`.
 
 If you are a **dataset author**... you know what to do, it is your dataset after all ;) ! We would especially appreciate if you could help us fill in information about the process of creating the dataset, and take a moment to reflect on its social impact and possible limitations if you haven't already done so in the dataset paper or in another data statement.
 
@@ -170,5 +113,5 @@ Thank you for your contribution!
 
 ## Code of conduct
 
-This project adheres to the HuggingFace [code of conduct](CODE_OF_CONDUCT.md). 
+This project adheres to the HuggingFace [code of conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.

--- a/docs/source/dataset_script.mdx
+++ b/docs/source/dataset_script.mdx
@@ -6,6 +6,12 @@ The script can download data files from any website, or from the same dataset re
 
 Any dataset script, for example `my_dataset.py`, can be placed in a folder or a repository named `my_dataset` and be loaded with:
 
+```
+my_dataset/
+├── README.md
+└── my_dataset.py
+```
+
 ```py
 >>> from datasets import load_dataset
 >>> load_dataset("path/to/my_dataset")
@@ -20,7 +26,7 @@ The following guide includes instructions for dataset scripts for how to:
 - Create a Dataset card.
 - Upload a dataset to the Hugging Face Hub or GitHub.
 
-Open the [SQuAD dataset loading script](https://github.com/huggingface/datasets/blob/master/datasets/squad/squad.py) template to follow along on how to share a dataset.
+Open the [SQuAD dataset loading script](https://huggingface.co/datasets/squad/blob/main/squad.py) template to follow along on how to share a dataset.
 
 <Tip>
 
@@ -277,14 +283,11 @@ Make sure you run all of the following commands **from the root** of your local 
 1. Run the following command to create the metadata file, `dataset_infos.json`. This will also test your new dataset loading script and make sure it works correctly.
 
 ```
-datasets-cli test datasets/<your-dataset-folder> --save_infos --all_configs
+datasets-cli test path/to/<your-dataset-folder> --save_infos --all_configs
 ```
 
 2. If your dataset loading script passed the test, you should now have a `dataset_infos.json` file in your dataset folder. This file contains information about the dataset, like its `features` and `download_size`.
 
-### (Optional) Dummy data
-
-If you want to be able to test your dataset script without downloading the full dataset, you need to create some dummy data for automated testing. There are two methods for generating dummy data: automatically and manually. 
 
 #### Automatic
 
@@ -341,19 +344,13 @@ There should be two new files in your dataset folder:
 
 - `dummy_data.zip` is a file used to test the behavior of the loading script without having to download the full dataset.
 
+## Upload to the Hub
 
-#### Run the tests
+Once your script is ready, you can [create a dataset card](dataset_card) and [upload it to the Hub](share).
 
-The last step is to actually test dataset generation with the real and dummy data. Clone the `huggingface/datasets` repository and run the following command to test the real data:
+Congrats ! you can now load your dataset using
 
+```py
+>>> from datasets import load_dataset
+>>> load_dataset("<username>/my_dataset")
 ```
-RUN_SLOW=1 pytest tests/test_dataset_common.py::LocalDatasetTest::test_load_real_dataset_<your_dataset_name>
-```
-
-Test the dummy data:
-
-```
-RUN_SLOW=1 pytest tests/test_dataset_common.py::LocalDatasetTest::test_load_dataset_all_configs_<your_dataset_name>
-```
-
-If both tests pass, your dataset was generated correctly!

--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -119,6 +119,30 @@ Congratulations, your dataset has now been uploaded to the Hugging Face Hub wher
 dataset = load_dataset("namespace/your_dataset_name")
 ```
 
+### Ask for a help and reviews
+
+If you need help with a dataset script, feel free to check the [datasets forum](https://discuss.huggingface.co/c/datasets/10): it's possible that someone had similar issues and shared how they managed to fix them.
+
+Then if your script is ready and if you wish your dataset script to be reviewed by the Hugging Face team, you can open a discussion in the Community tab of your dataset with this message:
+
+```
+# Dataset rewiew request for <Dataset name>
+
+## Description
+
+<brief description of the dataset>
+
+## Files to review
+
+- file1
+- file2
+- ...
+
+cc @lhoestq @polinaeterna @mariosasko @albertvillanova
+```
+
+Members of the Hugging Face team will be happy to review your dataset script and give you advice.
+
 ## Datasets on GitHub (legacy)
 
 Datasets used to be hosted on our GitHub repository, but all datasets have now been migrated to the Hugging Face Hub.
@@ -134,10 +158,6 @@ The distinction between a Hub dataset and a dataset from GitHub only comes from 
 
 The code of these datasets are reviewed by the Hugging Face team, and they require test data in order to be regularly tested.
 
-In some cases it makes more sense to open a PR on GitHub:
-
-- when you need the dataset to be reviewed
-- when you need long-term maintenance from the Hugging Face team
-- when there's no clear org name / namespace that you can put the dataset under
+In some rare cases it makes more sense to open a PR on GitHub. For example when you are not the author of the dataset and there is no clear organization / namespace that you can put the dataset under.
 
 For more info, please take a look at the documentation on [How to add a new dataset in the huggingface/datasets repository](https://github.com/huggingface/datasets/blob/master/ADD_NEW_DATASET.md).

--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -147,7 +147,7 @@ Members of the Hugging Face team will be happy to review your dataset script and
 
 Datasets used to be hosted on our GitHub repository, but all datasets have now been migrated to the Hugging Face Hub.
 The legacy GitHub datasets were added originally on our GitHub repository and therefore don't have a namespace: "squad", "glue", etc. unlike the other datasets that are named "username/dataset_name" or "org/dataset_name".
-Those datasets are still maintained, and if you'd like to edit them, please open a Pull Request on the huggingface/datasets repository.
+Those datasets are still maintained on GitHub, and if you'd like to edit them, please open a Pull Request on the huggingface/datasets repository.
 Sharing your dataset to the Hub is the recommended way of adding a dataset.
 
 <Tip>


### PR DESCRIPTION
As noted in https://github.com/huggingface/datasets/pull/4534, it is still not clear that it is recommended to add datasets on the Hugging Face Hub directly instead of GitHub, so I updated some docs.

Moreover since users won't be able to get reviews from us on the Hub, I added a paragraph to tell users that they can open a discussion and tag `datasets` maintainers for reviews.

Finally I removed the _previous good reasons_ to add a dataset on GitHub to only keep this one:

> In some rare cases it makes more sense to open a PR on GitHub. For example when you are not the author of the dataset and there is no clear organization / namespace that you can put the dataset under.

Does it sound good to you @albertvillanova @julien-c ?