### PR TITLE
Add ffmpeg4 installation instructions in warnings

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -295,14 +295,24 @@ class Audio:
             try:  # try torchaudio anyway because sometimes it works (depending on the os and os packages installed)
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
+                warnings.warn(
+                    "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
+                    "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
+                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
+                    " "
+                    'Or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
+                    "Otherwise it will be decoded with `librosa`"
+                )
                 try:
                     # flake8: noqa
                     import librosa
                 except ImportError as err:
                     raise ImportError(
                         "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
-                        "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg>=4` system package "
-                        'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
+                        "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
+                        "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
+                        " "
+                        'Or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
                         "To support decoding 'mp3' audio files without `torchaudio`, please install `librosa`: "
                         "`pip install librosa`. Note that decoding will be extremely slow in that case."
                     ) from err

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -296,10 +296,10 @@ class Audio:
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
                 warnings.warn(
-                    "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
-                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
-                    "and restart your runtime. Alternatively, you can downgrade `torchaudio`: "
-                    "`pip install \"torchaudio<0.12\"`. Otherwise 'mp3' files will be decoded with `librosa`."
+                    "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
+                    "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
+                    "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
+                    "\tpip install \"torchaudio<0.12\"`.\n\nOtherwise 'mp3' files will be decoded with `librosa`."
                 )
                 try:
                     # flake8: noqa

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -298,9 +298,9 @@ class Audio:
                 warnings.warn(
                     "\nYour version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
                     "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
-                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`, "
-                    'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
-                    "Otherwise 'mp3' files will be decoded with `librosa`."
+                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
+                    "and restart your runtime. Alternatively, you can downgrade `torchaudio`: "
+                    "`pip install \"torchaudio<0.12\"`. Otherwise 'mp3' files will be decoded with `librosa`."
                 )
                 try:
                     # flake8: noqa
@@ -310,8 +310,9 @@ class Audio:
                         "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
                         "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
                         "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`, "
-                        'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
-                        "To support decoding 'mp3' audio files without `torchaudio`, please install `librosa`: "
+                        "and restart your runtime. Alternatively, you can downgrade `torchaudio`: "
+                        '`pip install "torchaudio<0.12"`. '
+                        "To support decoding of 'mp3' audio files without `torchaudio`, please install `librosa`: "
                         "`pip install librosa`. Note that decoding will be extremely slow in that case."
                     ) from err
                 # try to decode with librosa for torchaudio>=0.12.0 as a workaround

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -306,12 +306,11 @@ class Audio:
                     import librosa
                 except ImportError as err:
                     raise ImportError(
-                        "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
-                        "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`, "
-                        "and restart your runtime. Alternatively, you can downgrade `torchaudio`: "
-                        '`pip install "torchaudio<0.12"`. '
-                        "To support decoding of 'mp3' audio files without `torchaudio`, please install `librosa`: "
-                        "`pip install librosa`. Note that decoding will be extremely slow in that case."
+                        "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
+                        "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
+                        "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
+                        "\tpip install \"torchaudio<0.12\"`.\n\nOtherwise 'mp3' files will be decoded with `librosa`:\n\n"
+                        "\tpip install librosa\n\nNote that decoding will be extremely slow in that case."
                     ) from err
                 # try to decode with librosa for torchaudio>=0.12.0 as a workaround
                 warnings.warn("Decoding mp3 with `librosa` instead of `torchaudio`, decoding is slow.")

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -296,12 +296,12 @@ class Audio:
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
                 warnings.warn(
-                    "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
-                    "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
-                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
-                    " "
-                    'Or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
-                    "Otherwise it will be decoded with `librosa`"
+                    "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine.\n"
+                    "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package:\n"
+                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`\n"
+                    "\n"
+                    'Or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`.\n'
+                    "Otherwise it will be decoded with `librosa`."
                 )
                 try:
                     # flake8: noqa

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -296,12 +296,11 @@ class Audio:
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
                 warnings.warn(
-                    "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine.\n"
+                    "\nYour version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine.\n"
                     "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package:\n"
-                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`\n"
-                    "\n"
-                    'Or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`.\n'
-                    "Otherwise it will be decoded with `librosa`."
+                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`,\n"
+                    'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`.\n'
+                    "Otherwise 'mp3' files will be decoded with `librosa`."
                 )
                 try:
                     # flake8: noqa
@@ -310,9 +309,8 @@ class Audio:
                     raise ImportError(
                         "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
                         "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
-                        "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
-                        " "
-                        'Or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
+                        "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`, "
+                        'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
                         "To support decoding 'mp3' audio files without `torchaudio`, please install `librosa`: "
                         "`pip install librosa`. Note that decoding will be extremely slow in that case."
                     ) from err

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -296,10 +296,10 @@ class Audio:
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
                 warnings.warn(
-                    "\nYour version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine.\n"
-                    "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package:\n"
-                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`,\n"
-                    'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`.\n'
+                    "\nYour version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
+                    "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
+                    "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`, "
+                    'or downgrade `torchaudio` to <0.12: `pip install "torchaudio<0.12"`. '
                     "Otherwise 'mp3' files will be decoded with `librosa`."
                 )
                 try:

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -296,8 +296,7 @@ class Audio:
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
                 warnings.warn(
-                    "\nYour version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
-                    "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
+                    "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
                     "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg` "
                     "and restart your runtime. Alternatively, you can downgrade `torchaudio`: "
                     "`pip install \"torchaudio<0.12\"`. Otherwise 'mp3' files will be decoded with `librosa`."
@@ -307,7 +306,6 @@ class Audio:
                     import librosa
                 except ImportError as err:
                     raise ImportError(
-                        "Your version of `torchaudio` (>=0.12.0) doesn't support decoding 'mp3' files on your machine. "
                         "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package: "
                         "`add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg`, "
                         "and restart your runtime. Alternatively, you can downgrade `torchaudio`: "


### PR DESCRIPTION
Adds instructions on how to install `ffmpeg=4` on Linux (relevant for Colab users).

Looks pretty ugly because I didn't find a way to check `ffmpeg` version from python (without `subprocess.call()`; `ctypes.util.find_library` doesn't work`), so the warning is raised on each decoding. Any suggestions on how to make it look nice are welcome!

This is how it looks on Colab:
![image](https://user-images.githubusercontent.com/16348744/198052412-d48018d1-4416-4aa5-9114-f7f9b4af031f.png)
