### PR TITLE
Fix label renaming and add a battery of tests

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -260,7 +260,7 @@ class TensorflowDatasetMixin:
         if batch_size is not None:
             batch_size = min(len(dataset), batch_size)
         test_batch_size = min(len(dataset), 2)
-        
+
         if cols_to_retain is None or not set(cols_to_retain) & {"label", "label_ids", "labels"}:
             auto_rename_labels = False
         if auto_rename_labels:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -225,7 +225,6 @@ class TensorflowDatasetMixin:
         cols_to_retain: Optional[List[str]] = None,
         batch_size: Optional[int] = None,
         num_test_batches: int = 200,
-        auto_rename_labels: bool = True,
     ):
         """Private method used by `to_tf_dataset()` to find the shapes and dtypes of samples from this dataset
            after being passed through the collate_fn. Tensorflow needs an exact signature for tf.numpy_function, so
@@ -243,8 +242,6 @@ class TensorflowDatasetMixin:
             batch_size (:obj:`int`, optional): The size of batches loaded from the dataset. Used for shape inference.
                 Can be None, which indicates that batch sizes can be variable.
             num_test_batches (:obj:`int`): The number of batches to load from the dataset for shape inference.
-            auto_rename_labels (:obj:`bool`): Whether to automatically rename labels from "label" or "label_ids"
-                to match `transformers`. In future, we will probably move this to the `transformers` library itself.
 
         Returns:
             :obj:`dict`: Dict mapping column names to tf.Tensorspec objects
@@ -261,9 +258,7 @@ class TensorflowDatasetMixin:
             batch_size = min(len(dataset), batch_size)
         test_batch_size = min(len(dataset), 2)
 
-        if cols_to_retain is None or not set(cols_to_retain) & {"label", "label_ids", "labels"}:
-            auto_rename_labels = False
-        if auto_rename_labels:
+        if cols_to_retain is not None:
             cols_to_retain = list(set(cols_to_retain + ["label_ids", "label", "labels"]))
 
         test_batches = []
@@ -330,7 +325,6 @@ class TensorflowDatasetMixin:
         collate_fn_args: Optional[Dict[str, Any]] = None,
         label_cols: Optional[Union[str, List[str]]] = None,
         prefetch: bool = True,
-        auto_rename_labels: bool = True,
     ):
         """Create a tf.data.Dataset from the underlying Dataset. This tf.data.Dataset will load and collate batches from
         the Dataset, and is suitable for passing to methods like model.fit() or model.predict(). The dataset will yield
@@ -355,12 +349,6 @@ class TensorflowDatasetMixin:
             prefetch (:obj:`bool`, default ``True``): Whether to run the dataloader in a separate thread and maintain
                 a small buffer of batches for training. Improves performance by allowing data to be loaded in the
                 background while the model is training.
-            auto_rename_labels (:obj:`bool`, default ``True``): Whether to automatically handle the case where labels
-                are renamed by data collators, particularly those used in the `transformers` library. Label columns
-                are usually named "label" in `datasets`, but `transformers` models use "labels" instead. This renaming
-                is usually handled by the data collator. This argument is usually safe to leave as `True`, even when
-                not using `transformers` models or data collators, but we provide the option to disable it as it may
-                create strange edge cases when you want to preserve multiple columns that have label-like names.
 
         Returns:
             :class:`tf.data.Dataset`
@@ -411,18 +399,12 @@ class TensorflowDatasetMixin:
         else:
             cols_to_retain = None  # Indicates keeping all valid columns
             columns = []
-        if cols_to_retain is None or not (set(cols_to_retain) & {"label", "labels", "label_ids"}):
-            auto_rename_labels = False
 
         if self.format["type"] != "custom":
             dataset = self.with_format("numpy")
         else:
             dataset = self
 
-        # Following the logic in `transformers.Trainer`, we do not drop `label_ids` or `label` even if they
-        # are not in the list of requested columns when auto_rename_labels is set, because the collator may rename them
-        # This might work better if moved to a method attached to our transformers Model objects, but doing so
-        # could break backward compatibility
         # TODO(Matt, QL): deprecate the retention of label_ids and label
 
         output_signature, columns_to_np_types = dataset._get_output_signature(
@@ -431,10 +413,9 @@ class TensorflowDatasetMixin:
             collate_fn_args=collate_fn_args,
             cols_to_retain=cols_to_retain,
             batch_size=batch_size if drop_remainder else None,
-            auto_rename_labels=auto_rename_labels,
         )
 
