### PR TITLE
Remove all paperswithcode_id: null

### DIFF
--- a/datasets/ade_corpus_v2/README.md
+++ b/datasets/ade_corpus_v2/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - coreference-resolution
 - fact-checking
-paperswithcode_id: null
 pretty_name: Adverse Drug Reaction Data v2
 train-eval-index:
 - config: Ade_corpus_v2_classification

--- a/datasets/afrikaans_ner_corpus/README.md
+++ b/datasets/afrikaans_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Afrikaans Ner Corpus
 ---
 

--- a/datasets/ai2_arc/README.md
+++ b/datasets/ai2_arc/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - open-domain-qa
 - multiple-choice-qa
-paperswithcode_id: null
 pretty_name: Ai2Arc
 ---
 

--- a/datasets/air_dialogue/README.md
+++ b/datasets/air_dialogue/README.md
@@ -23,7 +23,6 @@ task_ids:
 - dialogue-modeling
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 ---
 
 # Dataset Card for air_dialogue

--- a/datasets/ajgt_twitter_ar/README.md
+++ b/datasets/ajgt_twitter_ar/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Arabic Jordanian General Tweets
 ---
 

--- a/datasets/amazon_polarity/README.md
+++ b/datasets/amazon_polarity/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Amazon Review Polarity
 train-eval-index:
 - config: amazon_polarity

--- a/datasets/amazon_reviews_multi/README.md
+++ b/datasets/amazon_reviews_multi/README.md
@@ -32,7 +32,6 @@ task_ids:
 - sentiment-classification
 - sentiment-scoring
 - topic-classification
-paperswithcode_id: null
 pretty_name: The Multilingual Amazon Reviews Corpus
 configs:
 - all_languages

--- a/datasets/amazon_us_reviews/README.md
+++ b/datasets/amazon_us_reviews/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: AmazonUsReviews
 ---
 

--- a/datasets/amttl/README.md
+++ b/datasets/amttl/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - parsing
-paperswithcode_id: null
 pretty_name: AMTTL
 ---
 

--- a/datasets/app_reviews/README.md
+++ b/datasets/app_reviews/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - text-scoring
 - sentiment-scoring
-paperswithcode_id: null
 pretty_name: AppReviews
 ---
 

--- a/datasets/ar_res_reviews/README.md
+++ b/datasets/ar_res_reviews/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: ArRestReviews
 ---
 

--- a/datasets/ar_sarcasm/README.md
+++ b/datasets/ar_sarcasm/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - sentiment-classification
 - text-classification-other-sarcasm-detection
-paperswithcode_id: null
 pretty_name: ArSarcasm
 ---
 

--- a/datasets/arabic_billion_words/README.md
+++ b/datasets/arabic_billion_words/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Arabic Billion Words
 configs:
 - Alittihad

--- a/datasets/arabic_pos_dialect/README.md
+++ b/datasets/arabic_pos_dialect/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - part-of-speech-tagging
-paperswithcode_id: null
 pretty_name: Arabic POS Dialect
 ---
 

--- a/datasets/arxiv_dataset/README.md
+++ b/datasets/arxiv_dataset/README.md
@@ -23,7 +23,6 @@ task_ids:
 - explanation-generation
 - fact-checking-retrieval
 - text-simplification
-paperswithcode_id: null
 pretty_name: arXiv Dataset
 ---
 

--- a/datasets/autshumato/README.md
+++ b/datasets/autshumato/README.md
@@ -20,7 +20,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: autshumato
 configs:
 - autshumato-en-tn

--- a/datasets/banking77/README.md
+++ b/datasets/banking77/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - intent-classification
 - multi-class-classification
-paperswithcode_id: null
 pretty_name: BANKING77
 train-eval-index:
 - config: default

--- a/datasets/bbaw_egyptian/README.md
+++ b/datasets/bbaw_egyptian/README.md
@@ -18,7 +18,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: BbawEgyptian
 ---
 

--- a/datasets/bbc_hindi_nli/README.md
+++ b/datasets/bbc_hindi_nli/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - natural-language-inference
-paperswithcode_id: null
 pretty_name: BBC Hindi NLI Dataset
 ---
 

--- a/datasets/bc2gm_corpus/README.md
+++ b/datasets/bc2gm_corpus/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Bc2GmCorpus
 ---
 

--- a/datasets/best2009/README.md
+++ b/datasets/best2009/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - token-classification-other-word-tokenization
-paperswithcode_id: null
 pretty_name: best2009
 ---
 

--- a/datasets/bible_para/README.md
+++ b/datasets/bible_para/README.md
@@ -117,7 +117,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: BiblePara
 ---
 

--- a/datasets/bing_coronavirus_query_set/README.md
+++ b/datasets/bing_coronavirus_query_set/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - intent-classification
-paperswithcode_id: null
 pretty_name: BingCoronavirusQuerySet
 ---
 

--- a/datasets/bprec/README.md
+++ b/datasets/bprec/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-retrieval
 task_ids:
 - entity-linking-retrieval
-paperswithcode_id: null
 pretty_name: bprec
 ---
 

--- a/datasets/bswac/README.md
+++ b/datasets/bswac/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: BsWac
 ---
 

--- a/datasets/caner/README.md
+++ b/datasets/caner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: CANER
 ---
 

--- a/datasets/cdt/README.md
+++ b/datasets/cdt/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: cdt
 ---
 

--- a/datasets/civil_comments/README.md
+++ b/datasets/civil_comments/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: CivilComments
 ---
 

--- a/datasets/clickbait_news_bg/README.md
+++ b/datasets/clickbait_news_bg/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - fact-checking
-paperswithcode_id: null
 pretty_name: Clickbait/Fake News in Bulgarian
 ---
 

--- a/datasets/conv_ai/README.md
+++ b/datasets/conv_ai/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - text-scoring
 - text-classification-other-evaluating-dialogue-systems
-paperswithcode_id: null
 pretty_name: ConvAi
 ---
 

--- a/datasets/conv_ai_3/README.md
+++ b/datasets/conv_ai_3/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - text-scoring
 - text-scoring-other-evaluating-dialogue-systems
-paperswithcode_id: null
 pretty_name: More Information Needed
 ---
 

--- a/datasets/covid_qa_deepset/README.md
+++ b/datasets/covid_qa_deepset/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - closed-domain-qa
 - extractive-qa
-paperswithcode_id: null
 pretty_name: COVID-QA
 ---
 

--- a/datasets/covid_qa_ucsd/README.md
+++ b/datasets/covid_qa_ucsd/README.md
@@ -20,7 +20,6 @@ task_categories:
 - question-answering
 task_ids:
 - closed-domain-qa
-paperswithcode_id: null
 pretty_name: CovidQaUcsd
 configs:
 - en

--- a/datasets/covid_tweets_japanese/README.md
+++ b/datasets/covid_tweets_japanese/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - fact-checking
-paperswithcode_id: null
 pretty_name: COVID-19 日本語Twitterデータセット (COVID-19 Japanese Twitter Dataset)
 ---
 

--- a/datasets/covost2/README.md
+++ b/datasets/covost2/README.md
@@ -37,7 +37,6 @@ source_datasets:
 task_categories:
 - automatic-speech-recognition
 task_ids: []
-paperswithcode_id: null
 pretty_name: CoVoST 2
 ---
 

--- a/datasets/crime_and_punish/README.md
+++ b/datasets/crime_and_punish/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: CrimeAndPunish
 ---
 

--- a/datasets/cryptonite/README.md
+++ b/datasets/cryptonite/README.md
@@ -18,7 +18,6 @@ task_categories:
 - question-answering
 task_ids:
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: Cryptonite
 configs:
 - cryptonite

