### PR TITLE
patch CI_HUB_TOKEN_PATH with Path instead of str

### DIFF
--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -1,4 +1,3 @@
-import os.path
 import time
 from contextlib import contextmanager
 from pathlib import Path

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -1,6 +1,7 @@
 import os.path
 import time
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +17,7 @@ CI_HUB_USER_TOKEN = "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"
 
 CI_HUB_ENDPOINT = "https://hub-ci.huggingface.co"
 CI_HUB_DATASETS_URL = CI_HUB_ENDPOINT + "/datasets/{repo_id}/resolve/{revision}/{path}"
-CI_HUB_TOKEN_PATH = os.path.expanduser("~/.huggingface/hub_ci_token")
+CI_HUB_TOKEN_PATH = Path("~/.huggingface/hub_ci_token").expanduser()
 
 
 @pytest.fixture


### PR DESCRIPTION
Should fix the tests for `huggingface_hub==0.10.0rc0` prerelease (see [failed CI](https://github.com/huggingface/datasets/actions/runs/3127805250/jobs/5074879144)). 
Related to [this thread](https://huggingface.slack.com/archives/C02V5EA0A95/p1664195165294559) (internal link).

Note: this should be a backward compatible fix (e.g. works also with previous versions of `huggingface_hub`)

I am not sure where to put the changes so feel free to cherry-pick the commit and close this one without merging.

cc @lhoestq 