### PR TITLE
Add Papers with Code ID to scifact dataset

### DIFF
--- a/datasets/scifact/README.md
+++ b/datasets/scifact/README.md
@@ -18,7 +18,7 @@ task_categories:
 - text-classification
 task_ids:
 - fact-checking
-paperswithcode_id: null
+paperswithcode_id: scifact
 ---
 
 # Dataset Card for "scifact"


### PR DESCRIPTION
This PR:
- adds Papers with Code ID
- forces sync between GitHub and Hub, which previously failed due to Hub validation error of the license tag: https://github.com/huggingface/datasets/runs/8200223631?check_suite_focus=true