### PR TITLE
Clean up docstrings

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -563,20 +563,24 @@ class ReadInstruction:
 
     @classmethod
     def from_spec(cls, spec):
-        """Creates a ReadInstruction instance out of a string spec.
+        """Creates a `ReadInstruction` instance out of a string spec.
 
         Args:
-            spec (str): split(s) + optional slice(s) to read + optional rounding
-                        if percents are used as the slicing unit. A slice can be specified,
-                        using absolute numbers (int) or percentages (int). E.g.
-                            `test`: test split.
-                            `test + validation`: test split + validation split.
-                            `test[10:]`: test split, minus its first 10 records.
-                            `test[:10%]`: first 10% records of test split.
-                            `test[:20%](pct1_dropremainder)`: first 10% records, rounded with
-                                                              the `pct1_dropremainder` rounding.
-                            `test[:-5%]+train[40%:60%]`: first 95% of test + middle 20% of
-                                                         train.
+            spec (`str`):
+                Split(s) + optional slice(s) to read + optional rounding
+                if percents are used as the slicing unit. A slice can be specified,
+                using absolute numbers (`int`) or percentages (`int`).
+
+        Examples:
+
+            ```
+            test: test split.
+            test + validation: test split + validation split.
+            test[10:]: test split, minus its first 10 records.
+            test[:10%]: first 10% records of test split.
+            test[:20%](pct1_dropremainder): first 10% records, rounded with the pct1_dropremainder rounding.
+            test[:-5%]+train[40%:60%]: first 95% of test + middle 20% of train.
+            ```
 
         Returns:
             ReadInstruction instance.
@@ -635,7 +639,8 @@ class ReadInstruction:
         Those absolute instructions are then to be added together.
 
         Args:
-            name2len: dict associating split names to number of examples.
+            name2len (`dict`):
+                Associating split names to number of examples.
 
         Returns:
             list of _AbsoluteInstruction instances (corresponds to the + in spec).

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -98,17 +98,18 @@ class DatasetGenerationError(DatasetBuildError):
 
 @dataclass
 class BuilderConfig:
-    """Base class for :class:`DatasetBuilder` data configuration.
+    """Base class for `DatasetBuilder` data configuration.
 
-    DatasetBuilder subclasses with data configuration options should subclass
-    :class:`BuilderConfig` and add their own properties.
+    `DatasetBuilder` subclasses with data configuration options should subclass
+    `BuilderConfig` and add their own properties.
 
     Attributes:
-        name (:obj:`str`, default ``"default"``):
-        version (:class:`Version` or :obj:`str`, optional):
-        data_dir (:obj:`str`, optional):
-        data_files (:obj:`str` or :obj:`Sequence` or :obj:`Mapping`, optional): Path(s) to source data file(s).
-        description (:obj:`str`, optional):
+        name (`str`, defaults to `default`):
+        version (`Version` or `str`, *optional*):
+        data_dir (`str`, *optional*):
+        data_files (`str` or `Sequence` or `Mapping`, *optional*):
+            Path(s) to source data file(s).
+        description (`str`, *optional*):
     """
 
     name: str = "default"
@@ -148,6 +149,7 @@ class BuilderConfig:
         - the config kwargs that can be used to overwrite attributes
         - the custom features used to write the dataset
         - the data_files for json/text/csv/pandas datasets
+
         Therefore the config id is just the config name with an optional suffix based on these.
         """
         # Possibly add a suffix to the name to handle custom features/data_files/config_kwargs
@@ -203,7 +205,7 @@ class DatasetBuilder:
           and writes it to disk.
         - [`DatasetBuilder.as_dataset`]: Generates a [`Dataset`].
 
-    **Configuration**: Some `DatasetBuilder`s expose multiple variants of the
+    Some `DatasetBuilder`s expose multiple variants of the
     dataset by defining a [`BuilderConfig`] subclass and accepting a
     config object (or name) on construction. Configurable datasets expose a
     pre-defined set of configurations in [`DatasetBuilder.builder_configs`].
@@ -213,7 +215,7 @@ class DatasetBuilder:
             Directory to cache data. Defaults to `"~/.cache/huggingface/datasets"`.
         config_name (`str`, *optional*):
             Name of the dataset configuration.
-            It affects the data generated on disk: different configurations will have their own subdirectories and
+            It affects the data generated on disk. Different configurations will have their own subdirectories and
             versions.
             If not provided, the default configuration is used (if it exists).
 
@@ -225,7 +227,7 @@ class DatasetBuilder:
         hash (`str`, *optional*):
             Hash specific to the dataset code. Used to update the caching directory when the
             dataset loading script code is updated (to avoid reusing old data).
-            The typical caching directory (defined in `self._relative_data_dir`) is: `name/version/hash/`.
+            The typical caching directory (defined in `self._relative_data_dir`) is `name/version/hash/`.
         base_path (`str`, *optional*):
             Base path for relative paths that are used to download files.
             This can be a remote URL.
@@ -415,7 +417,7 @@ class DatasetBuilder:
         return DatasetInfosDict.from_directory(cls.get_imported_module_dir())
 
     def get_exported_dataset_info(self) -> DatasetInfo:
