### PR TITLE
[Extract] Place the lock file next to the destination directory

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -51,12 +51,12 @@ class ExtractManager:
 class BaseExtractor(ABC):
     @classmethod
     @abstractmethod
-    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union[Path, str], **kwargs) -> bool:
         ...
 
     @staticmethod
     @abstractmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         ...
 
 
@@ -64,12 +64,12 @@ class MagicNumberBaseExtractor(BaseExtractor, ABC):
     magic_number = b""
 
     @staticmethod
-    def read_magic_number(path: Union["Path", str], magic_number_length: int):
+    def read_magic_number(path: Union[Path, str], magic_number_length: int):
         with open(path, "rb") as f:
             return f.read(magic_number_length)
 
     @classmethod
-    def is_extractable(cls, path: Union["Path", str], magic_number: bytes = b"") -> bool:
+    def is_extractable(cls, path: Union[Path, str], magic_number: bytes = b"") -> bool:
         if not magic_number:
             try:
                 magic_number = cls.read_magic_number(path, len(cls.magic_number))
@@ -80,7 +80,7 @@ class MagicNumberBaseExtractor(BaseExtractor, ABC):
 
 class TarExtractor(BaseExtractor):
     @classmethod
-    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union[Path, str], **kwargs) -> bool:
         return tarfile.is_tarfile(path)
 
     @staticmethod
@@ -120,7 +120,7 @@ class TarExtractor(BaseExtractor):
                 yield finfo
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         os.makedirs(output_path, exist_ok=True)
         tar_file = tarfile.open(input_path)
         tar_file.extractall(output_path, members=TarExtractor.safemembers(tar_file))
@@ -131,7 +131,7 @@ class GzipExtractor(MagicNumberBaseExtractor):
     magic_number = b"\x1F\x8B"
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         with gzip.open(input_path, "rb") as gzip_file:
             with open(output_path, "wb") as extracted_file:
                 shutil.copyfileobj(gzip_file, extracted_file)
@@ -139,11 +139,11 @@ class GzipExtractor(MagicNumberBaseExtractor):
 
 class ZipExtractor(BaseExtractor):
     @classmethod
-    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union[Path, str], **kwargs) -> bool:
         return zipfile.is_zipfile(path)
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         os.makedirs(output_path, exist_ok=True)
         with zipfile.ZipFile(input_path, "r") as zip_file:
             zip_file.extractall(output_path)
@@ -154,7 +154,7 @@ class XzExtractor(MagicNumberBaseExtractor):
     magic_number = b"\xFD\x37\x7A\x58\x5A\x00"
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         with lzma.open(input_path) as compressed_file:
             with open(output_path, "wb") as extracted_file:
                 shutil.copyfileobj(compressed_file, extracted_file)
@@ -165,14 +165,14 @@ class RarExtractor(BaseExtractor):
     RAR5_ID = b"Rar!\x1a\x07\x01\x00"
 
     @classmethod
-    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union[Path, str], **kwargs) -> bool:
         """https://github.com/markokr/rarfile/blob/master/rarfile.py"""
         with open(path, "rb") as f:
             magic_number = f.read(len(cls.RAR5_ID))
         return magic_number == cls.RAR5_ID or magic_number.startswith(cls.RAR_ID)
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         if not config.RARFILE_AVAILABLE:
             raise ImportError("Please pip install rarfile")
         import rarfile
@@ -187,7 +187,7 @@ class ZstdExtractor(MagicNumberBaseExtractor):
     magic_number = b"\x28\xb5\x2F\xFD"
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         if not config.ZSTANDARD_AVAILABLE:
             raise ImportError("Please pip install zstandard")
         import zstandard as zstd
@@ -201,7 +201,7 @@ class Bzip2Extractor(MagicNumberBaseExtractor):
     magic_number = b"\x42\x5A\x68"
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         with bz2.open(input_path, "rb") as compressed_file:
             with open(output_path, "wb") as extracted_file:
                 shutil.copyfileobj(compressed_file, extracted_file)
@@ -211,7 +211,7 @@ class SevenZipExtractor(MagicNumberBaseExtractor):
     magic_number = b"\x37\x7A\xBC\xAF\x27\x1C"
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         if not config.PY7ZR_AVAILABLE:
             raise ImportError("Please pip install py7zr")
         import py7zr
@@ -225,7 +225,7 @@ class Lz4Extractor(MagicNumberBaseExtractor):
     magic_number = b"\x04\x22\x4D\x18"
 
     @staticmethod
-    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
+    def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         if not config.LZ4_AVAILABLE:
             raise ImportError("Please pip install lz4")
         import lz4.frame
@@ -261,14 +261,14 @@ class Extractor:
         return magic_number_max_length
 
     @staticmethod
-    def _read_magic_number(path: Union["Path", str], magic_number_length: int):
+    def _read_magic_number(path: Union[Path, str], magic_number_length: int):
         try:
             return MagicNumberBaseExtractor.read_magic_number(path, magic_number_length=magic_number_length)
         except OSError:
             return b""
 
     @classmethod
