### PR TITLE
Single TQDM bar in multi-proc map

### DIFF
--- a/docs/source/upload_dataset.mdx
+++ b/docs/source/upload_dataset.mdx
@@ -23,6 +23,12 @@ A repository hosts all your dataset files, including the revision history, makin
 
 1. Once you've created a repository, navigate to the **Files and versions** tab to add a file. Select **Add file** to upload your dataset files. We currently support the following data formats: CSV, JSON, JSON lines, text, and Parquet. For this tutorial, you can use the following sample CSV files: <a href="https://huggingface.co/datasets/stevhliu/demo/raw/main/train.csv" download>train.csv</a>, <a href="https://huggingface.co/datasets/stevhliu/demo/raw/main/test.csv" download>test.csv</a>.
 
+<Tip warning={true}>
+
+For additional dataset configuration options, like defining multiple configurations or enabling streaming, you'll need to write a dataset loading script. Check out how to write a dataset loading script for <a href="https://huggingface.co/docs/datasets/dataset_script#create-a-dataset-loading-script"><span class="underline decoration-green-400 decoration-2 font-semibold">text</span></a>, <a href="https://huggingface.co/docs/datasets/audio_dataset#loading-script"><span class="underline decoration-pink-400 decoration-2 font-semibold">audio</span></a>, and <a href="https://huggingface.co/docs/datasets/image_dataset#loading-script"><span class="underline decoration-yellow-400 decoration-2 font-semibold">image</span></a> datasets.
+
+</Tip>
+
 <div class="flex justify-center">
     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/upload_files.png"/>
 </div>

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -510,8 +510,10 @@ class DatasetTransformationNotAllowedError(Exception):
 def transmit_format(func):
     """Wrapper for dataset transforms that recreate a new Dataset to transmit the format of the original dataset to the new dataset"""
 
-    is_generator_func = (
-        func._is_generator_func if hasattr(func, "_is_generator_func") else inspect.isgeneratorfunction(func)
+    is_wrapped_generator_func = (
+        func._is_wrapped_generator_func
+        if hasattr(func, "_is_wrapped_generator_func")
+        else inspect.isgeneratorfunction(func)
     )
 
     def _transmit_format(in_dataset, out_dataset):
@@ -568,21 +570,23 @@ def transmit_format(func):
 
         return (
             _transmit_format_func(input_dataset, *args, **kwargs)
-            if not is_generator_func
+            if not is_wrapped_generator_func
             else _transmit_format_generator_func(input_dataset, *args, **kwargs)
         )
 
     wrapper._decorator_name_ = "transmit_format"
     # inspect.isgeneratorfunction(func) is not working for decorated functions, so we store the information in the wrapper
-    wrapper._is_generator_func = is_generator_func
+    wrapper._is_wrapped_generator_func = is_wrapped_generator_func
     return wrapper
 
 
 def transmit_tasks(func):
     """Wrapper for dataset transforms that recreate a new Dataset to transmit the task templates of the original dataset to the new dataset"""
 
-    is_generator_func = (
-        func._is_generator_func if hasattr(func, "_is_generator_func") else inspect.isgeneratorfunction(func)
+    is_wrapped_generator_func = (
+        func._is_wrapped_generator_func
+        if hasattr(func, "_is_wrapped_generator_func")
+        else inspect.isgeneratorfunction(func)
     )
 
     def _transmit_tasks(in_dataset, out_dataset):
@@ -626,13 +630,13 @@ def transmit_tasks(func):
 
         return (
             _transmit_tasks_func(input_dataset, *args, **kwargs)
-            if not is_generator_func
+            if not is_wrapped_generator_func
             else _transmit_tasks_generator_func(input_dataset, *args, **kwargs)
         )
 
     wrapper._decorator_name_ = "transmit_tasks"
     # inspect.isgeneratorfunction(func) is not working for decorated functions, so we store the information in the wrapper
-    wrapper._is_generator_func = is_generator_func
+    wrapper._is_wrapped_generator_func = is_wrapped_generator_func
     return wrapper
 
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2932,16 +2932,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     unit=" examples",
                     total=pbar_total,
                     leave=False,
-                    desc=(desc or "Map") + f" (num_proc={num_proc})"
-                    f"Processing the dataset ({shards_done}/{num_shards} shards)"
-                    if desc is None
-                    else desc,
-                )
-                pbar = logging.tqdm(
-                    disable=not logging.is_progress_bar_enabled(),
-                    unit=" examples",
-                    total=pbar_total,
-                    leave=False,
                     desc=desc or "Map",
                 )
                 for rank, done, content in Dataset._map_single(**dataset_kwargs):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2986,8 +2986,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                                 init_pbar()
                             pbar.update(content)
                 # Avoids PermissionError on Windows
-                for kwarg in kwargs_per_job:
-                    del kwarg["shard"]
+                for kwargs in kwargs_per_job:
+                    del kwargs["shard"]
             assert (
                 None not in transformed_shards
             ), f"Failed to retrieve results from map: result list {transformed_shards} still contains None - at least one worker failed to return its results"

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3019,7 +3019,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     ):
                         if done:
                             shards_done += 1