--- a/datasets/danish_political_comments/README.md
+++ b/datasets/danish_political_comments/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-class-classification
-paperswithcode_id: null
 pretty_name: DanishPoliticalComments
 ---
 

--- a/datasets/datacommons_factcheck/README.md
+++ b/datasets/datacommons_factcheck/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text-classification
 task_ids:
 - fact-checking
-paperswithcode_id: null
 pretty_name: DataCommons Fact Checked claims
 configs:
 - fctchk_politifact_wapo

--- a/datasets/diplomacy_detection/README.md
+++ b/datasets/diplomacy_detection/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - intent-classification
-paperswithcode_id: null
 pretty_name: HateOffensive
 ---
 

--- a/datasets/disaster_response_messages/README.md
+++ b/datasets/disaster_response_messages/README.md
@@ -24,7 +24,6 @@ task_ids:
 - intent-classification
 - sentiment-classification
 - text-simplification
-paperswithcode_id: null
 pretty_name: Disaster Response Messages
 ---
 

--- a/datasets/dutch_social/README.md
+++ b/datasets/dutch_social/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - sentiment-classification
 - multi-label-classification
-paperswithcode_id: null
 pretty_name: Dutch Social Media Collection
 ---
 

--- a/datasets/dyk/README.md
+++ b/datasets/dyk/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: dyk
 ---
 

--- a/datasets/e2e_nlg_cleaned/README.md
+++ b/datasets/e2e_nlg_cleaned/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text2text-generation
 task_ids:
 - text2text-generation-other-meaning-representtion-to-text
-paperswithcode_id: null
 pretty_name: the Cleaned Version of the E2E Dataset
 ---
 

--- a/datasets/ehealth_kd/README.md
+++ b/datasets/ehealth_kd/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - named-entity-recognition
 - token-classification-other-relation-prediction
-paperswithcode_id: null
 pretty_name: eHealth-KD
 ---
 

--- a/datasets/eli5_category/README.md
+++ b/datasets/eli5_category/README.md
@@ -9,7 +9,6 @@ license:
 - unknown
 multilinguality:
 - monolingual
-paperswithcode_id: null
 pretty_name: ELI5-Category
 size_categories:
 - 100K<n<1M

--- a/datasets/emea/README.md
+++ b/datasets/emea/README.md
@@ -37,7 +37,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: EMEA
 configs:
 - bg-el

--- a/datasets/emotone_ar/README.md
+++ b/datasets/emotone_ar/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Emotional Tone in Arabic
 ---
 

--- a/datasets/enriched_web_nlg/README.md
+++ b/datasets/enriched_web_nlg/README.md
@@ -18,7 +18,6 @@ task_categories:
 - tabular-to-text
 task_ids:
 - rdf-to-text
-paperswithcode_id: null
 pretty_name: Enriched WebNLG
 configs:
 - de

--- a/datasets/eraser_multi_rc/README.md
+++ b/datasets/eraser_multi_rc/README.md
@@ -2,7 +2,6 @@
 pretty_name: Eraser Multi Rc
 language:
 - en
-paperswithcode_id: null
 ---
 
 # Dataset Card for "eraser_multi_rc"

--- a/datasets/eu_regulatory_ir/README.md
+++ b/datasets/eu_regulatory_ir/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - document-retrieval
 - text-retrieval-other-document-to-document-retrieval
-paperswithcode_id: null
 pretty_name: the RegIR datasets
 ---
 

--- a/datasets/europa_eac_tm/README.md
+++ b/datasets/europa_eac_tm/README.md
@@ -41,7 +41,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: Europa Education and Culture Translation Memory (EAC-TM)
 ---
 

--- a/datasets/europa_ecdc_tm/README.md
+++ b/datasets/europa_ecdc_tm/README.md
@@ -40,7 +40,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: EuropaEcdcTm
 ---
 

--- a/datasets/europarl_bilingual/README.md
+++ b/datasets/europarl_bilingual/README.md
@@ -36,7 +36,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: europarl-bilingual
 ---
 

--- a/datasets/evidence_infer_treatment/README.md
+++ b/datasets/evidence_infer_treatment/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text-retrieval
 task_ids:
 - fact-checking-retrieval
-paperswithcode_id: null
 ---
 # Dataset Card for Evidence Infer
 

--- a/datasets/factckbr/README.md
+++ b/datasets/factckbr/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - fact-checking
-paperswithcode_id: null
 pretty_name: FACTCK BR
 ---
 

--- a/datasets/fake_news_english/README.md
+++ b/datasets/fake_news_english/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-label-classification
-paperswithcode_id: null
 pretty_name: Fake News English
 ---
 

--- a/datasets/farsi_news/README.md
+++ b/datasets/farsi_news/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: FarsiNews
 ---
 

--- a/datasets/financial_phrasebank/README.md
+++ b/datasets/financial_phrasebank/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - multi-class-classification
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: FinancialPhrasebank
 ---
 

--- a/datasets/flue/README.md
+++ b/datasets/flue/README.md
@@ -22,7 +22,6 @@ task_ids:
 - semantic-similarity-classification
 - sentiment-classification
 - text-classification-other-Word Sense Disambiguation for Verbs
-paperswithcode_id: null
 configs:
 - CLS
 - PAWS-X

--- a/datasets/generated_reviews_enth/README.md
+++ b/datasets/generated_reviews_enth/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - multi-class-classification
 - semantic-similarity-classification
-paperswithcode_id: null
 pretty_name: generated_reviews_enth
 ---
 

--- a/datasets/germaner/README.md
+++ b/datasets/germaner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: GermaNER
 ---
 

--- a/datasets/germeval_14/README.md
+++ b/datasets/germeval_14/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: GermEval14
 ---
 

--- a/datasets/giga_fren/README.md
+++ b/datasets/giga_fren/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: GigaFren
 ---
 

--- a/datasets/gigaword/README.md
+++ b/datasets/gigaword/README.md
@@ -17,7 +17,6 @@ task_categories:
 - summarization
 task_ids:
 - summarization--other-headline-generation
-paperswithcode_id: null
 pretty_name: Gigaword
 train-eval-index:
 - config: default

--- a/datasets/gnad10/README.md
+++ b/datasets/gnad10/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - topic-classification
-paperswithcode_id: null
 pretty_name: 10k German News Articles Datasets
 ---
 

--- a/datasets/google_wellformed_query/README.md
+++ b/datasets/google_wellformed_query/README.md
@@ -15,7 +15,6 @@ size_categories:
 - 10K<n<100K
 license:
 - cc-by-sa-4.0
-paperswithcode_id: null
 pretty_name: GoogleWellformedQuery
 language_creators: 
 - found

--- a/datasets/grail_qa/README.md
+++ b/datasets/grail_qa/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - question-answering-other-knowledge-base-qa
-paperswithcode_id: null
 pretty_name: Grail QA
 ---
 

--- a/datasets/great_code/README.md
+++ b/datasets/great_code/README.md
@@ -16,7 +16,6 @@ source_datasets:
 task_categories:
 - table-to-text
 task_ids: []
-paperswithcode_id: null
 pretty_name: GREAT
 ---
 

--- a/datasets/guardian_authorship/README.md
+++ b/datasets/guardian_authorship/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: GuardianAuthorship
 ---
 

--- a/datasets/hansards/README.md
+++ b/datasets/hansards/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: hansards
 ---
 

--- a/datasets/harem/README.md
+++ b/datasets/harem/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: HAREM
 ---
 

--- a/datasets/hate_speech_filipino/README.md
+++ b/datasets/hate_speech_filipino/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-analysis
-paperswithcode_id: null
 pretty_name: Hate Speech in Filipino
 ---
 

