### PR TITLE
Support xPath for Windows pathnames

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -691,7 +691,9 @@ class xPath(type(Path())):
         return self.joinpath(p)
 
     def with_suffix(self, suffix):
-        main_hop, *rest_hops = self.as_posix().split("::")
+        main_hop, *rest_hops = str(self).split("::")
+        if is_local_path(main_hop):
+            return type(self)(str(super().with_suffix(suffix)))
         return type(self)("::".join([type(self)(PurePosixPath(main_hop).with_suffix(suffix)).as_posix()] + rest_hops))
 
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -580,6 +580,9 @@ class xPath(type(Path())):
             str
         """
         path_as_posix = super().as_posix()
+        main_hop, *rest_hops = str(self).split("::")
+        if is_local_path(main_hop):
+            return path_as_posix
         path_as_posix = SINGLE_SLASH_AFTER_PROTOCOL_PATTERN.sub("://", path_as_posix)
         path_as_posix += "//" if path_as_posix.endswith(":") else ""  # Add slashes to root of the protocol
         return path_as_posix

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -573,16 +573,12 @@ def xwalk(urlpath, use_auth_token: Optional[Union[str, bool]] = None):
 class xPath(type(Path())):
     """Extension of `pathlib.Path` to support both local paths and remote URLs."""
 
-    def as_posix(self):
-        """Extend :meth:`pathlib.PurePath.as_posix` to fix missing slashes after protocol.
-
-        Returns:
-            str
-        """
-        path_as_posix = super().as_posix()
-        main_hop, *rest_hops = str(self).split("::")
+    def __str__(self):
+        path_str = super().__str__()
+        main_hop, *rest_hops = path_str.split("::")
         if is_local_path(main_hop):
-            return path_as_posix
+            return main_hop
+        path_as_posix = path_str.replace("\\", "/")
         path_as_posix = SINGLE_SLASH_AFTER_PROTOCOL_PATTERN.sub("://", path_as_posix)
         path_as_posix += "//" if path_as_posix.endswith(":") else ""  # Add slashes to root of the protocol
         return path_as_posix

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -482,7 +482,13 @@ def test_xrelpath(input_path, start_path, expected_path):
 class TestxPath:
     @pytest.mark.parametrize(
         "input_path, expected_path",
-        [("zip://test.txt::/Users/username/bar.zip", "zip://test.txt::/Users/username/bar.zip")],
+        [
+            ("https://host.com/archive.zip", "https://host.com/archive.zip"),
+            ("zip://file.txt::https://host.com/archive.zip", "zip://file.txt::https://host.com/archive.zip"),
+            ("zip://dir/file.txt::https://host.com/archive.zip", "zip://dir/file.txt::https://host.com/archive.zip"),
+            ("file.txt", "file.txt"),
+            (str(Path().resolve() / "file.txt"), (Path().resolve() / "file.txt").as_posix()),
+        ],
     )
     def test_xpath_as_posix(self, input_path, expected_path):
         assert xPath(input_path).as_posix() == expected_path
@@ -585,28 +591,23 @@ class TestxPath:
     @pytest.mark.parametrize(
         "input_path, expected_path",
         [
-            (Path(__file__).resolve(), Path(__file__).resolve().parent),
-            (Path("https://host.com/archive.zip"), Path("https://host.com")),
-            (
-                Path("zip://file.txt::https://host.com/archive.zip"),
-                Path("zip://::https://host.com/archive.zip"),
-            ),
-            (
-                Path("zip://folder/file.txt::https://host.com/archive.zip"),
-                Path("zip://folder::https://host.com/archive.zip"),
-            ),
+            ("https://host.com/archive.zip", "https://host.com"),
+            ("zip://file.txt::https://host.com/archive.zip", "zip://::https://host.com/archive.zip"),
+            ("zip://dir/file.txt::https://host.com/archive.zip", "zip://dir::https://host.com/archive.zip"),
+            ("file.txt", ""),
+            (str(Path().resolve() / "file.txt"), str(Path().resolve())),
         ],
     )
     def test_xpath_parent(self, input_path, expected_path):
-        output_path = xPath(input_path).parent
-        output_path = _readd_double_slash_removed_by_path(output_path.as_posix())
-        assert output_path == _readd_double_slash_removed_by_path(expected_path.as_posix())
+        assert xPath(input_path).parent == xPath(expected_path)
 
     @pytest.mark.parametrize(
         "input_path, expected",
         [
+            ("https://host.com/archive.zip", "archive.zip"),
             ("zip://file.txt::https://host.com/archive.zip", "file.txt"),
-            ("datasets/file.txt", "file.txt"),
+            ("zip://dir/file.txt::https://host.com/archive.zip", "file.txt"),
+            ("file.txt", "file.txt"),
             (str(Path().resolve() / "file.txt"), "file.txt"),
         ],
     )
@@ -616,7 +617,9 @@ class TestxPath:
     @pytest.mark.parametrize(
         "input_path, expected",
         [
+            ("https://host.com/archive.zip", "archive"),
             ("zip://file.txt::https://host.com/archive.zip", "file"),
+            ("zip://dir/file.txt::https://host.com/archive.zip", "file"),
             ("file.txt", "file"),
             (str(Path().resolve() / "file.txt"), "file"),
         ],
@@ -627,7 +630,9 @@ class TestxPath:
     @pytest.mark.parametrize(
         "input_path, expected",
         [
+            ("https://host.com/archive.zip", ".zip"),
             ("zip://file.txt::https://host.com/archive.zip", ".txt"),
+            ("zip://dir/file.txt::https://host.com/archive.zip", ".txt"),
             ("file.txt", ".txt"),
             (str(Path().resolve() / "file.txt"), ".txt"),
         ],
@@ -638,7 +643,13 @@ class TestxPath:
     @pytest.mark.parametrize(
         "input_path, suffix, expected",
         [
+            ("https://host.com/archive.zip", ".ann", "https://host.com/archive.ann"),
             ("zip://file.txt::https://host.com/archive.zip", ".ann", "zip://file.ann::https://host.com/archive.zip"),
+            (
+                "zip://dir/file.txt::https://host.com/archive.zip",
+                ".ann",
+                "zip://dir/file.ann::https://host.com/archive.zip",
+            ),
             ("file.txt", ".ann", "file.ann"),
             (str(Path().resolve() / "file.txt"), ".ann", str(Path().resolve() / "file.ann")),
         ],

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -9,7 +9,6 @@ from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 
 from datasets.download.streaming_download_manager import (
     StreamingDownloadManager,
-    _as_posix,
     _get_extraction_protocol,
     xbasename,
     xgetsize,
@@ -152,14 +151,6 @@ def _readd_double_slash_removed_by_path(path_as_posix: str) -> str:
         str: the url path with :// instead of :/
     """
     return re.sub("([A-z]:/)([A-z:])", r"\g<1>/\g<2>", path_as_posix)