-        if auto_rename_labels and "labels" in output_signature:
+        if "labels" in output_signature:
             if ("label_ids" in columns or "label" in columns) and "labels" not in columns:
                 columns = [col for col in columns if col not in ["label_ids", "label"]] + ["labels"]
             if ("label_ids" in label_cols or "label" in label_cols) and "labels" not in label_cols:
@@ -455,7 +436,7 @@ class TensorflowDatasetMixin:
             else:
                 batch = dataset[indices]
 
-            if cols_to_retain is not None and auto_rename_labels:
+            if cols_to_retain is not None:
                 batch = {
                     key: value
                     for key, value in batch.items()

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -38,6 +38,14 @@ def minimal_tf_collate_fn(features):
     return batch
 
 
+def minimal_tf_collate_fn_with_renaming(features):
+    batch = minimal_tf_collate_fn(features)
+    if "label" in batch:
+        batch["labels"] = batch["label"]
+        del batch["label"]
+    return batch
+
+
 def is_numeric_pa_type(pa_type):
     if pa.types.is_list(pa_type):
         return is_numeric_pa_type(pa_type.value_type)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2395,88 +2395,88 @@ class BaseDatasetTest(TestCase):
 
         from datasets.utils.tf_utils import minimal_tf_collate_fn_with_renaming
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
-                with dset.rename_columns({"col_1": "features", "col_2": "label"}) as new_dset:
-                    tf_dataset = new_dset.to_tf_dataset(collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4)
-                    batch = next(iter(tf_dataset))
-                    self.assertTrue("labels" in batch and "features" in batch)
+        tmp_dir = tempfile.TemporaryDirectory()
+        with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
+            with dset.rename_columns({"col_1": "features", "col_2": "label"}) as new_dset:
+                tf_dataset = new_dset.to_tf_dataset(collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4)
+                batch = next(iter(tf_dataset))
+                self.assertTrue("labels" in batch and "features" in batch)
 
+                tf_dataset = new_dset.to_tf_dataset(
+                    columns=["features", "labels"], collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4
+                )
+                batch = next(iter(tf_dataset))
+                self.assertTrue("labels" in batch and "features" in batch)
+
+                tf_dataset = new_dset.to_tf_dataset(
+                    columns=["features", "label"], collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4
+                )
+                batch = next(iter(tf_dataset))
+                self.assertTrue("labels" in batch and "features" in batch)  # Assert renaming was handled correctly
+
+                with pytest.raises(ValueError):
+                    # Assert that this throws an error when we don't rename columns
                     tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features", "labels"], collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4
-                    )
-                    batch = next(iter(tf_dataset))
-                    self.assertTrue("labels" in batch and "features" in batch)
-
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features", "label"], collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4
-                    )
-                    batch = next(iter(tf_dataset))
-                    self.assertTrue("labels" in batch and "features" in batch)  # Assert renaming was handled correctly
-
-                    with pytest.raises(ValueError):
-                        # Assert that this throws an error when we don't rename columns
-                        tf_dataset = new_dset.to_tf_dataset(
-                            columns=["features", "label"],
-                            collate_fn=minimal_tf_collate_fn_with_renaming,
-                            batch_size=4,
-                            auto_rename_labels=False,
-                        )
-                        batch = next(iter(tf_dataset))
-
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features"],
-                        label_cols=["labels"],
-                        collate_fn=minimal_tf_collate_fn_with_renaming,
-                        batch_size=4,
-                    )
-                    batch = next(iter(tf_dataset))
-                    self.assertEqual(len(batch), 2)
-                    # Assert that we don't have any empty entries here
-                    self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
-
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features"],
-                        label_cols=["label"],
-                        collate_fn=minimal_tf_collate_fn_with_renaming,
-                        batch_size=4,
-                    )
-                    batch = next(iter(tf_dataset))
-                    self.assertEqual(len(batch), 2)
-                    # Assert that we don't have any empty entries here
-                    self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
-
-                    with pytest.raises(ValueError):
-                        tf_dataset = new_dset.to_tf_dataset(
-                            columns=["features"],
-                            label_cols=["label"],
-                            collate_fn=minimal_tf_collate_fn_with_renaming,
-                            batch_size=4,
-                            auto_rename_labels=False,
-                        )
-                        batch = next(iter(tf_dataset))
-
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features"],
-                        collate_fn=minimal_tf_collate_fn_with_renaming,
-                        batch_size=4,
-                        auto_rename_labels=True,
-                    )
-                    batch = next(iter(tf_dataset))
-                    # Assert that labels didn't creep in when we don't ask for them
-                    # just because the collate_fn added them
-                    self.assertTrue(isinstance(batch, tf.Tensor))
-
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features"],
+                        columns=["features", "label"],
                         collate_fn=minimal_tf_collate_fn_with_renaming,
                         batch_size=4,
                         auto_rename_labels=False,
                     )
                     batch = next(iter(tf_dataset))