--- a/datasets/hate_speech_pl/README.md
+++ b/datasets/hate_speech_pl/README.md
@@ -22,7 +22,6 @@ task_ids:
 - sentiment-classification
 - sentiment-scoring
 - topic-classification
-paperswithcode_id: null
 pretty_name: HateSpeechPl
 ---
 

--- a/datasets/hate_speech_portuguese/README.md
+++ b/datasets/hate_speech_portuguese/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-hate-speech-detection
-paperswithcode_id: null
 pretty_name: HateSpeechPortuguese
 ---
 

--- a/datasets/hausa_voa_ner/README.md
+++ b/datasets/hausa_voa_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Hausa VOA NER Corpus
 ---
 

--- a/datasets/hausa_voa_topics/README.md
+++ b/datasets/hausa_voa_topics/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - topic-classification
-paperswithcode_id: null
 pretty_name: Hausa Voa News Topic Classification Dataset (HausaVoaTopics)
 ---
 

--- a/datasets/hda_nli_hindi/README.md
+++ b/datasets/hda_nli_hindi/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - natural-language-inference
-paperswithcode_id: null
 pretty_name: Hindi Discourse Analysis Dataset
 ---
 

--- a/datasets/hebrew_projectbenyehuda/README.md
+++ b/datasets/hebrew_projectbenyehuda/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Hebrew Projectbenyehuda
 ---
 

--- a/datasets/hebrew_this_world/README.md
+++ b/datasets/hebrew_this_world/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: HebrewSentiment
 ---
 

--- a/datasets/hindi_discourse/README.md
+++ b/datasets/hindi_discourse/README.md
@@ -19,7 +19,6 @@ task_categories:
 - text-generation
 - fill-mask
 - text-generation-other-discourse-analysis
-paperswithcode_id: null
 pretty_name: Discourse Analysis dataset
 ---
 

--- a/datasets/hippocorpus/README.md
+++ b/datasets/hippocorpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - text-scoring
 - text-classification-other-narrative-flow
-paperswithcode_id: null
 pretty_name: hippocorpus
 ---
 

--- a/datasets/hrenwac_para/README.md
+++ b/datasets/hrenwac_para/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: HrenwacPara
 ---
 

--- a/datasets/hrwac/README.md
+++ b/datasets/hrwac/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: HrWac
 ---
 

--- a/datasets/hyperpartisan_news_detection/README.md
+++ b/datasets/hyperpartisan_news_detection/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: HyperpartisanNewsDetection
 ---
 

--- a/datasets/iapp_wiki_qa_squad/README.md
+++ b/datasets/iapp_wiki_qa_squad/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - extractive-qa
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: IappWikiQaSquad
 ---
 

--- a/datasets/id_clickbait/README.md
+++ b/datasets/id_clickbait/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - fact-checking
-paperswithcode_id: null
 pretty_name: Indonesian Clickbait Headlines
 ---
 

--- a/datasets/id_liputan6/README.md
+++ b/datasets/id_liputan6/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - summarization-other-extractive-summarization
 - news-articles-summarization
-paperswithcode_id: null
 pretty_name: Large-scale Indonesian Summarization
 ---
 

--- a/datasets/id_newspapers_2018/README.md
+++ b/datasets/id_newspapers_2018/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Indonesian Newspapers 2018
 ---
 

--- a/datasets/id_panl_bppt/README.md
+++ b/datasets/id_panl_bppt/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: IdPanlBppt
 ---
 

--- a/datasets/id_puisi/README.md
+++ b/datasets/id_puisi/README.md
@@ -19,7 +19,6 @@ task_categories:
 - fill-mask
 task_ids:
 - text2text-generation-other-poem-generation
-paperswithcode_id: null
 pretty_name: Indonesian Puisi
 ---
 

--- a/datasets/igbo_monolingual/README.md
+++ b/datasets/igbo_monolingual/README.md
@@ -20,7 +20,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Igbo Monolingual Dataset
 configs:
 - bbc-igbo

--- a/datasets/igbo_ner/README.md
+++ b/datasets/igbo_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Igbo NER dataset
 ---
 

--- a/datasets/ilist/README.md
+++ b/datasets/ilist/README.md
@@ -19,7 +19,6 @@ size_categories:
 - 10K<n<100K
 license:
 - unknown
-paperswithcode_id: null
 pretty_name: ilist
 ---
 

--- a/datasets/imdb_urdu_reviews/README.md
+++ b/datasets/imdb_urdu_reviews/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: ImDB Urdu Reviews
 ---
 

--- a/datasets/indic_glue/README.md
+++ b/datasets/indic_glue/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: IndicGLUE
-paperswithcode_id: null
 ---
 
 # Dataset Card for "indic_glue"

--- a/datasets/interpress_news_category_tr/README.md
+++ b/datasets/interpress_news_category_tr/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-news-category-classification
-paperswithcode_id: null
 pretty_name: Interpress Turkish News Category Dataset (270K)
 ---
 

--- a/datasets/interpress_news_category_tr_lite/README.md
+++ b/datasets/interpress_news_category_tr_lite/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-news-category-classification
-paperswithcode_id: null
 pretty_name: Interpress Turkish News Category Dataset (270K - Lite Version)
 ---
 

--- a/datasets/isixhosa_ner_corpus/README.md
+++ b/datasets/isixhosa_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: IsixhosaNerCorpus
 ---
 

--- a/datasets/isizulu_ner_corpus/README.md
+++ b/datasets/isizulu_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Isizulu Ner Corpus
 ---
 

--- a/datasets/iwslt2017/README.md
+++ b/datasets/iwslt2017/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: IWSLT 2017
 license:
 - cc-by-nc-nd-4.0

--- a/datasets/jeopardy/README.md
+++ b/datasets/jeopardy/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: jeopardy
 ---
 

--- a/datasets/jigsaw_toxicity_pred/README.md
+++ b/datasets/jigsaw_toxicity_pred/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-label-classification
-paperswithcode_id: null
 pretty_name: JigsawToxicityPred
 train-eval-index:
 - config: default

--- a/datasets/jnlpba/README.md
+++ b/datasets/jnlpba/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: BioNLP / JNLPBA Shared Task 2004
 ---
 

--- a/datasets/journalists_questions/README.md
+++ b/datasets/journalists_questions/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-question-identification
-paperswithcode_id: null
 pretty_name: JournalistsQuestions
 ---
 

--- a/datasets/kannada_news/README.md
+++ b/datasets/kannada_news/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - topic-classification
-paperswithcode_id: null
 pretty_name: KannadaNews Dataset
 ---
 

--- a/datasets/kde4/README.md
+++ b/datasets/kde4/README.md
@@ -107,7 +107,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: KDE4
 ---
 # Dataset Card for KDE4

--- a/datasets/kilt_wikipedia/README.md
+++ b/datasets/kilt_wikipedia/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: KiltWikipedia
 ---
 

--- a/datasets/kor_3i4k/README.md
+++ b/datasets/kor_3i4k/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - intent-classification
-paperswithcode_id: null
 pretty_name: 3i4K
 ---
 

--- a/datasets/kor_ner/README.md
+++ b/datasets/kor_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: KorNER
 ---
 

--- a/datasets/kor_nlu/README.md
+++ b/datasets/kor_nlu/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - natural-language-inference
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: KorNlu
 ---
 

--- a/datasets/kor_qpair/README.md
+++ b/datasets/kor_qpair/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - semantic-similarity-classification
-paperswithcode_id: null
 pretty_name: KorQpair
 ---
 

--- a/datasets/kor_sae/README.md
+++ b/datasets/kor_sae/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - intent-classification
-paperswithcode_id: null
 pretty_name: Structured Argument Extraction for Korean
 ---
 

