### PR TITLE
Set `IterableDataset.map` param `batch_size` typing as optional

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -374,8 +374,8 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         iterator = iter(self.ex_iterable)
         current_idx = 0
         if self.batched:
-            if batch_size is None or batch_size <= 0:
-                batch_size = 1000
+            if self.batch_size is None or self.batch_size <= 0:
+                self.batch_size = 1000
             for key, example in iterator:
                 # If batched, first build the batch
                 key_examples_list = [(key, example)] + [
@@ -484,8 +484,8 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
         iterator = iter(self.ex_iterable)
         current_idx = 0
         if self.batched:
-            if batch_size is None or batch_size <= 0:
-                batch_size = 1000
+            if self.batch_size is None or self.batch_size <= 0:
+                self.batch_size = 1000
             for key, example in iterator:
                 # If batched, first build the batch
                 key_examples_list = [(key, example)] + [

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -374,13 +374,14 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         iterator = iter(self.ex_iterable)
         current_idx = 0
         if self.batched:
-            if self.batch_size is None or self.batch_size <= 0:
-                self.batch_size = 1000
             for key, example in iterator:
-                # If batched, first build the batch
-                key_examples_list = [(key, example)] + [
-                    (key, example) for key, example in islice(iterator, self.batch_size - 1)
-                ]
+                # If `batched`, first build the batch, if `batch_size` is None or <=0, then the batch is the whole dataset
+                iterator_batch = (
+                        iterator
+                        if self.batch_size is None or self.batch_size <= 0
+                        else islice(iterator, self.batch_size - 1)
+                    )
+                key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
                 keys, examples = zip(*key_examples_list)
                 if self.drop_last_batch and len(examples) < self.batch_size:  # ignore last batch
                     return
@@ -484,13 +485,14 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
         iterator = iter(self.ex_iterable)
         current_idx = 0
         if self.batched:
-            if self.batch_size is None or self.batch_size <= 0:
-                self.batch_size = 1000
             for key, example in iterator:
-                # If batched, first build the batch
-                key_examples_list = [(key, example)] + [
-                    (key, example) for key, example in islice(iterator, self.batch_size - 1)
-                ]
+                # If `batched`, first build the batch, if `batch_size` is None or <=0, then the batch is the whole dataset
+                iterator_batch = (
+                        iterator
+                        if self.batch_size is None or self.batch_size <= 0
+                        else islice(iterator, self.batch_size - 1)
+                    )
+                key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
                 keys, examples = zip(*key_examples_list)
                 batch = _examples_to_batch(examples)
                 # then compute the mask for the batch

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -374,6 +374,8 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         iterator = iter(self.ex_iterable)
         current_idx = 0
         if self.batched:
+            if batch_size is None or batch_size <= 0:
+                batch_size = 1000
             for key, example in iterator:
                 # If batched, first build the batch
                 key_examples_list = [(key, example)] + [
@@ -482,6 +484,8 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
         iterator = iter(self.ex_iterable)
         current_idx = 0
         if self.batched:
+            if batch_size is None or batch_size <= 0:
+                batch_size = 1000
             for key, example in iterator:
                 # If batched, first build the batch
                 key_examples_list = [(key, example)] + [

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -377,13 +377,18 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             for key, example in iterator:
                 # If `batched`, first build the batch, if `batch_size` is None or <=0, then the batch is the whole dataset
                 iterator_batch = (
-                        iterator
-                        if self.batch_size is None or self.batch_size <= 0
-                        else islice(iterator, self.batch_size - 1)
-                    )
+                    iterator
+                    if self.batch_size is None or self.batch_size <= 0
+                    else islice(iterator, self.batch_size - 1)
+                )
                 key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
                 keys, examples = zip(*key_examples_list)
-                if self.drop_last_batch and len(examples) < self.batch_size:  # ignore last batch
+                if (
+                    self.drop_last_batch
+                    and self.batch_size is not None
+                    and self.batch_size > 0
+                    and len(examples) < self.batch_size
+                ):  # ignore last batch
                     return
                 batch = _examples_to_batch(examples)
                 # then apply the transform
@@ -488,10 +493,10 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
             for key, example in iterator:
                 # If `batched`, first build the batch, if `batch_size` is None or <=0, then the batch is the whole dataset
                 iterator_batch = (
-                        iterator
-                        if self.batch_size is None or self.batch_size <= 0
-                        else islice(iterator, self.batch_size - 1)
-                    )
+                    iterator
+                    if self.batch_size is None or self.batch_size <= 0
+                    else islice(iterator, self.batch_size - 1)
+                )
                 key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
                 keys, examples = zip(*key_examples_list)
                 batch = _examples_to_batch(examples)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -884,6 +884,7 @@ class IterableDataset(DatasetInfoMixin):
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
             batched (:obj:`bool`, default `False`): Provide batch of examples to `function`.
             batch_size (:obj:`int`, optional, default ``1000``): Number of examples per batch provided to `function` if `batched=True`.
+                `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`.
             drop_last_batch (:obj:`bool`, default `False`): Whether a last batch smaller than the batch_size should be
                 dropped instead of being processed by the function.
             remove_columns (`Optional[List[str]]`, defaults to `None`): Remove a selection of columns while doing the mapping.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -355,7 +355,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         with_indices: bool = False,
         input_columns: Optional[List[str]] = None,
         batched: bool = False,
-        batch_size: int = 1000,
+        batch_size: Union[int, None] = 1000,
         drop_last_batch: bool = False,
         remove_columns: Optional[List[str]] = None,
         fn_kwargs: Optional[dict] = None,
@@ -469,7 +469,7 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
         with_indices: bool = False,
         input_columns: Optional[List[str]] = None,
         batched: bool = False,
-        batch_size: int = 1000,
+        batch_size: Union[int, None] = 1000,
     ):
         self.ex_iterable = ex_iterable
         self.function = function
@@ -835,7 +835,7 @@ class IterableDataset(DatasetInfoMixin):
         with_indices: bool = False,
         input_columns: Optional[Union[str, List[str]]] = None,
         batched: bool = False,
-        batch_size: int = 1000,
+        batch_size: Union[int, None] = 1000,
         drop_last_batch: bool = False,
         remove_columns: Optional[Union[str, List[str]]] = None,
         features: Optional[Features] = None,
@@ -936,7 +936,7 @@ class IterableDataset(DatasetInfoMixin):
         with_indices=False,
         input_columns: Optional[Union[str, List[str]]] = None,
         batched: bool = False,
-        batch_size: Optional[int] = 1000,
+        batch_size: Union[int, None] = 1000,
     ) -> "IterableDataset":
         """Apply a filter function to all the elements so that the dataset only includes examples according to the filter function.
         The filtering is done on-the-fly when iterating over the dataset.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -355,7 +355,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         with_indices: bool = False,
         input_columns: Optional[List[str]] = None,
         batched: bool = False,
-        batch_size: Union[int, None] = 1000,
+        batch_size: Optional[int] = 1000,
         drop_last_batch: bool = False,
         remove_columns: Optional[List[str]] = None,
         fn_kwargs: Optional[dict] = None,
@@ -471,7 +471,7 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
         with_indices: bool = False,
         input_columns: Optional[List[str]] = None,
         batched: bool = False,
-        batch_size: Union[int, None] = 1000,
+        batch_size: Optional[int] = 1000,
     ):
         self.ex_iterable = ex_iterable
         self.function = function
@@ -839,7 +839,7 @@ class IterableDataset(DatasetInfoMixin):
         with_indices: bool = False,
         input_columns: Optional[Union[str, List[str]]] = None,
         batched: bool = False,
-        batch_size: Union[int, None] = 1000,
+        batch_size: Optional[int] = 1000,
         drop_last_batch: bool = False,
         remove_columns: Optional[Union[str, List[str]]] = None,
         features: Optional[Features] = None,
@@ -940,7 +940,7 @@ class IterableDataset(DatasetInfoMixin):
         with_indices=False,
         input_columns: Optional[Union[str, List[str]]] = None,
         batched: bool = False,
-        batch_size: Union[int, None] = 1000,
+        batch_size: Optional[int] = 1000,
     ) -> "IterableDataset":
         """Apply a filter function to all the elements so that the dataset only includes examples according to the filter function.
         The filtering is done on-the-fly when iterating over the dataset.

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -197,6 +197,8 @@ def test_randomly_cycling_multi_sources_examples_iterable(probabilities):
         (3, lambda x: {"id+1": [x["id"][0] + 1]}, True, 1),  # same with bs=1
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
         (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None),  # same with bs=None
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1),  # same with bs<=0
         (3, lambda x: {k: v * 2 for k, v in x.items()}, True, 1),  # make a duplicate of each example
     ],
 )