-        """Empty DatasetInfo if doesn't exist
+        """Empty `DatasetInfo` if doesn't exist
 
         Example:
 
@@ -629,41 +631,53 @@ class DatasetBuilder:
         """Downloads and prepares dataset for reading.
 
         Args:
-            output_dir (:obj:`str`, optional): output directory for the dataset.
-                Default to this builder's ``cache_dir``, which is inside ~/.cache/huggingface/datasets by default.
+            output_dir (`str`, *optional*):
+                Output directory for the dataset.
+                Default to this builder's `cache_dir`, which is inside `~/.cache/huggingface/datasets` by default.
 
                 <Added version="2.5.0"/>
-            download_config (:class:`DownloadConfig`, optional): specific download configuration parameters.
-            download_mode (:class:`DownloadMode`, optional): select the download/generate mode - Default to ``REUSE_DATASET_IF_EXISTS``
-            ignore_verifications (:obj:`bool`): Ignore the verifications of the downloaded/processed dataset information (checksums/size/splits/...)
-            try_from_hf_gcs (:obj:`bool`): If True, it will try to download the already prepared dataset from the Hf google cloud storage
-            dl_manager (:class:`DownloadManager`, optional): specific Download Manger to use
-            base_path (:obj:`str`, optional): base path for relative paths that are used to download files. This can be a remote url.
+            download_config (`DownloadConfig`, *optional*):
+                Specific download configuration parameters.
+            download_mode (`DownloadMode`, *optional*):
+                Select the download/generate mode, default to `REUSE_DATASET_IF_EXISTS`.
+            ignore_verifications (`bool`):
+                Ignore the verifications of the downloaded/processed dataset information (checksums/size/splits/...).
+            try_from_hf_gcs (`bool`):
+                If `True`, it will try to download the already prepared dataset from the HF Google cloud storage.
+            dl_manager (`DownloadManager`, *optional*):
+                Specific `DownloadManger` to use.
+            base_path (`str`, *optional*):
+                Base path for relative paths that are used to download files. This can be a remote url.
                 If not specified, the value of the `base_path` attribute (`self.base_path`) will be used instead.
-            use_auth_token (:obj:`Union[str, bool]`, optional): Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
-                If True, will get token from ~/.huggingface.
-            file_format (:obj:`str`, optional): format of the data files in which the dataset will be written.
+            use_auth_token (`Union[str, bool]`, *optional*):
+                Optional string or boolean to use as Bearer token for remote files on the Datasets Hub.
+                If `True`, will get token from `~/.huggingface`.
+            file_format (`str`, *optional*):
+                Format of the data files in which the dataset will be written.
                 Supported formats: "arrow", "parquet". Default to "arrow" format.
                 If the format is "parquet", then image and audio data are embedded into the Parquet files instead of pointing to local files.
 
                 <Added version="2.5.0"/>
-            max_shard_size (:obj:`Union[str, int]`, optional): Maximum number of bytes written per shard, default is "500MB".
+            max_shard_size (`Union[str, int]`, *optional*):
+                Maximum number of bytes written per shard, default is "500MB".
                 The size is based on uncompressed data size, so in practice your shard files may be smaller than
                 `max_shard_size` thanks to Parquet compression for example.
 
                 <Added version="2.5.0"/>
-            num_proc (:obj:`int`, optional, default `None`): Number of processes when downloading and generating the dataset locally.
+            num_proc (`int`, *optional*, defaults to `None`):
+                Number of processes when downloading and generating the dataset locally.
                 Multiprocessing is disabled by default.
 
                 <Added version="2.7.0"/>
-            storage_options (:obj:`dict`, *optional*): Key/value pairs to be passed on to the caching file-system backend, if any.
+            storage_options (`dict`, *optional*):
+                Key/value pairs to be passed on to the caching file-system backend, if any.
 
                 <Added version="2.5.0"/>
             **download_and_prepare_kwargs (additional keyword arguments): Keyword arguments.
 
         Example:
 
-        Downdload and prepare the dataset as Arrow files that can be loaded as a Dataset using `builder.as_dataset()`
+        Download and prepare the dataset as Arrow files that can be loaded as a Dataset using `builder.as_dataset()`:
 
         ```py
         >>> from datasets import load_dataset_builder
@@ -671,7 +685,7 @@ class DatasetBuilder:
         >>> ds = builder.download_and_prepare()
         ```
 
-        Downdload and prepare the dataset as sharded Parquet files locally
+        Download and prepare the dataset as sharded Parquet files locally:
 
         ```py
         >>> from datasets import load_dataset_builder
@@ -679,7 +693,7 @@ class DatasetBuilder:
         >>> ds = builder.download_and_prepare("./output_dir", file_format="parquet")
         ```
 
-        Downdload and prepare the dataset as sharded Parquet files in a cloud storage
+        Download and prepare the dataset as sharded Parquet files in a cloud storage:
 
         ```py
         >>> from datasets import load_dataset_builder
@@ -890,9 +904,11 @@ class DatasetBuilder:
         the pre-processed datasets files.
 
         Args:
-            dl_manager: (:obj:`DownloadManager`) `DownloadManager` used to download and cache data.
-            verify_infos (:obj:`bool`): if False, do not perform checksums and size tests.
-            prepare_split_kwargs: Additional options, such as file_format, max_shard_size
+            dl_manager (`DownloadManager`):
+                `DownloadManager` used to download and cache data.
+            verify_infos (`bool`):
+                if False, do not perform checksums and size tests.
+            prepare_split_kwargs: Additional options, such as `file_format`, `max_shard_size`
         """
         # Generating data for all splits
         split_dict = SplitDict(dataset_name=self.name)
