### PR TITLE
Fix CONTRIBUTING once dataset scripts transferred to Hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@
 
 Datasets is an open source project, so all contributions and suggestions are welcome.
 
-You can contribute in many different ways: giving ideas, answering questions, reporting bugs, proposing enhancements, 
+You can contribute in many different ways: giving ideas, answering questions, reporting bugs, proposing enhancements,
 improving the documentation, fixing bugs,...
 
 Many thanks in advance to every contributor.
 
-In order to facilitate healthy, constructive behavior in an open and inclusive community, we all respect and abide by 
+In order to facilitate healthy, constructive behavior in an open and inclusive community, we all respect and abide by
 our [code of conduct](CODE_OF_CONDUCT.md).
 
 ## How to work on an open Issue?
@@ -83,7 +83,7 @@ If you want to add a dataset see specific instructions in the section [*How to a
    ```bash
    git push -u origin a-descriptive-name-for-my-changes
    ```
-   
+
    Go the webpage of your fork on GitHub. Click on "Pull request" to send your to the project maintainers for review.
 
 ## How to add a dataset

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,13 @@ If you would like to work on any of the open Issues:
 
 1. Make sure it is not already assigned to someone else. You have the assignee (if any) on the top of the right column of the Issue page.
 
-2. You can self-assign it by commenting on the Issue page with one of the keywords: `#take` or `#self-assign`.
+2. You can self-assign it by commenting on the Issue page with the keyword: `#self-assign`.
 
 3. Work on your self-assigned issue and eventually create a Pull Request.
 
 ## How to create a Pull Request?
+If you want to add a dataset see specific instructions in the section [*How to add a dataset*](#how-to-add-a-dataset).
+
 1. Fork the [repository](https://github.com/huggingface/datasets) by clicking on the 'Fork' button on the repository's page. This creates a copy of the code under your GitHub user account.
 
 2. Clone your fork to your local disk, and add the base repository as a remote:
@@ -53,7 +55,7 @@ If you would like to work on any of the open Issues:
    it with `pip uninstall datasets` before reinstalling it in editable
    mode with the `-e` flag.)
 
-5. Develop the features on your branch. If you want to add a dataset see more in-detail instructions in the section [*How to add a dataset*](#how-to-add-a-dataset). 
+5. Develop the features on your branch.
 
 6. Format your code. Run black and isort so that your newly added files look nice with the following command:
 
@@ -61,10 +63,10 @@ If you would like to work on any of the open Issues:
 	make style
 	```
 
-7. Once you're happy with your dataset script file, add your changes and make a commit to record your changes locally:
+7. Once you're happy with your contribution, add your changed files and make a commit to record your changes locally:
 
 	```bash
-	git add datasets/<your_dataset_name>
+	git add -u
 	git commit
 	```
 
@@ -76,13 +78,13 @@ If you would like to work on any of the open Issues:
 	git rebase upstream/main
     ```
 
-   Push the changes to your account using:
+8. Once you are satisfied, push the changes to your fork repo using:
 
    ```bash
    git push -u origin a-descriptive-name-for-my-changes
    ```
-
-8. Once you are satisfied, go the webpage of your fork on GitHub. Click on "Pull request" to send your to the project maintainers for review.
+   
+   Go the webpage of your fork on GitHub. Click on "Pull request" to send your to the project maintainers for review.
 
 ## How to add a dataset
 
@@ -93,15 +95,13 @@ You can share your dataset on https://huggingface.co/datasets directly using you
 
 ## How to contribute to the dataset cards
 
-Improving the documentation of datasets is an ever increasing effort and we invite users to contribute by sharing their insights with the community in the `README.md` dataset cards provided for each dataset.
+Improving the documentation of datasets is an ever-increasing effort, and we invite users to contribute by sharing their insights with the community in the `README.md` dataset cards provided for each dataset.
 
-If you see that a dataset card is missing information that you are in a position to provide (as an author of the dataset or as an experienced user), the best thing you can do is to open a Pull Request on the Hugging Face Hub. To to do, go to the "Files and versions" tab of the dataset page and edit the `README.md` file. We provide:
+If you see that a dataset card is missing information that you are in a position to provide (as an author of the dataset or as an experienced user), the best thing you can do is to open a Pull Request on the Hugging Face Hub. To do, go to the "Files and versions" tab of the dataset page and edit the `README.md` file. We provide:
 
 * a [template](https://github.com/huggingface/datasets/blob/main/templates/README.md)
 * a [guide](https://github.com/huggingface/datasets/blob/main/templates/README_guide.md) describing what information should go into each of the paragraphs
 * and if you need inspiration, we recommend looking through a [completed example](https://github.com/huggingface/datasets/blob/main/datasets/eli5/README.md)
-
-Note that datasets that are outside of a namespace (`squad`, `imagenet-1k`, etc.) are maintained on GitHub. In this case you have to open a Pull request on GitHub to edit the file at `datasets/<dataset-name>/README.md`.
 
 If you are a **dataset author**... you know what to do, it is your dataset after all ;) ! We would especially appreciate if you could help us fill in information about the process of creating the dataset, and take a moment to reflect on its social impact and possible limitations if you haven't already done so in the dataset paper or in another data statement.
 
@@ -114,4 +114,4 @@ Thank you for your contribution!
 ## Code of conduct
 
 This project adheres to the HuggingFace [code of conduct](CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code.
+By participating, you are expected to abide by this code.


### PR DESCRIPTION
This PR updates the `CONTRIBUTING.md` guide, once the all dataset scripts have been removed from the GitHub repo and transferred to the HF Hub:
- #4974

See diff here: https://github.com/huggingface/datasets/commit/e3291ecff9e54f09fcee3f313f051a03fdc3d94b

Additionally, this PR fixes the line separator that by some previous mistake was CRLF instead of LF.