### PR TITLE
Raise ManualDownloadError from get_dataset_config_info

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -682,8 +682,7 @@ class DatasetBuilder:
                 print(
                     f"Downloading and preparing dataset {self.info.builder_name}/{self.info.config_name} to {self._cache_dir}..."
                 )
-
-            self._check_manual_download(dl_manager)
+            self._check_manual_download()
 
             # Create a tmp dir and rename to self._cache_dir on successful exit.
             with incomplete_dir(self._cache_dir) as tmp_data_dir:
@@ -719,8 +718,8 @@ class DatasetBuilder:
                 f"Subsequent calls will reuse this data."
             )
 
-    def _check_manual_download(self, dl_manager):
-        if self.manual_download_instructions is not None and dl_manager.manual_dir is None:
+    def _check_manual_download(self):
+        if self.manual_download_instructions is not None and self.config.data_dir is None:
             raise ManualDownloadError(
                 textwrap.dedent(
                     f"""\
@@ -1021,7 +1020,7 @@ class DatasetBuilder:
             dataset_name=self.name,
             data_dir=self.config.data_dir,
         )
-        self._check_manual_download(dl_manager)
+        self._check_manual_download()
         splits_generators = {sg.name: sg for sg in self._split_generators(dl_manager)}
         # By default, return all splits
         if split is None:

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -682,7 +682,8 @@ class DatasetBuilder:
                 print(
                     f"Downloading and preparing dataset {self.info.builder_name}/{self.info.config_name} to {self._cache_dir}..."
                 )
-            self._check_manual_download()
+
+            self._check_manual_download(dl_manager)
 
             # Create a tmp dir and rename to self._cache_dir on successful exit.
             with incomplete_dir(self._cache_dir) as tmp_data_dir:
@@ -718,8 +719,8 @@ class DatasetBuilder:
                 f"Subsequent calls will reuse this data."
             )
 
-    def _check_manual_download(self):
-        if self.manual_download_instructions is not None and self.config.data_dir is None:
+    def _check_manual_download(self, dl_manager):
+        if self.manual_download_instructions is not None and dl_manager.manual_dir is None:
             raise ManualDownloadError(
                 textwrap.dedent(
                     f"""\
@@ -1020,7 +1021,7 @@ class DatasetBuilder:
             dataset_name=self.name,
             data_dir=self.config.data_dir,
         )
-        self._check_manual_download()
+        self._check_manual_download(dl_manager)
         splits_generators = {sg.name: sg for sg in self._split_generators(dl_manager)}
         # By default, return all splits
         if split is None:

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -362,6 +362,7 @@ def get_dataset_config_info(
         use_auth_token=use_auth_token,
         **config_kwargs,
     )
+    builder._check_manual_download()
     info = builder.info
     if info.splits is None:
         try:

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -362,13 +362,15 @@ def get_dataset_config_info(
         use_auth_token=use_auth_token,
         **config_kwargs,
     )
-    builder._check_manual_download()
     info = builder.info
     if info.splits is None:
+        download_config = download_config.copy() if download_config else DownloadConfig()
+        if use_auth_token is not None:
+            download_config.use_auth_token = use_auth_token
+        builder._check_manual_download(
+            StreamingDownloadManager(base_path=builder.base_path, download_config=download_config)
+        )
         try:
-            download_config = download_config.copy() if download_config else DownloadConfig()
-            if use_auth_token is not None:
-                download_config.use_auth_token = use_auth_token
             info.splits = {
                 split_generator.name: {"name": split_generator.name, "dataset_name": path}
                 for split_generator in builder._split_generators(


### PR DESCRIPTION
This PRs raises a specific `ManualDownloadError` when `get_dataset_config_info` is called for a dataset that requires manual download.

Related to:
- #4898

CC: @severo 