### PR TITLE
Fix loading example in opus dataset cards

### DIFF
--- a/datasets/opus_dgt/README.md
+++ b/datasets/opus_dgt/README.md
@@ -98,7 +98,7 @@ To load a language pair which isn't part of the config, all you need to do is sp
 You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/DGT.php
 E.g.
 
-`dataset = load_dataset("dgt", lang1="it", lang2="pl")`
+`dataset = load_dataset("opus_dgt", lang1="it", lang2="pl")`
 
 
 ### Supported Tasks and Leaderboards

--- a/datasets/opus_dgt/README.md
+++ b/datasets/opus_dgt/README.md
@@ -57,7 +57,7 @@ configs:
 - mt-sh
 ---
 
-# Dataset Card Creation Guide
+# Dataset Card for OpusDgt
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)
@@ -93,12 +93,18 @@ configs:
 
 ### Dataset Summary
 
+A collection of translation memories provided by the Joint Research Centre (JRC) Directorate-General for Translation (DGT): https://ec.europa.eu/jrc/en/language-technologies/dgt-translation-memory
 
-To load a language pair which isn't part of the config, all you need to do is specify the language code as pairs.
+Tha dataset contains 25 languages and 299 bitexts.
+
+To load a language pair which isn't part of the config, all you need to do is specify the language code as pairs,
+e.g.
+
+```python
+dataset = load_dataset("opus_dgt", lang1="it", lang2="pl")
+```
+
 You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/DGT.php
-E.g.
-
-`dataset = load_dataset("opus_dgt", lang1="it", lang2="pl")`
 
 
 ### Supported Tasks and Leaderboards
@@ -107,21 +113,55 @@ E.g.
 
 ### Languages
 
-[More Information Needed]
+The languages in the dataset are:
+- bg
+- cs
+- da
+- de
+- el
+- en
+- es
+- et
+- fi
+- fr
+- ga
+- hr
+- hu
+- it
+- lt
+- lv
+- mt
+- nl
+- pl
+- pt
+- ro
+- sh
+- sk
+- sl
+- sv
 
 ## Dataset Structure
 
 ### Data Instances
 
-[More Information Needed]
+```
+{
+  'id': '0', 
+  'translation': {
+    "bg": "Протокол за поправка на Конвенцията относно компетентността, признаването и изпълнението на съдебни решения по граждански и търговски дела, подписана в Лугано на 30 октомври 2007 г.",
+    "ga": "Miontuairisc cheartaitheach maidir le Coinbhinsiún ar dhlínse agus ar aithint agus ar fhorghníomhú breithiúnas in ábhair shibhialta agus tráchtála, a siníodh in Lugano an 30 Deireadh Fómhair 2007"
+  }
+}
+```
 
 ### Data Fields
 
-[More Information Needed]
+- `id` (`str`): Unique identifier of the parallel sentence for the pair of languages.
+- `translation` (`dict`): Parallel sentences for the pair of languages.
 
 ### Data Splits
 
-[More Information Needed]
+The dataset contains a single `train` split.
 
 ## Dataset Creation
 
@@ -183,6 +223,7 @@ E.g.
 
 ### Citation Information
 
+```bibtex
 @InProceedings{TIEDEMANN12.463,
   author = {J{\"o}rg Tiedemann},
   title = {Parallel Data, Tools and Interfaces in OPUS},
@@ -195,7 +236,8 @@ E.g.
   publisher = {European Language Resources Association (ELRA)},
   isbn = {978-2-9517408-7-7},
   language = {english}
- }
+}
+```
 
 ### Contributions
 

--- a/datasets/opus_paracrawl/README.md
+++ b/datasets/opus_paracrawl/README.md
@@ -72,7 +72,7 @@ configs:
 - fr-nl
 ---
 
-# Dataset Card Creation Guide
+# Dataset Card for OpusParaCrawl
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)
@@ -108,11 +108,18 @@ configs:
 
 ### Dataset Summary
 
