### PR TITLE
Trigger CI on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 env:
   HF_SCRIPTS_VERSION: main


### PR DESCRIPTION
Currently, new CI (on GitHub Actions) is only triggered on pull requests branches when the base branch is main.

This PR also triggers the CI when a PR is merged to main branch.