### PR TITLE
[zstd] Use max window log size

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -195,7 +195,7 @@ class ZstdExtractor(MagicNumberBaseExtractor):
             raise ImportError("Please pip install zstandard")
         import zstandard as zstd
 
-        dctx = zstd.ZstdDecompressor()
+        dctx = zstd.ZstdDecompressor(max_window_size=2**zstd.WINDOWLOG_MAX)
         with open(input_path, "rb") as ifh, open(output_path, "wb") as ofh:
             dctx.copy_stream(ifh, ofh)
 


### PR DESCRIPTION
ZstdDecompressor has a parameter `max_window_size` to limit max memory usage when decompressing zstd files. The default `max_window_size` is not enough when files are compressed by `zstd --ultra` flags.

Change `max_window_size` to the zstd's max window size. NOTE, the `zstd.WINDOWLOG_MAX` is the log_2 value of the max window size.