### PR TITLE
Support dill 0.3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'latest' }}
         run: |
-          pip uninstall apache-beam
+          pip uninstall -y apache-beam
           pip install --upgrade pyarrow huggingface-hub dill
       - name: Install dependencies (minimum versions)
         if: ${{ matrix.deps_versions != 'latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
           pip install -r additional-tests-requirements.txt --no-deps
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub
+        run: pip install --upgrade pyarrow huggingface-hub dill
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'latest' }}
-        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers
+        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,10 @@ jobs:
           pip install -r additional-tests-requirements.txt --no-deps
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill
-      - name: Install depencencies (minimum versions)
+        run: |
+          pip uninstall apache-beam
+          pip install --upgrade pyarrow huggingface-hub dill
+      - name: Install dependencies (minimum versions)
         if: ${{ matrix.deps_versions != 'latest' }}
         run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1
       - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ REQUIRED_PKGS = [
     # Minimum 6.0.0 to support wrap_array which is needed for ArrayND features
     "pyarrow>=6.0.0",
     # For smart caching dataset processing
-    "dill",
+    "dill<0.3.7",  # tmp pin until next 0.3.7 release: see https://github.com/huggingface/datasets/pull/5166
     # For performance gains with apache arrow
     "pandas",
     # for downloading datasets over HTTPS

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ REQUIRED_PKGS = [
     # Minimum 6.0.0 to support wrap_array which is needed for ArrayND features
     "pyarrow>=6.0.0",
     # For smart caching dataset processing
-    "dill<0.3.6",  # tmp pin until 0.3.6 release: see https://github.com/huggingface/datasets/pull/4397
+    "dill",
     # For performance gains with apache arrow
     "pandas",
     # for downloading datasets over HTTPS

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -1250,13 +1250,13 @@ try:
 
         @pklregister(type(regex.Regex("", 0)))
         def _save_regex(pickler, obj):
-            dill._dill.logger.trace(f"Re: {obj}")
+            dill._dill.logger.trace(pickler, "Re: %s", obj)
             args = (
                 obj.pattern,
                 obj.flags,
             )
             pickler.save_reduce(regex.compile, args, obj=obj)
-            dill._dill.logger.trace("# Re")
+            dill._dill.logger.trace(pickler, "# Re")
             return
 
 except ImportError:

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -1233,16 +1233,31 @@ def copyfunc(func):
 try:
     import regex
 
-    @pklregister(type(regex.Regex("", 0)))
-    def _save_regex(pickler, obj):
-        dill._dill.log.info(f"Re: {obj}")
-        args = (
-            obj.pattern,
-            obj.flags,
-        )
-        pickler.save_reduce(regex.compile, args, obj=obj)
-        dill._dill.log.info("# Re")
-        return
+    if config.DILL_VERSION < version.parse("0.3.6"):
+
+        @pklregister(type(regex.Regex("", 0)))
+        def _save_regex(pickler, obj):
+            dill._dill.log.info(f"Re: {obj}")
+            args = (
+                obj.pattern,
+                obj.flags,
+            )
+            pickler.save_reduce(regex.compile, args, obj=obj)
+            dill._dill.log.info("# Re")
+            return
+
+    elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
+
+        @pklregister(type(regex.Regex("", 0)))
+        def _save_regex(pickler, obj):
+            dill._dill.logger.trace(f"Re: {obj}")
+            args = (
+                obj.pattern,
+                obj.flags,
+            )
+            pickler.save_reduce(regex.compile, args, obj=obj)
+            dill._dill.logger.trace("# Re")
+            return
 
 except ImportError:
     pass

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -1091,29 +1091,29 @@ elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
             if type(obj.__code__) is not CodeType:
                 # Some PyPy builtin functions have no module name, and thus are not
                 # able to be located
-                module_name = getattr(obj, '__module__', None)
+                module_name = getattr(obj, "__module__", None)
                 if module_name is None:
                     module_name = dill._dill.__builtin__.__name__
                 module = dill._dill._import_module(module_name, safe=True)
                 _pypy_builtin = False
                 try:
                     found, _ = dill._dill._getattribute(module, obj.__qualname__)
-                    if getattr(found, '__func__', None) is obj:
+                    if getattr(found, "__func__", None) is obj:
                         _pypy_builtin = True
                 except AttributeError:
                     pass
 
                 if _pypy_builtin:
                     dill._dill.logger.trace(pickler, "F3: %s", obj)
-                    pickler.save_reduce(getattr, (found, '__func__'), obj=obj)
+                    pickler.save_reduce(getattr, (found, "__func__"), obj=obj)
                     dill._dill.logger.trace(pickler, "# F3")
                     return
 
             dill._dill.logger.trace(pickler, "F1: %s", obj)
-            _recurse = getattr(pickler, '_recurse', None)
-            _postproc = getattr(pickler, '_postproc', None)
-            _main_modified = getattr(pickler, '_main_modified', None)
-            _original_main = getattr(pickler, '_original_main', dill._dill.__builtin__)  # 'None'
+            _recurse = getattr(pickler, "_recurse", None)
+            _postproc = getattr(pickler, "_postproc", None)
+            _main_modified = getattr(pickler, "_main_modified", None)
+            _original_main = getattr(pickler, "_original_main", dill._dill.__builtin__)  # 'None'
             postproc_list = []
             if _recurse:
                 # recurse to get all globals referred to by obj

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -796,7 +796,7 @@ if config.DILL_VERSION < version.parse("0.3.5"):
             dill._dill.log.info("# F2")
         return
 
-else:  # config.DILL_VERSION >= version.parse("0.3.5")
+elif config.DILL_VERSION.release[:3] == version.parse("0.3.5").release:  # 0.3.5, 0.3.5.1
 
     # https://github.com/uqfoundation/dill/blob/dill-0.3.5.1/dill/_dill.py
     @pklregister(FunctionType)
@@ -804,7 +804,6 @@ else:  # config.DILL_VERSION >= version.parse("0.3.5")
         if not dill._dill._locate_function(obj, pickler):
             dill._dill.log.info("F1: %s" % obj)
             _recurse = getattr(pickler, "_recurse", None)
-            # _byref = getattr(pickler, "_byref", None)  # TODO: not used
             _postproc = getattr(pickler, "_postproc", None)
             _main_modified = getattr(pickler, "_main_modified", None)
             _original_main = getattr(pickler, "_original_main", dill._dill.__builtin__)  # 'None'

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -64,7 +64,7 @@ from .utils import (
 
 class PickableMagicMock(MagicMock):
     def __reduce__(self):
-        return (MagicMock, ())
+        return MagicMock, ()
 
 
 class Unpicklable:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -105,14 +105,6 @@ IN_MEMORY_PARAMETERS = [
 
 @parameterized.named_parameters(IN_MEMORY_PARAMETERS)
 class BaseDatasetTest(TestCase):
-    def setUp(self):
-        # google colab doesn't allow to pickle loggers
-        # so we want to make sure each tests passes without pickling the logger
-        def reduce_ex(self):
-            raise pickle.PicklingError()
-
-        datasets.arrow_dataset.logger.__reduce_ex__ = reduce_ex
-
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self._caplog = caplog


### PR DESCRIPTION
This PR:
- ~~Unpins dill to allow installing dill>=0.3.6~~
- ~~Removes the fix on dill for >=0.3.6 because they implemented a deterministic mode (to be confirmed by @anivegesana)~~
- Pins dill<0.3.7 to allow latest dill 0.3.6
- Implements a fix for dill `save_function` for dill 0.3.6
- Additionally had to implement a fix for dill `save_code` and `_save_regex` for dill 0.3.6
- Fixes the CI so that the latest dill version is tested (besides the minimum 0.3.1.1 required by apache-beam 2.42.0)

Fix #5162.