### PR TITLE
Preserve non-`input_colums` in `Dataset.map` if `input_columns` are specified

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2666,7 +2666,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 validate_function_output(processed_inputs, indices)
             if not update_data:
                 return None  # Nothing to update, let's move on
-            if self._format_type is not None:
+            if self._format_type is not None or input_columns:
                 inputs = self._getitem(
                     key=(indices if isinstance(indices, int) else slice(indices[0], indices[-1] + 1)),
                     format_type=None,
@@ -2731,7 +2731,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 # Only load the columns we actually need
                 if input_columns:
                     input_dataset = self.with_format(
-                        self._format_type, columns=input_columns, output_all_columns=True, **self._format_kwargs
+                        self._format_type, columns=input_columns, output_all_columns=False, **self._format_kwargs
                     )
                     if remove_columns:
                         remove_columns = list(set(remove_columns) & set(input_columns))

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2731,7 +2731,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 # Only load the columns we actually need
                 if input_columns:
                     input_dataset = self.with_format(
-                        self._format_type, columns=input_columns, output_all_columns=False, **self._format_kwargs
+                        self._format_type, columns=input_columns, output_all_columns=True, **self._format_kwargs
                     )
                     if remove_columns:
                         remove_columns = list(set(remove_columns) & set(input_columns))

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1341,6 +1341,19 @@ class BaseDatasetTest(TestCase):
                     )
                     self.assertListEqual(dset_test[0]["tensor"], [1, 2, 3])
 
+    def test_map_input_columns(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                print("dset", dset[0])
+                with dset.map(
+                    lambda filename: {"label": int(filename.rsplit("_", 1)[-1]) % 2}, input_columns="filename"
+                ) as mapped_dset:
+                    self.assertTrue("filename" in mapped_dset[0] and "label" in mapped_dset[0])
+                    self.assertTrue("label" in mapped_dset[0])
+                    self.assertEqual(
+                        mapped_dset.features, Features({"filename": Value("string"), "label": Value("int64")})
+                    )
+
     def test_map_remove_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1343,14 +1343,19 @@ class BaseDatasetTest(TestCase):
 
     def test_map_input_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
-                print("dset", dset[0])
-                with dset.map(
-                    lambda filename: {"label": int(filename.rsplit("_", 1)[-1]) % 2}, input_columns="filename"
-                ) as mapped_dset:
-                    self.assertTrue("filename" in mapped_dset[0] and "label" in mapped_dset[0])
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
+                with dset.map(lambda col_1: {"label": col_1 % 2}, input_columns="col_1") as mapped_dset:
+                    self.assertEqual(mapped_dset[0].keys(), {"col_1", "col_2", "col_3", "label"})
                     self.assertEqual(
-                        mapped_dset.features, Features({"filename": Value("string"), "label": Value("int64")})
+                        mapped_dset.features,
+                        Features(
+                            {
+                                "col_1": Value("int64"),
+                                "col_2": Value("string"),
+                                "col_3": Value("bool"),
+                                "label": Value("int64"),
+                            }
+                        ),
                     )
 
     def test_map_remove_columns(self, in_memory):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1349,7 +1349,6 @@ class BaseDatasetTest(TestCase):
                     lambda filename: {"label": int(filename.rsplit("_", 1)[-1]) % 2}, input_columns="filename"
                 ) as mapped_dset:
                     self.assertTrue("filename" in mapped_dset[0] and "label" in mapped_dset[0])
-                    self.assertTrue("label" in mapped_dset[0])
                     self.assertEqual(
                         mapped_dset.features, Features({"filename": Value("string"), "label": Value("int64")})
                     )


### PR DESCRIPTION
Currently, if the `input_columns` list in `Dataset.map` is specified, the columns not in that list are dropped after the `map` transform.

This makes the behavior inconsistent with `IterableDataset.map`.
 
(It seems this issue was introduced by mistake in https://github.com/huggingface/datasets/pull/2246) 

Fix https://github.com/huggingface/datasets/issues/4858