@@ -204,11 +206,14 @@ def test_mapped_examples_iterable(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(base_ex_iterable, func, batched=batched, batch_size=batch_size)
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    if batch_size is None:
+    if batched is False:
         expected = [{**x, **func(x)} for x in all_examples]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -222,28 +227,33 @@ def test_mapped_examples_iterable(n, func, batched, batch_size):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size",
+    "n, func, batched, batch_size",
     [
-        (3, lambda x: {"id+1": x["id"] + 1}, None),  # just add 1 to the id
-        (3, lambda x: {"id+1": [x["id"][0] + 1]}, 1),  # same with bs=1
-        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, 10),  # same with bs=10
-        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, 10),  # same with bs=10
-        (3, lambda x: {k: v * 2 for k, v in x.items()}, 1),  # make a duplicate of each example
+        (3, lambda x: {"id+1": x["id"] + 1}, False, None),  # just add 1 to the id
+        (3, lambda x: {"id+1": [x["id"][0] + 1]}, True, 1),  # same with bs=1
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
+        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None),  # same with bs=None
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1),  # same with bs<=0
+        (3, lambda x: {k: v * 2 for k, v in x.items()}, True, 1),  # make a duplicate of each example
     ],
 )
-def test_mapped_examples_iterable_drop_last_batch(n, func, batch_size):
+def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, drop_last_batch=True
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, drop_last_batch=True
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     is_empty = False
-    if batch_size is None:
+    if batched is False:
         # `drop_last_batch` has no effect here
         expected = [{**x, **func(x)} for x in all_examples]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             if len(examples) < batch_size:  # ignore last batch
