### PR TITLE
Remove deprecated identical_ok

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4235,7 +4235,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                         token=token,
                         repo_type="dataset",
                         revision=branch,
-                        identical_ok=False,
                     ),
                     exceptions=HTTPError,
                     status_codes=[504],
@@ -4390,7 +4389,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             token=token,
             repo_type="dataset",
             revision=branch,
-            identical_ok=True,
         )
 
     @transmit_format

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1377,7 +1377,6 @@ class DatasetDict(dict):
             token=token,
             repo_type="dataset",
             revision=branch,
-            identical_ok=True,
         )
 
 


### PR DESCRIPTION
`huggingface-hub` says that the `identical_ok` argument of `HfApi.upload_file` is now deprecated, and will be removed soon. It even has no effect at the moment when it's passed:

```python
Args:
...
    identical_ok (`bool`, *optional*, defaults to `True`):
        Deprecated: will be removed in 0.11.0.
        Changing this value has no effect.
...
```

There was only one occurence of `identical_ok=False` but it's maybe not worth adding a check ti verify if the files were the same.

cc @mariosasko 