-                    # Assert that labels didn't creep in when we don't ask for them
-                    # just because the collate_fn added them
-                    self.assertTrue(isinstance(batch, tf.Tensor))
+
+                tf_dataset = new_dset.to_tf_dataset(
+                    columns=["features"],
+                    label_cols=["labels"],
+                    collate_fn=minimal_tf_collate_fn_with_renaming,
+                    batch_size=4,
+                )
+                batch = next(iter(tf_dataset))
+                self.assertEqual(len(batch), 2)
+                # Assert that we don't have any empty entries here
+                self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
+
+                tf_dataset = new_dset.to_tf_dataset(
+                    columns=["features"],
+                    label_cols=["label"],
+                    collate_fn=minimal_tf_collate_fn_with_renaming,
+                    batch_size=4,
+                )
+                batch = next(iter(tf_dataset))
+                self.assertEqual(len(batch), 2)
+                # Assert that we don't have any empty entries here
+                self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
+
+                with pytest.raises(ValueError):
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features"],
+                        label_cols=["label"],
+                        collate_fn=minimal_tf_collate_fn_with_renaming,
+                        batch_size=4,
+                        auto_rename_labels=False,
+                    )
+                    batch = next(iter(tf_dataset))
+
+                tf_dataset = new_dset.to_tf_dataset(
+                    columns=["features"],
+                    collate_fn=minimal_tf_collate_fn_with_renaming,
+                    batch_size=4,
+                    auto_rename_labels=True,
+                )
+                batch = next(iter(tf_dataset))
+                # Assert that labels didn't creep in when we don't ask for them
+                # just because the collate_fn added them
+                self.assertTrue(isinstance(batch, tf.Tensor))
+
+                tf_dataset = new_dset.to_tf_dataset(
+                    columns=["features"],
+                    collate_fn=minimal_tf_collate_fn_with_renaming,
+                    batch_size=4,
+                    auto_rename_labels=False,
+                )
+                batch = next(iter(tf_dataset))
+                # Assert that labels didn't creep in when we don't ask for them
+                # just because the collate_fn added them
+                self.assertTrue(isinstance(batch, tf.Tensor))
 
         del tf_dataset  # For correct cleanup
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2389,6 +2389,98 @@ class BaseDatasetTest(TestCase):
         del tf_dataset  # For correct cleanup
 
     @require_tf
+    def test_tf_label_renaming(self, in_memory):
+        # Protect TF-specific imports in here
+        import tensorflow as tf
+
+        from datasets.utils.tf_utils import minimal_tf_collate_fn_with_renaming
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
+                with dset.rename_columns({"col_1": "features", "col_2": "label"}) as new_dset:
+                    tf_dataset = new_dset.to_tf_dataset(collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4)
+                    batch = next(iter(tf_dataset))
+                    self.assertTrue("labels" in batch and "features" in batch)
+
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features", "labels"], collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4
+                    )
+                    batch = next(iter(tf_dataset))
+                    self.assertTrue("labels" in batch and "features" in batch)
+
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features", "label"], collate_fn=minimal_tf_collate_fn_with_renaming, batch_size=4
+                    )
+                    batch = next(iter(tf_dataset))
+                    self.assertTrue("labels" in batch and "features" in batch)  # Assert renaming was handled correctly
+
+                    with pytest.raises(ValueError):
+                        # Assert that this throws an error when we don't rename columns
+                        tf_dataset = new_dset.to_tf_dataset(
+                            columns=["features", "label"],
+                            collate_fn=minimal_tf_collate_fn_with_renaming,
+                            batch_size=4,
+                            auto_rename_labels=False,
+                        )
+                        batch = next(iter(tf_dataset))
+
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features"],
+                        label_cols=["labels"],
+                        collate_fn=minimal_tf_collate_fn_with_renaming,
+                        batch_size=4,
+                    )
+                    batch = next(iter(tf_dataset))
+                    self.assertEqual(len(batch), 2)
+                    # Assert that we don't have any empty entries here
+                    self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
+
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features"],
+                        label_cols=["label"],
+                        collate_fn=minimal_tf_collate_fn_with_renaming,
+                        batch_size=4,
+                    )
+                    batch = next(iter(tf_dataset))
+                    self.assertEqual(len(batch), 2)
+                    # Assert that we don't have any empty entries here
+                    self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
+
+                    with pytest.raises(ValueError):
+                        tf_dataset = new_dset.to_tf_dataset(
+                            columns=["features"],
+                            label_cols=["label"],
+                            collate_fn=minimal_tf_collate_fn_with_renaming,
+                            batch_size=4,
+                            auto_rename_labels=False,
+                        )
+                        batch = next(iter(tf_dataset))
+
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features"],
+                        collate_fn=minimal_tf_collate_fn_with_renaming,
+                        batch_size=4,
+                        auto_rename_labels=True,
+                    )
+                    batch = next(iter(tf_dataset))
+                    # Assert that labels didn't creep in when we don't ask for them
+                    # just because the collate_fn added them
+                    self.assertTrue(isinstance(batch, tf.Tensor))
+
+                    tf_dataset = new_dset.to_tf_dataset(
+                        columns=["features"],
+                        collate_fn=minimal_tf_collate_fn_with_renaming,
+                        batch_size=4,
+                        auto_rename_labels=False,
+                    )
+                    batch = next(iter(tf_dataset))
+                    # Assert that labels didn't creep in when we don't ask for them
+                    # just because the collate_fn added them
+                    self.assertTrue(isinstance(batch, tf.Tensor))
+
+        del tf_dataset  # For correct cleanup
+
+    @require_tf
     def test_tf_dataset_options(self, in_memory):
         tmp_dir = tempfile.TemporaryDirectory()
         # Test that batch_size option works as expected

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2436,16 +2436,6 @@ class BaseDatasetTest(TestCase):
                 # Assert that we don't have any empty entries here
                 self.assertTrue(isinstance(batch[0], tf.Tensor) and isinstance(batch[1], tf.Tensor))
 
