### PR TITLE
Support streaming gzip.open

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -692,6 +692,16 @@ class xPath(type(Path())):
         return self.joinpath(p)
 
 
+def xgzip_open(filepath_or_buffer, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):
+    import gzip
+
+    if hasattr(filepath_or_buffer, "read"):
+        return gzip.open(filepath_or_buffer, **kwargs)
+    else:
+        filepath_or_buffer = str(filepath_or_buffer)
+        return gzip.open(xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token), **kwargs)
+
+
 def xpandas_read_csv(filepath_or_buffer, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):
     import pandas as pd
 

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -9,6 +9,7 @@ from .download.streaming_download_manager import (
     xet_parse,
     xgetsize,
     xglob,
+    xgzip_open,
     xisdir,
     xisfile,
     xjoin,
@@ -88,6 +89,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     patch_submodule(module, "os.path.getsize", wrap_auth(xgetsize)).start()
     patch_submodule(module, "pathlib.Path", xPath).start()
     # file readers
+    patch_submodule(module, "gzip.open", wrap_auth(xgzip_open)).start()
     patch_submodule(module, "pandas.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
     patch_submodule(module, "pandas.read_excel", xpandas_read_excel, attrs=["__version__"]).start()
     patch_submodule(module, "scipy.io.loadmat", wrap_auth(xsio_loadmat), attrs=["__version__"]).start()


### PR DESCRIPTION
This PR implements support for streaming out-of-the-box dataset scripts containing `gzip.open`. 

This has been a recurring issue. See, e.g.:
- #5060
- #3191