### PR TITLE
[LibriSpeech] Fix dev split local_extracted_archive for 'all' config

### DIFF
--- a/datasets/librispeech_asr/librispeech_asr.py
+++ b/datasets/librispeech_asr/librispeech_asr.py
@@ -209,14 +209,14 @@ class LibrispeechASR(datasets.GeneratorBasedBuilder):
                 datasets.SplitGenerator(
                     name="validation.clean",
                     gen_kwargs={
-                        "local_extracted_archive": local_extracted_archive.get("validation.clean"),
+                        "local_extracted_archive": local_extracted_archive.get("dev.clean"),
                         "files": dl_manager.iter_archive(archive_path["dev.clean"]),
                     },
                 ),
                 datasets.SplitGenerator(
                     name="validation.other",
                     gen_kwargs={
-                        "local_extracted_archive": local_extracted_archive.get("validation.other"),
+                        "local_extracted_archive": local_extracted_archive.get("dev.other"),
                         "files": dl_manager.iter_archive(archive_path["dev.other"]),
                     },
                 ),


### PR DESCRIPTION
We define the keys for the `_DL_URLS` of the dev split as `dev.clean` and `dev.other`:
https://github.com/huggingface/datasets/blob/2e7142a3c6500b560da45e8d5128e320a09fcbd4/datasets/librispeech_asr/librispeech_asr.py#L60-L61

These keys get forwarded to the `dl_manager` and thus the `local_extracted_archive`.

However, when calling `SplitGenerator` for the dev sets, we query the `local_extracted_archive` keys `validation.clean` and `validation.other`:
https://github.com/huggingface/datasets/blob/2e7142a3c6500b560da45e8d5128e320a09fcbd4/datasets/librispeech_asr/librispeech_asr.py#L212
https://github.com/huggingface/datasets/blob/2e7142a3c6500b560da45e8d5128e320a09fcbd4/datasets/librispeech_asr/librispeech_asr.py#L219

The consequence of this is that the `local_extracted_archive` arg passed to `_generate_examples` is always `None`, as the keys `validation.clean` and `validation.other` do not exists in the `local_extracted_archive`.

When defining the `audio_file` in `_generate_examples`, since `local_extracted_archive` is always `None`, we always omit the `local_extracted_archive` path from the `audio_file` path, **even** if in non-streaming mode:
https://github.com/huggingface/datasets/blob/2e7142a3c6500b560da45e8d5128e320a09fcbd4/datasets/librispeech_asr/librispeech_asr.py#L259-L263

Thus, `audio_file` will only ever be the streaming path (`audio_file`, not `os.path.join(local_extracted_archive, audio_file)`).

This PR fixes the `.get()` keys for the `local_extracted_archive` for the dev splits.