-                with pytest.raises(ValueError):
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features"],
-                        label_cols=["label"],
-                        collate_fn=minimal_tf_collate_fn_with_renaming,
-                        batch_size=4,
-                        auto_rename_labels=False,
-                    )
-                    batch = next(iter(tf_dataset))
-
                 tf_dataset = new_dset.to_tf_dataset(
                     columns=["features"],
                     collate_fn=minimal_tf_collate_fn_with_renaming,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2446,17 +2446,6 @@ class BaseDatasetTest(TestCase):
                 # just because the collate_fn added them
                 self.assertTrue(isinstance(batch, tf.Tensor))
 
-                tf_dataset = new_dset.to_tf_dataset(
-                    columns=["features"],
-                    collate_fn=minimal_tf_collate_fn_with_renaming,
-                    batch_size=4,
-                    auto_rename_labels=False,
-                )
-                batch = next(iter(tf_dataset))
-                # Assert that labels didn't creep in when we don't ask for them
-                # just because the collate_fn added them
-                self.assertTrue(isinstance(batch, tf.Tensor))
-
         del tf_dataset  # For correct cleanup
 
     @require_tf

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2440,7 +2440,6 @@ class BaseDatasetTest(TestCase):
                     columns=["features"],
                     collate_fn=minimal_tf_collate_fn_with_renaming,
                     batch_size=4,
-                    auto_rename_labels=True,
                 )
                 batch = next(iter(tf_dataset))
                 # Assert that labels didn't creep in when we don't ask for them

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2414,16 +2414,6 @@ class BaseDatasetTest(TestCase):
                 batch = next(iter(tf_dataset))
                 self.assertTrue("labels" in batch and "features" in batch)  # Assert renaming was handled correctly
 
-                with pytest.raises(ValueError):
-                    # Assert that this throws an error when we don't rename columns
-                    tf_dataset = new_dset.to_tf_dataset(
-                        columns=["features", "label"],
-                        collate_fn=minimal_tf_collate_fn_with_renaming,
-                        batch_size=4,
-                        auto_rename_labels=False,
-                    )
-                    batch = next(iter(tf_dataset))
-
                 tf_dataset = new_dset.to_tf_dataset(
                     columns=["features"],
                     label_cols=["labels"],


### PR DESCRIPTION
This PR makes some changes to label renaming in `to_tf_dataset()`, both to fix some issues when users input something we weren't expecting, and also to make it easier to deprecate label renaming in future, if/when we want to move this special-casing logic to a function in `transformers`.

The main changes are:
- Label renaming now only happens when the `auto_rename_labels` argument is set. For backward compatibility, this defaults to `True` for now.
- If the user requests "label" but the data collator renames that column to "labels", the label renaming logic will now handle that case correctly.
- Added a battery of tests to make this more reliable in future.
- Adds an optimization to loading in `to_tf_dataset()` for unshuffled datasets (uses slicing instead of a list of indices)

Fixes #4772