### PR TITLE
Fix docs building for main

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -2,8 +2,10 @@ name: Build documentation
 
 on:
   push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
+    branches:
+      - main
+      - doc-builder*
+      - v*-release
 
 jobs:
    build:


### PR DESCRIPTION
This PR reverts the triggering event for building documentation introduced by:
- #5250

Fix #5326.