### PR TITLE
Use same `num_proc` for dataset download and generation

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -705,6 +705,7 @@ class DatasetBuilder:
                     force_download=bool(download_mode == DownloadMode.FORCE_REDOWNLOAD),
                     force_extract=bool(download_mode == DownloadMode.FORCE_REDOWNLOAD),
                     use_etag=False,
+                    num_proc=num_proc,
                     use_auth_token=use_auth_token,
                 )  # We don't use etag for data files to speed up the process
 

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -281,8 +281,7 @@ class DownloadManager:
     def download(self, url_or_urls):
         """Download given URL(s).
 
-        By default, if there is more than one URL to download, multiprocessing is used with maximum `num_proc = 16`.
-        Pass customized `download_config.num_proc` to change this behavior.
+        By default, only one process is used for download. Pass customized `download_config.num_proc` to change this behavior.
 
         Args:
             url_or_urls (`str` or `list` or `dict`): URL or list/dict of URLs to download. Each URL is a `str`.
@@ -298,10 +297,6 @@ class DownloadManager:
         """
         download_config = self.download_config.copy()
         download_config.extract_compressed_file = False
-        # Default to using 16 parallel thread for downloading
-        # Note that if we have less than or equal to 16 files, multi-processing is not activated
-        if download_config.num_proc is None:
-            download_config.num_proc = 16
         if download_config.download_desc is None:
             download_config.download_desc = "Downloading data"
 
@@ -313,7 +308,6 @@ class DownloadManager:
             url_or_urls,
             map_tuple=True,
             num_proc=download_config.num_proc,
-            parallel_min_length=16,
             disable_tqdm=not is_progress_bar_enabled(),
             desc="Downloading data files",
         )
@@ -414,8 +408,6 @@ class DownloadManager:
         # Extract downloads the file first if it is not already downloaded
         if download_config.download_desc is None:
             download_config.download_desc = "Downloading data"
-        if download_config.num_proc is None:
-            download_config.num_proc = 16
         extracted_paths = map_nested(
             partial(cached_path, download_config=download_config),
             path_or_paths,


### PR DESCRIPTION
Use the same `num_proc` value for data download and generation. Additionally, do not set `num_proc` to 16 in `DownloadManager` by default (`num_proc` now has to be specified explicitly).