### PR TITLE
Test extractors for all compression formats

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,11 +150,11 @@ def tar_file(tmp_path_factory, text_file):
 
 @pytest.fixture(scope="session")
 def xz_file(tmp_path_factory):
-    filename = tmp_path_factory.mktemp("data") / "file.txt.xz"
+    path = tmp_path_factory.mktemp("data") / "file.txt.xz"
     data = bytes(FILE_CONTENT, "utf-8")
-    with lzma.open(filename, "wb") as f:
+    with lzma.open(path, "wb") as f:
         f.write(data)
-    return filename
+    return path
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,8 +293,6 @@ def bz2_csv_path(csv_path, tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def zip_csv_path(csv_path, csv2_path, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset.csv.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(csv_path, arcname=os.path.basename(csv_path))
@@ -304,8 +302,6 @@ def zip_csv_path(csv_path, csv2_path, tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def zip_csv_with_dir_path(csv_path, csv2_path, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.csv.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(csv_path, arcname=os.path.join("main_dir", os.path.basename(csv_path)))
@@ -409,8 +405,6 @@ def jsonl_gz_path(tmp_path_factory, jsonl_path):
 
 @pytest.fixture(scope="session")
 def zip_jsonl_path(jsonl_path, jsonl2_path, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset.jsonl.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(jsonl_path, arcname=os.path.basename(jsonl_path))
@@ -420,8 +414,6 @@ def zip_jsonl_path(jsonl_path, jsonl2_path, tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def zip_jsonl_with_dir_path(jsonl_path, jsonl2_path, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.jsonl.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(jsonl_path, arcname=os.path.join("main_dir", os.path.basename(jsonl_path)))
@@ -468,8 +460,6 @@ def text2_path(tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def zip_text_path(text_path, text2_path, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset.text.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(text_path, arcname=os.path.basename(text_path))
@@ -479,8 +469,6 @@ def zip_text_path(text_path, text2_path, tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def zip_text_with_dir_path(text_path, text2_path, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.text.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(text_path, arcname=os.path.join("main_dir", os.path.basename(text_path)))
@@ -504,8 +492,6 @@ def image_file():
 
 @pytest.fixture(scope="session")
 def zip_image_path(image_file, tmp_path_factory):
-    import zipfile
-
     path = tmp_path_factory.mktemp("data") / "dataset.img.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(image_file, arcname=os.path.basename(image_file))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import lzma
 import os
 import tarfile
 import textwrap
+import zipfile
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -95,26 +96,6 @@ def text_file(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def xz_file(tmp_path_factory):
-    filename = tmp_path_factory.mktemp("data") / "file.txt.xz"
-    data = bytes(FILE_CONTENT, "utf-8")
-    with lzma.open(filename, "wb") as f:
-        f.write(data)
-    return filename
-
-
-@pytest.fixture(scope="session")
-def gz_file(tmp_path_factory):
-    import gzip
-
-    path = str(tmp_path_factory.mktemp("data") / "file.txt.gz")
-    data = bytes(FILE_CONTENT, "utf-8")
-    with gzip.open(path, "wb") as f:
-        f.write(data)
-    return path
-
-
-@pytest.fixture(scope="session")
 def bz2_file(tmp_path_factory):
     import bz2
 
@@ -126,15 +107,14 @@ def bz2_file(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def zstd_file(tmp_path_factory):
-    if config.ZSTANDARD_AVAILABLE:
-        import zstandard as zstd
+def gz_file(tmp_path_factory):
+    import gzip
 
-        path = tmp_path_factory.mktemp("data") / "file.txt.zst"
-        data = bytes(FILE_CONTENT, "utf-8")
-        with zstd.open(path, "wb") as f:
-            f.write(data)
-        return path
+    path = str(tmp_path_factory.mktemp("data") / "file.txt.gz")
+    data = bytes(FILE_CONTENT, "utf-8")
+    with gzip.open(path, "wb") as f:
+        f.write(data)
+    return path
 
 
 @pytest.fixture(scope="session")
@@ -157,6 +137,43 @@ def seven_zip_file(tmp_path_factory, text_file):
         path = tmp_path_factory.mktemp("data") / "file.txt.7z"
         with py7zr.SevenZipFile(path, "w") as archive:
             archive.write(text_file, arcname=os.path.basename(text_file))
+        return path
+
+
+@pytest.fixture(scope="session")
+def tar_file(tmp_path_factory, text_file):
+    path = tmp_path_factory.mktemp("data") / "file.txt.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(text_file, arcname=os.path.basename(text_file))
+    return path
+
+
+@pytest.fixture(scope="session")
+def xz_file(tmp_path_factory):
+    filename = tmp_path_factory.mktemp("data") / "file.txt.xz"
+    data = bytes(FILE_CONTENT, "utf-8")
+    with lzma.open(filename, "wb") as f:
+        f.write(data)
+    return filename
+
+
+@pytest.fixture(scope="session")
+def zip_file(tmp_path_factory, text_file):
+    path = tmp_path_factory.mktemp("data") / "file.txt.zip"
+    with zipfile.ZipFile(path, "w") as f:
+        f.write(text_file, arcname=os.path.basename(text_file))
+    return path
+
+
+@pytest.fixture(scope="session")
+def zstd_file(tmp_path_factory):
+    if config.ZSTANDARD_AVAILABLE:
+        import zstandard as zstd
+
+        path = tmp_path_factory.mktemp("data") / "file.txt.zst"
+        data = bytes(FILE_CONTENT, "utf-8")
+        with zstd.open(path, "wb") as f:
+            f.write(data)
         return path
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -33,12 +33,31 @@ def test_zstd_extractor(zstd_file, tmp_path, text_file):
 
 
 @pytest.mark.parametrize(
-    "compression_format, is_archive", [("gzip", False), ("xz", False), ("zstd", False), ("bz2", False), ("7z", True)]
+    "compression_format, is_archive",
+    [("7z", True), ("bz2", False), ("gzip", False), ("tar", True), ("xz", False), ("zip", True), ("zstd", False)],
 )
 def test_extractor(
-    compression_format, is_archive, gz_file, xz_file, zstd_file, bz2_file, seven_zip_file, tmp_path, text_file
+    compression_format,
+    is_archive,
+    bz2_file,
+    gz_file,
+    seven_zip_file,
+    tar_file,
+    xz_file,
+    zip_file,
+    zstd_file,
+    tmp_path,
+    text_file,
 ):
-    input_paths = {"gzip": gz_file, "xz": xz_file, "zstd": zstd_file, "bz2": bz2_file, "7z": seven_zip_file}
+    input_paths = {
+        "7z": seven_zip_file,
+        "bz2": bz2_file,
+        "gzip": gz_file,
+        "tar": tar_file,
+        "xz": xz_file,
+        "zip": zip_file,
+        "zstd": zstd_file,
+    }
     input_path = input_paths[compression_format]
     if input_path is None:
         reason = f"for '{compression_format}' compression_format, "


### PR DESCRIPTION
This PR:
- Adds all compression formats to `test_extractor`
- Tests each base extractor for all compression formats

Note that all compression formats are tested except "rar".