### PR TITLE
Fix RuntimeError: Sharding is ambiguous for this dataset

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1414,17 +1414,18 @@ class GeneratorBasedBuilder(DatasetBuilder):
         fname = f"{self.name}-{split_generator.name}{SUFFIX}.{file_format}"
         fpath = path_join(self._output_dir, fname)
 
-        num_input_shards = _number_of_shards_in_gen_kwargs(split_generator.gen_kwargs)
-        if num_input_shards <= 1 and num_proc is not None:
-            logger.warning(
-                f"Setting num_proc from {num_proc} back to 1 for the {split_info.name} split to disable multiprocessing as it only contains one shard."
-            )
-            num_proc = 1
-        elif num_proc is not None and num_input_shards < num_proc:
-            logger.info(
-                f"Setting num_proc from {num_proc} to {num_input_shards} for the {split_info.name} split as it only contains {num_input_shards} shards."
-            )
-            num_proc = num_input_shards
+        if num_proc and num_proc > 1:
+            num_input_shards = _number_of_shards_in_gen_kwargs(split_generator.gen_kwargs)
+            if num_input_shards <= 1 and num_proc is not None:
+                logger.warning(
+                    f"Setting num_proc from {num_proc} back to 1 for the {split_info.name} split to disable multiprocessing as it only contains one shard."
+                )
+                num_proc = 1
+            elif num_proc is not None and num_input_shards < num_proc:
+                logger.info(
+                    f"Setting num_proc from {num_proc} to {num_input_shards} for the {split_info.name} split as it only contains {num_input_shards} shards."
+                )
+                num_proc = num_input_shards
 
         pbar = logging.tqdm(
             disable=not logging.is_progress_bar_enabled(),
@@ -1673,17 +1674,18 @@ class ArrowBasedBuilder(DatasetBuilder):
         fname = f"{self.name}-{split_generator.name}{SUFFIX}.{file_format}"
         fpath = path_join(self._output_dir, fname)
 
-        num_input_shards = _number_of_shards_in_gen_kwargs(split_generator.gen_kwargs)
-        if num_input_shards <= 1 and num_proc is not None:
-            logger.warning(
-                f"Setting num_proc from {num_proc} back to 1 for the {split_info.name} split to disable multiprocessing as it only contains one shard."
-            )
-            num_proc = 1
-        elif num_proc is not None and num_input_shards < num_proc:
-            logger.info(
-                f"Setting num_proc from {num_proc} to {num_input_shards} for the {split_info.name} split as it only contains {num_input_shards} shards."
-            )
-            num_proc = num_input_shards
+        if num_proc and num_proc > 1:
+            num_input_shards = _number_of_shards_in_gen_kwargs(split_generator.gen_kwargs)
+            if num_input_shards <= 1 and num_proc is not None:
+                logger.warning(
+                    f"Setting num_proc from {num_proc} back to 1 for the {split_info.name} split to disable multiprocessing as it only contains one shard."
+                )
+                num_proc = 1
+            elif num_proc is not None and num_input_shards < num_proc:
+                logger.info(
+                    f"Setting num_proc from {num_proc} to {num_input_shards} for the {split_info.name} split as it only contains {num_input_shards} shards."
+                )
+                num_proc = num_input_shards
 
         pbar = logging.tqdm(
             disable=not logging.is_progress_bar_enabled(),

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import tempfile
 import types
+from contextlib import nullcontext as does_not_raise
 from multiprocessing import Process
 from pathlib import Path
 from unittest import TestCase
@@ -187,6 +188,52 @@ class DummyGeneratorBasedBuilderWithShards(GeneratorBasedBuilder):
         return [SplitGenerator(name=Split.TRAIN, gen_kwargs={"filepaths": [f"data{i}.txt" for i in range(4)]})]
 
     def _generate_examples(self, filepaths):
+        idx = 0
+        for filepath in filepaths:
+            for i in range(100):
+                yield idx, {"id": i, "filepath": filepath}
+                idx += 1
+
+
+class DummyArrowBasedBuilderWithAmbiguousShards(ArrowBasedBuilder):
+    def _info(self):
+        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+
+    def _split_generators(self, dl_manager):
+        return [
+            SplitGenerator(
+                name=Split.TRAIN,
+                gen_kwargs={
+                    "filepaths": [f"data{i}.txt" for i in range(4)],
+                    "dummy_kwarg_with_different_length": [f"dummy_data{i}.txt" for i in range(3)],
+                },
+            )
+        ]
+
+    def _generate_tables(self, filepaths, dummy_kwarg_with_different_length):
+        idx = 0
+        for filepath in filepaths:
+            for i in range(10):
+                yield idx, pa.table({"id": range(10 * i, 10 * (i + 1)), "filepath": [filepath] * 10})
+                idx += 1
+
+
+class DummyGeneratorBasedBuilderWithAmbiguousShards(GeneratorBasedBuilder):
+    def _info(self):
+        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+
+    def _split_generators(self, dl_manager):
+        return [
+            SplitGenerator(
+                name=Split.TRAIN,
+                gen_kwargs={
+                    "filepaths": [f"data{i}.txt" for i in range(4)],
+                    "dummy_kwarg_with_different_length": [f"dummy_data{i}.txt" for i in range(3)],
+                },
+            )
+        ]
+
+    def _generate_examples(self, filepaths, dummy_kwarg_with_different_length):
         idx = 0
         for filepath in filepaths:
             for i in range(100):
@@ -1068,6 +1115,15 @@ def test_generator_based_builder_download_and_prepare_with_num_proc(tmp_path):
     }
 
 
+@pytest.mark.parametrize(
+    "num_proc, expectation", [(None, does_not_raise()), (1, does_not_raise()), (2, pytest.raises(RuntimeError))]
+)
+def test_generator_based_builder_download_and_prepare_with_ambiguous_shards(num_proc, expectation, tmp_path):
+    builder = DummyGeneratorBasedBuilderWithAmbiguousShards(cache_dir=tmp_path)
+    with expectation:
+        builder.download_and_prepare(num_proc=num_proc)
+
+
 def test_arrow_based_builder_download_and_prepare_as_parquet(tmp_path):
     builder = DummyArrowBasedBuilder(cache_dir=tmp_path)
     builder.download_and_prepare(file_format="parquet")
@@ -1128,6 +1184,15 @@ def test_arrow_based_builder_download_and_prepare_with_num_proc(tmp_path):
         "id": [i for _ in range(4) for i in range(100)],
         "filepath": [f"data{i}.txt" for i in range(4) for _ in range(100)],
     }
+
+
+@pytest.mark.parametrize(
+    "num_proc, expectation", [(None, does_not_raise()), (1, does_not_raise()), (2, pytest.raises(RuntimeError))]
+)
+def test_arrow_based_builder_download_and_prepare_with_ambiguous_shards(num_proc, expectation, tmp_path):
+    builder = DummyArrowBasedBuilderWithAmbiguousShards(cache_dir=tmp_path)
+    with expectation:
+        builder.download_and_prepare(num_proc=num_proc)
 
 
 @require_beam


### PR DESCRIPTION
This PR fixes the RuntimeError: Sharding is ambiguous for this dataset.

The error for ambiguous sharding will be raised only if num_proc > 1.

Fix #5415, fix #5414.
Fix https://huggingface.co/datasets/ami/discussions/3.