### PR TITLE
[Windows] Fix Access Denied when using os.rename()

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -664,6 +664,8 @@ class DatasetBuilder:
                         if os.path.isdir(dirname):
                             shutil.rmtree(dirname)
                         os.rename(tmp_dir, dirname)
+                    except PermissionError:
+                        shutil.move(tmp_dir, dirname)
                     finally:
                         if os.path.exists(tmp_dir):
                             shutil.rmtree(tmp_dir)

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -663,8 +663,6 @@ class DatasetBuilder:
                         yield tmp_dir
                         if os.path.isdir(dirname):
                             shutil.rmtree(dirname)
-                        os.rename(tmp_dir, dirname)
-                    except PermissionError:
                         shutil.move(tmp_dir, dirname)
                     finally:
                         if os.path.exists(tmp_dir):


### PR DESCRIPTION
In this PR, we are including an additional step when `os.rename()` raises a PermissionError.

Basically, we will use `shutil.move()` on the temp files.

Fix #2937 