### PR TITLE
add Dataset.from_list

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -211,7 +211,7 @@ Load a list of Python dictionaries with [`~Dataset.from_list`]:
 
 ```py
 >>> from datasets import Dataset
->>> my_list = [{"a": 1}, {"a": 2}]
+>>> my_list = [{"a": 1}, {"a": 2}, {"a": 3}]
 >>> dataset = Dataset.from_list(my_list)
 ```
 

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -205,6 +205,16 @@ Load Python dictionaries with [`~Dataset.from_dict`]:
 >>> dataset = Dataset.from_dict(my_dict)
 ```
 
+### Python list of dictionaries
+
+Load a list of Python dictionaries with [`~Dataset.from_list`]:
+
+```py
+>>> from datasets import Dataset
+>>> my_list = [{"a": 1}, {"a": 2}]
+>>> dataset = Dataset.from_list(my_list)
+```
+
 ### Pandas DataFrame
 
 Load Pandas DataFrames with [`~Dataset.from_pandas`]:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -63,13 +63,7 @@ from .arrow_writer import ArrowWriter, OptimizedTypedSequence
 from .download.download_config import DownloadConfig
 from .download.streaming_download_manager import xgetsize
 from .features import Audio, ClassLabel, Features, Image, Sequence, Value
-from .features.features import (
-    FeatureType,
-    decode_nested_example,
-    generate_from_arrow_type,
-    pandas_types_mapper,
-    require_decoding,
-)
+from .features.features import FeatureType, decode_nested_example, pandas_types_mapper, require_decoding
 from .filesystems import extract_path_from_uri, is_remote_filesystem
 from .fingerprint import (
     fingerprint_transform,
@@ -848,7 +842,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         split: Optional[NamedSplit] = None,
     ) -> "Dataset":
         """
-        Convert a list of dicts to a :obj:`pyarrow.Table` to create a :class:`Dataset`.
+        Convert :obj:`dict` to a :obj:`pyarrow.Table` to create a :class:`Dataset`.
 
         Args:
             mapping (:obj:`Mapping`): Mapping of strings to Arrays or Python lists.
@@ -887,7 +881,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         split: Optional[NamedSplit] = None,
     ) -> "Dataset":
         """
-        Convert :obj:`list of dicts` to a :obj:`pyarrow.Table` to create a :class:`Dataset`.
+        Convert a list of dicts to a :obj:`pyarrow.Table` to create a :class:`Dataset`.
+
+        Note that the keys of the first entry will be used to determine the dataset columns,
+        regardless of what is passed to features.
 
         Args:
             mapping (:obj:`List[dict]`): A list of mappings of strings to row values.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -895,16 +895,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Returns:
             :class:`Dataset`
         """
-        if info is not None and features is not None and info.features != features:
-            raise ValueError(
-                f"Features specified in `features` and `info.features` can't be different:\n{features}\n{info.features}"
-            )
-        features = features if features is not None else info.features if info is not None else None
-        if info is None:
-            info = DatasetInfo()
-        info.features = features
-        pa_table = InMemoryTable.from_pylist(mapping=mapping)
-        return cls(pa_table, info=info, split=split)
+        # for simplicity and consistency wrt OptimizedTypedSequence we do not use InMemoryTable.from_pylist here
+        mapping = {k: [r.get(k) for r in mapping] for k in mapping[0]} if mapping else {}
+        return cls.from_dict(mapping, features, info, split)
 
     @staticmethod
     def from_csv(

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -750,7 +750,7 @@ class InMemoryTable(TableBlock):
         return cls(pa.Table.from_pydict(*args, **kwargs))
 
     @classmethod
-    def from_pylist(cls, *args, **kwargs):
+    def from_pylist(cls, mapping, *args, **kwargs):
         """
         Construct a Table from list of rows / dictionaries.
 
@@ -765,7 +765,11 @@ class InMemoryTable(TableBlock):
         Returns:
             :class:`datasets.table.Table`:
         """
-        return cls(pa.Table.from_pylist(*args, **kwargs))
+        try:
+            return cls(pa.Table.from_pylist(mapping, *args, **kwargs))
+        except AttributeError:  # pyarrow <7 does not have from_pylist, so we convert and use from_pydict
+            mapping = {k: [r.get(k) for r in mapping] for k in mapping[0]}
+            return cls(pa.Table.from_pydict(mapping, *args, **kwargs))
 
     @classmethod
     def from_batches(cls, *args, **kwargs):

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -768,7 +768,7 @@ class InMemoryTable(TableBlock):
         try:
             return cls(pa.Table.from_pylist(mapping, *args, **kwargs))
         except AttributeError:  # pyarrow <7 does not have from_pylist, so we convert and use from_pydict
-            mapping = {k: [r.get(k) for r in mapping] for k in mapping[0]}
+            mapping = {k: [r.get(k) for r in mapping] for k in mapping[0]} if mapping else {}
             return cls(pa.Table.from_pydict(mapping, *args, **kwargs))
 
     @classmethod

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -252,6 +252,19 @@ class Table(IndexedTableMixin):
         """
         return self.table.to_pydict(*args, **kwargs)
 
+    def to_pylist(self, *args, **kwargs):
+        """
+        Convert the Table to a list
+
+        Returns:
+            :obj:`list`
+        """
+        try:
+            return self.table.to_pylist(*args, **kwargs)
+        except AttributeError:  # pyarrow <7 does not have to_pylist, so we use to_pydict
+            pydict = self.table.to_pydict(*args, **kwargs)
+            return [{k: pydict[k][i] for k in pydict} for i in range(len(self.table))]
+
     def to_pandas(self, *args, **kwargs):
         """
         Convert to a pandas-compatible NumPy array or DataFrame, as appropriate

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -750,6 +750,24 @@ class InMemoryTable(TableBlock):
         return cls(pa.Table.from_pydict(*args, **kwargs))
 
     @classmethod
+    def from_pylist(cls, *args, **kwargs):
+        """
+        Construct a Table from list of rows / dictionaries.
+
+        Args:
+            mapping (:obj:`List[dict]`):
+                A mapping of strings to row values.
+            schema (:obj:`Schema`, defaults to :obj:`None`):
+                If not passed, will be inferred from the Mapping values
+            metadata (:obj:`Union[dict, Mapping]`, default None):
+                Optional metadata for the schema (if inferred).
+
+        Returns:
+            :class:`datasets.table.Table`:
+        """
+        return cls(pa.Table.from_pylist(*args, **kwargs))
+
+    @classmethod
     def from_batches(cls, *args, **kwargs):
         """
         Construct a Table from a sequence or iterator of Arrow RecordBatches.

--- a/tests/test_dataset_list.py
+++ b/tests/test_dataset_list.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from datasets import Sequence, Value
 from datasets.arrow_dataset import Dataset
 
 
@@ -28,3 +29,14 @@ class DatasetListTest(TestCase):
         dset = Dataset.from_list(example_records)
         dset_from_dict = Dataset.from_dict({k: [r[k] for r in example_records] for k in example_records[0]})
         self.assertEqual(dset.info, dset_from_dict.info)
+
+    def test_uneven_records(self):  # checks what happens with missing columns
+        uneven_records = [{"col_1": 1}, {"col_2": "x"}]
+        dset = Dataset.from_list(uneven_records)
+        self.assertDictEqual(dset[0], {"col_1": 1})
+        self.assertDictEqual(dset[1], {"col_1": None})  # NB: first record is used for columns
+
+    def test_variable_list_records(self):  # checks if the type can be inferred from the second record
+        list_records = [{"col_1": []}, {"col_1": [1, 2]}]
+        dset = Dataset.from_list(list_records)
+        self.assertEqual(dset.info.features["col_1"], Sequence(Value("int64")))

--- a/tests/test_dataset_list.py
+++ b/tests/test_dataset_list.py
@@ -40,3 +40,8 @@ class DatasetListTest(TestCase):
         list_records = [{"col_1": []}, {"col_1": [1, 2]}]
         dset = Dataset.from_list(list_records)
         self.assertEqual(dset.info.features["col_1"], Sequence(Value("int64")))
+
+    def test_create_empty(self):
+        dset = Dataset.from_list([])
+        self.assertEqual(len(dset), 0)
+        self.assertListEqual(dset.column_names, [])

--- a/tests/test_dataset_list.py
+++ b/tests/test_dataset_list.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from datasets.arrow_dataset import Dataset
+
+
+class DatasetListTest(TestCase):
+    def _create_example_records(self):
+        return [
+            {"col_1": 3, "col_2": "a"},
+            {"col_1": 2, "col_2": "b"},
+            {"col_1": 1, "col_2": "c"},
+            {"col_1": 0, "col_2": "d"},
+        ]
+
+    def _create_example_dict(self):
+        data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}
+        return Dataset.from_dict(data)
+
+    def test_create(self):
+        example_records = self._create_example_records()
+        dset = Dataset.from_list(example_records)
+        self.assertListEqual(dset.column_names, ["col_1", "col_2"])
+        for i, r in enumerate(dset):
+            self.assertDictEqual(r, example_records[i])
+
+    def test_list_dict_equivalent(self):
+        example_records = self._create_example_records()
+        dset = Dataset.from_list(example_records)
+        dset_from_dict = Dataset.from_dict({k: [r[k] for r in example_records] for k in example_records[0]})
+        self.assertEqual(dset.info, dset_from_dict.info)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -256,11 +256,10 @@ def test_in_memory_table_from_pydict(in_memory_pa_table):
 
 
 def test_in_memory_table_from_pylist(in_memory_pa_table):
-    pylist = in_memory_pa_table.to_pylist()
-    with assert_arrow_memory_increases():
-        table = InMemoryTable.from_pylist(pylist)
-        assert isinstance(table, InMemoryTable)
-        assert table.table == pa.Table.from_pylist(pylist)
+    pylist = InMemoryTable(in_memory_pa_table).to_pylist()
+    table = InMemoryTable.from_pylist(pylist)
+    assert isinstance(table, InMemoryTable)
+    assert pylist == table.to_pylist()
 
 
 def test_in_memory_table_from_batches(in_memory_pa_table):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -255,6 +255,14 @@ def test_in_memory_table_from_pydict(in_memory_pa_table):
         assert table.table == pa.Table.from_pydict(pydict)
 
 
+def test_in_memory_table_from_pylist(in_memory_pa_table):
+    pylist = in_memory_pa_table.to_pylist()
+    with assert_arrow_memory_increases():
+        table = InMemoryTable.from_pylist(pylist)
+        assert isinstance(table, InMemoryTable)
+        assert table.table == pa.Table.from_pylist(pylist)
+
+
 def test_in_memory_table_from_batches(in_memory_pa_table):
     batches = list(in_memory_pa_table.to_batches())
     table = InMemoryTable.from_batches(batches)


### PR DESCRIPTION
As discussed in #4885 

I initially added this bit at the end, thinking filling this field was necessary as it is done in from_dict. 
However, it seems the constructor takes care of filling info when it is empty.
```
if info.features is None:
  info.features = Features(
      {
          col: generate_from_arrow_type(coldata.type)
          for col, coldata in zip(pa_table.column_names, pa_table.columns)
      }
  )
```