### PR TITLE
WIP: drop labels in Image and Audio folders by default

### DIFF
--- a/src/datasets/packaged_modules/audiofolder/audiofolder.py
+++ b/src/datasets/packaged_modules/audiofolder/audiofolder.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List
 
 import datasets
@@ -9,10 +10,11 @@ from ..folder_based_builder import folder_based_builder
 logger = datasets.utils.logging.get_logger(__name__)
 
 
+@dataclass
 class AudioFolderConfig(folder_based_builder.FolderBasedBuilderConfig):
     """Builder Config for AudioFolder."""
 
-    drop_labels: bool = None
+    drop_labels: bool = True
     drop_metadata: bool = None
 
 

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -84,8 +84,8 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
 
         # Do an early pass if:
-        # * `drop_labels` is None (default) or False, to infer the class labels
-        # * `drop_metadata` is None (default) or False, to find the metadata files
+        # * `drop_labels` is None or False, to infer the class labels
+        # * `drop_metadata` is None or False, to find the metadata files
         do_analyze = not self.config.drop_labels or not self.config.drop_metadata
         labels = set()
         metadata_files = collections.defaultdict(set)

--- a/src/datasets/packaged_modules/imagefolder/imagefolder.py
+++ b/src/datasets/packaged_modules/imagefolder/imagefolder.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List
 
 import datasets
@@ -9,10 +10,11 @@ from ..folder_based_builder import folder_based_builder
 logger = datasets.utils.logging.get_logger(__name__)
 
 
+@dataclass
 class ImageFolderConfig(folder_based_builder.FolderBasedBuilderConfig):
     """BuilderConfig for ImageFolder."""
 
-    drop_labels: bool = None
+    drop_labels: bool = True
     drop_metadata: bool = None
 
 


### PR DESCRIPTION
will fix https://github.com/huggingface/datasets/issues/5153 and redundant labels displaying for most of the images datasets on the Hub (which are used just to store files)

TODO: discuss adding `drop_labels` (and `drop_metadata`) params to yaml