### PR TITLE
Distributed support

### DIFF
--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -100,6 +100,8 @@ The base class [`Dataset`] implements a Dataset backed by an Apache Arrow table.
 
 [[autodoc]] datasets.interleave_datasets
 
+[[autodoc]] datasets.distributed.split_dataset_by_node
+
 [[autodoc]] datasets.enable_caching
 
 [[autodoc]] datasets.disable_caching

--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -201,7 +201,7 @@ You must use a `BatchSampler` if you want the transform to be given full batches
 ### Stream data
 
 Loading a dataset in streaming mode allows one to iterate over the dataset without downloading it on disk.
-An iterable dataset from `datasets` inherits from `torch.utils.data.IterableDataset` so you can pass it to a `DataLoader`:
+An iterable dataset from `datasets` inherits from `torch.utils.data.IterableDataset` so you can pass it to a `torch.utils.data.DataLoader`:
 
 ```py
 >>> import numpy as np
@@ -222,4 +222,30 @@ If the dataset is split in several shards (i.e. if the dataset consists of multi
 >>> dataloader = DataLoader(ds, batch_size=32, num_workers=4)
 ```
 
-In this case each worker will be given a subset of the list of shards to stream from.
+In this case each worker is given a subset of the list of shards to stream from.
+
+### Distributed
+
+To split your dataset across your training nodes, you can use [`datasets.distributed.split_dataset_by_node`]:
+
+```python
+import os
+from datasets.distributed import split_dataset_by_node
+
+ds = split_dataset_by_node(ds, rank=int(os.environ["RANK"]), world_size=int(os.environ["WORLD_SIZE"]))
+```
+
+This works for both map-style datasets and iterable datasets.
+The dataset is split for the node at rank `rank` in a pool of nodes of size `world_size`.
+
+For map-style datasets:
+
+Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of the dataset.
+
+For iterable datasets:
+
+If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.n_shards % world_size == 0`),
+then the shards are evenly assigned across the nodes, which is the most optimized.
+Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+
+This can also be combined with a `torch.utils.data.DataLoader` if you want each node to use multiple workers to load the data.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5615,6 +5615,25 @@ def _interleave_map_style_datasets(
     return concatenated_datasets.select(indices, **kwargs)
 
 
+def _split_by_node_map_style_dataset(dataset: Dataset, rank: int, world_size: int) -> Dataset:
+    """
+    Split a dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
+    Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of the dataset.
+
+    Args:
+        dataset ([`Dataset`]):
+            The dataset to split by node.
+        rank (`int`):
+            Rank of the current node.
+        world_size (`int`):
+            Total number of nodes.
+
+    Returns:
+        [`Dataset`]: The dataset to be used on the node at rank `rank`.
+    """
+    return dataset.shard(num_shards=world_size, index=rank, contiguous=True)
+
+
 # This is outside Dataset.filter as it needs to be picklable for multiprocessing
 
 

--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -10,7 +10,7 @@ from .utils import logging
 logger = logging.get_logger(__name__)
 
 
-DatasetType = TypeVar("DatasetType", "Dataset", "IterableDataset")
+DatasetType = TypeVar("DatasetType", Dataset, IterableDataset)
 
 
 def interleave_datasets(
@@ -137,11 +137,11 @@ def interleave_datasets(
 
 
 def concatenate_datasets(
-    dsets: List[Dataset],
+    dsets: List[DatasetType],
     info: Optional[DatasetInfo] = None,
     split: Optional[NamedSplit] = None,
     axis: int = 0,
-):
+) -> DatasetType:
     """
     Converts a list of [`Dataset`] with the same schema into a single [`Dataset`].
 

--- a/src/datasets/distributed.py
+++ b/src/datasets/distributed.py
@@ -18,8 +18,8 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
     For iterable datasets:
 
     If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.n_shards % world_size == 0`),
-    then the shards are evenly assign across the nodes, which is the most optimized.
-    Otherwise, each node will keep 1 example out of `world_size`, skipping the other examples.
+    then the shards are evenly assigned across the nodes, which is the most optimized.
+    Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
 
     Args:
         dataset ([`Dataset`] or [`IterableDataset`]):

--- a/src/datasets/distributed.py
+++ b/src/datasets/distributed.py
@@ -1,0 +1,38 @@
+from typing import TypeVar
+
+from .arrow_dataset import Dataset, _split_by_node_map_style_dataset
+from .iterable_dataset import IterableDataset, _split_by_node_iterable_dataset
+
+
+DatasetType = TypeVar("DatasetType", Dataset, IterableDataset)
+
+
+def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> DatasetType:
+    """
+    Split a dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
+
+    For map-style datasets:
+
+    Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of the dataset.
+
+    For iterable datasets:
+
+    If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.n_shards % world_size == 0`),
+    then the shards are evenly assign across the nodes, which is the most optimized.
+    Otherwise, each node will keep 1 example out of `world_size`, skipping the other examples.
+
+    Args:
+        dataset ([`Dataset`] or [`IterableDataset`]):
+            The dataset to split by node.
+        rank (`int`):
+            Rank of the current node.
+        world_size (`int`):
+            Total number of nodes.
+
+    Returns:
+        [`Dataset`] or [`IterableDataset`]: The dataset to be used on the node at rank `rank`.
+    """
+    if isinstance(dataset, Dataset):
+        return _split_by_node_map_style_dataset(dataset, rank=rank, world_size=world_size)
+    else:
+        return _split_by_node_iterable_dataset(dataset, rank=rank, world_size=world_size)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1764,8 +1764,8 @@ def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_s
     Split an iterable dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
     If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.n_shards % world_size == 0`),
-    then the shards are evenly assign across the nodes, which is the most optimized.
-    Otherwise, each node will keep 1 example out of `world_size`, skipping the other examples.
+    then the shards are evenly assigned across the nodes, which is the most optimized.
+    Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
 
     Args:
         dataset ([`IterableDataset`]):

--- a/src/datasets/utils/sharding.py
+++ b/src/datasets/utils/sharding.py
@@ -68,6 +68,15 @@ def _split_gen_kwargs(gen_kwargs: dict, max_num_jobs: int) -> List[dict]:
         ]
 
 
+def _merge_gen_kwargs(gen_kwargs_list: List[dict]) -> dict:
+    return {
+        key: [value for gen_kwargs in gen_kwargs_list for value in gen_kwargs[key]]
+        if isinstance(gen_kwargs_list[0][key], list)
+        else gen_kwargs_list[0][key]
+        for key in gen_kwargs_list[0]
+    }
+
+
 def _shuffle_gen_kwargs(rng: np.random.Generator, gen_kwargs: dict) -> dict:
     """Return a shuffled copy of the input gen_kwargs"""
     # We must shuffle all the lists, and lists of the same size must have the same shuffling.

--- a/tests/distributed_scripts/test_torch_distributed_launch.py
+++ b/tests/distributed_scripts/test_torch_distributed_launch.py
@@ -1,0 +1,55 @@
+import os
+from argparse import ArgumentParser
+from typing import List
+
+import torch.utils.data
+
+from datasets import Dataset, IterableDataset
+from datasets.distributed import split_dataset_by_node
+
+
+NUM_SHARDS = 4
+NUM_ITEMS_PER_SHARD = 3
+
+
+class TestFailedError(RuntimeError):
+    pass
+
+
+def gen(shards: List[str]):
+    for shard in shards:
+        for i in range(NUM_ITEMS_PER_SHARD):
+            yield {"i": i, "shard": shard}
+
+
+def main():
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    parser = ArgumentParser()
+    parser.add_argument("--streaming", type=bool)
+    parser.add_argument("--local_rank", type=int)
+    parser.add_argument("--num_workers", type=int, default=0)
+    args = parser.parse_args()
+    streaming = args.streaming
+    num_workers = args.num_workers
+
+    gen_kwargs = {"shards": [f"shard_{shard_idx}" for shard_idx in range(NUM_SHARDS)]}
+    ds = IterableDataset.from_generator(gen, gen_kwargs=gen_kwargs)
+    if not streaming:
+        ds = Dataset.from_list(list(ds))
+
+    ds = split_dataset_by_node(ds, rank=rank, world_size=world_size)
+    dataloader = torch.utils.data.DataLoader(ds, num_workers=num_workers)
+
+    full_size = NUM_SHARDS * NUM_ITEMS_PER_SHARD
+    expected_local_size = full_size // world_size
+    expected_local_size += int(rank < (full_size % world_size))
+
+    local_size = sum(1 for _ in dataloader)
+    if local_size != expected_local_size:
+        raise TestFailedError(f"local_size {local_size} != expected_local_size {expected_local_size}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,0 +1,102 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from datasets import Dataset, IterableDataset
+from datasets.distributed import split_dataset_by_node
+
+from .utils import execute_subprocess_async, get_torch_dist_unique_port, require_torch
+
+
+def test_split_dataset_by_node_map_style():
+    full_ds = Dataset.from_dict({"i": range(17)})
+    full_size = len(full_ds)
+    world_size = 3
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+    ]
+    assert sum(len(ds) for ds in datasets_per_rank) == full_size
+    assert len(set(tuple(x.values()) for ds in datasets_per_rank for x in ds)) == full_size
+
+
+def test_split_dataset_by_node_iterable():
+    def gen():
+        return ({"i": i} for i in range(17))
+
+    world_size = 3
+    full_ds = IterableDataset.from_generator(gen)
+    full_size = len(list(full_ds))
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+    ]
+    assert sum(len(list(ds)) for ds in datasets_per_rank) == full_size
+    assert len(set(tuple(x.values()) for ds in datasets_per_rank for x in ds)) == full_size
+
+
+@pytest.mark.parametrize("shards_per_node", [1, 2, 3])
+def test_split_dataset_by_node_iterable_sharded(shards_per_node):
+    def gen(shards):
+        for shard in shards:
+            yield from ({"i": i, "shard": shard} for i in range(17))
+
+    world_size = 3
+    num_shards = shards_per_node * world_size
+    gen_kwargs = {"shards": [f"shard_{shard_idx}.txt" for shard_idx in range(num_shards)]}
+    full_ds = IterableDataset.from_generator(gen, gen_kwargs=gen_kwargs)
+    full_size = len(list(full_ds))
+    assert full_ds.n_shards == world_size * shards_per_node
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+    ]
+    assert [ds.n_shards for ds in datasets_per_rank] == [shards_per_node] * world_size
+    assert sum(len(list(ds)) for ds in datasets_per_rank) == full_size
+    assert len(set(tuple(x.values()) for ds in datasets_per_rank for x in ds)) == full_size
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@require_torch
+@pytest.mark.integration
+def test_torch_distributed_launch(streaming):
+    nproc_per_node = 2
+    master_port = get_torch_dist_unique_port()
+    test_script = Path(__file__).resolve().parent / "distributed_scripts" / "test_torch_distributed_launch.py"
+    distributed_args = f"""
+        -m torch.distributed.launch
+        --nproc_per_node={nproc_per_node}
+        --master_port={master_port}
+        {test_script}
+    """.split()
+    args = f"""
+        --streaming={streaming}
+    """.split()
+    cmd = [sys.executable] + distributed_args + args
+    execute_subprocess_async(cmd, env=os.environ.copy())
+
+
+@pytest.mark.parametrize(
+    "nproc_per_node, num_workers",
+    [
+        (2, 2),  # each node has 2 shards and each worker has 1 shards
+        (3, 2),  # each node uses all the shards but skips examples, and each worker has 2 shards
+    ],
+)
+@require_torch
+@pytest.mark.integration
+def test_torch_distributed_launch_streaming_with_num_workers(nproc_per_node, num_workers):
+    streaming = True
+    master_port = get_torch_dist_unique_port()
+    test_script = Path(__file__).resolve().parent / "distributed_scripts" / "test_torch_distributed_launch.py"
+    distributed_args = f"""
+        -m torch.distributed.launch
+        --nproc_per_node={nproc_per_node}
+        --master_port={master_port}
+        {test_script}
+    """.split()
+    args = f"""
+        --streaming={streaming}
+        --num_workers={num_workers}
+    """.split()
+    cmd = [sys.executable] + distributed_args + args
+    execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
+import asyncio
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -417,3 +419,110 @@ def xfail_if_500_502_http_error(func):
             raise err
 
     return decorator.decorator(_wrapper, func)
+
+
+# --- distributed testing functions --- #
+
+# copied from transformers
+# originally adapted from https://stackoverflow.com/a/59041913/9201239
+
+
+class _RunOutput:
+    def __init__(self, returncode, stdout, stderr):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+async def _read_stream(stream, callback):
+    while True:
+        line = await stream.readline()
+        if line:
+            callback(line)
+        else:
+            break
+
+
+async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=False, echo=False) -> _RunOutput:
+    if echo:
+        print("\nRunning: ", " ".join(cmd))
+
+    p = await asyncio.create_subprocess_exec(
+        cmd[0],
+        *cmd[1:],
+        stdin=stdin,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+
+    # note: there is a warning for a possible deadlock when using `wait` with huge amounts of data in the pipe
+    # https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.asyncio.subprocess.Process.wait
+    #
+    # If it starts hanging, will need to switch to the following code. The problem is that no data
+    # will be seen until it's done and if it hangs for example there will be no debug info.
+    # out, err = await p.communicate()
+    # return _RunOutput(p.returncode, out, err)
+
+    out = []
+    err = []
+
+    def tee(line, sink, pipe, label=""):
+        line = line.decode("utf-8").rstrip()
+        sink.append(line)
+        if not quiet:
+            print(label, line, file=pipe)
+
+    # XXX: the timeout doesn't seem to make any difference here
+    await asyncio.wait(
+        [
+            _read_stream(p.stdout, lambda l: tee(l, out, sys.stdout, label="stdout:")),
+            _read_stream(p.stderr, lambda l: tee(l, err, sys.stderr, label="stderr:")),
+        ],
+        timeout=timeout,
+    )
+    return _RunOutput(await p.wait(), out, err)
+
+
+def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(
+        _stream_subprocess(cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo)
+    )
+
+    cmd_str = " ".join(cmd)
+    if result.returncode > 0:
+        stderr = "\n".join(result.stderr)
+        raise RuntimeError(
+            f"'{cmd_str}' failed with returncode {result.returncode}\n\n"
+            f"The combined stderr from workers follows:\n{stderr}"
+        )
+
+    # check that the subprocess actually did run and produced some output, should the test rely on
+    # the remote side to do the testing
+    if not result.stdout and not result.stderr:
+        raise RuntimeError(f"'{cmd_str}' produced no output.")
+
+    return result
+
+
+def pytest_xdist_worker_id():
+    """
+    Returns an int value of worker's numerical id under `pytest-xdist`'s concurrent workers `pytest -n N` regime, or 0
+    if `-n 1` or `pytest-xdist` isn't being used.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    worker = re.sub(r"^gw", "", worker, 0, re.M)
+    return int(worker)
+
+
+def get_torch_dist_unique_port():
+    """
+    Returns a port number that can be fed to `torch.distributed.launch`'s `--master_port` argument.
+
+    Under `pytest-xdist` it adds a delta number based on a worker id so that concurrent tests don't try to use the same
+    port at once.
+    """
+    port = 29500
+    uniq_delta = pytest_xdist_worker_id()
+    return port + uniq_delta


### PR DESCRIPTION
To split your dataset across your training nodes, you can use the new [`datasets.distributed.split_dataset_by_node`]:

```python
import os
from datasets.distributed import split_dataset_by_node

ds = split_dataset_by_node(ds, rank=int(os.environ["RANK"]), world_size=int(os.environ["WORLD_SIZE"]))
```

This works for both map-style datasets and iterable datasets.
The dataset is split for the node at rank `rank` in a pool of nodes of size `world_size`.

For map-style datasets:

Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of the dataset.

For iterable datasets:

If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.n_shards % world_size == 0`),
then the shards are evenly assigned across the nodes, which is the most optimized.
Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.

This can also be combined with a `torch.utils.data.DataLoader` if you want each node to use multiple workers to load the data.

TODO:
- [x] docs for usage in PyTorch
- [x] unit tests
- [x] integration tests with torch.distributed.launch

Related to https://github.com/huggingface/transformers/issues/20770
Close https://github.com/huggingface/datasets/issues/5360