### PR TITLE
[GH->HF] Load datasets from the Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
       - main
 
 env:
-  HF_SCRIPTS_VERSION: main
   HF_ALLOW_CODE_EVAL: 1
 
 jobs:

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -36,8 +36,6 @@ if version.parse(pyarrow.__version__).major < 6:
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."
     )
 
-SCRIPTS_VERSION = "main" if version.parse(__version__).is_devrelease else __version__
-
 del platform
 del pyarrow
 del version

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -739,7 +739,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         self.data_dir = data_dir
         self.download_config = download_config or DownloadConfig()
         self.download_mode = download_mode
-        assert self.name.count("/") == 1
+        assert self.name.count("/") <= 1
         increase_load_count(name, resource_type="dataset")
 
     def get_module(self) -> DatasetModule:

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Type, TypeVar, Union
 from urllib.parse import urljoin, urlparse
 
 import requests
+from packaging import version
 
 from .. import __version__, config
 from ..download.download_config import DownloadConfig
@@ -97,9 +98,9 @@ def head_hf_s3(
 
 
 def hf_github_url(path: str, name: str, dataset=True, revision: Optional[str] = None) -> str:
-    from .. import SCRIPTS_VERSION
 
-    revision = revision or os.getenv("HF_SCRIPTS_VERSION", SCRIPTS_VERSION)
+    default_revision = "main" if version.parse(__version__).is_devrelease else __version__
+    revision = revision or default_revision
     if dataset:
         return config.REPO_DATASETS_URL.format(revision=revision, path=path, name=name)
     else:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,6 +1,5 @@
 import importlib
 import os
-import re
 import shutil
 import tempfile
 import time
@@ -34,7 +33,6 @@ from datasets.load import (
     infer_module_for_data_files,
     infer_module_for_data_files_in_archives,
 )
-from datasets.utils.file_utils import is_remote_url
 
 from .utils import (
     OfflineSimulationMode,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -697,11 +697,11 @@ def test_load_dataset_local(dataset_loading_script_dir, data_dir, keep_in_memory
             assert "Using the latest cached version of the module" in caplog.text
     with pytest.raises(FileNotFoundError) as exc_info:
         datasets.load_dataset(SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST)
-    m_combined_path = re.search(
-        rf"http\S*{re.escape(SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST + '/' + SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST + '.py')}\b",
-        str(exc_info.value),
+    assert f"Dataset '{SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST}' doesn't exist on the Hub" in str(exc_info.value)
+    expected_script_location = (
+        Path() / SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST / f"{SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST}.py"
     )
-    assert m_combined_path is not None and is_remote_url(m_combined_path.group())
+    assert f"Couldn't find a dataset script at {expected_script_location.resolve()}" in str(exc_info.value)
     assert os.path.abspath(SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST) in str(exc_info.value)
 
 


### PR DESCRIPTION
Currently datasets with no namespace (e.g. squad, glue) are loaded from github.

In this PR I changed this logic to use the Hugging Face Hub instead.

This is the first step in removing all the dataset scripts in this repository

related to discussions in https://github.com/huggingface/datasets/pull/4059 (I should have continued from this PR actually)