### PR TITLE
fix wrong print

### DIFF
--- a/notebooks/Overview.ipynb
+++ b/notebooks/Overview.ipynb
@@ -2204,13 +2204,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['id', 'title', 'context', 'question', 'answers']\n"
+      "['id', 'title', 'context', 'question', 'answers', 'input_ids', 'token_type_ids', 'attention_mask']\n"
      ]
     }
    ],
    "source": [
     "# we have added additional columns\n",
-    "pprint(dataset.column_names)"
+    "pprint(encoded_dataset.column_names)"
    ]
   },
   {


### PR DESCRIPTION
print `encoded_dataset.column_names` not `dataset.column_names`