### PR TITLE
Add `features` param to `IterableDataset.map`

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -838,6 +838,7 @@ class IterableDataset(DatasetInfoMixin):
         batch_size: int = 1000,
         drop_last_batch: bool = False,
         remove_columns: Optional[Union[str, List[str]]] = None,
+        features: Optional[Features] = None,
         fn_kwargs: Optional[dict] = None,
     ) -> "IterableDataset":
         """
@@ -877,6 +878,8 @@ class IterableDataset(DatasetInfoMixin):
             remove_columns (`Optional[List[str]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
+            features (`Optional[datasets.Features]`, defaults to `None`): Use a specific Features to store the cache file
+                instead of the automatically generated one.
             fn_kwargs (:obj:`Dict`, optional, default `None`): Keyword arguments to be passed to `function`.
 
         Example:
@@ -918,7 +921,7 @@ class IterableDataset(DatasetInfoMixin):
             fn_kwargs=fn_kwargs,
         )
         info = self.info.copy()
-        info.features = None
+        info.features = features
         return iterable_dataset(
             ex_iterable=ex_iterable,
             info=info,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -878,8 +878,7 @@ class IterableDataset(DatasetInfoMixin):
             remove_columns (`Optional[List[str]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
-            features (`Optional[datasets.Features]`, defaults to `None`): Use a specific Features to store the cache file
-                instead of the automatically generated one.
+            features (`Optional[datasets.Features]`, defaults to `None`): Feature types of the resulting dataset.
             fn_kwargs (:obj:`Dict`, optional, default `None`): Keyword arguments to be passed to `function`.
 
         Example:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -761,6 +761,30 @@ def test_iterable_dataset_map_complex_features(
     ]
 
 
+def test_iterable_dataset_map_with_features(dataset: IterableDataset) -> None:
+    # https://github.com/huggingface/datasets/issues/3888
+    ex_iterable = ExamplesIterable(generate_examples_fn, {"label": "positive"})
+    features_before_map = Features(
+        {
+            "id": Value("int64"),
+            "label": Value("string"),
+        }
+    )
+    dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features_before_map))
+    assert dataset.info.features is not None
+    assert dataset.info.features == features_before_map
+    features_after_map = Features(
+        {
+            "id": Value("int64"),
+            "label": Value("string"),
+            "target": Value("string"),
+        }
+    )
+    dataset = dataset.map(lambda x: {"target": x["label"]}, features=features_after_map)
+    assert dataset.info.features is not None
+    assert dataset.info.features == features_after_map
+
+
 @pytest.mark.parametrize("seed", [42, 1337, 101010, 123456])
 @pytest.mark.parametrize("epoch", [None, 0, 1])
 def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):


### PR DESCRIPTION
## Description

As suggested by @lhoestq in #3888, we should be adding the param `features` to `IterableDataset.map` so that the features can be preserved (not turned into `None` as that's the default behavior) whenever the user passes those as param, so as to be consistent with `Dataset.map`, as it provides the `features` param so that those are not inferred by default, but specified by the user, and later validated by `ArrowWriter`.

This is internally handled already by the functions relying on `IterableDataset.map` such as `rename_column`, `rename_columns`, and `remove_columns` as described in #5287.

## Usage Example

```python
from datasets import load_dataset, Features

ds = load_dataset("rotten_tomatoes", split="validation", streaming=True)
print(ds.info.features)
ds = ds.map(
    lambda x: {"target": x["label"]},
    features=Features(
        {"target": ds.info.features["label"], "label": ds.info.features["label"], "text": ds.info.features["text"]}
    ),
)
print(ds.info.features)
```