### PR TITLE
don't zero copy timestamps

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -685,7 +685,7 @@ def _is_zero_copy_only(pa_type: pa.DataType, unnest: bool = False) -> bool:
     When converting a pyarrow array to a numpy array, we must know whether this could be done in zero-copy or not.
     This function returns the value of the ``zero_copy_only`` parameter to pass to ``.to_numpy()``, given the type of the pyarrow array.
 
-    # zero copy is available for all primitive types except booleans and timestamps
+    # zero copy is available for all primitive types except booleans and temporal types (date, time, timestamp or duration)
     # primitive types are types for which the physical representation in arrow and in numpy
     # https://github.com/wesm/arrow/blob/c07b9b48cf3e0bbbab493992a492ae47e5b04cad/python/pyarrow/types.pxi#L821
     # see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -685,7 +685,7 @@ def _is_zero_copy_only(pa_type: pa.DataType, unnest: bool = False) -> bool:
     When converting a pyarrow array to a numpy array, we must know whether this could be done in zero-copy or not.
     This function returns the value of the ``zero_copy_only`` parameter to pass to ``.to_numpy()``, given the type of the pyarrow array.
 
-    # zero copy is available for all primitive types except booleans
+    # zero copy is available for all primitive types except booleans and timestamps
     # primitive types are types for which the physical representation in arrow and in numpy
     # https://github.com/wesm/arrow/blob/c07b9b48cf3e0bbbab493992a492ae47e5b04cad/python/pyarrow/types.pxi#L821
     # see https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy
@@ -699,7 +699,7 @@ def _is_zero_copy_only(pa_type: pa.DataType, unnest: bool = False) -> bool:
 
     if unnest:
         pa_type = _unnest_pa_type(pa_type)
-    return pa.types.is_primitive(pa_type) and not pa.types.is_boolean(pa_type)
+    return pa.types.is_primitive(pa_type) and not (pa.types.is_boolean(pa_type) or pa.types.is_temporal(pa_type))
 
 
 class ArrayExtensionArray(pa.ExtensionArray):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -24,6 +24,7 @@ from .utils import require_jax, require_pil, require_sndfile, require_tf, requir
 _COL_A = [0, 1, 2]
 _COL_B = ["foo", "bar", "foobar"]
 _COL_C = [[[1.0, 0.0, 0.0]] * 2, [[0.0, 1.0, 0.0]] * 2, [[0.0, 0.0, 1.0]] * 2]
+_COL_D = [datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)] * 3
 
 _INDICES = [1, 0]
 
@@ -34,20 +35,20 @@ AUDIO_PATH_1 = Path(__file__).parent / "features" / "data" / "test_audio_44100.w
 
 class ArrowExtractorTest(TestCase):
     def _create_dummy_table(self):
-        return pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C})
+        return pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C, "d": _COL_D})
 
     def test_python_extractor(self):
         pa_table = self._create_dummy_table()
         extractor = PythonArrowExtractor()
         row = extractor.extract_row(pa_table)
-        self.assertEqual(row, {"a": _COL_A[0], "b": _COL_B[0], "c": _COL_C[0]})
+        self.assertEqual(row, {"a": _COL_A[0], "b": _COL_B[0], "c": _COL_C[0], "d": _COL_D[0]})
         col = extractor.extract_column(pa_table)
         self.assertEqual(col, _COL_A)
         batch = extractor.extract_batch(pa_table)
-        self.assertEqual(batch, {"a": _COL_A, "b": _COL_B, "c": _COL_C})
+        self.assertEqual(batch, {"a": _COL_A, "b": _COL_B, "c": _COL_C, "d": _COL_D})
 
     def test_numpy_extractor(self):
-        pa_table = self._create_dummy_table().drop(["c"])
+        pa_table = self._create_dummy_table().drop(["c", "d"])
         extractor = NumpyArrowExtractor()
         row = extractor.extract_row(pa_table)
         np.testing.assert_equal(row, {"a": _COL_A[0], "b": _COL_B[0]})
@@ -72,15 +73,16 @@ class ArrowExtractorTest(TestCase):
         self.assertEqual(batch["c"].dtype, object)
 
     def test_numpy_extractor_temporal(self):
-        _col_a = [datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)] * 3
-        pa_table = pa.Table.from_pydict({"a": _col_a})
+        pa_table = self._create_dummy_table().drop(["a", "b", "c"])
         extractor = NumpyArrowExtractor()
         row = extractor.extract_row(pa_table)
-        np.testing.assert_equal(row, {"a": np.datetime64(_col_a[0])})
+        self.assertTrue(np.issubdtype(row["d"].dtype, np.datetime64))
         col = extractor.extract_column(pa_table)
