### PR TITLE
Add EmptyDatasetError

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -24,6 +24,10 @@ class Url(str):
     pass
 
 
+class EmptyDatasetError(FileNotFoundError):
+    pass
+
+
 SPLIT_PATTERN_SHARDED = "data/{split}-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"
 
 TRAIN_KEYWORDS = ["train", "training"]
@@ -453,7 +457,7 @@ def get_data_patterns_locally(base_path: str) -> Dict[str, List[str]]:
     try:
         return _get_data_files_patterns(resolver)
     except FileNotFoundError:
-        raise FileNotFoundError(f"The directory at {base_path} doesn't contain any data file") from None
+        raise EmptyDatasetError(f"The directory at {base_path} doesn't contain any data file") from None
 
 
 def get_metadata_patterns_locally(base_path: str) -> List[str]:
@@ -669,7 +673,7 @@ def get_data_patterns_in_dataset_repository(
     try:
         return _get_data_files_patterns(resolver)
     except FileNotFoundError:
-        raise FileNotFoundError(
+        raise EmptyDatasetError(
             f"The dataset repository at '{dataset_info.id}' doesn't contain any data file."
         ) from None
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -457,7 +457,7 @@ def get_data_patterns_locally(base_path: str) -> Dict[str, List[str]]:
     try:
         return _get_data_files_patterns(resolver)
     except FileNotFoundError:
-        raise EmptyDatasetError(f"The directory at {base_path} doesn't contain any data file") from None
+        raise EmptyDatasetError(f"The directory at {base_path} doesn't contain any data files") from None
 
 
 def get_metadata_patterns_locally(base_path: str) -> List[str]:
@@ -674,7 +674,7 @@ def get_data_patterns_in_dataset_repository(
         return _get_data_files_patterns(resolver)
     except FileNotFoundError:
         raise EmptyDatasetError(
-            f"The dataset repository at '{dataset_info.id}' doesn't contain any data file."
+            f"The dataset repository at '{dataset_info.id}' doesn't contain any data files"
         ) from None
 
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -38,6 +38,7 @@ from .data_files import (
     DEFAULT_PATTERNS_ALL,
     DataFilesDict,
     DataFilesList,
+    EmptyDatasetError,
     get_data_patterns_in_dataset_repository,
     get_data_patterns_locally,
     get_metadata_patterns_in_dataset_repository,
@@ -1166,6 +1167,8 @@ def dataset_module_factory(
             except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
                 if isinstance(e1, OfflineModeIsEnabled):
                     raise ConnectionError(f"Couln't reach the Hugging Face Hub for dataset '{path}': {e1}") from None
+                if isinstance(e1, EmptyDatasetError):
+                    raise e1 from None
                 if isinstance(e1, FileNotFoundError):
                     raise FileNotFoundError(
                         f"Couldn't find a dataset script at {relative_to_absolute_path(combined_path)} or any data file in the same directory. "


### PR DESCRIPTION
examples:

from the hub:
```python
Traceback (most recent call last):
  File "playground/ttest.py", line 3, in <module>
    print(load_dataset("lhoestq/empty"))
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1686, in load_dataset
    **config_kwargs,
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1458, in load_dataset_builder
    data_files=data_files,
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1171, in dataset_module_factory
    raise e1 from None
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1162, in dataset_module_factory
    download_mode=download_mode,
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 760, in get_module
    else get_data_patterns_in_dataset_repository(hfh_dataset_info, self.data_dir)
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/data_files.py", line 678, in get_data_patterns_in_dataset_repository
    ) from None
datasets.data_files.EmptyDatasetError: The dataset repository at 'lhoestq/empty' doesn't contain any data file.
```

from local directory:
```python
Traceback (most recent call last):
  File "playground/ttest.py", line 3, in <module>
    print(load_dataset("playground/empty"))
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1686, in load_dataset
    **config_kwargs,
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1458, in load_dataset_builder
    data_files=data_files,
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 1107, in dataset_module_factory
    path, data_dir=data_dir, data_files=data_files, download_mode=download_mode
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/load.py", line 625, in get_module
    else get_data_patterns_locally(base_path)
  File "/Users/quentinlhoest/Desktop/hf/nlp/src/datasets/data_files.py", line 460, in get_data_patterns_locally
    raise EmptyDatasetError(f"The directory at {base_path} doesn't contain any data file") from None
datasets.data_files.EmptyDatasetError: The directory at playground/empty doesn't contain any data file
```

Close https://github.com/huggingface/datasets/issues/4995