### PR TITLE
Restore saved format state in `load_from_disk`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1346,12 +1346,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         split = state["_split"]
         split = Split(split) if split is not None else split
 
-        return Dataset(
+        dataset = Dataset(
             arrow_table=arrow_table,
             info=dataset_info,
             split=split,
             fingerprint=state["_fingerprint"],
         )
+        dataset.set_format(
+            state["_format_type"], state["_format_columns"], state["_output_all_columns"], **state["_format_kwargs"]
+        )
+
+        return dataset
 
     @property
     def data(self) -> Table:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1352,9 +1352,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             split=split,
             fingerprint=state["_fingerprint"],
         )
-        dataset.set_format(
-            state["_format_type"], state["_format_columns"], state["_output_all_columns"], **state["_format_kwargs"]
-        )
+
+        format = {
+            "type": state["_format_type"],
+            "format_kwargs": state["_format_kwargs"],
+            "columns": state["_format_columns"],
+            "output_all_columns": state["_output_all_columns"],
+        }
+        dataset = dataset.with_format(**format)
 
         return dataset
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -318,6 +318,17 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(dset[0]["filename"], "my_name-train_0")
                 self.assertEqual(dset["filename"][0], "my_name-train_0")
 
+    def test_restore_saved_format(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
+                dset.set_format(type="numpy", columns=["col_1"], output_all_columns=True)
+                dataset_path = os.path.join(tmp_dir, "my_dataset")
+                dset.save_to_disk(dataset_path)
+
+                with load_from_disk(dataset_path) as loaded_dset:
+                    self.assertEqual(dset.format, loaded_dset.format)
+
     def test_set_format_numpy_multiple_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:


### PR DESCRIPTION
Hello! @mariosasko 

This pull request relates to issue #5050 and intends to add the format to datasets loaded from disk. 
All I did was add a set_format in the Dataset.load_from_disk, as DatasetDict.load_from_disk relies on the first.

I don't know if I should add a test and where, so let me know if I should and I can work on that as well!
