### PR TITLE
Fix mock fsspec

### DIFF
--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -3,10 +3,10 @@ import os
 import re
 from pathlib import Path
 
+import fsspec
 import pytest
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 
-import datasets
 from datasets.download.streaming_download_manager import (
     StreamingDownloadManager,
     _as_posix,
@@ -129,9 +129,7 @@ class DummyTestFS(AbstractFileSystem):
 
 @pytest.fixture
 def mock_fsspec(monkeypatch):
-    dummy_registry = datasets.download.streaming_download_manager.fsspec.registry.target.copy()
-    dummy_registry["mock"] = DummyTestFS
-    monkeypatch.setattr("datasets.download.streaming_download_manager.fsspec.registry.target", dummy_registry)
+    monkeypatch.setitem(fsspec.registry.target, "mock", DummyTestFS)
 
 
 def _readd_double_slash_removed_by_path(path_as_posix: str) -> str:


### PR DESCRIPTION
This PR:
- Removes an unused method from `DummyTestFS`
- Refactors `mock_fsspec` to make it simpler