### PR TITLE
Re-add code and und language tags

### DIFF
--- a/src/datasets/utils/resources/languages.json
+++ b/src/datasets/utils/resources/languages.json
@@ -1,4 +1,5 @@
 {
+    "code": "Programming language (C++, Java, Javascript, Python, etc.)",
     "aa": "Afar",
     "aaa": "Ghotuo",
     "aab": "Alumu-Tesu",

--- a/src/datasets/utils/resources/languages.json
+++ b/src/datasets/utils/resources/languages.json
@@ -6896,6 +6896,7 @@
     "ums": "Pendau",
     "umu": "Munsee",
     "una": "North Watut",
+    "und": "Undetermined",
     "une": "Uneme",
     "ung": "Ngarinyin",
     "uni": "Uni",


### PR DESCRIPTION
This PR fixes the removal of 2 language tags done by:
- #4882

The tags are:
- "code": this is not a IANA tag but needed
- "und": this is one of the special scoped tags removed by 0d53202b9abce6fd0358cb00d06fcfd904b875af
  - used in "mc4" and "udhr" datasets