### PR TITLE
feat: improve error message on Keys mismatch. closes #4917

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -690,7 +690,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 self.info.features = self.info.features.reorder_fields_as(inferred_features)
             except ValueError as e:
                 raise ValueError(
-                    f"{e}\n'source' means dataset_info.json and 'target' means inferred from dataset.arrow"
+                    f"{e}\nThe 'source' features come from dataset_info.json, and the 'target' ones are those of the dataset arrow file."
                 )
 
         # Infer fingerprint if None

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -686,7 +686,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if self.info.features is None:
             self.info.features = inferred_features
         else:  # make sure the nested columns are in the right order
-            self.info.features = self.info.features.reorder_fields_as(inferred_features)
+            try:
+                self.info.features = self.info.features.reorder_fields_as(inferred_features)
+            except ValueError as e:
+                raise ValueError(
+                    f"{e}\n'source' means dataset_info.json and 'target' means inferred from dataset.arrow"
+                )
 
         # Infer fingerprint if None
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1756,10 +1756,9 @@ class Features(dict):
                     raise ValueError(f"Type mismatch: between {source} and {target}" + stack_position)
                 if sorted(source) != sorted(target):
                     message = (
-                        f"Keys mismatch: between {source} (dataset_info.json) "
-                        f"and {target} (inferred from dataset.arrow).\n"
-                        f"{source.keys()-target.keys()} are missing from dataset.arrow "
-                        f"and {target.keys()-source.keys()} are missing from dataset_info.json" + stack_position
+                        f"Keys mismatch: between {source} (source) and {target} (target).\n"
+                        f"{source.keys()-target.keys()} are missing from target "
+                        f"and {target.keys()-source.keys()} are missing from source" + stack_position
                     )
                     raise ValueError(message)
                 return {key: recursive_reorder(source[key], target[key], stack + f".{key}") for key in target}

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1755,10 +1755,12 @@ class Features(dict):
                 if not isinstance(target, dict):
                     raise ValueError(f"Type mismatch: between {source} and {target}" + stack_position)
                 if sorted(source) != sorted(target):
-                    message = (f"Keys mismatch: between {source} (dataset_info.json) "
-                               f"and {target} (inferred from dataset.arrow).\n"
-                               f"{source.keys()-target.keys()} are missing from dataset.arrow "
-                               f"and {target.keys()-source.keys()} are missing from dataset_info.json"+stack_position)
+                    message = (
+                        f"Keys mismatch: between {source} (dataset_info.json) "
+                        f"and {target} (inferred from dataset.arrow).\n"
+                        f"{source.keys()-target.keys()} are missing from dataset.arrow "
+                        f"and {target.keys()-source.keys()} are missing from dataset_info.json" + stack_position
+                    )
                     raise ValueError(message)
                 return {key: recursive_reorder(source[key], target[key], stack + f".{key}") for key in target}
             elif isinstance(source, list):

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1755,7 +1755,11 @@ class Features(dict):
                 if not isinstance(target, dict):
                     raise ValueError(f"Type mismatch: between {source} and {target}" + stack_position)
                 if sorted(source) != sorted(target):
-                    raise ValueError(f"Keys mismatch: between {source} and {target}" + stack_position)
+                    message = (f"Keys mismatch: between {source} (dataset_info.json) "
+                               f"and {target} (inferred from dataset.arrow).\n"
+                               f"{source.keys()-target.keys()} are missing from dataset.arrow "
+                               f"and {target.keys()-source.keys()} are missing from dataset_info.json"+stack_position)
+                    raise ValueError(message)
                 return {key: recursive_reorder(source[key], target[key], stack + f".{key}") for key in target}
             elif isinstance(source, list):
                 if not isinstance(target, list):


### PR DESCRIPTION
Hi @lhoestq what do you think?

Let me give you a code sample:
```py
>>> import datasets
>>> foo = datasets.Dataset.from_dict({'foo':[0,1], 'bar':[2,3]})
>>> foo.save_to_disk('foo')
# edit foo/dataset_info.json e.g. rename the 'foo' feature to 'baz'
>>> datasets.load_from_disk('foo')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-4863e606b330> in <module>
----> 1 datasets.load_from_disk('foo')

~/code/datasets/src/datasets/load.py in load_from_disk(dataset_path, fs, keep_in_memory)
   1851         raise FileNotFoundError(f"Directory {dataset_path} not found")
   1852     if fs.isfile(Path(dest_dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
-> 1853         return Dataset.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
   1854     elif fs.isfile(Path(dest_dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
   1855         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)

~/code/datasets/src/datasets/arrow_dataset.py in load_from_disk(dataset_path, fs, keep_in_memory)
   1230             info=dataset_info,
   1231             split=split,
-> 1232             fingerprint=state["_fingerprint"],
   1233         )
   1234 

~/code/datasets/src/datasets/arrow_dataset.py in __init__(self, arrow_table, info, split, indices_table, fingerprint)
    687             self.info.features = inferred_features
    688         else:  # make sure the nested columns are in the right order
--> 689             self.info.features = self.info.features.reorder_fields_as(inferred_features)
    690 
    691         # Infer fingerprint if None

~/code/datasets/src/datasets/features/features.py in reorder_fields_as(self, other)
   1771                 return source
   1772 
-> 1773         return Features(recursive_reorder(self, other))
   1774 
   1775     def flatten(self, max_depth=16) -> "Features":

~/code/datasets/src/datasets/features/features.py in recursive_reorder(source, target, stack)
   1760                                f"{source.keys()-target.keys()} are missing from dataset.arrow "
   1761                                f"and {target.keys()-source.keys()} are missing from dataset_info.json"+stack_position)
-> 1762                     raise ValueError(message)
   1763                 return {key: recursive_reorder(source[key], target[key], stack + f".{key}") for key in target}
   1764             elif isinstance(source, list):

ValueError: Keys mismatch: between {'baz': Value(dtype='int64', id=None), 'bar': Value(dtype='int64', id=None)} (dataset_info.json) and {'foo': Value(dtype='int64', id=None), 'bar': Value(dtype='int64', id=None)} (inferred from dataset.arrow).
{'baz'} are missing from dataset.arrow and {'foo'} are missing from dataset_info.json
```