### PR TITLE
Update actions/checkout in CD Conda release

### DIFF
--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
This PR updates the "checkout" GitHub Action to its latest version, as previous ones are deprecated: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/