@@ -987,12 +1003,16 @@ class DatasetBuilder:
         """Return a Dataset for the specified split.
 
         Args:
-            split (`datasets.Split`): Which subset of the data to return.
-            run_post_process (bool, default=True): Whether to run post-processing dataset transforms and/or add
+            split (`datasets.Split`):
+                Which subset of the data to return.
+            run_post_process (`bool`, defaults to `True`):
+                Whether to run post-processing dataset transforms and/or add
                 indexes.
-            ignore_verifications (bool, default=False): Whether to ignore the verifications of the
+            ignore_verifications (`bool`, defaults to `False`):
+                Whether to ignore the verifications of the
                 downloaded/processed dataset information (checksums/size/splits/...).
-            in_memory (bool, default=False): Whether to copy the data in-memory.
+            in_memory (`bool`, defaults to `False`):
+                Whether to copy the data in-memory.
 
         Returns:
             datasets.Dataset
@@ -1121,8 +1141,10 @@ class DatasetBuilder:
         the `Dataset` object.
 
         Args:
-            split: `datasets.Split` which subset of the data to read.
-            in_memory (bool, default False): Whether to copy the data in-memory.
+            split (`datasets.Split`):
+                which subset of the data to read.
+            in_memory (`bool`, defaults to `False`):
+                Whether to copy the data in-memory.
 
         Returns:
             `Dataset`
@@ -1217,7 +1239,7 @@ class DatasetBuilder:
         This function returns a list of `SplitGenerator`s defining how to generate
         data and what splits to use.
 
-        Example::
+        Example:
 
             return [
                     datasets.SplitGenerator(
@@ -1249,7 +1271,8 @@ class DatasetBuilder:
         distribute the relevant parts to each split with the `gen_kwargs` argument
 
         Args:
-            dl_manager: (DownloadManager) Download manager to download the data
+            dl_manager (`DownloadManager`):
+                Download manager to download the data
 
         Returns:
             `list<SplitGenerator>`.
@@ -1268,13 +1291,17 @@ class DatasetBuilder:
         """Generate the examples and record them on disk.
 
         Args:
-            split_generator: `SplitGenerator`, Split generator to process
-            file_format (:obj:`str`, optional): format of the data files in which the dataset will be written.
+            split_generator (`SplitGenerator`):
+                Split generator to process
+            file_format (`str`, *optional*):
+                format of the data files in which the dataset will be written.
                 Supported formats: "arrow", "parquet". Default to "arrow" format.
-            max_shard_size (:obj:`Union[str, int]`, optional): Maximum number of bytes written per shard, default is "500MB".
+            max_shard_size (`Union[str, int]`, *optional*):
+                Maximum number of bytes written per shard, default is "500MB".
                 The size is based on uncompressed data size, so in practice your shard files may be smaller than
                 `max_shard_size` thanks to Parquet compression for example.
-            num_proc (:obj:`int`, optional, default `None`): Number of processes when downloading and generating the dataset locally.
+            num_proc (`int`, *optional*, defaults to `None`):
+                Number of processes when downloading and generating the dataset locally.
                 Multiprocessing is disabled by default.
 
                 <Added version="2.7.0"/>
@@ -1287,7 +1314,8 @@ class DatasetBuilder:
         """Generate the examples on the fly.
 
         Args:
-            split_generator: `SplitGenerator`, Split generator to process
+            split_generator (`SplitGenerator`):
+                Split generator to process
         """
         raise NotImplementedError()
 
@@ -1329,7 +1357,8 @@ class GeneratorBasedBuilder(DatasetBuilder):
         disk.
 
         Args:
-            **kwargs (additional keyword arguments): Arguments forwarded from the SplitGenerator.gen_kwargs
+            **kwargs (additional keyword arguments):
+                Arguments forwarded from the SplitGenerator.gen_kwargs
 
         Yields:
             key: `str` or `int`, a unique deterministic example identification key.
@@ -1586,7 +1615,8 @@ class ArrowBasedBuilder(DatasetBuilder):
         disk.
 
         Args:
-            **kwargs (additional keyword arguments): Arguments forwarded from the SplitGenerator.gen_kwargs
+            **kwargs (additional keyword arguments):
+                Arguments forwarded from the SplitGenerator.gen_kwargs
 
         Yields:
             key: `str` or `int`, a unique deterministic example identification key.
@@ -1816,7 +1846,7 @@ class MissingBeamOptions(ValueError):
 
 
 class BeamBasedBuilder(DatasetBuilder):
-    """Beam based Builder."""
+    """Beam-based Builder."""
 
     # BeamBasedBuilder does not have dummy data for tests yet
     test_dummy_data = False
