### PR TITLE
Update stackexchange license

### DIFF
--- a/datasets/the_pile_stack_exchange/README.md
+++ b/datasets/the_pile_stack_exchange/README.md
@@ -6,7 +6,7 @@ language_creators:
 language:
 - en
 license:
-- mit
+- cc-by-sa-4.0
 multilinguality:
 - monolingual
 pretty_name: Stack Exchange


### PR DESCRIPTION
The correct license of the stackexchange subset of the Pile is `cc-by-sa-4.0`, as can for example be seen here: https://stackoverflow.com/help/licensing