### PR TITLE
Raise ffmpeg warnings only once

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -354,7 +354,7 @@ class Audio:
         global _audioread_warned
 
         with warnings.catch_warnings():
-            if not _audioread_warned:
+            if _audioread_warned:
                 warnings.filterwarnings("ignore", "pysoundfile failed.+?", UserWarning, module=librosa.__name__)
             else:
                 _audioread_warned = True

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .features import FeatureType
 
 
-_ffmpeg_warned, _librosa_warned = True, True
+_ffmpeg_warned, _librosa_warned = False, False
 
 
 @dataclass

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -299,14 +299,14 @@ class Audio:
                 array, sampling_rate = self._decode_mp3_torchaudio(path_or_file)
             except RuntimeError:
                 global _ffmpeg_warned
-                if _ffmpeg_warned == 0:
+                if not _ffmpeg_warned:
                     warnings.warn(
                         "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
                         "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
                         "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
                         "\tpip install \"torchaudio<0.12\"`.\n\nOtherwise 'mp3' files will be decoded with `librosa`."
                     )
-                    _ffmpeg_warned += 1
+                    _ffmpeg_warned = False
                 try:
                     # flake8: noqa
                     import librosa

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -306,7 +306,7 @@ class Audio:
                         "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
                         "\tpip install \"torchaudio<0.12\"`.\n\nOtherwise 'mp3' files will be decoded with `librosa`."
                     )
-                    _ffmpeg_warned = False
+                    _ffmpeg_warned = True
                 try:
                     # flake8: noqa
                     import librosa
@@ -315,7 +315,7 @@ class Audio:
                         "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
                         "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
                         "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
-                        "\tpip install \"torchaudio<0.12\"`.\n\nOtherwise 'mp3' files will be decoded with `librosa`:\n\n"
+                        "\tpip install \"torchaudio<0.12\".\n\nTo decode 'mp3' files without torchaudio, please install `librosa`:\n\n"
                         "\tpip install librosa\n\nNote that decoding will be extremely slow in that case."
                     ) from err
                 # try to decode with librosa for torchaudio>=0.12.0 as a workaround

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -321,7 +321,9 @@ class Audio:
                 # try to decode with librosa for torchaudio>=0.12.0 as a workaround
                 global _librosa_warned
                 if not _librosa_warned:
-                    warnings.warn("Decoding mp3 with `librosa` instead of `torchaudio`, decoding is slow.")
+                    warnings.warn(
+                        "Decoding mp3 with `librosa` and `audioread` instead of `torchaudio`, decoding is slow."
+                    )
                     _librosa_warned = True
                 try:
                     array, sampling_rate = self._decode_mp3_librosa(path_or_file)
@@ -351,5 +353,8 @@ class Audio:
     def _decode_mp3_librosa(self, path_or_file):
         import librosa
 
-        array, sampling_rate = librosa.load(path_or_file, mono=self.mono, sr=self.sampling_rate)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "PySoundFile.+?", UserWarning, module=librosa.__name__)
+            array, sampling_rate = librosa.load(path_or_file, mono=self.mono, sr=self.sampling_rate)
+
         return array, sampling_rate

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .features import FeatureType
 
 
-_ffmpeg_warned, _librosa_warned = False, False
+_ffmpeg_warned, _librosa_warned, _audioread_warned = False, False, False
 
 
 @dataclass
@@ -315,15 +315,13 @@ class Audio:
                         "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
                         "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
                         "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
-                        "\tpip install \"torchaudio<0.12\".\n\nTo decode 'mp3' files without torchaudio, please install `librosa`:\n\n"
-                        "\tpip install librosa\n\nNote that decoding will be extremely slow in that case."
+                        "\tpip install \"torchaudio<0.12\".\n\nTo decode 'mp3' files without `torchaudio`, please install `librosa`:\n\n"
+                        "\tpip install librosa\n\nNote that decoding might be extremely slow in that case."
                     ) from err
                 # try to decode with librosa for torchaudio>=0.12.0 as a workaround
                 global _librosa_warned
                 if not _librosa_warned:
-                    warnings.warn(
-                        "Decoding mp3 with `librosa` instead of `torchaudio`, decoding is slow."
-                    )
+                    warnings.warn("Decoding mp3 with `librosa` instead of `torchaudio`, decoding might be slow.")
                     _librosa_warned = True
                 try:
                     array, sampling_rate = self._decode_mp3_librosa(path_or_file)
