### PR TITLE
Origin/fix missing features error

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -128,6 +128,13 @@ class Json(datasets.ArrowBasedBuilder):
                                     pa_table = paj.read_json(
                                         io.BytesIO(batch), read_options=paj.ReadOptions(block_size=block_size)
                                     )
+                                    feature_columns = set(self.config.features.arrow_schema.names)
+                                    pa_columns = set(pa_table.column_names)
+                                    missing_columns = feature_columns - pa_columns
+                                    if missing_columns:  # some columns are missing
+                                        num_rows = len(pa_table)
+                                        for column_name in missing_columns:
+                                            pa_table = pa_table.append_column(column_name, pa.nulls(num_rows))
                                     break
                                 except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
                                     if (

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -128,7 +128,7 @@ class Json(datasets.ArrowBasedBuilder):
                                     pa_table = paj.read_json(
                                         io.BytesIO(batch), read_options=paj.ReadOptions(block_size=block_size)
                                     )
-                                    if self.config.features != None:
+                                    if self.config.features is not None:
                                         feature_columns = set(self.config.features.arrow_schema.names)
                                         pa_columns = set(pa_table.column_names)
                                         missing_columns = feature_columns - pa_columns

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -128,13 +128,14 @@ class Json(datasets.ArrowBasedBuilder):
                                     pa_table = paj.read_json(
                                         io.BytesIO(batch), read_options=paj.ReadOptions(block_size=block_size)
                                     )
-                                    feature_columns = set(self.config.features.arrow_schema.names)
-                                    pa_columns = set(pa_table.column_names)
-                                    missing_columns = feature_columns - pa_columns
-                                    if missing_columns:  # some columns are missing
-                                        num_rows = len(pa_table)
-                                        for column_name in missing_columns:
-                                            pa_table = pa_table.append_column(column_name, pa.nulls(num_rows))
+                                    if self.config.features != None:
+                                        feature_columns = set(self.config.features.arrow_schema.names)
+                                        pa_columns = set(pa_table.column_names)
+                                        missing_columns = feature_columns - pa_columns
+                                        if missing_columns:  # some columns are missing
+                                            num_rows = len(pa_table)
+                                            for column_name in missing_columns:
+                                                pa_table = pa_table.append_column(column_name, pa.nulls(num_rows))
                                     break
                                 except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
                                     if (

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -135,7 +135,12 @@ class Json(datasets.ArrowBasedBuilder):
                                         if missing_columns:  # some columns are missing
                                             num_rows = len(pa_table)
                                             for column_name in missing_columns:
-                                                pa_table = pa_table.append_column(column_name, pa.nulls(num_rows))
+                                                # pa_table = pa_table.append_column(column_name, pa.nulls(num_rows))
+                                                type = self.config.features.arrow_schema.field(column_name).type
+                                                pa_table = pa_table.append_column(
+                                                    column_name, pa.array([None] * num_rows, type=type)
+                                                )
+
                                     break
                                 except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
                                     if (

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -3,6 +3,7 @@ import textwrap
 import pyarrow as pa
 import pytest
 
+from datasets import Features, Value
 from datasets.packaged_modules.json.json import Json
 
 
@@ -65,6 +66,33 @@ def json_file_with_list_of_dicts_field(tmp_path):
     ],
 )
 def test_json_generate_tables(file_fixture, config_kwargs, request):
+    json = Json(**config_kwargs)
+    generator = json._generate_tables([[request.getfixturevalue(file_fixture)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.to_pydict() == {"col_1": [1, 10], "col_2": [2, 20]}
+
+
+@pytest.mark.parametrize(
+    "file_fixture, config_kwargs",
+    [
+        (
+            "jsonl_file",
+            {"features": Features({"col_1": Value(dtype="int64", id=None), "col_2": Value(dtype="int64", id=None)})},
+        ),
+        (
+            "json_file_with_list_of_dicts",
+            {"features": Features({"col_1": Value(dtype="int64", id=None), "col_2": Value(dtype="int64", id=None)})},
+        ),
+        (
+            "json_file_with_list_of_dicts_field",
+            {
+                "field": "field3",
+                "features": Features({"col_1": Value(dtype="int64", id=None), "col_2": Value(dtype="int64", id=None)}),
+            },
+        ),
+    ],
+)
+def test_json_generate_tables_with_features(file_fixture, config_kwargs, request):
     json = Json(**config_kwargs)
     generator = json._generate_tables([[request.getfixturevalue(file_fixture)]])
     pa_table = pa.concat_tables([table for _, table in generator])

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -77,23 +77,25 @@ def test_json_generate_tables(file_fixture, config_kwargs, request):
     [
         (
             "jsonl_file",
-            {"features": Features({"col_1": Value(dtype="int64", id=None), "col_2": Value(dtype="int64", id=None)})},
+            {"features": Features({"col_1": Value("int64"), "col_2": Value("int64"), "missing_col": Value("string")})},
         ),
         (
             "json_file_with_list_of_dicts",
-            {"features": Features({"col_1": Value(dtype="int64", id=None), "col_2": Value(dtype="int64", id=None)})},
+            {"features": Features({"col_1": Value("int64"), "col_2": Value("int64"), "missing_col": Value("string")})},
         ),
         (
             "json_file_with_list_of_dicts_field",
             {
                 "field": "field3",
-                "features": Features({"col_1": Value(dtype="int64", id=None), "col_2": Value(dtype="int64", id=None)}),
+                "features": Features(
+                    {"col_1": Value("int64"), "col_2": Value("int64"), "missing_col": Value("string")}
+                ),
             },
         ),
     ],
 )
-def test_json_generate_tables_with_features(file_fixture, config_kwargs, request):
+def test_json_generate_tables_with_missing_features(file_fixture, config_kwargs, request):
     json = Json(**config_kwargs)
     generator = json._generate_tables([[request.getfixturevalue(file_fixture)]])
     pa_table = pa.concat_tables([table for _, table in generator])
-    assert pa_table.to_pydict() == {"col_1": [1, 10], "col_2": [2, 20]}
+    assert pa_table.to_pydict() == {"col_1": [1, 10], "col_2": [2, 20], "missing_col": [None, None]}


### PR DESCRIPTION
This fixes the problem of when the dataset_load function reads a function with "features" provided but some read batches don't have columns that later show up. For instance, the provided "features" requires columns A,B,C but only columns B,C show. This fixes this by adding the column A with nulls. 