### PR TITLE
Fix CI benchmarks by temporarily pinning Docker image version

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   run:
     runs-on: [ubuntu-latest]
-    container: docker://dvcorg/cml:latest
+    container: docker://dvcorg/cml@sha256:d38dc5c9708a5fbde4fdf2f5411c9930ed41cdf8ae3cb5ccf55c1f7a7cbe7bbe
     steps:
       - uses: actions/checkout@v2
       - name: cml_run

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,5 +1,5 @@
 name: benchmarks
-on: [push, pull_request]
+on: [push]
 jobs:
   run:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -46,4 +46,4 @@ jobs:
           cat report.md >> final_report.md
           echo "\n</details>" >> final_report.md
 
-          cml-send-comment final_report.md
+          cml comment create final_report.md

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,5 +1,5 @@
 name: benchmarks
-on: [push]
+on: [push, pull_request]
 jobs:
   run:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
This PR fixes CI benchmarks, by temporarily pinning Docker image version, instead of "latest" tag.

It also updates deprecated `cml-send-comment` command and using `cml comment create` instead.

Fix #5431.