### PR TITLE
Make `Version` hashable

### DIFF
--- a/src/datasets/utils/version.py
+++ b/src/datasets/utils/version.py
@@ -22,9 +22,7 @@ from functools import total_ordering
 from typing import Optional, Union
 
 
-_VERSION_TMPL = r"^(?P<major>{v})" r"\.(?P<minor>{v})" r"\.(?P<patch>{v})$"
-_VERSION_WILDCARD_REG = re.compile(_VERSION_TMPL.format(v=r"\d+|\*"))
-_VERSION_RESOLVED_REG = re.compile(_VERSION_TMPL.format(v=r"\d+"))
+_VERSION_REG = re.compile(r"^(?P<major>\d+)" r"\.(?P<minor>\d+)" r"\.(?P<patch>\d+)$")
 
 
 @total_ordering
@@ -88,16 +86,6 @@ class Version:
     def __hash__(self):
         return hash(_version_tuple_to_str(self.tuple))
 
-    def match(self, other_version):
-        """Returns True if other_version matches.
-
-        Args:
-            other_version: string, of the form "x[.y[.x]]" where {x,y,z} can be a
-                number or a wildcard.
-        """
-        major, minor, patch = _str_to_version_tuple(other_version, allow_wildcard=True)
-        return major in [self.major, "*"] and minor in [self.minor, "*"] and patch in [self.patch, "*"]
-
     @classmethod
     def from_dict(cls, dic):
         field_names = {f.name for f in dataclasses.fields(cls)}
@@ -107,18 +95,12 @@ class Version:
         return self.version_str
 
 
-def _str_to_version_tuple(version_str, allow_wildcard=False):
+def _str_to_version_tuple(version_str):
     """Return the tuple (major, minor, patch) version extracted from the str."""
-    reg = _VERSION_WILDCARD_REG if allow_wildcard else _VERSION_RESOLVED_REG
-    res = reg.match(version_str)
+    res = _VERSION_REG.match(version_str)
     if not res:
-        msg = f"Invalid version '{version_str}'. Format should be x.y.z"
-        if allow_wildcard:
-            msg += " with {x,y,z} being digits or wildcard."
-        else:
-            msg += " with {x,y,z} being digits."
-        raise ValueError(msg)
-    return tuple(v if v == "*" else int(v) for v in [res.group("major"), res.group("minor"), res.group("patch")])
+        raise ValueError(f"Invalid version '{version_str}'. Format should be x.y.z with {{x,y,z}} being digits.")
+    return tuple(int(v) for v in [res.group("major"), res.group("minor"), res.group("patch")])
 
 
 def _version_tuple_to_str(version_tuple):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -16,7 +16,8 @@ from datasets.utils.version import Version
         (None, False),
     ],
 )
-def test_version_equalities(other, expected_equality):
+def test_version_equality_and_hash(other, expected_equality):
     version = Version("1.0.0")
     assert (version == other) is expected_equality
     assert (version != other) is not expected_equality
+    assert (hash(version) == hash(other)) is expected_equality


### PR DESCRIPTION
Add `__hash__` to the `Version` class to make it hashable (and remove the unneeded methods), as  `Version("0.0.0")` is the default value of `BuilderConfig.version` and the default fields of a dataclass need to be hashable in Python 3.11.

Fix https://github.com/huggingface/datasets/issues/5230