### PR TITLE
Remove deprecated `shard_size` arg from `.push_to_hub()` 

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4854,7 +4854,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         branch: Optional[str] = None,
         max_shard_size: Optional[Union[int, str]] = None,
         num_shards: Optional[int] = None,
-        shard_size: Optional[int] = "deprecated",
         embed_external_files: bool = True,
     ):
         """Pushes the dataset to the hub as a Parquet dataset.
@@ -4887,14 +4886,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             num_shards (`int`, *optional*): Number of shards to write. By default the number of shards depends on `max_shard_size`.
 
                 <Added version="2.8.0"/>
-            shard_size (`int`, *optional*):
-
-                <Deprecated version="2.4.0">
-
-                `shard_size` was renamed to `max_shard_size` in version 2.1.1 and will be removed in 2.4.0.
-
-                </Deprecated>
-
             embed_external_files (`bool`, defaults to `True`):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:
@@ -4910,13 +4901,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> dataset.push_to_hub("<organization>/<dataset_id>", num_shards=1024)
         ```
         """
-        if shard_size != "deprecated":
-            warnings.warn(
-                "'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.",
-                FutureWarning,
-            )
-            max_shard_size = shard_size
-
         if max_shard_size is not None and num_shards is not None:
             raise ValueError(
                 "Failed to push_to_hub: please specify either max_shard_size or num_shards, but not both."

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1461,7 +1461,6 @@ class DatasetDict(dict):
         branch: Optional[None] = None,
         max_shard_size: Optional[Union[int, str]] = None,
         num_shards: Optional[Dict[str, int]] = None,
-        shard_size: Optional[Union[int, str]] = "deprecated",
         embed_external_files: bool = True,
     ):
         """Pushes the [`DatasetDict`] to the hub as a Parquet dataset.
@@ -1495,14 +1494,6 @@ class DatasetDict(dict):
                 Use a dictionary to define a different num_shards for each split.
 
                 <Added version="2.8.0"/>
-            shard_size (`int` or `str`, *optional*):
-
-                <Deprecated version="2.4.0">
-
-                `shard_size` was renamed to `max_shard_size` in version 2.1.1 and will be removed in 2.4.0.
-
-                </Deprecated>
-
             embed_external_files (`bool`, defaults to `True`):
                 Whether to embed file bytes in the shards.
                 In particular, this will do the following before the push for the fields of type:
@@ -1518,12 +1509,6 @@ class DatasetDict(dict):
         >>> dataset_dict.push_to_hub("<organization>/<dataset_id>", num_shards={"train": 1024, "test": 8})
         ```
         """
-        if shard_size != "deprecated":
-            warnings.warn(
-                "'shard_size' was renamed to 'max_shard_size' in version 2.1.1 and will be removed in 2.4.0.",
-                FutureWarning,
-            )
-            max_shard_size = shard_size
 
         if num_shards is None:
             num_shards = {k: None for k in self}


### PR DESCRIPTION
The docstrings say that it was supposed to be deprecated since version 2.4.0, can we remove it?