### PR TITLE
Add text decorators

### DIFF
--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -31,7 +31,7 @@ Index into an audio dataset using the row index first and then the `audio` colum
 
 </Tip>
 
-For a guide on how to load any type of dataset, take a look at the [general loading guide](./loading).
+For a guide on how to load any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./loading">general loading guide</a>.
 
 ## Local files
 

--- a/docs/source/audio_process.mdx
+++ b/docs/source/audio_process.mdx
@@ -5,7 +5,8 @@ This guide shows specific methods for processing audio datasets. Learn how to:
 - Resample the sampling rate.
 - Use [`~Dataset.map`] with audio datasets.
 
-For a guide on how to process any type of dataset, take a look at the [general process guide](./process).
+For a guide on how to process any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./process">general process guide</a>.
+
 
 ## Cast
 

--- a/docs/source/how_to.md
+++ b/docs/source/how_to.md
@@ -12,10 +12,10 @@ Interested in learning more? Take a look at [Chapter 5](https://huggingface.co/c
 
 The guides are organized into five sections:
 
-- **General usage**: Functions for general dataset loading and processing. The functions shown in this section are applicable across all dataset modalities.
-- **Audio**: How to load, process, and share audio datasets.
-- **Vision**: How to load, process, and share image datasets.
-- **Text**: How to load, process, and share text datasets.
-- **Dataset repository**: How to share and upload a dataset to the [Hub](https://huggingface.co/datasets).
+- <span class="underline decoration-sky-400 decoration-2 font-semibold">General usage</span>: Functions for general dataset loading and processing. The functions shown in this section are applicable across all dataset modalities.
+- <span class="underline decoration-pink-400 decoration-2 font-semibold">Audio</span>: How to load, process, and share audio datasets.
+- <span class="underline decoration-yellow-400 decoration-2 font-semibold">Vision</span>: How to load, process, and share image datasets.
+- <span class="underline decoration-green-400 decoration-2 font-semibold">Text</span>: How to load, process, and share text datasets.
+- <span class="underline decoration-indigo-400 decoration-2 font-semibold">Dataset repository</span>: How to share and upload a dataset to the [Hub](https://huggingface.co/datasets).
 
 If you have any questions about 🤗 Datasets, feel free to join and ask the community on our [forum](https://discuss.huggingface.co/c/datasets/10).

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -23,7 +23,7 @@ Index into an image dataset using the row index first and then the `image` colum
 
 </Tip>
 
-For a guide on how to load any type of dataset, take a look at the [general loading guide](./loading).
+For a guide on how to load any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./loading">general loading guide</a>.
 
 ## Local files
 

--- a/docs/source/image_process.mdx
+++ b/docs/source/image_process.mdx
@@ -5,7 +5,7 @@ This guide shows specific methods for processing image datasets. Learn how to:
 - Use [`~Dataset.map`] with image dataset.
 - Apply data augmentations to your dataset with [`~Dataset.set_transform`].
 
-For a guide on how to process any type of dataset, take a look at the [general process guide](./process).
+For a guide on how to process any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./process">general process guide</a>.
 
 ## Map
 

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -11,7 +11,7 @@ This guide will show you how to load a dataset from:
 - Offline
 - A specific slice of a split
 
-For more details specific to loading other dataset modalities, take a look at the [load audio dataset guide](./audio_load), the [load image dataset guide](./image_load), or the [load text dataset guide](./nlp_load).
+For more details specific to loading other dataset modalities, take a look at the <a class="underline decoration-pink-400 decoration-2 font-semibold" href="./audio_load">load audio dataset guide</a>, the <a class="underline decoration-yellow-400 decoration-2 font-semibold" href="./image_load">load image dataset guide</a>, or the <a class="underline decoration-green-400 decoration-2 font-semibold" href="./nlp_load">load text dataset guide</a>.
 
 <a id='load-from-the-hub'></a>
 

--- a/docs/source/nlp_load.mdx
+++ b/docs/source/nlp_load.mdx
@@ -1,6 +1,6 @@
 # Load text data
 
-This guide shows you how to load text datasets. To learn how to load any type of dataset, take a look at the [general loading guide](./loading).
+This guide shows you how to load text datasets. To learn how to load any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./loading">general loading guide</a>.
 
 Text files are one of the most common file types for storing a dataset. By default, 🤗 Datasets samples a text file line by line to build the dataset.
 

--- a/docs/source/nlp_process.mdx
+++ b/docs/source/nlp_process.mdx
@@ -5,7 +5,7 @@ This guide shows specific methods for processing text datasets. Learn how to:
 - Tokenize a dataset with [`~Dataset.map`].
 - Align dataset labels with label ids for NLI datasets.
 
-For a guide on how to process any type of dataset, take a look at the [general process guide](./process).
+For a guide on how to process any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./process">general process guide</a>.
 
 ## Map
 

--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -11,7 +11,7 @@ This guide will show you how to:
 - Apply a custom formatting transform.
 - Save and export processed datasets.
 
-For more details specific to processing other dataset modalities, take a look at the take a look at the [process audio dataset guide](./audio_process), the [process image dataset guide](./image_process), or the [process text dataset guide](./nlp_process).
+For more details specific to processing other dataset modalities, take a look at the <a class="underline decoration-pink-400 decoration-2 font-semibold" href="./audio_process">process audio dataset guide</a>, the <a class="underline decoration-yellow-400 decoration-2 font-semibold" href="./image_process">process image dataset guide</a>, or the <a class="underline decoration-green-400 decoration-2 font-semibold" href="./nlp_process">process text dataset guide</a>.
 
 The examples in this guide use the MRPC dataset, but feel free to load any dataset of your choice and follow along!
 


### PR DESCRIPTION
This PR adds some decoration to text about different modalities to make it more obvious separate guides exist for audio, vision, and text. The goal is to make it easier for users to discover these guides!

![underline](https://user-images.githubusercontent.com/59462357/178044392-9596693e-9a4a-479a-a282-f1edbd90be1a.png)

TODO:

- [x] Open PR to support new Tailwind classes