### PR TITLE
Fix named split sorting and remove unnecessary casting

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -951,7 +951,7 @@ class DatasetBuilder:
                     self.info.post_processed = PostProcessedInfo()
                 if self.info.post_processed.resources_checksums is None:
                     self.info.post_processed.resources_checksums = {}
-                self.info.post_processed.resources_checksums[split] = recorded_checksums
+                self.info.post_processed.resources_checksums[str(split)] = recorded_checksums
                 self.info.post_processing_size = sum(
                     checksums_dict["num_bytes"]
                     for split_checksums_dicts in self.info.post_processed.resources_checksums.values()

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -951,7 +951,7 @@ class DatasetBuilder:
                     self.info.post_processed = PostProcessedInfo()
                 if self.info.post_processed.resources_checksums is None:
                     self.info.post_processed.resources_checksums = {}
-                self.info.post_processed.resources_checksums[str(split)] = recorded_checksums
+                self.info.post_processed.resources_checksums[split] = recorded_checksums
                 self.info.post_processing_size = sum(
                     checksums_dict["num_bytes"]
                     for split_checksums_dicts in self.info.post_processed.resources_checksums.values()

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -14,7 +14,7 @@ from .utils.file_utils import hf_hub_url, is_relative_path, is_remote_url, reque
 from .utils.py_utils import string_to_dict
 
 
-DEFAULT_SPLIT = str(Split.TRAIN)
+DEFAULT_SPLIT = Split.TRAIN
 
 
 logger = logging.get_logger(__name__)
@@ -34,17 +34,17 @@ KEYWORDS_IN_FILENAME_BASE_PATTERNS = ["**[{sep}/]{keyword}[{sep}]*", "{keyword}[
 KEYWORDS_IN_DIR_NAME_BASE_PATTERNS = ["{keyword}[{sep}/]**", "**[{sep}/]{keyword}[{sep}/]**"]
 
 DEFAULT_PATTERNS_SPLIT_IN_FILENAME = {
-    str(Split.TRAIN): [
+    Split.TRAIN: [
         pattern.format(keyword=keyword, sep=NON_WORDS_CHARS)
         for keyword in TRAIN_KEYWORDS
         for pattern in KEYWORDS_IN_FILENAME_BASE_PATTERNS
     ],
-    str(Split.TEST): [
+    Split.TEST: [
         pattern.format(keyword=keyword, sep=NON_WORDS_CHARS)
         for keyword in TEST_KEYWORDS
         for pattern in KEYWORDS_IN_FILENAME_BASE_PATTERNS
     ],
-    str(Split.VALIDATION): [
+    Split.VALIDATION: [
         pattern.format(keyword=keyword, sep=NON_WORDS_CHARS)
         for keyword in VALIDATION_KEYWORDS
         for pattern in KEYWORDS_IN_FILENAME_BASE_PATTERNS
@@ -52,17 +52,17 @@ DEFAULT_PATTERNS_SPLIT_IN_FILENAME = {
 }
 
 DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
-    str(Split.TRAIN): [
+    Split.TRAIN: [
         pattern.format(keyword=keyword, sep=NON_WORDS_CHARS)
         for keyword in TRAIN_KEYWORDS
         for pattern in KEYWORDS_IN_DIR_NAME_BASE_PATTERNS
     ],
-    str(Split.TEST): [
+    Split.TEST: [
         pattern.format(keyword=keyword, sep=NON_WORDS_CHARS)
         for keyword in TEST_KEYWORDS
         for pattern in KEYWORDS_IN_DIR_NAME_BASE_PATTERNS
     ],
-    str(Split.VALIDATION): [
+    Split.VALIDATION: [
         pattern.format(keyword=keyword, sep=NON_WORDS_CHARS)
         for keyword in VALIDATION_KEYWORDS
         for pattern in KEYWORDS_IN_DIR_NAME_BASE_PATTERNS
@@ -70,7 +70,7 @@ DEFAULT_PATTERNS_SPLIT_IN_DIR_NAME = {
 }
 
 DEFAULT_PATTERNS_ALL = {
-    str(Split.TRAIN): ["**"],
+    Split.TRAIN: ["**"],
 }
 
 ALL_SPLIT_PATTERNS = [SPLIT_PATTERN_SHARDED]
@@ -98,7 +98,7 @@ def sanitize_patterns(patterns: Union[Dict, List, str]) -> Dict[str, Union[List[
         patterns: dictionary of split_name -> list_of _atterns
     """
     if isinstance(patterns, dict):
-        return {str(key): value if isinstance(value, list) else [value] for key, value in patterns.items()}
+        return {key: value if isinstance(value, list) else [value] for key, value in patterns.items()}
     elif isinstance(patterns, str):
         return {DEFAULT_SPLIT: [patterns]}
     elif isinstance(patterns, list):
@@ -689,10 +689,10 @@ def _get_single_origin_metadata_locally_or_by_urls(
 ) -> Tuple[str]:
     if isinstance(data_file, Url):
         data_file = str(data_file)
-        return (request_etag(data_file, use_auth_token=use_auth_token),)
+        return request_etag(data_file, use_auth_token=use_auth_token),
     else:
         data_file = str(data_file.resolve())
-        return (str(os.path.getmtime(data_file)),)
+        return str(os.path.getmtime(data_file)),
 
 
 def _get_origin_metadata_locally_or_by_urls(

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -689,10 +689,10 @@ def _get_single_origin_metadata_locally_or_by_urls(
 ) -> Tuple[str]:
     if isinstance(data_file, Url):
         data_file = str(data_file)
-        return request_etag(data_file, use_auth_token=use_auth_token),
+        return (request_etag(data_file, use_auth_token=use_auth_token),)
     else:
         data_file = str(data_file.resolve())
-        return str(os.path.getmtime(data_file)),
+        return (str(os.path.getmtime(data_file)),)
 
 
 def _get_origin_metadata_locally_or_by_urls(

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -14,7 +14,7 @@ from .utils.file_utils import hf_hub_url, is_relative_path, is_remote_url, reque
 from .utils.py_utils import string_to_dict
 
 
-DEFAULT_SPLIT = Split.TRAIN
+SANITIZED_DEFAULT_SPLIT = str(Split.TRAIN)
 
 
 logger = logging.get_logger(__name__)
@@ -98,13 +98,13 @@ def sanitize_patterns(patterns: Union[Dict, List, str]) -> Dict[str, Union[List[
         patterns: dictionary of split_name -> list_of _atterns
     """
     if isinstance(patterns, dict):
-        return {key: value if isinstance(value, list) else [value] for key, value in patterns.items()}
+        return {str(key): value if isinstance(value, list) else [value] for key, value in patterns.items()}
     elif isinstance(patterns, str):
-        return {DEFAULT_SPLIT: [patterns]}
+        return {SANITIZED_DEFAULT_SPLIT: [patterns]}
     elif isinstance(patterns, list):
-        return {DEFAULT_SPLIT: patterns}
+        return {SANITIZED_DEFAULT_SPLIT: patterns}
     else:
-        return {DEFAULT_SPLIT: list(patterns)}
+        return {SANITIZED_DEFAULT_SPLIT: list(patterns)}
 
 
 def _is_inside_unrequested_special_dir(matched_rel_path: str, pattern: str) -> bool:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -50,7 +50,7 @@ class DatasetDict(dict):
             return super().__getitem__(k)
         else:
             available_suggested_splits = [
-                str(split) for split in (Split.TRAIN, Split.TEST, Split.VALIDATION) if split in self
+                split for split in (Split.TRAIN, Split.TEST, Split.VALIDATION) if split in self
             ]
             suggested_split = available_suggested_splits[0] if available_suggested_splits else list(self)[0]
             raise KeyError(

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -362,6 +362,9 @@ class NamedSplit(SplitBase):
         else:
             raise ValueError(f"Equality not supported between split {self} and {other}")
 
+    def __lt__(self, other):
+        return self._name < other._name  # pylint: disable=protected-access
+
     def __hash__(self):
         return hash(self._name)
 

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -55,7 +55,7 @@ def test_dataset_from_csv_split(split, csv_path, tmp_path):
     expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     dataset = CsvDatasetReader(csv_path, cache_dir=cache_dir, split=split).read()
     _check_csv_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -95,7 +95,7 @@ def test_dataset_from_json_split(split, jsonl_path, tmp_path):
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     dataset = JsonDatasetReader(jsonl_path, cache_dir=cache_dir, split=split).read()
     _check_json_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -52,7 +52,7 @@ def test_dataset_from_parquet_split(split, parquet_path, tmp_path):
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     dataset = ParquetDatasetReader(parquet_path, cache_dir=cache_dir, split=split).read()
     _check_parquet_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])

--- a/tests/io/test_text.py
+++ b/tests/io/test_text.py
@@ -50,7 +50,7 @@ def test_dataset_from_text_split(split, text_path, tmp_path):
     expected_features = {"text": "string"}
     dataset = TextDatasetReader(text_path, cache_dir=cache_dir, split=split).read()
     _check_text_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2863,7 +2863,7 @@ def test_dataset_from_csv_split(split, csv_path, tmp_path):
     expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     dataset = Dataset.from_csv(csv_path, cache_dir=cache_dir, split=split)
     _check_csv_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])
@@ -2932,7 +2932,7 @@ def test_dataset_from_json_split(split, jsonl_path, tmp_path):
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     dataset = Dataset.from_json(jsonl_path, cache_dir=cache_dir, split=split)
     _check_json_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])
@@ -2992,7 +2992,7 @@ def test_dataset_from_parquet_split(split, parquet_path, tmp_path):
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     dataset = Dataset.from_parquet(parquet_path, cache_dir=cache_dir, split=split)
     _check_parquet_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])
@@ -3051,7 +3051,7 @@ def test_dataset_from_text_split(split, text_path, tmp_path):
     expected_features = {"text": "string"}
     dataset = Dataset.from_text(text_path, cache_dir=cache_dir, split=split)
     _check_text_dataset(dataset, expected_features)
-    assert dataset.split == str(split) if split else "train"
+    assert dataset.split == split if split else "train"
 
 
 @pytest.mark.parametrize("path_type", [str, list])

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -604,7 +604,7 @@ def test_get_data_files_patterns(data_file_per_split):
         return [PurePath(file_path) for file_path in fs.glob(pattern) if fs.isfile(file_path)]
 
     patterns_per_split = _get_data_files_patterns(resolver)
-    assert sorted(patterns_per_split.keys()) == sorted(data_file_per_split.keys())
+    assert patterns_per_split.keys() == data_file_per_split.keys()
     for split, patterns in patterns_per_split.items():
         matched = [file_path.as_posix() for pattern in patterns for file_path in resolver(pattern)]
         assert matched == data_file_per_split[split]


### PR DESCRIPTION
This PR:
- makes `NamedSplit` sortable: so that `sorted()` can be called on them
- removes unnecessary `sorted()` on `dict.keys()`: `dict_keys` view is already like a `set`
- removes unnecessary casting of `NamedSplit` to `str`