### PR TITLE
Clean up remaining Main Classes docstrings

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1430,8 +1430,9 @@ class IterableDatasetDict(dict):
 
         Args:
 
-            type (:obj:`str`, optional, default None): if set to "torch", the returned dataset
-                will be a subclass of torch.utils.data.IterableDataset to be used in a DataLoader
+            type (`str`, *optional*, defaults to `None`):
+                If set to "torch", the returned dataset
+                will be a subclass of `torch.utils.data.IterableDataset` to be used in a `DataLoader`.
 
         Example:
 
@@ -1464,18 +1465,19 @@ class IterableDatasetDict(dict):
         The function is applied on-the-fly on the examples when iterating over the dataset.
         The transformation is applied to all the datasets of the dataset dictionary.
 
-        You can specify whether the function should be batched or not with the ``batched`` parameter:
+        You can specify whether the function should be batched or not with the `batched` parameter:
 
-        - If batched is False, then the function takes 1 example in and should return 1 example.
-          An example is a dictionary, e.g. {"text": "Hello there !"}
-        - If batched is True and batch_size is 1, then the function takes a batch of 1 example as input and can return a batch with 1 or more examples.
-          A batch is a dictionary, e.g. a batch of 1 example is {"text": ["Hello there !"]}
-        - If batched is True and batch_size is ``n`` > 1, then the function takes a batch of ``n`` examples as input and can return a batch with ``n`` examples, or with an arbitrary number of examples.
-          Note that the last batch may have less than ``n`` examples.
-          A batch is a dictionary, e.g. a batch of ``n`` examples is {"text": ["Hello there !"] * n}
+        - If batched is `False`, then the function takes 1 example in and should return 1 example.
+          An example is a dictionary, e.g. `{"text": "Hello there !"}`.
+        - If batched is `True` and `batch_size` is 1, then the function takes a batch of 1 example as input and can return a batch with 1 or more examples.
+          A batch is a dictionary, e.g. a batch of 1 example is `{"text": ["Hello there !"]}`.
+        - If batched is `True` and `batch_size` is `n` > 1, then the function takes a batch of `n` examples as input and can return a batch with `n` examples, or with an arbitrary number of examples.
+          Note that the last batch may have less than `n` examples.
+          A batch is a dictionary, e.g. a batch of `n` examples is `{"text": ["Hello there !"] * n}`.
 
         Args:
-            function (:obj:`Callable`, optional, default None): Function applied on-the-fly on the examples when you iterate on the dataset
+            function (`Callable`, *optional*, defaults to `None`):
+                Function applied on-the-fly on the examples when you iterate on the dataset.
                 It must have one of the following signatures:
 
                 - `function(example: Dict[str, Any]) -> Dict[str, Any]` if `batched=False` and `with_indices=False`
@@ -1485,15 +1487,21 @@ class IterableDatasetDict(dict):
 
                 For advanced usage, the function can also return a `pyarrow.Table`.
                 Moreover if your function returns nothing (`None`), then `map` will run your function and return the dataset unchanged.
-                If no function is provided, default to identity function: ``lambda x: x``.
-            with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
-            input_columns (`Optional[Union[str, List[str]]]`, default `None`): The columns to be passed into `function`
+                If no function is provided, default to identity function: `lambda x: x`.
+            with_indices (`bool`, defaults to `False`):
+                Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
+            input_columns (`[Union[str, List[str]]]`, *optional*, defaults to `None`):
+                The columns to be passed into `function`
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
-            batched (:obj:`bool`, default `False`): Provide batch of examples to `function`.
-            batch_size (:obj:`int`, optional, default ``1000``): Number of examples per batch provided to `function` if `batched=True`.
-            drop_last_batch (:obj:`bool`, default `False`): Whether a last batch smaller than the batch_size should be
+            batched (`bool`, defaults to `False`):
+                Provide batch of examples to `function`.
+            batch_size (`int`, *optional*, defaults to `1000`):
+                Number of examples per batch provided to `function` if `batched=True`.
+            drop_last_batch (`bool`, defaults to `False`):
+                Whether a last batch smaller than the `batch_size` should be
                 dropped instead of being processed by the function.
