### PR TITLE
Add binary classification task IDs

### DIFF
--- a/src/datasets/utils/resources/tasks.json
+++ b/src/datasets/utils/resources/tasks.json
@@ -35,7 +35,8 @@
         "type": "cv",
         "subtasks": [
             "multi-label-image-classification",
-            "multi-class-image-classification"
+            "multi-class-image-classification",
+            "binary-image-classification"
         ]
     },
     "image-segmentation": {
@@ -104,7 +105,8 @@
         "subtasks": [
             "tabular-multi-class-classification",
             "tabular-multi-label-classification",
-            "tabular-single-column-regression"
+            "tabular-single-column-regression",
+            "tabular-binary-classification"
         ]
     },
     "tabular-to-text": {
@@ -120,6 +122,7 @@
             "entity-linking-classification",
             "fact-checking",
             "intent-classification",
+            "binary-classification",
             "multi-class-classification",
             "multi-label-classification",
             "natural-language-inference",


### PR DESCRIPTION
As a precursor to aligning the task IDs in `datasets` and AutoTrain, we need a way to distinguish binary vs multiclass vs multilabel classification.

This PR adds binary classification to the task IDs to enable this.

Related AutoTrain issue: https://github.com/huggingface/autonlp-backend/issues/597

cc @abhishekkrthakur @SBrandeis 