### PR TITLE
Make cast in `from_pandas` more robust

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -825,8 +825,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             info = DatasetInfo()
         info.features = features
         table = InMemoryTable.from_pandas(
-            df=df, preserve_index=preserve_index, schema=features.arrow_schema if features is not None else None
+            df=df,
+            preserve_index=preserve_index,
         )
+        if features is not None:
+            # more expensive cast than InMemoryTable.from_pandas(..., schema=features.arrow_schema)
+            # needed to support str to Audio for example
+            table = table.cast(features.arrow_schema)
         return cls(table, info=info, split=split)
 
     @classmethod

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -830,7 +830,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         )
         if features is not None:
             # more expensive cast than InMemoryTable.from_pandas(..., schema=features.arrow_schema)
-            # needed to support str to Audio for example
+            # needed to support the str to Audio conversion for instance
             table = table.cast(features.arrow_schema)
         return cls(table, info=info, split=split)
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2443,8 +2443,8 @@ class MiscellaneousDatasetTest(TestCase):
             self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
             self.assertDictEqual(dset.features, Features({"col_1": Value("int64"), "col_2": Value("string")}))
 
-        features = Features({"col_1": Value("string"), "col_2": Value("string")})
-        self.assertRaises(pa.ArrowTypeError, Dataset.from_pandas, df, features=features)
+        features = Features({"col_1": Sequence(Value("string")), "col_2": Value("string")})
+        self.assertRaises(TypeError, Dataset.from_pandas, df, features=features)
 
     def test_from_dict(self):
         data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}


### PR DESCRIPTION
Make the cast in `from_pandas` more robust (as it was done for the packaged modules in https://github.com/huggingface/datasets/pull/4364)

This should be useful in situations like [this one](https://discuss.huggingface.co/t/loading-custom-audio-dataset-and-fine-tuning-model/8836/4).