### PR TITLE
Return a split Dataset in load_dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3230,7 +3230,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             input_columns=input_columns,
             desc=desc,
         )
-        return Dataset(self.data, info=indices.info, indices_table=indices.data, fingerprint=new_fingerprint)
+        info = self.info.copy()
+        if info.splits:
+            for split_name, split_info in info.splits.items():
+                split_info.num_examples = indices.info.splits[split_name].num_examples
+                split_info.num_bytes = None
+        return Dataset(self.data, info=info, indices_table=indices.data, fingerprint=new_fingerprint)
 
     @transmit_format
     @fingerprint_transform(inplace=False, ignore_kwargs=["cache_file_name"])

--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -264,7 +264,12 @@ class BaseReader:
             split = Split(str(original_instructions))
         else:
             split = None
-        dataset_kwargs = dict(arrow_table=pa_table, info=self._info, split=split)
+        if self._info:
+            info = self._info.copy()
+            info.splits = None
+        else:
+            info = None
+        dataset_kwargs = dict(arrow_table=pa_table, info=info, split=split)
         return dataset_kwargs
 
     def download_from_hf_gcs(self, download_config: DownloadConfig, relative_data_dir):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1157,9 +1157,13 @@ class DatasetDict(dict):
         # Dynamic import to avoid circular dependency
         from .io.csv import CsvDatasetReader
 
