### PR TITLE
More rigorous shape inference in to_tf_dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -299,24 +299,17 @@ class TensorflowDatasetMixin:
                     f"Unrecognized array dtype {np_arrays[0].dtype}. \n"
                     "Nested types and image/audio types are not supported yet."
                 )
-            if (
-                column in dataset
-                and isinstance(dataset.features[column], Sequence)
-                and dataset.features[column].length != -1
-            ):
-                static_shape = [batch_size, dataset.features[column].length]
-            else:
-                shapes = [array.shape for array in np_arrays]
-                static_shape = []
-                for dim in range(len(shapes[0])):
-                    sizes = set([shape[dim] for shape in shapes])
-                    if dim == 0:
-                        static_shape.append(batch_size)
-                        continue
-                    if len(sizes) == 1:  # This dimension looks constant
-                        static_shape.append(sizes.pop())
-                    else:  # Use None for variable dimensions
-                        static_shape.append(None)
+            shapes = [array.shape for array in np_arrays]
+            static_shape = []
+            for dim in range(len(shapes[0])):
+                sizes = set([shape[dim] for shape in shapes])
+                if dim == 0:
+                    static_shape.append(batch_size)
+                    continue
+                if len(sizes) == 1:  # This dimension looks constant
+                    static_shape.append(sizes.pop())
+                else:  # Use None for variable dimensions
+                    static_shape.append(None)
             tf_columns_to_signatures[column] = tf.TensorSpec(shape=static_shape, dtype=tf_dtype)
             np_columns_to_dtypes[column] = np_dtype
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -299,17 +299,20 @@ class TensorflowDatasetMixin:
                     f"Unrecognized array dtype {np_arrays[0].dtype}. \n"
                     "Nested types and image/audio types are not supported yet."
                 )
-            shapes = [array.shape for array in np_arrays]
-            static_shape = []
-            for dim in range(len(shapes[0])):
-                sizes = set([shape[dim] for shape in shapes])
-                if dim == 0:
-                    static_shape.append(batch_size)
-                    continue
-                if len(sizes) == 1:  # This dimension looks constant
-                    static_shape.append(sizes.pop())
-                else:  # Use None for variable dimensions
-                    static_shape.append(None)
+            if column in dataset and isinstance(dataset.features[column], Sequence) and dataset.features[column].length != -1:
+                static_shape = [batch_size, dataset.features[column].length]
+            else:
+                shapes = [array.shape for array in np_arrays]
+                static_shape = []
+                for dim in range(len(shapes[0])):
+                    sizes = set([shape[dim] for shape in shapes])
+                    if dim == 0:
+                        static_shape.append(batch_size)
+                        continue
+                    if len(sizes) == 1:  # This dimension looks constant
+                        static_shape.append(sizes.pop())
+                    else:  # Use None for variable dimensions
+                        static_shape.append(None)
             tf_columns_to_signatures[column] = tf.TensorSpec(shape=static_shape, dtype=tf_dtype)
             np_columns_to_dtypes[column] = np_dtype
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -299,7 +299,11 @@ class TensorflowDatasetMixin:
                     f"Unrecognized array dtype {np_arrays[0].dtype}. \n"
                     "Nested types and image/audio types are not supported yet."
                 )
-            if column in dataset and isinstance(dataset.features[column], Sequence) and dataset.features[column].length != -1:
+            if (
+                column in dataset
+                and isinstance(dataset.features[column], Sequence)
+                and dataset.features[column].length != -1
+            ):
                 static_shape = [batch_size, dataset.features[column].length]
             else:
                 shapes = [array.shape for array in np_arrays]


### PR DESCRIPTION
`tf.data` needs to know the shape of tensors emitted from a `tf.data.Dataset`. Although `None` dimensions are possible, overusing them can cause problems - Keras uses the dataset tensor spec at compile-time, and so saying that a dimension is `None` when it's actually constant can hurt performance, or even cause training to fail for dimensions that are needed to determine the shape of weight tensors!

The compromise I used here was to sample several batches from the underlying dataset and apply the `collate_fn` to them, and then to see which dimensions were "empirically variable". There's an obvious problem here, though - if you sample 10 batches and they all have the same shape on a certain dimension, there's still a small chance that the 11th batch will be different, and Keras will throw an error  if a dataset tries to emit a tensor whose shape doesn't match the spec.

I encountered this bug in practice once or twice for datasets that were mostly-but-not-totally constant on a given dimension, and I still don't have a perfect solution, but this PR should greatly reduce the risk. It samples many more batches, and also samples very small batches (size 2) - this increases the variability, making it more likely that a few outlier samples will be detected.

Ideally, of course, we'd determine the full output shape analytically, but that's surprisingly tricky when the `collate_fn` can be any arbitrary Python code!