@@ -268,23 +278,33 @@ def test_mapped_examples_iterable_drop_last_batch(n, func, batch_size):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size",
+    "n, func, batched, batch_size",
     [
-        (3, lambda x, index: {"id+idx": x["id"] + index}, None),  # add the index to the id
-        (25, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, 10),  # add the index to the id
+        (3, lambda x, index: {"id+idx": x["id"] + index}, False, None),  # add the index to the id
+        (
+            25,
+            lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
+            True,
+            10,
+        ),  # add the index to the id
+        (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, None),  # same with bs=None
+        (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, -1),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_with_indices(n, func, batch_size):
+def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, with_indices=True
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, with_indices=True
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    if batch_size is None:
+    if batched is False:
         expected = [{**x, **func(x, idx)} for idx, x in enumerate(all_examples)]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -299,30 +319,36 @@ def test_mapped_examples_iterable_with_indices(n, func, batch_size):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size, remove_columns",
+    "n, func, batched, batch_size, remove_columns",
     [
-        (3, lambda x: {"id+1": x["id"] + 1}, None, ["extra_column"]),  # just add 1 to the id
-        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, 10, ["extra_column"]),  # same with bs=10
+        (3, lambda x: {"id+1": x["id"] + 1}, False, None, ["extra_column"]),  # just add 1 to the id
+        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10, ["extra_column"]),  # same with bs=10
         (
             50,
             lambda x: {"foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)},
+            True,
             8,
             ["extra_column", "id"],
         ),  # make a duplicate of each example
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None, ["extra_column"]),  # same with bs=None
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1, ["extra_column"]),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_remove_columns(n, func, batch_size, remove_columns):
+def test_mapped_examples_iterable_remove_columns(n, func, batched, batch_size, remove_columns):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n, "extra_column": "foo"})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, remove_columns=remove_columns
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, remove_columns=remove_columns
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     columns_to_remove = remove_columns if isinstance(remove_columns, list) else [remove_columns]
-    if batch_size is None:
+    if batched is False:
         expected = [{**{k: v for k, v in x.items() if k not in columns_to_remove}, **func(x)} for x in all_examples]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -336,26 +362,31 @@ def test_mapped_examples_iterable_remove_columns(n, func, batch_size, remove_col
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size, fn_kwargs",
+    "n, func, batched, batch_size, fn_kwargs",
     [
-        (3, lambda x, y=0: {"id+y": x["id"] + y}, None, None),
-        (3, lambda x, y=0: {"id+y": x["id"] + y}, None, {"y": 3}),
-        (25, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, 10, {"y": 3}),
+        (3, lambda x, y=0: {"id+y": x["id"] + y}, False, None, None),
+        (3, lambda x, y=0: {"id+y": x["id"] + y}, False, None, {"y": 3}),
+        (25, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, True, 10, {"y": 3}),
+        (5, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, True, None, {"y": 3}),  # same with bs=None
+        (5, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, True, -1, {"y": 3}),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_fn_kwargs(n, func, batch_size, fn_kwargs):
+def test_mapped_examples_iterable_fn_kwargs(n, func, batched, batch_size, fn_kwargs):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, fn_kwargs=fn_kwargs
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, fn_kwargs=fn_kwargs
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if fn_kwargs is None:
         fn_kwargs = {}
-    if batch_size is None:
+    if batched is False:
         expected = [{**x, **func(x, **fn_kwargs)} for x in all_examples]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -369,24 +400,29 @@ def test_mapped_examples_iterable_fn_kwargs(n, func, batch_size, fn_kwargs):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size, input_columns",
+    "n, func, batched, batch_size, input_columns",
     [
-        (3, lambda id_: {"id+1": id_ + 1}, None, ["id"]),  # just add 1 to the id
-        (25, lambda ids_: {"id+1": [i + 1 for i in ids_]}, 10, ["id"]),  # same with bs=10
+        (3, lambda id_: {"id+1": id_ + 1}, False, None, ["id"]),  # just add 1 to the id
+        (25, lambda ids_: {"id+1": [i + 1 for i in ids_]}, True, 10, ["id"]),  # same with bs=10
+        (5, lambda ids_: {"id+1": [i + 1 for i in ids_]}, True, None, ["id"]),  # same with bs=None
+        (5, lambda ids_: {"id+1": [i + 1 for i in ids_]}, True, -1, ["id"]),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_input_columns(n, func, batch_size, input_columns):
+def test_mapped_examples_iterable_input_columns(n, func, batched, batch_size, input_columns):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, input_columns=input_columns
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, input_columns=input_columns
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     columns_to_input = input_columns if isinstance(input_columns, list) else [input_columns]
-    if batch_size is None:
+    if batched is False:
         expected = [{**x, **func(*[x[col] for col in columns_to_input])} for x in all_examples]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -400,27 +436,29 @@ def test_mapped_examples_iterable_input_columns(n, func, batch_size, input_colum
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size",
+    "n, func, batched, batch_size",
     [
-        (3, lambda x: x["id"] % 2 == 0, None),  # keep even number
-        (3, lambda x: [x["id"][0] % 2 == 0], 1),  # same with bs=1
-        (5, lambda x: [i % 2 == 0 for i in x["id"]], 10),  # same with bs=10
-        (25, lambda x: [i % 2 == 0 for i in x["id"]], 10),  # same with bs=10
-        (3, lambda x: False, None),  # return 0 examples
-        (3, lambda x: [False] * len(x["id"]), 10),  # same with bs=10
+        (3, lambda x: x["id"] % 2 == 0, False, None),  # keep even number
+        (3, lambda x: [x["id"][0] % 2 == 0], True, 1),  # same with bs=1
+        (25, lambda x: [i % 2 == 0 for i in x["id"]], True, 10),  # same with bs=10
+        (5, lambda x: [i % 2 == 0 for i in x["id"]], True, None),  # same with bs=None
+        (5, lambda x: [i % 2 == 0 for i in x["id"]], True, -1),  # same with bs<=0
+        (3, lambda x: False, False, None),  # return 0 examples
+        (3, lambda x: [False] * len(x["id"]), True, 10),  # same with bs=10
     ],
 )
-def test_filtered_examples_iterable(n, func, batch_size):
+def test_filtered_examples_iterable(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = FilteredExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size
-    )
+    ex_iterable = FilteredExamplesIterable(base_ex_iterable, func, batched=batched, batch_size=batch_size)
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    if batch_size is None:
+    if batched is False:
         expected = [x for x in all_examples if func(x)]
     else:
         # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         expected = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -432,23 +470,28 @@ def test_filtered_examples_iterable(n, func, batch_size):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size",
+    "n, func, batched, batch_size",
     [
-        (3, lambda x, index: index % 2 == 0, None),  # keep even number
-        (25, lambda x, indices: [idx % 2 == 0 for idx in indices], 10),  # same with bs=10
+        (3, lambda x, index: index % 2 == 0, False, None),  # keep even number
+        (25, lambda x, indices: [idx % 2 == 0 for idx in indices], True, 10),  # same with bs=10
+        (5, lambda x, indices: [idx % 2 == 0 for idx in indices], True, None),  # same with bs=None
+        (5, lambda x, indices: [idx % 2 == 0 for idx in indices], True, -1),  # same with bs<=0
     ],
 )
-def test_filtered_examples_iterable_with_indices(n, func, batch_size):
+def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = FilteredExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, with_indices=True
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, with_indices=True
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    if batch_size is None:
+    if batched is False:
         expected = [x for idx, x in enumerate(all_examples) if func(x, idx)]
     else:
         # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         expected = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
@@ -460,24 +503,29 @@ def test_filtered_examples_iterable_with_indices(n, func, batch_size):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size, input_columns",
+    "n, func, batched, batch_size, input_columns",
     [
-        (3, lambda id_: id_ % 2 == 0, None, ["id"]),  # keep even number
-        (25, lambda ids_: [i % 2 == 0 for i in ids_], 10, ["id"]),  # same with bs=10
+        (3, lambda id_: id_ % 2 == 0, False, None, ["id"]),  # keep even number
+        (25, lambda ids_: [i % 2 == 0 for i in ids_], True, 10, ["id"]),  # same with bs=10
+        (3, lambda ids_: [i % 2 == 0 for i in ids_], True, None, ["id"]),  # same with bs=None
+        (3, lambda ids_: [i % 2 == 0 for i in ids_], True, None, ["id"]),  # same with bs=None
     ],
 )
-def test_filtered_examples_iterable_input_columns(n, func, batch_size, input_columns):
+def test_filtered_examples_iterable_input_columns(n, func, batched, batch_size, input_columns):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = FilteredExamplesIterable(
-        base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size, input_columns=input_columns
+        base_ex_iterable, func, batched=batched, batch_size=batch_size, input_columns=input_columns
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     columns_to_input = input_columns if isinstance(input_columns, list) else [input_columns]
-    if batch_size is None:
+    if batched is False:
         expected = [x for x in all_examples if func(*[x[col] for col in columns_to_input])]
     else:
         # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         expected = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -191,18 +191,18 @@ def test_randomly_cycling_multi_sources_examples_iterable(probabilities):
 
 
 @pytest.mark.parametrize(
-    "n, func, batch_size",
+    "n, func, batched, batch_size",
     [
-        (3, lambda x: {"id+1": x["id"] + 1}, None),  # just add 1 to the id
-        (3, lambda x: {"id+1": [x["id"][0] + 1]}, 1),  # same with bs=1
-        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, 10),  # same with bs=10
-        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, 10),  # same with bs=10
-        (3, lambda x: {k: v * 2 for k, v in x.items()}, 1),  # make a duplicate of each example
+        (3, lambda x: {"id+1": x["id"] + 1}, False, None),  # just add 1 to the id
+        (3, lambda x: {"id+1": [x["id"][0] + 1]}, True, 1),  # same with bs=1
+        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
+        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
+        (3, lambda x: {k: v * 2 for k, v in x.items()}, True, 1),  # make a duplicate of each example
     ],
 )
