### PR TITLE
Pin `typer` version in tests to <0.5 to fix Windows CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ TESTS_REQUIRE = [
     "tldextract",
     # to speed up pip backtracking
     "toml>=0.10.1",
+    "typer<0.5.0",  # pined to work with Spacy==3.4.3 on Windows: see https://github.com/tiangolo/typer/issues/427
     "requests_file>=1.5.1",
     "tldextract>=3.1.0",
     "texttable>=1.6.3",
@@ -210,7 +211,10 @@ setup(
     license="Apache 2.0",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    package_data={"datasets": ["py.typed", "scripts/templates/*"], "datasets.utils.resources": ["*.json", "*.yaml", "*.tsv"]},
+    package_data={
+        "datasets": ["py.typed", "scripts/templates/*"],
+        "datasets.utils.resources": ["*.json", "*.yaml", "*.tsv"],
+    },
     entry_points={"console_scripts": ["datasets-cli=datasets.commands.datasets_cli:main"]},
     python_requires=">=3.7.0",
     install_requires=REQUIRED_PKGS,


### PR DESCRIPTION
Otherwise `click` fails on Windows: 
```
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\spacy\__main__.py", line 4, in <module>
    setup_cli()
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\spacy\cli\_util.py", line 71, in setup_cli
    command(prog_name=COMMAND)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\typer\core.py", line 785, in main
    **extra,
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\typer\core.py", line 190, in _main
    args = click.utils._expand_args(args)
AttributeError: module 'click.utils' has no attribute '_expand_args'
```

See https://github.com/tiangolo/typer/issues/427