### PR TITLE
Fix deprecation warning when use_auth_token passed to download_and_prepare

### DIFF
--- a/src/datasets/io/csv.py
+++ b/src/datasets/io/csv.py
@@ -49,7 +49,6 @@ class CsvDatasetReader(AbstractDatasetReader):
             download_config = None
             download_mode = None
             ignore_verifications = False
-            use_auth_token = None
             base_path = None
 
             self.builder.download_and_prepare(
@@ -58,7 +57,6 @@ class CsvDatasetReader(AbstractDatasetReader):
                 ignore_verifications=ignore_verifications,
                 # try_from_hf_gcs=try_from_hf_gcs,
                 base_path=base_path,
-                use_auth_token=use_auth_token,
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(

--- a/src/datasets/io/generator.py
+++ b/src/datasets/io/generator.py
@@ -42,7 +42,6 @@ class GeneratorDatasetInputStream(AbstractDatasetInputStream):
             download_config = None
             download_mode = None
             ignore_verifications = False
-            use_auth_token = None
             base_path = None
 
             self.builder.download_and_prepare(
@@ -51,7 +50,6 @@ class GeneratorDatasetInputStream(AbstractDatasetInputStream):
                 ignore_verifications=ignore_verifications,
                 # try_from_hf_gcs=try_from_hf_gcs,
                 base_path=base_path,
-                use_auth_token=use_auth_token,
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -54,7 +54,6 @@ class JsonDatasetReader(AbstractDatasetReader):
             download_config = None
             download_mode = None
             ignore_verifications = False
-            use_auth_token = None
             base_path = None
 
             self.builder.download_and_prepare(
@@ -63,7 +62,6 @@ class JsonDatasetReader(AbstractDatasetReader):
                 ignore_verifications=ignore_verifications,
                 # try_from_hf_gcs=try_from_hf_gcs,
                 base_path=base_path,
-                use_auth_token=use_auth_token,
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -53,7 +53,6 @@ class ParquetDatasetReader(AbstractDatasetReader):
             download_config = None
             download_mode = None
             ignore_verifications = False
-            use_auth_token = None
             base_path = None
 
             self.builder.download_and_prepare(
@@ -62,7 +61,6 @@ class ParquetDatasetReader(AbstractDatasetReader):
                 ignore_verifications=ignore_verifications,
                 # try_from_hf_gcs=try_from_hf_gcs,
                 base_path=base_path,
-                use_auth_token=use_auth_token,
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(

--- a/src/datasets/io/sql.py
+++ b/src/datasets/io/sql.py
@@ -37,7 +37,6 @@ class SqlDatasetReader(AbstractDatasetInputStream):
         download_config = None
         download_mode = None
         ignore_verifications = False
-        use_auth_token = None
         base_path = None
 
         self.builder.download_and_prepare(
@@ -46,7 +45,6 @@ class SqlDatasetReader(AbstractDatasetInputStream):
             ignore_verifications=ignore_verifications,
             # try_from_hf_gcs=try_from_hf_gcs,
             base_path=base_path,
-            use_auth_token=use_auth_token,
         )
 
         # Build dataset for splits

--- a/src/datasets/io/text.py
+++ b/src/datasets/io/text.py
@@ -45,7 +45,6 @@ class TextDatasetReader(AbstractDatasetReader):
             download_config = None
             download_mode = None
             ignore_verifications = False
-            use_auth_token = None
             base_path = None
 
             self.builder.download_and_prepare(
@@ -54,7 +53,6 @@ class TextDatasetReader(AbstractDatasetReader):
                 ignore_verifications=ignore_verifications,
                 # try_from_hf_gcs=try_from_hf_gcs,
                 base_path=base_path,
-                use_auth_token=use_auth_token,
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(


### PR DESCRIPTION
The `DatasetBuilder.download_and_prepare` argument `use_auth_token` was deprecated in:
- #5302

However, `use_auth_token` is still passed to `download_and_prepare`  in our built-in `io` readers (csv, json, parquet,...).

This PR fixes it, so that no deprecation warning is raised.

Fix #5407.