### PR TITLE
Swap log messages for symbolic/hard links in tar extractor

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -113,9 +113,9 @@ class TarExtractor(BaseExtractor):
             if badpath(finfo.name, base):
                 logger.error(f"Extraction of {finfo.name} is blocked (illegal path)")
             elif finfo.issym() and badlink(finfo, base):
-                logger.error(f"Extraction of {finfo.name} is blocked: Hard link to {finfo.linkname}")
-            elif finfo.islnk() and badlink(finfo, base):
                 logger.error(f"Extraction of {finfo.name} is blocked: Symlink to {finfo.linkname}")
+            elif finfo.islnk() and badlink(finfo, base):
+                logger.error(f"Extraction of {finfo.name} is blocked: Hard link to {finfo.linkname}")
             else:
                 yield finfo
 


### PR DESCRIPTION
The log messages do not match their if-condition. This PR swaps them.

Found while investigating:
- #5441