### PR TITLE
Remove "unkown" language tags

### DIFF
--- a/datasets/wikipedia/README.md
+++ b/datasets/wikipedia/README.md
@@ -296,7 +296,6 @@ language:
 - udm
 - ug
 - uk
-- unknown
 - ur
 - uz
 - ve


### PR DESCRIPTION
Following https://github.com/huggingface/datasets/pull/4753 there was still a "unknown" langauge tag in `wikipedia` so the job at https://github.com/huggingface/datasets/runs/7542567336?check_suite_focus=true failed for wikipedia