### PR TITLE
Align remove columns behavior and input dict mutation in `map` with previous behavior

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3121,11 +3121,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             if with_rank:
                 additional_args += (rank,)
             processed_inputs = function(*fn_args, *additional_args, **fn_kwargs)
-            processed_inputs, returned_lazy_dict = (
-                ({k: v for k, v in processed_inputs.data.items() if k not in processed_inputs.keys_to_format}, True)
-                if isinstance(processed_inputs, LazyDict)
-                else (processed_inputs, False)
-            )
+            if isinstance(processed_inputs, LazyDict):
+                processed_inputs = {
+                    k: v for k, v in processed_inputs.data.items() if k not in processed_inputs.keys_to_format
+                }
+                returned_lazy_dict = True
+            else:
+                returned_lazy_dict = False
             if update_data is None:
                 # Check if the function returns updated examples
                 update_data = isinstance(processed_inputs, (Mapping, pa.Table))

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -272,7 +272,6 @@ class LazyDict(MutableMapping):
 
         self.data = {key: None for key in pa_table.column_names}
         self.keys_to_format = set(self.data.keys())
-        self.keys_added_by_user = set()
 
     def __len__(self):
         return len(self.data)
@@ -286,7 +285,6 @@ class LazyDict(MutableMapping):
         return value
 
     def __setitem__(self, key, value):
-        self.keys_added_by_user.add(key)
         if key in self.keys_to_format:
             self.keys_to_format.remove(key)
         self.data[key] = value

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4214,6 +4214,20 @@ def test_map_cases(return_lazy_dict):
     assert outputs == ({"a": [-1, -1, 2, 3]} if return_lazy_dict is False else {})
 
     def f(x):
+        """May return a mix of LazyDict and regular Dict, but we modify a nested lazy column in-place"""
+        if x["a"]["b"] < 2:
+            x["a"]["c"] = -1
+            return dict(x) if return_lazy_dict is False else x
+        else:
+            x["a"]["c"] = x["a"]["b"]
+            return x if return_lazy_dict is True else {}
+
+    ds = Dataset.from_dict({"a": [{"b": 0}, {"b": 1}, {"b": 2}, {"b": 3}]})
+    ds = ds.map(f)
+    outputs = ds[:]
+    assert outputs == {"a": [{"b": 0, "c": -1}, {"b": 1, "c": -1}, {"b": 2, "c": 2}, {"b": 3, "c": 3}]}
+
+    def f(x):
         """May return a mix of LazyDict and regular Dict, but using an extension type"""
         if x["a"][0][0] < 2:
             x["a"] = [[-1]]

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4199,6 +4199,14 @@ def test_map_cases(return_lazy_dict):
     outputs = ds[:]
     assert outputs == {"b": [-1, -1, 2, 3]}
 
+    # The formatted dataset version removes the lazy column from a different dictionary, hence it should be preserved in the output
+    ds = Dataset.from_dict({"a": [0, 1, 2, 3]})
+    ds = ds.with_format("numpy")
+    ds = ds.map(f, remove_columns=["a"])
+    ds = ds.with_format(None)
+    outputs = ds[:]
+    assert outputs == {"a": [0, 1, 2, 3], "b": [-1, -1, 2, 3]}
+
     def f(x):
         """May return a mix of LazyDict and regular Dict, but we replace a lazy column"""
         if x["a"] < 2:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4211,7 +4211,7 @@ def test_map_cases(return_lazy_dict):
     ds = Dataset.from_dict({"a": [0, 1, 2, 3]})
     ds = ds.map(f, remove_columns=["a"])
     outputs = ds[:]
-    assert outputs == {"a": [-1, -1, 2, 3]}
+    assert outputs == ({"a": [-1, -1, 2, 3]} if return_lazy_dict is False else {})
 
     def f(x):
         """May return a mix of LazyDict and regular Dict, but using an extension type"""


### PR DESCRIPTION
Align the `remove_columns` behavior and input dict mutation in `map` with the behavior before https://github.com/huggingface/datasets/pull/5252.