### PR TITLE
Fix conda command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install datasets
 🤗 Datasets can be installed using conda as follows:
 
 ```bash
-conda install -c huggingface -c conda-forge datasets
+conda install -c huggingface datasets
 ```
 
 Follow the installation pages of TensorFlow and PyTorch to see how to install them with conda.


### PR DESCRIPTION
The [conda forge channel](https://anaconda.org/conda-forge/datasets) is lagging behind (as of right now, only 2.7.1 is available), we should recommend using the [Hugging face channel](https://anaconda.org/HuggingFace/datasets) that we are maintaining
```
conda install -c huggingface datasets
```