### PR TITLE
fix: 🐛 pass the token to get the list of config names

### DIFF
--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -237,6 +237,7 @@ def get_dataset_infos(
         download_config=download_config,
         download_mode=download_mode,
         data_files=data_files,
+        use_auth_token=use_auth_token,
     )
     return {
         config_name: get_dataset_config_info(


### PR DESCRIPTION
Otherwise, get_dataset_infos doesn't work on gated or private datasets, even with the correct token.