-To load a language pair which isn't part of the config, all you need to do is specify the language code as pairs.
-You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/ParaCrawl.php
-E.g.
+Parallel corpora from Web Crawls collected in the ParaCrawl project.
 
-`dataset = load_dataset("opus_paracrawl", lang1="en", lang2="so")`
+Tha dataset contains 40 languages and 41 bitexts.
+
+To load a language pair which isn't part of the config, all you need to do is specify the language code as pairs,
+e.g.
+
+```python
+dataset = load_dataset("opus_paracrawl", lang1="en", lang2="so")
+```
+
+You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/ParaCrawl.php
 
 ### Supported Tasks and Leaderboards
 
@@ -120,21 +127,70 @@ E.g.
 
 ### Languages
 
-[More Information Needed]
+The languages in the dataset are:
+- bg
+- ca
+- cs
+- da
+- de
+- el
+- en
+- es
+- et
+- eu
+- fi
+- fr
+- ga
+- gl
+- ha
+- hr
+- hu
+- ig
+- is
+- it
+- km
+- lt
+- lv
+- mt
+- my
+- nb
+- ne
+- nl
+- nn
+- pl
+- pt
+- ro
+- ru
+- si
+- sk
+- sl
+- so
+- sv
+- sw
+- tl
 
 ## Dataset Structure
 
 ### Data Instances
 
-[More Information Needed]
+```
+{
+  'id': '0', 
+  'translation': {
+    "el": "Συνεχίστε ευθεία 300 μέτρα μέχρι να καταλήξουμε σε μια σωστή οδός (ul. Gagarina)? Περπατήστε περίπου 300 μέτρα μέχρι να φτάσετε το πρώτο ορθή οδός (ul Khotsa Namsaraeva)?",
+    "en": "Go straight 300 meters until you come to a proper street (ul. Gagarina); Walk approximately 300 meters until you reach the first proper street (ul Khotsa Namsaraeva);"
+  }
+}
+```
 
 ### Data Fields
 
-[More Information Needed]
+- `id` (`str`): Unique identifier of the parallel sentence for the pair of languages.
+- `translation` (`dict`): Parallel sentences for the pair of languages.
 
 ### Data Splits
 
-[More Information Needed]
+The dataset contains a single `train` split.
 
 ## Dataset Creation
 
@@ -196,6 +252,7 @@ E.g.
 
 ### Citation Information
 
+```bibtex
 @InProceedings{TIEDEMANN12.463,
 author = {J{\"o}rg Tiedemann},
 title = {Parallel Data, Tools and Interfaces in OPUS},
@@ -209,6 +266,7 @@ publisher = {European Language Resources Association (ELRA)},
 isbn = {978-2-9517408-7-7},
 language = {english}
 }
+```
 
 ### Contributions
 

--- a/datasets/opus_paracrawl/README.md
+++ b/datasets/opus_paracrawl/README.md
@@ -112,7 +112,7 @@ To load a language pair which isn't part of the config, all you need to do is sp
 You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/ParaCrawl.php
 E.g.
 
-`dataset = load_dataset("paracrawl", lang1="en", lang2="so")`
+`dataset = load_dataset("opus_paracrawl", lang1="en", lang2="so")`
 
 ### Supported Tasks and Leaderboards
 

--- a/datasets/opus_wikipedia/README.md
+++ b/datasets/opus_wikipedia/README.md
@@ -87,7 +87,7 @@ To load a language pair which isn't part of the config, all you need to do is sp
 You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/Wikipedia.php
 E.g.
 
-`dataset = load_dataset("wikipedia", lang1="it", lang2="pl")`
+`dataset = load_dataset("opus_wikipedia", lang1="it", lang2="pl")`
 
 
 ### Supported Tasks and Leaderboards

--- a/datasets/opus_wikipedia/README.md
+++ b/datasets/opus_wikipedia/README.md
@@ -46,7 +46,7 @@ configs:
 - en-vi
 ---
 
