### PR TITLE
fix: update exception throw from OSError to EnvironmentError in `push…

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4303,7 +4303,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         token = token if token is not None else HfFolder.get_token()
 
         if token is None:
-            raise OSError(
+            raise EnvironmentError(
                 "You need to provide a `token` or be logged in to Hugging Face with `huggingface-cli login`."
             )
 


### PR DESCRIPTION
Status:
Ready for review

Description of Changes:
Fixes #5075

Changes proposed in this pull request:
- Throw EnvironmentError instead of OSError in `push_to_hub` when the Hub token is not present.