### PR TITLE
Fix description of streaming in the docs

### DIFF
--- a/docs/source/audio_dataset.mdx
+++ b/docs/source/audio_dataset.mdx
@@ -367,7 +367,7 @@ def _info(self):
 
 Now that you've added some information about your dataset, the next step is to download the dataset and define the splits.
 
-1. Use the [`~DownloadManager.download`] method to download metadata file at `_PROMPTS_URLS` and audio TAR archive at `_DATA_URL`. This method returns the path to the local file/archive. In streaming mode, it doesn't download the file(s) and returns a URL to stream the data from. This method accepts:
+1. Use the [`~DownloadManager.download`] method to download metadata file at `_PROMPTS_URLS` and audio TAR archive at `_DATA_URL`. This method returns the path to the local file/archive. In streaming mode, it doesn't download the file(s) and just returns a URL to stream the data from. This method accepts:
 
     * a relative path to a file inside a Hub dataset repository (for example, in the `data/` folder)
     * a URL to a file hosted somewhere else

--- a/docs/source/audio_dataset.mdx
+++ b/docs/source/audio_dataset.mdx
@@ -192,9 +192,9 @@ This directory structure allows your dataset to be loaded in one line:
 ```
 
 This guide will show you how to create a dataset loading script for audio datasets, which is a bit different from <a class="underline decoration-green-400 decoration-2 font-semibold" href="./dataset_script">creating a loading script for text datasets</a>.
-Audio datasets are commonly stored in `tar.gz` archives which requires a particular approach to support streaming mode. While streaming is not required, we highly encourage enabling streaming support in your audio dataset because:
+Audio datasets are commonly stored in `tar.gz` archives which requires a particular approach to support streaming mode. While streaming is not required, we highly encourage implementing streaming support in your audio dataset because:
 
-1. Users without a lot of disk space can use your dataset without waiting for the entire dataset to be downloaded. Learn more about streaming in the [Stream](./stream) guide!
+1. Users without a lot of disk space can use your dataset without downloading it. Learn more about streaming in the [Stream](./stream) guide!
 2. Users can preview a dataset in the dataset viewer.
 
 Here is an example using TAR archives:
@@ -367,7 +367,7 @@ def _info(self):
 
 Now that you've added some information about your dataset, the next step is to download the dataset and define the splits.
 
-1. Use the [`~DownloadManager.download`] method to download metadata file at `_PROMPTS_URLS` and audio TAR archive at `_DATA_URL`. This method returns the path to the local file/archive. In streaming mode, it returns a URL to stream the data from. This method accepts:
+1. Use the [`~DownloadManager.download`] method to download metadata file at `_PROMPTS_URLS` and audio TAR archive at `_DATA_URL`. This method returns the path to the local file/archive. In streaming mode, it doesn't download the file(s) and returns a URL to stream the data from. This method accepts:
 
     * a relative path to a file inside a Hub dataset repository (for example, in the `data/` folder)
     * a URL to a file hosted somewhere else
@@ -504,21 +504,15 @@ To explain how to do the extraction in a way that it also supports streaming, we
    local_extracted_archive = dl_manager.extract(audio_path) if not dl_manager.is_streaming else None
    ```
 
-3. Use the [`~DownloadManager.iter_archive`] method to iterate over the archive at `audio_path` after it's downloaded, just like in the Vivos example above. [`~DownloadManager.iter_archive`] doesn't provide any information about the full paths of files from the archive, even if it has been extracted. As a result, you need to pass the `local_extracted_archive` path to the next step in `gen_kwargs`, in order to preserve information about where the archive was extracted to. This is required to construct the correct paths to the local files when you generate the examples.
+3. Use the [`~DownloadManager.iter_archive`] method to iterate over the archive at `audio_path`, just like in the Vivos example above. [`~DownloadManager.iter_archive`] doesn't provide any information about the full paths of files from the archive, even if it has been extracted. As a result, you need to pass the `local_extracted_archive` path to the next step in `gen_kwargs`, in order to preserve information about where the archive was extracted to. This is required to construct the correct paths to the local files when you generate the examples.
 
