### PR TITLE
Add warning

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -755,6 +755,8 @@ class DatasetBuilder:
             @contextlib.contextmanager
             def incomplete_dir(dirname):
                 """Create temporary dir for dirname and rename on exit."""
+                if os.path.exists(dirname):
+                    logger.warning(f"Unknown data in dataset directory, removing all data in {dirname}.")
                 if not is_local:
                     self._fs.makedirs(dirname, exist_ok=True)
                     yield dirname


### PR DESCRIPTION
Fixes: #5105 

I think removing the directory with warning is a better solution for this issue. Because if we decide to keep existing files in directory, then we should deal with the case providing same directory for several datasets! Which we know is not possible since `dataset_info.json` exists in that directory.