### PR TITLE
Support streaming nli_tr dataset

### DIFF
--- a/datasets/nli_tr/nli_tr.py
+++ b/datasets/nli_tr/nli_tr.py
@@ -15,7 +15,6 @@
 """NLI-TR: The Turkish translation of SNLI and MultiNLI datasets using Amazon Translate."""
 
 
-import codecs
 import json
 import os
 

--- a/datasets/nli_tr/nli_tr.py
+++ b/datasets/nli_tr/nli_tr.py
@@ -152,7 +152,7 @@ class NliTr(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepath, split):
         """Yields examples."""
 
-        with codecs.open(filepath, encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             for idx, row in enumerate(f):
                 data = json.loads(row)
                 example = {"idx": idx, "premise": data["sentence1"], "hypothesis": data["sentence2"]}


### PR DESCRIPTION
Support streaming nli_tr dataset.

This PR removes legacy `codecs.open` and replaces it with `open` that supports passing encoding.

Fix #3186.