### PR TITLE
Fix streaming pandas.read_excel

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -727,10 +727,22 @@ def xpandas_read_csv(filepath_or_buffer, use_auth_token: Optional[Union[str, boo
         return pd.read_csv(xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token), **kwargs)
 
 
-def xpandas_read_excel(filepath_or_buffer, **kwargs):
+def xpandas_read_excel(filepath_or_buffer, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):
     import pandas as pd
 
-    return pd.read_excel(BytesIO(filepath_or_buffer.read()), **kwargs)
+    if hasattr(filepath_or_buffer, "read"):
+        try:
+            return pd.read_excel(filepath_or_buffer, **kwargs)
+        except ValueError:  # Cannot seek streaming HTTP file
+            return pd.read_excel(BytesIO(filepath_or_buffer.read()), **kwargs)
+    else:
+        filepath_or_buffer = str(filepath_or_buffer)
+        try:
+            return pd.read_excel(xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token), **kwargs)
+        except ValueError:  # Cannot seek streaming HTTP file
+            return pd.read_excel(
+                BytesIO(xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token).read()), **kwargs
+            )
 
 
 def xsio_loadmat(filepath_or_buffer, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -91,7 +91,7 @@ def extend_module_for_streaming(module_path, use_auth_token: Optional[Union[str,
     # file readers
     patch_submodule(module, "gzip.open", wrap_auth(xgzip_open)).start()
     patch_submodule(module, "pandas.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
-    patch_submodule(module, "pandas.read_excel", xpandas_read_excel, attrs=["__version__"]).start()
+    patch_submodule(module, "pandas.read_excel", wrap_auth(xpandas_read_excel), attrs=["__version__"]).start()
     patch_submodule(module, "scipy.io.loadmat", wrap_auth(xsio_loadmat), attrs=["__version__"]).start()
     patch_submodule(module, "xml.etree.ElementTree.parse", wrap_auth(xet_parse)).start()
     patch_submodule(module, "xml.dom.minidom.parse", wrap_auth(xxml_dom_minidom_parse)).start()


### PR DESCRIPTION
This PR fixes `xpandas_read_excel`:
- Support passing a path string, besides a file-like object
- Support passing `use_auth_token`
- First assumes the host server supports HTTP range requests; only if a ValueError is thrown (Cannot seek streaming HTTP file), then it preserves previous behavior (see [#3355](https://github.com/huggingface/datasets/pull/3355)).

Fix https://huggingface.co/datasets/bigbio/meqsum/discussions/1
Fix:
- https://github.com/bigscience-workshop/biomedical/issues/801

Related to:
- #3355