--- a/datasets/kor_sarcasm/README.md
+++ b/datasets/kor_sarcasm/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-sarcasm-detection
-paperswithcode_id: null
 pretty_name: Korean Sarcasm Detection
 ---
 

--- a/datasets/large_spanish_corpus/README.md
+++ b/datasets/large_spanish_corpus/README.md
@@ -21,7 +21,6 @@ task_categories:
 - other
 task_ids:
 - other-other-pretraining-language-models
-paperswithcode_id: null
 pretty_name: The Large Spanish Corpus
 configs:
 - DGT

--- a/datasets/laroseda/README.md
+++ b/datasets/laroseda/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: LaRoSeDa
 ---
 

--- a/datasets/librispeech_lm/README.md
+++ b/datasets/librispeech_lm/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: LibrispeechLm
 ---
 

--- a/datasets/lst20/README.md
+++ b/datasets/lst20/README.md
@@ -21,7 +21,6 @@ task_ids:
 - token-classification-other-clause-segmentation
 - token-classification-other-sentence-segmentation
 - token-classification-other-word-segmentation
-paperswithcode_id: null
 pretty_name: LST20
 ---
 

--- a/datasets/m_lama/README.md
+++ b/datasets/m_lama/README.md
@@ -76,7 +76,6 @@ task_ids:
 - open-domain-qa
 - text-scoring
 - text-classification-other-probing
-paperswithcode_id: null
 pretty_name: MLama
 ---
 

--- a/datasets/mac_morpho/README.md
+++ b/datasets/mac_morpho/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - part-of-speech-tagging
-paperswithcode_id: null
 ---
 
 # Dataset Card for Mac-Morpho

--- a/datasets/makhzan/README.md
+++ b/datasets/makhzan/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: makhzan
 ---
 

--- a/datasets/masakhaner/README.md
+++ b/datasets/masakhaner/README.md
@@ -27,7 +27,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: MasakhaNER
 configs:
 - am

--- a/datasets/medical_dialog/README.md
+++ b/datasets/medical_dialog/README.md
@@ -19,7 +19,6 @@ task_categories:
 - question-answering
 task_ids:
 - closed-domain-qa
-paperswithcode_id: null
 pretty_name: MedDialog
 configs:
 - en

--- a/datasets/medical_questions_pairs/README.md
+++ b/datasets/medical_questions_pairs/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - semantic-similarity-classification
-paperswithcode_id: null
 pretty_name: MedicalQuestionsPairs
 ---
 

--- a/datasets/menyo20k_mt/README.md
+++ b/datasets/menyo20k_mt/README.md
@@ -18,7 +18,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: MENYO-20k
 ---
 

--- a/datasets/miam/README.md
+++ b/datasets/miam/README.md
@@ -26,7 +26,6 @@ task_ids:
 - language-modeling
 - masked-language-modeling
 - text-classification-other-dialogue-act-classification
-paperswithcode_id: null
 pretty_name: MIAM
 configs:
 - dihana

--- a/datasets/mkb/README.md
+++ b/datasets/mkb/README.md
@@ -28,7 +28,6 @@ size_categories:
 - n<1K
 license:
 - cc-by-4.0
-paperswithcode_id: null
 pretty_name: CVIT MKB
 configs:
 - bn-en

--- a/datasets/movie_rationales/README.md
+++ b/datasets/movie_rationales/README.md
@@ -2,7 +2,6 @@
 pretty_name: MovieRationales
 language:
 - en
-paperswithcode_id: null
 ---
 
 # Dataset Card for "movie_rationales"

--- a/datasets/ms_terms/README.md
+++ b/datasets/ms_terms/README.md
@@ -131,7 +131,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: MsTerms
 ---
 

--- a/datasets/msr_genomics_kbcomp/README.md
+++ b/datasets/msr_genomics_kbcomp/README.md
@@ -17,7 +17,6 @@ task_categories:
 - other
 task_ids:
 - other-other-NCI-PID-PubMed Genomics Knowledge Base Completion Dataset
-paperswithcode_id: null
 pretty_name: MsrGenomicsKbcomp
 ---
 

--- a/datasets/msr_sqa/README.md
+++ b/datasets/msr_sqa/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - extractive-qa
-paperswithcode_id: null
 pretty_name: Microsoft Research Sequential Question Answering
 ---
 

--- a/datasets/msr_zhen_translation_parity/README.md
+++ b/datasets/msr_zhen_translation_parity/README.md
@@ -18,7 +18,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: MsrZhenTranslationParity
 ---
 

--- a/datasets/msra_ner/README.md
+++ b/datasets/msra_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: MSRA NER
 train-eval-index:
 - config: msra_ner

--- a/datasets/mt_eng_vietnamese/README.md
+++ b/datasets/mt_eng_vietnamese/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: MtEngVietnamese
 ---
 

--- a/datasets/muchocine/README.md
+++ b/datasets/muchocine/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Muchocine
 ---
 

--- a/datasets/multi_para_crawl/README.md
+++ b/datasets/multi_para_crawl/README.md
@@ -55,7 +55,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: MultiParaCrawl
 ---
 

--- a/datasets/mwsc/README.md
+++ b/datasets/mwsc/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: The modified Winograd Schema Challenge (MWSC)
 ---
 

--- a/datasets/myanmar_news/README.md
+++ b/datasets/myanmar_news/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - topic-classification
-paperswithcode_id: null
 pretty_name: MyanmarNews
 ---
 

--- a/datasets/nchlt/README.md
+++ b/datasets/nchlt/README.md
@@ -25,7 +25,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: NCHLT
 ---
 # Dataset Card for NCHLT

--- a/datasets/ncslgr/README.md
+++ b/datasets/ncslgr/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: NCSLGR
 ---
 

--- a/datasets/news_commentary/README.md
+++ b/datasets/news_commentary/README.md
@@ -27,7 +27,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: NewsCommentary
 ---
 

--- a/datasets/newsgroup/README.md
+++ b/datasets/newsgroup/README.md
@@ -2,7 +2,6 @@
 pretty_name: 20 Newsgroups
 language:
 - en
-paperswithcode_id: null
 ---
 
 # Dataset Card for "newsgroup"

--- a/datasets/newspop/README.md
+++ b/datasets/newspop/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - text-scoring
 - text-classification-other-social-media-shares-prediction
-paperswithcode_id: null
 pretty_name: News Popularity in Multiple Social Media Platforms
 ---
 

--- a/datasets/nkjp-ner/README.md
+++ b/datasets/nkjp-ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: NJKP NER
 ---
 

--- a/datasets/nlu_evaluation_data/README.md
+++ b/datasets/nlu_evaluation_data/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - intent-classification
 - multi-class-classification
-paperswithcode_id: null
 pretty_name: NLU Evaluation Data
 ---
 

--- a/datasets/norne/README.md
+++ b/datasets/norne/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: 'NorNE: Norwegian Named Entities'
 ---
 

--- a/datasets/norwegian_ner/README.md
+++ b/datasets/norwegian_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Norwegian NER
 ---
 

--- a/datasets/nq_open/README.md
+++ b/datasets/nq_open/README.md
@@ -18,7 +18,6 @@ task_categories:
 - question-answering
 task_ids:
 - open-domain-qa
-paperswithcode_id: null
 ---
 
 # Dataset Card for nq_open

--- a/datasets/oclar/README.md
+++ b/datasets/oclar/README.md
@@ -19,7 +19,6 @@ task_ids:
 - text-scoring
 - sentiment-classification
 - sentiment-scoring
-paperswithcode_id: null
 pretty_name: OCLAR
 ---
 

