### PR TITLE
Use CI unit/integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
   test:
     needs: check_code_quality
     strategy:
-      fail-fast: false
       matrix:
+        test: ['unit', 'integration']
         os: [ubuntu-latest, windows-latest]
         pyarrow_version: [latest, 6.0.1]
+    continue-on-error: ${{ matrix.test == 'integration' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install OS dependencies
@@ -76,4 +77,4 @@ jobs:
         run: pip install pyarrow==${{ matrix.pyarrow_version }}
       - name: Test with pytest
         run: |
-          python -m pytest -n 2 --dist loadfile -sv ./tests/
+          python -m pytest -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ exclude =
 per-file-ignores =
     metrics/*:F401
 
-[pytest]
+[tool:pytest]
 markers =
     unit: unit test
     integration: integration test

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,8 @@ exclude =
     src/datasets/metrics
 per-file-ignores =
     metrics/*:F401
+
+[pytest]
+markers =
+    unit: unit test
+    integration: integration test

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -3,6 +3,7 @@ import os
 from collections import namedtuple
 from dataclasses import dataclass
 
+import pytest
 from packaging import version
 
 from datasets import config
@@ -43,6 +44,7 @@ else:
             return iter(self.__dict__.values())
 
 
+@pytest.mark.integration
 def test_test_command(dataset_loading_script_dir):
     args = _TestCommandArgs(dataset=dataset_loading_script_dir, all_configs=True, save_infos=True)
     test_command = TestCommand(*args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,14 @@ import datasets
 pytest_plugins = ["tests.fixtures.files", "tests.fixtures.hub", "tests.fixtures.s3"]
 
 
+def pytest_collection_modifyitems(config, items):
+    # Mark tests as "unit" by default if not marked as "integration" (or already marked as "unit")
+    for item in items:
+        if any(marker in item.keywords for marker in ["integration", "unit"]):
+            continue
+        item.add_marker(pytest.mark.unit)
+
+
 @pytest.fixture(autouse=True)
 def set_test_cache_config(tmp_path_factory, monkeypatch):
     # test_hf_cache_home = tmp_path_factory.mktemp("cache")  # TODO: why a cache dir per test function does not work?

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -602,6 +602,7 @@ def test_load_dataset_with_audio_feature(streaming, jsonl_audio_dataset_path, sh
 
 
 @require_sndfile
+@pytest.mark.integration
 def test_dataset_with_audio_feature_loaded_from_cache():
     # load first time
     ds = load_dataset("patrickvonplaten/librispeech_asr_dummy", "clean")

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2495,6 +2495,7 @@ class MiscellaneousDatasetTest(TestCase):
                     self.assertListEqual(concatenated_dset["id"], dset1["id"] + dset2["id"] + dset3["id"])
 
     @require_transformers
+    @pytest.mark.integration
     def test_set_format_encode(self):
         from transformers import BertTokenizer
 
@@ -3122,6 +3123,7 @@ def test_pickle_dataset_after_transforming_the_table(in_memory, method_and_param
     reason='On Windows CircleCI or GitHub Actions, it raises botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://127.0.0.1:5555/test"',
 )  # TODO: find what's wrong with CircleCI / GitHub Actions
 @require_s3
+@pytest.mark.integration
 def test_dummy_dataset_serialize_s3(s3, dataset, s3_test_bucket_name):
     mock_bucket = s3_test_bucket_name
     dataset_path = f"s3://{mock_bucket}/my_dataset"

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -21,6 +21,7 @@ from multiprocessing import Pool
 from typing import List, Optional
 from unittest import TestCase
 
+import pytest
 from absl.testing import parameterized
 
 from datasets.builder import BuilderConfig, DatasetBuilder
@@ -293,6 +294,7 @@ def get_packaged_dataset_names():
 
 @parameterized.named_parameters(get_packaged_dataset_names())
 @packaged
+@pytest.mark.integration
 class PackagedDatasetTest(parameterized.TestCase):
     dataset_name = None
 

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -668,6 +668,7 @@ def test_datasetdict_from_text_split(split, text_path, tmp_path):
     reason='On Windows CircleCI or GitHub Actions, it raises botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://127.0.0.1:5555/test"',
 )  # TODO: find what's wrong with CircleCI / GitHub Actions
 @require_s3
+@pytest.mark.integration
 def test_dummy_dataset_serialize_s3(s3, dataset, s3_test_bucket_name):
     dsets = DatasetDict({"train": dataset, "test": dataset.select(range(2))})
     mock_bucket = s3_test_bucket_name

--- a/tests/test_dataset_scripts.py
+++ b/tests/test_dataset_scripts.py
@@ -2,7 +2,10 @@ import re
 from pathlib import Path
 from unittest import TestCase
 
+import pytest
 
+
+@pytest.mark.integration
 class TestDatasetScripts(TestCase):
     def _no_encoding_on_file_open(self, filepath: str):
         r"""Find all instances where a non-binary file is opened without UTF-8 encoding.

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -91,6 +91,7 @@ def test_fs_isfile(protocol, zip_jsonl_path, jsonl_gz_path):
     assert not fs.isfile("non_existing_" + member_file_path)
 
 
+@pytest.mark.integration
 def test_hf_filesystem(hf_token, hf_api, hf_private_dataset_repo_txt_data, text_file):
     repo_info = hf_api.dataset_info(hf_private_dataset_repo_txt_data, token=hf_token)
     hffs = HfFileSystem(repo_info=repo_info, token=hf_token)

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -8,6 +8,7 @@ from types import CodeType, FunctionType
 from unittest import TestCase
 from unittest.mock import patch
 
+import pytest
 from multiprocess import Pool
 
 import datasets
@@ -49,6 +50,7 @@ class UnpicklableCallable:
 
 class TokenizersDumpTest(TestCase):
     @require_transformers
+    @pytest.mark.integration
     def test_hash_tokenizer(self):
         from transformers import AutoTokenizer
 
@@ -76,6 +78,7 @@ class TokenizersDumpTest(TestCase):
         self.assertNotEqual(hash1_encode, hash2_encode)
 
     @require_transformers
+    @pytest.mark.integration
     def test_hash_tokenizer_with_cache(self):
         from transformers import AutoTokenizer
 

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -297,6 +297,7 @@ class HashingTest(TestCase):
         self.assertEqual(hash1, hash3)
 
 
+@pytest.mark.integration
 def test_move_script_doesnt_change_hash(tmp_path: Path):
     dir1 = tmp_path / "dir1"
     dir2 = tmp_path / "dir2"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -53,6 +53,7 @@ def test_get_dataset_config_info_error(path, config_name, expected_exception):
         get_dataset_config_info(path, config_name=config_name)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "path, expected",
     [

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,6 +12,9 @@ from datasets import (
 )
 
 
+pytestmark = pytest.mark.integration
+
+
 @pytest.mark.parametrize("path", ["paws", "csv"])
 def test_inspect_dataset(path, tmp_path):
     inspect_dataset(path, tmp_path)
@@ -53,7 +56,6 @@ def test_get_dataset_config_info_error(path, config_name, expected_exception):
         get_dataset_config_info(path, config_name=config_name)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "path, expected",
     [

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -603,6 +603,7 @@ def test_sharded_iterable_dataset_torch_dataloader_parallel(n_shards, num_worker
 
 
 @require_torch
+@pytest.mark.integration
 @pytest.mark.parametrize("num_workers", [1, 2])
 def test_iterable_dataset_from_hub_torch_dataloader_parallel(num_workers, tmp_path):
     from torch.utils.data import DataLoader

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -381,6 +381,7 @@ class ModuleFactoryTest(TestCase):
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )
 
+    @pytest.mark.integration
     def test_HubDatasetModuleFactoryWithoutScript(self):
         factory = HubDatasetModuleFactoryWithoutScript(
             SAMPLE_DATASET_IDENTIFIER2, download_config=self.download_config
@@ -389,6 +390,7 @@ class ModuleFactoryTest(TestCase):
         assert importlib.import_module(module_factory_result.module_path) is not None
         assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
 
+    @pytest.mark.integration
     def test_HubDatasetModuleFactoryWithoutScript_with_data_dir(self):
         data_dir = "data2"
         factory = HubDatasetModuleFactoryWithoutScript(
@@ -408,6 +410,7 @@ class ModuleFactoryTest(TestCase):
             + module_factory_result.builder_kwargs["data_files"]["test"]
         )
 
+    @pytest.mark.integration
     def test_HubDatasetModuleFactoryWithoutScript_with_metadata(self):
         factory = HubDatasetModuleFactoryWithoutScript(
             SAMPLE_DATASET_IDENTIFIER4, download_config=self.download_config
@@ -429,6 +432,7 @@ class ModuleFactoryTest(TestCase):
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )
 
+    @pytest.mark.integration
     def test_HubDatasetModuleFactoryWithScript(self):
         factory = HubDatasetModuleFactoryWithScript(
             SAMPLE_DATASET_IDENTIFIER,
@@ -658,6 +662,7 @@ def test_load_dataset_builder_for_relative_data_dir(complex_data_dir):
         assert len(builder.config.data_files["test"]) > 0
 
 
+@pytest.mark.integration
 def test_load_dataset_builder_for_community_dataset_with_script():
     builder = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER)
     assert isinstance(builder, DatasetBuilder)
@@ -669,6 +674,7 @@ def test_load_dataset_builder_for_community_dataset_with_script():
     assert SAMPLE_DATASET_IDENTIFIER.replace("/", "--") in builder.__module__
 
 
+@pytest.mark.integration
 def test_load_dataset_builder_for_community_dataset_without_script():
     builder = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER2)
     assert isinstance(builder, DatasetBuilder)
@@ -725,6 +731,7 @@ def test_load_dataset_streaming_gz_json(jsonl_gz_path):
     assert ds_item == {"col_1": "0", "col_2": 0, "col_3": 0.0}
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "path", ["sample.jsonl", "sample.jsonl.gz", "sample.tar", "sample.jsonl.xz", "sample.zip", "sample.jsonl.zst"]
 )
@@ -758,6 +765,7 @@ def test_load_dataset_streaming_csv(path_extension, streaming, csv_path, bz2_csv
 
 
 @require_pil
+@pytest.mark.integration
 @pytest.mark.parametrize("streaming", [False, True])
 def test_load_dataset_private_zipped_images(hf_private_dataset_repo_zipped_img_data, hf_token, streaming):
     ds = load_dataset(
@@ -848,6 +856,7 @@ def test_load_dataset_text_with_unicode_new_lines(text_path_with_unicode_new_lin
     assert ds.num_rows == 3
 
 
+@pytest.mark.integration
 def test_loading_from_the_datasets_hub():
     with tempfile.TemporaryDirectory() as tmp_dir:
         dataset = load_dataset(SAMPLE_DATASET_IDENTIFIER, cache_dir=tmp_dir)
@@ -872,6 +881,7 @@ def test_loading_from_the_datasets_hub_with_use_auth_token():
         mock_head.assert_called()
 
 
+@pytest.mark.integration
 def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_data):
     with pytest.raises(FileNotFoundError):
         load_dataset(hf_private_dataset_repo_txt_data, streaming=True)
@@ -879,6 +889,7 @@ def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_da
     assert next(iter(ds)) is not None
 
 
+@pytest.mark.integration
 def test_load_streaming_private_dataset_with_zipped_data(hf_token, hf_private_dataset_repo_zipped_txt_data):
     with pytest.raises(FileNotFoundError):
         load_dataset(hf_private_dataset_repo_zipped_txt_data, streaming=True)
@@ -953,6 +964,7 @@ def test_load_from_disk_with_default_in_memory(
         _ = load_from_disk(dataset_path)
 
 
+@pytest.mark.integration
 def test_remote_data_files():
     repo_id = "albertvillanova/tests-raw-jsonl"
     filename = "wikiann-bn-validation.jsonl"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -498,6 +498,7 @@ def test_module_factories(factory_class):
     assert factory.name == name
 
 
+@pytest.mark.integration
 class LoadTest(TestCase):
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
@@ -865,6 +866,7 @@ def test_loading_from_the_datasets_hub():
         del dataset
 
 
+@pytest.mark.integration
 def test_loading_from_the_datasets_hub_with_use_auth_token():
     from requests import get
 

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -69,6 +69,7 @@ def get_local_metric_names():
 @parameterized.named_parameters(get_local_metric_names())
 @for_all_test_methods(skip_if_metric_requires_fairseq, skip_on_windows_if_not_windows_compatible)
 @local
+@pytest.mark.integration
 class LocalMetricTest(parameterized.TestCase):
     INTENSIVE_CALLS_PATCHER = {}
     metric_name = None

--- a/tests/test_offline_util.py
+++ b/tests/test_offline_util.py
@@ -6,6 +6,7 @@ from datasets.utils.file_utils import http_head
 from .utils import OfflineSimulationMode, RequestWouldHangIndefinitelyError, offline
 
 
+@pytest.mark.integration
 def test_offline_with_timeout():
     with offline(OfflineSimulationMode.CONNECTION_TIMES_OUT):
         with pytest.raises(RequestWouldHangIndefinitelyError):
@@ -14,6 +15,7 @@ def test_offline_with_timeout():
             requests.request("GET", "https://huggingface.co", timeout=1.0)
 
 
+@pytest.mark.integration
 def test_offline_with_connection_error():
     with offline(OfflineSimulationMode.CONNECTION_FAILS):
         with pytest.raises(requests.exceptions.ConnectionError):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,11 +5,15 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from datasets.arrow_dataset import Dataset
 from datasets.search import ElasticSearchIndex, FaissIndex, MissingIndex
 
 from .utils import require_elasticsearch, require_faiss
+
+
+pytestmark = pytest.mark.integration
 
 
 @require_faiss

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -271,6 +271,7 @@ def test_xopen_local(text_path):
         assert list(f) == list(expected_file)
 
 
+@pytest.mark.integration
 def test_xopen_remote():
     with xopen(TEST_URL, "r", encoding="utf-8") as f:
         assert list(f) == TEST_URL_CONTENT.splitlines(keepends=True)
@@ -296,6 +297,7 @@ def test_xlistdir(input_path, expected_paths, tmp_path, mock_fsspec):
     assert output_paths == expected_paths
 
 
+@pytest.mark.integration
 def test_xlistdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     assert len(xlistdir("zip://::" + root_url, use_auth_token=hf_token)) == 1
@@ -323,6 +325,7 @@ def test_xisdir(input_path, isdir, tmp_path, mock_fsspec):
     assert xisdir(input_path) == isdir
 
 
+@pytest.mark.integration
 def test_xisdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     assert xisdir("zip://::" + root_url, use_auth_token=hf_token) is True
@@ -348,6 +351,7 @@ def test_xisfile(input_path, isfile, tmp_path, mock_fsspec):
     assert xisfile(input_path) == isfile
 
 
+@pytest.mark.integration
 def test_xisfile_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_txt_data, "")
     assert xisfile(root_url + "data/text_data.txt", use_auth_token=hf_token) is True
@@ -370,6 +374,7 @@ def test_xgetsize(input_path, size, tmp_path, mock_fsspec):
     assert xgetsize(input_path) == size
 
 
+@pytest.mark.integration
 def test_xgetsize_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_txt_data, "")
     assert xgetsize(root_url + "data/text_data.txt", use_auth_token=hf_token) == 39
@@ -412,6 +417,7 @@ def test_xglob(input_path, expected_paths, tmp_path, mock_fsspec):
     assert output_paths == expected_paths
 
 
+@pytest.mark.integration
 def test_xglob_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     assert len(xglob("zip://**::" + root_url, use_auth_token=hf_token)) == 3
@@ -449,6 +455,7 @@ def test_xwalk(input_path, expected_outputs, tmp_path, mock_fsspec):
     assert outputs == expected_outputs
 
 
+@pytest.mark.integration
 def test_xwalk_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     assert len(list(xwalk("zip://::" + root_url, use_auth_token=hf_token))) == 2
@@ -751,12 +758,14 @@ def test_streaming_dl_manager_get_extraction_protocol_throws(urlpath):
 
 
 @slow  # otherwise it spams google drive and the CI gets banned
+@pytest.mark.integration
 def test_streaming_gg_drive():
     with xopen(TEST_GG_DRIVE_URL) as f:
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
 @slow  # otherwise it spams google drive and the CI gets banned
+@pytest.mark.integration
 def test_streaming_gg_drive_no_extract():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_URL)
     with xopen(urlpath) as f:
@@ -764,6 +773,7 @@ def test_streaming_gg_drive_no_extract():
 
 
 @slow  # otherwise it spams google drive and the CI gets banned
+@pytest.mark.integration
 def test_streaming_gg_drive_gzipped():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_GZIPPED_URL)
     with xopen(urlpath) as f:
@@ -771,6 +781,7 @@ def test_streaming_gg_drive_gzipped():
 
 
 @slow  # otherwise it spams google drive and the CI gets banned
+@pytest.mark.integration
 def test_streaming_gg_drive_zipped():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_ZIPPED_URL)
     all_files = list(xglob(xjoin(urlpath, "*")))

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -15,6 +15,9 @@ from tests.fixtures.hub import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
 from tests.utils import require_pil, require_sndfile
 
 
+pytestmark = pytest.mark.integration
+
+
 @pytest.mark.usefixtures("set_ci_hub_access_token")
 class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)


### PR DESCRIPTION
This PR:
- Implements separate unit/integration tests
- A fail in integration tests does not cancel the rest of the jobs
  - We should implement more robust integration tests: work in progress in a subsequent PR
- For the moment, test involving network requests are marked as integration: to be evolved