### PR TITLE
Simplify skipping

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -608,10 +608,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
         self.n = n
 
     def __iter__(self):
-        ex_iterator = iter(self.ex_iterable)
-        for _ in islice(ex_iterator, self.n):
-            pass
-        yield from ex_iterator
+        yield from islice(self.ex_iterable, self.n, None)
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "SkipExamplesIterable":
         """Doesn't shuffle the wrapped examples iterable since it would skip examples from other shards instead."""


### PR DESCRIPTION
Was hoping to find a way to speed up the skipping as I'm running into bottlenecks skipping 100M examples on C4 (it takes 12 hours to skip), but didn't find anything better than this small change :(

Maybe there's a way to directly skip whole shards to speed it up? 🧐