### PR TITLE
remove an unused statement

### DIFF
--- a/notebooks/Overview.ipynb
+++ b/notebooks/Overview.ipynb
@@ -2251,7 +2251,6 @@
     "# for training a model from Transformers\n",
     "def convert_to_features(batch):\n",
     "    # Tokenize contexts and questions (as pairs of inputs)\n",
-    "    input_pairs = list(zip())\n",
     "    encodings = tokenizer(batch['context'], batch['question'], truncation=True)\n",
     "\n",
     "    # Compute start and end tokens for labels\n",


### PR DESCRIPTION
remove the unused statement: `input_pairs = list(zip())`