### PR TITLE
fix(dataset_wrappers): Fixes access to fsspec.asyn in torch_iterable_dataset.py.

### DIFF
--- a/src/datasets/formatting/dataset_wrappers/torch_iterable_dataset.py
+++ b/src/datasets/formatting/dataset_wrappers/torch_iterable_dataset.py
@@ -1,4 +1,4 @@
-import fsspec
+import fsspec.asyn
 import torch
 
 from ...iterable_dataset import IterableDataset, _apply_feature_types


### PR DESCRIPTION
Fix #4612.

Apparently, newest `fsspec` versions do not allow access to attribute-based modules if they are not imported, such as `fsspec.async`.

Thus, @mariosasko suggested to add the missing part to the module import to allow for its access.