### PR TITLE
Add cc-by-nc-2.0 to list of licenses

### DIFF
--- a/src/datasets/utils/resources/standard_licenses.tsv
+++ b/src/datasets/utils/resources/standard_licenses.tsv
@@ -16,6 +16,7 @@ Creative Commons Attribution 3.0	cc-by-3.0
 Creative Commons Attribution 4.0	cc-by-4.0
 Creative Commons Attribution Share Alike 3.0	cc-by-sa-3.0
 Creative Commons Attribution Share Alike 4.0	cc-by-sa-4.0
+Creative Commons Attribution Non Commercial 2.0	cc-by-nc-2.0
 Creative Commons Attribution Non Commercial 3.0	cc-by-nc-3.0
 Creative Commons Attribution Non Commercial 4.0	cc-by-nc-4.0
 Creative Commons Attribution No Derivatives 4.0	cc-by-nd-4.0


### PR DESCRIPTION
This PR adds the `cc-by-nc-2.0` to the list of licenses because it is required by `scifact` dataset: https://github.com/allenai/scifact/blob/master/LICENSE.md