### PR TITLE
Save file name in embed_storage

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -204,12 +204,11 @@ class Audio:
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, drop_paths: bool = True) -> pa.StructArray:
+    def embed_storage(self, storage: pa.StructArray) -> pa.StructArray:
         """Embed audio files into the Arrow array.
 
         Args:
             storage (pa.StructArray): PyArrow array to embed.
-            drop_paths (bool, default ``True``): If True, the paths are set to None.
 
         Returns:
             pa.StructArray: Array in the Audio arrow storage type, that is
@@ -229,7 +228,10 @@ class Audio:
             ],
             type=pa.binary(),
         )
-        path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")
+        path_array = pa.array(
+            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            type=pa.string(),
+        )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
         return array_cast(storage, self.pa_type)
 

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -215,12 +215,11 @@ class Image:
             )
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, drop_paths: bool = True) -> pa.StructArray:
+    def embed_storage(self, storage: pa.StructArray) -> pa.StructArray:
         """Embed image files into the Arrow array.
 
         Args:
             storage (pa.StructArray): PyArrow array to embed.
-            drop_paths (bool, default ``True``): If True, the paths are set to None.
 
         Returns:
             pa.StructArray: Array in the Image arrow storage type, that is
@@ -240,7 +239,10 @@ class Image:
             ],
             type=pa.binary(),
         )
-        path_array = pa.array([None] * len(storage), type=pa.string()) if drop_paths else storage.field("path")
+        path_array = pa.array(
+            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            type=pa.string(),
+        )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
         return array_cast(storage, self.pa_type)
 

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -832,3 +832,12 @@ def test_dataset_with_audio_feature_map_undecoded(shared_datadir):
             assert audio == {"path": audio_path, "bytes": None}
 
     dset.map(assert_audio_batch_undecoded, batched=True)
+
+
+def test_audio_embed_storage(shared_datadir):
+    audio_path = str(shared_datadir / "test_audio_44100.wav")
+    example = {"bytes": None, "path": audio_path}
+    storage = pa.array([example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()}))
+    embedded_storage = Audio().embed_storage(storage)
+    embedded_example = embedded_storage.to_pylist()[0]
+    assert embedded_example == {"bytes": open(audio_path, "rb").read(), "path": "test_audio_44100.wav"}

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -619,3 +619,13 @@ def test_dataset_with_image_feature_map_undecoded(shared_datadir):
             assert image == {"path": image_path, "bytes": None}
 
     dset.map(assert_image_batch_undecoded, batched=True)
+
+
+@require_pil
+def test_image_embed_storage(shared_datadir):
+    image_path = str(shared_datadir / "test_image_rgb.jpg")
+    example = {"bytes": None, "path": image_path}
+    storage = pa.array([example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()}))
+    embedded_storage = Image().embed_storage(storage)
+    embedded_example = embedded_storage.to_pylist()[0]
+    assert embedded_example == {"bytes": open(image_path, "rb").read(), "path": "test_image_rgb.jpg"}


### PR DESCRIPTION
Having the file name is useful in case we need to check the extension of the file (e.g. mp3), or in general in case it includes some metadata information (track id, image id etc.)

Related to https://github.com/huggingface/datasets/issues/5276