### PR TITLE
Add note about loading image / audio files to docs

### DIFF
--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -85,12 +85,14 @@ Load your dataset by specifying `audiofolder` and the directory of your dataset 
  'label': 1}
 ```
 
-If your directory contains multiple splits, use the `data_files` argument to load the images associated with each split:
+You can also use `audiofolder` to load datasets involving multiple splits. To do so, your dataset directory should have the following structure:
 
-```py
->>> from datasets import load_dataset
+```
+folder/train/electronic/01.mp3
+folder/train/punk/01.mp3
 
->>> dataset = load_dataset("audiofolder", data_files={"train":["train/electronic/01.mp3", ...], "test": ["test/electronic/01.mp3", ...]})
+folder/test/electronic/09.mp3
+folder/test/punk/09.mp3
 ```
 
 ## AudioFolder with metadata
@@ -140,6 +142,12 @@ You can load remote datasets from their URLs with the `data_files` parameter:
 ```py
 >>> dataset = load_dataset("audiofolder", data_files="https://s3.amazonaws.com/datasets.huggingface.co/SpeechCommands/v0.01/v0.01_test.tar.gz")
 ```
+
+<Tip>
+
+Some audio datasets, like those found in [Kaggle competitions](https://www.kaggle.com/), have separate metadata files for each split. Provided the metadata features are the same for each split, `audiofolder` can be used to load all splits at once. If the metadata features differ across each split, you should load them with separate `load_dataset()` calls.
+
+</Tip>
 
 ## AudioFolder with labels
 

--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -57,7 +57,41 @@ If you only want to load the underlying path to the audio dataset without decodi
 
 ## AudioFolder
 
-You can also load a dataset with an `AudioFolder` dataset builder. It does not require writing a custom dataloader, making it useful for quickly loading audio data.
+You can also load a dataset with an `AudioFolder` dataset builder. It does not require writing a custom dataloader, making it useful for quickly loading audio data. For classification tasks, your audio dataset structure should look like this:
+
+```
+folder/train/electronic/01.mp3
+folder/train/punk/01.mp3
+```
+
+Load your dataset by specifying `audiofolder` and the directory of your dataset in `data_dir`:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("audiofolder", data_dir="/path/to/folder")
+>>> dataset["train"][0]
+{'audio': {'path': '/path/to/electronic/01.mp3',
+  'array': array([ 3.9714024e-07,  7.3031038e-07,  7.5640685e-07, ...,
+         -1.1963668e-01, -1.1681189e-01, -1.1244172e-01], dtype=float32),
+  'sampling_rate': 44100},
+ 'label': 0}
+
+>>> dataset["train"][-1]
+{'audio': {'path': '/path/to/punk/01.mp3',
+  'array': array([0.15237972, 0.13222949, 0.10627693, ..., 0.41940814, 0.37578005,
+         0.33717662], dtype=float32),
+  'sampling_rate': 44100},
+ 'label': 1}
+```
+
+If your directory contains multiple splits, use the `data_files` argument to load the images associated with each split:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("audiofolder", data_files={"train":["train/electronic/01.mp3", ...], "test": ["test/electronic/01.mp3", ...)
+```
 
 ## AudioFolder with metadata
 

--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -90,7 +90,7 @@ If your directory contains multiple splits, use the `data_files` argument to loa
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("audiofolder", data_files={"train":["train/electronic/01.mp3", ...], "test": ["test/electronic/01.mp3", ...)
+>>> dataset = load_dataset("audiofolder", data_files={"train":["train/electronic/01.mp3", ...], "test": ["test/electronic/01.mp3", ...]})
 ```
 
 ## AudioFolder with metadata

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -72,14 +72,6 @@ Load your dataset by specifying `imagefolder` and the directory of your dataset 
 {"image": <PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E8DAD30>, "label": 1}
 ```
 
-If your directory contains multiple splits, use the `data_files` argument to load the images associated with each split:
-
-```py
->>> from datasets import load_dataset
-
->>> dataset = load_dataset("imagefolder", data_files={"train":["train/dog/golden_retriever.png", ...], "test": ["test/dog/german_shepherd.png", ...)
-```
-
 Load remote datasets from their URLs with the `data_files` parameter:
 
 ```py
@@ -90,21 +82,24 @@ Load remote datasets from their URLs with the `data_files` parameter:
 
 ## ImageFolder with metadata
 
-Metadata associated with your dataset can also be loaded, extending the utility of `ImageFolder` to additional vision tasks like image captioning and object detection. Make sure your dataset has a `metadata.jsonl` file:
+Metadata associated with your dataset can also be loaded, extending the utility of `ImageFolder` to additional vision tasks like image captioning and object detection. Make sure your dataset has a `metadata.csv` file:
 
 ```
-folder/train/metadata.jsonl
+folder/train/metadata.csv
 folder/train/0001.png
 folder/train/0002.png
 folder/train/0003.png
 ```
-Your `metadata.jsonl` file must have a `file_name` column which links image files with their metadata:
+Your `metadata.csv` file must have a `file_name` column which links image files with their metadata:
 
-```jsonl
-{"file_name": "0001.png", "additional_feature": "This is a first value of a text feature you added to your images"}
-{"file_name": "0002.png", "additional_feature": "This is a second value of a text feature you added to your images"}
-{"file_name": "0003.png", "additional_feature": "This is a third value of a text feature you added to your images"}
+```text
+file_name,additional_feature
+0001.png,This is a first value of a text feature you added to your images
+0002.png,This is a second value of a text feature you added to your images
+0003.png,This is a third value of a text feature you added to your images
 ```
+
+For complex value types, e.g. a list of floats, it may be more convenient to specify metadata as JSON Lines to avoid parsing errors or reading them as strings. In that case, use `metadata.jsonl` as the name of the metadata file.
 
 <Tip>
 
@@ -114,12 +109,13 @@ If metadata files are present, the inferred labels based on the directory name a
 
 ### Image captioning
 
-Image captioning datasets have text describing an image. An example `metadata.jsonl` may look like:
+Image captioning datasets have text describing an image. An example `metadata.csv` may look like:
 
-```jsonl
-{"file_name": "0001.png", "text": "This is a golden retriever playing with a ball"}
-{"file_name": "0002.png", "text": "A german shepherd"}
-{"file_name": "0003.png", "text": "One chihuahua"}
+```text
+file_name,text
+0001.png,This is a golden retriever playing with a ball
+0002.png,A german shepherd
+0003.png,One chihuahua
 ```
 
 Load the dataset with `ImageFolder`, and it will create a `text` column for the image captions:

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -72,6 +72,16 @@ Load your dataset by specifying `imagefolder` and the directory of your dataset 
 {"image": <PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E8DAD30>, "label": 1}
 ```
 
+You can also use `imagefolder` to load datasets involving multiple splits. To do so, your dataset directory should have the following structure:
+
+```
+folder/train/dog/golden_retriever.png
+folder/train/cat/maine_coon.png
+
+folder/test/dog/german_shepherd.png
+folder/test/cat/bengal.png
+```
+
 Load remote datasets from their URLs with the `data_files` parameter:
 
 ```py

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -72,6 +72,14 @@ Load your dataset by specifying `imagefolder` and the directory of your dataset 
 {"image": <PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E8DAD30>, "label": 1}
 ```
 
+If your directory contains multiple splits, use the `data_files` argument to load the images associated with each split:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("imagefolder", data_files={"train":["train/dog/golden_retriever.png", ...], "test": ["test/dog/german_shepherd.png", ...)
+```
+
 Load remote datasets from their URLs with the `data_files` parameter:
 
 ```py
@@ -82,24 +90,21 @@ Load remote datasets from their URLs with the `data_files` parameter:
 
 ## ImageFolder with metadata
 
-Metadata associated with your dataset can also be loaded, extending the utility of `ImageFolder` to additional vision tasks like image captioning and object detection. Make sure your dataset has a `metadata.csv` file:
+Metadata associated with your dataset can also be loaded, extending the utility of `ImageFolder` to additional vision tasks like image captioning and object detection. Make sure your dataset has a `metadata.jsonl` file:
 
 ```
-folder/train/metadata.csv
+folder/train/metadata.jsonl
 folder/train/0001.png
 folder/train/0002.png
 folder/train/0003.png
 ```
-Your `metadata.csv` file must have a `file_name` column which links image files with their metadata:
+Your `metadata.jsonl` file must have a `file_name` column which links image files with their metadata:
 
-```text
-file_name,additional_feature
-0001.png,This is a first value of a text feature you added to your images
-0002.png,This is a second value of a text feature you added to your images
-0003.png,This is a third value of a text feature you added to your images
+```jsonl
+{"file_name": "0001.png", "additional_feature": "This is a first value of a text feature you added to your images"}
+{"file_name": "0002.png", "additional_feature": "This is a second value of a text feature you added to your images"}
+{"file_name": "0003.png", "additional_feature": "This is a third value of a text feature you added to your images"}
 ```
-
-For complex value types, e.g. a list of floats, it may be more convenient to specify metadata as JSON Lines to avoid parsing errors or reading them as strings. In that case, use `metadata.jsonl` as the name of the metadata file.
 
 <Tip>
 
@@ -109,13 +114,12 @@ If metadata files are present, the inferred labels based on the directory name a
 
 ### Image captioning
 
-Image captioning datasets have text describing an image. An example `metadata.csv` may look like:
+Image captioning datasets have text describing an image. An example `metadata.jsonl` may look like:
 
-```text
-file_name,text
-0001.png,This is a golden retriever playing with a ball
-0002.png,A german shepherd
-0003.png,One chihuahua
+```jsonl
+{"file_name": "0001.png", "text": "This is a golden retriever playing with a ball"}
+{"file_name": "0002.png", "text": "A german shepherd"}
+{"file_name": "0003.png", "text": "One chihuahua"}
 ```
 
 Load the dataset with `ImageFolder`, and it will create a `text` column for the image captions:


### PR DESCRIPTION
This PR adds a small note about how to load image / audio datasets that have multiple splits in their dataset structure.

Related forum thread: https://discuss.huggingface.co/t/loading-train-and-test-splits-with-audiofolder/22447

cc @NielsRogge 