@@ -353,9 +351,11 @@ class Audio:
     def _decode_mp3_librosa(self, path_or_file):
         import librosa
 
+        global _audioread_warned
+
         with warnings.catch_warnings():
-            if _audioread_warned:
-                warnings.filterwarnings("ignore", "PySoundFile.+?", UserWarning, module=librosa.__name__)
+            if not _audioread_warned:
+                warnings.filterwarnings("ignore", "pysoundfile failed.+?", UserWarning, module=librosa.__name__)
             else:
                 _audioread_warned = True
             array, sampling_rate = librosa.load(path_or_file, mono=self.mono, sr=self.sampling_rate)

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -322,7 +322,7 @@ class Audio:
                 global _librosa_warned
                 if not _librosa_warned:
                     warnings.warn(
-                        "Decoding mp3 with `librosa` and `audioread` instead of `torchaudio`, decoding is slow."
+                        "Decoding mp3 with `librosa` instead of `torchaudio`, decoding is slow."
                     )
                     _librosa_warned = True
                 try:
@@ -354,7 +354,10 @@ class Audio:
         import librosa
 
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "PySoundFile.+?", UserWarning, module=librosa.__name__)
+            if _audioread_warned:
+                warnings.filterwarnings("ignore", "PySoundFile.+?", UserWarning, module=librosa.__name__)
+            else:
+                _audioread_warned = True
             array, sampling_rate = librosa.load(path_or_file, mono=self.mono, sr=self.sampling_rate)
 
         return array, sampling_rate

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -150,9 +150,7 @@ def test_audio_decode_example_mp3_torchaudio_latest(shared_datadir, torchaudio_f
     audio_path = str(shared_datadir / "test_audio_44100.mp3")
     audio = Audio()
 
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock, pytest.warns(
-        UserWarning, match=r"Decoding mp3 with `librosa` instead of `torchaudio`.+?"
-    ) if torchaudio_failed else nullcontext():
+    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
 
         if torchaudio_failed:
             load_mock.side_effect = RuntimeError()
@@ -215,9 +213,7 @@ def test_audio_resampling_mp3_different_sampling_rates_torchaudio_latest(shared_
     audio = Audio(sampling_rate=48000)
 
     # if torchaudio>=0.12 failed, mp3 must be decoded anyway (with librosa)
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock, pytest.warns(
-        UserWarning, match=r"Decoding mp3 with `librosa` instead of `torchaudio`.+?"
-    ) if torchaudio_failed else nullcontext():
+    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
         if torchaudio_failed:
             load_mock.side_effect = RuntimeError()
 
@@ -453,9 +449,7 @@ def test_resampling_at_loading_dataset_with_audio_feature_mp3_torchaudio_latest(
     dset = Dataset.from_dict(data, features=features)
 
     # if torchaudio>=0.12 failed, mp3 must be decoded anyway (with librosa)
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock, pytest.warns(
-        UserWarning, match=r"Decoding mp3 with `librosa` instead of `torchaudio`.+?"
-    ) if torchaudio_failed else nullcontext():
+    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
         if torchaudio_failed:
             load_mock.side_effect = RuntimeError()
 
@@ -551,9 +545,7 @@ def test_resampling_after_loading_dataset_with_audio_feature_mp3_torchaudio_late
     dset = Dataset.from_dict(data, features=features)
 
     # if torchaudio>=0.12 failed, mp3 must be decoded anyway (with librosa)
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock, pytest.warns(
-        UserWarning, match=r"Decoding mp3 with `librosa` instead of `torchaudio`.+?"
-    ) if torchaudio_failed else nullcontext():
+    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
         if torchaudio_failed:
             load_mock.side_effect = RuntimeError()
 


### PR DESCRIPTION
Our warnings looks nice now.

`librosa` warning that was raised at each decoding: 
```
/usr/local/lib/python3.7/dist-packages/librosa/core/audio.py:165: UserWarning: PySoundFile failed. Trying audioread instead.
  warnings.warn("PySoundFile failed. Trying audioread instead.")
```
is suppressed with `filterwarnings("ignore")` in a context manager. That means the first warning is also ignored (setting `filterwarnings("once")` didn't work!), so I added info that audioread is used for decoding to our message. Hope it's enough.


Tests failed at first because they used to check if the warning was raised at (each) decoding in `librosa` case but now we throw only one warning (at first decoding). I removed this check for warnings, do you think it's fine? 