### PR TITLE
Add num_test_batches option

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -313,7 +313,7 @@ class TensorflowDatasetMixin:
         label_cols: Optional[Union[str, List[str]]] = None,
         prefetch: bool = True,
         num_workers: int = 0,
-        num_test_batches: int = 200,
+        num_test_batches: int = 20,
     ):
         """Create a `tf.data.Dataset` from the underlying Dataset. This `tf.data.Dataset` will load and collate batches from
         the Dataset, and is suitable for passing to methods like `model.fit()` or `model.predict()`. The dataset will yield
@@ -348,7 +348,7 @@ class TensorflowDatasetMixin:
                 background while the model is training.
             num_workers (`int`, defaults to `0`):
                 Number of workers to use for loading the dataset. Only supported on Python versions >= 3.8.
-            num_test_batches (`int`, defaults to `200`):
+            num_test_batches (`int`, defaults to `20`):
                 Number of batches to use to infer the output signature of the dataset.
                 The higher this number, the more accurate the signature will be, but the longer it will take to
                 create the dataset.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -348,7 +348,7 @@ class TensorflowDatasetMixin:
                 background while the model is training.
             num_workers (`int`, defaults to `0`):
                 Number of workers to use for loading the dataset. Only supported on Python versions >= 3.8.
-            num_test_batches (:obj:`int`, default ``200``): Number of batches to use to infer the output signature of the
+            num_test_batches (:obj:`int`, defaults to `200`): Number of batches to use to infer the output signature of the
                 dataset. The higher this number, the more accurate the signature will be, but the longer it will take to
                 create the dataset.
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -348,8 +348,9 @@ class TensorflowDatasetMixin:
                 background while the model is training.
             num_workers (`int`, defaults to `0`):
                 Number of workers to use for loading the dataset. Only supported on Python versions >= 3.8.
-            num_test_batches (:obj:`int`, defaults to `200`): Number of batches to use to infer the output signature of the
-                dataset. The higher this number, the more accurate the signature will be, but the longer it will take to
+            num_test_batches (`int`, defaults to `200`):
+                Number of batches to use to infer the output signature of the dataset.
+                The higher this number, the more accurate the signature will be, but the longer it will take to
                 create the dataset.
 
         Returns:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -313,6 +313,7 @@ class TensorflowDatasetMixin:
         label_cols: Optional[Union[str, List[str]]] = None,
         prefetch: bool = True,
         num_workers: int = 0,
+        num_test_batches: int = 200,
     ):
         """Create a `tf.data.Dataset` from the underlying Dataset. This `tf.data.Dataset` will load and collate batches from
         the Dataset, and is suitable for passing to methods like `model.fit()` or `model.predict()`. The dataset will yield
@@ -347,6 +348,9 @@ class TensorflowDatasetMixin:
                 background while the model is training.
             num_workers (`int`, defaults to `0`):
                 Number of workers to use for loading the dataset. Only supported on Python versions >= 3.8.
+            num_test_batches (:obj:`int`, default ``200``): Number of batches to use to infer the output signature of the
+                dataset. The higher this number, the more accurate the signature will be, but the longer it will take to
+                create the dataset.
 
         Returns:
             `tf.data.Dataset`
@@ -414,6 +418,7 @@ class TensorflowDatasetMixin:
             collate_fn_args=collate_fn_args,
             cols_to_retain=cols_to_retain,
             batch_size=batch_size if drop_remainder else None,
+            num_test_batches=num_test_batches,
         )
 
         if "labels" in output_signature:


### PR DESCRIPTION
`to_tf_dataset` calls can be very costly because of the number of test batches drawn during `_get_output_signature`. The test batches are draw in order to estimate the shapes when creating the tensorflow dataset. This is necessary when the shapes can be irregular, but not in cases when the tensor shapes are the same across all samples. This PR adds an option to change the number of batches drawn, so the user can speed this conversion up. 

Running the following, and modifying `num_test_batches`
```
import time
from datasets import load_dataset
from transformers import DefaultDataCollator

data_collator = DefaultDataCollator()
dataset = load_dataset("beans")
dataset = dataset["train"].with_format("np")
start = time.time()
dataset = dataset.to_tf_dataset(
    columns=["image"],
    label_cols=["label"],
    batch_size=8,
    collate_fn=data_collator,
    num_test_batches=NUM_TEST_BATCHES,
)
end = time.time()
print(end - start)
```

NUM_TEST_BATCHES=200:  0.8197s
NUM_TEST_BATCHES=50:    0.3070s
NUM_TEST_BATCHES=2:      0.1417s
NUM_TEST_BATCHES=1:      0.1352s 