### PR TITLE
Validate new_fingerprint passed by user

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -105,11 +105,11 @@ class BuilderConfig:
 
     def __post_init__(self):
         # The config name is used to name the cache directory.
-        invalid_windows_characters = r"<>:/\|?*"
-        for invalid_char in invalid_windows_characters:
+        invalid_windows_characters_in_path = r"<>:/\|?*"
+        for invalid_char in invalid_windows_characters_in_path:
             if invalid_char in self.name:
                 raise InvalidConfigName(
-                    f"Bad characters from black list '{invalid_windows_characters}' found in '{self.name}'. "
+                    f"Bad characters from black list '{invalid_windows_characters_in_path}' found in '{self.name}'. "
                     f"They could create issues when creating a directory for this config on Windows filesystem."
                 )
         if self.data_files is not None and not isinstance(self.data_files, DataFilesDict):

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -344,6 +344,27 @@ def update_fingerprint(fingerprint, transform, transform_args):
     return hasher.hexdigest()
 
 
+def validate_fingerprint(fingerprint: str, max_length=64):
+    """
+    Make sure the fingerprint is a non-empty string that is not longer that max_length=64 by default,
+    so that the fingerprint can be used to name cache files without issues.
+    """
+    invalid_windows_characters_in_path = r"<>:/\|?*"
+    if not isinstance(fingerprint, str) or not fingerprint:
+        raise ValueError(f"Invalid fingerprint '{fingerprint}': it should be a non-empty string.")
+    for invalid_char in invalid_windows_characters_in_path:
+        if invalid_char in fingerprint:
+            raise ValueError(
+                f"Invalid fingerprint. Bad characters from black list '{invalid_windows_characters_in_path}' found in '{fingerprint}'. "
+                f"They could create issues when creating cache files."
+            )
+    if len(fingerprint) > max_length:
+        raise ValueError(
+            f"Invalid fingerprint. Maximum lenth is {max_length} but '{fingerprint}' has length {len(fingerprint)}."
+            "It could create issues when creating cache files."
+        )
+
+
 def fingerprint_transform(
     inplace: bool,
     use_kwargs: Optional[List[str]] = None,
@@ -452,6 +473,8 @@ def fingerprint_transform(
                         kwargs[fingerprint_name] = update_fingerprint(
                             self._fingerprint, transform, kwargs_for_fingerprint
                         )
+                    else:
+                        validate_fingerprint(kwargs[fingerprint_name])
 
             # Call actual function
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1045,8 +1045,12 @@ class BaseDatasetTest(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # new_fingerprint
             new_fingerprint = "foobar"
+            invalid_new_fingerprint = "foobar/hey"
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
                 fingerprint = dset._fingerprint
+                self.assertRaises(
+                    ValueError, dset.map, picklable_map_function, num_proc=2, new_fingerprint=invalid_new_fingerprint
+                )
                 with dset.map(picklable_map_function, num_proc=2, new_fingerprint=new_fingerprint) as dset_test:
                     self.assertEqual(len(dset_test), 30)
                     self.assertDictEqual(dset.features, Features({"filename": Value("string")}))


### PR DESCRIPTION
Users can pass the dataset fingerprint they want in `map` and other dataset transforms.

However the fingerprint is used to name cache files so we need to make sure it doesn't contain bad characters as mentioned in https://github.com/huggingface/datasets/issues/1718, and that it's not too long