### PR TITLE
Include `metadata.jsonl` in resolved data files

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -48,6 +48,7 @@ ALL_DEFAULT_PATTERNS = [
     DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME,
     DEFAULT_PATTERNS_ALL,
 ]
+METADATA_PATTERN = "metadata.jsonl"  # metadata file for ImageFolder and AudioFolder
 WILDCARD_CHARACTERS = "*[]"
 FILES_TO_IGNORE = ["README.md", "config.json", "dataset_infos.json", "dummy_data.zip", "dataset_dict.json"]
 
@@ -103,7 +104,19 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], List[PurePath]]) 
             except FileNotFoundError:
                 pass
         if non_empty_splits:
-            return {split: patterns_dict[split] for split in non_empty_splits}
+            include_metadata_pattern = False
+            if patterns_dict != DEFAULT_PATTERNS_ALL:
+                try:
+                    pattern_resolver(METADATA_PATTERN)
+                except FileNotFoundError:
+                    pass
+                else:
+                    include_metadata_pattern = True
+
+            return {
+                split: patterns_dict[split] + [METADATA_PATTERN] if include_metadata_pattern else patterns_dict[split]
+                for split in non_empty_splits
+            }
     raise FileNotFoundError(f"Couldn't resolve pattern {pattern} with resolver {pattern_resolver}")
 
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -48,7 +48,7 @@ ALL_DEFAULT_PATTERNS = [
     DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME,
     DEFAULT_PATTERNS_ALL,
 ]
-METADATA_PATTERN = "metadata.jsonl"  # metadata file for ImageFolder and AudioFolder
+METADATA_PATTERNS = ["metadata.jsonl", "**/metadata.jsonl"]  # metadata file for ImageFolder and AudioFolder
 WILDCARD_CHARACTERS = "*[]"
 FILES_TO_IGNORE = ["README.md", "config.json", "dataset_infos.json", "dummy_data.zip", "dataset_dict.json"]
 
