### PR TITLE
Don't add a tag on the Hub on release

### DIFF
--- a/.github/hub/update_hub_repositories.py
+++ b/.github/hub/update_hub_repositories.py
@@ -194,13 +194,8 @@ if __name__ == "__main__":
     commit_args += (f"-m Commit from {DATASETS_LIB_COMMIT_URL.format(hexsha=current_commit.hexsha)}",)
     commit_args += (f"--author={author_name} <{author_email}>",)
 
-    for _tag in datasets_lib_repo.tags:
-        # Add a new tag if this is a `datasets` release
-        if _tag.commit == current_commit and re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", _tag.name):
-            new_tag = _tag
-            break
-    else:
-        new_tag = None
+    # we don't add a new tag as we used to when there's a release
+    new_tag = None
 
     changed_files_since_last_commit = [
         path


### PR DESCRIPTION
Datasets with no namespace on the Hub have tags to redirect to the version of datasets where they come from.
I’m about to remove them all because I think it looks bad/unexpected in the UI and it’s not actually useful

Therefore I'm also disabling tagging.

Note that the CI job will be completely removed in https://github.com/huggingface/datasets/pull/4974 anyway