### PR TITLE
Support fsspec 2023.1.0 in CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ REQUIRED_PKGS = [
     "importlib_metadata;python_version<'3.8'",
     # to save datasets locally or on any filesystem
     # minimum 2021.11.1 so that BlockSizeError is fixed: see https://github.com/fsspec/filesystem_spec/pull/830
-    "fsspec[http]>=2021.11.1,<2023.1.0",
+    "fsspec[http]>=2021.11.1",
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -74,8 +74,11 @@ class MockFileSystem(AbstractFileSystem):
 
 
 @pytest.fixture
-def mock_fsspec(monkeypatch):
-    monkeypatch.setitem(fsspec.registry.target, "mock", MockFileSystem)
+def mock_fsspec():
+    original_registry = fsspec.registry.copy()
+    fsspec.register_implementation("mock", MockFileSystem)
+    yield
+    fsspec.registry = original_registry
 
 
 @pytest.fixture

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -128,8 +128,11 @@ class DummyTestFS(AbstractFileSystem):
 
 
 @pytest.fixture
-def mock_fsspec(monkeypatch):
-    monkeypatch.setitem(fsspec.registry.target, "mock", DummyTestFS)
+def mock_fsspec():
+    original_registry = fsspec.registry.copy()
+    fsspec.register_implementation("mock", DummyTestFS)
+    yield
+    fsspec.registry = original_registry
 
 
 def _readd_double_slash_removed_by_path(path_as_posix: str) -> str:


### PR DESCRIPTION
Support fsspec 2023.1.0 in CI.

In the 2023.1.0 fsspec release, they replaced the type of `fsspec.registry`:
- from `ReadOnlyRegistry`, with an attribute called `target`
- to `MappingProxyType`, without that attribute

Consequently, we need to change our `mock_fsspec` fixtures, that were using the `target` attribute.

Fix #5448.