### PR TITLE
Mark CI tests as xfail when 502 error

### DIFF
--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -12,13 +12,13 @@ from huggingface_hub import HfApi
 
 from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
 from tests.fixtures.hub import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
-from tests.utils import for_all_test_methods, require_pil, require_sndfile, xfail_if_500_http_error
+from tests.utils import for_all_test_methods, require_pil, require_sndfile, xfail_if_500_502_http_error
 
 
 pytestmark = pytest.mark.integration
 
 
-@for_all_test_methods(xfail_if_500_http_error)
+@for_all_test_methods(xfail_if_500_502_http_error)
 @pytest.mark.usefixtures("set_ci_hub_access_token")
 class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -369,7 +369,7 @@ def is_rng_equal(rng1, rng2):
     return deepcopy(rng1).integers(0, 100, 10).tolist() == deepcopy(rng2).integers(0, 100, 10).tolist()
 
 
-def xfail_if_500_http_error(func):
+def xfail_if_500_502_http_error(func):
     import decorator
     from requests.exceptions import HTTPError
 
@@ -377,7 +377,7 @@ def xfail_if_500_http_error(func):
         try:
             return func(*args, **kwargs)
         except HTTPError as err:
-            if str(err).startswith("500"):
+            if str(err).startswith("500") or str(err).startswith("502"):
                 pytest.xfail(str(err))
             raise err
 


### PR DESCRIPTION
To make CI more robust, we could mark as xfail when the Hub raises a 502 error (besides 500 error):

- FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_to_hub_skip_identical_files
  - https://github.com/huggingface/datasets/actions/runs/3174626525/jobs/5171672431
  ```
  >           raise HTTPError(http_error_msg, response=self)
  E           requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: https://hub-ci.huggingface.co/datasets/__DUMMY_TRANSFORMERS_USER__/test-16648055339047.git/info/lfs/objects/batch
  ```

- FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_dict_to_hub_overwrite_files
  - https://github.com/huggingface/datasets/actions/runs/3145587033/jobs/5113074889
  ```
  >           raise HTTPError(http_error_msg, response=self)
  E           requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: https://hub-ci.huggingface.co/datasets/__DUMMY_TRANSFORMERS_USER__/test-16643866807322.git/info/lfs/objects/verify
  ```

Currently, we mark as xfail when 500 error:
- #4845