### PR TITLE
Added method to remove excess nesting in a DatasetDict

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1025,6 +1025,24 @@ class DatasetDict(dict):
             }
         )
 
+    def remove_excess_nesting(self) -> "DatasetDict":
+        """
+        Flattens any leading dimensions of shape 1 for all features in the dataset.
+        """
+
+        def clean_row_nesting(row):
+            row_keys = row.keys()
+            for key in row_keys:
+                arr = np.array(row[key])
+                for _ in range(arr.ndim - 1):
+                    arr = arr[0] if arr.shape[0] == 1 else arr
+                row[key] = arr.tolist()
+            return row
+
+        claned_dataset = self.map(clean_row_nesting)
+
+        return claned_dataset
+
     def save_to_disk(self, dataset_dict_path: str, fs=None):
         """
         Saves a dataset dict to a filesystem using either :class:`~filesystems.S3FileSystem` or


### PR DESCRIPTION
Added the ability for a DatasetDict to remove additional nested layers within its features to avoid conflicts when collating. It is meant to accompany [this PR](https://github.com/huggingface/transformers/pull/18119) to resolve the same issue [#15505](https://github.com/huggingface/transformers/issues/15505).

@stas00 @lhoestq 