### PR TITLE
document fix in opus_gnome dataset

### DIFF
--- a/datasets/opus_gnome/README.md
+++ b/datasets/opus_gnome/README.md
@@ -262,7 +262,7 @@ To load a language pair which isn't part of the config, all you need to do is sp
 You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/GNOME.php
 E.g.
 
-`dataset = load_dataset("gnome", lang1="it", lang2="pl")`
+`dataset = load_dataset("opus_gnome", lang1="it", lang2="pl")`
 
 
 ### Supported Tasks and Leaderboards


### PR DESCRIPTION
I fixed a issue #4805.

I changed `"gnome"` to `"opus_gnome"` in[ README.md](https://github.com/huggingface/datasets/tree/main/datasets/opus_gnome#dataset-summary).