--- a/datasets/offenseval2020_tr/README.md
+++ b/datasets/offenseval2020_tr/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-offensive-language-classification
-paperswithcode_id: null
 pretty_name: OffensEval-TR 2020
 ---
 

--- a/datasets/offenseval_dravidian/README.md
+++ b/datasets/offenseval_dravidian/README.md
@@ -21,7 +21,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-offensive-language
-paperswithcode_id: null
 pretty_name: Offenseval Dravidian
 configs:
 - kannada

--- a/datasets/ofis_publik/README.md
+++ b/datasets/ofis_publik/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OfisPublik
 ---
 

--- a/datasets/ohsumed/README.md
+++ b/datasets/ohsumed/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-label-classification
-paperswithcode_id: null
 ---
 
 # Dataset Card for ohsumed

--- a/datasets/ollie/README.md
+++ b/datasets/ollie/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text-to-structured
 task_ids:
 - relation-extraction
-paperswithcode_id: null
 pretty_name: Ollie
 configs:
 - ollie_lemmagrep

--- a/datasets/openslr/README.md
+++ b/datasets/openslr/README.md
@@ -45,7 +45,6 @@ source_datasets:
 task_categories:
 - automatic-speech-recognition
 task_ids: []
-paperswithcode_id: null
 configs:
 - SLR32
 - SLR35

--- a/datasets/opus_books/README.md
+++ b/datasets/opus_books/README.md
@@ -31,7 +31,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusBooks
 ---
 

--- a/datasets/opus_dgt/README.md
+++ b/datasets/opus_dgt/README.md
@@ -42,7 +42,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusDgt
 configs:
 - bg-ga

--- a/datasets/opus_dogc/README.md
+++ b/datasets/opus_dogc/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OPUS DOGC
 ---
 

--- a/datasets/opus_elhuyar/README.md
+++ b/datasets/opus_elhuyar/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusElhuyar
 ---
 

--- a/datasets/opus_euconst/README.md
+++ b/datasets/opus_euconst/README.md
@@ -36,7 +36,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusEuconst
 ---
 

--- a/datasets/opus_finlex/README.md
+++ b/datasets/opus_finlex/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusFinlex
 ---
 

--- a/datasets/opus_fiskmo/README.md
+++ b/datasets/opus_fiskmo/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusFiskmo
 ---
 

--- a/datasets/opus_gnome/README.md
+++ b/datasets/opus_gnome/README.md
@@ -204,7 +204,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusGnome
 configs:
 - ar-bal

--- a/datasets/opus_infopankki/README.md
+++ b/datasets/opus_infopankki/README.md
@@ -27,7 +27,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusInfopankki
 configs:
 - ar-en

--- a/datasets/opus_memat/README.md
+++ b/datasets/opus_memat/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusMemat
 ---
 

--- a/datasets/opus_montenegrinsubs/README.md
+++ b/datasets/opus_montenegrinsubs/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusMontenegrinsubs
 ---
 

--- a/datasets/opus_openoffice/README.md
+++ b/datasets/opus_openoffice/README.md
@@ -23,7 +23,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusOpenoffice
 configs:
 - de-en_GB

--- a/datasets/opus_paracrawl/README.md
+++ b/datasets/opus_paracrawl/README.md
@@ -57,7 +57,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusParaCrawl
 configs:
 - de-pl

--- a/datasets/opus_rf/README.md
+++ b/datasets/opus_rf/README.md
@@ -20,7 +20,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusRf
 configs:
 - de-en

--- a/datasets/opus_tedtalks/README.md
+++ b/datasets/opus_tedtalks/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusTedtalks
 ---
 

--- a/datasets/opus_ubuntu/README.md
+++ b/datasets/opus_ubuntu/README.md
@@ -260,7 +260,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: Opus Ubuntu
 configs:
 - as-bs

--- a/datasets/opus_wikipedia/README.md
+++ b/datasets/opus_wikipedia/README.md
@@ -36,7 +36,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusWikipedia
 configs:
 - ar-en

--- a/datasets/opus_xhosanavy/README.md
+++ b/datasets/opus_xhosanavy/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: OpusXhosanavy
 ---
 

--- a/datasets/parsinlu_reading_comprehension/README.md
+++ b/datasets/parsinlu_reading_comprehension/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - extractive-qa
-paperswithcode_id: null
 pretty_name: PersiNLU (Reading Comprehension)
 ---
 

--- a/datasets/peoples_daily_ner/README.md
+++ b/datasets/peoples_daily_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: People's Daily NER
 ---
 

--- a/datasets/php/README.md
+++ b/datasets/php/README.md
@@ -38,7 +38,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: php
 ---
 

--- a/datasets/piaf/README.md
+++ b/datasets/piaf/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - extractive-qa
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: Piaf
 ---
 

--- a/datasets/pib/README.md
+++ b/datasets/pib/README.md
@@ -31,7 +31,6 @@ size_categories:
 - 10K<n<100K
 license:
 - cc-by-4.0
-paperswithcode_id: null
 pretty_name: CVIT PIB
 configs:
 - bn-en

--- a/datasets/polemo2/README.md
+++ b/datasets/polemo2/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: polemo2
 ---
 

--- a/datasets/poleval2019_cyberbullying/README.md
+++ b/datasets/poleval2019_cyberbullying/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - intent-classification
-paperswithcode_id: null
 pretty_name: Poleval 2019 cyberbullying
 ---
 

--- a/datasets/poleval2019_mt/README.md
+++ b/datasets/poleval2019_mt/README.md
@@ -19,7 +19,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: Poleval2019Mt
 ---
 

--- a/datasets/polsum/README.md
+++ b/datasets/polsum/README.md
@@ -17,7 +17,6 @@ task_categories:
 - summarization
 task_ids:
 - news-articles-summarization
-paperswithcode_id: null
 pretty_name: Polish Summaries Corpus
 ---
 

--- a/datasets/pragmeval/README.md
+++ b/datasets/pragmeval/README.md
@@ -19,7 +19,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-class-classification
-paperswithcode_id: null
 pretty_name: pragmeval
 configs:
 - emergent

--- a/datasets/psc/README.md
+++ b/datasets/psc/README.md
@@ -17,7 +17,6 @@ task_categories:
 - summarization
 task_ids:
 - news-articles-summarization
-paperswithcode_id: null
 pretty_name: psc
 ---
 

--- a/datasets/ptb_text_only/README.md
+++ b/datasets/ptb_text_only/README.md
@@ -20,7 +20,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Penn Treebank
 ---
 

--- a/datasets/py_ast/README.md
+++ b/datasets/py_ast/README.md
@@ -21,7 +21,6 @@ task_categories:
 - text-generation
 - fill-mask
 - text-generation-other-code-modeling
-paperswithcode_id: null
 ---
 # Dataset Card for [py_ast]
 

--- a/datasets/qa_zre/README.md
+++ b/datasets/qa_zre/README.md
@@ -18,7 +18,6 @@ task_categories:
 - question-answering
 task_ids:
 - question-answering-other-zero-shot-relation-extraction
-paperswithcode_id: null
 ---
 
 # Dataset Card for QaZre

--- a/datasets/qangaroo/README.md
+++ b/datasets/qangaroo/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: qangaroo
 ---
 

--- a/datasets/qed_amara/README.md
+++ b/datasets/qed_amara/README.md
@@ -240,7 +240,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: QedAmara
 ---
 

--- a/datasets/quora/README.md
+++ b/datasets/quora/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: quora
 ---
 

--- a/datasets/reasoning_bg/README.md
+++ b/datasets/reasoning_bg/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - multiple-choice-qa
-paperswithcode_id: null
 pretty_name: ReasoningBg
 ---
 # Dataset Card for reasoning_bg

