### PR TITLE
Warn about checksums

### DIFF
--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -233,7 +233,7 @@ class DownloadManager:
             list(zip(url_or_urls.flatten(), downloaded_path_or_paths.flatten())),
             delay=delay,
             desc="Verifying checksums",
-            disable=not is_progress_bar_enabled() and not warn_about_checksums
+            disable=not is_progress_bar_enabled() and not warn_about_checksums,
         ):
             # call str to support PathLike objects
             self._recorded_sizes_checksums[str(url)] = get_size_checksum_dict(


### PR DESCRIPTION
It takes a lot of time on big datasets to compute the checksums, we should at least add a warning to notify the user about this step. I also mentioned how to disable it, and added a tqdm bar (delay=5 seconds)

cc @ola13 