### PR TITLE
Fix backward compatibility for dataset_infos.json

### DIFF
--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -366,8 +366,9 @@ class DatasetInfosDict(Dict[str, DatasetInfo]):
         # Load the info from the YAML part of README.md
         if os.path.exists(os.path.join(dataset_infos_dir, "README.md")):
             dataset_metadata = DatasetMetadata.from_readme(Path(dataset_infos_dir) / "README.md")
-            return cls.from_metadata(dataset_metadata)
-        elif os.path.exists(os.path.join(dataset_infos_dir, config.DATASETDICT_INFOS_FILENAME)):
+            if "dataset_info" in dataset_metadata:
+                return cls.from_metadata(dataset_metadata)
+        if os.path.exists(os.path.join(dataset_infos_dir, config.DATASETDICT_INFOS_FILENAME)):
             # this is just to have backward compatibility with dataset_infos.json files
             with open(os.path.join(dataset_infos_dir, config.DATASETDICT_INFOS_FILENAME), encoding="utf-8") as f:
                 return cls(

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -22,7 +22,7 @@ class _NoDuplicateSafeLoader(yaml.SafeLoader):
 
 def _split_yaml_from_readme(readme_content: str) -> Tuple[Optional[str], str]:
     full_content = [line for line in readme_content.splitlines()]
-    if full_content[0] == "---" and "---" in full_content[1:]:
+    if full_content and full_content[0] == "---" and "---" in full_content[1:]:
         sep_idx = full_content[1:].index("---") + 1
         yamlblock = "\n".join(full_content[1:sep_idx])
         return yamlblock, "\n".join(full_content[sep_idx + 1 :])

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -8,6 +8,32 @@ from datasets.info import DatasetInfo, DatasetInfosDict
 
 
 @pytest.mark.parametrize(
+    "files",
+    [
+        ["full:README.md", "dataset_infos.json"],
+        ["empty:README.md", "dataset_infos.json"],
+        ["dataset_infos.json"],
+        ["full:README.md"],
+    ],
+)
+def test_from_dir(files, tmp_path_factory):
+    dataset_infos_dir = tmp_path_factory.mktemp("dset_infos_dir")
+    if "full:README.md" in files:
+        with open(dataset_infos_dir / "README.md", "w") as f:
+            f.write("---\ndataset_info:\n  dataset_size: 42\n---")
+    if "empty:README.md" in files:
+        with open(dataset_infos_dir / "README.md", "w") as f:
+            f.write("")
+    # we want to support dataset_infos.json for backward compatibility
+    if "dataset_infos.json" in files:
+        with open(dataset_infos_dir / "dataset_infos.json", "w") as f:
+            f.write('{"default": {"dataset_size": 42}}')
+    dataset_infos = DatasetInfosDict.from_directory(dataset_infos_dir)
+    assert dataset_infos
+    assert dataset_infos["default"].dataset_size == 42
+
+
+@pytest.mark.parametrize(
     "dataset_info",
     [
         DatasetInfo(),


### PR DESCRIPTION
While working on https://github.com/huggingface/datasets/pull/5018 I noticed a small bug introduced in #4926 regarding backward compatibility for dataset_infos.json

Indeed, when a dataset repo had both dataset_infos.json and README.md, the JSON file was ignored. This is unexpected: in practice it should be ignored only if the README.md has a dataset_info field, which has precedence over the data in the JSON file.