### PR TITLE
Encode path only for old versions of hfh

### DIFF
--- a/src/datasets/utils/hub.py
+++ b/src/datasets/utils/hub.py
@@ -2,7 +2,11 @@ from typing import Optional
 from urllib.parse import quote
 
 import huggingface_hub as hfh
+from packaging import version
 
 
 def hf_hub_url(repo_id: str, path: str, revision: Optional[str] = None) -> str:
-    return hfh.hf_hub_url(repo_id, quote(path), repo_type="dataset", revision=revision)
+    if version.parse(hfh.__version__) < version.parse("0.11.0"):
+        # old versions of hfh don't url-encode the file path
+        path = quote(path)
+    return hfh.hf_hub_url(repo_id, path, repo_type="dataset", revision=revision)


### PR DESCRIPTION
Next version of `huggingface-hub` 0.11 does encode the `path`, and we don't want to encode twice