### PR TITLE
Fix import in `ClassLabel` docstring example

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -880,7 +880,7 @@ class ClassLabel:
     Example:
 
     ```py
-    >>> from datasets Features
+    >>> from datasets import Features
     >>> features = Features({'label': ClassLabel(num_classes=3, names=['bad', 'ok', 'good'])})
     >>> features
     {'label': ClassLabel(num_classes=3, names=['bad', 'ok', 'good'], id=None)}


### PR DESCRIPTION
This PR addresses a super-simple fix: adding a missing `import` to the `ClassLabel` docstring example, as it was formatted as `from datasets Features`, so it's been fixed to `from datasets import Features`. 