### PR TITLE
Fix loading from HF GCP cache

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -21,6 +21,7 @@ import os
 import re
 import shutil
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import pyarrow as pa
@@ -294,11 +295,12 @@ class BaseReader:
                     split_infos=self._info.splits.values(),
                 )
                 for file_instruction in file_instructions:
-                    remote_prepared_filename = os.path.join(remote_cache_dir, file_instruction["filename"])
+                    file_to_download = str(Path(file_instruction["filename"]).relative_to(self._path))
+                    remote_prepared_filename = os.path.join(remote_cache_dir, file_to_download)
                     downloaded_prepared_filename = cached_path(
                         remote_prepared_filename.replace(os.sep, "/"), download_config=download_config
                     )
-                    shutil.move(downloaded_prepared_filename, os.path.join(self._path, file_instruction["filename"]))
+                    shutil.move(downloaded_prepared_filename, file_instruction["filename"])
         except FileNotFoundError as err:
             raise MissingFilesOnHfGcsError(err) from None
 

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -11,8 +11,6 @@ from datasets.builder import DatasetBuilder
 from datasets.load import dataset_module_factory, import_main_class
 from datasets.utils.file_utils import cached_path
 
-from .utils import require_beam
-
 
 DATASETS_ON_HF_GCP = [
     {"dataset": "wikipedia", "config_name": "20220301.de"},

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -2,6 +2,7 @@ import os
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
 from absl.testing import parameterized
 
 from datasets import config
@@ -9,6 +10,8 @@ from datasets.arrow_reader import HF_GCP_BASE_URL
 from datasets.builder import DatasetBuilder
 from datasets.load import dataset_module_factory, import_main_class
 from datasets.utils.file_utils import cached_path
+
+from .utils import require_beam
 
 
 DATASETS_ON_HF_GCP = [
@@ -67,3 +70,23 @@ class TestDatasetOnHfGcp(TestCase):
             ).replace(os.sep, "/")
             datset_info_path = cached_path(dataset_info_url, cache_dir=tmp_dir)
             self.assertTrue(os.path.exists(datset_info_path))
+
+
+@pytest.mark.integration
+def test_wikipedia_frr(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("test_hf_gcp") / "test_wikipedia_simple"
+    dataset_module = dataset_module_factory("wikipedia", cache_dir=tmp_dir)
+
+    builder_cls = import_main_class(dataset_module.module_path, dataset=True)
+
+    builder_instance: DatasetBuilder = builder_cls(
+        cache_dir=tmp_dir,
+        config_name="20220301.frr",
+        hash=dataset_module.hash,
+    )
+
+    # use the HF cloud storage, not the original download_and_prepare that uses apache-beam
+    builder_instance._download_and_prepare = None
+    builder_instance.download_and_prepare()
+    ds = builder_instance.as_dataset()
+    assert ds is not None


### PR DESCRIPTION
As reported in https://discuss.huggingface.co/t/error-loading-wikipedia-dataset/26599/4 it's not possible to download a cached version of Wikipedia from the HF GCP cache

I fixed it and added an integration test (runs in 10sec)