### PR TITLE
add_column should preserve _indexes

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -650,11 +650,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         info: Optional[DatasetInfo] = None,
         split: Optional[NamedSplit] = None,
         indices_table: Optional[Table] = None,
+        indexes: Optional[dict] = None,
         fingerprint: Optional[str] = None,
     ):
         info = info.copy() if info is not None else DatasetInfo()
         DatasetInfoMixin.__init__(self, info=info, split=split)
-        IndexableMixin.__init__(self)
+        IndexableMixin.__init__(self, indexes=indexes)
 
         self._data: Table = _check_table(arrow_table)
         self._indices: Optional[Table] = _check_table(indices_table) if indices_table is not None else None
@@ -4393,7 +4394,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         info = dataset.info.copy()
         info.features.update(Features.from_arrow_schema(column_table.schema))
         table = update_metadata_with_features(table, info.features)
-        return Dataset(table, info=info, split=self.split, indices_table=None, fingerprint=new_fingerprint)
+        return Dataset(
+            table, info=info, split=self.split, indices_table=None, indexes=self._indexes, fingerprint=new_fingerprint
+        )
 
     def add_faiss_index(
         self,

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -405,8 +405,8 @@ class FaissIndex(BaseIndex):
 class IndexableMixin:
     """Add indexing features to `datasets.Dataset`"""
 
-    def __init__(self):
-        self._indexes: Dict[str, BaseIndex] = {}
+    def __init__(self, indexes: Optional[Dict[str, BaseIndex]]):
+        self._indexes = {} if indexes is None else indexes
 
     def __len__(self):
         raise NotImplementedError

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2723,6 +2723,10 @@ def test_dataset_add_column(column, expected_dtype, in_memory, transform, datase
         expected_dataset_indices = original_dataset._indices["indices"].to_pylist()
         assert dataset_indices == expected_dataset_indices
     assert_arrow_metadata_are_synced_with_dataset_features(dataset)
+    indexed_dataset = original_dataset.map(lambda x: {"emb": np.random.uniform(-1, 0, 5).astype(np.float32)})
+    indexed_dataset.add_faiss_index(column="emb")
+    dataset = indexed_dataset.add_column(column_name, column)
+    assert dataset.list_indexes() == indexed_dataset.list_indexes()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://github.com/huggingface/datasets/issues/3769#issuecomment-1167146126

doing `.add_column("x",x_data)` also removed any `_indexes` on the dataset, decided this shouldn't be the case.

This was because `add_column` was creating a new `Dataset(...)` and wasn't possible to pass indexes on init.
with this PR now can pass 'indexes' on init through `IndexableMixin`

- [ ] Added test