@@ -1854,8 +1884,10 @@ class BeamBasedBuilder(DatasetBuilder):
         </Tip>
 
         Args:
-            pipeline ([`utils.beam_utils.BeamPipeline`]): Apache Beam pipeline.
-            **kwargs (additional keyword arguments): Arguments forwarded from the SplitGenerator.gen_kwargs.
+            pipeline ([`utils.beam_utils.BeamPipeline`]):
+                Apache Beam pipeline.
+            **kwargs (additional keyword arguments):
+                Arguments forwarded from the SplitGenerator.gen_kwargs.
 
         Returns:
             `beam.PCollection`: Apache Beam PCollection containing the
@@ -1875,7 +1907,7 @@ class BeamBasedBuilder(DatasetBuilder):
         raise NotImplementedError()
 
     def _download_and_prepare(self, dl_manager, verify_infos, **prepare_splits_kwargs):
-        # Create the Beam pipeline and forward it to _prepare_split
+        # Create the Beam pipeline and forward it to `_prepare_split`
         import apache_beam as beam
 
         import datasets.utils.beam_utils as beam_utils

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -198,7 +198,7 @@ class DatasetBuilder:
     `DatasetBuilder` has 3 key methods:
 
         - [`DatasetBuilder.info`]: Documents the dataset, including feature
-          names, types, and shapes, version, splits, citation, etc.
+          names, types, shapes, version, splits, citation, etc.
         - [`DatasetBuilder.download_and_prepare`]: Downloads the source data
           and writes it to disk.
         - [`DatasetBuilder.as_dataset`]: Generates a [`Dataset`].
@@ -209,8 +209,10 @@ class DatasetBuilder:
     pre-defined set of configurations in [`DatasetBuilder.builder_configs`].
 
     Args:
-        cache_dir (`str`, *optional*): Directory to cache data. Defaults to ``"~/.cache/huggingface/datasets"``.
-        config_name (`str`, *optional*): Name of the dataset configuration.
+        cache_dir (`str`, *optional*): 
+            Directory to cache data. Defaults to `"~/.cache/huggingface/datasets"`.
+        config_name (`str`, *optional*): 
+            Name of the dataset configuration.
             It affects the data generated on disk: different configurations will have their own subdirectories and
             versions.
             If not provided, the default configuration is used (if it exists).
@@ -220,24 +222,31 @@ class DatasetBuilder:
             Parameter `name` was renamed to `config_name`.
 
             </Added>
-        hash (`str`, *optional*): Hash specific to the dataset code. Used to update the caching directory when the
+        hash (`str`, *optional*): 
+            Hash specific to the dataset code. Used to update the caching directory when the
             dataset loading script code is updated (to avoid reusing old data).
-            The typical caching directory (defined in ``self._relative_data_dir``) is: ``name/version/hash/``.
-        base_path (`str`, *optional*): Base path for relative paths that are used to download files.
+            The typical caching directory (defined in `self._relative_data_dir`) is: `name/version/hash/`.
+        base_path (`str`, *optional*): 
+            Base path for relative paths that are used to download files.
             This can be a remote URL.
-        features ([`Features`], *optional*): Features types to use with this dataset.
-            It can be used to change the Features types of a dataset, for example.
-        use_auth_token (`str` or `bool`, *optional*): String or boolean to use as Bearer token for remote files on the
-            Datasets Hub. If `True`, will get token from ``"~/.huggingface"``.
-        repo_id (`str`, *optional*): ID of the dataset repository.
+        features ([`Features`], *optional*): 
+            Features types to use with this dataset.
+            It can be used to change the [`Features`] types of a dataset, for example.
+        use_auth_token (`str` or `bool`, *optional*): 
+            String or boolean to use as Bearer token for remote files on the
+            Datasets Hub. If `True`, will get token from `"~/.huggingface"`.
+        repo_id (`str`, *optional*): 
+            ID of the dataset repository.
             Used to distinguish builders with the same name but not coming from the same namespace, for example "squad"
             and "lhoestq/squad" repo IDs. In the latter, the builder name would be "lhoestq___squad".
-        data_files (`str` or `Sequence` or `Mapping`, *optional*): Path(s) to source data file(s).
+        data_files (`str` or `Sequence` or `Mapping`, *optional*): 
+            Path(s) to source data file(s).
             For builders like "csv" or "json" that need the user to specify data files. They can be either
-            local or remote files. For convenience, you can use a DataFilesDict.
-        data_dir (`str`, *optional*): Path to directory containing source data file(s).
+            local or remote files. For convenience, you can use a `DataFilesDict`.
+        data_dir (`str`, *optional*): 
+            Path to directory containing source data file(s).
             Use only if `data_files` is not passed, in which case it is equivalent to passing
-            ``os.path.join(data_dir, "**")`` as `data_files`.
+            `os.path.join(data_dir, "**")` as `data_files`.
             For builders that require manual download, it must be the path to the local directory containing the
             manually downloaded data.
         name (`str`): Configuration name for the dataset.

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -209,9 +209,9 @@ class DatasetBuilder:
     pre-defined set of configurations in [`DatasetBuilder.builder_configs`].
 
     Args:
