### PR TITLE
Fix evaluation metadata for ncbi_disease

### DIFF
--- a/datasets/ncbi_disease/README.md
+++ b/datasets/ncbi_disease/README.md
@@ -22,52 +22,13 @@ pretty_name: NCBI Disease
 train-eval-index:
 - config: ncbi_disease
   task: token-classification
-  task_id: multi_class_classification
+  task_id: entity_extraction
   splits:
     train_split: train
     eval_split: test
   col_mapping:
-    tokens: text
-    ner_tags: target
-  metrics:
-    - type: accuracy
-      name: Accuracy
-    - type: f1
-      name: F1 macro
-      args:
-        average: macro
-    - type: f1
-      name: F1 micro
-      args:
-        average: micro
-    - type: f1
-      name: F1 weighted
-      args:
-        average: weighted
-    - type: precision
-      name: Precision macro
-      args:
-        average: macro
-    - type: precision
-      name: Precision micro
-      args:
-        average: micro
-    - type: precision
-      name: Precision weighted
-      args:
-        average: weighted
-    - type: recall
-      name: Recall macro
-      args:
-        average: macro
-    - type: recall
-      name: Recall micro
-      args:
-        average: micro
-    - type: recall
-      name: Recall weighted
-      args:
-        average: weighted
+    tokens: tokens
+    ner_tags: ner_tags
 ---
 
 # Dataset Card for NCBI Disease


### PR DESCRIPTION
This PR fixes the task in the evaluation metadata and removes the metrics info as we've decided this is not a great way to propagate this information downstream.