### PR TITLE
Add note about the name of a dataset script

### DIFF
--- a/docs/source/audio_dataset.mdx
+++ b/docs/source/audio_dataset.mdx
@@ -158,7 +158,7 @@ Load the dataset with `AudioFolder`, and it will create a `label` column from th
 
 <Tip>
 
-Some audio datasets, like those found in [Kaggle competitions](https://www.kaggle.com/), have separate metadata files for each split. Provided the metadata features are the same for each split, `audiofolder` can be used to load all splits at once. If the metadata features differ across each split, you should load them with separate `load_dataset()` calls.
+Some audio datasets, like those found in [Kaggle competitions](https://www.kaggle.com/competitions/kaggle-pog-series-s01e02/overview), have separate metadata files for each split. Provided the metadata features are the same for each split, `audiofolder` can be used to load all splits at once. If the metadata features differ across each split, you should load them with separate `load_dataset()` calls.
 
 </Tip>
 
@@ -333,7 +333,7 @@ There is a lot of information you can include about your dataset, but some impor
 
 <Tip>
 
-You'll notice a lot of the dataset information is defined earlier in the loading script which can make it easier to read. There are also other [`~Dataset.Features`] you can input, so be sure to check out the full list and [features guide](./audio_dataset_features) for more details.
+You'll notice a lot of the dataset information is defined earlier in the loading script which can make it easier to read. There are also other [`~Dataset.Features`] you can input, so be sure to check out the full list and [features guide](./about_dataset_features) for more details.
 
 </Tip>
 

--- a/docs/source/dataset_script.mdx
+++ b/docs/source/dataset_script.mdx
@@ -12,7 +12,7 @@ Write a dataset script to load and share your own datasets. It is a Python file 
 
 The script can download data files from any website, or from the same dataset repository.
 
-Any dataset script, for example `my_dataset.py`, can be placed in a folder or a repository named `my_dataset` and be loaded with:
+A dataset loading script should have the same name as a dataset repository or directory. For example, a repository named `my_dataset` should contain `my_dataset.py` script. This way it can be loaded with:
 
 ```
 my_dataset/

--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -116,7 +116,7 @@ Upload your dataset with [`~datasets.DatasetDict.push_to_hub`]:
 
 ## Loading script
 
-Write a dataset loading script to share a dataset. It defines a dataset's splits and configurations, and handles downloading and generating a dataset. The script is located in the same folder or repository as the dataset. 
+Write a dataset loading script to share a dataset. It defines a dataset's splits and configurations, and handles downloading and generating a dataset. The script is located in the same folder or repository as the dataset and should have the same name.
 
 ```
 my_dataset/


### PR DESCRIPTION
Add note that a dataset script should has the same name as a repo/dir, a bit related to this issue https://github.com/huggingface/datasets/issues/5193

also fixed two minor issues in audio docs (broken links)