### PR TITLE
Pin rouge_score test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ TESTS_REQUIRE = [
     "bert_score>=0.3.6",
     "jiwer",
     "mauve-text",
-    "rouge_score",
+    "rouge_score<0.0.7",
     "sacrebleu",
     "sacremoses",
     "scikit-learn",


### PR DESCRIPTION
Temporarily pin `rouge_score` (to avoid latest version 0.7.0) until the issue is fixed.

Fix #4734 