### PR TITLE
Revert container image pin in CI benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -3,12 +3,12 @@ on: [push]
 jobs:
   run:
     runs-on: [ubuntu-latest]
-    container: docker://dvcorg/cml@sha256:d38dc5c9708a5fbde4fdf2f5411c9930ed41cdf8ae3cb5ccf55c1f7a7cbe7bbe
+    container: ghcr.io/iterative/cml
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: cml_run
         env:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          CML_DRIVER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # See https://github.com/actions/checkout/issues/760
           git config --global --add safe.directory /__w/datasets/datasets


### PR DESCRIPTION
Closes #5433, reverts #5432, and also:
* Uses [ghcr.io container images](https://cml.dev/doc/self-hosted-runners/#docker-images) for extra speed
* Updates `actions/checkout` to `v3` (note that `v2` is [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/))
* Follows the new naming convention for environment variables introduced with [iterative/cml#1272](https://github.com/iterative/cml/pull/1272)