-def test_mapped_examples_iterable(n, func, batch_size):
+def test_mapped_examples_iterable(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = MappedExamplesIterable(base_ex_iterable, func, batched=batch_size is not None, batch_size=batch_size)
+    ex_iterable = MappedExamplesIterable(base_ex_iterable, func, batched=batched, batch_size=batch_size)
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batch_size is None:
         expected = [{**x, **func(x)} for x in all_examples]


### PR DESCRIPTION
This PR solves #5325 

~Indeed we're using the typing for optional values as `Union[type, None]` as it's similar to how Python 3.10 handles optional values as `type | None`, instead of using `Optional[type]`.~

~Do we want to start using `Union[type, None]` for type-hinting optional values or just keep on using `Optional`?~ -> Keeping `Optional` still for consistency with the rest of the code in `datasets`

Also we now allow `batch_size` to be `None` for `IterableDataset.map` and `IterableDataset.filter`e.g. `MappedExamplesIterable` as `map` is internally instantiating those and propagating the `batch_size` param so if it can be `None` for `map` it should also do so for `MappedExamplesIterable`, as well as for `FilteredExamplesIterable` when calling `IterableDataset.filter`.

## TODOs

- [x] Add integration tests
- [x] Handle scenario where `batched=True` and `batch_size=None` or `batch_size<=0`