### PR TITLE
fsspec lock reset in multiprocessing

### DIFF
--- a/src/datasets/formatting/dataset_wrappers/torch_iterable_dataset.py
+++ b/src/datasets/formatting/dataset_wrappers/torch_iterable_dataset.py
@@ -1,5 +1,6 @@
-import fsspec.asyn
 import threading
+
+import fsspec.asyn
 import torch
 
 from ...iterable_dataset import IterableDataset, _apply_feature_types

--- a/src/datasets/formatting/dataset_wrappers/torch_iterable_dataset.py
+++ b/src/datasets/formatting/dataset_wrappers/torch_iterable_dataset.py
@@ -1,4 +1,5 @@
 import fsspec.asyn
+import threading
 import torch
 
 from ...iterable_dataset import IterableDataset, _apply_feature_types
@@ -15,8 +16,13 @@ def _set_fsspec_for_multiprocess() -> None:
     Only required for fsspec >= 0.9.0
     See https://github.com/fsspec/gcsfs/issues/379
     """
-    fsspec.asyn.iothread[0] = None
-    fsspec.asyn.loop[0] = None
+    if hasattr(fsspec.asyn, "reset_lock"):
+        # for future fsspec>2022.05.0
+        fsspec.asyn.reset_lock()
+    else:
+        fsspec.asyn.iothread[0] = None
+        fsspec.asyn.loop[0] = None
+        fsspec.asyn.lock = threading.Lock()
 
 
 class TorchIterableDataset(IterableDataset, torch.utils.data.IterableDataset):


### PR DESCRIPTION
`fsspec` added a clean way of resetting its lock - instead of doing it manually