### PR TITLE
Map-style Dataset to IterableDataset

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -493,7 +493,7 @@ class DatasetBuilder:
         )
         is_custom = (config_id not in self.builder_configs) and config_id != "default"
         if is_custom:
-            logger.warning(f"Using custom data configuration {config_id}")
+            logger.info(f"Using custom data configuration {config_id}")
         else:
             if (
                 builder_config.name in self.builder_configs


### PR DESCRIPTION
Added `ds.to_iterable()` to get an iterable dataset from a map-style arrow dataset.

It also has a `num_shards` argument to split the dataset before converting to an iterable dataset. Sharding is important to enable efficient shuffling and parallel loading of iterable datasets.

TODO:
- [ ] tests
- [ ] docs

Fix https://github.com/huggingface/datasets/issues/5265