-    def is_extractable(cls, path: Union["Path", str], return_extractor: bool = False) -> bool:
+    def is_extractable(cls, path: Union[Path, str], return_extractor: bool = False) -> bool:
         warnings.warn(
             "Method 'is_extractable' was deprecated in version 2.4.0 and will be removed in 3.0.0. "
             "Use 'infer_extractor_format' instead.",
@@ -280,7 +280,7 @@ class Extractor:
         return False if not return_extractor else (False, None)
 
     @classmethod
-    def infer_extractor_format(cls, path: Union["Path", str]) -> str:  # <Added version="2.4.0"/>
+    def infer_extractor_format(cls, path: Union[Path, str]) -> str:  # <Added version="2.4.0"/>
         magic_number_max_length = cls._get_magic_number_max_length()
         magic_number = cls._read_magic_number(path, magic_number_max_length)
         for extractor_format, extractor in cls.extractors.items():
@@ -290,8 +290,8 @@ class Extractor:
     @classmethod
     def extract(
         cls,
-        input_path: Union["Path", str],
-        output_path: Union["Path", str],
+        input_path: Union[Path, str],
+        output_path: Union[Path, str],
         extractor_format: Optional[str] = None,  # <Added version="2.4.0"/>
         extractor: Optional[BaseExtractor] = "deprecated",
     ) -> None:

--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -8,7 +8,7 @@ import warnings
 import zipfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 
 from .. import config
 from .filelock import FileLock

--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -7,6 +7,7 @@ import tarfile
 import warnings
 import zipfile
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
 from .. import config
@@ -15,10 +16,6 @@ from .logging import get_logger
 
 
 logger = get_logger(__name__)
-
-
-if TYPE_CHECKING:
-    import pathlib
 
 
 class ExtractManager:
@@ -54,12 +51,12 @@ class ExtractManager:
 class BaseExtractor(ABC):
     @classmethod
     @abstractmethod
-    def is_extractable(cls, path: Union["pathlib.Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
         ...
 
     @staticmethod
     @abstractmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         ...
 
 
@@ -67,12 +64,12 @@ class MagicNumberBaseExtractor(BaseExtractor, ABC):
     magic_number = b""
 
     @staticmethod
-    def read_magic_number(path: Union["pathlib.Path", str], magic_number_length: int):
+    def read_magic_number(path: Union["Path", str], magic_number_length: int):
         with open(path, "rb") as f:
             return f.read(magic_number_length)
 
     @classmethod
-    def is_extractable(cls, path: Union["pathlib.Path", str], magic_number: bytes = b"") -> bool:
+    def is_extractable(cls, path: Union["Path", str], magic_number: bytes = b"") -> bool:
         if not magic_number:
             try:
                 magic_number = cls.read_magic_number(path, len(cls.magic_number))
@@ -83,7 +80,7 @@ class MagicNumberBaseExtractor(BaseExtractor, ABC):
 
 class TarExtractor(BaseExtractor):
     @classmethod
-    def is_extractable(cls, path: Union["pathlib.Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
         return tarfile.is_tarfile(path)
 
     @staticmethod
@@ -123,7 +120,7 @@ class TarExtractor(BaseExtractor):
                 yield finfo
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         os.makedirs(output_path, exist_ok=True)
         tar_file = tarfile.open(input_path)
         tar_file.extractall(output_path, members=TarExtractor.safemembers(tar_file))
@@ -134,7 +131,7 @@ class GzipExtractor(MagicNumberBaseExtractor):
     magic_number = b"\x1F\x8B"
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         with gzip.open(input_path, "rb") as gzip_file:
             with open(output_path, "wb") as extracted_file:
                 shutil.copyfileobj(gzip_file, extracted_file)
@@ -142,11 +139,11 @@ class GzipExtractor(MagicNumberBaseExtractor):
 
 class ZipExtractor(BaseExtractor):
     @classmethod
-    def is_extractable(cls, path: Union["pathlib.Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
         return zipfile.is_zipfile(path)
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         os.makedirs(output_path, exist_ok=True)
         with zipfile.ZipFile(input_path, "r") as zip_file:
             zip_file.extractall(output_path)
@@ -157,7 +154,7 @@ class XzExtractor(MagicNumberBaseExtractor):
     magic_number = b"\xFD\x37\x7A\x58\x5A\x00"
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         with lzma.open(input_path) as compressed_file:
             with open(output_path, "wb") as extracted_file:
                 shutil.copyfileobj(compressed_file, extracted_file)
@@ -168,14 +165,14 @@ class RarExtractor(BaseExtractor):
     RAR5_ID = b"Rar!\x1a\x07\x01\x00"
 
     @classmethod
-    def is_extractable(cls, path: Union["pathlib.Path", str], **kwargs) -> bool:
+    def is_extractable(cls, path: Union["Path", str], **kwargs) -> bool:
         """https://github.com/markokr/rarfile/blob/master/rarfile.py"""
         with open(path, "rb") as f:
             magic_number = f.read(len(cls.RAR5_ID))
         return magic_number == cls.RAR5_ID or magic_number.startswith(cls.RAR_ID)
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         if not config.RARFILE_AVAILABLE:
             raise ImportError("Please pip install rarfile")
         import rarfile
@@ -190,7 +187,7 @@ class ZstdExtractor(MagicNumberBaseExtractor):
     magic_number = b"\x28\xb5\x2F\xFD"
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         if not config.ZSTANDARD_AVAILABLE:
             raise ImportError("Please pip install zstandard")
         import zstandard as zstd
@@ -204,7 +201,7 @@ class Bzip2Extractor(MagicNumberBaseExtractor):
     magic_number = b"\x42\x5A\x68"
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         with bz2.open(input_path, "rb") as compressed_file:
             with open(output_path, "wb") as extracted_file:
                 shutil.copyfileobj(compressed_file, extracted_file)
@@ -214,7 +211,7 @@ class SevenZipExtractor(MagicNumberBaseExtractor):
     magic_number = b"\x37\x7A\xBC\xAF\x27\x1C"
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         if not config.PY7ZR_AVAILABLE:
             raise ImportError("Please pip install py7zr")
         import py7zr
@@ -228,7 +225,7 @@ class Lz4Extractor(MagicNumberBaseExtractor):
     magic_number = b"\x04\x22\x4D\x18"
 
     @staticmethod
-    def extract(input_path: Union["pathlib.Path", str], output_path: Union["pathlib.Path", str]) -> None:
+    def extract(input_path: Union["Path", str], output_path: Union["Path", str]) -> None:
         if not config.LZ4_AVAILABLE:
             raise ImportError("Please pip install lz4")
         import lz4.frame
@@ -264,14 +261,14 @@ class Extractor:
         return magic_number_max_length
 
     @staticmethod
-    def _read_magic_number(path: Union["pathlib.Path", str], magic_number_length: int):
+    def _read_magic_number(path: Union["Path", str], magic_number_length: int):
         try:
             return MagicNumberBaseExtractor.read_magic_number(path, magic_number_length=magic_number_length)
         except OSError:
             return b""
 
     @classmethod
-    def is_extractable(cls, path: Union["pathlib.Path", str], return_extractor: bool = False) -> bool:
+    def is_extractable(cls, path: Union["Path", str], return_extractor: bool = False) -> bool:
         warnings.warn(
             "Method 'is_extractable' was deprecated in version 2.4.0 and will be removed in 3.0.0. "
             "Use 'infer_extractor_format' instead.",
@@ -283,7 +280,7 @@ class Extractor:
         return False if not return_extractor else (False, None)
 
     @classmethod
-    def infer_extractor_format(cls, path: Union["pathlib.Path", str]) -> str:  # <Added version="2.4.0"/>
+    def infer_extractor_format(cls, path: Union["Path", str]) -> str:  # <Added version="2.4.0"/>
         magic_number_max_length = cls._get_magic_number_max_length()
         magic_number = cls._read_magic_number(path, magic_number_max_length)
         for extractor_format, extractor in cls.extractors.items():
@@ -293,16 +290,16 @@ class Extractor:
     @classmethod
     def extract(
         cls,
-        input_path: Union["pathlib.Path", str],
-        output_path: Union["pathlib.Path", str],
+        input_path: Union["Path", str],
+        output_path: Union["Path", str],
         extractor_format: Optional[str] = None,  # <Added version="2.4.0"/>
         extractor: Optional[BaseExtractor] = "deprecated",
     ) -> None:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
         # Prevent parallel extractions
-        lock_path = str(input_path) + ".lock"
+        lock_path = str(Path(output_path).with_suffix(".lock"))
         with FileLock(lock_path):
             shutil.rmtree(output_path, ignore_errors=True)
-            os.makedirs(os.path.dirname(output_path), exist_ok=True)
             if extractor_format or extractor != "deprecated":
                 if extractor != "deprecated" or not isinstance(extractor_format, str):  # passed as positional arg
                     warnings.warn(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -982,7 +982,9 @@ def test_load_dataset_deletes_extracted_files(deleted, jsonl_gz_path, tmp_path):
     else:  # default
         ds = load_dataset("json", split="train", data_files=data_files, cache_dir=cache_dir)
     assert ds[0] == {"col_1": "0", "col_2": 0, "col_3": 0.0}
-    assert (sorted((cache_dir / "downloads" / "extracted").iterdir()) == []) is deleted
+    assert (
+        [path for path in (cache_dir / "downloads" / "extracted").iterdir() if path.suffix != ".lock"] == []
+    ) is deleted
 
 
 def distributed_load_dataset(args):


### PR DESCRIPTION
Previously it was placed next to the archive to extract, but the archive can be in a read-only directory as noticed in https://github.com/huggingface/datasets/issues/5295

Therefore I moved the lock location to be next to the destination directory, which is required to have write permissions