### PR TITLE
Add DatasetDict.to_pandas

### DIFF
--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -143,6 +143,7 @@ It also has dataset transform methods like map or filter, to process all the spl
     - from_parquet
     - from_text
     - prepare_for_task
+    - to_pandas
 
 <a id='package_reference_features'></a>
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4194,7 +4194,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
-        >>> ds.to_pandas()
+        >>> df = ds.to_pandas()
         ```
         """
         if not batched:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1434,7 +1434,7 @@ class DatasetDict(Dict[str, Dataset]):
         You must specify which splits to convert if the dataset is made of multiple splits.
 
         Args:
-            splits (:obj:`List[str]`, optional): List of splits to convert to a DataFrame.
+            splits (:obj:`Union[Literal["all"], List[str]]`, optional): List of splits to convert to a DataFrame.
                 You don't need to specify the splits if there's only one.
                 Use splits="all" to convert all the splits (they will be converted in the order of the dictionary).
             batched (:obj:`bool`): Set to :obj:`True` to return a generator that yields the dataset as batches
@@ -1470,6 +1470,9 @@ class DatasetDict(Dict[str, Dataset]):
                 '\n    df = ds.to_pandas(splits="all")'
             )
         splits = splits if splits is not None and splits != "all" else list(self)
+        bad_splits = list(set(splits) - set(self))
+        if bad_splits:
+            raise ValueError(f"Can't convert those splits to pandas : {bad_splits}. Available splits: {list(self)}.")
         if batched:
             return (df for split in splits for df in self[split].to_pandas(batch_size=batch_size, batched=batched))
         else:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -12,6 +12,7 @@ import fsspec
 import numpy as np
 import pandas as pd
 from huggingface_hub import HfApi
+from typing_extensions import Literal
 
 from datasets.utils.metadata import DatasetMetadata
 
@@ -1423,7 +1424,10 @@ class DatasetDict(Dict[str, Dataset]):
         )
 
     def to_pandas(
-        self, splits: Optional[List[str]] = None, batch_size: Optional[int] = None, batched: bool = False
+        self,
+        splits: Optional[Union[Literal["all"], List[str]]] = None,
+        batch_size: Optional[int] = None,
+        batched: bool = False,
     ) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
         """Returns the dataset as a :class:`pandas.DataFrame`. Can also return a generator for large datasets.
 
@@ -1432,6 +1436,7 @@ class DatasetDict(Dict[str, Dataset]):
         Args:
             splits (:obj:`List[str]`, optional): List of splits to convert to a DataFrame.
                 You don't need to specify the splits if there's only one.
+                Use splits="all" to convert all the splits (they will be converted in the order of the dictionary).
             batched (:obj:`bool`): Set to :obj:`True` to return a generator that yields the dataset as batches
                 of ``batch_size`` rows. Defaults to :obj:`False` (returns the whole datasets once)
             batch_size (:obj:`int`, optional): The size (number of rows) of the batches if ``batched`` is `True`.
@@ -1450,6 +1455,7 @@ class DatasetDict(Dict[str, Dataset]):
         If the dataset has multiple splits:
         ```py
         >>> df_train = dataset_dict["train"].to_pandas()
+        >>> df_test = dataset_dict.to_pandas(splits="all")
         >>> df_test = dataset_dict.to_pandas(splits=["train", "test"])
         ```
         """
@@ -1462,7 +1468,7 @@ class DatasetDict(Dict[str, Dataset]):
                 '\n    df = ds["train"].to_pandas()'
                 '\n    df = ds.to_pandas(splits=["train", "test"])'
             )
-        splits = splits if splits is not None else list(self)
+        splits = splits if splits is not None and splits != "all" else list(self)
         if batched:
             return (df for split in splits for df in self[split].to_pandas(batch_size=batch_size, batched=batched))
         else:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1455,8 +1455,8 @@ class DatasetDict(Dict[str, Dataset]):
         If the dataset has multiple splits:
         ```py
         >>> df_train = dataset_dict["train"].to_pandas()
-        >>> df_test = dataset_dict.to_pandas(splits="all")
-        >>> df_test = dataset_dict.to_pandas(splits=["train", "test"])
+        >>> df_all = dataset_dict.to_pandas(splits="all")
+        >>> df_train_test = dataset_dict.to_pandas(splits=["train", "test"])
         ```
         """
         self._check_values_type()
@@ -1467,6 +1467,7 @@ class DatasetDict(Dict[str, Dataset]):
                 f"Available splits: {list(self)}. For example:"
                 '\n    df = ds["train"].to_pandas()'
                 '\n    df = ds.to_pandas(splits=["train", "test"])'
+                '\n    df = ds.to_pandas(splits="all")'
             )
         splits = splits if splits is not None and splits != "all" else list(self)
         if batched:

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -708,6 +708,10 @@ def test_datasetdict_to_pandas():
     )
     with pytest.raises(SplitsError):
         df = dsets.to_pandas()
+    df = dsets.to_pandas(splits=["train", "test"])
+    assert df.shape == (4, 2)
+    assert list(df["foo"]) == ["hello", "there", "general", "kenobi"]
+    assert list(df["bar"]) == [0, 1, 2, 3]
 
     # batched
     dsets = DatasetDict(

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -8,7 +8,7 @@ import pytest
 
 from datasets import load_from_disk
 from datasets.arrow_dataset import Dataset
-from datasets.dataset_dict import DatasetDict
+from datasets.dataset_dict import DatasetDict, SplitsError
 from datasets.features import ClassLabel, Features, Sequence, Value
 from datasets.splits import NamedSplit
 
@@ -706,10 +706,8 @@ def test_datasetdict_to_pandas():
             "test": Dataset.from_dict({"foo": ["general", "kenobi"], "bar": [2, 3]}),
         }
     )
-    df = dsets.to_pandas()
-    assert df.shape == (4, 2)
-    assert list(df["foo"]) == ["hello", "there", "general", "kenobi"]
-    assert list(df["bar"]) == [0, 1, 2, 3]
+    with pytest.raises(SplitsError):
+        df = dsets.to_pandas()
 
     # batched
     dsets = DatasetDict(

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -712,6 +712,10 @@ def test_datasetdict_to_pandas():
     assert df.shape == (4, 2)
     assert list(df["foo"]) == ["hello", "there", "general", "kenobi"]
     assert list(df["bar"]) == [0, 1, 2, 3]
+    df = dsets.to_pandas(splits="all")
+    assert df.shape == (4, 2)
+    assert list(df["foo"]) == ["hello", "there", "general", "kenobi"]
+    assert list(df["bar"]) == [0, 1, 2, 3]
 
     # batched
     dsets = DatasetDict(


### PR DESCRIPTION
From discussions in https://github.com/huggingface/datasets/issues/5189, for tabular data it doesn't really make sense to have to do
```python
df = load_dataset(...)["train"].to_pandas()
```
because many datasets are not split.

In this PR I added `to_pandas` to `DatasetDict` which returns the DataFrame:

If there's only one split, you don't need to specify the split name:
```python
df = load_dataset(...).to_pandas()
```
EDIT: and if a dataset has multiple splits:
```python
df = load_dataset(...).to_pandas(splits=["train", "test"])
# or
df = load_dataset(...).to_pandas(splits="all")

# raises an error because you need to select the split(s) to convert
load_dataset(...).to_pandas()
```

I do have one question though @merveenoyan @adrinjalali @mariosasko:

Should we raise an error if there are multiple splits and ask the user to choose one explicitly ?

