### PR TITLE
docs: ✏️ add links to the Datasets API

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -6,7 +6,13 @@
 
 Load a dataset in a single line of code, and use our powerful data processing methods to quickly get your dataset ready for training in a deep learning model. Backed by the Apache Arrow format, process large datasets with zero-copy reads without any memory constraints for optimal speed and efficiency. We also feature a deep integration with the [Hugging Face Hub](https://huggingface.co/datasets), allowing you to easily load and share a dataset with the wider machine learning community.
 
-Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), and take an in-depth look inside of it with the live viewer.
+Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), and take an in-depth look inside of it with the [live viewer](https://huggingface.co/datasets/glue/viewer/cola/train).
+
+<Tip>
+
+Are you looking for the [Datasets REST API](https://huggingface.co/docs/datasets-server)? Integrate into your apps over 10,000 datasets via simple **HTTP requests**, with pre-processed responses and scalability built-in.
+
+</Tip>
 
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -303,6 +303,8 @@ def get_dataset_config_names(
      'rte',
      'wnli',
      'ax']
+
+    Note that you can fetch the list of configs for a dataset on the Hugging Face Hub via an HTTP request with the [Datasets REST API endpoint /splits](https://huggingface.co/docs/datasets-server/splits).
     ```
     """
     dataset_module = dataset_module_factory(
@@ -422,6 +424,8 @@ def get_dataset_split_names(
     >>> get_dataset_split_names('rotten_tomatoes')
     ['train', 'validation', 'test']
     ```
+
+    Note that you can fetch the list of split names for a dataset on the Hugging Face Hub via an HTTP request with the [Datasets REST API endpoint /splits](https://huggingface.co/docs/datasets-server/splits).
     """
     info = get_dataset_config_info(
         path,


### PR DESCRIPTION
I added some links to the Datasets API in the docs. See https://github.com/huggingface/datasets-server/pull/566 for a companion PR in the datasets-server. The idea is to improve the discovery of the API through the docs.

I'm a bit shy about pasting a lot of links to the API in the docs, so it's minimal for now. I'm interested in ideas to integrate the API better in these docs without being too much. cc @lhoestq @julien-c @albertvillanova @stevhliu.