-        cache_dir (`str`, *optional*): 
+        cache_dir (`str`, *optional*):
             Directory to cache data. Defaults to `"~/.cache/huggingface/datasets"`.
-        config_name (`str`, *optional*): 
+        config_name (`str`, *optional*):
             Name of the dataset configuration.
             It affects the data generated on disk: different configurations will have their own subdirectories and
             versions.
@@ -222,28 +222,28 @@ class DatasetBuilder:
             Parameter `name` was renamed to `config_name`.
 
             </Added>
-        hash (`str`, *optional*): 
+        hash (`str`, *optional*):
             Hash specific to the dataset code. Used to update the caching directory when the
             dataset loading script code is updated (to avoid reusing old data).
             The typical caching directory (defined in `self._relative_data_dir`) is: `name/version/hash/`.
-        base_path (`str`, *optional*): 
+        base_path (`str`, *optional*):
             Base path for relative paths that are used to download files.
             This can be a remote URL.
-        features ([`Features`], *optional*): 
+        features ([`Features`], *optional*):
             Features types to use with this dataset.
             It can be used to change the [`Features`] types of a dataset, for example.
-        use_auth_token (`str` or `bool`, *optional*): 
+        use_auth_token (`str` or `bool`, *optional*):
             String or boolean to use as Bearer token for remote files on the
             Datasets Hub. If `True`, will get token from `"~/.huggingface"`.
-        repo_id (`str`, *optional*): 
+        repo_id (`str`, *optional*):
             ID of the dataset repository.
             Used to distinguish builders with the same name but not coming from the same namespace, for example "squad"
             and "lhoestq/squad" repo IDs. In the latter, the builder name would be "lhoestq___squad".
-        data_files (`str` or `Sequence` or `Mapping`, *optional*): 
+        data_files (`str` or `Sequence` or `Mapping`, *optional*):
             Path(s) to source data file(s).
             For builders like "csv" or "json" that need the user to specify data files. They can be either
             local or remote files. For convenience, you can use a `DataFilesDict`.
-        data_dir (`str`, *optional*): 
+        data_dir (`str`, *optional*):
             Path to directory containing source data file(s).
             Use only if `data_files` is not passed, in which case it is equivalent to passing
             `os.path.join(data_dir, "**")` as `data_files`.

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -9,28 +9,41 @@ class DownloadConfig:
     """Configuration for our cached path manager.
 
     Attributes:
-        cache_dir (:obj:`str` or :obj:`Path`, optional): Specify a cache directory to save the file to (overwrite the
+        cache_dir (`str` or `Path`, *optional*):
+            Specify a cache directory to save the file to (overwrite the
             default cache dir).
-        force_download (:obj:`bool`, default ``False``): If True, re-dowload the file even if it's already cached in
+        force_download (`bool`, defaults to `False`):
+            If `True`, re-dowload the file even if it's already cached in
             the cache dir.
-        resume_download (:obj:`bool`, default ``False``): If True, resume the download if incompletly recieved file is
+        resume_download (`bool`, defaults to `False`):
+            If `True`, resume the download if incompletly recieved file is
             found.
-        proxies (:obj:`dict`, optional):
-        user_agent (:obj:`str`, optional): Optional string or dict that will be appended to the user-agent on remote
+        proxies (`dict`, *optional*):
+        user_agent (`str`, *optional*):
+            Optional string or dict that will be appended to the user-agent on remote
             requests.
-        extract_compressed_file (:obj:`bool`, default ``False``): If True and the path point to a zip or tar file,
+        extract_compressed_file (`bool`, defaults to `False`):
+            If `True` and the path point to a zip or tar file,
             extract the compressed file in a folder along the archive.
-        force_extract (:obj:`bool`, default ``False``): If True when extract_compressed_file is True and the archive
+        force_extract (`bool`, defaults to `False`):
+            If `True` when `extract_compressed_file` is `True` and the archive
             was already extracted, re-extract the archive and override the folder where it was extracted.
-        delete_extracted (:obj:`bool`, default ``False``): Whether to delete (or keep) the extracted files.
-        use_etag (:obj:`bool`, default ``True``): Whether to use the ETag HTTP response header to validate the cached files.
-        num_proc (:obj:`int`, optional): The number of processes to launch to download the files in parallel.
-        max_retries (:obj:`int`, default ``1``): The number of times to retry an HTTP request if it fails.
-        use_auth_token (:obj:`str` or :obj:`bool`, optional): Optional string or boolean to use as Bearer token
-            for remote files on the Datasets Hub. If True, will get token from ~/.huggingface.
-        ignore_url_params (:obj:`bool`, default ``False``): Whether to strip all query parameters and #fragments from
+        delete_extracted (`bool`, defaults to `False`):
+            Whether to delete (or keep) the extracted files.
+        use_etag (`bool`, defaults to `True`):
+            Whether to use the ETag HTTP response header to validate the cached files.
+        num_proc (`int`, *optional*):
+            The number of processes to launch to download the files in parallel.
+        max_retries (`int`, default to `1`):
+            The number of times to retry an HTTP request if it fails.
+        use_auth_token (`str` or `bool`, *optional*):
+            Optional string or boolean to use as Bearer token
+            for remote files on the Datasets Hub. If `True`, will get token from `~/.huggingface`.
+        ignore_url_params (`bool`, defaults to `False`):
+            Whether to strip all query parameters and fragments from
             the download URL before using it for caching the file.
-        download_desc (:obj:`str`, optional): A description to be displayed alongside with the progress bar while downloading the files.
+        download_desc (`str`, *optional*):
+            A description to be displayed alongside with the progress bar while downloading the files.
     """
 
     cache_dir: Optional[Union[str, Path]] = None

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -261,7 +261,7 @@ class DownloadManager:
             url_or_urls (`str` or `list` or `dict`):
                 URL or `list` or `dict` of URLs to download and extract. Each URL is a `str`.
             custom_download (`Callable[src_url, dst_path]`):