-            remove_columns (`Optional[List[str]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
+            remove_columns (`[List[str]]`, *optional*, defaults to `None`):
+                Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
 
@@ -1539,19 +1547,24 @@ class IterableDatasetDict(dict):
         The filtering is applied to all the datasets of the dataset dictionary.
 
         Args:
-            function (:obj:`Callable`): Callable with one of the following signatures:
+            function (`Callable`):
+                Callable with one of the following signatures:
 
-                - ``function(example: Dict[str, Any]) -> bool`` if ``with_indices=False, batched=False``
-                - ``function(example: Dict[str, Any], indices: int) -> bool`` if ``with_indices=True, batched=False``
-                - ``function(example: Dict[str, List]) -> List[bool]`` if ``with_indices=False, batched=True``
-                - ``function(example: Dict[str, List], indices: List[int]) -> List[bool]`` if ``with_indices=True, batched=True``
+                - `function(example: Dict[str, Any]) -> bool` if `with_indices=False, batched=False`
+                - `function(example: Dict[str, Any], indices: int) -> bool` if `with_indices=True, batched=False`
+                - `function(example: Dict[str, List]) -> List[bool]` if `with_indices=False, batched=True`
+                - `function(example: Dict[str, List], indices: List[int]) -> List[bool]` if `with_indices=True, batched=True`
 
-                If no function is provided, defaults to an always True function: ``lambda x: True``.
-            with_indices (:obj:`bool`, default `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
-            input_columns (:obj:`str` or `List[str]`, optional): The columns to be passed into `function` as
+                If no function is provided, defaults to an always True function: `lambda x: True`.
+            with_indices (`bool`, defaults to `False`):
+                Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
+            input_columns (`str` or `List[str]`, *optional*):
+                The columns to be passed into `function` as
                 positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
-            batched (:obj:`bool`, defaults to `False`): Provide batch of examples to `function`
-            batch_size (:obj:`int`, optional, default ``1000``): Number of examples per batch provided to `function` if `batched=True`.
+            batched (`bool`, defaults to `False`):
+                Provide batch of examples to `function`
+            batch_size (`int`, *optional*, defaults to `1000`):
+                Number of examples per batch provided to `function` if `batched=True`.
 
         Example:
 
@@ -1591,21 +1604,24 @@ class IterableDatasetDict(dict):
         replacing the selected elements with new elements. For perfect shuffling, a buffer size greater than or
         equal to the full size of the dataset is required.
 
-        For instance, if your dataset contains 10,000 elements but ``buffer_size`` is set to 1,000, then shuffle will
-        initially select a random element from only the first 1,000 elements in the buffer. Once an element is
+        For instance, if your dataset contains 10,000 elements but `buffer_size` is set to 1000, then `shuffle` will
+        initially select a random element from only the first 1000 elements in the buffer. Once an element is
         selected, its space in the buffer is replaced by the next (i.e. 1,001-st) element,
-        maintaining the 1,000 element buffer.
+        maintaining the 1000 element buffer.
 
-        If the dataset is made of several shards, it also does shuffle the order of the shards.
-        However if the order has been fixed by using :func:`datasets.IterableDataset.skip` or :func:`datasets.IterableDataset.take`
+        If the dataset is made of several shards, it also does `shuffle` the order of the shards.
+        However if the order has been fixed by using [`~datasets.IterableDataset.skip`] or [`~datasets.IterableDataset.take`]
         then the order of the shards is kept unchanged.
 
         Args:
-            seed (:obj:`int`, optional, default None): random seed that will be used to shuffle the dataset.
+            seed (`int`, *optional*, defaults to `None`):
+                Random seed that will be used to shuffle the dataset.
                 It is used to sample from the shuffle buffe and als oto shuffle the data shards.
-            generator (:obj:`numpy.random.Generator`, optional): Numpy random Generator to use to compute the permutation of the dataset rows.
-                If ``generator=None`` (default), uses np.random.default_rng (the default BitGenerator (PCG64) of NumPy).
-            buffer_size (:obj:`int`, default 1000): size of the buffer.
+            generator (`numpy.random.Generator`, *optional*):
+                Numpy random Generator to use to compute the permutation of the dataset rows.
+                If `generator=None` (default), uses `np.random.default_rng` (the default BitGenerator (PCG64) of NumPy).
+            buffer_size (`int`, defaults to `1000`):
+                Size of the buffer.
 
         Example:
 
@@ -1642,11 +1658,13 @@ class IterableDatasetDict(dict):
         The renaming is applied to all the datasets of the dataset dictionary.
 
         Args:
-            original_column_name (:obj:`str`): Name of the column to rename.
-            new_column_name (:obj:`str`): New name for the column.
+            original_column_name (`str`):
+                Name of the column to rename.
+            new_column_name (`str`):
+                New name for the column.
 
         Returns:
-            :class:`IterableDatasetDict`: A copy of the dataset with a renamed column.
+            [`IterableDatasetDict`]: A copy of the dataset with a renamed column.
 
         Example:
 
@@ -1673,10 +1691,11 @@ class IterableDatasetDict(dict):
         The renaming is applied to all the datasets of the dataset dictionary.
 
         Args:
-            column_mapping (:obj:`Dict[str, str]`): A mapping of columns to rename to their new names
+            column_mapping (`Dict[str, str]`):
+                A mapping of columns to rename to their new names.
 
         Returns:
-            :class:`IterableDatasetDict`: A copy of the dataset with renamed columns
+            [`IterableDatasetDict`]: A copy of the dataset with renamed columns
 
         Example:
 
@@ -1701,10 +1720,11 @@ class IterableDatasetDict(dict):
 
 
         Args:
-            column_names (:obj:`Union[str, List[str]]`): Name of the column(s) to remove.
+            column_names (`Union[str, List[str]]`):
+                Name of the column(s) to remove.
 
         Returns:
-            :class:`IterableDatasetDict`: A copy of the dataset object without the columns to remove.
+            [`IterableDatasetDict`]: A copy of the dataset object without the columns to remove.
 
         Example:
 
@@ -1723,11 +1743,13 @@ class IterableDatasetDict(dict):
         The type casting is applied to all the datasets of the dataset dictionary.
 
         Args:
-            column (:obj:`str`): Column name.
-            feature (:class:`Feature`): Target feature.
+            column (`str`):
+                Column name.
+            feature ([`Feature`]):
+                Target feature.
 
         Returns:
-            :class:`IterableDatasetDict`
+            [`IterableDatasetDict`]
 
         Example:
 
@@ -1756,13 +1778,14 @@ class IterableDatasetDict(dict):
         The type casting is applied to all the datasets of the dataset dictionary.
 
         Args:
-            features (:class:`datasets.Features`): New features to cast the dataset to.
+            features (`Features`):
+                New features to cast the dataset to.
                 The name of the fields in the features must match the current column names.
                 The type of the data must also be convertible from one type to the other.
-                For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
+                For non-trivial conversion, e.g. `string` <-> `ClassLabel` you should use [`map`] to update the Dataset.
 
         Returns:
-            :class:`IterableDatasetDict`: A copy of the dataset with casted features.
+            [`IterableDatasetDict`]: A copy of the dataset with casted features.
 
         Example:
 

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -23,31 +23,34 @@ _ffmpeg_warned, _librosa_warned, _audioread_warned = False, False, False
 
 @dataclass
 class Audio:
-    """Audio Feature to extract audio data from an audio file.
+    """Audio [`Feature`] to extract audio data from an audio file.
 
     Input: The Audio feature accepts as input:
-    - A :obj:`str`: Absolute path to the audio file (i.e. random access is allowed).
-    - A :obj:`dict` with the keys:
+    - A `str`: Absolute path to the audio file (i.e. random access is allowed).
+    - A `dict` with the keys:
 
-        - path: String with relative path of the audio file to the archive file.
-        - bytes: Bytes content of the audio file.
+        - `path`: String with relative path of the audio file to the archive file.
+        - `bytes`: Bytes content of the audio file.
 
       This is useful for archived files with sequential access.
 
-    - A :obj:`dict` with the keys:
+    - A `dict` with the keys:
 
-        - path: String with relative path of the audio file to the archive file.
-        - array: Array containing the audio sample
-        - sampling_rate: Integer corresponding to the sampling rate of the audio sample.
+        - `path`: String with relative path of the audio file to the archive file.
+        - `array`: Array containing the audio sample
+        - `sampling_rate`: Integer corresponding to the sampling rate of the audio sample.
 
       This is useful for archived files with sequential access.
 
     Args:
-        sampling_rate (:obj:`int`, optional): Target sampling rate. If `None`, the native sampling rate is used.
-        mono (:obj:`bool`, default ``True``): Whether to convert the audio signal to mono by averaging samples across
+        sampling_rate (`int`, *optional*):
+            Target sampling rate. If `None`, the native sampling rate is used.
+        mono (`bool`, defaults to `True`):
+            Whether to convert the audio signal to mono by averaging samples across
             channels.
-        decode (:obj:`bool`, default ``True``): Whether to decode the audio data. If `False`,
-            returns the underlying dictionary in the format {"path": audio_path, "bytes": audio_bytes}.
+        decode (`bool`, defaults to `True`):
+            Whether to decode the audio data. If `False`,
+            returns the underlying dictionary in the format `{"path": audio_path, "bytes": audio_bytes}`.
 
     Example:
 
@@ -79,10 +82,11 @@ class Audio:
         """Encode example into a format for Arrow.
 
         Args:
-            value (:obj:`str` or :obj:`dict`): Data passed as input to Audio feature.
+            value (`str` or `dict`):
+                Data passed as input to Audio feature.
 
         Returns:
-            :obj:`dict`
+            `dict`
         """
         try:
             import soundfile as sf  # soundfile is a dependency of librosa, needed to decode audio files.
@@ -127,16 +131,18 @@ class Audio:
         """Decode example audio file into audio data.
 
         Args:
-            value (:obj:`dict`): a dictionary with keys:
+            value (`dict`):
+                A dictionary with keys:
 
-                - path: String with relative audio file path.
-                - bytes: Bytes of the audio file.
-            token_per_repo_id (:obj:`dict`, optional): To access and decode
+                - `path`: String with relative audio file path.
+                - `bytes`: Bytes of the audio file.
+            token_per_repo_id (`dict`, *optional*):
+                To access and decode
                 audio files from private repositories on the Hub, you can pass
-                a dictionary repo_id (str) -> token (bool or str)
+                a dictionary repo_id (`str`) -> token (`bool` or `str`)
 
         Returns:
-            dict
+            `dict`
         """
         if not self.decode:
             raise RuntimeError("Decoding is disabled for this feature. Please use Audio(decode=True) instead.")
@@ -175,17 +181,18 @@ class Audio:
         """Cast an Arrow array to the Audio arrow storage type.
         The Arrow types that can be converted to the Audio pyarrow storage type are:
 
-        - pa.string() - it must contain the "path" data
-        - pa.struct({"bytes": pa.binary()})
-        - pa.struct({"path": pa.string()})
-        - pa.struct({"bytes": pa.binary(), "path": pa.string()})  - order doesn't matter
+        - `pa.string()` - it must contain the "path" data
+        - `pa.struct({"bytes": pa.binary()})`
+        - `pa.struct({"path": pa.string()})`
+        - `pa.struct({"bytes": pa.binary(), "path": pa.string()})`  - order doesn't matter
 
         Args:
-            storage (Union[pa.StringArray, pa.StructArray]): PyArrow array to cast.
+            storage (`Union[pa.StringArray, pa.StructArray]`):
+                PyArrow array to cast.
 
         Returns:
-            pa.StructArray: Array in the Audio arrow storage type, that is
-                pa.struct({"bytes": pa.binary(), "path": pa.string()})
+            `pa.StructArray`: Array in the Audio arrow storage type, that is
+                `pa.struct({"bytes": pa.binary(), "path": pa.string()})`
         """
         if pa.types.is_string(storage.type):
             bytes_array = pa.array([None] * len(storage), type=pa.binary())
@@ -208,11 +215,12 @@ class Audio:
         """Embed audio files into the Arrow array.
 
         Args:
-            storage (pa.StructArray): PyArrow array to embed.
+            storage (`pa.StructArray`):
+                PyArrow array to embed.
 
         Returns:
-            pa.StructArray: Array in the Audio arrow storage type, that is
-                pa.struct({"bytes": pa.binary(), "path": pa.string()})
+            `pa.StructArray`: Array in the Audio arrow storage type, that is
+                `pa.struct({"bytes": pa.binary(), "path": pa.string()})`.
         """
 
         @no_op_if_value_is_null

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -418,34 +418,34 @@ def cast_to_python_objects(obj: Any, only_1d_for_numpy=False, optimize_list_cast
 @dataclass
 class Value:
     """
-    The Value dtypes are as follows:
+    The `Value` dtypes are as follows:
 
-    null
-    bool
-    int8
-    int16
-    int32
-    int64
-    uint8
-    uint16
-    uint32
-    uint64
-    float16
-    float32 (alias float)
-    float64 (alias double)
-    time32[(s|ms)]
-    time64[(us|ns)]
-    timestamp[(s|ms|us|ns)]
-    timestamp[(s|ms|us|ns), tz=(tzstring)]
-    date32
-    date64
-    duration[(s|ms|us|ns)]
-    decimal128(precision, scale)
-    decimal256(precision, scale)
-    binary
-    large_binary
-    string
-    large_string
+    - `null`
+    - `bool`
+    - `int8`
+    - `int16`
+    - `int32`
+    - `int64`
+    - `uint8`
+    - `uint16`
+    - `uint32`
+    - `uint64`
+    - `float16`
+    - `float32` (alias float)
+    - `float64` (alias double)
+    - `time32[(s|ms)]`
+    - `time64[(us|ns)]`
+    - `timestamp[(s|ms|us|ns)]`
+    - `timestamp[(s|ms|us|ns), tz=(tzstring)]`
+    - `date32`
+    - `date64`
+    - `duration[(s|ms|us|ns)]`
+    - `decimal128(precision, scale)`
+    - `decimal256(precision, scale)`
+    - `binary`
+    - `large_binary`
+    - `string`
+    - `large_string`
 
     Example:
 
@@ -505,8 +505,10 @@ class Array2D(_ArrayXD):
     """Create a two-dimensional array.
 
     Args:
-        shape (`tuple`): The size of each dimension.
-        dtype (`str`): The value of the data type.
+        shape (`tuple`):
+            The size of each dimension.
+        dtype (`str`):
+            The value of the data type.
 
     Example:
 
@@ -528,8 +530,10 @@ class Array3D(_ArrayXD):
     """Create a three-dimensional array.
 
     Args:
-        shape (`tuple`): The size of each dimension.
-        dtype (`str`): The value of the data type.
+        shape (`tuple`):
+            The size of each dimension.
+        dtype (`str`):
+            The value of the data type.
 
     Example:
 
@@ -551,8 +555,10 @@ class Array4D(_ArrayXD):
     """Create a four-dimensional array.
 
     Args:
-        shape (`tuple`): The size of each dimension.
-        dtype (`str`): The value of the data type.
+        shape (`tuple`):
+            The size of each dimension.
+        dtype (`str`):
+            The value of the data type.
 
     Example:
 
@@ -574,8 +580,10 @@ class Array5D(_ArrayXD):
     """Create a five-dimensional array.
 
     Args:
-        shape (`tuple`): The size of each dimension.
-        dtype (`str`): The value of the data type.
+        shape (`tuple`):
+            The size of each dimension.
+        dtype (`str`):
+            The value of the data type.
 
     Example:
 
@@ -873,10 +881,13 @@ class ClassLabel:
     You can use negative integers to represent unknown/missing labels.
 
     Args:
-        num_classes (:obj:`int`, optional): Number of classes. All labels must be < `num_classes`.
-        names (:obj:`list` of :obj:`str`, optional): String names for the integer classes.
+        num_classes (`int`, *optional*):
+            Number of classes. All labels must be < `num_classes`.
+        names (`list` of `str`, *optional*):
+            String names for the integer classes.
             The order in which the names are provided is kept.
-        names_file (:obj:`str`, optional): Path to a file with names for the integer classes, one per line.
+        names_file (`str`, *optional*):
+            Path to a file with names for the integer classes, one per line.
 
     Example:
 
@@ -930,7 +941,7 @@ class ClassLabel:
         return self.pa_type
 
     def str2int(self, values: Union[str, Iterable]) -> Union[int, Iterable]:
-        """Conversion class name string => integer.
+        """Conversion class name `string` => `integer`.
 
         Example:
 
@@ -975,9 +986,9 @@ class ClassLabel:
         return int_value
 
     def int2str(self, values: Union[int, Iterable]) -> Union[str, Iterable]:
-        """Conversion integer => class name string.
+        """Conversion `integer` => class name `string`.
 
-        Regarding unknown/missing labels: passing negative integers raises ValueError.
+        Regarding unknown/missing labels: passing negative integers raises `ValueError`.
 
         Example:
 
@@ -1021,17 +1032,18 @@ class ClassLabel:
         return example_data
 
     def cast_storage(self, storage: Union[pa.StringArray, pa.IntegerArray]) -> pa.Int64Array:
-        """Cast an Arrow array to the ClassLabel arrow storage type.
-        The Arrow types that can be converted to the ClassLabel pyarrow storage type are:
+        """Cast an Arrow array to the `ClassLabel` arrow storage type.
+        The Arrow types that can be converted to the `ClassLabel` pyarrow storage type are:
 
-        - pa.string()
-        - pa.int()
+        - `pa.string()`
+        - `pa.int()`
 
         Args:
-            storage (Union[pa.StringArray, pa.IntegerArray]): PyArrow array to cast.
+            storage (`Union[pa.StringArray, pa.IntegerArray]`):
+                PyArrow array to cast.
 
         Returns:
-            pa.Int64Array: Array in the ClassLabel arrow storage type
+            `pa.Int64Array`: Array in the `ClassLabel` arrow storage type.
         """
         if isinstance(storage, pa.IntegerArray):
             min_max = pc.min_max(storage).as_py()
@@ -1057,8 +1069,10 @@ class Sequence:
     Mostly here for compatiblity with tfds.
 
     Args:
-        feature: A list of features of a single type or a dictionary of types.
-        length (`int`): Length of the sequence.
+        feature:
+            A list of features of a single type or a dictionary of types.
+        length (`int`):
+            Length of the sequence.
 
     Example:
 
@@ -1483,34 +1497,34 @@ def keep_features_dicts_synced(func):
 class Features(dict):
     """A special dictionary that defines the internal structure of a dataset.
 
-    Instantiated with a dictionary of type ``dict[str, FieldType]``, where keys are the desired column names,
+    Instantiated with a dictionary of type `dict[str, FieldType]`, where keys are the desired column names,
     and values are the type of that column.
 
-    ``FieldType`` can be one of the following:
-        - a :class:`datasets.Value` feature specifies a single typed value, e.g. ``int64`` or ``string``
-        - a :class:`datasets.ClassLabel` feature specifies a field with a predefined set of classes which can have labels
-          associated to them and will be stored as integers in the dataset
-        - a python :obj:`dict` which specifies that the field is a nested field containing a mapping of sub-fields to sub-fields
-          features. It's possible to have nested fields of nested fields in an arbitrary manner
-        - a python :obj:`list` or a :class:`datasets.Sequence` specifies that the field contains a list of objects. The python
-          :obj:`list` or :class:`datasets.Sequence` should be provided with a single sub-feature as an example of the feature
-          type hosted in this list
+    `FieldType` can be one of the following:
+        - a [`~datasets.Value`] feature specifies a single typed value, e.g. `int64` or `string`.
+        - a [`~datasets.ClassLabel`] feature specifies a field with a predefined set of classes which can have labels
+          associated to them and will be stored as integers in the dataset.
+        - a python `dict` which specifies that the field is a nested field containing a mapping of sub-fields to sub-fields
+          features. It's possible to have nested fields of nested fields in an arbitrary manner.
+        - a python `list` or a [`~datasets.Sequence`] specifies that the field contains a list of objects. The python
+          `list` or [`~datasets.Sequence`] should be provided with a single sub-feature as an example of the feature
+          type hosted in this list.
 
           <Tip>
 
-           A :class:`datasets.Sequence` with a internal dictionary feature will be automatically converted into a dictionary of
+           A [`~datasets.Sequence`] with a internal dictionary feature will be automatically converted into a dictionary of
            lists. This behavior is implemented to have a compatilbity layer with the TensorFlow Datasets library but may be
-           un-wanted in some cases. If you don't want this behavior, you can use a python :obj:`list` instead of the
-           :class:`datasets.Sequence`.
+           un-wanted in some cases. If you don't want this behavior, you can use a python `list` instead of the
+           [`~datasets.Sequence`].
 
           </Tip>
 
-        - a :class:`Array2D`, :class:`Array3D`, :class:`Array4D` or :class:`Array5D` feature for multidimensional arrays
-        - an :class:`Audio` feature to store the absolute path to an audio file or a dictionary with the relative path
+        - a [`Array2D`], [`Array3D`], [`Array4D`] or [`Array5D`] feature for multidimensional arrays.
+        - an [`Audio`] feature to store the absolute path to an audio file or a dictionary with the relative path
           to an audio file ("path" key) and its bytes content ("bytes" key). This feature extracts the audio data.
-        - an :class:`Image` feature to store the absolute path to an image file, an :obj:`np.ndarray` object, a :obj:`PIL.Image.Image` object
+        - an [`Image`] feature to store the absolute path to an image file, an `np.ndarray` object, a `PIL.Image.Image` object
           or a dictionary with the relative path to an image file ("path" key) and its bytes content ("bytes" key). This feature extracts the image data.
-        - :class:`datasets.Translation` and :class:`datasets.TranslationVariableLanguages`, the two features specific to Machine Translation
+        - [`~datasets.Translation`] and [`~datasets.TranslationVariableLanguages`], the two features specific to Machine Translation.
     """
 
     def __init__(self, *args, **kwargs):
@@ -1554,14 +1568,15 @@ class Features(dict):
     @classmethod
     def from_arrow_schema(cls, pa_schema: pa.Schema) -> "Features":
         """
-        Construct Features from Arrow Schema.
+        Construct [`Features`] from Arrow Schema.
         It also checks the schema metadata for Hugging Face Datasets features.
 
         Args:
-            pa_schema (:obj:`pyarrow.Schema`): Arrow Schema.
+            pa_schema (`pyarrow.Schema`):
+                Arrow Schema.
 
         Returns:
-            :class:`Features`
+            [`Features`]
         """
         # try to load features from the arrow schema metadata
         if pa_schema.metadata is not None and "huggingface".encode("utf-8") in pa_schema.metadata:
@@ -1574,23 +1589,24 @@ class Features(dict):
     @classmethod
     def from_dict(cls, dic) -> "Features":
         """
-        Construct Features from dict.
+        Construct [`Features`] from dict.
 
         Regenerate the nested feature object from a deserialized dict.
-        We use the '_type' key to infer the dataclass name of the feature FieldType.
+        We use the `_type` key to infer the dataclass name of the feature `FieldType`.
 
         It allows for a convenient constructor syntax
         to define features from deserialized JSON dictionaries. This function is used in particular when deserializing
-        a :class:`DatasetInfo` that was dumped to a JSON object. This acts as an analogue to
-        :meth:`Features.from_arrow_schema` and handles the recursive field-by-field instantiation, but doesn't require
+        a [`DatasetInfo`] that was dumped to a JSON object. This acts as an analogue to
+        [`Features.from_arrow_schema`] and handles the recursive field-by-field instantiation, but doesn't require
         any mapping to/from pyarrow, except for the fact that it takes advantage of the mapping of pyarrow primitive
-        dtypes that :class:`Value` automatically performs.
+        dtypes that [`Value`] automatically performs.
 
         Args:
-            dic (:obj:`dict[str, Any]`): Python dictionary.
+            dic (`dict[str, Any]`):
+                Python dictionary.
 
         Returns:
-            :class:`Features`
+            `Features`
 
         Example::
             >>> Features.from_dict({'_type': {'dtype': 'string', 'id': None, '_type': 'Value'}})
@@ -1752,10 +1768,11 @@ class Features(dict):
         Encode example into a format for Arrow.
 
         Args:
-            example (:obj:`dict[str, Any]`): Data in a Dataset row.
+            example (`dict[str, Any]`):
+                Data in a Dataset row.
 
         Returns:
-            :obj:`dict[str, Any]`
+            `dict[str, Any]`
         """
         example = cast_to_python_objects(example)
         return encode_nested_example(self, example)
@@ -1765,10 +1782,11 @@ class Features(dict):
         Encode batch into a format for Arrow.
 
         Args:
-            batch (:obj:`dict[str, list[Any]]`): Data in a Dataset batch.
+            batch (`dict[str, list[Any]]`):
+                Data in a Dataset batch.
 
         Returns:
-            :obj:`dict[str, list[Any]]`
+            `dict[str, list[Any]]`
         """
         encoded_batch = {}
         if set(batch) != set(self):
@@ -1782,13 +1800,15 @@ class Features(dict):
         """Decode example with custom feature decoding.
 
         Args:
-            example (:obj:`dict[str, Any]`): Dataset row data.
-            token_per_repo_id (:obj:`dict`, optional): To access and decode
+            example (`dict[str, Any]`):
+                Dataset row data.
+            token_per_repo_id (`dict`, *optional*):
+                To access and decode
                 audio or image files from private repositories on the Hub, you can pass
-                a dictionary repo_id (str) -> token (bool or str)
+                a dictionary `repo_id (str) -> token (bool or str)`.
 
         Returns:
-            :obj:`dict[str, Any]`
+            `dict[str, Any]`
         """
 
         return {
@@ -1804,11 +1824,13 @@ class Features(dict):
         """Decode column with custom feature decoding.
 
         Args:
-            column (:obj:`list[Any]`): Dataset column data.
-            column_name (:obj:`str`): Dataset column name.
+            column (`list[Any]`):
+                Dataset column data.
+            column_name (`str`):
+                Dataset column name.
 
         Returns:
-            :obj:`list[Any]`
+            `list[Any]`
         """
         return (
             [decode_nested_example(self[column_name], value) if value is not None else None for value in column]
@@ -1820,10 +1842,11 @@ class Features(dict):
         """Decode batch with custom feature decoding.
 
         Args:
-            batch (:obj:`dict[str, list[Any]]`): Dataset batch data.
+            batch (`dict[str, list[Any]]`):
+                Dataset batch data.
 
         Returns:
-            :obj:`dict[str, list[Any]]`
+            `dict[str, list[Any]]`
         """
         decoded_batch = {}
         for column_name, column in batch.items():
@@ -1836,10 +1859,10 @@ class Features(dict):
 
     def copy(self) -> "Features":
         """
-        Make a deep copy of Features.
+        Make a deep copy of [`Features`].
 
         Returns:
-            :class:`Features`
+            [`Features`]
 
         Example:
 
@@ -1856,16 +1879,17 @@ class Features(dict):
 
     def reorder_fields_as(self, other: "Features") -> "Features":
         """
-        Reorder Features fields to match the field order of other Features.
+        Reorder Features fields to match the field order of other [`Features`].
 
         The order of the fields is important since it matters for the underlying arrow data.
         Re-ordering the fields allows to make the underlying arrow data type match.
 
         Args:
-            other (:class:`Features`): The other Features to align with.
+            other ([`Features`]):
+                The other [`Features`] to align with.
 
         Returns:
-            :class:`Features`
+            [`Features`]
 
         Example::
 
@@ -1923,13 +1947,14 @@ class Features(dict):
     def flatten(self, max_depth=16) -> "Features":
         """Flatten the features. Every dictionary column is removed and is replaced by
         all the subfields it contains. The new fields are named by concatenating the
-        name of the original column and the subfield name like this: "<original>.<subfield>".
+        name of the original column and the subfield name like this: `<original>.<subfield>`.
 
         If a column contains nested dictionaries, then all the lower-level subfields names are
-        also concatenated to form new columns: "<original>.<subfield>.<subsubfield>", etc.
+        also concatenated to form new columns: `<original>.<subfield>.<subsubfield>`, etc.
 
         Returns:
-            Features: the flattened features
+            [`Features`]:
+                The flattened features.
 
         Example:
 

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -24,23 +24,24 @@ _IMAGE_COMPRESSION_FORMATS: Optional[List[str]] = None
 
 @dataclass
 class Image:
-    """Image feature to read image data from an image file.
+    """Image [`Feature`] to read image data from an image file.
 
     Input: The Image feature accepts as input:
-    - A :obj:`str`: Absolute path to the image file (i.e. random access is allowed).
-    - A :obj:`dict` with the keys:
+    - A `str`: Absolute path to the image file (i.e. random access is allowed).
+    - A `dict` with the keys:
 
-        - path: String with relative path of the image file to the archive file.
-        - bytes: Bytes of the image file.
+        - `path`: String with relative path of the image file to the archive file.
+        - `bytes`: Bytes of the image file.
 
       This is useful for archived files with sequential access.
 
-    - An :obj:`np.ndarray`: NumPy array representing an image.
-    - A :obj:`PIL.Image.Image`: PIL image object.
+    - An `np.ndarray`: NumPy array representing an image.
+    - A `PIL.Image.Image`: PIL image object.
 
     Args:
-        decode (:obj:`bool`, default ``True``): Whether to decode the image data. If `False`,
-            returns the underlying dictionary in the format {"path": image_path, "bytes": image_bytes}.
+        decode (`bool`, defaults to `True`):
+            Whether to decode the image data. If `False`,
+            returns the underlying dictionary in the format `{"path": image_path, "bytes": image_bytes}`.
 
     Examples:
 
@@ -71,10 +72,11 @@ class Image:
         """Encode example into a format for Arrow.
 
         Args:
-            value (:obj:`str`, :obj:`np.ndarray`, :obj:`PIL.Image.Image` or :obj:`dict`): Data passed as input to Image feature.
+            value (`str`, `np.ndarray`, `PIL.Image.Image` or `dict`):
+                Data passed as input to Image feature.
 
         Returns:
-            :obj:`dict` with "path" and "bytes" fields
+            `dict` with "path" and "bytes" fields
         """
         if config.PIL_AVAILABLE:
             import PIL.Image
@@ -108,17 +110,19 @@ class Image:
         """Decode example image file into image data.
 
         Args:
-            value (obj:`str` or :obj:`dict`): a string with the absolute image file path, a dictionary with
+            value (`str` or `dict`):
+                A string with the absolute image file path, a dictionary with
                 keys:
 
-                - path: String with absolute or relative image file path.
-                - bytes: The bytes of the image file.
-            token_per_repo_id (:obj:`dict`, optional): To access and decode
+                - `path`: String with absolute or relative image file path.
+                - `bytes`: The bytes of the image file.
+            token_per_repo_id (`dict`, *optional*):
+                To access and decode
                 image files from private repositories on the Hub, you can pass
-                a dictionary repo_id (str) -> token (bool or str)
+                a dictionary repo_id (`str`) -> token (`bool` or `str`).
 
         Returns:
-            :obj:`PIL.Image.Image`
+            `PIL.Image.Image`
         """
         if not self.decode:
             raise RuntimeError("Decoding is disabled for this feature. Please use Image(decode=True) instead.")
@@ -170,18 +174,19 @@ class Image:
         """Cast an Arrow array to the Image arrow storage type.
         The Arrow types that can be converted to the Image pyarrow storage type are:
 
-        - pa.string() - it must contain the "path" data
-        - pa.struct({"bytes": pa.binary()})
-        - pa.struct({"path": pa.string()})
-        - pa.struct({"bytes": pa.binary(), "path": pa.string()})  - order doesn't matter
-        - pa.list(*) - it must contain the image array data
+        - `pa.string()` - it must contain the "path" data
+        - `pa.struct({"bytes": pa.binary()})`
+        - `pa.struct({"path": pa.string()})`
+        - `pa.struct({"bytes": pa.binary(), "path": pa.string()})`  - order doesn't matter
+        - `pa.list(*)` - it must contain the image array data
 
         Args:
-            storage (Union[pa.StringArray, pa.StructArray, pa.ListArray]): PyArrow array to cast.
+            storage (`Union[pa.StringArray, pa.StructArray, pa.ListArray]`):
+                PyArrow array to cast.
 
         Returns:
-            pa.StructArray: Array in the Image arrow storage type, that is
-                pa.struct({"bytes": pa.binary(), "path": pa.string()})
+            `pa.StructArray`: Array in the Image arrow storage type, that is
+                `pa.struct({"bytes": pa.binary(), "path": pa.string()})`.
         """
         if config.PIL_AVAILABLE:
             import PIL.Image
@@ -219,11 +224,12 @@ class Image:
         """Embed image files into the Arrow array.
 
         Args:
-            storage (pa.StructArray): PyArrow array to embed.
+            storage (`pa.StructArray`):
+                PyArrow array to embed.
 
         Returns:
-            pa.StructArray: Array in the Image arrow storage type, that is
-                pa.struct({"bytes": pa.binary(), "path": pa.string()})
+            `pa.StructArray`: Array in the Image arrow storage type, that is
+                `pa.struct({"bytes": pa.binary(), "path": pa.string()})`.
         """
 
         @no_op_if_value_is_null
@@ -278,7 +284,7 @@ def encode_pil_image(image: "PIL.Image.Image") -> dict:
 def objects_to_list_of_image_dicts(
     objs: Union[List[str], List[dict], List[np.ndarray], List["PIL.Image.Image"]]
 ) -> List[dict]:
-    """Encode a list of objects into a format suitable for creating an extension array of type :obj:`ImageExtensionType`."""
+    """Encode a list of objects into a format suitable for creating an extension array of type `ImageExtensionType`."""
     if config.PIL_AVAILABLE:
         import PIL.Image
     else:

--- a/src/datasets/features/translation.py
+++ b/src/datasets/features/translation.py
@@ -13,11 +13,9 @@ class Translation:
     """`FeatureConnector` for translations with fixed languages per example.
     Here for compatiblity with tfds.
 
-    Input: The Translate feature accepts a dictionary for each example mapping
-        string language codes to string translations.
-
-    Output: A dictionary mapping string language codes to translations as `Text`
-        features.
+    Args:
+        languages (`dict`):
+            A dictionary for each example mapping string language codes to string translations.
 
     Example:
 
@@ -55,15 +53,14 @@ class TranslationVariableLanguages:
     """`FeatureConnector` for translations with variable languages per example.
     Here for compatiblity with tfds.
 
-    Input: The TranslationVariableLanguages feature accepts a dictionary for each
-        example mapping string language codes to one or more string translations.
-        The languages present may vary from example to example.
+    Args:
+        languages (`dict`):
+            A dictionary for each example mapping string language codes to one or more string translations.
+            The languages present may vary from example to example.
 
-    Output:
-        language: variable-length 1D tf.Tensor of tf.string language codes, sorted
-            in ascending order.
-        translation: variable-length 1D tf.Tensor of tf.string plain text
-            translations, sorted to align with language codes.
+    Returns:
+        - `language` or `translation` (variable-length 1D `tf.Tensor` of `tf.string`):
+            Language codes sorted in ascending order or plain text translations, sorted to align with language codes.
 
     Example:
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -772,14 +772,17 @@ class IterableDataset(DatasetInfoMixin):
         """Create an Iterable Dataset from a generator.
 
         Args:
-            generator (:obj:`Callable`): A generator function that `yields` examples.
-            features (:class:`Features`, optional): Dataset features.
-            gen_kwargs(:obj:`dict`, optional): Keyword arguments to be passed to the `generator` callable.
+            generator (`Callable`):
+                A generator function that `yields` examples.
+            features (`Features`, *optional*):
+                Dataset features.
+            gen_kwargs(`dict`, *optional*):
+                Keyword arguments to be passed to the `generator` callable.
                 You can define a sharded iterable dataset by passing the list of shards in `gen_kwargs`.
                 This can be used to improve shuffling and when iterating over the dataset with multiple workers.
 
         Returns:
-            :class:`IterableDataset`
+            `IterableDataset`
 
         Example:
 
@@ -824,7 +827,7 @@ class IterableDataset(DatasetInfoMixin):
 
         Args:
 
-            type (:obj:`str`, optional, default None): if set to "torch", the returned dataset
+            type (`str`, optional, default None): if set to "torch", the returned dataset
                 will be a subclass of torch.utils.data.IterableDataset to be used in a DataLoader
         """
         # TODO(QL): add examples formatting to get tensors when using the "torch" format
@@ -857,18 +860,19 @@ class IterableDataset(DatasetInfoMixin):
         If your function returns a column that already exists, then it overwrites it.
         The function is applied on-the-fly on the examples when iterating over the dataset.
 
-        You can specify whether the function should be batched or not with the ``batched`` parameter:
+        You can specify whether the function should be batched or not with the `batched` parameter:
 
-        - If batched is False, then the function takes 1 example in and should return 1 example.
-          An example is a dictionary, e.g. {"text": "Hello there !"}
-        - If batched is True and batch_size is 1, then the function takes a batch of 1 example as input and can return a batch with 1 or more examples.
-          A batch is a dictionary, e.g. a batch of 1 example is {"text": ["Hello there !"]}
-        - If batched is True and batch_size is ``n`` > 1, then the function takes a batch of ``n`` examples as input and can return a batch with ``n`` examples, or with an arbitrary number of examples.
-          Note that the last batch may have less than ``n`` examples.
-          A batch is a dictionary, e.g. a batch of ``n`` examples is {"text": ["Hello there !"] * n}
+        - If batched is `False`, then the function takes 1 example in and should return 1 example.
+          An example is a dictionary, e.g. `{"text": "Hello there !"}`.
+        - If batched is `True` and `batch_size` is 1, then the function takes a batch of 1 example as input and can return a batch with 1 or more examples.
+          A batch is a dictionary, e.g. a batch of 1 example is {"text": ["Hello there !"]}.
+        - If batched is `True` and `batch_size` is `n` > 1, then the function takes a batch of `n` examples as input and can return a batch with `n` examples, or with an arbitrary number of examples.
+          Note that the last batch may have less than `n` examples.
+          A batch is a dictionary, e.g. a batch of `n` examples is `{"text": ["Hello there !"] * n}`.
 
         Args:
-            function (:obj:`Callable`, optional, default None): Function applied on-the-fly on the examples when you iterate on the dataset
+            function (`Callable`, *optional*, defaults to `None`):
+                Function applied on-the-fly on the examples when you iterate on the dataset.
                 It must have one of the following signatures:
 
                 - `function(example: Dict[str, Any]) -> Dict[str, Any]` if `batched=False` and `with_indices=False`
@@ -878,20 +882,28 @@ class IterableDataset(DatasetInfoMixin):
 
                 For advanced usage, the function can also return a `pyarrow.Table`.
                 Moreover if your function returns nothing (`None`), then `map` will run your function and return the dataset unchanged.
-                If no function is provided, default to identity function: ``lambda x: x``.
-            with_indices (:obj:`bool`, defaults to `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
-            input_columns (`Optional[Union[str, List[str]]]`, default `None`): The columns to be passed into `function`
+                If no function is provided, default to identity function: `lambda x: x`.
+            with_indices (`bool`, defaults to `False`):
+                Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx[, rank]): ...`.
+            input_columns (`Optional[Union[str, List[str]]]`, defaults to `None`):
+                The columns to be passed into `function`
                 as positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
-            batched (:obj:`bool`, default `False`): Provide batch of examples to `function`.
-            batch_size (:obj:`int`, optional, default ``1000``): Number of examples per batch provided to `function` if `batched=True`.
-                `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`.
-            drop_last_batch (:obj:`bool`, default `False`): Whether a last batch smaller than the batch_size should be
+            batched (`bool`, defaults to `False`):
+                Provide batch of examples to `function`.
+            batch_size (`int`, *optional*, defaults to `1000`):
+                Number of examples per batch provided to `function` if `batched=True`.
+                `batch_size <= 0` or `batch_size == None` then provide the full dataset as a single batch to `function`.
+            drop_last_batch (`bool`, defaults to `False`):
+                Whether a last batch smaller than the batch_size should be
                 dropped instead of being processed by the function.
-            remove_columns (`Optional[List[str]]`, defaults to `None`): Remove a selection of columns while doing the mapping.
+            remove_columns (`[List[str]]`, *optional*, defaults to `None`):
+                Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
-            features (`Optional[datasets.Features]`, defaults to `None`): Feature types of the resulting dataset.
-            fn_kwargs (:obj:`Dict`, optional, default `None`): Keyword arguments to be passed to `function`.
+            features (`[Features]`, *optional*, defaults to `None`):
+                Feature types of the resulting dataset.
+            fn_kwargs (`Dict`, *optional*, default `None`):
+                Keyword arguments to be passed to `function`.
 
         Example:
 
@@ -954,19 +966,24 @@ class IterableDataset(DatasetInfoMixin):
         The filtering is done on-the-fly when iterating over the dataset.
 
         Args:
-            function (:obj:`Callable`): Callable with one of the following signatures:
+            function (`Callable`):
+                Callable with one of the following signatures:
 
-                - ``function(example: Dict[str, Any]) -> bool`` if ``with_indices=False, batched=False``
-                - ``function(example: Dict[str, Any], indices: int) -> bool`` if ``with_indices=True, batched=False``
-                - ``function(example: Dict[str, List]) -> List[bool]`` if ``with_indices=False, batched=True``
-                - ``function(example: Dict[str, List], indices: List[int]) -> List[bool]`` if ``with_indices=True, batched=True``
+                - `function(example: Dict[str, Any]) -> bool` if `with_indices=False, batched=False`
+                - `function(example: Dict[str, Any], indices: int) -> bool` if `with_indices=True, batched=False`
+                - `function(example: Dict[str, List]) -> List[bool]` if `with_indices=False, batched=True`
+                - `function(example: Dict[str, List], indices: List[int]) -> List[bool]` if `with_indices=True, batched=True`
 
-                If no function is provided, defaults to an always True function: ``lambda x: True``.
-            with_indices (:obj:`bool`, default `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
-            input_columns (:obj:`str` or `List[str]`, optional): The columns to be passed into `function` as
+                If no function is provided, defaults to an always True function: `lambda x: True`.
+            with_indices (`bool`, defaults to `False`):
+                Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
+            input_columns (`str` or `List[str]`, *optional*):
+                The columns to be passed into `function` as
                 positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
-            batched (:obj:`bool`, defaults to `False`): Provide batch of examples to `function`
-            batch_size (:obj:`int`, optional, default ``1000``): Number of examples per batch provided to `function` if `batched=True`.
+            batched (`bool`, defaults to `False`):
+                Provide batch of examples to `function`.
+            batch_size (`int`, *optional*, default `1000`):
+                Number of examples per batch provided to `function` if `batched=True`.
 
         Example:
 
@@ -1015,25 +1032,28 @@ class IterableDataset(DatasetInfoMixin):
         """
         Randomly shuffles the elements of this dataset.
 
-        This dataset fills a buffer with buffer_size elements, then randomly samples elements from this buffer,
+        This dataset fills a buffer with `buffer_size` elements, then randomly samples elements from this buffer,
         replacing the selected elements with new elements. For perfect shuffling, a buffer size greater than or
         equal to the full size of the dataset is required.
 
-        For instance, if your dataset contains 10,000 elements but ``buffer_size`` is set to 1,000, then shuffle will
-        initially select a random element from only the first 1,000 elements in the buffer. Once an element is
+        For instance, if your dataset contains 10,000 elements but `buffer_size` is set to 1000, then `shuffle` will
+        initially select a random element from only the first 1000 elements in the buffer. Once an element is
         selected, its space in the buffer is replaced by the next (i.e. 1,001-st) element,
-        maintaining the 1,000 element buffer.
+        maintaining the 1000 element buffer.
 
         If the dataset is made of several shards, it also does shuffle the order of the shards.
-        However if the order has been fixed by using :func:`datasets.IterableDataset.skip` or :func:`datasets.IterableDataset.take`
+        However if the order has been fixed by using [`~datasets.IterableDataset.skip`] or [`~datasets.IterableDataset.take`]
         then the order of the shards is kept unchanged.
 
         Args:
-            seed (:obj:`int`, optional, default None): random seed that will be used to shuffle the dataset.
-                It is used to sample from the shuffle buffe and als oto shuffle the data shards.
-            generator (:obj:`numpy.random.Generator`, optional): Numpy random Generator to use to compute the permutation of the dataset rows.
-                If ``generator=None`` (default), uses np.random.default_rng (the default BitGenerator (PCG64) of NumPy).
-            buffer_size (:obj:`int`, default 1000): size of the buffer.
+            seed (`int`, *optional*, defaults to `None`):
+                Random seed that will be used to shuffle the dataset.
+                It is used to sample from the shuffle buffe and also to shuffle the data shards.
+            generator (`numpy.random.Generator`, *optional*):
+                Numpy random Generator to use to compute the permutation of the dataset rows.
+                If `generator=None` (default), uses `np.random.default_rng` (the default BitGenerator (PCG64) of NumPy).
+            buffer_size (`int`, defaults to `1000`):
+                Size of the buffer.
 
         Example:
 
@@ -1077,10 +1097,11 @@ class IterableDataset(DatasetInfoMixin):
 
     def skip(self, n) -> "IterableDataset":
         """
-        Create a new IterableDataset that skips the first ``n`` elements.
+        Create a new [`IterableDataset`] that skips the first `n` elements.
 
         Args:
-            n (:obj:`int`): number of elements to skip.
+            n (`int`):
+                Number of elements to skip.
 
         Example:
 
@@ -1114,10 +1135,11 @@ class IterableDataset(DatasetInfoMixin):
 
     def take(self, n) -> "IterableDataset":
         """
-        Create a new IterableDataset with only the first ``n`` elements.
+        Create a new [`IterableDataset`] with only the first `n` elements.
 
         Args:
-            n (:obj:`int`): number of elements to take.
+            n (`int`):
+                Number of elements to take.
 
         Example:
 
@@ -1150,7 +1172,7 @@ class IterableDataset(DatasetInfoMixin):
             column (list or np.array): Column data to be added.
 
         Returns:
-            :class:`IterableDataset`
+            `IterableDataset`
         """
 
         def add_column_fn(example, idx):
@@ -1166,11 +1188,13 @@ class IterableDataset(DatasetInfoMixin):
         name.
 
         Args:
-            original_column_name (:obj:`str`): Name of the column to rename.
-            new_column_name (:obj:`str`): New name for the column.
+            original_column_name (`str`):
+                Name of the column to rename.
+            new_column_name (`str`):
+                New name for the column.
 
         Returns:
-            :class:`IterableDataset`: A copy of the dataset with a renamed column.
+            `IterableDataset`: A copy of the dataset with a renamed column.
 
         Example:
 
@@ -1215,10 +1239,10 @@ class IterableDataset(DatasetInfoMixin):
         the new column names.
 
         Args:
-            column_mapping (:obj:`Dict[str, str]`): A mapping of columns to rename to their new names
+            column_mapping (`Dict[str, str]`): A mapping of columns to rename to their new names
 
         Returns:
-            :class:`IterableDataset`: A copy of the dataset with renamed columns
+            `IterableDataset`: A copy of the dataset with renamed columns
         """
 
         def rename_columns_fn(example):
@@ -1253,10 +1277,11 @@ class IterableDataset(DatasetInfoMixin):
 
 
         Args:
-            column_names (:obj:`Union[str, List[str]]`): Name of the column(s) to remove.
+            column_names (`Union[str, List[str]]`):
+                Name of the column(s) to remove.
 
         Returns:
-            :class:`IterableDataset`: A copy of the dataset object without the columns to remove.
+            `IterableDataset`: A copy of the dataset object without the columns to remove.
 
         Example:
 
@@ -1283,11 +1308,13 @@ class IterableDataset(DatasetInfoMixin):
         """Cast column to feature for decoding.
 
         Args:
-            column (:obj:`str`): Column name.
-            feature (:class:`Feature`): Target feature.
+            column (`str`):
+                Column name.
+            feature (`Feature`):
+                Target feature.
 
         Returns:
-            :class:`IterableDataset`
+            `IterableDataset`
 
         Example:
 
@@ -1335,13 +1362,14 @@ class IterableDataset(DatasetInfoMixin):
         Cast the dataset to a new set of features.
 
         Args:
-            features (:class:`datasets.Features`): New features to cast the dataset to.
+            features ([`Features`]):
+                New features to cast the dataset to.
                 The name of the fields in the features must match the current column names.
                 The type of the data must also be convertible from one type to the other.
-                For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
+                For non-trivial conversion, e.g. `string` <-> `ClassLabel` you should use [`~Dataset.map`] to update the Dataset.
 
         Returns:
-            :class:`IterableDataset`: A copy of the dataset with casted features.
+            `IterableDataset`: A copy of the dataset with casted features.
 
         Example:
 
@@ -1426,15 +1454,15 @@ def _concatenate_iterable_datasets(
     axis: int = 0,
 ) -> IterableDataset:
     """
-    Converts a list of :class:`IterableDataset` with the same schema into a single :class:`IterableDataset`.
+    Converts a list of `IterableDataset` with the same schema into a single `IterableDataset`.
     Missing data are filled with None values.
 
     <Added version="2.4.0"/>
 
     Args:
-        dsets (:obj:`List[datasets.IterableDataset]`): List of Datasets to concatenate.
-        info (:class:`DatasetInfo`, optional): Dataset information, like description, citation, etc.
-        split (:class:`NamedSplit`, optional): Name of the dataset split.
+        dsets (`List[datasets.IterableDataset]`): List of Datasets to concatenate.
+        info (`DatasetInfo`, optional): Dataset information, like description, citation, etc.
+        split (`NamedSplit`, optional): Name of the dataset split.
         axis (``{0, 1}``, default ``0``, meaning over rows):
             Axis to concatenate over, where ``0`` means over rows (vertically) and ``1`` means over columns
             (horizontally).
@@ -1496,11 +1524,11 @@ def _interleave_iterable_datasets(
     <Added version="2.4.0"/>
 
     Args:
-        datasets (:obj:`List[IterableDataset]`): list of datasets to interleave
-        probabilities (:obj:`List[float]`, optional, default None): If specified, the new iterable dataset samples
+        datasets (`List[IterableDataset]`): list of datasets to interleave
+        probabilities (`List[float]`, optional, default None): If specified, the new iterable dataset samples
             examples from one source at a time according to these probabilities.
-        seed (:obj:`int`, optional, default None): The random seed used to choose a source for each example.
-        stopping_strategy (Optional :obj:`str`, defaults to `first_exhausted`):
+        seed (`int`, optional, default None): The random seed used to choose a source for each example.
+        stopping_strategy (Optional `str`, defaults to `first_exhausted`):
             Two strategies are proposed right now.
             By default, `first_exhausted` is an undersampling strategy, i.e the dataset construction is stopped as soon as one dataset has ran out of samples.
             If the strategy is `all_exhausted`,  we use an oversampling strategy, i.e the dataset construction is stopped as soon as every samples of every dataset has been added at least once.
@@ -1509,7 +1537,7 @@ def _interleave_iterable_datasets(
             - with given probabilities, the resulting dataset will have more samples if some datasets have really low probability of visiting.
 
     Output:
-        :class:`datasets.IterableDataset`
+        `datasets.IterableDataset`
     """
     datasets = [d._resolve_features() for d in datasets]
 


### PR DESCRIPTION
This PR cleans up the remaining docstrings in Main Classes (`IterableDataset`, `IterableDatasetDict`, and `Features`).