--- a/datasets/reddit/README.md
+++ b/datasets/reddit/README.md
@@ -9,7 +9,6 @@ license:
 - cc-by-4.0
 multilinguality:
 - monolingual
-paperswithcode_id: null
 pretty_name: Reddit Webis-TLDR-17
 size_categories:
 - 1M<n<10M

--- a/datasets/ro_sent/README.md
+++ b/datasets/ro_sent/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: RoSent
 ---
 

--- a/datasets/ro_sts/README.md
+++ b/datasets/ro_sts/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - text-scoring
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: RO-STS
 ---
 

--- a/datasets/ro_sts_parallel/README.md
+++ b/datasets/ro_sts_parallel/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: RO-STS-Parallel
 ---
 

--- a/datasets/sanskrit_classic/README.md
+++ b/datasets/sanskrit_classic/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: SanskritClassic
 ---
 

--- a/datasets/saudinewsnet/README.md
+++ b/datasets/saudinewsnet/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: saudinewsnet
 ---
 

--- a/datasets/scielo/README.md
+++ b/datasets/scielo/README.md
@@ -18,7 +18,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: SciELO
 configs:
 - en-es

--- a/datasets/scientific_papers/README.md
+++ b/datasets/scientific_papers/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: ScientificPapers
 ---
 

--- a/datasets/scifact/README.md
+++ b/datasets/scifact/README.md
@@ -2,7 +2,6 @@
 pretty_name: SciFact
 language:
 - en
-paperswithcode_id: null
 ---
 
 # Dataset Card for "scifact"

--- a/datasets/sem_eval_2014_task_1/README.md
+++ b/datasets/sem_eval_2014_task_1/README.md
@@ -19,7 +19,6 @@ task_ids:
 - text-scoring
 - natural-language-inference
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: SemEval 2014 - Task 1
 ---
 

--- a/datasets/sem_eval_2020_task_11/README.md
+++ b/datasets/sem_eval_2020_task_11/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - text-classification-other-propaganda-technique-classification
 - token-classification-other-propaganda-span-identification
-paperswithcode_id: null
 pretty_name: "SemEval-2020 Task 11"
 ---
 

--- a/datasets/senti_lex/README.md
+++ b/datasets/senti_lex/README.md
@@ -100,7 +100,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: SentiWS
 configs:
 - 'no'

--- a/datasets/senti_ws/README.md
+++ b/datasets/senti_ws/README.md
@@ -21,7 +21,6 @@ task_ids:
 - text-scoring
 - sentiment-scoring
 - part-of-speech-tagging
-paperswithcode_id: null
 pretty_name: SentiWS
 ---
 

--- a/datasets/sepedi_ner/README.md
+++ b/datasets/sepedi_ner/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Sepedi NER Corpus
 ---
 

--- a/datasets/sesotho_ner_corpus/README.md
+++ b/datasets/sesotho_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Sesotho NER Corpus
 ---
 

--- a/datasets/setimes/README.md
+++ b/datasets/setimes/README.md
@@ -26,7 +26,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 ---
 
 # Dataset Card Creation Guide

--- a/datasets/setswana_ner_corpus/README.md
+++ b/datasets/setswana_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Setswana NER Corpus
 ---
 

--- a/datasets/sharc_modified/README.md
+++ b/datasets/sharc_modified/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - extractive-qa
 - question-answering-other-conversational-qa
-paperswithcode_id: null
 pretty_name: SharcModified
 ---
 

--- a/datasets/silicone/README.md
+++ b/datasets/silicone/README.md
@@ -27,7 +27,6 @@ task_ids:
 - text-classification-other-dialogue-act-classification
 - text-classification-other-emotion-classification
 - text-scoring
-paperswithcode_id: null
 pretty_name: SILICONE Benchmark
 configs:
 - dyda_da

--- a/datasets/siswati_ner_corpus/README.md
+++ b/datasets/siswati_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Siswati NER Corpus
 ---
 

--- a/datasets/smartdata/README.md
+++ b/datasets/smartdata/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: SmartData
 ---
 

--- a/datasets/snow_simplified_japanese_corpus/README.md
+++ b/datasets/snow_simplified_japanese_corpus/README.md
@@ -18,7 +18,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: SNOW T15 and T23 (simplified Japanese corpus)
 ---
 

--- a/datasets/so_stacksample/README.md
+++ b/datasets/so_stacksample/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - abstractive-qa
 - open-domain-abstractive-qa
-paperswithcode_id: null
 pretty_name: SO StackSample
 ---
 

--- a/datasets/social_bias_frames/README.md
+++ b/datasets/social_bias_frames/README.md
@@ -20,7 +20,6 @@ task_categories:
 task_ids:
 - text2text-generation-other-explanation-generation
 - hate-speech-detection
-paperswithcode_id: null
 ---
 
 

--- a/datasets/sofc_materials_articles/README.md
+++ b/datasets/sofc_materials_articles/README.md
@@ -22,7 +22,6 @@ task_ids:
 - named-entity-recognition
 - slot-filling
 - topic-classification
-paperswithcode_id: null
 pretty_name: SofcMaterialsArticles
 ---
 

--- a/datasets/sogou_news/README.md
+++ b/datasets/sogou_news/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: Sogou News
-paperswithcode_id: null
 ---
 
 # Dataset Card for "sogou_news"

--- a/datasets/spc/README.md
+++ b/datasets/spc/README.md
@@ -19,7 +19,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: spc
 configs:
 - af-en

--- a/datasets/species_800/README.md
+++ b/datasets/species_800/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: species800
 ---
 

--- a/datasets/squad_adversarial/README.md
+++ b/datasets/squad_adversarial/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - extractive-qa
-paperswithcode_id: null
 pretty_name: '''Adversarial Examples for SQuAD'''
 ---
 

--- a/datasets/squad_kor_v2/README.md
+++ b/datasets/squad_kor_v2/README.md
@@ -18,7 +18,6 @@ task_categories:
 - question-answering
 task_ids:
 - extractive-qa
-paperswithcode_id: null
 pretty_name: KorQuAD v2.1
 ---
 

--- a/datasets/squad_v1_pt/README.md
+++ b/datasets/squad_v1_pt/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - extractive-qa
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: SquadV1Pt
 ---
 

--- a/datasets/srwac/README.md
+++ b/datasets/srwac/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: SrWac
 ---
 

--- a/datasets/story_cloze/README.md
+++ b/datasets/story_cloze/README.md
@@ -17,7 +17,6 @@ task_categories:
 - other
 task_ids:
 - other-other-story-completion
-paperswithcode_id: null
 pretty_name: Story Cloze Test
 ---
 

--- a/datasets/stsb_mt_sv/README.md
+++ b/datasets/stsb_mt_sv/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - text-scoring
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: Swedish Machine Translated STS-B
 ---
 

--- a/datasets/stsb_multi_mt/README.md
+++ b/datasets/stsb_multi_mt/README.md
@@ -29,7 +29,6 @@ task_categories:
 task_ids:
 - text-scoring
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: STSb Multi MT
 ---
 

--- a/datasets/style_change_detection/README.md
+++ b/datasets/style_change_detection/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: StyleChangeDetection
 ---
 

--- a/datasets/swahili/README.md
+++ b/datasets/swahili/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: swahili
 ---
 

--- a/datasets/swahili_news/README.md
+++ b/datasets/swahili_news/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-class-classification
-paperswithcode_id: null
 pretty_name: "Swahili : News Classification Dataset"
 ---
 

--- a/datasets/swda/README.md
+++ b/datasets/swda/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - multi-label-classification
-paperswithcode_id: null
 pretty_name: The Switchboard Dialog Act Corpus (SwDA)
 ---
 