-        return CsvDatasetReader(
-            path_or_paths, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
-        ).read()
+        return DatasetDict(
+            CsvDatasetReader(
+                path_or_paths, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
+            )
+            .read()
+            .splits
+        )
 
     @staticmethod
     def from_json(
@@ -1191,9 +1195,13 @@ class DatasetDict(dict):
         # Dynamic import to avoid circular dependency
         from .io.json import JsonDatasetReader
 
-        return JsonDatasetReader(
-            path_or_paths, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
-        ).read()
+        return DatasetDict(
+            JsonDatasetReader(
+                path_or_paths, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
+            )
+            .read()
+            .splits
+        )
 
     @staticmethod
     def from_parquet(
@@ -1229,14 +1237,18 @@ class DatasetDict(dict):
         # Dynamic import to avoid circular dependency
         from .io.parquet import ParquetDatasetReader
 
-        return ParquetDatasetReader(
-            path_or_paths,
-            features=features,
-            cache_dir=cache_dir,
-            keep_in_memory=keep_in_memory,
-            columns=columns,
-            **kwargs,
-        ).read()
+        return DatasetDict(
+            ParquetDatasetReader(
+                path_or_paths,
+                features=features,
+                cache_dir=cache_dir,
+                keep_in_memory=keep_in_memory,
+                columns=columns,
+                **kwargs,
+            )
+            .read()
+            .splits
+        )
 
     @staticmethod
     def from_text(
@@ -1268,9 +1280,13 @@ class DatasetDict(dict):
         # Dynamic import to avoid circular dependency
         from .io.text import TextDatasetReader
 
-        return TextDatasetReader(
-            path_or_paths, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
-        ).read()
+        return DatasetDict(
+            TextDatasetReader(
+                path_or_paths, features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs
+            )
+            .read()
+            .splits
+        )
 
     @is_documented_by(Dataset.prepare_for_task)
     def prepare_for_task(self, task: Union[str, TaskTemplate], id: int = 0) -> "DatasetDict":

--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -134,7 +134,7 @@ class DatasetInfo:
     config_name: Optional[str] = None
     version: Optional[Union[str, Version]] = None
     # Set later by `download_and_prepare`
-    splits: Optional[dict] = None
+    splits: Optional[SplitDict] = None
     download_checksums: Optional[dict] = None
     download_size: Optional[int] = None
     post_processing_size: Optional[int] = None

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1545,7 +1545,7 @@ def load_dataset(
     streaming: bool = False,
     num_proc: int = None,
     **config_kwargs,
-) -> Union[DatasetDict, Dataset, IterableDatasetDict, IterableDataset]:
+) -> Union[Dataset, IterableDataset]:
     """Load a dataset from the Hugging Face Hub, or a local dataset.
 
     You can find the list of datasets on the Hub at https://huggingface.co/datasets or with ``datasets.list_datasets()``.

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -45,7 +45,7 @@ from .data_files import (
     get_metadata_patterns_locally,
     sanitize_patterns,
 )
-from .dataset_dict import DatasetDict, IterableDatasetDict
+from .dataset_dict import DatasetDict
 from .download.download_config import DownloadConfig
 from .download.download_manager import DownloadMode
 from .download.streaming_download_manager import StreamingDownloadManager, xglob, xjoin

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -31,17 +31,17 @@ from .utils.py_utils import NonMutableDict, asdict
 
 @dataclass
 class SplitInfo:
-    name: str = ""
-    num_bytes: int = 0
-    num_examples: int = 0
-    shard_lengths: Optional[List[int]] = None
+    name: str
+    num_bytes: Optional[int] = None
+    num_examples: Optional[int] = None
+    shard_lengths: Optional[List[int]] = dataclasses.field(default=None, repr=False)
 
     # Deprecated
     # For backward compatibility, this field needs to always be included in files like
     # dataset_infos.json and dataset_info.json files
     # To do so, we always include it in the output of datasets.utils.py_utils.asdict(split_info)
     dataset_name: Optional[str] = dataclasses.field(
-        default=None, metadata={"include_in_asdict_even_if_is_default": True}
+        default=None, metadata={"include_in_asdict_even_if_is_default": True}, repr=False
     )
 
     @property
@@ -509,7 +509,7 @@ class SplitReadInstruction:
         return list(self._splits.values())
 
 
-class SplitDict(dict):
+class SplitDict(Dict[Union[SplitBase, str], SplitInfo]):
     """Split info object."""
 
     def __init__(self, *args, dataset_name=None, **kwargs):

--- a/tests/io/test_text.py
+++ b/tests/io/test_text.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datasets import Dataset, DatasetDict, Features, NamedSplit, Value
+from datasets import Dataset, Features, NamedSplit, Value
 from datasets.io.text import TextDatasetReader
 
 from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases
@@ -65,10 +65,10 @@ def test_dataset_from_text_path_type(path_type, text_path, tmp_path):
     _check_text_dataset(dataset, expected_features)
 
 
-def _check_text_datasetdict(dataset_dict, expected_features, splits=("train",)):
-    assert isinstance(dataset_dict, DatasetDict)
+def _check_text_dataset_splits(dataset_splits, expected_features, splits=("train",)):
+    assert isinstance(dataset_splits, Dataset)
     for split in splits:
-        dataset = dataset_dict[split]
+        dataset = dataset_splits[split]
         assert dataset.num_rows == 4
         assert dataset.num_columns == 1
         assert dataset.column_names == ["text"]
@@ -77,12 +77,12 @@ def _check_text_datasetdict(dataset_dict, expected_features, splits=("train",)):
 
 
 @pytest.mark.parametrize("keep_in_memory", [False, True])
-def test_datasetdict_from_text_keep_in_memory(keep_in_memory, text_path, tmp_path):
+def test_dataset_splits_from_text_keep_in_memory(keep_in_memory, text_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"text": "string"}
     with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
         dataset = TextDatasetReader({"train": text_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
-    _check_text_datasetdict(dataset, expected_features)
+    _check_text_dataset_splits(dataset, expected_features)
 
 
 @pytest.mark.parametrize(
@@ -94,7 +94,7 @@ def test_datasetdict_from_text_keep_in_memory(keep_in_memory, text_path, tmp_pat
         {"text": "float32"},
     ],
 )
-def test_datasetdict_from_text_features(features, text_path, tmp_path):
+def test_dataset_splits_from_text_features(features, text_path, tmp_path):
     cache_dir = tmp_path / "cache"
     # CSV file loses col_1 string dtype information: default now is "int64" instead of "string"
     default_expected_features = {"text": "string"}
@@ -103,11 +103,11 @@ def test_datasetdict_from_text_features(features, text_path, tmp_path):
         Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
     )
     dataset = TextDatasetReader({"train": text_path}, features=features, cache_dir=cache_dir).read()
-    _check_text_datasetdict(dataset, expected_features)
+    _check_text_dataset_splits(dataset, expected_features)
 
 
 @pytest.mark.parametrize("split", [None, NamedSplit("train"), "train", "test"])
-def test_datasetdict_from_text_split(split, text_path, tmp_path):
+def test_dataset_splits_from_text_split(split, text_path, tmp_path):
     if split:
         path = {split: text_path}
     else:
@@ -116,5 +116,5 @@ def test_datasetdict_from_text_split(split, text_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"text": "string"}
     dataset = TextDatasetReader(path, cache_dir=cache_dir).read()
-    _check_text_datasetdict(dataset, expected_features, splits=list(path.keys()))
+    _check_text_dataset_splits(dataset, expected_features, splits=list(path.keys()))
     assert all(dataset[split].split == split for split in path.keys())

--- a/tests/packaged_modules/test_audiofolder.py
+++ b/tests/packaged_modules/test_audiofolder.py
@@ -384,7 +384,7 @@ def test_data_files_with_metadata_and_single_split(streaming, cache_dir, data_fi
     datasets = audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
     for split, data_files in data_files.items():
         expected_num_of_audios = len(data_files) - 1  # don't count the metadata file
-        assert split in datasets
+        assert split in datasets.splits
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_audios
         # make sure each sample has its own audio and metadata
@@ -402,7 +402,7 @@ def test_data_files_with_metadata_and_multiple_splits(streaming, cache_dir, data
     datasets = audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
     for split, data_files in data_files.items():
         expected_num_of_audios = len(data_files) - 1  # don't count the metadata file
-        assert split in datasets
+        assert split in datasets.splits
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_audios
         # make sure each sample has its own audio and metadata
@@ -420,7 +420,7 @@ def test_data_files_with_metadata_and_archives(streaming, cache_dir, data_files_
     for split, data_files in data_files_with_zip_archives.items():
         num_of_archives = len(data_files)  # the metadata file is inside the archive
         expected_num_of_audios = 2 * num_of_archives
-        assert split in datasets
+        assert split in datasets.splits
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_audios
         # make sure each sample has its own audio (all arrays are different) and metadata

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -391,7 +391,7 @@ def test_data_files_with_metadata_and_single_split(streaming, cache_dir, data_fi
     datasets = imagefolder.as_streaming_dataset() if streaming else imagefolder.as_dataset()
     for split, data_files in data_files.items():
         expected_num_of_images = len(data_files) - 1  # don't count the metadata file
-        assert split in datasets
+        assert split in datasets.splits
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_images
         # make sure each sample has its own image and metadata
@@ -409,7 +409,7 @@ def test_data_files_with_metadata_and_multiple_splits(streaming, cache_dir, data
     datasets = imagefolder.as_streaming_dataset() if streaming else imagefolder.as_dataset()
     for split, data_files in data_files.items():
         expected_num_of_images = len(data_files) - 1  # don't count the metadata file
-        assert split in datasets
+        assert split in datasets.splits
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_images
         # make sure each sample has its own image and metadata
@@ -427,7 +427,7 @@ def test_data_files_with_metadata_and_archives(streaming, cache_dir, data_files_
     for split, data_files in data_files_with_zip_archives.items():
         num_of_archives = len(data_files)  # the metadata file is inside the archive
         expected_num_of_images = 2 * num_of_archives
-        assert split in datasets
+        assert split in datasets.splits
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_images
         # make sure each sample has its own image and metadata

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4089,3 +4089,11 @@ class StratifiedTest(TestCase):
             assert len(d1["train"]["text"]) + len(d1["test"]["text"]) == y.size
             assert len(d1["train"]["text"]) == train_size
             assert len(d1["test"]["text"]) == test_size
+
+
+def test_dataset_from_splits_with_different_features():
+    ds_train = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    ds_test = Dataset.from_dict({"x": [True, False, True], "y": ["a", "b", "c"]})
+
+    with pytest.raises(ValueError):
+        Dataset.from_splits({"train": ds_train, "test": ds_test})

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -805,7 +805,7 @@ def test_beam_based_as_dataset(tmp_path):
 @pytest.mark.parametrize(
     "split, expected_dataset_length",
     [
-        (None, 10),
+        (None, 20),
         ("train", 10),
         ("train+test[:30%]", 13),
     ],
@@ -831,18 +831,12 @@ def test_builder_as_dataset(split, expected_dataset_length, in_memory, tmp_path)
     with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
         dataset = builder.as_dataset(split=split, in_memory=in_memory)
     assert isinstance(dataset, Dataset)
-    if isinstance(dataset, Dataset):
-        assert list(dataset.splits.keys()) == ["train", "test"]
-        datasets = dataset.splits.values()
-        expected_splits = ["train", "test"]
-    elif isinstance(dataset, Dataset):
-        datasets = [dataset]
-        expected_splits = [split]
-    for dataset, expected_split in zip(datasets, expected_splits):
-        assert dataset.split == expected_split
-        assert len(dataset) == expected_dataset_length
-        assert dataset.features == Features({"text": Value("string")})
-        dataset.column_names == ["text"]
+    if split is None:
+        assert list(dataset.splits) == ["train", "test"]
+    else:
+        dataset.splits == split
+    assert len(dataset) == expected_dataset_length
+    assert dataset.features == Features({"text": Value("string")})
 
 
 @pytest.mark.parametrize("in_memory", [False, True])

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,17 +1,9 @@
 import os
 
-import boto3
 import fsspec
 import pytest
-from moto import mock_s3
 
-from datasets.filesystems import (
-    COMPRESSION_FILESYSTEMS,
-    HfFileSystem,
-    S3FileSystem,
-    extract_path_from_uri,
-    is_remote_filesystem,
-)
+from datasets.filesystems import COMPRESSION_FILESYSTEMS, HfFileSystem, extract_path_from_uri, is_remote_filesystem
 from datasets.utils._hf_hub_fixes import dataset_info as hf_api_dataset_info
 
 from .utils import require_lz4, require_zstandard
@@ -26,17 +18,9 @@ def aws_credentials():
     os.environ["AWS_SESSION_TOKEN"] = "fake_session_token"
 
 
-@pytest.fixture(scope="function")
-def s3(aws_credentials):
-    with mock_s3():
-        yield boto3.client("s3", region_name="us-east-1")
-
-
-def test_extract_path_from_uri(s3):
+def test_extract_path_from_uri():
 
     mock_bucket = "moto-mock-s3-bucket"
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    s3.create_bucket(Bucket=mock_bucket)
 
     dataset_path = f"s3://{mock_bucket}"
 
@@ -48,11 +32,9 @@ def test_extract_path_from_uri(s3):
     assert dataset_path == new_dataset_path
 
 
-def test_is_remote_filesystem():
+def test_is_remote_filesystem(mockfs):
 
-    fs = S3FileSystem(key="fake_access_key", secret="fake_secret")
-
-    is_remote = is_remote_filesystem(fs)
+    is_remote = is_remote_filesystem(mockfs)
     assert is_remote is True
 
     fs = fsspec.filesystem("file")

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -763,10 +763,10 @@ def test_iterable_dataset_map_complex_features(
 
 @pytest.mark.parametrize("seed", [42, 1337, 101010, 123456])
 @pytest.mark.parametrize("epoch", [None, 0, 1])
-def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):
+def test_iterable_dataset_shuffle(seed, epoch):
     buffer_size = 3
-    dataset = deepcopy(dataset)
-    dataset._ex_iterable.kwargs["filepaths"] = ["0.txt", "1.txt"]
+    ex_iterable = ExamplesIterable(generate_examples_fn, {"filepaths": ["0.txt", "1.txt"]})
+    dataset = IterableDataset(ex_iterable)
     dataset = dataset.shuffle(seed, buffer_size=buffer_size)
     assert isinstance(dataset._shuffling, ShufflingConfig)
     assert isinstance(dataset._shuffling.generator, np.random.Generator)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -17,7 +17,6 @@ from datasets import config, load_dataset, load_from_disk
 from datasets.arrow_dataset import Dataset
 from datasets.builder import DatasetBuilder
 from datasets.data_files import DataFilesDict
-from datasets.dataset_dict import DatasetDict, IterableDatasetDict
 from datasets.download.download_config import DownloadConfig
 from datasets.features import Features, Value
 from datasets.iterable_dataset import IterableDataset
@@ -692,8 +691,8 @@ def test_load_dataset_builder_fail():
 def test_load_dataset_local(dataset_loading_script_dir, data_dir, keep_in_memory, caplog):
     with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
         dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, keep_in_memory=keep_in_memory)
-    assert isinstance(dataset, DatasetDict)
-    assert all(isinstance(d, Dataset) for d in dataset.values())
+    assert isinstance(dataset, Dataset)
+    assert all(isinstance(d, Dataset) for d in dataset.splits.values())
     assert len(dataset) == 2
     assert isinstance(next(iter(dataset["train"])), dict)
     for offline_simulation_mode in list(OfflineSimulationMode):
@@ -711,8 +710,8 @@ def test_load_dataset_local(dataset_loading_script_dir, data_dir, keep_in_memory
 
 def test_load_dataset_streaming(dataset_loading_script_dir, data_dir):
     dataset = load_dataset(dataset_loading_script_dir, streaming=True, data_dir=data_dir)
-    assert isinstance(dataset, IterableDatasetDict)
-    assert all(isinstance(d, IterableDataset) for d in dataset.values())
+    assert isinstance(dataset, IterableDataset)
+    assert all(isinstance(d, IterableDataset) for d in dataset.splits.values())
     assert len(dataset) == 2
     assert isinstance(next(iter(dataset["train"])), dict)
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -693,14 +693,14 @@ def test_load_dataset_local(dataset_loading_script_dir, data_dir, keep_in_memory
         dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir, keep_in_memory=keep_in_memory)
     assert isinstance(dataset, Dataset)
     assert all(isinstance(d, Dataset) for d in dataset.splits.values())
-    assert len(dataset) == 2
+    assert len(dataset.splits) == 2
     assert isinstance(next(iter(dataset["train"])), dict)
     for offline_simulation_mode in list(OfflineSimulationMode):
         with offline(offline_simulation_mode):
             caplog.clear()
             # Load dataset from cache
             dataset = datasets.load_dataset(DATASET_LOADING_SCRIPT_NAME, data_dir=data_dir)
-            assert len(dataset) == 2
+            assert len(dataset.splits) == 2
             assert "Using the latest cached version of the module" in caplog.text
     with pytest.raises(FileNotFoundError) as exc_info:
         datasets.load_dataset(SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST)
@@ -712,7 +712,7 @@ def test_load_dataset_streaming(dataset_loading_script_dir, data_dir):
     dataset = load_dataset(dataset_loading_script_dir, streaming=True, data_dir=data_dir)
     assert isinstance(dataset, IterableDataset)
     assert all(isinstance(d, IterableDataset) for d in dataset.splits.values())
-    assert len(dataset) == 2
+    assert len(dataset.splits) == 2
     assert isinstance(next(iter(dataset["train"])), dict)
 
 
@@ -933,7 +933,7 @@ def test_load_dataset_local_with_default_in_memory(
 
     with assert_arrow_memory_increases() if expected_in_memory else assert_arrow_memory_doesnt_increase():
         dataset = load_dataset(dataset_loading_script_dir, data_dir=data_dir)
-    assert (dataset["train"].dataset_size < max_in_memory_dataset_size) is expected_in_memory
+    assert (dataset.data.nbytes < max_in_memory_dataset_size) is expected_in_memory
 
 
 @pytest.mark.parametrize("max_in_memory_dataset_size", ["default", 0, 100, 1000])

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -10,7 +10,7 @@ from datasets.utils.py_utils import asdict
         SplitDict(),
         SplitDict({"train": SplitInfo(name="train", num_bytes=1337, num_examples=42, dataset_name="my_dataset")}),
         SplitDict({"train": SplitInfo(name="train", num_bytes=1337, num_examples=42)}),
-        SplitDict({"train": SplitInfo()}),
+        SplitDict({"train": SplitInfo(name="train")}),
     ],
 )
 def test_split_dict_to_yaml_list(split_dict: SplitDict):
@@ -26,7 +26,12 @@ def test_split_dict_to_yaml_list(split_dict: SplitDict):
 
 
 @pytest.mark.parametrize(
-    "split_info", [SplitInfo(), SplitInfo(dataset_name=None), SplitInfo(dataset_name="my_dataset")]
+    "split_info",
+    [
+        SplitInfo(name="train"),
+        SplitInfo(name="train", dataset_name=None),
+        SplitInfo(name="train", dataset_name="my_dataset"),
+    ],
 )
 def test_split_dict_asdict_has_dataset_name(split_info):
     # For backward compatibility, we need asdict(split_dict) to return split info dictrionaries with the "dataset_name"

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from huggingface_hub import HfApi
 
-from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
+from datasets import Audio, ClassLabel, Dataset, Features, Image, Value, load_dataset
 from datasets.utils._hf_hub_fixes import list_repo_files
 from tests.fixtures.hub import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
 from tests.utils import for_all_test_methods, require_pil, require_sndfile, xfail_if_500_502_http_error
@@ -25,10 +25,10 @@ class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)
     _token = CI_HUB_USER_TOKEN
 
-    def test_push_dataset_dict_to_hub_no_token(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_no_token(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name)
@@ -47,10 +47,10 @@ class TestPushToHub:
                 )
             )
 
-    def test_push_dataset_dict_to_hub_name_without_namespace(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_name_without_namespace(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name.split("/")[-1], token=self._token)
@@ -69,11 +69,11 @@ class TestPushToHub:
                 )
             )
 
-    def test_push_dataset_dict_to_hub_datasets_with_different_features(self, cleanup_repo):
+    def test_push_dataset_splits_to_hub_datasets_with_different_features(self, cleanup_repo):
         ds_train = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_test = Dataset.from_dict({"x": [True, False, True], "y": ["a", "b", "c"]})
 
-        local_ds = DatasetDict({"train": ds_train, "test": ds_test})
+        local_ds = Dataset.from_splits({"train": ds_train, "test": ds_test})
 
         ds_name = f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}"
         try:
@@ -83,10 +83,10 @@ class TestPushToHub:
             cleanup_repo(ds_name)
             raise
 
-    def test_push_dataset_dict_to_hub_private(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_private(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, private=True)
@@ -105,10 +105,10 @@ class TestPushToHub:
                 )
             )
 
-    def test_push_dataset_dict_to_hub(self, temporary_repo):
+    def test_push_dataset_splits_to_hub(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token)
@@ -127,10 +127,10 @@ class TestPushToHub:
                 )
             )
 
-    def test_push_dataset_dict_to_hub_multiple_files(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_multiple_files(self, temporary_repo):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
 
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             with patch("datasets.config.MAX_SHARD_SIZE", "16KB"):
@@ -156,10 +156,10 @@ class TestPushToHub:
                 )
             )
 
-    def test_push_dataset_dict_to_hub_multiple_files_with_max_shard_size(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_multiple_files_with_max_shard_size(self, temporary_repo):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
 
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, max_shard_size="16KB")
@@ -184,11 +184,11 @@ class TestPushToHub:
                 )
             )
 
-    def test_push_dataset_dict_to_hub_overwrite_files(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_overwrite_files(self, temporary_repo):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
         ds2 = Dataset.from_dict({"x": list(range(100)), "y": list(range(100))})
 
-        local_ds = DatasetDict({"train": ds, "random": ds2})
+        local_ds = Dataset.from_splits({"train": ds, "random": ds2})
 
         ds_name = f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}"
 
@@ -291,14 +291,14 @@ class TestPushToHub:
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, split="train", token=self._token)
-            local_ds_dict = {"train": local_ds}
-            hub_ds_dict = load_dataset(ds_name, download_mode="force_redownload")
+            local_ds_splits = {"train": local_ds}
+            hub_ds_splits = load_dataset(ds_name, download_mode="force_redownload")
 
-            assert list(local_ds_dict.keys()) == list(hub_ds_dict.keys())
+            assert list(local_ds_splits.splits.keys()) == list(hub_ds_splits.splits.keys())
 
-            for ds_split_name in local_ds_dict.keys():
-                local_ds = local_ds_dict[ds_split_name]
-                hub_ds = hub_ds_dict[ds_split_name]
+            for ds_split_name in local_ds_splits.splits.keys():
+                local_ds = local_ds_splits[ds_split_name]
+                hub_ds = hub_ds_splits[ds_split_name]
                 assert local_ds.column_names == hub_ds.column_names
                 assert list(local_ds.features.keys()) == list(hub_ds.features.keys())
                 assert local_ds.features == hub_ds.features
@@ -383,11 +383,11 @@ class TestPushToHub:
                 assert bool(path) == (not embed_external_files)
                 assert bool(bytes_) == embed_external_files
 
-    def test_push_dataset_dict_to_hub_custom_features(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_custom_features(self, temporary_repo):
         features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [0, 0, 1]}, features=features)
 
-        local_ds = DatasetDict({"test": ds})
+        local_ds = Dataset.from_splits({"test": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token)
@@ -444,10 +444,10 @@ class TestPushToHub:
             assert list(ds.features.keys()) == list(hub_ds["train"].features.keys())
             assert ds.features == hub_ds["train"].features
 
-    def test_push_dataset_dict_to_hub_custom_splits(self, temporary_repo):
+    def test_push_dataset_splits_to_hub_custom_splits(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        local_ds = DatasetDict({"random": ds})
+        local_ds = Dataset.from_splits({"random": ds})
 
         with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token)
@@ -458,9 +458,9 @@ class TestPushToHub:
             assert local_ds["random"].features == hub_ds["random"].features
 
     @unittest.skip("This test cannot pass until iterable datasets have push to hub")
-    def test_push_streaming_dataset_dict_to_hub(self, temporary_repo):
+    def test_push_streaming_dataset_splits_to_hub(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
-        local_ds = DatasetDict({"train": ds})
+        local_ds = Dataset.from_splits({"train": ds})
         with tempfile.TemporaryDirectory() as tmp:
             local_ds.save_to_disk(tmp)
             local_ds = load_dataset(tmp, streaming=True)


### PR DESCRIPTION
...instead of a DatasetDict.

```python
# now supported
ds = load_dataset("squad")
ds[0]  
for example in ds:
    pass

# still works
ds["train"]
ds["validation"]

# new
ds.splits  # Dict[str, Dataset] | None

# soon to be supported (not in this PR)
ds = load_dataset("dataset_with_no_splits")
ds[0]
for example in ds:
    pass
```

I implemented `Dataset.__getitem__` and `IterableDataset.__getitem__` to be able to get a split from a dataset.
The splits are defined by the `ds.info.splits` dictionary.

Therefore a dataset is a table that optionally has some splits defined in the dataset info. And a split dataset is the concatenation of all its splits.

I made as little breaking changes as possible. Notable breaking changes:
- `load_dataset("potato").keys() / .items() / .values() /` don't work anymore, since we don't return a dict
- same for `for split_name in load_dataset("potato")`, since we now iterate on the examples
- ..

TODO:
- [x] Update push_to_hub
- [x] Update save_to_disk/load_from_disk
- [ ] check for other breaking changes
- [ ] fix existing tests
- [ ] add new tests
- [ ] docs

This is related to https://github.com/huggingface/datasets/issues/5189, to extend `load_dataset` to return datasets without splits