### PR TITLE
Mark CI tests as xfail if Hub HTTP error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
         run: pip install pyarrow==${{ matrix.pyarrow_version }}
       - name: Test with pytest
         run: |
-          python -m pytest -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/
+          python -m pytest -rxX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -12,12 +12,13 @@ from huggingface_hub import HfApi
 
 from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
 from tests.fixtures.hub import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
-from tests.utils import require_pil, require_sndfile
+from tests.utils import for_all_test_methods, require_pil, require_sndfile, xfail_if_500_http_error
 
 
 pytestmark = pytest.mark.integration
 
 
+@for_all_test_methods(xfail_if_500_http_error)
 @pytest.mark.usefixtures("set_ci_hub_access_token")
 class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -126,20 +126,13 @@ class TestPushToHub:
                 )
             )
 
-    # @xfailif500
     def test_push_dataset_dict_to_hub_multiple_files(self, temporary_repo):
-        from requests.exceptions import HTTPError
-
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
 
         local_ds = DatasetDict({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, max_shard_size="16KB")
-            # pytest.xfail()
-            raise HTTPError(
-                "501 Server Error: Internal Server Error for url: https://hub-ci.huggingface.co/api/datasets/__DUMMY_TRANSFORMERS_USER__/test-16603108028233/commit/main (Request ID: aZeAQ5yLktoGHQYBcJ3zo)"
-            )
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -126,13 +126,20 @@ class TestPushToHub:
                 )
             )
 
+    # @xfailif500
     def test_push_dataset_dict_to_hub_multiple_files(self, temporary_repo):
+        from requests.exceptions import HTTPError
+
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
 
         local_ds = DatasetDict({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, max_shard_size="16KB")
+            # pytest.xfail()
+            raise HTTPError(
+                "501 Server Error: Internal Server Error for url: https://hub-ci.huggingface.co/api/datasets/__DUMMY_TRANSFORMERS_USER__/test-16603108028233/commit/main (Request ID: aZeAQ5yLktoGHQYBcJ3zo)"
+            )
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,6 @@ from importlib.util import find_spec
 from pathlib import Path
 from unittest.mock import patch
 
-import decorator
 import pyarrow as pa
 import pytest
 from packaging import version
@@ -362,6 +361,7 @@ def is_rng_equal(rng1, rng2):
 
 
 def xfail_if_500_http_error(func):
+    import decorator
     from requests.exceptions import HTTPError
 
     def _wrapper(func, *args, **kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@ from importlib.util import find_spec
 from pathlib import Path
 from unittest.mock import patch
 
+import decorator
 import pyarrow as pa
 import pytest
 from packaging import version
@@ -358,3 +359,17 @@ def assert_arrow_memory_doesnt_increase():
 
 def is_rng_equal(rng1, rng2):
     return deepcopy(rng1).integers(0, 100, 10).tolist() == deepcopy(rng2).integers(0, 100, 10).tolist()
+
+
+def xfail_if_500_http_error(func):
+    from requests.exceptions import HTTPError
+
+    def _wrapper(func, *args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPError as err:
+            if str(err).startswith("500"):
+                pytest.xfail(str(err))
+            raise err
+
+    return decorator.decorator(_wrapper, func)


### PR DESCRIPTION
In order to make testing more robust (and avoid merges to master with red tests), we could mark tests as xfailed (instead of failed) when the Hub raises some temporary HTTP errors.

This PR:
- marks tests as xfailed only if the Hub raises a 500 error for:
  - test_upstream_hub
- makes pytest report the xfailed/xpassed tests.

More tests could also be marked if needed.

Examples of CI failures due to temporary Hub HTTP errors:
- FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_dict_to_hub_multiple_files
  - https://github.com/huggingface/datasets/runs/7806855399?check_suite_focus=true
    `requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://hub-ci.huggingface.co/api/datasets/__DUMMY_TRANSFORMERS_USER__/test-16603108028233/commit/main (Request ID: aZeAQ5yLktoGHQYBcJ3zo)`
- FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_dict_to_hub_no_token
  - https://github.com/huggingface/datasets/runs/7840022996?check_suite_focus=true
    `requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://s3.us-east-1.amazonaws.com/lfs-staging.huggingface.co/repos/81/e3/81e3b831fa9bf23190ec041f26ef7ff6d6b71c1a937b8ec1ef1f1f05b508c089/caae596caa179cf45e7c9ac0c6d9a9cb0fe2d305291bfbb2d8b648ae26ed38b6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIA4N7VTDGOZQA2IKWK%2F20220815%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220815T144713Z&X-Amz-Expires=900&X-Amz-Signature=5ddddfe8ef2b0601e80ab41c78a4d77d921942b0d8160bcab40ff894095e6823&X-Amz-SignedHeaders=host&x-id=PutObject`
- FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_dict_to_hub_private
  - https://github.com/huggingface/datasets/runs/7835921082?check_suite_focus=true
    `requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://hub-ci.huggingface.co/api/repos/create (Request ID: gL_1I7i2dii9leBhlZen-) - Internal Error - We're working hard to fix that as soon as possible!`
- FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_to_hub_custom_features_image_list
  - https://github.com/huggingface/datasets/runs/7835920900?check_suite_focus=true
  - This is not 500, but 404:
    `requests.exceptions.HTTPError: 404 Client Error: Not Found for url: [https://hub-ci.huggingface.co/datasets/__DUMMY_TRANSFORMERS_USER__/test-16605586458339.git/info/lfs/objects](https://hub-ci.huggingface.co/datasets/__DUMMY_TRANSFORMERS_USER__/test-16605586458339.git/info/lfs/objects/batch)`