@@ -83,6 +83,8 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], List[PurePath]]) 
 
     In order, it first tests if SPLIT_PATTERN_SHARDED works, otherwise it tests the patterns in ALL_DEFAULT_PATTERNS.
     """
+    from .packaged_modules import _EXTENSION_WITH_OPTIONAL_METADATA
+
     # first check the split patterns like data/{split}-00000-of-00001.parquet
     for split_pattern in ALL_SPLIT_PATTERNS:
         pattern = split_pattern.replace("{split}", "*")
@@ -94,27 +96,40 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], List[PurePath]]) 
     # then check the default patterns based on train/valid/test splits
     for patterns_dict in ALL_DEFAULT_PATTERNS:
         non_empty_splits = []
+        include_metadata_pattern_if_non_empty = False
+        data_files_support_metadata = True
+        # check if the current pattern is eligible for the metadata pattern check
+        if patterns_dict != DEFAULT_PATTERNS_ALL:
+            for pattern in METADATA_PATTERNS:
+                try:
+                    pattern_resolver(pattern)
+                except FileNotFoundError:
+                    pass
+                else:
+                    include_metadata_pattern_if_non_empty = True
+                    break
         for split, patterns in patterns_dict.items():
             try:
                 for pattern in patterns:
                     data_files = pattern_resolver(pattern)
                     if len(data_files) > 0:
                         non_empty_splits.append(split)
+                        # check if data files support metadata
+                        # (if the current pattern supports them and metadata files are present)
+                        if include_metadata_pattern_if_non_empty and data_files_support_metadata:
+                            for data_file in data_files:
+                                _, ext = os.path.splitext(data_file)
+                                if ext[1:] in _EXTENSION_WITH_OPTIONAL_METADATA:
+                                    break
+                            else:
+                                data_files_support_metadata = False
                         break
             except FileNotFoundError:
                 pass
         if non_empty_splits:
-            include_metadata_pattern = False
-            if patterns_dict != DEFAULT_PATTERNS_ALL:
-                try:
-                    pattern_resolver(METADATA_PATTERN)
-                except FileNotFoundError:
-                    pass
-                else:
-                    include_metadata_pattern = True
-
+            include_metadata_pattern = include_metadata_pattern_if_non_empty and data_files_support_metadata
             return {
-                split: patterns_dict[split] + [METADATA_PATTERN] if include_metadata_pattern else patterns_dict[split]
+                split: patterns_dict[split] + METADATA_PATTERNS if include_metadata_pattern else patterns_dict[split]
                 for split in non_empty_splits
             }
     raise FileNotFoundError(f"Couldn't resolve pattern {pattern} with resolver {pattern_resolver}")

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -120,7 +120,9 @@ def _get_metadata_files_patterns(pattern_resolver: Callable[[str], List[PurePath
                 non_empty_patterns.append(pattern)
         except FileNotFoundError:
             pass
-    return non_empty_patterns
+    if non_empty_patterns:
+        return non_empty_patterns
+    raise FileNotFoundError(f"Couldn't resolve pattern {pattern} with resolver {pattern_resolver}")
 
 
 def _resolve_single_pattern_locally(

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -44,3 +44,5 @@ _EXTENSION_TO_MODULE = {
 }
 _EXTENSION_TO_MODULE.update({ext[1:]: ("imagefolder", {}) for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext[1:].upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS})
+
+_MODULE_SUPPORTS_METADATA = {"imagefolder"}

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -44,3 +44,6 @@ _EXTENSION_TO_MODULE = {
 }
 _EXTENSION_TO_MODULE.update({ext[1:]: ("imagefolder", {}) for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext[1:].upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS})
+
+_EXTENSION_WITH_OPTIONAL_METADATA = {ext[1:] for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS}
+_EXTENSION_WITH_OPTIONAL_METADATA |= {ext[1:].upper() for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS}

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -44,6 +44,3 @@ _EXTENSION_TO_MODULE = {
 }
 _EXTENSION_TO_MODULE.update({ext[1:]: ("imagefolder", {}) for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext[1:].upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS})
-
-_EXTENSION_WITH_OPTIONAL_METADATA = {ext[1:] for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS}
-_EXTENSION_WITH_OPTIONAL_METADATA |= {ext[1:].upper() for ext in imagefolder.ImageFolder.IMAGE_EXTENSIONS}

--- a/src/datasets/packaged_modules/imagefolder/imagefolder.py
+++ b/src/datasets/packaged_modules/imagefolder/imagefolder.py
@@ -70,7 +70,7 @@ class ImageFolder(datasets.GeneratorBasedBuilder):
         do_analyze = (self.config.features is None and not self.config.drop_labels) or not self.config.drop_metadata
         if do_analyze:
             labels = set()
-            metadata_files = collections.defaultdict(list)
+            metadata_files = collections.defaultdict(set)
 
             def analyze(files_or_archives, downloaded_files_or_dirs, split):
                 if len(downloaded_files_or_dirs) == 0:
@@ -85,7 +85,7 @@ class ImageFolder(datasets.GeneratorBasedBuilder):
                         if original_file_ext.lower() in self.IMAGE_EXTENSIONS:
                             labels.add(os.path.basename(os.path.dirname(original_file)))
                         elif os.path.basename(original_file) == self.METADATA_FILENAME:
-                            metadata_files[split].append((original_file, downloaded_file))
+                            metadata_files[split].add((original_file, downloaded_file))
                         else:
                             original_file_name = os.path.basename(original_file)
                             logger.debug(
@@ -100,7 +100,7 @@ class ImageFolder(datasets.GeneratorBasedBuilder):
                             if downloaded_dir_file_ext in self.IMAGE_EXTENSIONS:
                                 labels.add(os.path.basename(os.path.dirname(downloaded_dir_file)))
                             elif os.path.basename(downloaded_dir_file) == self.METADATA_FILENAME:
-                                metadata_files[split].append((None, downloaded_dir_file))
+                                metadata_files[split].add((None, downloaded_dir_file))
                             else:
                                 archive_file_name = os.path.basename(archive)
                                 original_file_name = os.path.basename(downloaded_dir_file)

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -106,13 +106,13 @@ def data_files_with_two_splits_and_metadata(tmp_path, image_file):
     )
     with open(train_image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
-    train_image_metadata_filename = test_dir / "metadata.jsonl"
+    test_image_metadata_filename = test_dir / "metadata.jsonl"
     image_metadata = textwrap.dedent(
         """\
         {"file_name": "image_rgb3.jpg", "caption": "Nice test image"}
         """
     )
-    with open(train_image_metadata_filename, "w", encoding="utf-8") as f:
+    with open(test_image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
     data_files_with_two_splits_and_metadata = DataFilesDict.from_local_or_remote(
         get_data_patterns_locally(data_dir), data_dir

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -51,7 +51,7 @@ def image_files_with_metadata_that_misses_one_image(tmp_path, image_file):
 
 @pytest.fixture
 def data_files_with_one_split_and_metadata(tmp_path, image_file):
-    data_dir = tmp_path / "imagefolder_data_dir_with_metadata"
+    data_dir = tmp_path / "imagefolder_data_dir_with_metadata_one_split"
     data_dir.mkdir(parents=True, exist_ok=True)
     subdir = data_dir / "subdir"
     subdir.mkdir(parents=True, exist_ok=True)
@@ -83,7 +83,7 @@ def data_files_with_one_split_and_metadata(tmp_path, image_file):
 
 @pytest.fixture
 def data_files_with_two_splits_and_metadata(tmp_path, image_file):
-    data_dir = tmp_path / "imagefolder_data_dir_with_metadata"
+    data_dir = tmp_path / "imagefolder_data_dir_with_metadata_two_splits"
     data_dir.mkdir(parents=True, exist_ok=True)
     train_dir = data_dir / "train"
     train_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from datasets import Features, Image, Value
-from datasets.data_files import DataFilesDict, get_patterns_locally
+from datasets.data_files import DataFilesDict, get_data_patterns_locally
 from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder
 from datasets.streaming import extend_module_for_streaming
 
@@ -74,7 +74,7 @@ def data_files_with_one_split_and_metadata(tmp_path, image_file):
     with open(image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
     data_files_with_one_split_and_metadata = DataFilesDict.from_local_or_remote(
-        get_patterns_locally(data_dir), data_dir
+        get_data_patterns_locally(data_dir), data_dir
     )
     assert len(data_files_with_one_split_and_metadata) == 1
     assert len(data_files_with_one_split_and_metadata["train"]) == 4
@@ -115,7 +115,7 @@ def data_files_with_two_splits_and_metadata(tmp_path, image_file):
     with open(train_image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
     data_files_with_two_splits_and_metadata = DataFilesDict.from_local_or_remote(
-        get_patterns_locally(data_dir), data_dir
+        get_data_patterns_locally(data_dir), data_dir
     )
     assert len(data_files_with_two_splits_and_metadata) == 2
     assert len(data_files_with_two_splits_and_metadata["train"]) == 3
@@ -154,7 +154,7 @@ def data_files_with_zip_archives(tmp_path, image_file):
     shutil.make_archive(archive_dir, "zip", archive_dir)
     shutil.rmtree(str(archive_dir))
 
-    data_files_with_zip_archives = DataFilesDict.from_local_or_remote(get_patterns_locally(data_dir), data_dir)
+    data_files_with_zip_archives = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
 
     assert len(data_files_with_zip_archives) == 1
     assert len(data_files_with_zip_archives["train"]) == 1
@@ -305,7 +305,7 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, image_fil
     with open(image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
     imagefolder = ImageFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     imagefolder.download_and_prepare()
     dataset = imagefolder.as_dataset(split="train")
@@ -327,7 +327,7 @@ def test_data_files_with_wrong_image_file_name_column_in_metadata_file(cache_dir
     with open(image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
     imagefolder = ImageFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     with pytest.raises(ValueError) as exc_info:
         imagefolder.download_and_prepare()

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -377,12 +377,6 @@ def test_DataFilesDict_from_hf_local_or_remote_hashing(text_file):
             "test": "data/test.txt",
             "validation": "data/valid.txt",
         },
-        # file named after split in a directory + metadata file
-        {
-            "train": ["data/train.jpg", "data/metadata.jsonl"],
-            "test": ["data/test.jpg", "data/metadata.jsonl"],
-            "validation": ["data/valid.jpg", "data/metadata.jsonl"],
-        },
         # directory named after split
         {
             "train": "train/split.txt",
@@ -438,10 +432,6 @@ def test_get_data_files_patterns(data_file_per_split):
     patterns_per_split = _get_data_files_patterns(resolver)
     assert sorted(patterns_per_split.keys()) == sorted(data_file_per_split.keys())
     for split, patterns in patterns_per_split.items():
-        # remove extra metadata pattern to avoid an error due to the difference
-        # in behavior of fsspec's glob and pathlib's match
-        if "**/metadata.jsonl" in patterns:
-            patterns.remove("**/metadata.jsonl")
         matched = [
             path
             for path in set(chain(*data_file_per_split.values()))

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -367,11 +367,6 @@ def test_DataFilesDict_from_hf_local_or_remote_hashing(text_file):
         # === Main cases ===
         # file named after split at the root
         {"train": "train.txt", "test": "test.txt", "validation": "valid.txt"},
-        # # file named after split and metadata file at the root
-        # {
-        #     "train": ["train.jpg", "metadata.jsonl"],
-        #     "test": ["test.jpg", "metadata.jsonl"],
-        # },
         # file named after split in a directory
         {
             "train": "data/train.txt",

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -377,6 +377,12 @@ def test_DataFilesDict_from_hf_local_or_remote_hashing(text_file):
             "test": "data/test.txt",
             "validation": "data/valid.txt",
         },
+        # file named after split in a directory + metadata file
+        {
+            "train": ["data/train.jpg", "data/metadata.jsonl"],
+            "test": ["data/test.jpg", "data/metadata.jsonl"],
+            "validation": ["data/valid.jpg", "data/metadata.jsonl"],
+        },
         # directory named after split
         {
             "train": "train/split.txt",
@@ -432,6 +438,10 @@ def test_get_data_files_patterns(data_file_per_split):
     patterns_per_split = _get_data_files_patterns(resolver)
     assert sorted(patterns_per_split.keys()) == sorted(data_file_per_split.keys())
     for split, patterns in patterns_per_split.items():
+        # remove extra metadata pattern to avoid an error due to the difference
+        # in behavior of fsspec's glob and pathlib's match
+        if "**/metadata.jsonl" in patterns:
+            patterns.remove("**/metadata.jsonl")
         matched = [
             path
             for path in set(chain(*data_file_per_split.values()))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -374,9 +374,11 @@ class ModuleFactoryTest(TestCase):
             self._data_dir_with_metadata
         )
         assert any(
-            data_file == "metadata.jsonl" for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
+            data_file.name == "metadata.jsonl"
+            for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
         ) and any(
-            data_file == "metadata.jsonl" for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
+            data_file.name == "metadata.jsonl"
+            for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )
 
     def test_HubDatasetModuleFactoryWithoutScript(self):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -332,7 +332,8 @@ class ModuleFactoryTest(TestCase):
         assert any(
             data_file.name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
-        ) and any(
+        )
+        assert any(
             data_file.name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -77,7 +77,7 @@ SAMPLE_DATASET_IDENTIFIER = "lhoestq/test"  # has dataset script
 SAMPLE_DATASET_IDENTIFIER2 = "lhoestq/test2"  # only has data files
 SAMPLE_DATASET_IDENTIFIER3 = "mariosasko/test_multi_dir_dataset"  # has multiple data directories
 SAMPLE_DATASET_IDENTIFIER4 = (
-    "mariosasko/test_imagefolder_with_metadata"  # imagefolder with a metadata file outside of it
+    "mariosasko/test_imagefolder_with_metadata"  # imagefolder with a metadata file outside of the train/test directories
 )
 SAMPLE_NOT_EXISTING_DATASET_IDENTIFIER = "lhoestq/_dummy"
 SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST = "_dummy"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -423,7 +423,8 @@ class ModuleFactoryTest(TestCase):
         assert any(
             Path(data_file).name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
-        ) and any(
+        )
+        assert any(
             Path(data_file).name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -376,7 +376,8 @@ class ModuleFactoryTest(TestCase):
         assert any(
             data_file.name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
-        ) and any(
+        )
+        assert any(
             data_file.name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -76,9 +76,7 @@ class __DummyDataset1__(datasets.GeneratorBasedBuilder):
 SAMPLE_DATASET_IDENTIFIER = "lhoestq/test"  # has dataset script
 SAMPLE_DATASET_IDENTIFIER2 = "lhoestq/test2"  # only has data files
 SAMPLE_DATASET_IDENTIFIER3 = "mariosasko/test_multi_dir_dataset"  # has multiple data directories
-SAMPLE_DATASET_IDENTIFIER4 = (
-    "mariosasko/test_imagefolder_with_metadata"  # imagefolder with a metadata file outside of the train/test directories
-)
+SAMPLE_DATASET_IDENTIFIER4 = "mariosasko/test_imagefolder_with_metadata"  # imagefolder with a metadata file outside of the train/test directories
 SAMPLE_NOT_EXISTING_DATASET_IDENTIFIER = "lhoestq/_dummy"
 SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST = "_dummy"
 


### PR DESCRIPTION
Include `metadata.jsonl` in resolved data files.

Fix #4548 

@lhoestq ~~https://github.com/huggingface/datasets/commit/d94336d30eef17fc9abc67f67fa1c139661f4e75 adds support for metadata files placed at the root, and https://github.com/huggingface/datasets/commit/4d20618ea7a19bc143ddc5fdff9d79e671fcbb95 accounts for nested metadata files also, but this results in more complex code. Let me know which one of these two approaches you prefer.~~ Maybe https://github.com/huggingface/datasets/commit/d94336d30eef17fc9abc67f67fa1c139661f4e75 is good enough for now (for the sake of simplicity). https://github.com/huggingface/datasets/commit/4d20618ea7a19bc143ddc5fdff9d79e671fcbb95 breaks the imagefolder tests due to duplicates in the resolved metadata files. One way to fix this would be to resolve the metadata pattern only on parent directories, but this adds even more logic to `_get_data_files_patterns`, so not sure if this is what we should do.