### PR TITLE
Fix license information in qasc dataset card

### DIFF
--- a/datasets/qasc/README.md
+++ b/datasets/qasc/README.md
@@ -6,7 +6,7 @@ language:
 language_creators:
 - found
 license:
-- unknown
+- cc-by-4.0
 multilinguality:
 - monolingual
 pretty_name: Question Answering via Sentence Composition (QASC)
@@ -173,7 +173,7 @@ The data fields are the same among all splits.
 
 ### Licensing Information
 
-[More Information Needed](https://github.com/huggingface/datasets/blob/master/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)
+The dataset is released under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.
 
 ### Citation Information
 
@@ -184,9 +184,7 @@ The data fields are the same among all splits.
       journal   = {arXiv:1910.11473v2},
       year      = {2020},
 }
-
 ```
-
 
 ### Contributions
 


### PR DESCRIPTION
This PR adds the license information to `qasc` dataset, once reported via GitHub by Tushar Khot, the dataset is licensed under CC BY 4.0:
- https://github.com/allenai/qasc/issues/5
