### PR TITLE
Refactor CI hub fixtures to use monkeypatch instead of patch

### DIFF
--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -1,7 +1,6 @@
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import requests

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -97,10 +97,8 @@ def hf_private_dataset_repo_txt_data_(hf_api: HfApi, hf_token, text_file):
 
 
 @pytest.fixture()
-def hf_private_dataset_repo_txt_data(hf_private_dataset_repo_txt_data_):
-    with patch("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT):
-        with patch("datasets.config.HUB_DATASETS_URL", CI_HUB_DATASETS_URL):
-            yield hf_private_dataset_repo_txt_data_
+def hf_private_dataset_repo_txt_data(hf_private_dataset_repo_txt_data_, ci_hub_config):
+    return hf_private_dataset_repo_txt_data_
 
 
 @pytest.fixture(scope="session")
@@ -123,10 +121,8 @@ def hf_private_dataset_repo_zipped_txt_data_(hf_api: HfApi, hf_token, zip_csv_wi
 
 
 @pytest.fixture()
-def hf_private_dataset_repo_zipped_txt_data(hf_private_dataset_repo_zipped_txt_data_):
-    with patch("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT):
-        with patch("datasets.config.HUB_DATASETS_URL", CI_HUB_DATASETS_URL):
-            yield hf_private_dataset_repo_zipped_txt_data_
+def hf_private_dataset_repo_zipped_txt_data(hf_private_dataset_repo_zipped_txt_data_, ci_hub_config):
+    return hf_private_dataset_repo_zipped_txt_data_
 
 
 @pytest.fixture(scope="session")
@@ -149,7 +145,5 @@ def hf_private_dataset_repo_zipped_img_data_(hf_api: HfApi, hf_token, zip_image_
 
 
 @pytest.fixture()
-def hf_private_dataset_repo_zipped_img_data(hf_private_dataset_repo_zipped_img_data_):
-    with patch("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT):
-        with patch("datasets.config.HUB_DATASETS_URL", CI_HUB_DATASETS_URL):
-            yield hf_private_dataset_repo_zipped_img_data_
+def hf_private_dataset_repo_zipped_img_data(hf_private_dataset_repo_zipped_img_data_, ci_hub_config):
+    return hf_private_dataset_repo_zipped_img_data_


### PR DESCRIPTION
Minor refactoring of CI to use `pytest` `monkeypatch` instead of `unittest` `patch`.