### PR TITLE
Refactor base extractors

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import struct
 import tarfile
+from abc import ABC, abstractmethod
 from zipfile import ZipFile
 from zipfile import is_zipfile as _is_zipfile
 
@@ -40,6 +41,24 @@ class ExtractManager:
         if self._do_extract(output_path, force_extract):
             self.extractor.extract(input_path, output_path, extractor=extractor)
         return output_path
+
+
+class BaseExtractor(ABC):
+    magic_number = b""
+
+    @classmethod
+    def is_extractable(cls, path: str) -> bool:
+        with open(path, "rb") as f:
+            try:
+                magic_number = f.read(len(cls.magic_number))
+            except OSError:
+                return False
+        return magic_number == cls.magic_number
+
+    @staticmethod
+    @abstractmethod
+    def extract(input_path: str, output_path: str) -> None:
+        ...
 
 
 class TarExtractor:

--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -186,9 +186,29 @@ class Extractor:
     ]
 
     @classmethod
-    def is_extractable(cls, path, return_extractor=False):
+    def _get_magic_number_max_length(cls):
+        magic_number_max_length = 0
         for extractor in cls.extractors:
-            if extractor.is_extractable(path):
+            if hasattr(extractor, "magic_number"):
+                magic_number_length = len(extractor.magic_number)
+                magic_number_max_length = (
+                    magic_number_length if magic_number_length > magic_number_max_length else magic_number_max_length
+                )
+        return magic_number_max_length
+
+    @staticmethod
+    def _read_magic_number(path: str, magic_number_length: int):
+        try:
+            return BaseExtractor.read_magic_number(path, magic_number_length=magic_number_length)
+        except OSError:
+            return b""
+
+    @classmethod
+    def is_extractable(cls, path, return_extractor=False):
+        magic_number_max_length = cls._get_magic_number_max_length()
+        magic_number = cls._read_magic_number(path, magic_number_max_length)
+        for extractor in cls.extractors:
+            if extractor.is_extractable(path, magic_number=magic_number):
                 return True if not return_extractor else (True, extractor)
         return False if not return_extractor else (False, None)
 

--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -4,9 +4,8 @@ import lzma
 import os
 import shutil
 import tarfile
+import zipfile
 from abc import ABC, abstractmethod
-from zipfile import ZipFile
-from zipfile import is_zipfile as _is_zipfile
 
 from .. import config
 from .filelock import FileLock
@@ -86,12 +85,12 @@ class GzipExtractor(BaseExtractor):
 class ZipExtractor(BaseExtractor):
     @classmethod
     def is_extractable(cls, path: str) -> bool:
-        return _is_zipfile(path)
+        return zipfile.is_zipfile(path)
 
     @staticmethod
     def extract(input_path: str, output_path: str) -> None:
         os.makedirs(output_path, exist_ok=True)
-        with ZipFile(input_path, "r") as zip_file:
+        with zipfile.ZipFile(input_path, "r") as zip_file:
             zip_file.extractall(output_path)
             zip_file.close()
 

--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -33,12 +33,12 @@ class ExtractManager:
         )
 
     def extract(self, input_path, force_extract=False):
-        is_extractable, extractor = self.extractor.is_extractable(input_path, return_extractor=True)
-        if not is_extractable:
+        extractor_format = self.extractor.infer_extractor_format(input_path)
+        if not extractor_format:
             return input_path
         output_path = self._get_output_path(input_path)
         if self._do_extract(output_path, force_extract):
-            self.extractor.extract(input_path, output_path, extractor=extractor)
+            self.extractor.extract(input_path, output_path, extractor_format)
         return output_path
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -97,10 +97,10 @@ def test_extractor(
             reason += require_zstandard.kwargs["reason"]
         pytest.skip(reason)
     input_path = str(input_path)
-    is_extractable, extractor = Extractor.is_extractable(input_path, return_extractor=True)
-    assert is_extractable
+    extractor_format = Extractor.infer_extractor_format(input_path)
+    assert extractor_format is not None
     output_path = tmp_path / ("extracted" if is_archive else "extracted.txt")
-    Extractor.extract(input_path, output_path, extractor=extractor)
+    Extractor.extract(input_path, output_path, extractor_format)
     if is_archive:
         assert output_path.is_dir()
         for file_path in output_path.iterdir():

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -97,9 +97,10 @@ def test_extractor(
             reason += require_zstandard.kwargs["reason"]
         pytest.skip(reason)
     input_path = str(input_path)
-    assert Extractor.is_extractable(input_path)
+    is_extractable, extractor = Extractor.is_extractable(input_path, return_extractor=True)
+    assert is_extractable
     output_path = tmp_path / ("extracted" if is_archive else "extracted.txt")
-    Extractor.extract(input_path, output_path)
+    Extractor.extract(input_path, output_path, extractor=extractor)
     if is_archive:
         assert output_path.is_dir()
         for file_path in output_path.iterdir():


### PR DESCRIPTION
This PR:
- Refactors base extractors as subclasses of `BaseExtractor`:
  - this is an abstract class defining the interface with:
    - `is_extractable`: abstract class method
    - `extract`: abstract static method
- Implements abstract `MagicNumberBaseExtractor` (as subclass of `BaseExtractor`): 
  - this has a default implementation of `is_extractable`
  - this improves performance (reducing the number of file reads) by allowing passing already read `magic_number`
- Refactors `Extractor`:
  - reads magic number from file only once

This PR deprecates:
```python
is_extractable, extractor = self.extractor.is_extractable(input_path, return_extractor=True)
self.extractor.extract(input_path, output_path, extractor=extractor)
```
and uses more Pythonic instead:
```python
extractor_format = self.extractor.infer_extractor_format(input_path)
self.extractor.extract(input_path, output_path, extractor_format)
```