### PR TITLE
Fix header level in Audio docs

### DIFF
--- a/docs/source/about_dataset_features.mdx
+++ b/docs/source/about_dataset_features.mdx
@@ -65,7 +65,7 @@ The array type also allows the first dimension of the array to be dynamic. This 
 >>> features = Features({'a': Array3D(shape=(None, 5, 2), dtype='int32')})
 ```
 
-# The Audio type
+## Audio feature
 
 Audio datasets have a column with type [`Audio`], which contains three important fields:
 


### PR DESCRIPTION
Fixes header level so `Dataset features` is the doc title instead of `The Audio type`:

![Screen Shot 2022-10-05 at 1 22 02 PM](https://user-images.githubusercontent.com/59462357/194155840-eeb5d62f-f4eb-411e-b281-8494c5fffdce.png)