### PR TITLE
fix: dataset path should be absolute

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1028,7 +1028,7 @@ class MemoryMappedTable(TableBlock):
 
     def __init__(self, table: pa.Table, path: str, replays: Optional[List[Replay]] = None):
         super().__init__(table)
-        self.path = path
+        self.path = os.path.abspath(path)
         self.replays: List[Replay] = replays if replays is not None else []
 
     @classmethod


### PR DESCRIPTION
cache_file_name depends on dataset's path.

A simple way where this could cause a problem:
```
import os
import datasets


def add_prefix(example):
    example["text"] = "Review: " + example["text"]
    return example


ds = datasets.load_from_disk("a/relative/path")
os.chdir("/tmp")

ds_1 = ds.map(add_prefix)
```

while it may feel that the `chdir` is quite constructed, there are many scenarios when the current working dir can/will change...