### PR TITLE
[doc] Fix broken snippet that had too many quotes

### DIFF
--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -256,7 +256,7 @@ Start by creating a function that adds `'My sentence: '` to the beginning of eac
 
 ```py
 >>> def add_prefix(example):
-...     example["sentence1"] = 'My sentence: '' + example["sentence1"]
+...     example["sentence1"] = 'My sentence: ' + example["sentence1"]
 ...     return example
 ```
 


### PR DESCRIPTION
Hello!

### Pull request overview
* Fix broken snippet in https://huggingface.co/docs/datasets/main/en/process that has too many quotes

### Details
The snippet in question can be found here: https://huggingface.co/docs/datasets/main/en/process#map
This screenshot shows the issue, there is a quote too many, causing the snippet to be colored incorrectly:
![image](https://user-images.githubusercontent.com/37621491/190640627-f7587362-0e44-4464-a5d1-a0b98df6986f.png)

The change speaks for itself.

Thank you for the detailed documentation, by the way. 

- Tom Aarsen
