### PR TITLE
Improved error message for gated/private repos

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1180,7 +1180,7 @@ def dataset_module_factory(
                     msg = msg + f" at revision '{revision}'" if revision else msg
                     raise FileNotFoundError(
                         msg
-                        + ". If the repo is private, make sure you are authenticated with `use_auth_token=True` after logging in with `huggingface-cli login`."
+                        + ". If the repo is private or gated, make sure to log in with `huggingface-cli login`."
                     )
                 else:
                     raise e

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1179,8 +1179,7 @@ def dataset_module_factory(
                     msg = f"Dataset '{path}' doesn't exist on the Hub"
                     msg = msg + f" at revision '{revision}'" if revision else msg
                     raise FileNotFoundError(
-                        msg
-                        + ". If the repo is private or gated, make sure to log in with `huggingface-cli login`."
+                        msg + ". If the repo is private or gated, make sure to log in with `huggingface-cli login`."
                     )
                 else:
                     raise e


### PR DESCRIPTION
Using `use_auth_token=True` is not needed anymore. If a user logged in, the token will be automatically retrieved. Also include a mention for gated repos

See https://github.com/huggingface/huggingface_hub/pull/1064