### PR TITLE
Use correct dataset type in `from_generator` docs

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -257,7 +257,7 @@ You can also define a sharded dataset by passing lists to `gen_kwargs`:
 ...                 yield {"line": line}
 ...
 >>> shards = [f"data{i}.txt" for i in range(32)]
->>> ds = Dataset.from_generator(gen, gen_kwargs={"shards": shards})
+>>> ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": shards})
 >>> ds = ds.shuffle(seed=42, buffer_size=10_000)  # shuffles the shards order + uses a shuffle buffer
 >>> from torch.utils.data import DataLoader
 >>> dataloader = DataLoader(ds.with_format("torch"), num_workers=4)  # give each worker a subset of 32/4=8 shards


### PR DESCRIPTION
Use the correct dataset type in the `from_generator` docs (example with sharding).