-<Tip>
+<Tip warning={true}>
 
-The reason you need to use a combination of [`~DownloadManager.download`] and [`~DownloadManager.iter_archive`] is because data in TAR archives can't be accessed directly from their paths. Instead, you'll need to download it first and then sequentially iterate over the files within the archive!
-
-</Tip>
-
-4. Use the [`~DownloadManager.download_and_extract`] method to download the metadata file specified in `_METADATA_URL`. This method returns a path to a local file in non-streaming mode. In streaming mode, it opens the file at the URL remotely and returns this URL.
-
-<Tip>
-
-    You can use [`~DownloadManager.download_and_extract`] to download and extract TAR archives too, but this method, as well as [`~DownloadManager.extract`], would throw an error if you run [`~Datasets.load_dataset`] in streaming mode, i.e. with `streaming=True`. This is the reason you need to use a combination of [`~DownloadManager.download`] and [`~DownloadManager.iter_archive`]. Files in TAR archives can't be accessed directly by their paths. Instead, you have to sequentially iterate over the files within the archive to find a specific file.
+The reason you need to use a combination of [`~DownloadManager.download`] and [`~DownloadManager.iter_archive`] is because files in TAR archives can't be accessed directly by their paths. Instead, you'll need to iterate over the files within the archive! You can use [`~DownloadManager.download_and_extract`] and [`~DownloadManager.extract`] with TAR archives only in non-streaming mode, otherwise it would throw an error.
 
 </Tip>
+
+4. Use the [`~DownloadManager.download_and_extract`] method to download the metadata file specified in `_METADATA_URL`. This method returns a path to a local file in non-streaming mode. In streaming mode, it doesn't download file locally and returns the same URL.
 
 5. Now use the [`SplitGenerator`] to organize the audio files and metadata in each split. Name each split with a standard name like: `Split.TRAIN`, `Split.TEST`, and `SPLIT.Validation`.
 

--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -1,9 +1,10 @@
 # Stream
 
-Dataset streaming lets you get started with a dataset without waiting for the entire dataset to download. The data is downloaded progressively as you iterate over the dataset. This is especially helpful when:
+Dataset streaming lets you work with a dataset without downloading it. The data is streamed progressively as you iterate over the dataset. This is especially helpful when:
 
 - You don't want to wait for an extremely large dataset to download.
 - The dataset size exceeds the amount of disk space on your computer.
+- You want to quickly explore just a few samples of a dataset.
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/streaming.gif"/>

--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -1,6 +1,6 @@
 # Stream
 
-Dataset streaming lets you work with a dataset without downloading it. The data is streamed progressively as you iterate over the dataset. This is especially helpful when:
+Dataset streaming lets you work with a dataset without downloading it. The data is streamed as you iterate over the dataset. This is especially helpful when:
 
 - You don't want to wait for an extremely large dataset to download.
 - The dataset size exceeds the amount of disk space on your computer.
@@ -42,7 +42,7 @@ The `buffer_size` argument controls the size of the buffer to randomly sample ex
 
 <Tip>
 
-[`IterableDataset.shuffle`] will also shuffle the order of the shards if the dataset is sharded into multiple sets.
+[`IterableDataset.shuffle`] will also shuffle the order of the shards if the dataset is sharded into multiple files.
 
 </Tip>
 

--- a/docs/source/upload_dataset.mdx
+++ b/docs/source/upload_dataset.mdx
@@ -126,7 +126,7 @@ Congratulations, you've completed the tutorials! 🥳
 From here, you can go on to:
 
 - Learn more about how to use 🤗 Datasets other functions to [process your dataset](process).
