### PR TITLE
Fix base directory while extracting insecure TAR files

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -84,7 +84,7 @@ class TarExtractor(BaseExtractor):
         return tarfile.is_tarfile(path)
 
     @staticmethod
-    def safemembers(members):
+    def safemembers(members, output_path):
         """
         Fix for CVE-2007-4559
         Desc:
@@ -107,7 +107,7 @@ class TarExtractor(BaseExtractor):
             tip = resolved(os.path.join(base, os.path.dirname(info.name)))
             return badpath(info.linkname, base=tip)
 
-        base = resolved(".")
+        base = resolved(output_path)
 
         for finfo in members:
             if badpath(finfo.name, base):
@@ -123,7 +123,7 @@ class TarExtractor(BaseExtractor):
     def extract(input_path: Union[Path, str], output_path: Union[Path, str]) -> None:
         os.makedirs(output_path, exist_ok=True)
         tar_file = tarfile.open(input_path)
-        tar_file.extractall(output_path, members=TarExtractor.safemembers(tar_file))
+        tar_file.extractall(output_path, members=TarExtractor.safemembers(tar_file, output_path))
         tar_file.close()
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -161,7 +161,7 @@ def tar_file_with_sym_link(tmp_path):
     path = directory / "tar_file_with_sym_link.tar"
     os.symlink("..", directory / "subdir", target_is_directory=True)
     with tarfile.TarFile(path, "w") as f:
-        f.add(str(directory / "subdir"), arcname="subdir")
+        f.add(str(directory / "subdir"), arcname="subdir")  # str required by os.readlink on Windows and Python < 3.8
     return path
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from datasets.utils.extract import (
@@ -136,3 +138,48 @@ def test_extractor(
         extracted_file_content = output_path.read_text(encoding="utf-8")
     expected_file_content = text_file.read_text(encoding="utf-8")
     assert extracted_file_content == expected_file_content
+
+
+@pytest.fixture
+def tar_file_with_dot_dot(tmp_path, text_file):
+    import tarfile
+
+    directory = tmp_path / "data_dot_dot"
+    directory.mkdir()
+    path = directory / "tar_file_with_dot_dot.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(text_file, arcname=os.path.join("..", text_file.name))
+    return path
+
+
+@pytest.fixture
+def tar_file_with_sym_link(tmp_path):
+    import tarfile
+
+    directory = tmp_path / "data_sym_link"
+    directory.mkdir()
+    path = directory / "tar_file_with_sym_link.tar"
+    os.symlink("..", directory / "subdir", target_is_directory=True)
+    with tarfile.TarFile(path, "w") as f:
+        f.add(directory / "subdir", arcname="subdir")
+    return path
+
+
+@pytest.mark.parametrize(
+    "insecure_tar_file, error_log",
+    [("tar_file_with_dot_dot", "illegal path"), ("tar_file_with_sym_link", "Symlink")],
+)
+def test_tar_extract_insecure_files(
+    insecure_tar_file, error_log, tar_file_with_dot_dot, tar_file_with_sym_link, tmp_path, caplog
+):
+    insecure_tar_files = {
+        "tar_file_with_dot_dot": tar_file_with_dot_dot,
+        "tar_file_with_sym_link": tar_file_with_sym_link,
+    }
+    input_path = insecure_tar_files[insecure_tar_file]
+    output_path = tmp_path / "extracted"
+    TarExtractor.extract(input_path, output_path)
+    assert caplog.text
+    for record in caplog.records:
+        assert record.levelname == "ERROR"
+        assert error_log in record.msg

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -161,7 +161,7 @@ def tar_file_with_sym_link(tmp_path):
     path = directory / "tar_file_with_sym_link.tar"
     os.symlink("..", directory / "subdir", target_is_directory=True)
     with tarfile.TarFile(path, "w") as f:
-        f.add(directory / "subdir", arcname="subdir")
+        f.add(str(directory / "subdir"), arcname="subdir")
     return path
 
 


### PR DESCRIPTION
This PR fixes the extraction of insecure TAR files by changing the base path against which TAR members are compared:
- from: "."
- to: `output_path`

This PR also adds tests for extracting insecure TAR files.

Related to:
- #5441
- #5452

@stas00 please note this PR addresses just one of the issues you pointed out: the use of the cwd by the extractor. The other issues (actionable error messages, raise instead of log error) should be addressed in other PRs.