### PR TITLE
Unpin pydantic test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,6 @@ METRICS_TESTS_REQUIRE = [
     "seqeval",
     "sqlalchemy",
     "spacy>=3.0.0",
-    "pydantic<1.10.3",  # GH-5394: temporary pin (dependency of spacy)
     "tldextract",
     # to speed up pip backtracking
     "toml>=0.10.1",


### PR DESCRIPTION
Once pydantic-1.10.3 has been yanked, we can unpin it: https://pypi.org/project/pydantic/1.10.3/

See reply by pydantic team https://github.com/pydantic/pydantic/issues/4885#issuecomment-1367819807
```
v1.10.3 has been yanked.
```
in response to spacy request: https://github.com/pydantic/pydantic/issues/4885#issuecomment-1367810049
```
On behalf of spacy-related packages: would it be possible for you to temporarily yank v1.10.3?

To address this and be compatible with v1.10.4, we'd have to release new versions of a whole series of packages and nearly everyone (including me) is currently on vacation. Even if v1.10.4 is released with a fix, pip would still back off to v1.10.3 for spacy, etc. because of its current pins for typing_extensions. If it could instead back off to v1.10.2, we'd have a bit more breathing room to make the updates on our end.
```

Close #5398.
