### PR TITLE
Add a parallel implementation of to_tf_dataset()

### DIFF
--- a/docs/source/use_with_tensorflow.mdx
+++ b/docs/source/use_with_tensorflow.mdx
@@ -189,7 +189,7 @@ Using `to_tf_dataset()` is straightforward. Once your dataset is preprocessed an
             )
 ```
 
-The returned `tf_ds` object here is now fully ready to train on, and can be passed directly to `model.fit()`! Note
+The returned `tf_ds` object here is now fully ready to train on, and can be passed directly to `model.fit()`. Note
 that you set the batch size when creating the dataset, and so you don't need to specify it when calling `fit()`:
 
 ```py
@@ -203,6 +203,10 @@ suffice, but for more complex tasks a custom collator may be necessary. In parti
 with varying sequence lengths which will require a [data collator](https://huggingface.co/docs/transformers/main/en/main_classes/data_collator) that can pad batches correctly. You can see examples
 of this in the `transformers` NLP [examples](https://github.com/huggingface/transformers/tree/main/examples) and
 [notebooks](https://huggingface.co/docs/transformers/notebooks), where variable sequence lengths are very common.
+
+If you find that loading with `to_tf_dataset` is slow, you can also use the `num_workers` argument. This spins
+up multiple subprocesses to load data in parallel. This feature is recent and still somewhat experimental - please file
+an issue if you encounter any bugs while using it!
 
 ### When to use to_tf_dataset
 
@@ -231,4 +235,4 @@ instead:
 
 ### Caveats and limitations
 
-Right now, `to_tf_dataset()` always return a batched dataset - we will add support for unbatched datasets soon!
+Right now, `to_tf_dataset()` always returns a batched dataset - we will add support for unbatched datasets soon!

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -211,7 +211,7 @@ class TensorflowDatasetMixin:
         collate_fn_args: dict,
         cols_to_retain: Optional[List[str]] = None,
         batch_size: Optional[int] = None,
-        num_test_batches: int = 200,
+        num_test_batches: int = 20,
     ):
         """Private method used by `to_tf_dataset()` to find the shapes and dtypes of samples from this dataset
            after being passed through the collate_fn. Tensorflow needs an exact signature for tf.numpy_function, so
@@ -243,7 +243,7 @@ class TensorflowDatasetMixin:
             raise ValueError("Unable to get the output signature because the dataset is empty.")
         if batch_size is not None:
             batch_size = min(len(dataset), batch_size)
-        test_batch_size = min(len(dataset), 2)
+        test_batch_size = 1
 
         if cols_to_retain is not None:
             cols_to_retain = list(set(cols_to_retain + ["label_ids", "label", "labels"]))

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -345,6 +345,8 @@ class TensorflowDatasetMixin:
                 Whether to run the dataloader in a separate thread and maintain
                 a small buffer of batches for training. Improves performance by allowing data to be loaded in the
                 background while the model is training.
+            num_workers (`int`, defaults to `0`):
+                Number of workers to use for loading the dataset. Only supported on Python versions >= 3.8.
 
         Returns:
             `tf.data.Dataset`
@@ -372,6 +374,9 @@ class TensorflowDatasetMixin:
                 "try using a TPU VM or, if your data can fit in memory, loading it into memory as a dict of "
                 "Tensors instead of streaming with to_tf_dataset()."
             )
+
+        if num_workers > 0 and sys.version_info < (3, 8):
+            raise ValueError("Using multiple workers is only supported on Python versions >= 3.8.")
 
         if collate_fn is None:
             # Set a very simple default collator that just stacks things together

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -430,7 +430,7 @@ class TensorflowDatasetMixin:
             if col not in output_signature:
                 raise ValueError(f"Label column {col} not found in dataset!")
 
-        if num_workers <= 0:
+        if num_workers == 0:
             tf_dataset = dataset_to_tf(
                 dataset=dataset,
                 cols_to_retain=cols_to_retain,
@@ -442,7 +442,7 @@ class TensorflowDatasetMixin:
                 batch_size=batch_size,
                 drop_remainder=drop_remainder,
             )
-        else:
+        elif num_workers > 0:
             tf_dataset = multiprocess_dataset_to_tf(
                 dataset=dataset,
                 cols_to_retain=cols_to_retain,
@@ -455,6 +455,8 @@ class TensorflowDatasetMixin:
                 drop_remainder=drop_remainder,
                 num_workers=num_workers,
             )
+        else:
+            raise ValueError("num_workers must be >= 0")
 
         def split_features_and_labels(input_batch):
             # TODO(Matt, QL): deprecate returning the dict content when there's only one key

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -138,7 +138,7 @@ def dataset_to_tf(
                 cols_to_retain (`List[str]`): Dataset column(s) to load in the
                     tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
                     that do not exist in the original dataset.
-                collate_fn(:obj:`Callable`): A function or callable object (such as a `DataCollator`) that will collate
+                collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
                     lists of samples into a batch.
                 collate_fn_args (:obj:`Dict`): A  `dict` of keyword arguments to be passed to the
                     `collate_fn`. Can be empty.

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -143,7 +143,7 @@ def dataset_to_tf(
                 collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
                     `collate_fn`. Can be empty.
                 columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
-                output_signature (:obj:`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
+                output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
                     `tf.TensorSpec` objects.
                 shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
                     validation/evaluation.

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -148,7 +148,7 @@ def dataset_to_tf(
                 shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
                     validation/evaluation.
                 batch_size (`int`): Size of batches to load from the dataset.
-                drop_remainder(:obj:`bool`, default ``None``): Drop the last incomplete batch when loading. If not provided,
+                drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
                     defaults to the same setting as shuffle.
 
             Returns:

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -342,18 +342,19 @@ class NumpyMultiprocessingGenerator:
         indices = np.arange(len(dataset))
         if shuffle:
             np.random.shuffle(indices)
+        num_samples = len(indices)
         # We distribute the batches so that reading from the workers in round-robin order yields the exact
         # order specified in indices. This is only important when shuffle is False, but we do it regardless.
-        if drop_remainder or len(indices) % batch_size == 0:
+        if drop_remainder or num_samples % batch_size == 0:
             last_incomplete_batch = None
         else:
-            last_incomplete_batch = [indices[len(indices) // batch_size * batch_size :]]
-        if len(indices) % batch_size != 0:
-            indices = indices[: -(len(indices) % batch_size)]
+            last_incomplete_batch = [indices[num_samples // batch_size * batch_size :]]
+        if num_samples % batch_size != 0:
+            indices = indices[: -(num_samples % batch_size)]
         indices = indices.reshape(-1, batch_size)
-        if len(indices) % num_workers != 0:
-            final_batches = indices[-(len(indices) % num_workers) :]
-            indices = indices[: -(len(indices) % num_workers)]
+        if num_samples % num_workers != 0:
+            final_batches = indices[-(num_samples % num_workers) :]
+            indices = indices[: -(num_samples % num_workers)]
         else:
             final_batches = []
         indices = indices.reshape(-1, num_workers, batch_size)

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -153,7 +153,7 @@ def dataset_to_tf(
 
             Returns:
                 :class:`tf.data.Dataset`
-            """
+    """
     if config.TF_AVAILABLE:
         import tensorflow as tf
     else:

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -152,7 +152,7 @@ def dataset_to_tf(
                     defaults to the same setting as shuffle.
 
             Returns:
-                :class:`tf.data.Dataset`
+                `tf.data.Dataset`
     """
     if config.TF_AVAILABLE:
         import tensorflow as tf

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -103,8 +103,6 @@ def dataset_to_tf(
                 for key, value in batch.items()
                 if key in cols_to_retain or key in ("label", "label_ids", "labels")
             }
-        elif cols_to_retain is not None:
-            batch = {key: value for key, value in batch.items() if key in cols_to_retain}
 
         actual_size = len(list(batch.values())[0])  # Get the length of one of the arrays, assume all same
         # Our collators expect a list of dicts, not a dict of lists/arrays, so we invert

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -135,7 +135,7 @@ def dataset_to_tf(
 
             Args:
                 dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
-                cols_to_retain (:obj:`List[str]`): Dataset column(s) to load in the
+                cols_to_retain (`List[str]`): Dataset column(s) to load in the
                     tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
                     that do not exist in the original dataset.
                 collate_fn(:obj:`Callable`): A function or callable object (such as a `DataCollator`) that will collate

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -195,7 +195,7 @@ class NumpyMultiprocessingGenerator:
             for i in range(num_workers):
                 batch = worker_queues[i].get()
                 if isinstance(batch, str) and batch == "DONE":
-                    raise StopIteration
+                    return
                 yield batch
 
     def __call__(self):

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -147,7 +147,7 @@ def dataset_to_tf(
                     `tf.TensorSpec` objects.
                 shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
                     validation/evaluation.
-                batch_size (:obj:`int`): Size of batches to load from the dataset.
+                batch_size (`int`): Size of batches to load from the dataset.
                 drop_remainder(:obj:`bool`, default ``None``): Drop the last incomplete batch when loading. If not provided,
                     defaults to the same setting as shuffle.
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -19,6 +19,7 @@ from math import ceil
 import numpy as np
 import pyarrow as pa
 from multiprocess import get_context
+import os
 
 from .. import config
 
@@ -204,10 +205,12 @@ class NumpyMultiprocessingGenerator:
     def worker_loop(
         dataset, cols_to_retain, collate_fn, collate_fn_args, columns_to_np_types, queue, indices, extra_batch
     ):
+
         if config.TF_AVAILABLE:
             import tensorflow as tf
         else:
-            raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")  #
+            raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
+        tf.config.set_visible_devices([], 'GPU')  # Remember never to call this in the main process!
 
         def get_batch(indices):
             # Optimization - if we're loading a sequential batch, do it with slicing instead of a list of indices

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -134,7 +134,7 @@ def dataset_to_tf(
     equivalent is multiprocess_dataset_to_tf.
 
             Args:
-                dataset (:obj:`ArrowDataset`): Dataset to wrap with tf.data.Dataset.
+                dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
                 cols_to_retain (:obj:`List[str]`): Dataset column(s) to load in the
                     tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
                     that do not exist in the original dataset.

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -14,6 +14,9 @@
 
 """TF-specific utils import."""
 
+from math import ceil
+from multiprocessing import get_context
+
 import numpy as np
 import pyarrow as pa
 
@@ -68,3 +71,238 @@ def is_numeric_feature(feature):
         return True
     else:
         return False
+
+
+def dataset_to_tf(
+    dataset,
+    cols_to_retain,
+    collate_fn,
+    collate_fn_args,
+    columns_to_np_types,
+    output_signature,
+    shuffle,
+    batch_size,
+    drop_remainder,
+):
+    if config.TF_AVAILABLE:
+        import tensorflow as tf
+    else:
+        raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
+
+    def np_get_batch(indices):
+        # Optimization - if we're loading a sequential batch, do it with slicing instead of a list of indices
+        if np.all(np.diff(indices) == 1):
+            batch = dataset[indices[0] : indices[-1] + 1]
+        else:
+            batch = dataset[indices]
+
+        if cols_to_retain is not None:
+            batch = {
+                key: value
+                for key, value in batch.items()
+                if key in cols_to_retain or key in ("label", "label_ids", "labels")
+            }
+        elif cols_to_retain is not None:
+            batch = {key: value for key, value in batch.items() if key in cols_to_retain}
+
+        actual_size = len(list(batch.values())[0])  # Get the length of one of the arrays, assume all same
+        # Our collators expect a list of dicts, not a dict of lists/arrays, so we invert
+        batch = [{key: value[i] for key, value in batch.items()} for i in range(actual_size)]
+        batch = collate_fn(batch, **collate_fn_args)
+        out_batch = []
+        for col, cast_dtype in columns_to_np_types.items():
+            # In case the collate_fn returns something strange
+            array = np.array(batch[col])
+            array = array.astype(cast_dtype)
+            out_batch.append(array)
+        return out_batch
+
+    @tf.function(input_signature=[tf.TensorSpec(None, tf.int64)])
+    def fetch_function(indices):
+        output = tf.numpy_function(
+            np_get_batch,
+            inp=[indices],
+            # This works because dictionaries always output in the same order
+            Tout=[tf.dtypes.as_dtype(dtype) for dtype in columns_to_np_types.values()],
+        )
+        return {key: output[i] for i, key in enumerate(columns_to_np_types.keys())}
+
+    tf_dataset = tf.data.Dataset.from_tensor_slices(np.arange(len(dataset), dtype=np.int64))
+
+    if shuffle:
+        tf_dataset = tf_dataset.shuffle(len(dataset))
+
+    tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder).map(fetch_function)
+
+    def ensure_shapes(input_dict):
+        return {key: tf.ensure_shape(val, output_signature[key].shape) for key, val in input_dict.items()}
+
+    return tf_dataset.map(ensure_shapes)
+
+
+class NumpyMultiprocessingGenerator:
+    def __init__(
+        self,
+        dataset,
+        cols_to_retain,
+        collate_fn,
+        collate_fn_args,
+        columns_to_np_types,
+        shuffle,
+        batch_size,
+        drop_remainder,
+        num_workers,
+    ):
+        self.dataset = dataset
+        self.cols_to_retain = cols_to_retain
+        self.collate_fn = collate_fn
+        self.collate_fn_args = collate_fn_args
+        self.columns_to_np_types = columns_to_np_types
+        self.shuffle = shuffle
+        self.batch_size = batch_size
+        self.drop_remainder = drop_remainder
+        self.num_workers = num_workers
+
+    def __iter__(self):
+        # Make sure we only spawn workers if they have work to do
+        num_workers = min(self.num_workers, ceil(len(self.dataset) / self.batch_size))
+        # Do the shuffling in iter so that it's done at the start of each epoch
+        per_worker_batches, final_batch, final_batch_worker = self.distribute_batches(
+            self.dataset, self.batch_size, self.drop_remainder, num_workers, self.shuffle
+        )
+        ctx = get_context("spawn")
+        worker_queues = [ctx.Queue(maxsize=5) for _ in range(num_workers)]
+        workers = []
+        base_args = [
+            self.dataset,
+            self.cols_to_retain,
+            self.collate_fn,
+            self.collate_fn_args,
+            self.columns_to_np_types,
+        ]
+
+        for i in range(num_workers):
+            worker_args = [*base_args, worker_queues[i], per_worker_batches[i]]
+            if i == final_batch_worker:
+                worker_args.append(final_batch)
+            else:
+                worker_args.append(None)
+            worker_args = tuple(worker_args)
+            worker = ctx.Process(target=self.worker_loop, args=worker_args, daemon=True)
+            worker.start()
+            workers.append(worker)
+        while True:
+            for i in range(num_workers):
+                batch = worker_queues[i].get()
+                if isinstance(batch, str) and batch == "DONE":
+                    raise StopIteration
+                yield batch
+
+    def __call__(self):
+        return self
+
+    @staticmethod
+    def worker_loop(
+        dataset, cols_to_retain, collate_fn, collate_fn_args, columns_to_np_types, queue, indices, extra_batch
+    ):
+        if config.TF_AVAILABLE:
+            import tensorflow as tf
+        else:
+            raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")  #
+
+        def get_batch(indices):
+            # Optimization - if we're loading a sequential batch, do it with slicing instead of a list of indices
+            if np.all(np.diff(indices) == 1):
+                batch = dataset[indices[0] : indices[-1] + 1]
+            else:
+                batch = dataset[indices]
+
+            if cols_to_retain is not None:
+                batch = {
+                    key: value
+                    for key, value in batch.items()
+                    if key in cols_to_retain or key in ("label", "label_ids", "labels")
+                }
+            elif cols_to_retain is not None:
+                batch = {key: value for key, value in batch.items() if key in cols_to_retain}
+
+            actual_size = len(list(batch.values())[0])  # Get the length of one of the arrays, assume all same
+            # Our collators expect a list of dicts, not a dict of lists/arrays, so we invert
+            batch = [{key: value[i] for key, value in batch.items()} for i in range(actual_size)]
+            batch = collate_fn(batch, **collate_fn_args)
+            out_batch = dict()
+            for col, cast_dtype in columns_to_np_types.items():
+                # In case the collate_fn returns something strange
+                array = np.array(batch[col])
+                array = array.astype(cast_dtype)
+                out_batch[col] = array
+            return out_batch
+
+        with tf.device("/cpu:0"):
+            for batch in indices:
+                queue.put(get_batch(batch))
+            if extra_batch is not None:
+                queue.put(get_batch(extra_batch))
+        queue.put("DONE")
+
+    @staticmethod
+    def distribute_batches(dataset, batch_size, drop_remainder, num_workers, shuffle):
+        indices = np.arange(len(dataset))
+        if shuffle:
+            np.random.shuffle(indices)
+        # We distribute the batches so that reading from the workers in round-robin order yields the exact
+        # order specified in indices. This is only important when shuffle is False, but we do it regardless.
+        if drop_remainder or len(indices) % batch_size == 0:
+            last_incomplete_batch = None
+        else:
+            last_incomplete_batch = [indices[len(indices) // batch_size * batch_size :]]
+        indices = indices[: len(indices) // batch_size * batch_size]
+        indices = indices.reshape(-1, batch_size)
+        if len(indices) % num_workers != 0:
+            final_batches = indices[-(len(indices) % num_workers) :]
+        else:
+            final_batches = []
+        indices = indices.reshape(-1, num_workers, batch_size)
+        per_worker_indices = np.split(indices, indices.shape[1], axis=1)
+        per_worker_indices = [np.squeeze(worker_indices, 1) for worker_indices in per_worker_indices]
+        # Distribute the final batches to the first workers
+        for i in range(len(final_batches)):
+            per_worker_indices[i] = np.concatenate([per_worker_indices[i], final_batches[i].reshape(1, -1)], axis=0)
+        # Add the last incomplete batch to the next worker, which might be the first worker
+        if last_incomplete_batch is not None:
+            incomplete_batch_worker_idx = len(final_batches)
+        else:
+            incomplete_batch_worker_idx = None
+        return per_worker_indices, last_incomplete_batch, incomplete_batch_worker_idx
+
+
+def multiprocess_dataset_to_tf(
+    dataset,
+    cols_to_retain,
+    collate_fn,
+    collate_fn_args,
+    columns_to_np_types,
+    output_signature,
+    shuffle,
+    batch_size,
+    drop_remainder,
+    num_workers,
+):
+    if config.TF_AVAILABLE:
+        import tensorflow as tf
+    else:
+        raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
+
+    data_generator = NumpyMultiprocessingGenerator(
+        dataset,
+        cols_to_retain,
+        collate_fn,
+        collate_fn_args,
+        columns_to_np_types,
+        shuffle,
+        batch_size,
+        drop_remainder,
+        num_workers,
+    )
+
+    return tf.data.Dataset.from_generator(data_generator, output_signature=output_signature)

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -176,7 +176,7 @@ class SharedMemoryContext:
         self.opened_shms = []
 
     def get_shm(self, name, size, create):
-        shm = SharedMemory(size=size, name=name, create=create)
+        shm = SharedMemory(size=int(size), name=name, create=create)
         if create:
             # We only unlink the ones we created in this context
             self.created_shms.append(shm)

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -142,7 +142,7 @@ def dataset_to_tf(
                     lists of samples into a batch.
                 collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
                     `collate_fn`. Can be empty.
-                columns_to_np_types (:obj:`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
+                columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
                 output_signature (:obj:`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
                     `tf.TensorSpec` objects.
                 shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -140,7 +140,7 @@ def dataset_to_tf(
                     that do not exist in the original dataset.
                 collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
                     lists of samples into a batch.
-                collate_fn_args (:obj:`Dict`): A  `dict` of keyword arguments to be passed to the
+                collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
                     `collate_fn`. Can be empty.
                 columns_to_np_types (:obj:`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
                 output_signature (:obj:`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -476,6 +476,31 @@ def multiprocess_dataset_to_tf(
     drop_remainder,
     num_workers,
 ):
+    """Create a tf.data.Dataset from the underlying Dataset. This is a multi-process method - the single-process
+    equivalent is dataset_to_tf.
+
+            Args:
+                dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
+                cols_to_retain (`List[str]`): Dataset column(s) to load in the
+                    tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
+                    that do not exist in the original dataset.
+                collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
+                    lists of samples into a batch.
+                collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
+                    `collate_fn`. Can be empty.
+                columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
+                output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
+                    `tf.TensorSpec` objects.
+                shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
+                    validation/evaluation.
+                batch_size (`int`): Size of batches to load from the dataset.
+                drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
+                    defaults to the same setting as shuffle.
+                num_workers (`int`): Number of workers to use for loading the dataset. Should be >= 1.
+
+            Returns:
+                `tf.data.Dataset`
+    """
     if config.TF_AVAILABLE:
         import tensorflow as tf
     else:

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -301,8 +301,6 @@ class NumpyMultiprocessingGenerator:
                     for key, value in batch.items()
                     if key in cols_to_retain or key in ("label", "label_ids", "labels")
                 }
-            elif cols_to_retain is not None:
-                batch = {key: value for key, value in batch.items() if key in cols_to_retain}
 
             actual_size = len(list(batch.values())[0])  # Get the length of one of the arrays, assume all same
             # Our collators expect a list of dicts, not a dict of lists/arrays, so we invert

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -20,7 +20,6 @@ import numpy as np
 import pyarrow as pa
 from multiprocess import get_context
 from multiprocess.shared_memory import SharedMemory
-from numpy.random import default_rng
 
 from .. import config
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -261,6 +261,7 @@ class NumpyMultiprocessingGenerator:
             final_batches = indices[-(len(indices) % num_workers) :]
         else:
             final_batches = []
+        indices = indices[: -(len(indices) % num_workers)]
         indices = indices.reshape(-1, num_workers, batch_size)
         per_worker_indices = np.split(indices, indices.shape[1], axis=1)
         per_worker_indices = [np.squeeze(worker_indices, 1) for worker_indices in per_worker_indices]

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -272,7 +272,10 @@ class NumpyMultiprocessingGenerator:
         array_ready_event,
         array_loaded_event,
     ):
-        import tensorflow as tf
+        if config.TF_AVAILABLE:
+            import tensorflow as tf
+        else:
+            raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
 
         tf.config.set_visible_devices([], "GPU")  # Make sure workers don't try to allocate GPU memory
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -15,10 +15,10 @@
 """TF-specific utils import."""
 
 from math import ceil
-from multiprocessing import get_context
 
 import numpy as np
 import pyarrow as pa
+from multiprocess import get_context
 
 from .. import config
 
@@ -180,7 +180,6 @@ class NumpyMultiprocessingGenerator:
             self.collate_fn_args,
             self.columns_to_np_types,
         ]
-
         for i in range(num_workers):
             worker_args = [*base_args, worker_queues[i], per_worker_batches[i]]
             if i == final_batch_worker:

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -20,6 +20,8 @@ from math import ceil
 import numpy as np
 import pyarrow as pa
 from multiprocess import get_context
+
+
 try:
     from multiprocess.shared_memory import SharedMemory
 except ImportError:

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -231,6 +231,8 @@ class NumpyMultiprocessingGenerator:
                     for col, shape in array_shapes.items()
                 }
                 if any(size < 0 for size in array_sizes.values()):
+                    # Child processes send negative array shapes to indicate
+                    # that no more data is going to be sent
                     end_signal_received = True
                     break
                 array_shms = {

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -352,14 +352,14 @@ class NumpyMultiprocessingGenerator:
         num_samples = len(indices)
         # We distribute the batches so that reading from the workers in round-robin order yields the exact
         # order specified in indices. This is only important when shuffle is False, but we do it regardless.
-        incomplete_batch_cutoff = num_samples // batch_size * batch_size
+        incomplete_batch_cutoff = num_samples - (num_samples % batch_size)
         indices, last_incomplete_batch = np.split(indices, [incomplete_batch_cutoff])
         if drop_remainder or len(last_incomplete_batch) == 0:
             last_incomplete_batch = None
 
         indices = indices.reshape(-1, batch_size)
         num_batches = len(indices)
-        final_batches_cutoff = num_batches // num_workers * num_workers
+        final_batches_cutoff = num_batches - (num_batches % num_workers)
         indices, final_batches = np.split(indices, [final_batches_cutoff])
         indices = indices.reshape(-1, num_workers, batch_size)
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -14,13 +14,13 @@
 
 """TF-specific utils import."""
 
+from functools import partial
 from math import ceil
 
 import numpy as np
 import pyarrow as pa
 from multiprocess import get_context
 from multiprocess.shared_memory import SharedMemory
-from functools import partial
 
 from .. import config
 
@@ -124,7 +124,7 @@ def dataset_to_tf(
         cols_to_retain=cols_to_retain,
         collate_fn=collate_fn,
         collate_fn_args=collate_fn_args,
-        columns_to_np_types=columns_to_np_types
+        columns_to_np_types=columns_to_np_types,
     )
 
     @tf.function(input_signature=[tf.TensorSpec(None, tf.int64)])
@@ -300,12 +300,14 @@ class NumpyMultiprocessingGenerator:
         }
 
         def send_batch_to_parent(indices):
-            batch = np_get_batch(indices=indices,
-                                 dataset=dataset,
-                                 cols_to_retain=cols_to_retain,
-                                 collate_fn=collate_fn,
-                                 collate_fn_args=collate_fn_args,
-                                 columns_to_np_types=columns_to_np_types)
+            batch = np_get_batch(
+                indices=indices,
+                dataset=dataset,
+                cols_to_retain=cols_to_retain,
+                collate_fn=collate_fn,
+                collate_fn_args=collate_fn_args,
+                columns_to_np_types=columns_to_np_types,
+            )
 
             # Now begins the fun part where we start shovelling shared memory at the parent process
             out_shms = dict()

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -14,14 +14,11 @@
 
 """TF-specific utils import."""
 
-import logging
-import os
 from math import ceil
-from time import sleep
 
 import numpy as np
 import pyarrow as pa
-from multiprocess import Process, get_context
+from multiprocess import get_context
 
 from .. import config
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -20,7 +20,10 @@ from math import ceil
 import numpy as np
 import pyarrow as pa
 from multiprocess import get_context
-from multiprocess.shared_memory import SharedMemory
+try:
+    from multiprocess.shared_memory import SharedMemory
+except ImportError:
+    SharedMemory = None  # Version checks should prevent this being called on older Python versions
 
 from .. import config
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -130,6 +130,30 @@ def dataset_to_tf(
     batch_size,
     drop_remainder,
 ):
+    """Create a tf.data.Dataset from the underlying Dataset. This is a single-process method - the multiprocess
+    equivalent is multiprocess_dataset_to_tf.
+
+            Args:
+                dataset (:obj:`ArrowDataset`): Dataset to wrap with tf.data.Dataset.
+                cols_to_retain (:obj:`List[str]`): Dataset column(s) to load in the
+                    tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
+                    that do not exist in the original dataset.
+                collate_fn(:obj:`Callable`): A function or callable object (such as a `DataCollator`) that will collate
+                    lists of samples into a batch.
+                collate_fn_args (:obj:`Dict`): A  `dict` of keyword arguments to be passed to the
+                    `collate_fn`. Can be empty.
+                columns_to_np_types (:obj:`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
+                output_signature (:obj:`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
+                    `tf.TensorSpec` objects.
+                shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
+                    validation/evaluation.
+                batch_size (:obj:`int`): Size of batches to load from the dataset.
+                drop_remainder(:obj:`bool`, default ``None``): Drop the last incomplete batch when loading. If not provided,
+                    defaults to the same setting as shuffle.
+
+            Returns:
+                :class:`tf.data.Dataset`
+            """
     if config.TF_AVAILABLE:
         import tensorflow as tf
     else:
@@ -186,12 +210,6 @@ class SharedMemoryContext:
         return shm
 
     def get_array(self, name, shape, dtype, create):
-        if create:
-            print(f"Making array {name} with shape {shape} and dtype {dtype} and itemsize {np.dtype(dtype).itemsize}!")
-        else:
-            print(
-                f"Opening array {name} with shape {shape} and dtype {dtype} and itemsize {np.dtype(dtype).itemsize}!"
-            )
         shm = self.get_shm(name=name, size=np.prod(shape) * np.dtype(dtype).itemsize, create=create)
         return np.ndarray(shape, dtype=dtype, buffer=shm.buf)
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -145,7 +145,7 @@ def dataset_to_tf(
                 columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
                 output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
                     `tf.TensorSpec` objects.
-                shuffle(:obj:`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
+                shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
                     validation/evaluation.
                 batch_size (`int`): Size of batches to load from the dataset.
                 drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2629,12 +2629,9 @@ class BaseDatasetTest(TestCase):
                 self.assertFalse(np.array_equal(indices, second_indices))
 
                 tf_dataset = dset.to_tf_dataset(batch_size=1, shuffle=False, num_workers=num_workers)
-                last_index = None
-                for batch in tf_dataset:
+                for i, batch in enumerate(tf_dataset):
                     # Assert that the unshuffled order is fully preserved even when multiprocessing
-                    if last_index is not None:
-                        self.assertEqual(last_index + 1, batch["col_1"].numpy())
-                    last_index = batch["col_1"].numpy()
+                    self.assertEqual(i, batch["col_1"].numpy())
 
     @require_tf
     def test_tf_label_renaming(self, in_memory):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2581,6 +2581,8 @@ class BaseDatasetTest(TestCase):
         for num_workers in [0, 1, 2]:
             if num_workers > 0 and sys.version_info < (3, 8):
                 continue  # Skip multiprocessing tests for Python < 3.8
+            if num_workers > 0 and sys.platform == "win32" and not in_memory:
+                continue  # This test hangs on the Py3.10 test worker, but it runs fine locally on my Windows machine
             with self._create_dummy_dataset(in_memory, tmp_dir.name, array_features=True) as dset:
                 tf_dataset = dset.to_tf_dataset(columns="col_3", batch_size=2, num_workers=num_workers)
                 batch = next(iter(tf_dataset))

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2614,6 +2614,8 @@ class BaseDatasetTest(TestCase):
     def test_tf_index_reshuffling(self, in_memory):
         # This test checks that when we do two epochs over a tf.data.Dataset from to_tf_dataset
         # that we get a different shuffle order each time
+        # It also checks that when we aren't shuffling, that the dataset order is fully preserved
+        # even when loading is split across multiple workers
         data = {"col_1": list(range(20))}
         for num_workers in [0, 1, 2, 3]:
             with Dataset.from_dict(data) as dset:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5,6 +5,7 @@ import json
 import os
 import pickle
 import re
+import sys
 import tempfile
 from functools import partial
 from pathlib import Path
@@ -2578,6 +2579,8 @@ class BaseDatasetTest(TestCase):
     def test_tf_dataset_conversion(self, in_memory):
         tmp_dir = tempfile.TemporaryDirectory()
         for num_workers in [0, 1, 2]:
+            if num_workers > 0 and sys.version_info < (3, 8):
+                continue  # Skip multiprocessing tests for Python < 3.8
             with self._create_dummy_dataset(in_memory, tmp_dir.name, array_features=True) as dset:
                 tf_dataset = dset.to_tf_dataset(columns="col_3", batch_size=2, num_workers=num_workers)
                 batch = next(iter(tf_dataset))
@@ -2618,6 +2621,8 @@ class BaseDatasetTest(TestCase):
         # even when loading is split across multiple workers
         data = {"col_1": list(range(20))}
         for num_workers in [0, 1, 2, 3]:
+            if num_workers > 0 and sys.version_info < (3, 8):
+                continue  # Skip multiprocessing tests for Python < 3.8
             with Dataset.from_dict(data) as dset:
                 tf_dataset = dset.to_tf_dataset(batch_size=10, shuffle=True, num_workers=num_workers)
                 indices = []

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2628,6 +2628,14 @@ class BaseDatasetTest(TestCase):
                 second_indices = np.concatenate([arr.numpy() for arr in second_indices])
                 self.assertFalse(np.array_equal(indices, second_indices))
 
+                tf_dataset = dset.to_tf_dataset(batch_size=1, shuffle=False, num_workers=num_workers)
+                last_index = None
+                for batch in tf_dataset:
+                    # Assert that the unshuffled order is fully preserved even when multiprocessing
+                    if last_index is not None:
+                        self.assertEqual(last_index + 1, batch["col_1"].numpy())
+                    last_index = batch["col_1"].numpy()
+
     @require_tf
     def test_tf_label_renaming(self, in_memory):
         # Protect TF-specific imports in here

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2586,7 +2586,7 @@ class BaseDatasetTest(TestCase):
             with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
                 tf_dataset = dset.to_tf_dataset(columns="col_1", batch_size=2, num_workers=num_workers)
                 batch = next(iter(tf_dataset))
-                self.assertEqual(batch.shape.as_list(), [4])
+                self.assertEqual(batch.shape.as_list(), [2])
                 self.assertEqual(batch.dtype.name, "int64")
             with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
                 # Check that it works with all default options (except batch_size because the dummy dataset only has 4)
@@ -2620,11 +2620,11 @@ class BaseDatasetTest(TestCase):
                 tf_dataset = dset.to_tf_dataset(batch_size=10, shuffle=True, num_workers=num_workers)
                 indices = []
                 for batch in tf_dataset:
-                    indices.append(batch['col_1'])
+                    indices.append(batch["col_1"])
                 indices = np.concatenate([arr.numpy() for arr in indices])
                 second_indices = []
                 for batch in tf_dataset:
-                    second_indices.append(batch['col_1'])
+                    second_indices.append(batch["col_1"])
                 second_indices = np.concatenate([arr.numpy() for arr in second_indices])
                 self.assertFalse(np.array_equal(indices, second_indices))
 


### PR DESCRIPTION
Hey all! Here's a first draft of the PR to add a multiprocessing implementation for `to_tf_dataset()`. It worked in some quick testing for me, but obviously I need to do some much more rigorous testing/benchmarking, and add some proper library tests.

The core idea is that we do everything using `multiprocessing` and `numpy`, and just wrap a `tf.data.Dataset` around the output. We could also rewrite the existing single-threaded implementation based on this code, which might simplify it a bit.

Checklist:
- [X] Add initial draft
- [x] Check that it works regardless of whether the `collate_fn` or dataset returns `tf` or `np` arrays
- [x] Check that it works with `tf.string` return data
- [x] Check indices are correctly reshuffled each epoch
- [x] Make sure workers don't try to initialize a GPU device!!
- [x] Check `fit()` with multiple epochs works fine and that the progress bar is correct
- [x] Check there are no memory leaks or zombie processes
- [x] Benchmark performance
- [x] Tweak params for dataset inference - can we speed things up there a bit?
- [x] Add tests to the library
- [x] Add a PR to `transformers` to expose the `num_workers` argument via `prepare_tf_dataset` (will merge after this one is released)
- [x] Stop TF console spam!! (almost)
- [x] Add a method for creating SHM that doesn't crash if it was left and still linked
- [x] Add a barrier for Py <= 3.7 because it doesn't support SharedMemory
- [x] Support string dtypes by converting them into fixed-width character arrays