### PR TITLE
Replace one letter import in docs

### DIFF
--- a/docs/source/image_classification.mdx
+++ b/docs/source/image_classification.mdx
@@ -38,13 +38,13 @@ Now apply some augmentations with `albumentations`. You'll randomly crop the ima
 
 ```py
 >>> import cv2
->>> import albumentations as A
+>>> import albumentations
 >>> import numpy as np
 
->>> transform = A.Compose([
-...     A.RandomCrop(width=256, height=256),
-...     A.HorizontalFlip(p=0.5),
-...     A.RandomBrightnessContrast(p=0.2),
+>>> transform = albumentations.Compose([
+...     albumentations.RandomCrop(width=256, height=256),
+...     albumentations.HorizontalFlip(p=0.5),
+...     albumentations.RandomBrightnessContrast(p=0.2),
 ... ])
 ```
 

--- a/docs/source/object_detection.mdx
+++ b/docs/source/object_detection.mdx
@@ -77,14 +77,14 @@ With `albumentations`, you can apply transforms that will affect the image while
 `albumentations` expects the image to be in BGR format, not RGB, so you'll have to convert the image before applying the transform.
 
 ```py
->>> import albumentations as A
+>>> import albumentations
 >>> import numpy as np
 
->>> transform = A.Compose([
-...     A.Resize(480, 480),
-...     A.HorizontalFlip(p=1.0),
-...     A.RandomBrightnessContrast(p=1.0),
-... ], bbox_params=A.BboxParams(format='coco',  label_fields=['category']))
+>>> transform = albumentations.Compose([
+...     albumentations.Resize(480, 480),
+...     albumentations.HorizontalFlip(p=1.0),
+...     albumentations.RandomBrightnessContrast(p=1.0),
+... ], bbox_params=albumentations.BboxParams(format='coco',  label_fields=['category']))
 
 >>> # RGB PIL Image -> BGR Numpy array
 >>> image = np.flip(np.array(example['image']), -1)

--- a/docs/source/semantic_segmentation.mdx
+++ b/docs/source/semantic_segmentation.mdx
@@ -94,12 +94,12 @@ After defining the color palette, you should be ready to visualize some overlays
 Now apply some augmentations with `albumentations`. You’ll first resize the image and adjust its brightness.
 
 ```py
->>> import albumentations as A
+>>> import albumentations
 
->>> transform = A.Compose(
+>>> transform = albumentations.Compose(
 ...     [
-...         A.Resize(256, 256),
-...         A.RandomBrightnessContrast(brightness_limit=0.3, contrast_limit=0.3, p=0.5),
+...         albumentations.Resize(256, 256),
+...         albumentations.RandomBrightnessContrast(brightness_limit=0.3, contrast_limit=0.3, p=0.5),
 ...     ]
 ... )
 ```


### PR DESCRIPTION
This PR updates a code example for consistency across the docs based on [feedback from this comment](https://github.com/huggingface/transformers/pull/20925/files/9fda31634d203a47d3212e4e8d43d3267faf9808#r1058769500):

"In terms of style we usually stay away from one-letter imports like this (even if the community uses them) as they are not always known by beginners and one letter is very undescriptive. Here it wouldn't change anything to use albumentations instead of A."   


