### PR TITLE
Fix time type `_arrow_to_datasets_dtype` conversion

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -78,9 +78,9 @@ def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
     elif pyarrow.types.is_float64(arrow_type):
         return "float64"  # pyarrow dtype is "double"
     elif pyarrow.types.is_time32(arrow_type):
-        return f"time32[{arrow_type.unit}]"
+        return f"time32[{pa.type_for_alias(str(arrow_type)).unit}]"
     elif pyarrow.types.is_time64(arrow_type):
-        return f"time64[{arrow_type.unit}]"
+        return f"time64[{pa.type_for_alias(str(arrow_type)).unit}]"
     elif pyarrow.types.is_timestamp(arrow_type):
         if arrow_type.tz is None:
             return f"timestamp[{arrow_type.unit}]"

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import asdict
 from unittest import TestCase
 from unittest.mock import patch
@@ -58,6 +59,7 @@ class FeaturesTest(TestCase):
             pa.string(),
             pa.int32(),
             pa.float64(),
+            pa.array([datetime.time(1, 1, 1)]).type,  # arrow type: DataType(time64[us])
         ]
         for dt in supported_pyarrow_datatypes:
             self.assertEqual(dt, string_to_arrow(_arrow_to_datasets_dtype(dt)))


### PR DESCRIPTION
Fix #4620

The issue stems from the fact that `pa.array([time_data]).type` returns `DataType(time64[unit])`, which doesn't expose the `unit` attribute, instead of `Time64Type(time64[unit])`. I believe this is a bug in PyArrow. Luckily, the both types have the same `str()`, so in this PR I call `pa.type_for_alias(str(type))` to convert them both to the `Time64Type(time64[unit])` format.  