### PR TITLE
Disable aiohttp requoting of redirection URL

### DIFF
--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -39,7 +39,7 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
             mode="rb",
             protocol=target_protocol,
             compression=self.compression,
-            client_kwargs={"requote_redirect_url": False},
+            client_kwargs={"requote_redirect_url": False},  # see https://github.com/huggingface/datasets/pull/5459
             **(target_options or {}),
         )
         self.compressed_name = os.path.basename(self.file.path.split("::")[0])

--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -35,7 +35,12 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
         super().__init__(self, **kwargs)
         # always open as "rb" since fsspec can then use the TextIOWrapper to make it work for "r" mode
         self.file = fsspec.open(
-            fo, mode="rb", protocol=target_protocol, compression=self.compression, **(target_options or {})
+            fo,
+            mode="rb",
+            protocol=target_protocol,
+            compression=self.compression,
+            client_kwargs={"requote_redirect_url": False},
+            **(target_options or {}),
         )
         self.compressed_name = os.path.basename(self.file.path.split("::")[0])
         self.uncompressed_name = (


### PR DESCRIPTION
The library `aiohttp` performs a requoting of redirection URLs that unquotes the single quotation mark character: `%27` => `'`

This is a problem for our Hugging Face Hub, which requires exact URL from location header.

Specifically, in the query component of the URL (`https://netloc/path?query`), the value for `response-content-disposition` contains `%27`:
```
response-content-disposition=attachment%3B+filename*%3DUTF-8%27%27sample.jsonl.gz%3B+filename%3D%22sample.jsonl.gz%22%3B
```
and after the requoting, the `%27` characters get unquoted to `'`:
```
response-content-disposition=attachment%3B+filename*%3DUTF-8''sample.jsonl.gz%3B+filename%3D%22sample.jsonl.gz%22%3B
```

This PR disables the `aiohttp` requoting of redirection URLs.