--- a/datasets/swedish_ner_corpus/README.md
+++ b/datasets/swedish_ner_corpus/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Swedish NER Corpus
 ---
 

--- a/datasets/swedish_reviews/README.md
+++ b/datasets/swedish_reviews/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Swedish Reviews
 ---
 

--- a/datasets/tamilmixsentiment/README.md
+++ b/datasets/tamilmixsentiment/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Tamilmixsentiment
 ---
 

--- a/datasets/tanzil/README.md
+++ b/datasets/tanzil/README.md
@@ -57,7 +57,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: tanzil
 ---
 

--- a/datasets/tashkeela/README.md
+++ b/datasets/tashkeela/README.md
@@ -20,7 +20,6 @@ task_ids:
 - language-modeling
 - masked-language-modeling
 - other-diacritics-prediction
-paperswithcode_id: null
 pretty_name: Tashkeela
 ---
 

--- a/datasets/taskmaster3/README.md
+++ b/datasets/taskmaster3/README.md
@@ -18,7 +18,6 @@ task_categories:
 - fill-mask
 task_ids:
 - dialogue-modeling
-paperswithcode_id: null
 pretty_name: taskmaster3
 ---
 

--- a/datasets/ted_hrlr/README.md
+++ b/datasets/ted_hrlr/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: TEDHrlr
-paperswithcode_id: null
 ---
 
 # Dataset Card for "ted_hrlr"

--- a/datasets/ted_iwlst2013/README.md
+++ b/datasets/ted_iwlst2013/README.md
@@ -30,7 +30,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: TedIwlst2013
 configs:
 - ar-en

--- a/datasets/ted_multi/README.md
+++ b/datasets/ted_multi/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: TEDMulti
-paperswithcode_id: null
 ---
 
 # Dataset Card for "ted_multi"

--- a/datasets/ted_talks_iwslt/README.md
+++ b/datasets/ted_talks_iwslt/README.md
@@ -126,7 +126,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: Web Inventory of Transcribed & Translated(WIT) Ted Talks
 configs:
 - de_ja_2014

--- a/datasets/telugu_books/README.md
+++ b/datasets/telugu_books/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: TeluguBooks
 ---
 

--- a/datasets/telugu_news/README.md
+++ b/datasets/telugu_news/README.md
@@ -22,7 +22,6 @@ task_ids:
 - masked-language-modeling
 - multi-class-classification
 - topic-classification
-paperswithcode_id: null
 pretty_name: TeluguNews
 ---
 

--- a/datasets/tep_en_fa_para/README.md
+++ b/datasets/tep_en_fa_para/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: TepEnFaPara
 ---
 

--- a/datasets/thai_toxicity_tweet/README.md
+++ b/datasets/thai_toxicity_tweet/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: ThaiToxicityTweet
 ---
 

--- a/datasets/thainer/README.md
+++ b/datasets/thainer/README.md
@@ -20,7 +20,6 @@ task_categories:
 task_ids:
 - named-entity-recognition
 - part-of-speech-tagging
-paperswithcode_id: null
 pretty_name: thainer
 ---
 

--- a/datasets/thaiqa_squad/README.md
+++ b/datasets/thaiqa_squad/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - extractive-qa
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: thaiqa-squad
 ---
 

--- a/datasets/thaisum/README.md
+++ b/datasets/thaisum/README.md
@@ -20,7 +20,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: ThaiSum
 ---
 

--- a/datasets/times_of_india_news_headlines/README.md
+++ b/datasets/times_of_india_news_headlines/README.md
@@ -20,7 +20,6 @@ task_ids:
 - document-retrieval
 - fact-checking-retrieval
 - text-simplification
-paperswithcode_id: null
 pretty_name: Times of India News Headlines
 ---
 

--- a/datasets/tiny_shakespeare/README.md
+++ b/datasets/tiny_shakespeare/README.md
@@ -1,5 +1,4 @@
 ---
-paperswithcode_id: null
 pretty_name: TinyShakespeare
 ---
 

--- a/datasets/tlc/README.md
+++ b/datasets/tlc/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 ---
 
 # Dataset Card for Thai Literature Corpora (TLC)

--- a/datasets/tmu_gfm_dataset/README.md
+++ b/datasets/tmu_gfm_dataset/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text2text-generation
 task_ids:
 - text2text-generation-other-grammatical-error-correction
-paperswithcode_id: null
 pretty_name: TMU-GFM-Dataset
 ---
 

--- a/datasets/ttc4900/README.md
+++ b/datasets/ttc4900/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-news-category-classification
-paperswithcode_id: null
 pretty_name: TTC4900 - A Benchmark Data for Turkish Text Categorization
 ---
 

--- a/datasets/turk/README.md
+++ b/datasets/turk/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text2text-generation
 task_ids:
 - text-simplification
-paperswithcode_id: null
 pretty_name: TURK
 ---
 

--- a/datasets/turkish_movie_sentiment/README.md
+++ b/datasets/turkish_movie_sentiment/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - sentiment-classification
 - sentiment-scoring
-paperswithcode_id: null
 pretty_name: 'TurkishMovieSentiment: This dataset contains turkish movie reviews.'
 ---
 

--- a/datasets/turkish_ner/README.md
+++ b/datasets/turkish_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: TurkishNer
 ---
 

--- a/datasets/turkish_product_reviews/README.md
+++ b/datasets/turkish_product_reviews/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Turkish Product Reviews
 ---
 

--- a/datasets/turkish_shrinked_ner/README.md
+++ b/datasets/turkish_shrinked_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: TurkishShrinkedNer
 ---
 

--- a/datasets/turku_ner_corpus/README.md
+++ b/datasets/turku_ner_corpus/README.md
@@ -18,7 +18,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 ---
 
 # Dataset Card Creation Guide

--- a/datasets/tweets_hate_speech_detection/README.md
+++ b/datasets/tweets_hate_speech_detection/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: Tweets Hate Speech Detection
 train-eval-index:
 - config: default

--- a/datasets/twi_text_c3/README.md
+++ b/datasets/twi_text_c3/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Twi Text C3
 ---
 

--- a/datasets/twi_wordsim353/README.md
+++ b/datasets/twi_wordsim353/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - text-scoring
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: Yorùbá Wordsim-353
 ---
 

--- a/datasets/udhr/README.md
+++ b/datasets/udhr/README.md
@@ -469,7 +469,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: The Universal Declaration of Human Rights (UDHR)
 ---
 

--- a/datasets/un_ga/README.md
+++ b/datasets/un_ga/README.md
@@ -21,7 +21,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: UnGa
 configs:
 - ar-to-en

--- a/datasets/universal_morphologies/README.md
+++ b/datasets/universal_morphologies/README.md
@@ -131,7 +131,6 @@ task_ids:
 - multi-class-classification
 - multi-label-classification
 - token-classification-other-morphology
-paperswithcode_id: null
 pretty_name: UniversalMorphologies
 configs:
 - ady

--- a/datasets/urdu_fake_news/README.md
+++ b/datasets/urdu_fake_news/README.md
@@ -18,7 +18,6 @@ task_categories:
 task_ids:
 - fact-checking
 - intent-classification
-paperswithcode_id: null
 pretty_name: Bend the Truth (Urdu Fake News)
 ---
 

--- a/datasets/wiki_auto/README.md
+++ b/datasets/wiki_auto/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text2text-generation
 task_ids:
 - text-simplification
-paperswithcode_id: null
 pretty_name: WikiAuto
 configs:
 - auto

--- a/datasets/wiki_dpr/README.md
+++ b/datasets/wiki_dpr/README.md
@@ -4,7 +4,6 @@ annotations_creators:
 language_creators:
 - crowdsourced
 pretty_name: Wiki-DPR
