### PR TITLE
refactor: replace AssertionError with more meaningful exceptions (#5074)

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -211,7 +211,7 @@ class BaseReader:
         files = self.get_file_instructions(name, instructions, split_infos)
         if not files:
             msg = f'Instruction "{instructions}" corresponds to no data!'
-            raise FileNotFoundError(msg)
+            raise ValueError(msg)
         return self.read_files(files=files, original_instructions=instructions, in_memory=in_memory)
 
     def read_files(

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -991,7 +991,7 @@ class DatasetBuilder:
         if not is_local:
             raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
         if not os.path.exists(self._output_dir):
-            raise AssertionError(
+            raise FileNotFoundError(
                 f"Dataset {self.name}: could not find data in {self._output_dir}. Please make sure to call "
                 "builder.download_and_prepare(), or use "
                 "datasets.load_dataset() before trying to access the Dataset object."

--- a/src/datasets/utils/version.py
+++ b/src/datasets/utils/version.py
@@ -69,12 +69,12 @@ class Version:
             return Version(other)
         elif isinstance(other, Version):
             return other
-        raise AssertionError(f"{other} (type {type(other)}) cannot be compared to version.")
+        raise TypeError(f"{other} (type {type(other)}) cannot be compared to version.")
 
     def __eq__(self, other):
         try:
             other = self._validate_operand(other)
-        except (AssertionError, ValueError):
+        except (TypeError, ValueError):
             return False
         else:
             return self.tuple == other.tuple

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -560,7 +560,7 @@ class BuilderTest(TestCase):
                 try_from_hf_gcs=False,
                 download_mode=DownloadMode.FORCE_REDOWNLOAD,
             )
-            self.assertRaises(AssertionError, builder.as_dataset)
+            self.assertRaises(FileNotFoundError, builder.as_dataset)
 
     def test_generator_based_download_and_prepare(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Closes #5074

Replaces `AssertionError` in the following files with more descriptive exceptions:

- `src/datasets/arrow_reader.py`
- `src/datasets/builder.py`
- `src/datasets/utils/version.py`

The issue listed more files that needed to be fixed, but the rest of them were contained in the top-level `datasets` directory, which was removed when #4974 was merged