### PR TITLE
fixed duplicate calculation of spearmanr function in metrics wrapper.

### DIFF
--- a/metrics/spearmanr/spearmanr.py
+++ b/metrics/spearmanr/spearmanr.py
@@ -112,12 +112,8 @@ class Spearmanr(datasets.Metric):
         )
 
     def _compute(self, predictions, references, return_pvalue=False):
+        results = spearmanr(references, predictions)
         if return_pvalue:
-            return {
-                "spearmanr": spearmanr(references, predictions)[0],
-                "spearmanr_pvalue": spearmanr(references, predictions)[1],
-            }
+            return {"spearmanr": results[0], "spearmanr_pvalue": results[1]}
         else:
-            return {
-                "spearmanr": spearmanr(references, predictions)[0],
-            }
+            return {"spearmanr": results[0]}


### PR DESCRIPTION
During _compute, the scipy.stats spearmanr function was called twice, redundantly, once for calculating the score and once for calculating the p-value, under the conditional branch where return_pvalue=True. I adjusted the _compute function to execute the spearmanr function once, store the results tuple in a temporary variable, and then pass the indexed contents to the expected keys of the returned dictionary.