### PR TITLE
Fix test of _get_extraction_protocol for TAR files

### DIFF
--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -729,7 +729,7 @@ def test_streaming_dl_manager_extract_all_supported_single_file_compression_type
         ("https://foo.bar/train.tar", "tar")
     ],
 )
-def test_streaming_dl_manager_get_extraction_protocol_gg_drive(urlpath, expected_protocol):
+def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol):
     assert _get_extraction_protocol(urlpath) == expected_protocol
 
 
@@ -741,7 +741,7 @@ def test_streaming_dl_manager_get_extraction_protocol_gg_drive(urlpath, expected
     ],
 )
 @slow  # otherwise it spams google drive and the CI gets banned
-def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol):
+def test_streaming_dl_manager_get_extraction_protocol_gg_drive(urlpath, expected_protocol):
     assert _get_extraction_protocol(urlpath) == expected_protocol
 
 

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -726,7 +726,7 @@ def test_streaming_dl_manager_extract_all_supported_single_file_compression_type
         ("https://github.com/user/repo/blob/master/data/morph_train.tsv?raw=true", None),
         ("https://repo.org/bitstream/handle/20.500.12185/346/annotated_corpus.zip?sequence=3&isAllowed=y", "zip"),
         ("https://zenodo.org/record/2787612/files/SICK.zip?download=1", "zip"),
-        ("https://foo.bar/train.tar", "tar")
+        ("https://foo.bar/train.tar", "tar"),
     ],
 )
 def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -740,7 +740,7 @@ def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol
         (TEST_GG_DRIVE_ZIPPED_URL, "zip"),
     ],
 )
-@slow  # otherwise it spams google drive and the CI gets banned
+@slow  # otherwise it spams Google Drive and the CI gets banned
 def test_streaming_dl_manager_get_extraction_protocol_gg_drive(urlpath, expected_protocol):
     assert _get_extraction_protocol(urlpath) == expected_protocol
 
@@ -757,14 +757,14 @@ def test_streaming_dl_manager_get_extraction_protocol_throws(urlpath):
         _ = _get_extraction_protocol(urlpath)
 
 
-@slow  # otherwise it spams google drive and the CI gets banned
+@slow  # otherwise it spams Google Drive and the CI gets banned
 @pytest.mark.integration
 def test_streaming_gg_drive():
     with xopen(TEST_GG_DRIVE_URL) as f:
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
-@slow  # otherwise it spams google drive and the CI gets banned
+@slow  # otherwise it spams Google Drive and the CI gets banned
 @pytest.mark.integration
 def test_streaming_gg_drive_no_extract():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_URL)
@@ -772,7 +772,7 @@ def test_streaming_gg_drive_no_extract():
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
-@slow  # otherwise it spams google drive and the CI gets banned
+@slow  # otherwise it spams Google Drive and the CI gets banned
 @pytest.mark.integration
 def test_streaming_gg_drive_gzipped():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_GZIPPED_URL)
@@ -780,7 +780,7 @@ def test_streaming_gg_drive_gzipped():
         assert f.read() == TEST_GG_DRIVE_CONTENT
 
 
-@slow  # otherwise it spams google drive and the CI gets banned
+@slow  # otherwise it spams Google Drive and the CI gets banned
 @pytest.mark.integration
 def test_streaming_gg_drive_zipped():
     urlpath = StreamingDownloadManager().download_and_extract(TEST_GG_DRIVE_ZIPPED_URL)

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -726,6 +726,7 @@ def test_streaming_dl_manager_extract_all_supported_single_file_compression_type
         ("https://github.com/user/repo/blob/master/data/morph_train.tsv?raw=true", None),
         ("https://repo.org/bitstream/handle/20.500.12185/346/annotated_corpus.zip?sequence=3&isAllowed=y", "zip"),
         ("https://zenodo.org/record/2787612/files/SICK.zip?download=1", "zip"),
+        ("https://foo.bar/train.tar", "tar")
     ],
 )
 def test_streaming_dl_manager_get_extraction_protocol_gg_drive(urlpath, expected_protocol):
@@ -749,7 +750,6 @@ def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol
     [
         "zip://train-00000.tar.gz::https://foo.bar/data.zip",
         "https://foo.bar/train.tar.gz",
-        "https://foo.bar/train.tar",
     ],
 )
 def test_streaming_dl_manager_get_extraction_protocol_throws(urlpath):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -752,9 +752,9 @@ def test_streaming_dl_manager_get_extraction_protocol(urlpath, expected_protocol
         "https://foo.bar/train.tar",
     ],
 )
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_streaming_dl_manager_get_extraction_protocol_throws(urlpath):
-    _get_extraction_protocol(urlpath)
+    with pytest.raises(NotImplementedError):
+        _ = _get_extraction_protocol(urlpath)
 
 
 @slow  # otherwise it spams google drive and the CI gets banned


### PR DESCRIPTION
While working in another PR, I discovered an xpass test (a test that is supposed to xfail but nevertheless passes) when testing `_get_extraction_protocol`: https://github.com/huggingface/datasets/runs/7818845285?check_suite_focus=true
```
XPASS tests/test_streaming_download_manager.py::test_streaming_dl_manager_get_extraction_protocol_throws[https://foo.bar/train.tar] 
```

This PR:
- refactors the test so that it tests the raise of the exceptions instead of xfailing
- fixes the test for TAR files: it does not raise an exception, but returns "tar"
- fixes some tests wrongly named: exchange `test_streaming_dl_manager_get_extraction_protocol` with `test_streaming_dl_manager_get_extraction_protocol_gg_drive`