-- [Stream large datasets](stream) and avoid waiting for the entire dataset to download.
+- [Stream large datasets](stream) without downloading it locally.
 - [Write a dataset loading script](dataset_script) and share your dataset with the community.
 
 If you have any questions about 🤗 Datasets, feel free to join and ask the community on our [forum](https://discuss.huggingface.co/c/datasets/10).

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -889,7 +889,7 @@ class StreamingDownloadManager:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: Urls to stream data from corresponding to the given input url_or_urls.
+            `str`: URL(s) to stream data from corresponding to the given input url_or_urls.
 
         Example:
 
@@ -909,13 +909,14 @@ class StreamingDownloadManager:
 
     def extract(self, url_or_urls):
         """Add extraction protocol for given url(s) for streaming.
-        This is the lazy version of DownloadManager.extract for streaming.
+
+        This is the lazy version of `DownloadManager.extract` for streaming.
 
         Args:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: Urls to stream data from matching the given input path_or_paths.
+            `str`: URL(s) to stream data from matching the given input path_or_paths.
 
         Example:
 
@@ -947,7 +948,8 @@ class StreamingDownloadManager:
 
     def download_and_extract(self, url_or_urls):
         """Prepare given url_or_urls for streaming.
-        This is the lazy version of DownloadManager.download_and_extract for streaming.
+
+        This is the lazy version of `DownloadManager.download_and_extract` for streaming.
 
         Is equivalent to:
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -949,7 +949,7 @@ class StreamingDownloadManager:
             return f"{protocol}://::{urlpath}"
 
     def download_and_extract(self, url_or_urls):
-        """Prepare given url_or_urls for streaming.
+        """Prepare given url_or_urls for streaming (add extraction protocol).
 
         This is the lazy version of `DownloadManager.download_and_extract` for streaming.
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -882,13 +882,13 @@ class StreamingDownloadManager:
         return self._data_dir
 
     def download(self, url_or_urls):
-        """Download given url(s).
+        """Normalize url(s) of files to stream data from.
 
         Args:
-            url_or_urls (`str` or `list` or `dict`): URL or URLs to download and extract. Each url is a `str`.
+            url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: Downloaded paths matching the given input url_or_urls.
+            `str`: Urls to stream data from corresponding to the given input url_or_urls.
 
         Example:
 
@@ -906,14 +906,14 @@ class StreamingDownloadManager:
             urlpath = url_or_path_join(self._base_path, urlpath)
         return urlpath
 
-    def extract(self, path_or_paths):
-        """Extract given path(s).
+    def extract(self, url_or_urls):
+        """Add extraction protocol for given url(s) for streaming.
 
         Args:
-            path_or_paths (`str` or `list` or `dict`): Path or paths of file to extract. Each path is a `str`.
+            url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: Extracted paths matching the given input path_or_paths.
+            `str`: Urls to stream data from matching the given input path_or_paths.
 
         Example:
 
@@ -922,7 +922,7 @@ class StreamingDownloadManager:
         >>> extracted_files = dl_manager.extract(downloaded_files)
         ```
         """
-        urlpaths = map_nested(self._extract, path_or_paths, map_tuple=True)
+        urlpaths = map_nested(self._extract, url_or_urls, map_tuple=True)
         return urlpaths
 
     def _extract(self, urlpath: str) -> str:
@@ -944,20 +944,19 @@ class StreamingDownloadManager:
             return f"{protocol}://::{urlpath}"
 
     def download_and_extract(self, url_or_urls):
-        """Download and extract given url_or_urls.
+        """Prepare given url_or_urls for streaming.
 
-        Is roughly equivalent to:
+        Is equivalent to:
 
         ```
-        extracted_paths = dl_manager.extract(dl_manager.download(url_or_urls))
+        urls = dl_manager.extract(dl_manager.download(url_or_urls))
         ```
 
         Args:
-            url_or_urls: url or `list`/`dict` of urls to download and extract. Each
-                url is a `str`.
+            url_or_urls: url or `list`/`dict` of urls to stream from. Each url is a `str`.
 
         Returns:
-            extracted_path(s): `str`, extracted paths of given URL(s).
+            url(s): `str`, extracted paths of given URL(s).
         """
         return self.extract(self.download(url_or_urls))
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -883,6 +883,7 @@ class StreamingDownloadManager:
 
     def download(self, url_or_urls):
         """Normalize url(s) of files to stream data from.
+        This is the lazy version of DownloadManager.download for streaming.
 
         Args:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
@@ -908,6 +909,7 @@ class StreamingDownloadManager:
 
     def extract(self, url_or_urls):
         """Add extraction protocol for given url(s) for streaming.
+        This is the lazy version of DownloadManager.extract for streaming.
 
         Args:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
@@ -945,6 +947,7 @@ class StreamingDownloadManager:
 
     def download_and_extract(self, url_or_urls):
         """Prepare given url_or_urls for streaming.
+        This is the lazy version of DownloadManager.download_and_extract for streaming.
 
         Is equivalent to:
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -891,7 +891,7 @@ class StreamingDownloadManager:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: URL(s) to stream data from corresponding to the given input url_or_urls.
+            `str`: URL(s) to stream data from matching the given input url_or_urls.
 
         Example:
 
@@ -918,7 +918,7 @@ class StreamingDownloadManager:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: URL(s) to stream data from matching the given input path_or_paths.
+            `str`: URL(s) to stream data from matching the given input url_or_urls.
 
         Example:
 
@@ -963,7 +963,7 @@ class StreamingDownloadManager:
             url_or_urls: url or `list`/`dict` of urls to stream from. Each url is a `str`.
 
         Returns:
-            url(s): `str`, extracted paths of given URL(s).
+            url(s): `str`, URL(s) to stream data from matching the given input url_or_urls.
         """
         return self.extract(self.download(url_or_urls))
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -891,7 +891,7 @@ class StreamingDownloadManager:
             url_or_urls (`str` or `list` or `dict`): URL(s) of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str` or `list` or `dict`: URL(s) to stream data from matching the given input url_or_urls.
+            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input url_or_urls.
 
         Example:
 
@@ -918,7 +918,7 @@ class StreamingDownloadManager:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str` or `list` or `dict`: URL(s) to stream data from matching the given input url_or_urls.
+            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input url_or_urls.
 
         Example:
 
@@ -963,7 +963,7 @@ class StreamingDownloadManager:
             url_or_urls: url or `list`/`dict` of urls to stream from. Each url is a `str`.
 
         Returns:
-            `str` or `list` or `dict`: URL(s) to stream data from matching the given input url_or_urls.
+            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input url_or_urls.
         """
         return self.extract(self.download(url_or_urls))
 

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -884,14 +884,14 @@ class StreamingDownloadManager:
         return self._data_dir
 
     def download(self, url_or_urls):
-        """Normalize url(s) of files to stream data from.
+        """Normalize URL(s) of files to stream data from.
         This is the lazy version of DownloadManager.download for streaming.
 
         Args:
-            url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
+            url_or_urls (`str` or `list` or `dict`): URL(s) of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: URL(s) to stream data from matching the given input url_or_urls.
+            `str` or `list` or `dict`: URL(s) to stream data from matching the given input url_or_urls.
 
         Example:
 
@@ -918,7 +918,7 @@ class StreamingDownloadManager:
             url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
 
         Returns:
-            `str`: URL(s) to stream data from matching the given input url_or_urls.
+            `str` or `list` or `dict`: URL(s) to stream data from matching the given input url_or_urls.
 
         Example:
 
@@ -963,7 +963,7 @@ class StreamingDownloadManager:
             url_or_urls: url or `list`/`dict` of urls to stream from. Each url is a `str`.
 
         Returns:
-            url(s): `str`, URL(s) to stream data from matching the given input url_or_urls.
+            `str` or `list` or `dict`: URL(s) to stream data from matching the given input url_or_urls.
         """
         return self.extract(self.download(url_or_urls))
 


### PR DESCRIPTION
We say that "the data is being downloaded progressively" which is not true, it's just streamed, so I fixed it. Probably I missed some other places where it is written? 

Also changed docstrings for `StreamingDownloadManager`'s `download` and `extract` to reflect the same, as these docstrings are displayed in the documentation cc @lhoestq 