### PR TITLE
Do not add index column by default when exporting to CSV

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4391,6 +4391,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         path_or_buf: Union[PathLike, BinaryIO],
         batch_size: Optional[int] = None,
         num_proc: Optional[int] = None,
+        index: bool = False,
         **to_csv_kwargs,
     ) -> int:
         """Exports the dataset to csv
@@ -4421,7 +4422,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Dynamic import to avoid circular dependency
         from .io.csv import CsvDatasetWriter
 
-        return CsvDatasetWriter(self, path_or_buf, batch_size=batch_size, num_proc=num_proc, **to_csv_kwargs).write()
+        return CsvDatasetWriter(
+            self, path_or_buf, batch_size=batch_size, num_proc=num_proc, index=index, **to_csv_kwargs
+        ).write()
 
     def to_dict(self, batch_size: Optional[int] = None, batched: bool = False) -> Union[dict, Iterator[dict]]:
         """Returns the dataset as a Python dict. Can also return a generator for large datasets.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4407,6 +4407,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 use multiprocessing. `batch_size` in this case defaults to
                 `datasets.config.DEFAULT_MAX_BATCH_SIZE` but feel free to make it 5x or 10x of the default
                 value if you have sufficient compute power.
+            index (`bool`, default `False`): Write row names (index).
+
+                <Changed version="2.10.0">
+
+                Now, `index` defaults to `False`.
+
+                If you would like to write the index, set it to `True` and also set a name for the index column by
+                passing `index_label`.
+
+                </Changed>
+
             **to_csv_kwargs (additional keyword arguments):
                 Parameters to pass to pandas's `pandas.DataFrame.to_csv`.
 

--- a/src/datasets/io/csv.py
+++ b/src/datasets/io/csv.py
@@ -87,12 +87,13 @@ class CsvDatasetWriter:
 
     def write(self) -> int:
         _ = self.to_csv_kwargs.pop("path_or_buf", None)
+        index = self.to_csv_kwargs.pop("index", False)
 
         if isinstance(self.path_or_buf, (str, bytes, os.PathLike)):
             with open(self.path_or_buf, "wb+") as buffer:
-                written = self._write(file_obj=buffer, **self.to_csv_kwargs)
+                written = self._write(file_obj=buffer, index=index, **self.to_csv_kwargs)
         else:
-            written = self._write(file_obj=self.path_or_buf, **self.to_csv_kwargs)
+            written = self._write(file_obj=self.path_or_buf, index=index, **self.to_csv_kwargs)
         return written
 
     def _batch_csv(self, args):

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -117,7 +117,6 @@ def test_csv_datasetdict_reader_split(split, csv_path, tmp_path):
     if split:
         path = {split: csv_path}
     else:
-        split = "train"
         path = {"train": csv_path, "test": csv_path}
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
@@ -135,7 +134,7 @@ def test_dataset_to_csv(csv_path, tmp_path):
     cache_dir = tmp_path / "cache"
     output_csv = os.path.join(cache_dir, "tmp.csv")
     dataset = CsvDatasetReader({"train": csv_path}, cache_dir=cache_dir).read()
-    CsvDatasetWriter(dataset["train"], output_csv, index=False, num_proc=1).write()
+    CsvDatasetWriter(dataset["train"], output_csv, num_proc=1).write()
 
     original_csv = iter_csv_file(csv_path)
     expected_csv = iter_csv_file(output_csv)
@@ -148,7 +147,7 @@ def test_dataset_to_csv_multiproc(csv_path, tmp_path):
     cache_dir = tmp_path / "cache"
     output_csv = os.path.join(cache_dir, "tmp.csv")
     dataset = CsvDatasetReader({"train": csv_path}, cache_dir=cache_dir).read()
-    CsvDatasetWriter(dataset["train"], output_csv, index=False, num_proc=2).write()
+    CsvDatasetWriter(dataset["train"], output_csv, num_proc=2).write()
 
     original_csv = iter_csv_file(csv_path)
     expected_csv = iter_csv_file(output_csv)
@@ -162,4 +161,4 @@ def test_dataset_to_csv_invalidproc(csv_path, tmp_path):
     output_csv = os.path.join(cache_dir, "tmp.csv")
     dataset = CsvDatasetReader({"train": csv_path}, cache_dir=cache_dir).read()
     with pytest.raises(ValueError):
-        CsvDatasetWriter(dataset["train"], output_csv, index=False, num_proc=0)
+        CsvDatasetWriter(dataset["train"], output_csv, num_proc=0)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1988,7 +1988,7 @@ class BaseDatasetTest(TestCase):
 
                 self.assertTrue(os.path.isfile(file_path))
                 self.assertEqual(bytes_written, os.path.getsize(file_path))
-                csv_dset = pd.read_csv(file_path, header=0, index_col=0)
+                csv_dset = pd.read_csv(file_path)
 
                 self.assertEqual(csv_dset.shape, dset.shape)
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))
@@ -2001,7 +2001,7 @@ class BaseDatasetTest(TestCase):
 
                 self.assertTrue(os.path.isfile(file_path))
                 self.assertEqual(bytes_written, os.path.getsize(file_path))
-                csv_dset = pd.read_csv(file_path, header=0, index_col=0)
+                csv_dset = pd.read_csv(file_path)
 
                 self.assertEqual(csv_dset.shape, dset.shape)
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))
@@ -2014,7 +2014,7 @@ class BaseDatasetTest(TestCase):
 
                 self.assertTrue(os.path.isfile(file_path))
                 self.assertEqual(bytes_written, os.path.getsize(file_path))
-                csv_dset = pd.read_csv(file_path, header=0, index_col=0)
+                csv_dset = pd.read_csv(file_path)
 
                 self.assertEqual(csv_dset.shape, dset.shape)
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))
@@ -2026,7 +2026,7 @@ class BaseDatasetTest(TestCase):
 
                 self.assertTrue(os.path.isfile(file_path))
                 self.assertEqual(bytes_written, os.path.getsize(file_path))
-                csv_dset = pd.read_csv(file_path, header=0, index_col=0)
+                csv_dset = pd.read_csv(file_path)
 
                 self.assertEqual(csv_dset.shape, dset.shape)
                 self.assertListEqual(list(csv_dset.columns), list(dset.column_names))


### PR DESCRIPTION
As pointed out by @merveenoyan, default behavior of `Dataset.to_csv` adds the index as an additional column without name.

This PR changes the default behavior, so that now the index column is not written.

To add the index column, now you need to pass `index=True` and also `index_label=<name of the index colum>` to name that column.

CC: @merveenoyan 