### PR TITLE
Fix CI require_beam maximum compatible dill version

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,7 @@ require_torchaudio_latest = pytest.mark.skipif(
 
 # Beam
 require_beam = pytest.mark.skipif(
-    not config.BEAM_AVAILABLE or config.DILL_VERSION >= version.parse("0.3.6"),
+    not config.BEAM_AVAILABLE or config.DILL_VERSION >= version.parse("0.3.2"),
     reason="test requires apache-beam and a compatible dill version",
 )
 


### PR DESCRIPTION
A previous commit to main branch introduced an additional requirement on maximum compatible `dill` version with `apache-beam` in our CI `require_beam`:
- d7c942228b8dcf4de64b00a3053dce59b335f618
- ec222b220b79f10c8d7b015769f0999b15959feb

This PR fixes the maximum compatible `dill` version with `apache-beam`, which is <0.3.2 (and not 0.3.6): https://github.com/apache/beam/blob/v2.42.0/sdks/python/setup.py#L219