### PR TITLE
Make torch.Tensor and spacy models cacheable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           pip install .[tests]
           pip install -r additional-tests-requirements.txt --no-deps
+          python -m spacy download en_core_web_sm
+          python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'latest' }}
         run: |

--- a/setup.py
+++ b/setup.py
@@ -154,8 +154,6 @@ TESTS_REQUIRE = [
     "seqeval",
     "sqlalchemy",
     "spacy>=3.0.0",
-    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl",
-    "fr_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl",
     "tldextract",
     # to speed up pip backtracking
     "toml>=0.10.1",

--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,9 @@ TESTS_REQUIRE = [
     "sentencepiece",  # for bleurt
     "seqeval",
     "sqlalchemy",
+    "spacy>=3.0.0",
+    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl",
+    "fr_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl",
     "tldextract",
     # to speed up pip backtracking
     "toml>=0.10.1",

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -589,6 +589,65 @@ class Pickler(dill.Pickler):
 
     dispatch = dill._dill.MetaCatchingDict(dill.Pickler.dispatch.copy())
 
+    def save(self, obj, save_persistent_id=True):
+        # lazy registration of reduction functions
+        obj_type = type(obj)
+        if obj_type not in Pickler.dispatch:
+            if (obj_type.__module__, obj_type.__name__) == ("_regex", "Pattern"):
+                try:
+                    import regex
+
+                    @pklregister(obj_type)
+                    def _save_regex(pickler, obj):
+                        dill._dill.log.info(f"Re: {obj}")
+                        args = (
+                            obj.pattern,
+                            obj.flags,
+                        )
+                        pickler.save_reduce(regex.compile, args, obj=obj)
+                        dill._dill.log.info("# Re")
+                        return
+
+                except ImportError:
+                    pass
+            elif (obj_type.__module__, obj_type.__name__) == ("torch", "Tensor"):
+                try:
+                    import torch
+
+                    @pklregister(obj_type)
+                    def _save_tensor(pickler, obj):
+                        dill._dill.log.info(f"To: {obj}")
+                        args = (obj.cpu().numpy(),)
+                        pickler.save_reduce(torch.from_numpy, args, obj=obj)
+                        dill._dill.log.info("# To")
+                        return
+
+                except ImportError:
+                    pass
+            elif obj_type.__module__.startswith("spacy.lang") and any(
+                (cls.__module__, cls.__name__) == ("spacy.language", "Language") for cls in obj_type.__mro__
+            ):
+                try:
+                    import spacy
+
+                    @pklregister(obj_type)
+                    def _save_lang(pickler, obj):
+                        def _create_lang(config, bytes_data):
+                            lang_cls = spacy.util.get_lang_class(config["nlp"]["lang"])
+                            nlp = lang_cls.from_config(config)
+                            return nlp.from_bytes(bytes_data)
+
+                        dill._dill.log.info(f"Sp: {obj}")
+                        args = (obj.config, obj.to_bytes())
+                        pickler.save_reduce(_create_lang, args, obj=obj)
+                        dill._dill.log.info("# Sp")
+                        return
+
+                except ImportError:
+                    pass
+
+        dill.Pickler.save(self, obj, save_persistent_id=save_persistent_id)
+
     def memoize(self, obj):
         # don't memoize strings since two identical strings can have different python ids
         if type(obj) != str:
@@ -946,21 +1005,3 @@ def copyfunc(func):
     result = types.FunctionType(func.__code__, func.__globals__, func.__name__, func.__defaults__, func.__closure__)
     result.__kwdefaults__ = func.__kwdefaults__
     return result
-
-
-try:
-    import regex
-
-    @pklregister(type(regex.Regex("", 0)))
-    def _save_regex(pickler, obj):
-        dill._dill.log.info(f"Re: {obj}")
-        args = (
-            obj.pattern,
-            obj.flags,
-        )
-        pickler.save_reduce(regex.compile, args, obj=obj)
-        dill._dill.log.info("# Re")
-        return
-
-except ImportError:
-    pass

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -601,19 +601,18 @@ class Pickler(dill.Pickler):
 
     def save(self, obj, save_persistent_id=True):
         # lazy registration of reduction functions
-
-        if config.DILL_VERSION < version.parse("0.3.6"):
-
-            def dill_log(pickler, msg):
-                dill._dill.log.info(msg)
-
-        elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
-
-            def dill_log(pickler, msg):
-                dill._dill.logger.trace(pickler, msg)
-
         obj_type = type(obj)
         if obj_type not in Pickler.dispatch:
+            if config.DILL_VERSION < version.parse("0.3.6"):
+
+                def dill_log(pickler, msg):
+                    dill._dill.log.info(msg)
+
+            elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
+
+                def dill_log(pickler, msg):
+                    dill._dill.logger.trace(pickler, msg)
+
             if (obj_type.__module__, obj_type.__name__) == ("_regex", "Pattern"):
                 try:
                     import regex

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -601,37 +601,33 @@ class Pickler(dill.Pickler):
 
     def save(self, obj, save_persistent_id=True):
         # lazy registration of reduction functions
+
+        if config.DILL_VERSION < version.parse("0.3.6"):
+
+            def dill_log(pickler, msg):
+                dill._dill.log.info(msg)
+
+        elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
+
+            def dill_log(pickler, msg):
+                dill._dill.logger.trace(pickler, msg)
+
         obj_type = type(obj)
         if obj_type not in Pickler.dispatch:
             if (obj_type.__module__, obj_type.__name__) == ("_regex", "Pattern"):
                 try:
                     import regex
 
-                    if config.DILL_VERSION < version.parse("0.3.6"):
-
-                        @pklregister(obj_type)
-                        def _save_regex(pickler, obj):
-                            dill._dill.log.info(f"Re: {obj}")
-                            args = (
-                                obj.pattern,
-                                obj.flags,
-                            )
-                            pickler.save_reduce(regex.compile, args, obj=obj)
-                            dill._dill.log.info("# Re")
-                            return
-
-                    elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
-
-                        @pklregister(obj_type)
-                        def _save_regex(pickler, obj):
-                            dill._dill.logger.trace(pickler, "Re: %s", obj)
-                            args = (
-                                obj.pattern,
-                                obj.flags,
-                            )
-                            pickler.save_reduce(regex.compile, args, obj=obj)
-                            dill._dill.logger.trace(pickler, "# Re")
-                            return
+                    @pklregister(obj_type)
+                    def _save_regex(pickler, obj):
+                        dill_log(pickler, f"Re: {obj}")
+                        args = (
+                            obj.pattern,
+                            obj.flags,
+                        )
+                        pickler.save_reduce(regex.compile, args, obj=obj)
+                        dill_log(pickler, "# Re")
+                        return
 
                 except ImportError:
                     pass
@@ -639,25 +635,16 @@ class Pickler(dill.Pickler):
                 try:
                     import torch
 
-                    if config.DILL_VERSION < version.parse("0.3.6"):
-
-                        @pklregister(obj_type)
-                        def _save_tensor(pickler, obj):
-                            dill._dill.log.info(f"To: {obj}")
+                    @pklregister(obj_type)
+                    def _save_tensor(pickler, obj):
+                        dill_log(pickler, f"To: {obj}")
+                        if obj.requires_grad:
+                            args = (obj.detach().cpu().numpy(),)
+                        else:
                             args = (obj.cpu().numpy(),)
-                            pickler.save_reduce(torch.from_numpy, args, obj=obj)
-                            dill._dill.log.info("# To")
-                            return
-
-                    elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
-
-                        @pklregister(obj_type)
-                        def _save_tensor(pickler, obj):
-                            dill._dill.logger.trace(pickler, f"To: {obj}")
-                            args = (obj.cpu().numpy(),)
-                            pickler.save_reduce(torch.from_numpy, args, obj=obj)
-                            dill._dill.logger.trace(pickler, "# To")
-                            return
+                        pickler.save_reduce(torch.from_numpy, args, obj=obj)
+                        dill_log(pickler, "# To")
+                        return
 
                 except ImportError:
                     pass
@@ -667,35 +654,18 @@ class Pickler(dill.Pickler):
                 try:
                     import spacy
 
-                    if config.DILL_VERSION < version.parse("0.3.6"):
+                    @pklregister(obj_type)
+                    def _save_lang(pickler, obj):
+                        def _create_lang(config, bytes_data):
+                            lang_cls = spacy.util.get_lang_class(config["nlp"]["lang"])
+                            nlp = lang_cls.from_config(config)
+                            return nlp.from_bytes(bytes_data)
 
-                        @pklregister(obj_type)
-                        def _save_lang(pickler, obj):
-                            def _create_lang(config, bytes_data):
-                                lang_cls = spacy.util.get_lang_class(config["nlp"]["lang"])
-                                nlp = lang_cls.from_config(config)
-                                return nlp.from_bytes(bytes_data)
-
-                            dill._dill.log.info(f"Sp: {obj}")
-                            args = (obj.config, obj.to_bytes())
-                            pickler.save_reduce(_create_lang, args, obj=obj)
-                            dill._dill.log.info("# Sp")
-                            return
-
-                    elif config.DILL_VERSION.release[:3] == version.parse("0.3.6").release:
-
-                        @pklregister(obj_type)
-                        def _save_lang(pickler, obj):
-                            def _create_lang(config, bytes_data):
-                                lang_cls = spacy.util.get_lang_class(config["nlp"]["lang"])
-                                nlp = lang_cls.from_config(config)
-                                return nlp.from_bytes(bytes_data)
-
-                            dill._dill.logger.trace(pickler, f"Sp: {obj}")
-                            args = (obj.config, obj.to_bytes())
-                            pickler.save_reduce(_create_lang, args, obj=obj)
-                            dill._dill.logger.trace(pickler, "# Sp")
-                            return
+                        dill_log(pickler, f"Sp: {obj}")
+                        args = (obj.config, obj.to_bytes())
+                        pickler.save_reduce(_create_lang, args, obj=obj)
+                        dill_log(pickler, "# Sp")
+                        return
 
                 except ImportError:
                     pass

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -15,7 +15,7 @@ import datasets
 from datasets.fingerprint import Hasher, fingerprint_transform
 from datasets.table import InMemoryTable
 
-from .utils import require_regex, require_transformers
+from .utils import require_regex, require_spacy, require_spacy_model, require_torch, require_transformers
 
 
 class Foo:
@@ -280,6 +280,35 @@ class HashingTest(TestCase):
         hash3 = Hasher.hash(obj3)
         self.assertEqual(hash1, hash2)
         self.assertEqual(hash1, hash3)
+
+    @require_torch
+    def test_hash_torch_tensor(self):
+        import torch
+
+        t = torch.tensor([1.0])
+        hash1 = md5(datasets.utils.py_utils.dumps(t)).hexdigest()
+        t = torch.tensor([2.0])
+        hash2 = md5(datasets.utils.py_utils.dumps(t)).hexdigest()
+        t = torch.tensor([1.0])
+        hash3 = md5(datasets.utils.py_utils.dumps(t)).hexdigest()
+        self.assertEqual(hash1, hash3)
+        self.assertNotEqual(hash1, hash2)
+
+    @require_spacy
+    @require_spacy_model("en_core_web_sm")
+    @require_spacy_model("fr_core_news_sm")
+    @pytest.mark.integration
+    def test_hash_spacy_model(self):
+        import spacy
+
+        nlp = spacy.load("en_core_web_sm")
+        hash1 = md5(datasets.utils.py_utils.dumps(nlp)).hexdigest()
+        nlp = spacy.load("fr_core_news_sm")
+        hash2 = md5(datasets.utils.py_utils.dumps(nlp)).hexdigest()
+        nlp = spacy.load("en_core_web_sm")
+        hash3 = md5(datasets.utils.py_utils.dumps(nlp)).hexdigest()
+        self.assertEqual(hash1, hash3)
+        self.assertNotEqual(hash1, hash2)
 
 
 @pytest.mark.integration

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -223,6 +223,43 @@ def require_s3(test_case):
         return test_case
 
 
+def require_spacy(test_case):
+    """
+    Decorator marking a test that requires spacy.
+
+    These tests are skipped when they aren't installed.
+
+    """
+    try:
+        import spacy  # noqa F401
+    except ImportError:
+        return unittest.skip("test requires spacy")(test_case)
+    else:
+        return test_case
+
+
+def require_spacy_model(model):
+    """
+    Decorator marking a test that requires a spacy model.
+
+    These tests are skipped when they aren't installed.
+    """
+
+    def _require_spacy_model(test_case):
+        try:
+            import spacy  # noqa F401
+
+            spacy.load(model)
+        except ImportError:
+            return unittest.skip("test requires spacy")(test_case)
+        except OSError:
+            return unittest.skip("test requires spacy model '{}'".format(model))(test_case)
+        else:
+            return test_case
+
+    return _require_spacy_model
+
+
 def slow(test_case):
     """
     Decorator marking a test as slow.


### PR DESCRIPTION
Override `Pickler.save` to implement deterministic reduction (lazily registered; inspired by https://github.com/uqfoundation/dill/blob/master/dill/_dill.py#L343) functions for `torch.Tensor` and spaCy models.

Fix https://github.com/huggingface/datasets/issues/5170, fix https://github.com/huggingface/datasets/issues/3178