-                The source URL and destination path. Any as for example
+                The source URL and destination path. For example
                 `tf.io.gfile.copy`, that lets you download from  Google storage.
 
         Returns:

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -161,14 +161,19 @@ class DownloadManager:
         """Download manager constructor.
 
         Args:
-            data_dir: can be used to specify a manual directory to get the files from.
-            dataset_name: `str`, name of dataset this instance will be used for. If
+            data_dir:
+                can be used to specify a manual directory to get the files from.
+            dataset_name (`str`):
+                name of dataset this instance will be used for. If
                 provided, downloads will contain which datasets they were used for.
-            download_config: `DownloadConfig` to specify the cache directory and other
+            download_config (`DownloadConfig`):
+                to specify the cache directory and other
                 download options
-            base_path: `str`, base path that is used when relative paths are used to
+            base_path (`str`):
+                base path that is used when relative paths are used to
                 download files. This can be a remote url.
-            record_checksums (:obj:`bool`, default `True`): Whether to record the checksums of the downloaded files. If None, the value is inferred from the builder.
+            record_checksums (`bool`, defaults to `True`):
+                Whether to record the checksums of the downloaded files. If None, the value is inferred from the builder.
         """
         self._dataset_name = dataset_name
         self._data_dir = data_dir
@@ -194,9 +199,11 @@ class DownloadManager:
         """Ship the files using Beam FileSystems to the pipeline temp dir.
 
         Args:
-            downloaded_path_or_paths (`str` or `list[str]` or `dict[str, str]`): Nested structure containing the
+            downloaded_path_or_paths (`str` or `list[str]` or `dict[str, str]`):
+                Nested structure containing the
                 downloaded path(s).
-            pipeline ([`utils.beam_utils.BeamPipeline`]): Apache Beam Pipeline.
+            pipeline ([`utils.beam_utils.BeamPipeline`]):
+                Apache Beam Pipeline.
 
         Returns:
             `str` or `list[str]` or `dict[str, str]`
@@ -251,14 +258,15 @@ class DownloadManager:
         Download given urls(s) by calling `custom_download`.
 
         Args:
-            url_or_urls: url or `list`/`dict` of urls to download and extract. Each
-                url is a `str`.
-            custom_download: Callable with signature (src_url: str, dst_path: str) -> Any
-                as for example `tf.io.gfile.copy`, that lets you download from google storage
+            url_or_urls (`str` or `list` or `dict`):
+                URL or `list` or `dict` of URLs to download and extract. Each URL is a `str`.
+            custom_download (`Callable[src_url, dst_path]`):
+                The source URL and destination path. Any as for example
+                `tf.io.gfile.copy`, that lets you download from  Google storage.
 
         Returns:
             downloaded_path(s): `str`, The downloaded paths matching the given input
-                url_or_urls.
+                `url_or_urls`.
 
         Example:
 
@@ -296,14 +304,16 @@ class DownloadManager:
     def download(self, url_or_urls):
         """Download given URL(s).
 
-        By default, if there is more than one URL to download, multiprocessing is used with maximum `num_proc = 16`.
+        By default, if there is more than one URL to download, multiprocessing is used with maximum `num_proc=16`.
         Pass customized `download_config.num_proc` to change this behavior.
 
         Args:
-            url_or_urls (`str` or `list` or `dict`): URL or list/dict of URLs to download. Each URL is a `str`.
+            url_or_urls (`str` or `list` or `dict`):
+                URL or `list` or `dict` of URLs to download. Each URL is a `str`.
 
         Returns:
-            `str` or `list` or `dict`: The downloaded paths matching the given input `url_or_urls`.
+            `str` or `list` or `dict`:
+                The downloaded paths matching the given input `url_or_urls`.
 
         Example:
 
@@ -356,10 +366,12 @@ class DownloadManager:
         """Iterate over files within an archive.
 
         Args:
-            path_or_buf (:obj:`str` or :obj:`io.BufferedReader`): Archive path or archive binary file object.
+            path_or_buf (`str` or `io.BufferedReader`):
+                Archive path or archive binary file object.
 
         Yields:
-            :obj:`tuple`[:obj:`str`, :obj:`io.BufferedReader`]: 2-tuple (path_within_archive, file_object).
+            `tuple[str, io.BufferedReader]`:
+                2-tuple (path_within_archive, file_object).
                 File object is opened in binary mode.
 
         Example:
@@ -379,10 +391,11 @@ class DownloadManager:
         """Iterate over file paths.
 
         Args:
-            paths (:obj:`str` or :obj:`list` of :obj:`str`): Root paths.
+            paths (`str` or `list` of `str`):
+                Root paths.
 
         Yields:
-            str: File path.
+            `str`: File path.
 
         Example:
 
@@ -397,10 +410,11 @@ class DownloadManager:
         """Extract given path(s).
 
         Args:
-            path_or_paths: path or `list`/`dict` of path of file to extract. Each
-                path is a `str`.
-            num_proc: Use multi-processing if `num_proc` > 1 and the length of
-                `path_or_paths` is larger than `num_proc`
+            path_or_paths (path or `list` or `dict`):
+                Path of file to extract. Each path is a `str`.
+            num_proc (`int`):
+                Use multi-processing if `num_proc` > 1 and the length of
+                `path_or_paths` is larger than `num_proc`.
 
                 <Deprecated version="2.6.2">
 
@@ -410,7 +424,7 @@ class DownloadManager:
 
         Returns:
             extracted_path(s): `str`, The extracted paths matching the given input
-                path_or_paths.
+            path_or_paths.
 
         Example:
 
@@ -444,7 +458,7 @@ class DownloadManager:
         return extracted_paths.data
 
     def download_and_extract(self, url_or_urls):
-        """Download and extract given url_or_urls.
+        """Download and extract given `url_or_urls`.
 
         Is roughly equivalent to:
 
@@ -453,8 +467,8 @@ class DownloadManager:
         ```
 
         Args:
-            url_or_urls: url or `list`/`dict` of urls to download and extract. Each
-                url is a `str`.
+            url_or_urls (`str` or `list` or `dict`):
+                URL or `list` or `dict` of URLs to download and extract. Each URL is a `str`.
 
         Returns:
             extracted_path(s): `str`, extracted paths of given URL(s).

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -860,9 +860,9 @@ class FilesIterable(_IterableFromGenerator):
 class StreamingDownloadManager:
     """
     Download manager that uses the "::" separator to navigate through (possibly remote) compressed archives.
-    Contrary to the regular DownloadManager, the `download` and `extract` methods don't actually download nor extract
+    Contrary to the regular `DownloadManager`, the `download` and `extract` methods don't actually download nor extract
     data, but they rather return the path or url that could be opened using the `xopen` function which extends the
-    builtin `open` function to stream data from remote files.
+    built-in `open` function to stream data from remote files.
     """
 
     is_streaming = True
@@ -885,10 +885,11 @@ class StreamingDownloadManager:
 
     def download(self, url_or_urls):
         """Normalize URL(s) of files to stream data from.
-        This is the lazy version of DownloadManager.download for streaming.
+        This is the lazy version of `DownloadManager.download` for streaming.
 
         Args:
-            url_or_urls (`str` or `list` or `dict`): URL(s) of files to stream data from. Each url is a `str`.
+            url_or_urls (`str` or `list` or `dict`):
+                URL(s) of files to stream data from. Each url is a `str`.
 
         Returns:
             url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input url_or_urls.
@@ -915,10 +916,11 @@ class StreamingDownloadManager:
         This is the lazy version of `DownloadManager.extract` for streaming.
 
         Args:
-            url_or_urls (`str` or `list` or `dict`): URL or URLs of files to stream data from. Each url is a `str`.
+            url_or_urls (`str` or `list` or `dict`):
+                URL(s) of files to stream data from. Each url is a `str`.
 
         Returns:
-            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input url_or_urls.
+            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input `url_or_urls`.
 
         Example:
 
@@ -949,7 +951,7 @@ class StreamingDownloadManager:
             return f"{protocol}://::{urlpath}"
 
     def download_and_extract(self, url_or_urls):
-        """Prepare given url_or_urls for streaming (add extraction protocol).
+        """Prepare given `url_or_urls` for streaming (add extraction protocol).
 
         This is the lazy version of `DownloadManager.download_and_extract` for streaming.
 
