### PR TITLE
Fix methods using `IterableDataset.map` that lead to `features=None`

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1260,7 +1260,16 @@ class IterableDataset(DatasetInfoMixin):
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
-        return self.map(remove_columns=column_names)
+        original_features = self._info.features.copy() if self._info.features else None
+        ds_iterable = self.map(remove_columns=column_names)
+        if original_features is None:
+            ds_iterable._info.features = _infer_features_from_batch(ds_iterable._head())
+        else:
+            ds_iterable._info.features = original_features.copy()
+            for col, _ in original_features.items():
+                if col in column_names:
+                    del ds_iterable._info.features[col]
+        return ds_iterable
 
     def cast_column(self, column: str, feature: FeatureType) -> "IterableDataset":
         """Cast column to feature for decoding.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1186,9 +1186,7 @@ class IterableDataset(DatasetInfoMixin):
 
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(rename_column_fn, remove_columns=[original_column_name])
-        if original_features is None:
-            ds_iterable._info.features = _infer_features_from_batch(ds_iterable._head())
-        else:
+        if original_features is not None:
             ds_iterable._info.features = Features(
                 {
                     new_column_name if col == original_column_name else col: feature
@@ -1225,9 +1223,7 @@ class IterableDataset(DatasetInfoMixin):
 
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(rename_columns_fn, remove_columns=list(column_mapping))
-        if original_features is None:
-            ds_iterable._info.features = _infer_features_from_batch(ds_iterable._head())
-        else:
+        if original_features is not None:
             ds_iterable._info.features = Features(
                 {
                     column_mapping[col] if col in column_mapping.keys() else col: feature
@@ -1262,9 +1258,7 @@ class IterableDataset(DatasetInfoMixin):
         """
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(remove_columns=column_names)
-        if original_features is None:
-            ds_iterable._info.features = _infer_features_from_batch(ds_iterable._head())
-        else:
+        if original_features is not None:
             ds_iterable._info.features = original_features.copy()
             for col, _ in original_features.items():
                 if col in column_names:

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1184,7 +1184,7 @@ class IterableDataset(DatasetInfoMixin):
                 )
             return {new_column_name: example[original_column_name]}
 
-        original_features = self._info.features.copy()
+        original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(rename_column_fn, remove_columns=[original_column_name])
         if original_features is None:
             ds_iterable._info.features = _infer_features_from_batch(self._head())
@@ -1223,7 +1223,7 @@ class IterableDataset(DatasetInfoMixin):
                 for original_column_name, new_column_name in column_mapping.items()
             }
 
