### PR TITLE
Fix CI require beam

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1068,6 +1068,7 @@ def test_arrow_based_builder_download_and_prepare_as_sharded_parquet_with_max_sh
     assert sum(parquet_file.metadata.num_rows for parquet_file in parquet_files) == 100
 
 
+@require_beam
 def test_beam_based_builder_download_and_prepare_as_parquet(tmp_path):
     builder = DummyBeamBasedBuilder(cache_dir=tmp_path, beam_runner="DirectRunner")
     builder.download_and_prepare(file_format="parquet")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,8 +83,8 @@ def require_beam(test_case):
     These tests are skipped when Apache Beam isn't installed.
 
     """
-    if not config.TORCH_AVAILABLE:
-        test_case = unittest.skip("test requires PyTorch")(test_case)
+    if not config.BEAM_AVAILABLE:
+        test_case = unittest.skip("test requires apache-beam")(test_case)
     return test_case
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,17 +75,8 @@ require_torchaudio_latest = pytest.mark.skipif(
     reason="test requires torchaudio>=0.12",
 )
 
-
-def require_beam(test_case):
-    """
-    Decorator marking a test that requires Apache Beam.
-
-    These tests are skipped when Apache Beam isn't installed.
-
-    """
-    if not config.BEAM_AVAILABLE:
-        test_case = unittest.skip("test requires apache-beam")(test_case)
-    return test_case
+# Beam
+require_beam = pytest.mark.skipif(not config.BEAM_AVAILABLE, reason="test requires apache-beam")
 
 
 def require_faiss(test_case):


### PR DESCRIPTION
This PR:
- Fixes the CI `require_beam`: before it was requiring PyTorch instead
  ```python
  def require_beam(test_case):
      if not config.TORCH_AVAILABLE:
          test_case = unittest.skip("test requires PyTorch")(test_case)
      return test_case
  ```
- Fixes a missing `require_beam` in `test_beam_based_builder_download_and_prepare_as_parquet`
- Refactors `require_beam` to use `pytest` (`skipif`) instead