@@ -960,10 +962,11 @@ class StreamingDownloadManager:
         ```
 
         Args:
-            url_or_urls: url or `list`/`dict` of urls to stream from. Each url is a `str`.
+            url_or_urls (`str` or `list` or `dict`):
+                URL(s) to stream from data from. Each url is a `str`.
 
         Returns:
-            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input url_or_urls.
+            url(s): (`str` or `list` or `dict`), URL(s) to stream data from matching the given input `url_or_urls`.
         """
         return self.extract(self.download(url_or_urls))
 
@@ -971,10 +974,12 @@ class StreamingDownloadManager:
         """Iterate over files within an archive.
 
         Args:
-            urlpath_or_buf (:obj:`str` or :obj:`io.BufferedReader`): Archive path or archive binary file object.
+            urlpath_or_buf (`str` or `io.BufferedReader`):
+                Archive path or archive binary file object.
 
         Yields:
-            :obj:`tuple`[:obj:`str`, :obj:`io.BufferedReader`]: 2-tuple (path_within_archive, file_object).
+            `tuple[str, io.BufferedReader]`:
+                2-tuple (path_within_archive, file_object).
                 File object is opened in binary mode.
 
         Example:
@@ -994,7 +999,8 @@ class StreamingDownloadManager:
         """Iterate over files.
 
         Args:
-            urlpaths (:obj:`str` or :obj:`list` of :obj:`str`): Root paths.
+            urlpaths (`str` or `list` of `str`):
+                Root paths.
 
         Yields:
             str: File URL path.

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -313,39 +313,44 @@ class _SubSplit(SplitBase):
 class NamedSplit(SplitBase):
     """Descriptor corresponding to a named split (train, test, ...).
 
-    Example::
-        Each descriptor can be composed with other using addition or slice. Ex::
+    Example:
+        Each descriptor can be composed with other using addition or slice:
 
+            ```py
             split = datasets.Split.TRAIN.subsplit(datasets.percent[0:25]) + datasets.Split.TEST
+            ```
 
         The resulting split will correspond to 25% of the train split merged with
         100% of the test split.
 
-    Warning:
-        A split cannot be added twice, so the following will fail::
+        A split cannot be added twice, so the following will fail:
 
+            ```py
             split = (
                     datasets.Split.TRAIN.subsplit(datasets.percent[:25]) +
                     datasets.Split.TRAIN.subsplit(datasets.percent[75:])
             )  # Error
             split = datasets.Split.TEST + datasets.Split.ALL  # Error
+            ```
 
-    Warning:
-        The slices can be applied only one time. So the following are valid::
+        The slices can be applied only one time. So the following are valid:
 
+            ```py
             split = (
                     datasets.Split.TRAIN.subsplit(datasets.percent[:25]) +
                     datasets.Split.TEST.subsplit(datasets.percent[:50])
             )
             split = (datasets.Split.TRAIN + datasets.Split.TEST).subsplit(datasets.percent[:50])
+            ```
 
+        But this is not valid:
 
-        But not::
-
+            ```py
             train = datasets.Split.TRAIN
             test = datasets.Split.TEST
             split = train.subsplit(datasets.percent[:25]).subsplit(datasets.percent[:25])
             split = (train.subsplit(datasets.percent[:25]) + test).subsplit(datasets.percent[:50])
+            ```
     """
 
     def __init__(self, name):
@@ -412,9 +417,9 @@ class Split:
       you do not want to use this during model iteration as you may overfit to it.
     - `ALL`: the union of all defined dataset splits.
 
-    Note: All splits, including compositions inherit from `datasets.SplitBase`
+    All splits, including compositions inherit from `datasets.SplitBase`.
 
-    See the :doc:`guide on splits </loading>` for more information.
+    See the [guide](./load_hub#splits) on splits for more information.
 
     Example:
 
@@ -598,14 +603,16 @@ class SplitGenerator:
     """Defines the split information for the generator.
 
     This should be used as returned value of
-    :meth:`GeneratorBasedBuilder._split_generators`.
-    See :meth:`GeneratorBasedBuilder._split_generators` for more info and example
+    `GeneratorBasedBuilder._split_generators`.
+    See `GeneratorBasedBuilder._split_generators` for more info and example
     of usage.
 
     Args:
-        name (str): Name of the Split for which the generator will
+        name (`str`):
+            Name of the `Split` for which the generator will
             create the examples.
-        **gen_kwargs: Keyword arguments to forward to the :meth:`DatasetBuilder._generate_examples` method
+        **gen_kwargs (additional keyword arguments):
+            Keyword arguments to forward to the `DatasetBuilder._generate_examples` method
             of the builder.
 
     Example:

--- a/src/datasets/utils/version.py
+++ b/src/datasets/utils/version.py
@@ -28,18 +28,16 @@ _VERSION_REG = re.compile(r"^(?P<major>\d+)" r"\.(?P<minor>\d+)" r"\.(?P<patch>\
 @total_ordering
 @dataclass
 class Version:
-    """Dataset version MAJOR.MINOR.PATCH.
+    """Dataset version `MAJOR.MINOR.PATCH`.
 
     Args:
-        version_str (:obj:`str`): Eg: "1.2.3".
-        description (:obj:`str`): A description of what is new in this version.
-
-    Attributes:
-        version_str (:obj:`str`): Eg: "1.2.3".
-        description (:obj:`str`): A description of what is new in this version.
-        major (:obj:`str`):
-        minor (:obj:`str`):
-        patch (:obj:`str`):
+        version_str (`str`):
+            The dataset version.
+        description (`str`):
+            A description of what is new in this version.
+        major (`str`):
+        minor (`str`):
+        patch (`str`):
 
     Example:
 


### PR DESCRIPTION
As raised by @polinaeterna in #5324, some of the docstrings are a bit of a mess because it has both Markdown and Sphinx syntax. This PR fixes the docstring for `DatasetBuilder`. 

I'll start working on cleaning up the rest of the docstrings and removing the old Sphinx syntax (let me know if you prefer one big PR with all the cleaned changes or multiple smaller ones)! 🧼 