### PR TITLE
Do not sort splits in dataset info

### DIFF
--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -505,7 +505,7 @@ class SplitReadInstruction:
         return split_instruction
 
     def get_list_sliced_split_info(self):
-        return list(sorted(self._splits.values(), key=lambda x: x.split_info.name))
+        return self._splits.values()
 
 
 class SplitDict(dict):
@@ -569,7 +569,7 @@ class SplitDict(dict):
         """Returns a list of SplitInfo protos that we have."""
         # Return the SplitInfo, sorted by name
         out = []
-        for split_name, split_info in sorted(self.items()):
+        for split_name, split_info in self.items():
             split_info = copy.deepcopy(split_info)
             split_info.name = split_name
             out.append(split_info)

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -505,7 +505,7 @@ class SplitReadInstruction:
         return split_instruction
 
     def get_list_sliced_split_info(self):
-        return self._splits.values()
+        return list(self._splits.values())
 
 
 class SplitDict(dict):

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -567,7 +567,6 @@ class SplitDict(dict):
 
     def to_split_dict(self):
         """Returns a list of SplitInfo protos that we have."""
-        # Return the SplitInfo, sorted by name
         out = []
         for split_name, split_info in self.items():
             split_info = copy.deepcopy(split_info)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -87,7 +87,7 @@ def test_get_dataset_info(path, expected_configs, expected_splits_in_first_confi
     assert expected_config in infos
     info = infos[expected_config]
     assert info.config_name == expected_config
-    assert sorted(info.splits.keys()) == sorted(expected_splits_in_first_config)
+    assert list(info.splits.keys()) == expected_splits_in_first_config
 
 
 @pytest.mark.parametrize(
@@ -103,7 +103,7 @@ def test_get_dataset_split_names(path, expected_config, expected_splits):
     assert expected_config in infos
     info = infos[expected_config]
     assert info.config_name == expected_config
-    assert sorted(info.splits.keys()) == sorted(expected_splits)
+    assert list(info.splits.keys()) == expected_splits
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -87,7 +87,7 @@ def test_get_dataset_info(path, expected_configs, expected_splits_in_first_confi
     assert expected_config in infos
     info = infos[expected_config]
     assert info.config_name == expected_config
-    assert list(info.splits.keys()) == expected_splits_in_first_config
+    assert sorted(info.splits.keys()) == sorted(expected_splits_in_first_config)
 
 
 @pytest.mark.parametrize(
@@ -103,7 +103,7 @@ def test_get_dataset_split_names(path, expected_config, expected_splits):
     assert expected_config in infos
     info = infos[expected_config]
     assert info.config_name == expected_config
-    assert list(info.splits.keys()) == expected_splits
+    assert sorted(info.splits.keys()) == sorted(expected_splits)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I suggest not to sort splits by their names in dataset_info in README so that they are displayed in the order specified in the loading script. Otherwise `test` split is displayed first, see this repo: https://huggingface.co/datasets/paws
What do you think?

But I added sorting in tests to fix CI (for the same dataset).