### PR TITLE
Document loading from relative path

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -54,19 +54,13 @@ If you don't specify which data files to use, [`load_dataset`] will return all t
 
 </Tip>
 
-You can also load a specific subset of the files with the `data_files` or `data_dir` parameter. Datasets are loaded from the Hub if you pass a relative path to `data_dir`. The relative path is transformed to a URL corresponding to where the dataset is loaded from. If you want to load a dataset from a local directory, you need to pass an absolute path instead:
+You can also load a specific subset of the files with the `data_files` or `data_dir` parameter. These parameters can accept a relative path which resolves to the base path corresponding to where the dataset is loaded from.
 
 ```py
 >>> from datasets import load_dataset
 
 # load files that match the grep pattern
 >>> c4_subset = load_dataset("allenai/c4", data_files="en/c4-train.0000*-of-01024.json.gz")
-
-# load dataset from the en directory on the Hub
->>> c4_subset = load_dataset("allenai/c4", data_dir="./en/")
-
-# load dataset from the en directory on your computer
->>> c4_subset = load_dataset("allenai/c4", data_dir="path/to/local/allenai/c4/en/")
 ```
 
 The `split` parameter can also map a data file to a specific split:
@@ -86,13 +80,6 @@ You may have a 🤗 Datasets loading script locally on your computer. In this ca
 ```py
 >>> dataset = load_dataset("path/to/local/loading_script/loading_script.py", split="train")
 >>> dataset = load_dataset("path/to/local/loading_script", split="train")  # equivalent because the file has the same name as the directory
-```
-
-You can load a specific subset of files with the `data_files` or `data_dir` parameter. Passing a relative path to these parameters will load a dataset from your local directory:
-
-```py
->>> from datasets import load_dataset
->>> c4_subset = load_dataset("path/to/local/loading_script", data_dir="./train-v1/")
 ```
 
 ## Local and remote files

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -54,11 +54,19 @@ If you don't specify which data files to use, [`load_dataset`] will return all t
 
 </Tip>
 
-You can also load a specific subset of the files with the `data_files` parameter. The example below only loads files that match the grep pattern:
+You can also load a specific subset of the files with the `data_files` or `data_dir` parameter. Datasets are loaded from the Hub if you pass a relative path to `data_dir`. The relative path is transformed to a URL corresponding to where the dataset is loaded from. If you want to load a dataset from a local directory, you need to pass an absolute path instead:
 
 ```py
 >>> from datasets import load_dataset
+
+# load files that match the grep pattern
 >>> c4_subset = load_dataset("allenai/c4", data_files="en/c4-train.0000*-of-01024.json.gz")
+
+# load dataset from the en directory on the Hub
+>>> c4_subset = load_dataset("allenai/c4", data_dir="./en/")
+
+# load dataset from the en directory on your computer
+>>> c4_subset = load_dataset("allenai/c4", data_dir="path/to/local/allenai/c4/en/")
 ```
 
 The `split` parameter can also map a data file to a specific split:
@@ -66,13 +74,6 @@ The `split` parameter can also map a data file to a specific split:
 ```py
 >>> data_files = {"validation": "en/c4-validation.*.json.gz"}
 >>> c4_validation = load_dataset("allenai/c4", data_files=data_files, split="validation")
-```
-
-Datasets hosted on the Hub can also be loaded from a relative path through the `data_dir` or `data_files` parameters. The dataset's relative path is resolved to its URL in the repository where the loading script is stored.
-
-```py
->>> from datasets import load_dataset
->>> ds = load_dataset("namespace/your_dataset_name", data_dir="./train-v1/")
 ```
 
 ## Local loading script
@@ -85,6 +86,13 @@ You may have a 🤗 Datasets loading script locally on your computer. In this ca
 ```py
 >>> dataset = load_dataset("path/to/local/loading_script/loading_script.py", split="train")
 >>> dataset = load_dataset("path/to/local/loading_script", split="train")  # equivalent because the file has the same name as the directory
+```
+
+You can load a specific subset of files with the `data_files` or `data_dir` parameter. Passing a relative path to these parameters will load a dataset from your local directory:
+
+```py
+>>> from datasets import load_dataset
+>>> c4_subset = load_dataset("path/to/local/loading_script", data_dir="./train-v1/")
 ```
 
 ## Local and remote files

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -61,6 +61,9 @@ You can also load a specific subset of the files with the `data_files` or `data_
 
 # load files that match the grep pattern
 >>> c4_subset = load_dataset("allenai/c4", data_files="en/c4-train.0000*-of-01024.json.gz")
+
+# load dataset from the en directory on the Hub
+>>> c4_subset = load_dataset("allenai/c4", data_dir="en")
 ```
 
 The `split` parameter can also map a data file to a specific split:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -68,6 +68,13 @@ The `split` parameter can also map a data file to a specific split:
 >>> c4_validation = load_dataset("allenai/c4", data_files=data_files, split="validation")
 ```
 
+Datasets hosted on the Hub can also be loaded from a relative path through the `data_dir` or `data_files` parameters. The dataset's relative path is resolved to its URL in the repository where the loading script is stored.
+
+```py
+>>> from datasets import load_dataset
+>>> ds = load_dataset("namespace/your_dataset_name", data_dir="./train-v1/")
+```
+
 ## Local loading script
 
 You may have a 🤗 Datasets loading script locally on your computer. In this case, load the dataset by passing one of the following paths to [`load_dataset`]:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -315,6 +315,7 @@ Please follow the manual download instructions: To use MATINF you have to downlo
 Manual data can be loaded with `datasets.load_dataset(matinf, data_dir='<path/to/manual/data>') 
 ```
 
+If you've already downloaded a dataset from the *Hub with a loading script* to your computer, then you need to pass an absolute path to the `data_dir` or `data_files` parameter to load that dataset. Otherwise, if you pass a relative path, [`load_dataset`] will load the directory from the repository on the Hub instead of the local directory.
 
 ### Specify features
 


### PR DESCRIPTION
This PR describes loading a dataset from the Hub by specifying a relative path in `data_dir` or `data_files` in `load_dataset` (see #4757).