-        original_features = self._info.features.copy()
+        original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(rename_columns_fn, remove_columns=list(column_mapping))
         if original_features is None:
             ds_iterable._info.features = _infer_features_from_batch(self._head())

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1166,7 +1166,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> next(iter(ds))
         {'label': 1,
          'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
-        >>> ds.rename_column("text", "movie_review")
+        >>> ds = ds.rename_column("text", "movie_review")
         >>> next(iter(ds))
         {'label': 1,
          'movie_review': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1187,7 +1187,7 @@ class IterableDataset(DatasetInfoMixin):
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(rename_column_fn, remove_columns=[original_column_name])
         if original_features is None:
-            ds_iterable._info.features = _infer_features_from_batch(self._head())
+            ds_iterable._info.features = _infer_features_from_batch(ds_iterable._head())
         else:
             ds_iterable._info.features = Features(
                 {
@@ -1226,7 +1226,7 @@ class IterableDataset(DatasetInfoMixin):
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(rename_columns_fn, remove_columns=list(column_mapping))
         if original_features is None:
-            ds_iterable._info.features = _infer_features_from_batch(self._head())
+            ds_iterable._info.features = _infer_features_from_batch(ds_iterable._head())
         else:
             ds_iterable._info.features = Features(
                 {

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -887,6 +887,7 @@ def test_iterable_dataset_rename_column(dataset_with_several_columns):
     assert list(new_dataset) == [
         {("new_id" if k == "id" else k): v for k, v in example.items()} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is not None
 
 
 def test_iterable_dataset_rename_columns(dataset_with_several_columns):
@@ -895,6 +896,7 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns):
     assert list(new_dataset) == [
         {column_mapping.get(k, k): v for k, v in example.items()} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is not None
 
 
 def test_iterable_dataset_remove_columns(dataset_with_several_columns):

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -887,6 +887,9 @@ def test_iterable_dataset_rename_column(dataset_with_several_columns):
     assert list(new_dataset) == [
         {("new_id" if k == "id" else k): v for k, v in example.items()} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is None
+    # rename the column if ds.features was not None
+    new_dataset = dataset_with_several_columns._resolve_features().rename_column("id", "new_id")
     assert new_dataset.features is not None
 
 
@@ -896,6 +899,9 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns):
     assert list(new_dataset) == [
         {column_mapping.get(k, k): v for k, v in example.items()} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is None
+    # rename the columns if ds.features was not None
+    new_dataset = dataset_with_several_columns._resolve_features().rename_columns(column_mapping)
     assert new_dataset.features is not None
 
 
@@ -904,12 +910,14 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns):
     assert list(new_dataset) == [
         {k: v for k, v in example.items() if k != "id"} for example in dataset_with_several_columns
     ]
-    assert new_dataset.features is not None
-    assert "id" not in new_dataset.features
+    assert new_dataset.features is None
     new_dataset = dataset_with_several_columns.remove_columns(["id", "filepath"])
     assert list(new_dataset) == [
         {k: v for k, v in example.items() if k != "id" and k != "filepath"} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is None
+    # remove the columns if ds.features was not None
+    new_dataset = dataset_with_several_columns._resolve_features().remove_columns(["id", "filepath"])
     assert new_dataset.features is not None
     assert all(c not in new_dataset.features for c in ["id", "filepath"])
 

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -904,10 +904,14 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns):
     assert list(new_dataset) == [
         {k: v for k, v in example.items() if k != "id"} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is not None
+    assert "id" not in new_dataset.features
     new_dataset = dataset_with_several_columns.remove_columns(["id", "filepath"])
     assert list(new_dataset) == [
         {k: v for k, v in example.items() if k != "id" and k != "filepath"} for example in dataset_with_several_columns
     ]
+    assert new_dataset.features is not None
+    assert all(c not in new_dataset.features for c in ["id", "filepath"])
 
 
 def test_iterable_dataset_cast_column():


### PR DESCRIPTION
As currently `IterableDataset.map` is setting the `info.features` to `None` every time as we don't know the output of the dataset in advance, `IterableDataset` methods such as `rename_column`, `rename_columns`, and `remove_columns`. that internally use `map` lead to the features being `None`.

This PR is related to #3888, #5245, and #5284 

## ✅ Current solution

The code in this PR is basically making sure that if the features were there since the beginning and a `rename_column`/`rename_columns` happens, those are kept and the rename is applied to the `Features` too. Also, if the features were not there before applying `rename_column`, `rename_columns` or `remove_columns`, a batch is prefetched and the features are being inferred (that could potentially be part of `IterableDataset.__init__` in case the `info.features` value is `None`).

## 💡 Ideas

Some ideas were proposed in https://github.com/huggingface/datasets/issues/3888, but probably the most consistent solution even though it may take some time is to actually do the type inferencing during the `IterableDataset.__init__` in case the provided `info.features` is `None`, otherwise, we can just use the provided features.

Additionally, as mentioned at https://github.com/huggingface/datasets/issues/3888, we could also include a `features` parameter to the `map` function, but that's probably more tedious.

Also thanks to @lhoestq for sharing some ideas in both https://github.com/huggingface/datasets/issues/3888 and https://github.com/huggingface/datasets/issues/5245 :hugs: