### PR TITLE
Change release procedure to use only pull requests

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -2,10 +2,8 @@ name: Build documentation
 
 on:
   push:
-    branches:
-      - main
-      - doc-builder*
-      - v*-release
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
    build:

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -1,9 +1,8 @@
 name: Release - Conda
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+  release:
+    types: [published]
 
 env:
   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -1,8 +1,9 @@
 name: Release - Conda
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Steps to make a release:
      ```
      git checkout main
      git pull upstream main
-     git checkout -b release
+     git checkout -b vVERSION-release
      ```
 
 2. Change the version to the release VERSION in:
@@ -38,7 +38,7 @@ Steps to make a release:
      ```
      git add -u
      git commit -m "Release: VERSION"
-     git push upstream release
+     git push upstream vVERSION-release
      ```
    - Go to: https://github.com/huggingface/datasets/pull/new/release
    - Create pull request

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ Steps to make a release:
        ```
        git checkout main
        git pull upstream main
+       git branch -D dev-version
        git checkout -b dev-version
        ```
    - Change the version to X.X.X+1.dev0 (e.g. VERSION=1.18.3 -> 1.18.4.dev0) in:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Steps to make a release:
      ```
      git checkout main
      git pull upstream main
-     git checkout -b vVERSION-release
+     git checkout -b release-VERSION
      ```
 
 2. Change the version to the release VERSION in:
@@ -38,7 +38,7 @@ Steps to make a release:
      ```
      git add -u
      git commit -m "Release: VERSION"
-     git push upstream vVERSION-release
+     git push upstream release-VERSION
      ```
    - Go to: https://github.com/huggingface/datasets/pull/new/release
    - Create pull request

--- a/setup.py
+++ b/setup.py
@@ -8,55 +8,98 @@ Note:
 
 Simple check list for release from AllenNLP repo: https://github.com/allenai/allennlp/blob/master/setup.py
 
-To create the package for pypi.
+Steps to make a release:
 
 0. Prerequisites:
    - Dependencies:
-     - twine: "pip install twine"
+     - twine: `pip install twine`
    - Create an account in (and join the 'datasets' project):
      - PyPI: https://pypi.org/
      - Test PyPI: https://test.pypi.org/
-   - Don't break `transformers`
-     - Run the `transformers` CI using the `main` branch and make sure it's green.
-       In `transformers`, use "datasets @ git+https://github.com/huggingface/datasets@main#egg=datasets"
-       in both setup.py and src/transformers/dependency_versions_table.py and then run the CI
+   - Don't break `transformers`: run the `transformers` CI using the `main` branch and make sure it's green.
+     - In `transformers`, use `datasets @ git+https://github.com/huggingface/datasets@main#egg=datasets`
+       in both:
+       - setup.py and
+       - src/transformers/dependency_versions_table.py
+     - and then run the CI
 
-1. Change the version in:
+1. Create the release branch from main branch:
+     ```
+     git checkout main
+     git pull upstream main
+     git checkout -b release
+     ```
+
+2. Change the version to the release VERSION in:
    - __init__.py
    - setup.py
 
-2. Commit these changes: "git commit -m 'Release: VERSION'"
+3. Commit these changes, push and create a Pull Request:
+     ```
+     git add -u
+     git commit -m "Release: VERSION"
+     git push upstream release
+     ```
+   - Go to: https://github.com/huggingface/datasets/pull/new/release
+   - Create pull request
 
-3. Add a tag in git to mark the release: "git tag VERSION -m 'Add tag VERSION for pypi'"
-   Push the tag to remote: git push --tags origin main
-
-4. Build both the sources and the wheel. Do not change anything in setup.py between
+4. From your local release branch, build both the sources and the wheel. Do not change anything in setup.py between
    creating the wheel and the source distribution (obviously).
+   - First, delete any building directories that may exist from previous builds:
+     - build
+     - dist
+   - From the top level directory, build the wheel and the sources:
+       ```
+       python setup.py bdist_wheel
+       python setup.py sdist
+       ```
+   - You should now have a /dist directory with both .whl and .tar.gz source versions.
 
-   First, delete any "build" directory that may exist from previous builds.
-
-   For the wheel, run: "python setup.py bdist_wheel" in the top level directory.
-   (this will build a wheel for the python version you use to build it).
-
-   For the sources, run: "python setup.py sdist"
-   You should now have a /dist directory with both .whl and .tar.gz source versions.
-
-5. Check that everything looks correct by uploading the package to the pypi test server:
-
-   twine upload dist/* -r pypitest --repository-url=https://test.pypi.org/legacy/
-
+5. Check that everything looks correct by uploading the package to the test PyPI server:
+     ```
+     twine upload dist/* -r pypitest --repository-url=https://test.pypi.org/legacy/
+     ```
    Check that you can install it in a virtualenv/notebook by running:
-   pip install huggingface_hub fsspec aiohttp
-   pip install -U tqdm
-   pip install -i https://testpypi.python.org/pypi datasets
+     ```
+     pip install huggingface_hub fsspec aiohttp
+     pip install -U tqdm
+     pip install -i https://testpypi.python.org/pypi datasets
+     ```
 
-6. Upload the final version to actual pypi:
-   twine upload dist/* -r pypi
+6. Upload the final version to the actual PyPI:
+     ```
+     twine upload dist/* -r pypi
+     ```
 
-7. Fill release notes in the tag in github once everything is looking hunky-dory.
+7. Make the release on GitHub once everything is looking hunky-dory:
+   - Merge the release Pull Request
+   - Create a new release: https://github.com/huggingface/datasets/releases/new
+   - Choose a tag: Introduce the new VERSION as tag, that will be created when you publish the release
+     - Create new tag VERSION on publish
+   - Release title: Introduce the new VERSION as well
+   - Describe the release
+     - Use "Generate release notes" button for automatic generation
+   - Publish release
 
-8. Change the version in __init__.py and setup.py to X.X.X+1.dev0 (e.g. VERSION=1.18.3 -> 1.18.4.dev0).
-   Then push the change with a message 'set dev version'
+8. Set the dev version
+   - Create the dev-version branch from the main branch:
+       ```
+       git checkout main
+       git pull upstream main
+       git checkout -b dev-version
+       ```
+   - Change the version to X.X.X+1.dev0 (e.g. VERSION=1.18.3 -> 1.18.4.dev0) in:
+     - __init__.py
+     - setup.py
+   - Commit these changes, push and create a Pull Request:
+       ```
+       git add -u
+       git commit -m "Set dev version"
+       git push upstream dev-version
+       ```
+     - Go to: https://github.com/huggingface/datasets/pull/new/dev-version
+     - Create pull request
+   - Merge the dev version Pull Request
 """
 
 


### PR DESCRIPTION
This PR changes the release procedure so that:
- it only make changes to main branch via pull requests
- it is no longer necessary to directly commit/push to main branch

Close #5251.

