### PR TITLE
Skip test_extractor only for zstd param if zstandard not installed

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -32,7 +32,6 @@ def test_zstd_extractor(zstd_file, tmp_path, text_file):
     assert extracted_file_content == expected_file_content
 
 
-@require_zstandard
 @pytest.mark.parametrize(
     "compression_format, is_archive", [("gzip", False), ("xz", False), ("zstd", False), ("bz2", False), ("7z", True)]
 )
@@ -45,6 +44,8 @@ def test_extractor(
         reason = f"for '{compression_format}' compression_format, "
         if compression_format == "7z":
             reason += require_py7zr.kwargs["reason"]
+        elif compression_format == "zstd":
+            reason += require_zstandard.kwargs["reason"]
         pytest.skip(reason)
     input_path = str(input_path)
     assert Extractor.is_extractable(input_path)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,6 +41,7 @@ _run_packaged_tests = parse_flag_from_env("RUN_PACKAGED", default=True)
 
 
 require_py7zr = pytest.mark.skipif(not config.PY7ZR_AVAILABLE, reason="test requires py7zr")
+require_zstandard = pytest.mark.skipif(not config.ZSTANDARD_AVAILABLE, reason="test requires zstandard")
 
 
 def require_beam(test_case):
@@ -205,18 +206,6 @@ def require_torchaudio(test_case):
     """
     if find_spec("sox") is None:
         return unittest.skip("test requires 'torchaudio'")(test_case)
-    return test_case
-
-
-def require_zstandard(test_case):
-    """
-    Decorator marking a test that requires zstandard.
-
-    These tests are skipped when zstandard isn't installed.
-
-    """
-    if not config.ZSTANDARD_AVAILABLE:
-        test_case = unittest.skip("test requires zstandard")(test_case)
     return test_case
 
 


### PR DESCRIPTION
Currently, if `zstandard` is not installed, `test_extractor` is skipped for all compression format parameters.

This PR fixes `test_extractor` so that if `zstandard` is not installed, `test_extractor` is skipped only for the `zstd` compression parameter, that is, it is not skipped for all the other compression parameters (`gzip`, `xz`,...).