-
-
-@pytest.mark.parametrize(
-    "input_path, expected_path",
-    [("zip:/test.txt::/Users/username/bar.zip", "zip://test.txt::/Users/username/bar.zip")],
-)
-def test_as_posix(input_path, expected_path):
-    assert _as_posix(Path(input_path)) == expected_path
 
 
 @pytest.mark.parametrize(
@@ -486,6 +477,14 @@ def test_xwalk_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
 def test_xrelpath(input_path, start_path, expected_path):
     output_path = xrelpath(input_path, start=start_path)
     assert output_path == expected_path
+
+
+@pytest.mark.parametrize(
+    "input_path, expected_path",
+    [("zip:/test.txt::/Users/username/bar.zip", "zip://test.txt::/Users/username/bar.zip")],
+)
+def test_xpath_as_posix(input_path, expected_path):
+    assert xPath(input_path).as_posix() == expected_path
 
 
 @pytest.mark.parametrize(

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -481,7 +481,7 @@ def test_xrelpath(input_path, start_path, expected_path):
 
 @pytest.mark.parametrize(
     "input_path, expected_path",
-    [("zip:/test.txt::/Users/username/bar.zip", "zip://test.txt::/Users/username/bar.zip")],
+    [("zip://test.txt::/Users/username/bar.zip", "zip://test.txt::/Users/username/bar.zip")],
 )
 def test_xpath_as_posix(input_path, expected_path):
     assert xPath(input_path).as_posix() == expected_path

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -646,7 +646,7 @@ def test_xpathsuffix(input_path, expected):
     [
         ("zip://file.txt::https://host.com/archive.zip", ".ann", "zip://file.ann::https://host.com/archive.zip"),
         ("file.txt", ".ann", "file.ann"),
-        ((Path().resolve() / "file.txt").as_posix(), ".ann", (Path().resolve() / "file.ann").as_posix()),
+        (str(Path().resolve() / "file.txt"), ".ann", str(Path().resolve() / "file.ann")),
     ],
 )
 def test_xpath_with_suffix(input_path, suffix, expected):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -481,6 +481,19 @@ def test_xrelpath(input_path, start_path, expected_path):
 
 class TestxPath:
     @pytest.mark.parametrize(
+        "input_path",
+        [
+            "https://host.com/archive.zip",
+            "zip://file.txt::https://host.com/archive.zip",
+            "zip://dir/file.txt::https://host.com/archive.zip",
+            "file.txt",
+            str(Path().resolve() / "file.txt"),
+        ],
+    )
+    def test_xpath_str(self, input_path):
+        assert str(xPath(input_path)) == input_path
+
+    @pytest.mark.parametrize(
         "input_path, expected_path",
         [
             ("https://host.com/archive.zip", "https://host.com/archive.zip"),

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -607,7 +607,7 @@ class TestxPath:
         [
             ("zip://file.txt::https://host.com/archive.zip", "file.txt"),
             ("datasets/file.txt", "file.txt"),
-            ((Path().resolve() / "file.txt").as_posix(), "file.txt"),
+            (str(Path().resolve() / "file.txt"), "file.txt"),
         ],
     )
     def test_xpath_name(self, input_path, expected):
@@ -618,7 +618,7 @@ class TestxPath:
         [
             ("zip://file.txt::https://host.com/archive.zip", "file"),
             ("file.txt", "file"),
-            ((Path().resolve() / "file.txt").as_posix(), "file"),
+            (str(Path().resolve() / "file.txt"), "file"),
         ],
     )
     def test_xpath_stem(self, input_path, expected):
@@ -629,7 +629,7 @@ class TestxPath:
         [
             ("zip://file.txt::https://host.com/archive.zip", ".txt"),
             ("file.txt", ".txt"),
-            ((Path().resolve() / "file.txt").as_posix(), ".txt"),
+            (str(Path().resolve() / "file.txt"), ".txt"),
         ],
     )
     def test_xpath_suffix(self, input_path, expected):


### PR DESCRIPTION
This PR implements a string representation of `xPath`, which is valid for local paths (also windows) and remote URLs.

Additionally, some `os.path` methods are fixed for remote URLs on Windows machines.

Now, on Windows machines:
```python
In [2]: str(xPath("C:\\dir\\file.txt"))
Out[2]: 'C:\\dir\\file.txt'
In [3]: str(xPath("http://domain.com/file.txt"))
Out[3]: 'http://domain.com/file.txt'
```