### PR TITLE
Set HF_SCRIPTS_VERSION to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow --upgrade
-            - run: HF_SCRIPTS_VERSION=master HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=main HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_6:
         working_directory: ~/datasets
@@ -36,7 +36,7 @@ jobs:
             - run: pip install .[tests]
             - run: pip install -r additional-tests-requirements.txt --no-deps
             - run: pip install pyarrow==6.0.0
-            - run: HF_SCRIPTS_VERSION=master HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=main HF_ALLOW_CODE_EVAL=1 python -m pytest -d --tx 2*popen//python=python3.6 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_latest_WIN:
         working_directory: ~/datasets
@@ -56,7 +56,7 @@ jobs:
                 pip install pyarrow --upgrade
             - run: |
                 conda activate py37
-                $env:HF_SCRIPTS_VERSION="master"
+                $env:HF_SCRIPTS_VERSION="main"
                 python -m pytest -n 2 --dist loadfile -sv ./tests/
 
     run_dataset_script_tests_pyarrow_6_WIN:
@@ -77,7 +77,7 @@ jobs:
                 pip install pyarrow==6.0.0
             - run: |
                 conda activate py37
-                $env:HF_SCRIPTS_VERSION="master"
+                $env:HF_SCRIPTS_VERSION="main"
                 python -m pytest -n 2 --dist loadfile -sv ./tests/
 
     check_code_quality:

--- a/.github/workflows/test-audio.yml
+++ b/.github/workflows/test-audio.yml
@@ -27,4 +27,4 @@ jobs:
           pip install pyarrow --upgrade
       - name: Test audio with pytest
         run: |
-          HF_SCRIPTS_VERSION=master python -m pytest -n 2 -sv ./tests/features/test_audio.py
+          HF_SCRIPTS_VERSION=main python -m pytest -n 2 -sv ./tests/features/test_audio.py


### PR DESCRIPTION
After renaming "master" to "main", the CI fails with
```
AssertionError: 'https://raw.githubusercontent.com/huggingface/datasets/main/datasets/_dummy/_dummy.py' not found in "Couldn't find a dataset script at /home/circleci/datasets/_dummy/_dummy.py or any data file in the same directory. Couldn't find '_dummy' on the Hugging Face Hub either: FileNotFoundError: Couldn't find file at https://raw.githubusercontent.com/huggingface/datasets/master/datasets/_dummy/_dummy.py"
```

This is because in the CI we were still using `HF_SCRIPTS_VERSION=master`. I changed it to "main"