-                            if pbar is not None:
+                            if pbar is None:
                                 init_pbar()
                             pbar.set_description(f"Processing the dataset ({shards_done}/{num_shards} shards)")
                             logger.debug(f"Finished processing shard number {rank} of {num_shards}.")

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2985,7 +2985,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                             if pbar is None:
                                 init_pbar()
                             pbar.update(content)
-                # Avoids PermissionError on Windows
+                # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:
                     del kwargs["shard"]
             assert (

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -407,8 +407,10 @@ def fingerprint_transform(
     fingerprint_names = fingerprint_names if fingerprint_names is not None else ["new_fingerprint"]
 
     def _fingerprint(func):
-        is_generator_func = (
-            func._is_generator_func if hasattr(func, "_is_generator_func") else inspect.isgeneratorfunction(func)
+        is_wrapped_generator_func = (
+            func._is_wrapped_generator_func
+            if hasattr(func, "_is_wrapped_generator_func")
+            else inspect.isgeneratorfunction(func)
         )
 
         if not inplace and not all(name in func.__code__.co_varnames for name in fingerprint_names):
@@ -497,7 +499,7 @@ def fingerprint_transform(
 
             return (
                 _fingerprint_transform_func(dataset, *args, inplace_fingerprint=new_fingerprint, **kwargs)
-                if not is_generator_func
+                if not is_wrapped_generator_func
                 else _fingerprint_transform_generator_func(
                     dataset, inplace_fingerprint=new_fingerprint, *args, **kwargs
                 )
@@ -505,7 +507,7 @@ def fingerprint_transform(
 
         wrapper._decorator_name_ = "fingerprint"
         # inspect.isgeneratorfunction(func) is not working for decorated functions, so we store the information in the wrapper
-        wrapper._is_generator_func = is_generator_func
+        wrapper._is_wrapped_generator_func = is_wrapped_generator_func
         return wrapper
 
     return _fingerprint

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -7,7 +7,7 @@ import tempfile
 import weakref
 from functools import wraps
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
@@ -19,6 +19,10 @@ from .table import ConcatenationTable, InMemoryTable, MemoryMappedTable, Table
 from .utils.deprecation_utils import deprecated
 from .utils.logging import get_logger
 from .utils.py_utils import asdict, dumps
+
+
+if TYPE_CHECKING:
+    from .arrow_dataset import Dataset
 
 
 logger = get_logger(__name__)
@@ -360,6 +364,61 @@ def validate_fingerprint(fingerprint: str, max_length=64):
         )
 
 
+def format_transform_for_fingerprint(func: Callable, version: Optional[str] = None) -> str:
+    """
+    Format a transform to the format that will be used to update the fingerprint.
+    """
+    transform = f"{func.__module__}.{func.__qualname__}"
+    if version is not None:
+        transform += f"@{version}"
+    return transform
+
+
+def format_kwargs_for_fingerprint(
+    func: Callable,
+    args: Tuple,
+    kwargs: Dict[str, Any],
+    use_kwargs: Optional[List[str]] = None,
+    ignore_kwargs: Optional[List[str]] = None,
+    randomized_function: bool = False,
+) -> Dict[str, Any]:
+    """
+    Format the kwargs of a transform to the format that will be used to update the fingerprint.
+    """
+    kwargs_for_fingerprint = kwargs.copy()
+    if args:
+        params = [p.name for p in inspect.signature(func).parameters.values() if p != p.VAR_KEYWORD]
+        args = args[1:]  # assume the first argument is the dataset
+        params = params[1:]
+        kwargs_for_fingerprint.update(zip(params, args))
+    else:
+        del kwargs_for_fingerprint[
+            next(iter(inspect.signature(func).parameters))
+        ]  # assume the first key is the dataset
+
+    # keep the right kwargs to be hashed to generate the fingerprint
+
+    if use_kwargs:
+        kwargs_for_fingerprint = {k: v for k, v in kwargs_for_fingerprint.items() if k in use_kwargs}
+    if ignore_kwargs:
+        kwargs_for_fingerprint = {k: v for k, v in kwargs_for_fingerprint.items() if k not in ignore_kwargs}
+    if randomized_function:  # randomized functions have `seed` and `generator` parameters
+        if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
+            _, seed, pos, *_ = np.random.get_state()
+            seed = seed[pos] if pos < 624 else seed[0]
+            kwargs_for_fingerprint["generator"] = np.random.default_rng(seed)
+
+    # remove kwargs that are the default values
+
+    default_values = {
+        p.name: p.default for p in inspect.signature(func).parameters.values() if p.default != inspect._empty
+    }
+    for default_varname, default_value in default_values.items():
+        if default_varname in kwargs_for_fingerprint and kwargs_for_fingerprint[default_varname] == default_value:
+            kwargs_for_fingerprint.pop(default_varname)
+    return kwargs_for_fingerprint
+
+
 def fingerprint_transform(
     inplace: bool,
     use_kwargs: Optional[List[str]] = None,
@@ -370,7 +429,6 @@ def fingerprint_transform(
 ):
     """
     Wrapper for dataset transforms to update the dataset fingerprint using ``update_fingerprint``
-
     Args:
         inplace (:obj:`bool`):  If inplace is True, the fingerprint of the dataset is updated inplace.
             Otherwise, a parameter "new_fingerprint" is passed to the wrapped method that should take care of
@@ -395,6 +453,7 @@ def fingerprint_transform(
             same, then old cached data could be reused that are not compatible with the new transform.
             It should be in the format "MAJOR.MINOR.PATCH".
     """
+
     if use_kwargs is not None and not isinstance(use_kwargs, list):
         raise ValueError(f"use_kwargs is supposed to be a list, not {type(use_kwargs)}")
 
@@ -407,82 +466,36 @@ def fingerprint_transform(
     fingerprint_names = fingerprint_names if fingerprint_names is not None else ["new_fingerprint"]
 
     def _fingerprint(func):
-        is_wrapped_generator_func = (
-            func._is_wrapped_generator_func
-            if hasattr(func, "_is_wrapped_generator_func")
-            else inspect.isgeneratorfunction(func)
-        )
 
         if not inplace and not all(name in func.__code__.co_varnames for name in fingerprint_names):
-            raise ValueError(f"function {func} is missing parameters {fingerprint_names} in signature")
+            raise ValueError("function {func} is missing parameters {fingerprint_names} in signature")
 
         if randomized_function:  # randomized function have seed and generator parameters
             if "seed" not in func.__code__.co_varnames:
                 raise ValueError(f"'seed' must be in {func}'s signature")
             if "generator" not in func.__code__.co_varnames:
                 raise ValueError(f"'generator' must be in {func}'s signature")
-        # this has to be outside the wrapper or since __qualname__ changes in multiprocessing
-        transform = f"{func.__module__}.{func.__qualname__}"
-        if version is not None:
-            transform += f"@{version}"
-
-        def _fingerprint_transform_func(dataset, *args, inplace_fingerprint=None, **kwargs):
-            out = func(dataset, *args, **kwargs)
-            # update after calling func so that the fingerprint doesn't change if the function fails
-            if inplace:
-                dataset._fingerprint = inplace_fingerprint
-            return out
-
-        def _fingerprint_transform_generator_func(dataset, *args, inplace_fingerprint=None, **kwargs):
-            yield from func(dataset, *args, **kwargs)
-            # update after exhausting generator func so that the fingerprint doesn't change if the generator function fails
-            if inplace:
-                dataset._fingerprint = inplace_fingerprint
+        # this call has to be outside the wrapper or since __qualname__ changes in multiprocessing
+        transform = format_transform_for_fingerprint(func, version=version)
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            from .arrow_dataset import Dataset
+            kwargs_for_fingerprint = format_kwargs_for_fingerprint(
+                func,
+                args,
+                kwargs,
+                use_kwargs=use_kwargs,
+                ignore_kwargs=ignore_kwargs,
+                randomized_function=randomized_function,
+            )
 
-            kwargs_for_fingerprint = kwargs.copy()
-            func_signature = inspect.signature(func)
             if args:
-                params = [p.name for p in func_signature.parameters.values() if p != p.VAR_KEYWORD]
                 dataset: Dataset = args[0]
                 args = args[1:]
-                params = params[1:]
-                kwargs_for_fingerprint.update(zip(params, args))
             else:
-                first_func_param = next(iter(func_signature.parameters))
-                dataset: Dataset = kwargs.pop(first_func_param)
-
-            assert isinstance(dataset, Dataset), f"First argument of {func} should be a Dataset, not {type(dataset)}"
-
-            # keep the right kwargs to be hashed to generate the fingerprint
-
-            if use_kwargs:
-                kwargs_for_fingerprint = {k: v for k, v in kwargs_for_fingerprint.items() if k in use_kwargs}
-            if ignore_kwargs:
-                kwargs_for_fingerprint = {k: v for k, v in kwargs_for_fingerprint.items() if k not in ignore_kwargs}
-            if randomized_function:  # randomized functions have `seed` and `generator` parameters
-                if kwargs_for_fingerprint.get("seed") is None and kwargs_for_fingerprint.get("generator") is None:
-                    _, seed, pos, *_ = np.random.get_state()
-                    seed = seed[pos] if pos < 624 else seed[0]
-                    kwargs_for_fingerprint["generator"] = np.random.default_rng(seed)
-
-            # remove kwargs that are the default values
-
-            default_values = {
-                p.name: p.default for p in inspect.signature(func).parameters.values() if p.default != inspect._empty
-            }
-            for default_varname, default_value in default_values.items():
-                if (
-                    default_varname in kwargs_for_fingerprint
-                    and kwargs_for_fingerprint[default_varname] == default_value
-                ):
-                    kwargs_for_fingerprint.pop(default_varname)
+                dataset: Dataset = kwargs.pop(next(iter(inspect.signature(func).parameters)))
 
             # compute new_fingerprint and add it to the args of not in-place transforms
-            new_fingerprint = None
             if inplace:
                 new_fingerprint = update_fingerprint(dataset._fingerprint, transform, kwargs_for_fingerprint)
             else:
@@ -495,19 +508,18 @@ def fingerprint_transform(
                     else:
                         validate_fingerprint(kwargs[fingerprint_name])
 
+            # Call actual function
+
+            out = func(dataset, *args, **kwargs)
+
             # Update fingerprint of in-place transforms + update in-place history of transforms
 
-            return (
-                _fingerprint_transform_func(dataset, *args, inplace_fingerprint=new_fingerprint, **kwargs)
-                if not is_wrapped_generator_func
-                else _fingerprint_transform_generator_func(
-                    dataset, inplace_fingerprint=new_fingerprint, *args, **kwargs
-                )
-            )
+            if inplace:  # update after calling func so that the fingerprint doesn't change if the function fails
+                dataset._fingerprint = new_fingerprint
+
+            return out
 
         wrapper._decorator_name_ = "fingerprint"
-        # inspect.isgeneratorfunction(func) is not working for decorated functions, so we store the information in the wrapper
-        wrapper._is_wrapped_generator_func = is_wrapped_generator_func
         return wrapper
 
     return _fingerprint

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -424,14 +424,14 @@ def fingerprint_transform(
         if version is not None:
             transform += f"@{version}"
 
-        def _fingerprint_transform_func(dataset, inplace_fingerprint=None, *args, **kwargs):
+        def _fingerprint_transform_func(dataset, *args, inplace_fingerprint=None, **kwargs):
             out = func(dataset, *args, **kwargs)
             # update after calling func so that the fingerprint doesn't change if the function fails
             if inplace:
                 dataset._fingerprint = inplace_fingerprint
             return out
 
-        def _fingerprint_transform_generator_func(dataset, inplace_fingerprint=None, *args, **kwargs):
+        def _fingerprint_transform_generator_func(dataset, *args, inplace_fingerprint=None, **kwargs):
             yield from func(dataset, *args, **kwargs)
             # update after exhausting generator func so that the fingerprint doesn't change if the generator function fails
             if inplace:
@@ -496,7 +496,7 @@ def fingerprint_transform(
             # Update fingerprint of in-place transforms + update in-place history of transforms
 
             return (
-                _fingerprint_transform_func(dataset, new_fingerprint, *args, **kwargs)
+                _fingerprint_transform_func(dataset, *args, inplace_fingerprint=new_fingerprint, **kwargs)
                 if not is_generator_func
                 else _fingerprint_transform_generator_func(
                     dataset, inplace_fingerprint=new_fingerprint, *args, **kwargs

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1037,6 +1037,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(30)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # num_proc > num rows
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1053,6 +1054,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(2)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_indices
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1068,6 +1070,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(30)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_rank
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1083,6 +1086,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["rank"], [0] * 10 + [1] * 10 + [2] * 10)
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_indices AND with_rank
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1101,6 +1105,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["rank"], [0] * 10 + [1] * 10 + [2] * 10)
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # new_fingerprint
             new_fingerprint = "foobar"
@@ -1124,6 +1129,7 @@ class BaseDatasetTest(TestCase):
                     file_names = sorted(Path(cache_file["filename"]).name for cache_file in dset_test.cache_files)
                     for i, file_name in enumerate(file_names):
                         self.assertIn(new_fingerprint + f"_{i:05d}", file_name)
+            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # lambda (requires multiprocess from pathos)
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1139,6 +1145,7 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(30)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
+            check_if_safe_delete(tmp_dir)
 
     def test_new_features(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -4295,3 +4302,17 @@ def test_map_cases(return_lazy_dict):
     ds = ds.map(f)
     outputs = ds[:]
     assert outputs == {"a": [{"nested": [[i]]} for i in [-1, -1, 2, 3]]}
+
+
+def check_if_safe_delete(tmp_dir):
+    import os
+    import subprocess
+
+    # import gc
+    # gc.collect()
+    for dirname, _, filenames in os.walk(tmp_dir):
+        for filename in filenames:
+            filename = os.path.join(dirname, filename)
+            result = subprocess.run(f"lsof -t {filename}", shell=True, stdout=subprocess.PIPE)
+            if result.stdout:
+                raise AssertionError(f"File {filename} is being used by another process")

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1037,7 +1037,6 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(30)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
-            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # num_proc > num rows
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1054,7 +1053,6 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(2)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
-            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_indices
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1070,7 +1068,6 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(30)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
-            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_rank
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1086,7 +1083,6 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["rank"], [0] * 10 + [1] * 10 + [2] * 10)
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
-            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # with_indices AND with_rank
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1105,7 +1101,6 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["rank"], [0] * 10 + [1] * 10 + [2] * 10)
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
-            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # new_fingerprint
             new_fingerprint = "foobar"
@@ -1129,7 +1124,6 @@ class BaseDatasetTest(TestCase):
                     file_names = sorted(Path(cache_file["filename"]).name for cache_file in dset_test.cache_files)
                     for i, file_name in enumerate(file_names):
                         self.assertIn(new_fingerprint + f"_{i:05d}", file_name)
-            check_if_safe_delete(tmp_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:  # lambda (requires multiprocess from pathos)
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
@@ -1145,7 +1139,6 @@ class BaseDatasetTest(TestCase):
                     self.assertListEqual(dset_test["id"], list(range(30)))
                     self.assertNotEqual(dset_test._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test)
-            check_if_safe_delete(tmp_dir)
 
     def test_new_features(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -4302,17 +4295,3 @@ def test_map_cases(return_lazy_dict):
     ds = ds.map(f)
     outputs = ds[:]
     assert outputs == {"a": [{"nested": [[i]]} for i in [-1, -1, 2, 3]]}
-
-
-def check_if_safe_delete(tmp_dir):
-    import os
-    import subprocess
-
-    # import gc
-    # gc.collect()
-    for dirname, _, filenames in os.walk(tmp_dir):
-        for filename in filenames:
-            filename = os.path.join(dirname, filename)
-            result = subprocess.run(f"lsof -t {filename}", shell=True, stdout=subprocess.PIPE)
-            if result.stdout:
-                raise AssertionError(f"File {filename} is being used by another process")


### PR DESCRIPTION
Use the "shard generator approach with periodic progress updates" (used in `save_to_disk` and multi-proc `load_dataset`) in `Dataset.map` to enable having a single TQDM progress bar in the multi-proc mode.

Closes https://github.com/huggingface/datasets/issues/771, closes https://github.com/huggingface/datasets/issues/3177

TODO:
- [x] cleaner refactor of the `_map_single` decorators now that they also have to wrap generator functions (decorate `map` instead of `map_single` with the `transmit_` decorators and predict the shards' fingerprint in `map`)