### PR TITLE
Document installation of sox OS dependency for audio

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -85,6 +85,12 @@ pip install torchaudio
 
 torchaudio's `sox_io` [backend](https://pytorch.org/audio/stable/backend.html#) supports decoding MP3 files. Unfortunately, the `sox_io` backend is only available on Linux/macOS and isn't supported by Windows.
 
+You need to install it using your distribution package manager, for example:
+
+```bash
+sudo apt-get install sox
+```
+
 </Tip>
 
 ## Vision


### PR DESCRIPTION
The `sox` OS package needs being installed manually using the distribution package manager.

This PR adds this explanation to the docs.