### PR TITLE
Fix docs about dataset_info in YAML

### DIFF
--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -347,15 +347,15 @@ def _generate_examples(self, images, metadata_path):
 
 ### Generate the dataset metadata (optional)
 
-The dataset metadata you added earlier now needs to be generated and stored in a file called `datasets_infos.json`. In addition to information about a datasets features and description, this file also contains data file checksums to ensure integrity.
+The dataset metadata can be generated and stored in the dataset card (`README.md` file).
 
-Run the following command to generate your dataset metadata in `dataset_infos.json` and make sure your new loading script works correctly:
+Run the following command to generate your dataset metadata in `README.md` and make sure your new loading script works correctly:
 
 ```bash
 datasets-cli test path/to/<your-dataset-loading-script> --save_info --all_configs
 ```
 
-If your loading script passed the test, you should now have a `dataset_infos.json` file in your dataset folder.
+If your loading script passed the test, you should now have the `dataset_info` YAML fields in the header of the `README.md` file in your dataset folder.
 
 ### Upload the dataset to the Hub
 


### PR DESCRIPTION
This PR fixes some misalignment in the docs after we transferred the dataset_info from `dataset_infos.json` to YAML in the dataset card:
- #4926

Related to:
- #5193