### PR TITLE
Fix task template reload from dict

### DIFF
--- a/src/datasets/tasks/audio_classificiation.py
+++ b/src/datasets/tasks/audio_classificiation.py
@@ -1,5 +1,5 @@
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import Audio, ClassLabel, Features
@@ -8,7 +8,7 @@ from .base import TaskTemplate
 
 @dataclass(frozen=True)
 class AudioClassification(TaskTemplate):
-    task: str = "audio-classification"
+    task: str = field(default="audio-classification", metadata={"include_in_asdict_even_if_is_default": True})
     input_schema: ClassVar[Features] = Features({"audio": Audio()})
     label_schema: ClassVar[Features] = Features({"labels": ClassLabel})
     audio_column: str = "audio"

--- a/src/datasets/tasks/automatic_speech_recognition.py
+++ b/src/datasets/tasks/automatic_speech_recognition.py
@@ -1,5 +1,5 @@
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import Audio, Features, Value
@@ -8,7 +8,7 @@ from .base import TaskTemplate
 
 @dataclass(frozen=True)
 class AutomaticSpeechRecognition(TaskTemplate):
-    task: str = "automatic-speech-recognition"
+    task: str = field(default="automatic-speech-recognition", metadata={"include_in_asdict_even_if_is_default": True})
     input_schema: ClassVar[Features] = Features({"audio": Audio()})
     label_schema: ClassVar[Features] = Features({"transcription": Value("string")})
     audio_column: str = "audio"

--- a/src/datasets/tasks/image_classification.py
+++ b/src/datasets/tasks/image_classification.py
@@ -1,5 +1,5 @@
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import ClassLabel, Features, Image
@@ -8,7 +8,7 @@ from .base import TaskTemplate
 
 @dataclass(frozen=True)
 class ImageClassification(TaskTemplate):
-    task: str = "image-classification"
+    task: str = field(default="image-classification", metadata={"include_in_asdict_even_if_is_default": True})
     input_schema: ClassVar[Features] = Features({"image": Image()})
     label_schema: ClassVar[Features] = Features({"labels": ClassLabel})
     image_column: str = "image"

--- a/src/datasets/tasks/language_modeling.py
+++ b/src/datasets/tasks/language_modeling.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import Features, Value
@@ -7,7 +7,7 @@ from .base import TaskTemplate
 
 @dataclass(frozen=True)
 class LanguageModeling(TaskTemplate):
-    task: str = "language-modeling"
+    task: str = field(default="language-modeling", metadata={"include_in_asdict_even_if_is_default": True})
 
     input_schema: ClassVar[Features] = Features({"text": Value("string")})
     label_schema: ClassVar[Features] = Features({})

--- a/src/datasets/tasks/question_answering.py
+++ b/src/datasets/tasks/question_answering.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import Features, Sequence, Value
@@ -8,7 +8,7 @@ from .base import TaskTemplate
 @dataclass(frozen=True)
 class QuestionAnsweringExtractive(TaskTemplate):
     # `task` is not a ClassVar since we want it to be part of the `asdict` output for JSON serialization
-    task: str = "question-answering-extractive"
+    task: str = field(default="question-answering-extractive", metadata={"include_in_asdict_even_if_is_default": True})
     input_schema: ClassVar[Features] = Features({"question": Value("string"), "context": Value("string")})
     label_schema: ClassVar[Features] = Features(
         {

--- a/src/datasets/tasks/summarization.py
+++ b/src/datasets/tasks/summarization.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import Features, Value
@@ -8,7 +8,7 @@ from .base import TaskTemplate
 @dataclass(frozen=True)
 class Summarization(TaskTemplate):
     # `task` is not a ClassVar since we want it to be part of the `asdict` output for JSON serialization
-    task: str = "summarization"
+    task: str = field(default="summarization", metadata={"include_in_asdict_even_if_is_default": True})
     input_schema: ClassVar[Features] = Features({"text": Value("string")})
     label_schema: ClassVar[Features] = Features({"summary": Value("string")})
     text_column: str = "text"

--- a/src/datasets/tasks/text_classification.py
+++ b/src/datasets/tasks/text_classification.py
@@ -1,5 +1,5 @@
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Dict
 
 from ..features import ClassLabel, Features, Value
@@ -9,7 +9,7 @@ from .base import TaskTemplate
 @dataclass(frozen=True)
 class TextClassification(TaskTemplate):
     # `task` is not a ClassVar since we want it to be part of the `asdict` output for JSON serialization
-    task: str = "text-classification"
+    task: str = field(default="text-classification", metadata={"include_in_asdict_even_if_is_default": True})
     input_schema: ClassVar[Features] = Features({"text": Value("string")})
     label_schema: ClassVar[Features] = Features({"labels": ClassLabel})
     text_column: str = "text"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 from unittest.case import TestCase
 
+import pytest
+
 from datasets.arrow_dataset import Dataset
 from datasets.features import Audio, ClassLabel, Features, Image, Sequence, Value
 from datasets.info import DatasetInfo
@@ -12,7 +14,9 @@ from datasets.tasks import (
     QuestionAnsweringExtractive,
     Summarization,
     TextClassification,
+    task_template_from_dict,
 )
+from datasets.utils.py_utils import asdict
 
 
 SAMPLE_QUESTION_ANSWERING_EXTRACTIVE = {
@@ -22,6 +26,25 @@ SAMPLE_QUESTION_ANSWERING_EXTRACTIVE = {
     "question": "To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?",
     "answers": {"text": ["Saint Bernadette Soubirous"], "answer_start": [515]},
 }
+
+
+@pytest.mark.parametrize(
+    "task_cls",
+    [
+        AudioClassification,
+        AutomaticSpeechRecognition,
+        ImageClassification,
+        LanguageModeling,
+        QuestionAnsweringExtractive,
+        Summarization,
+        TextClassification,
+    ],
+)
+def test_reload_task_from_dict(task_cls):
+    task = task_cls()
+    task_dict = asdict(task)
+    reloaded = task_template_from_dict(task_dict)
+    assert task == reloaded
 
 
 class TestLanguageModeling:


### PR DESCRIPTION
Since #4926 the JSON dumps are simplified and it made task template dicts empty by default.

I fixed this by always including the task name which is needed to reload a task from a dict