### PR TITLE
Add evaluation metadata to wmt16

### DIFF
--- a/datasets/wmt16/README.md
+++ b/datasets/wmt16/README.md
@@ -6,6 +6,15 @@ multilinguality:
 task_categories:
 - translation
 task_ids: []
+train-eval-index:
+- config: de-en
+  task: translation
+  task_id: translation
+  splits:
+    eval_split: test
+  col_mapping:
+    translation.de: source
+    translation.en: target
 ---
 
 # Dataset Card for "wmt16"


### PR DESCRIPTION
Just to confirm: we should add this metadata via GitHub and not Hub PRs for canonical datasets right?