### PR TITLE
Update CI Windows orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    win: circleci/windows@2.2.0
+    win: circleci/windows@4.1.1
 
 jobs:
     run_dataset_script_tests_pyarrow_latest:


### PR DESCRIPTION
This PR tries to fix recurrent random CI failures on Windows.

After 2 runs, it seems to have fixed the issue.

Fix #4603.