### PR TITLE
Raise error if ClassLabel names is not python list

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -19,6 +19,7 @@ import json
 import re
 import sys
 from collections.abc import Iterable, Mapping
+from collections.abc import Sequence as SequenceABC
 from dataclasses import InitVar, dataclass, field, fields
 from functools import reduce, wraps
 from operator import mul
@@ -944,7 +945,7 @@ class ClassLabel:
                 self.names = [str(i) for i in range(self.num_classes)]
             else:
                 raise ValueError("Please provide either num_classes, names or names_file.")
-        elif not isinstance(self.names, list):
+        elif not isinstance(self.names, SequenceABC):
             raise ValueError(f"Please provide names as a list, is {type(self.names)}")
         # Set self.num_classes
         if self.num_classes is None:

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -946,7 +946,7 @@ class ClassLabel:
             else:
                 raise ValueError("Please provide either num_classes, names or names_file.")
         elif not isinstance(self.names, SequenceABC):
-            raise ValueError(f"Please provide names as a list, is {type(self.names)}")
+            raise TypeError(f"Please provide names as a list, is {type(self.names)}")
         # Set self.num_classes
         if self.num_classes is None:
             self.num_classes = len(self.names)

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -944,6 +944,8 @@ class ClassLabel:
                 self.names = [str(i) for i in range(self.num_classes)]
             else:
                 raise ValueError("Please provide either num_classes, names or names_file.")
+        elif not isinstance(self.names, list):
+            raise ValueError(f"Please provide names as a list, is {type(self.names)}")
         # Set self.num_classes
         if self.num_classes is None:
             self.num_classes = len(self.names)

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -287,6 +287,8 @@ def test_classlabel_init(tmp_path_factory):
         classlabel = ClassLabel(names=names, names_file=names_file)
     with pytest.raises(ValueError):
         classlabel = ClassLabel()
+    with pytest.raises(ValueError):
+        classlabel = ClassLabel(names=np.array(names))
 
 
 def test_classlabel_str2int():

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -287,7 +287,7 @@ def test_classlabel_init(tmp_path_factory):
         classlabel = ClassLabel(names=names, names_file=names_file)
     with pytest.raises(ValueError):
         classlabel = ClassLabel()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         classlabel = ClassLabel(names=np.array(names))
 
 


### PR DESCRIPTION
Checks type of names provided to ClassLabel to avoid easy and hard to debug errors (closes #5332 - see for discussion)