### PR TITLE
Unpin rouge_score test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ TESTS_REQUIRE = [
     "zstandard",
     "bigbench @ https://storage.googleapis.com/public_research_data/bigbench/bigbench-0.0.1.tar.gz",
     "sentencepiece",  # bigbench requires t5 which requires seqio which requires sentencepiece
-    "rouge_score<0.0.7",  # required by bigbench: bigbench.api.util.bb_utils > t5.evaluation.metrics > rouge_score
+    "rouge_score",  # required by bigbench: bigbench.api.util.bb_utils > t5.evaluation.metrics > rouge_score
     "sacremoses",
     # metrics dependencies
     "bert_score>=0.3.6",
@@ -148,7 +148,7 @@ TESTS_REQUIRE = [
     "langdetect",
     "mauve-text",
     "nltk",
-    # "rouge_score<0.0.7",  # also required by bigbench
+    # "rouge_score",  # also required by bigbench
     "sacrebleu",
     "sacremoses",
     "scikit-learn",


### PR DESCRIPTION
Once `rouge-score` has made the 0.1.2 release to fix their issue https://github.com/google-research/google-research/issues/1212, we can unpin it.

Related to:
- #4735 