-# Dataset Card Creation Guide
+# Dataset Card for OpusWikipedia
 
 ## Table of Contents
 - [Dataset Description](#dataset-description)
@@ -82,12 +82,18 @@ configs:
 
 ### Dataset Summary
 
+This is a corpus of parallel sentences extracted from Wikipedia by Krzysztof Wołk and Krzysztof Marasek.
 
-To load a language pair which isn't part of the config, all you need to do is specify the language code as pairs.
+Tha dataset contains 20 languages and 36 bitexts.
+
+To load a language pair which isn't part of the config, all you need to do is specify the language code as pairs,
+e.g.
+
+```python
+dataset = load_dataset("opus_wikipedia", lang1="it", lang2="pl")
+```
+
 You can find the valid pairs in Homepage section of Dataset Description: http://opus.nlpl.eu/Wikipedia.php
-E.g.
-
-`dataset = load_dataset("opus_wikipedia", lang1="it", lang2="pl")`
 
 
 ### Supported Tasks and Leaderboards
@@ -96,21 +102,50 @@ E.g.
 
 ### Languages
 
-[More Information Needed]
+The languages in the dataset are:
+- ar
+- bg
+- cs
+- de
+- el
+- en
+- es
+- fa
+- fr
+- he
+- hu
+- it
+- nl
+- pl
+- pt
+- ro
+- ru
+- sl
+- tr
+- vi
 
 ## Dataset Structure
 
 ### Data Instances
 
-[More Information Needed]
+```
+{
+  'id': '0', 
+  'translation': {
+    "ar": "* Encyclopaedia of Mathematics online encyclopaedia from Springer, Graduate-level reference work with over 8,000 entries, illuminating nearly 50,000 notions in mathematics.",
+    "en": "*Encyclopaedia of Mathematics online encyclopaedia from Springer, Graduate-level reference work with over 8,000 entries, illuminating nearly 50,000 notions in mathematics."
+  } 
+}
+```
 
 ### Data Fields
 
-[More Information Needed]
+- `id` (`str`): Unique identifier of the parallel sentence for the pair of languages.
+- `translation` (`dict`): Parallel sentences for the pair of languages.
 
 ### Data Splits
 
-[More Information Needed]
+The dataset contains a single `train` split.
 
 ## Dataset Creation
 
@@ -172,6 +207,23 @@ E.g.
 
 ### Citation Information
 
+```bibtex
+@article{WOLK2014126,
+title = {Building Subject-aligned Comparable Corpora and Mining it for Truly Parallel Sentence Pairs},
+journal = {Procedia Technology},
+volume = {18},
+pages = {126-132},
+year = {2014},
+note = {International workshop on Innovations in Information and Communication Science and Technology, IICST 2014, 3-5 September 2014, Warsaw, Poland},
+issn = {2212-0173},
+doi = {https://doi.org/10.1016/j.protcy.2014.11.024},
+url = {https://www.sciencedirect.com/science/article/pii/S2212017314005453},
+author = {Krzysztof Wołk and Krzysztof Marasek},
+keywords = {Comparable corpora, machine translation, NLP},
+}
+```
+
+```bibtex
 @InProceedings{TIEDEMANN12.463,
   author = {J{\"o}rg Tiedemann},
   title = {Parallel Data, Tools and Interfaces in OPUS},
@@ -184,7 +236,8 @@ E.g.
   publisher = {European Language Resources Association (ELRA)},
   isbn = {978-2-9517408-7-7},
   language = {english}
- }
+}
+```
 
 ### Contributions
 


### PR DESCRIPTION
This PR:
- fixes the examples to load the datasets, with the corrected dataset name, in their dataset cards for:
  - opus_dgt
  - opus_paracrawl
  - opus_wikipedia
- fixes their dataset cards with the missing required information: title, data instances/fields/splits
- enumerates the supported languages
- adds a missing citation reference for opus_wikipedia

Related to:
- #4806