### PR TITLE
Update create dataset card docs

### DIFF
--- a/docs/source/dataset_card.mdx
+++ b/docs/source/dataset_card.mdx
@@ -1,25 +1,24 @@
 # Create a dataset card
 
-Each dataset should be accompanied with a Dataset card to promote responsible usage, and alert the user to any potential biases within the dataset.
-This idea is inspired by the Model Cards proposed by [Mitchell, 2018](https://arxiv.org/abs/1810.03993).
-Dataset cards help users understand the contents of the dataset, context for how the dataset should be used, how it was created, and considerations for using the dataset.
-This guide shows you how to create your own Dataset card.
+Each dataset should have a dataset card to promote responsible usage and inform users of any potential biases within the dataset.
+This idea was inspired by the Model Cards proposed by [Mitchell, 2018](https://arxiv.org/abs/1810.03993).
+Dataset cards help users understand a dataset's contents, the context for using the dataset, how it was created, and any other considerations a user should be aware of.
 
-1. Create a new Dataset card by opening the [online card creator](https://huggingface.co/datasets/card-creator/), or manually copying the template from [here](https://raw.githubusercontent.com/huggingface/datasets/main/templates/README.md).
+This guide shows you how to create a dataset card.
 
-2. Next, you need to generate structured tags. The tags help users discover your dataset on the Hub. Create the tags with the [online Datasets Tagging app](https://huggingface.co/spaces/huggingface/datasets-tagging).
+1. Create a new dataset card by copying this [template](https://raw.githubusercontent.com/huggingface/datasets/main/templates/README.md) to a `README.md` file in your repository.
 
-3. Select the appropriate tags for your dataset from the dropdown menus, and save the file once you are done.
+2. Generate structured tags to help users discover your dataset on the Hub. Create the tags with the [online Datasets Tagging app](https://huggingface.co/spaces/huggingface/datasets-tagging).
 
-4. Expand the **Show YAML output aggregating the tags** section on the right, copy the YAML tags, and paste it under the matching section on the online form. Paste the tags into your `README.md` file if you manually created your Dataset card.
+3. Select the appropriate tags for your dataset from the dropdown menus.
 
-5. Expand the **Show Markdown Data Fields** section, paste it into the **Data Fields** section under **Data Structure** on the online form (or your local `README.md`). Modify the descriptions as needed, and briefly describe each of the fields.
+4. Copy the YAML tags under **Finalized tag set** and paste the tags at the top of your `README.md` file.
 
-6. Fill out the Dataset card to the best of your ability. Refer to the [Dataset Card Creation Guide](https://github.com/huggingface/datasets/blob/main/templates/README_guide.md) for more detailed information about each section of the card. For fields you are unable to complete, you can write **[More Information Needed]**.
+5. Fill out the dataset card sections to the best of your ability. Take a look at the [Dataset Card Creation Guide](https://github.com/huggingface/datasets/blob/main/templates/README_guide.md) for more detailed information about what to include in each section of the card. For fields you are unable to complete, you can write **[More Information Needed]**.
 
-7. Once you are done filling out the card with the online form, click the **Export** button to download the Dataset card. Place it in the same folder as your dataset.
+6. Once you're done filling out the dataset card, commit the changes to the `README.md` file and you should see the completed dataset card on your repository.
 
-Feel free to take a look at these examples of good Dataset cards for inspiration:
+Feel free to take a look at these dataset card examples to help you get started:
 
 - [SNLI](https://huggingface.co/datasets/snli)
 - [CNN / DailyMail](https://huggingface.co/datasets/cnn_dailymail)


### PR DESCRIPTION
This PR proposes removing the [online dataset card creator](https://huggingface.co/datasets/card-creator/) in favor of simply copy/pasting a template and using the [Datasets Tagger app](https://huggingface.co/spaces/huggingface/datasets-tagging) to generate the tags. The Tagger app provides more guidance by showing all possible values a user can select in the dropdown menus, whereas the online dataset card creator doesn't, which can make it difficult to know what tag values to input.

Let me know what you think! :)