### PR TITLE
Remove apache_beam import from module level in natural_questions dataset

### DIFF
--- a/datasets/natural_questions/natural_questions.py
+++ b/datasets/natural_questions/natural_questions.py
@@ -21,8 +21,6 @@ import html
 import json
 import re
 
-import apache_beam as beam
-
 import datasets
 
 
@@ -145,6 +143,12 @@ class NaturalQuestions(datasets.BeamBasedBuilder):
 
     def _build_pcollection(self, pipeline, filepaths):
         """Build PCollection of examples."""
+        try:
+            import apache_beam as beam
+        except ImportError as err:
+            raise ImportError(
+                "To be able to load natural_questions, you need to install apache_beam: 'pip install apache_beam'"
+            ) from err
 
         def _parse_example(line):
             """Parse a single json line and emit an example dict."""


### PR DESCRIPTION
Instead of importing `apache_beam` at the module level, import it in the method `_build_pcollection`.

Fix #4779.