### PR TITLE
Update dataset card creation

### DIFF
--- a/docs/source/dataset_card.mdx
+++ b/docs/source/dataset_card.mdx
@@ -12,7 +12,7 @@ Creating a dataset card is easy and can be done in a just a few steps:
 
   <Tip>
 
-  For a more complete, but not required, set of tag options you can also use the [Dataset Tagger](https://huggingface.co/spaces/huggingface/datasets-tagging). This'll have a few more tag options like `multilinguality` and `language_creators` which are useful but not absolutely necessary.
+  For a complete, but not required, set of tag options you can also look at the [Dataset Card specifications](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1). This'll have a few more tag options like `multilinguality` and `language_creators` which are useful but not absolutely necessary.
 
   </Tip>
 
@@ -21,88 +21,3 @@ Creating a dataset card is easy and can be done in a just a few steps:
 4. Once you're done, commit the changes to the `README.md` file and you'll see the completed dataset card on your repository.
 
 Feel free to take a look at the [SNLI](https://huggingface.co/datasets/snli), [CNN/DailyMail](https://huggingface.co/datasets/cnn_dailymail), and [Allociné](https://huggingface.co/datasets/allocine) dataset cards as examples to help you get started.
-
-You can also check out the (similar) documentation about [dataset cards on the Hub](https://huggingface.co/docs/hub/datasets-cards).
-
-## More YAML tags
-
-You can use the `dataset_info` YAML fields to define additional metadata for the dataset. Here is an example for SQuAD:
-
-```YAML
-pretty_name: SQuAD
-language:
-- en
-...
-dataset_info:
-  features:
-  - name: id
-    dtype: string
-  - name: title
-    dtype: string
-  - name: context
-    dtype: string
-  - name: question
-    dtype: string
-  - name: answers
-    sequence:
-    - name: text
-      dtype: string
-    - name: answer_start
-      dtype: int32
-  splits:
-  - name: train
-    num_bytes: 79346360
-    num_examples: 87599
-  - name: validation
-    num_bytes: 10473040
-    num_examples: 10570
-  download_size: 35142551
-  dataset_size: 89819400
-```
-
-These metadata used to be included in the `dataset_infos.json` file, which is now deprecated.
-
-### Feature types
-
-Using the `features` field you can explicitly define the feature types of your dataset.
-This is especially useful when type inference is not obvious.
-For example if there's only one non-empty example in a 1TB dataset, the type inference is not able to infer the type of each column without going through the full dataset.
-In this case, specifying the `features` field makes type inference much easier.
-
-### Split sizes
-
-Specifying the split sizes with `num_examples` enables TQDM bars (otherwise it doesn't know how many examples are left).
-It also enables integrity verifications: if the dataset doesn't have the right number of `num_examples`, an error is returned.
-
-Additionally you can add `num_bytes` to specify how big each split is.
-
-### Dataset size
-
-When [`load_dataset`] is called, it first downloads the dataset raw data files, and then it prepares the dataset in Arrow format.
-
-You can specify how many bytes are required to download the raw data files with `dataset_size`, and use `dataset_size` for the size of the dataset in Arrow format.
-
-### Multiple configurations
-
-Certain datasets like `glue` have several configurations (`cola`, `sst2`, etc.) that can be loaded using `load_dataset("glue", "cola")` for example.
-
-Each configuration can have different features, splits and sizes.
-You can specify those fields per configuration using a YAML list:
-
-```YAML
-dataset_info:
-- config_name: cola
-  features:
-    ...
-  splits:
-    ...
-  download_size: ...
-  dataset_size: ...
-- config_name: sst2
-  features:
-    ...
-  splits:
-    ...
-  download_size: ...
-  dataset_size: ...
-```

--- a/docs/source/dataset_card.mdx
+++ b/docs/source/dataset_card.mdx
@@ -4,27 +4,25 @@ Each dataset should have a dataset card to promote responsible usage and inform 
 This idea was inspired by the Model Cards proposed by [Mitchell, 2018](https://arxiv.org/abs/1810.03993).
 Dataset cards help users understand a dataset's contents, the context for using the dataset, how it was created, and any other considerations a user should be aware of.
 
-This guide shows you how to create a dataset card.
+Creating a dataset card is easy and can be done in a just a few steps:
 
-1. Create a new dataset card by copying this [template](https://raw.githubusercontent.com/huggingface/datasets/main/templates/README.md) to a `README.md` file in your repository.
+1. Go to your dataset repository on the [Hub](https://hf.co/new-dataset) and click on **Create Dataset Card** to create a new `README.md` file in your repository.
 
-2. Generate structured tags to help users discover your dataset on the Hub. Create the tags with the [online Datasets Tagging app](https://huggingface.co/spaces/huggingface/datasets-tagging).
+2. Use the **Metadata UI** to select the tags that describe your dataset. You can add a license, language, pretty_name, the task_categories, size_categories, and any other tags that you think are relevant. These tags help users discover and find your dataset on the Hub.
 
-3. Select the appropriate tags for your dataset from the dropdown menus.
+  <Tip>
 
-4. Copy the YAML tags under **Finalized tag set** and paste the tags at the top of your `README.md` file.
+  For a more complete, but not required, set of tag options you can also use the [Dataset Tagger](https://huggingface.co/spaces/huggingface/datasets-tagging). This'll have a few more tag options like `multilinguality` and `language_creators` which are useful but not absolutely necessary.
 
-5. Fill out the dataset card sections to the best of your ability. Take a look at the [Dataset Card Creation Guide](https://github.com/huggingface/datasets/blob/main/templates/README_guide.md) for more detailed information about what to include in each section of the card. For fields you are unable to complete, you can write **[More Information Needed]**.
+  </Tip>
 
-6. Once you're done filling out the dataset card, commit the changes to the `README.md` file and you should see the completed dataset card on your repository.
+3. Click on the **Import dataset card template** link to automatically create a template with all the relevant fields to complete. Fill out the template sections to the best of your ability. Take a look at the [Dataset Card Creation Guide](https://github.com/huggingface/datasets/blob/main/templates/README_guide.md) for more detailed information about what to include in each section of the card. For fields you are unable to complete, you can write **[More Information Needed]**.
 
-Feel free to take a look at these dataset card examples to help you get started:
+4. Once you're done, commit the changes to the `README.md` file and you'll see the completed dataset card on your repository.
 
-- [SNLI](https://huggingface.co/datasets/snli)
-- [CNN / DailyMail](https://huggingface.co/datasets/cnn_dailymail)
-- [Allociné](https://huggingface.co/datasets/allocine)
+Feel free to take a look at the [SNLI](https://huggingface.co/datasets/snli), [CNN/DailyMail](https://huggingface.co/datasets/cnn_dailymail), and [Allociné](https://huggingface.co/datasets/allocine) dataset cards as examples to help you get started.
 
-You can also check out the (similar) documentation about [dataset cards on the Hub side](https://huggingface.co/docs/hub/datasets-cards).
+You can also check out the (similar) documentation about [dataset cards on the Hub](https://huggingface.co/docs/hub/datasets-cards).
 
 ## More YAML tags
 

--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -75,15 +75,13 @@ Here the `namespace` is either your username or your organization name.
 
 4. Now is a good time to check your directory to ensure the only files you're uploading are:
 
-- `README.md` is a Dataset card that describes the datasets contents, creation, and usage. To write a Dataset card, see the [dataset card](dataset_card) page.
-
 - The raw data files of the dataset (optional, if they are hosted elsewhere you can specify the URLs in the dataset script). If you don't need a dataset script, you can take a look at [how to structure your dataset repository for your data files](repository_structure).
 
 - `your_dataset_name.py` is your dataset loading script (optional if your data files are already in the supported formats csv/jsonl/json/parquet/txt). To create a dataset script, see the [dataset script](dataset_script) page.
 
 ### Upload your files
 
-You can directly upload your files from your repository on the Hugging Face Hub, but this guide will show you how to upload the files from the terminal.
+You can directly upload your files to your repository on the Hugging Face Hub, but this guide will show you how to upload the files from the terminal.
 
 5. It is important to add the large data files first with `git lfs track` or else you will encounter an error later when you push your files:
 
@@ -95,10 +93,9 @@ git add *.json
 git commit -m "add json files"
 ```
 
-6. Add the dataset loading script and dataset card:
+6. Add the dataset loading script:
 
 ```
-cp /somewhere/data/README.md .
 cp /somewhere/data/load_script.py .
 git add --all
 ```
@@ -116,6 +113,8 @@ Congratulations, your dataset has now been uploaded to the Hugging Face Hub wher
 ```
 dataset = load_dataset("namespace/your_dataset_name")
 ```
+
+Finally, don't forget to create a dataset card to document your dataset and make it discoverable! Check out the [Create a dataset card](dataset_card) guide to learn more.
 
 ### Ask for a help and reviews
 

--- a/docs/source/upload_dataset.mdx
+++ b/docs/source/upload_dataset.mdx
@@ -57,7 +57,7 @@ Adding a Dataset card is super valuable for helping users find your dataset and 
 
 2. At the top, you'll see the **Metadata UI** with several fields to select from like license, language, and task categories. These are the most important tags for helping users discover your dataset on the Hub. When you select an option from each field, they'll be automatically added to the top of the dataset card.
 
-    You can also use the [Dataset Tagger](https://huggingface.co/spaces/huggingface/datasets-tagging), which has more comprehensive (but not required) tag options like `annotations_creators`, to help you generate the appropriate tags.
+    You can also look at the [Dataset Card specifications](https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1), which has a complete set of (but not required) tag options like `annotations_creators`, to help you choose the appropriate tags.
 
 <div class="flex justify-center">
     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/metadata_ui.png"/>

--- a/docs/source/upload_dataset.mdx
+++ b/docs/source/upload_dataset.mdx
@@ -55,17 +55,15 @@ Adding a Dataset card is super valuable for helping users find your dataset and 
     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/dataset_card.png"/>
 </div>
 
-2. Feel free to copy this Dataset card [template](https://raw.githubusercontent.com/huggingface/datasets/main/templates/README.md) to help you fill out all the relevant fields. 
+2. At the top, you'll see the **Metadata UI** with several fields to select from like license, language, and task categories. These are the most important tags for helping users discover your dataset on the Hub. When you select an option from each field, they'll be automatically added to the top of the dataset card.
 
-3. The Dataset card uses structured tags to help users discover your dataset on the Hub. Use the [Dataset Tagger](https://huggingface.co/spaces/huggingface/datasets-tagging) to help you generate the appropriate tags.
-
-4. Copy the generated tags, paste them at the top of your Dataset card, and then commit your changes.
+    You can also use the [Dataset Tagger](https://huggingface.co/spaces/huggingface/datasets-tagging), which has more comprehensive (but not required) tag options like `annotations_creators`, to help you generate the appropriate tags.
 
 <div class="flex justify-center">
-    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/card_tags.png"/>
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/metadata_ui.png"/>
 </div>
 
-For a detailed example of what a good Dataset card should look like, take a look at the [CNN DailyMail Dataset card](https://huggingface.co/datasets/cnn_dailymail).
+3. Click on the **Import dataset card template** link at the top of the editor to automatically create a dataset card template. Filling out the template is a great way to introduce your dataset to the community and help users understand how to use it. For a detailed example of what a good Dataset card should look like, take a look at the [CNN DailyMail Dataset card](https://huggingface.co/datasets/cnn_dailymail).
 
 ### Load dataset
 


### PR DESCRIPTION
Encourages users to create a dataset card on the Hub directly with the new metadata ui + import dataset card template instead of telling users to manually create and upload one.