-        np.testing.assert_equal(col, np.array(list(map(np.datetime64, _col_a))))
+        self.assertTrue(np.issubdtype(col[0].dtype, np.datetime64))
+        self.assertTrue(np.issubdtype(col.dtype, np.datetime64))
         batch = extractor.extract_batch(pa_table)
-        np.testing.assert_equal(batch, {"a": np.array(list(map(np.datetime64, _col_a)))})
+        self.assertTrue(np.issubdtype(batch["d"][0].dtype, np.datetime64))
+        self.assertTrue(np.issubdtype(batch["d"].dtype, np.datetime64))
 
     def test_pandas_extractor(self):
         pa_table = self._create_dummy_table()
@@ -90,6 +92,7 @@ class ArrowExtractorTest(TestCase):
         pd.testing.assert_series_equal(row["a"], pd.Series(_COL_A, name="a")[:1])
         pd.testing.assert_series_equal(row["b"], pd.Series(_COL_B, name="b")[:1])
         pd.testing.assert_series_equal(row["c"], pd.Series(_COL_C, name="c")[:1])
+        pd.testing.assert_series_equal(row["d"], pd.Series(_COL_C, name="d")[:1])
         col = extractor.extract_column(pa_table)
         pd.testing.assert_series_equal(col, pd.Series(_COL_A, name="a"))
         batch = extractor.extract_batch(pa_table)
@@ -97,6 +100,7 @@ class ArrowExtractorTest(TestCase):
         pd.testing.assert_series_equal(batch["a"], pd.Series(_COL_A, name="a"))
         pd.testing.assert_series_equal(batch["b"], pd.Series(_COL_B, name="b"))
         pd.testing.assert_series_equal(batch["c"], pd.Series(_COL_C, name="c"))
+        pd.testing.assert_series_equal(batch["d"], pd.Series(_COL_C, name="d"))
 
 
 class LazyDictTest(TestCase):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,3 +1,4 @@
+import datetime
 from pathlib import Path
 from unittest import TestCase
 
@@ -69,6 +70,17 @@ class ArrowExtractorTest(TestCase):
         self.assertEqual(batch["c"][0][0].dtype, np.float64)
         self.assertEqual(batch["c"][0].dtype, object)
         self.assertEqual(batch["c"].dtype, object)
+
+    def test_numpy_extractor_temporal(self):
+        _col_a = [datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)] * 3
+        pa_table = pa.Table.from_pydict({"a": _col_a})
+        extractor = NumpyArrowExtractor()
+        row = extractor.extract_row(pa_table)
+        np.testing.assert_equal(row, {"a": np.datetime64(_col_a[0])})
+        col = extractor.extract_column(pa_table)
+        np.testing.assert_equal(col, np.array(list(map(np.datetime64, _col_a))))
+        batch = extractor.extract_batch(pa_table)
+        np.testing.assert_equal(batch, {"a": np.array(list(map(np.datetime64, _col_a)))})
 
     def test_pandas_extractor(self):
         pa_table = self._create_dummy_table()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -92,7 +92,7 @@ class ArrowExtractorTest(TestCase):
         pd.testing.assert_series_equal(row["a"], pd.Series(_COL_A, name="a")[:1])
         pd.testing.assert_series_equal(row["b"], pd.Series(_COL_B, name="b")[:1])
         pd.testing.assert_series_equal(row["c"], pd.Series(_COL_C, name="c")[:1])
-        pd.testing.assert_series_equal(row["d"], pd.Series(_COL_C, name="d")[:1])
+        pd.testing.assert_series_equal(row["d"], pd.Series(_COL_D, name="d")[:1])
         col = extractor.extract_column(pa_table)
         pd.testing.assert_series_equal(col, pd.Series(_COL_A, name="a"))
         batch = extractor.extract_batch(pa_table)
@@ -100,7 +100,7 @@ class ArrowExtractorTest(TestCase):
         pd.testing.assert_series_equal(batch["a"], pd.Series(_COL_A, name="a"))
         pd.testing.assert_series_equal(batch["b"], pd.Series(_COL_B, name="b"))
         pd.testing.assert_series_equal(batch["c"], pd.Series(_COL_C, name="c"))
-        pd.testing.assert_series_equal(batch["d"], pd.Series(_COL_C, name="d"))
+        pd.testing.assert_series_equal(batch["d"], pd.Series(_COL_D, name="d"))
 
 
 class LazyDictTest(TestCase):


### PR DESCRIPTION
Fixes https://github.com/huggingface/datasets/issues/5495

I'm not sure whether we prefer a test here or if timestamps are known to be unsupported (like booleans). The current test at least covers the bug