### PR TITLE
Clarify imagefolder is for small datasets

### DIFF
--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -2,7 +2,7 @@
 
 There are two methods for creating and sharing an image dataset. This guide will show you how to:
 
-* Create an image dataset with `ImageFolder` and some metadata. This is a no-code solution for quickly creating an image dataset. 
+* Create an image dataset with `ImageFolder` and some metadata. This is a no-code solution for quickly creating a small image dataset to experiment with.
 * Create an image dataset by writing a loading script. This method is a bit more involved, but you have greater flexibility over how a dataset is defined, downloaded, and generated.
 
 <Tip>
@@ -13,7 +13,7 @@ You can control access to your dataset by requiring users to share their contact
 
 ## ImageFolder
 
-The `ImageFolder` is a dataset builder designed to quickly load an image dataset without requiring you to write any code. `ImageFolder` automatically infers the class labels of your dataset based on the directory name. Just store your dataset in a directory structure like:
+The `ImageFolder` is a dataset builder designed to quickly load a small image dataset without requiring you to write any code. `ImageFolder` automatically infers the class labels of your dataset based on the directory name. Just store your dataset in a directory structure like:
 
 ```
 folder/train/dog/golden_retriever.png

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -47,7 +47,7 @@ If you only want to load the underlying path to the image dataset without decodi
 
 ## ImageFolder
 
-You can also load a dataset with an `ImageFolder` dataset builder. It does not require writing a custom dataloader, making it useful for quickly loading a dataset for certain vision tasks. Your image dataset structure should look like this:
+You can also load a dataset with an `ImageFolder` dataset builder which does not require writing a custom dataloader. This makes `ImageFolder` ideal for quickly creating and loading small image datasets for different vision tasks. Your image dataset structure should look like this:
 
 ```
 folder/train/dog/golden_retriever.png


### PR DESCRIPTION
Based on feedback from [here](https://github.com/huggingface/datasets/issues/5317#issuecomment-1334108824), this PR adds a note to the `imagefolder` loading and creating docs that `imagefolder` is designed for small scale image datasets.