### PR TITLE
Fix remove columns from lazy dict

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3122,7 +3122,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 additional_args += (rank,)
             processed_inputs = function(*fn_args, *additional_args, **fn_kwargs)
             processed_inputs = (
-                {k: v for k, v in processed_inputs.data.items() if k not in processed_inputs.keys_to_format}
+                {k: v for k, v in processed_inputs.data.items() if k in processed_inputs.keys_added_by_user}
                 if isinstance(processed_inputs, LazyDict)
                 else processed_inputs
             )

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -272,6 +272,7 @@ class LazyDict(MutableMapping):
 
         self.data = {key: None for key in pa_table.column_names}
         self.keys_to_format = set(self.data.keys())
+        self.keys_added_by_user = set()
 
     def __len__(self):
         return len(self.data)
@@ -285,6 +286,7 @@ class LazyDict(MutableMapping):
         return value
 
     def __setitem__(self, key, value):
+        self.keys_added_by_user.add(key)
         if key in self.keys_to_format:
             self.keys_to_format.remove(key)
         self.data[key] = value

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4160,7 +4160,7 @@ def test_dataset_estimate_nbytes():
 @pytest.mark.parametrize("return_lazy_dict", [True, False, "mix"])
 def test_map_cases(return_lazy_dict):
     def f(x):
-        """May a mix of LazyDict and regular Dict"""
+        """May return a mix of LazyDict and regular Dict"""
         if x["a"] < 2:
             x["a"] = -1
             return dict(x) if return_lazy_dict is False else x
@@ -4173,7 +4173,7 @@ def test_map_cases(return_lazy_dict):
     assert outputs == {"a": [-1, -1, 2, 3]}
 
     def f(x):
-        """May a mix of LazyDict and regular Dict, but sometimes with None values"""
+        """May return a mix of LazyDict and regular Dict, but sometimes with None values"""
         if x["a"] < 2:
             x["a"] = None
             return dict(x) if return_lazy_dict is False else x
@@ -4186,7 +4186,35 @@ def test_map_cases(return_lazy_dict):
     assert outputs == {"a": [None, None, 2, 3]}
 
     def f(x):
-        """May a mix of LazyDict and regular Dict, but using an extension type"""
+        """Return a LazyDict, but we remove a lazy column and add a new one"""
+        if x["a"] < 2:
+            x["b"] = -1
+            return x
+        else:
+            x["b"] = x["a"]
+            return x
+
+    ds = Dataset.from_dict({"a": [0, 1, 2, 3]})
+    ds = ds.map(f, remove_columns=["a"])
+    outputs = ds[:]
+    assert outputs == {"b": [-1, -1, 2, 3]}
+
+    def f(x):
+        """May return a mix of LazyDict and regular Dict, but we replace a lazy column"""
+        if x["a"] < 2:
+            x["a"] = -1
+            return dict(x) if return_lazy_dict is False else x
+        else:
+            x["a"] = x["a"]
+            return x if return_lazy_dict is True else {"a": x["a"]}
+
+    ds = Dataset.from_dict({"a": [0, 1, 2, 3]})
+    ds = ds.map(f, remove_columns=["a"])
+    outputs = ds[:]
+    assert outputs == {"a": [-1, -1, 2, 3]}
+
+    def f(x):
+        """May return a mix of LazyDict and regular Dict, but using an extension type"""
         if x["a"][0][0] < 2:
             x["a"] = [[-1]]
             return dict(x) if return_lazy_dict is False else x
@@ -4200,7 +4228,7 @@ def test_map_cases(return_lazy_dict):
     assert outputs == {"a": [[[i]] for i in [-1, -1, 2, 3]]}
 
     def f(x):
-        """May a mix of LazyDict and regular Dict, but using a nested extension type"""
+        """May return a mix of LazyDict and regular Dict, but using a nested extension type"""
         if x["a"]["nested"][0][0] < 2:
             x["a"] = {"nested": [[-1]]}
             return dict(x) if return_lazy_dict is False else x


### PR DESCRIPTION
This was introduced in https://github.com/huggingface/datasets/pull/5252 and causing the transformers CI to break: https://app.circleci.com/pipelines/github/huggingface/transformers/53886/workflows/522faf2e-a053-454c-94f8-a617fde33393/jobs/648597

Basically this code should return a dataset with only one column:

```python
from datasets import *

ds = Dataset.from_dict({"a": range(5)})

def f(x):
    x["b"] = x["a"]
    return x

ds = ds.map(f, remove_columns=["a"])

assert ds.column_names == ["b"]
```