### PR TITLE
Support streaming datasets with pathlib.Path.with_suffix

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -691,6 +691,10 @@ class xPath(type(Path())):
     def __truediv__(self, p: str) -> "xPath":
         return self.joinpath(p)
 
+    def with_suffix(self, suffix):
+        main_hop, *rest_hops = _as_posix(self).split("::")
+        return type(self)("::".join([_as_posix(PurePosixPath(main_hop).with_suffix(suffix))] + rest_hops))
+
 
 def xgzip_open(filepath_or_buffer, *args, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):
     import gzip

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -640,6 +640,18 @@ def test_xpathsuffix(input_path, expected):
     assert xPath(input_path).suffix == expected
 
 
+@pytest.mark.parametrize(
+    "input_path, suffix, expected",
+    [
+        ("zip://file.txt::https://host.com/archive.zip", ".ann", "zip://file.ann::https://host.com/archive.zip"),
+        ("file.txt", ".ann", "file.ann"),
+        ((Path().resolve() / "file.txt").as_posix(), ".ann", (Path().resolve() / "file.ann").as_posix()),
+    ],
+)
+def test_xpath_with_suffix(input_path, suffix, expected):
+    assert xPath(input_path).with_suffix(suffix) == xPath(expected)
+
+
 @pytest.mark.parametrize("urlpath", [r"C:\\foo\bar.txt", "/foo/bar.txt", "https://f.oo/bar.txt"])
 def test_streaming_dl_manager_download_dummy_path(urlpath):
     dl_manager = StreamingDownloadManager()


### PR DESCRIPTION
This PR extends the support in streaming mode for datasets that use `pathlib.Path.with_suffix`.

Fix #5293.