### PR TITLE
Fixes a typo in loading documentation

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -275,7 +275,7 @@ Or select a percentage of a split with:
 Select a combination of percentages from each split:
 
 ```py
->>> train_10_80pct_ds = datasets.load_dataset("bookcorpus", split="tr"in[:10%]+train[-80%:]")
+>>> train_10_80pct_ds = datasets.load_dataset("bookcorpus", split="train[:10%]+train[-80%:]")
 ===STRINGAPI-READINSTRUCTION-SPLIT===
 >>> ri = (datasets.ReadInstruction("train", to=10, unit="%") + datasets.ReadInstruction("train", from_=-80, unit="%"))
 >>> train_10_80pct_ds = datasets.load_dataset("bookcorpus", split=ri)


### PR DESCRIPTION
As show in the [documentation page](https://huggingface.co/docs/datasets/loading) here the `"tr"in` should be `"train`.

![image](https://user-images.githubusercontent.com/7144772/188390445-e1f04d54-e3e3-4762-8686-63ecbe4087e5.png)
