### PR TITLE
Support PIL Image objects in `add_item`/`add_column`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4388,14 +4388,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         })
         ```
         """
-        column_table = InMemoryTable.from_pydict({name: column})
+        ts = OptimizedTypedSequence(column, type=None, col=name)
+        column_table = InMemoryTable.from_pydict({name: ts})
         _check_column_names(self._data.column_names + column_table.column_names)
         dataset = self.flatten_indices() if self._indices is not None else self
         # Concatenate tables horizontally
         table = concat_tables([dataset._data, column_table], axis=1)
         # Update features
         info = dataset.info.copy()
-        info.features.update(Features.from_arrow_schema(column_table.schema))
+        info.features.update(Features({name: ts.get_inferred_type()}))
         table = update_metadata_with_features(table, info.features)
         return Dataset(table, info=info, split=self.split, indices_table=None, fingerprint=new_fingerprint)
 
@@ -4626,9 +4627,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         {'label': 0, 'text': 'this movie is the absolute worst thing I have ever seen'}
         ```
         """
-        item_table = InMemoryTable.from_pydict({k: [v] for k, v in item.items()})
+        item = {k: OptimizedTypedSequence([v], type=None, col=k) for k, v in item.items()}
+        item_table = InMemoryTable.from_pydict(item)
         # We don't call _check_if_features_can_be_aligned here so this cast is "unsafe"
-        dset_features, item_features = _align_features([self.features, Features.from_arrow_schema(item_table.schema)])
+        dset_features, item_features = _align_features(
+            [self.features, Features({k: v.get_inferred_type() for k, v in item.items()})]
+        )
         # Cast to align the schemas of the tables and concatenate the tables
         table = concat_tables(
             [

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2741,6 +2741,18 @@ def test_dataset_add_column(column, expected_dtype, in_memory, transform, datase
     assert_arrow_metadata_are_synced_with_dataset_features(dataset)
 
 
+@require_pil
+def test_dataset_add_column_complex_features(image_file):
+    import PIL.Image
+
+    pil_image = PIL.Image.open(image_file)
+    dataset = Dataset.from_dict({"col_1": ["a", "b"]})
+    dataset = dataset.add_column("col_2", [pil_image, None])
+    assert dataset.data.shape == (2, 2)
+    assert dataset.features == Features({"col_1": Value("string"), "col_2": Image()})
+    assert dataset[:] == {"col_1": ["a", "b"], "col_2": [pil_image, None]}
+
+
 @pytest.mark.parametrize(
     "transform",
     [None, ("shuffle", (42,), {}), ("with_format", ("pandas",), {}), ("class_encode_column", ("col_2",), {})],
@@ -2805,6 +2817,18 @@ def test_dataset_add_item_introduce_feature_type():
     assert dataset.data.shape == (4, 1)
     assert dataset.features == Features({"col_1": Value("string")})
     assert dataset[:] == {"col_1": [None, None, None, "a"]}
+
+
+@require_pil
+def test_dataset_add_item_complex_features(image_file):
+    import PIL.Image
+
+    pil_image = PIL.Image.open(image_file)
+    dataset = Dataset.from_dict({"col_1": [pil_image, None]})
+    dataset = dataset.add_item({"col_1": pil_image})
+    assert dataset.data.shape == (3, 1)
+    assert dataset.features == Features({"col_1": Image()})
+    assert dataset[:] == {"col_1": [pil_image, None, pil_image]}
 
 
 @pytest.mark.parametrize("in_memory", [False, True])


### PR DESCRIPTION
Fix #4796 

PS: We should also improve the type inference in `OptimizedTypeSequence` to make it possible to also infer the complex types (only `Image` currently) in nested arrays (e.g.  `[[pil_image], [pil_image, pil_image]]` or `[{"img": pil_image}`]), but I plan to address this in a separate PR.