### PR TITLE
Fix tar extraction vuln

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -11,6 +11,10 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from .. import config
 from .filelock import FileLock
+from .logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 if TYPE_CHECKING:
@@ -83,10 +87,46 @@ class TarExtractor(BaseExtractor):
         return tarfile.is_tarfile(path)
 
     @staticmethod
+    def safemembers(members):
+        """
+        Fix for CVE-2007-4559
+        Desc:
+            Directory traversal vulnerability in the (1) extract and (2) extractall functions in the tarfile
+            module in Python allows user-assisted remote attackers to overwrite arbitrary files via a .. (dot dot)
+            sequence in filenames in a TAR archive, a related issue to CVE-2001-1267.
+        See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-4559
+        From: https://stackoverflow.com/a/10077309
+        """
+
+        def resolved(path: str) -> str:
+            return os.path.realpath(os.path.abspath(path))
+
+        def badpath(path: str, base: str) -> bool:
+            # joinpath will ignore base if path is absolute
+            return not resolved(os.path.join(base, path)).startswith(base)
+
+        def badlink(info, base: str) -> bool:
+            # Links are interpreted relative to the directory containing the link
+            tip = resolved(os.path.join(base, os.path.dirname(info.name)))
+            return badpath(info.linkname, base=tip)
+
+        base = resolved(".")
+
+        for finfo in members:
+            if badpath(finfo.name, base):
+                logger.error(f"Extraction of {finfo.name} is blocked (illegal path)")
+            elif finfo.issym() and badlink(finfo, base):
+                logger.error(f"Extraction of {finfo.name} is blocked: Hard link to {finfo.linkname}")
+            elif finfo.islnk() and badlink(finfo, base):
+                logger.error(f"Extraction of {finfo.name} is blocked: Symlink to {finfo.linkname}")
+            else:
+                yield finfo
+
+    @staticmethod
     def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
         os.makedirs(output_path, exist_ok=True)
         tar_file = tarfile.open(input_path)
-        tar_file.extractall(output_path)
+        tar_file.extractall(output_path, members=TarExtractor.safemembers(tar_file))
         tar_file.close()
 
 


### PR DESCRIPTION
Fix for CVE-2007-4559

Description:
Directory traversal vulnerability in the (1) extract and (2) extractall functions in the tarfile
module in Python allows user-assisted remote attackers to overwrite arbitrary files via a .. (dot dot)
sequence in filenames in a TAR archive, a related issue to CVE-2001-1267.

I fixed it by using the solution proposed in https://stackoverflow.com/questions/10060069/safely-extract-zip-or-tar-using-python

It blocks extraction of files with an absolute path or double dots and symlinks.