### PR TITLE
Preserve member order by MockDownloadManager.iter_archive

### DIFF
--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -216,7 +216,8 @@ class MockDownloadManager:
             with ZipFile(self.local_path_to_dummy_data) as zip_file:
                 members = zip_file.namelist()
             for member in members:
-                yield path.parent.joinpath(member)
+                member_path = path.parent.joinpath(member)
+                yield member_path if member_path.exists() else path.parent.parent.joinpath(member)
 
         path = Path(path)
         file_paths = _iter_archive_members(path) if self.use_local_dummy_data else path.rglob("*")

--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -211,7 +211,7 @@ class MockDownloadManager:
         pass
 
     def iter_archive(self, path):
-        def _yield_archive_members(path):
+        def _iter_archive_members(path):
             # this preserves the order of the members inside the ZIP archive
             with ZipFile(self.local_path_to_dummy_data) as zip_file:
                 members = zip_file.namelist()
@@ -219,7 +219,7 @@ class MockDownloadManager:
                 yield path.parent.joinpath(member)
 
         path = Path(path)
-        file_paths = _yield_archive_members(path) if self.use_local_dummy_data else path.rglob("*")
+        file_paths = _iter_archive_members(path) if self.use_local_dummy_data else path.rglob("*")
         for file_path in file_paths:
             if file_path.is_file() and not file_path.name.startswith((".", "__")):
                 yield file_path.relative_to(path).as_posix(), file_path.open("rb")

--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -217,13 +217,20 @@ class MockDownloadManager:
                 members = zip_file.namelist()
             for member in members:
                 member_path = path.parent.joinpath(member)
-                yield member_path if member_path.exists() else path.parent.parent.joinpath(member)
+                member_path = member_path if member_path.exists() else path.parent.parent.joinpath(member)
+                if member_path.exists():
+                    yield member_path
 
         path = Path(path)
         file_paths = _iter_archive_members(path) if self.use_local_dummy_data else path.rglob("*")
         for file_path in file_paths:
             if file_path.is_file() and not file_path.name.startswith((".", "__")):
-                yield file_path.relative_to(path).as_posix(), file_path.open("rb")
+                relative_file_path = (
+                    file_path.relative_to(path)
+                    if file_path.is_relative_to(path)
+                    else file_path.relative_to(path.parent)
+                )
+                yield relative_file_path.as_posix(), file_path.open("rb")
 
     def iter_files(self, paths):
         if not isinstance(paths, list):

--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -211,14 +211,15 @@ class MockDownloadManager:
         pass
 
     def iter_archive(self, path):
-        def _list_archive_members(path):
+        def _yield_archive_members(path):
             # this preserves the order of the members inside the ZIP archive
             with ZipFile(self.local_path_to_dummy_data) as zip_file:
                 members = zip_file.namelist()
-            return [path.joinpath(*member.split("/")[1:]) for member in members[1:]]
+            for member in members:
+                yield path.parent.joinpath(member)
 
         path = Path(path)
-        file_paths = _list_archive_members(path) if self.use_local_dummy_data else path.rglob("*")
+        file_paths = _yield_archive_members(path) if self.use_local_dummy_data else path.rglob("*")
         for file_path in file_paths:
             if file_path.is_file() and not file_path.name.startswith((".", "__")):
                 yield file_path.relative_to(path).as_posix(), file_path.open("rb")

--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -225,11 +225,10 @@ class MockDownloadManager:
         file_paths = _iter_archive_members(path) if self.use_local_dummy_data else path.rglob("*")
         for file_path in file_paths:
             if file_path.is_file() and not file_path.name.startswith((".", "__")):
-                relative_file_path = (
-                    file_path.relative_to(path)
-                    if file_path.is_relative_to(path)
-                    else file_path.relative_to(path.parent)
-                )
+                try:
+                    relative_file_path = file_path.relative_to(path)
+                except ValueError:
+                    relative_file_path = file_path.relative_to(path.parent)
                 yield relative_file_path.as_posix(), file_path.open("rb")
 
     def iter_files(self, paths):


### PR DESCRIPTION
Currently, `MockDownloadManager.iter_archive` yields paths to archive members in an order given by `path.rglob("*")`, which migh not be the same order as in the original archive.

See issue in:
- https://github.com/huggingface/datasets/pull/4579#issuecomment-1172135027

This PR fixes the order of the members yielded by `MockDownloadManager.iter_archive` so that it is the same as in the original archive.