-paperswithcode_id: null
 license:
 - cc-by-sa-3.0
 - gfdl

--- a/datasets/wiki_snippets/README.md
+++ b/datasets/wiki_snippets/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - language-modeling
 - other-text-search
-paperswithcode_id: null
 ---
 
 # Dataset Card for "wiki_snippets"

--- a/datasets/wiki_source/README.md
+++ b/datasets/wiki_source/README.md
@@ -17,7 +17,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 pretty_name: WikiSource
 ---
 

--- a/datasets/wikicorpus/README.md
+++ b/datasets/wikicorpus/README.md
@@ -30,7 +30,6 @@ task_ids:
 - part-of-speech-tagging
 - text-classification-other-word-sense-disambiguation
 - token-classification-other-lemmatization
-paperswithcode_id: null
 configs:
 - raw_ca
 - raw_en

--- a/datasets/wikipedia/README.md
+++ b/datasets/wikipedia/README.md
@@ -4,7 +4,6 @@ annotations_creators:
 language_creators:
 - crowdsourced
 pretty_name: Wikipedia
-paperswithcode_id: null
 license:
 - cc-by-sa-3.0
 - gfdl

--- a/datasets/wikitablequestions/README.md
+++ b/datasets/wikitablequestions/README.md
@@ -9,7 +9,6 @@ license:
 - cc-by-4.0
 multilinguality:
 - monolingual
-paperswithcode_id: null
 pretty_name: WikiTableQuestions
 size_categories:
 - 10K<n<100K

--- a/datasets/wisesight1000/README.md
+++ b/datasets/wisesight1000/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - token-classification-other-word-tokenization
-paperswithcode_id: null
 pretty_name: wisesight1000
 ---
 

--- a/datasets/wisesight_sentiment/README.md
+++ b/datasets/wisesight_sentiment/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: WisesightSentiment
 train-eval-index:
 - config: wisesight_sentiment

--- a/datasets/wmt17/README.md
+++ b/datasets/wmt17/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: WMT17
-paperswithcode_id: null
 multilinguality:
 - translation
 task_categories:

--- a/datasets/wmt19/README.md
+++ b/datasets/wmt19/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: WMT19
-paperswithcode_id: null
 multilinguality:
 - translation
 task_categories:

--- a/datasets/wmt20_mlqe_task1/README.md
+++ b/datasets/wmt20_mlqe_task1/README.md
@@ -26,7 +26,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 configs:
 - en-de
 - en-zh

--- a/datasets/wmt20_mlqe_task2/README.md
+++ b/datasets/wmt20_mlqe_task2/README.md
@@ -22,7 +22,6 @@ task_categories:
 - text-classification
 task_ids:
 - text-classification-other-translation-quality-estimation
-paperswithcode_id: null
 configs:
 - en-de
 - en-zh

--- a/datasets/wmt20_mlqe_task3/README.md
+++ b/datasets/wmt20_mlqe_task3/README.md
@@ -19,7 +19,6 @@ source_datasets:
 task_categories:
 - translation
 task_ids: []
-paperswithcode_id: null
 ---
 
 # Dataset Card Creation Guide

--- a/datasets/wmt_t2t/README.md
+++ b/datasets/wmt_t2t/README.md
@@ -1,6 +1,5 @@
 ---
 pretty_name: WMT T2t
-paperswithcode_id: null
 multilinguality:
 - translation
 task_categories:

--- a/datasets/wongnai_reviews/README.md
+++ b/datasets/wongnai_reviews/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: WongnaiReviews
 ---
 

--- a/datasets/wrbsc/README.md
+++ b/datasets/wrbsc/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - semantic-similarity-classification
-paperswithcode_id: null
 pretty_name: wrbsc
 ---
 

--- a/datasets/xglue/README.md
+++ b/datasets/xglue/README.md
@@ -62,7 +62,6 @@ task_ids:
 - text-classification-other-paraphrase-identification
 - text2text-generation-other-question-answering
 - topic-classification
-paperswithcode_id: null
 pretty_name: XGLUE
 configs:
 - mlqa

--- a/datasets/xsum_factuality/README.md
+++ b/datasets/xsum_factuality/README.md
@@ -17,7 +17,6 @@ task_categories:
 - summarization
 task_ids:
 - summarization-other-hallucinations
-paperswithcode_id: null
 pretty_name: XSum Hallucination Annotations
 ---
 

--- a/datasets/yahoo_answers_qa/README.md
+++ b/datasets/yahoo_answers_qa/README.md
@@ -17,7 +17,6 @@ task_categories:
 - question-answering
 task_ids:
 - open-domain-qa
-paperswithcode_id: null
 pretty_name: YahooAnswersQa
 ---
 

--- a/datasets/yahoo_answers_topics/README.md
+++ b/datasets/yahoo_answers_topics/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - topic-classification
-paperswithcode_id: null
 pretty_name: YahooAnswersTopics
 train-eval-index:
 - config: yahoo_answers_topics

--- a/datasets/yelp_polarity/README.md
+++ b/datasets/yelp_polarity/README.md
@@ -1,7 +1,6 @@
 ---
 language:
 - en
-paperswithcode_id: null
 pretty_name: YelpPolarity
 train-eval-index:
 - config: plain_text

--- a/datasets/yelp_review_full/README.md
+++ b/datasets/yelp_review_full/README.md
@@ -18,7 +18,6 @@ task_categories:
 - text-classification
 task_ids:
 - sentiment-classification
-paperswithcode_id: null
 pretty_name: YelpReviewFull
 train-eval-index:
 - config: yelp_review_full

--- a/datasets/yoruba_bbc_topics/README.md
+++ b/datasets/yoruba_bbc_topics/README.md
@@ -17,7 +17,6 @@ task_categories:
 - text-classification
 task_ids:
 - topic-classification
-paperswithcode_id: null
 pretty_name: Yoruba Bbc News Topic Classification Dataset (YorubaBbcTopics)
 ---
 

--- a/datasets/yoruba_gv_ner/README.md
+++ b/datasets/yoruba_gv_ner/README.md
@@ -17,7 +17,6 @@ task_categories:
 - token-classification
 task_ids:
 - named-entity-recognition
-paperswithcode_id: null
 pretty_name: Yoruba GV NER Corpus
 ---
 

--- a/datasets/yoruba_text_c3/README.md
+++ b/datasets/yoruba_text_c3/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - language-modeling
 - masked-language-modeling
-paperswithcode_id: null
 pretty_name: Yorùbá Text C3
 ---
 

--- a/datasets/yoruba_wordsim353/README.md
+++ b/datasets/yoruba_wordsim353/README.md
@@ -19,7 +19,6 @@ task_categories:
 task_ids:
 - text-scoring
 - semantic-similarity-scoring
-paperswithcode_id: null
 pretty_name: Wordsim-353 In Yorùbá (YorubaWordsim353)
 ---
 

--- a/datasets/youtube_caption_corrections/README.md
+++ b/datasets/youtube_caption_corrections/README.md
@@ -21,7 +21,6 @@ task_categories:
 task_ids:
 - other-other-token-classification-of-text-errors
 - slot-filling
-paperswithcode_id: null
 pretty_name: YouTube Caption Corrections
 ---
 


### PR DESCRIPTION
On the Hub there is a validation error on the `paperswithcode_id` tag when the value is `null`:

<img width="686" alt="image" src="https://user-images.githubusercontent.com/42851186/177151825-93d341c5-25bd-41ab-96c2-c0b516d51c68.png">

We've been using `null` to specify that we checked on pwc but the dataset doesn't exist there.

To have the validation working again we can simply remove all the `paperswithcode_id: null`.

cc @julien-c 