### PR TITLE
Reload features from Parquet metadata

### DIFF
--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -1,17 +1,14 @@
-import json
 import os
-from typing import BinaryIO, Dict, Optional, Union
+from typing import BinaryIO, Optional, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .. import Dataset, Features, NamedSplit, config
 from ..formatting import query_table
-from ..info import DatasetInfo
 from ..packaged_modules import _PACKAGED_DATASETS_MODULES
 from ..packaged_modules.parquet.parquet import Parquet
 from ..utils import logging
-from ..utils.py_utils import asdict
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
 
@@ -95,16 +92,6 @@ class ParquetDatasetWriter:
         else:
             written = self._write(file_obj=self.path_or_buf, batch_size=batch_size, **self.parquet_writer_kwargs)
         return written
-
-    @staticmethod
-    def _build_metadata(info: DatasetInfo, fingerprint: Optional[str] = None) -> Dict[str, str]:
-        info_keys = ["features"]  # we can add support for more DatasetInfo keys in the future
-        info_as_dict = asdict(info)
-        metadata = {}
-        metadata["info"] = {key: info_as_dict[key] for key in info_keys}
-        if fingerprint is not None:
-            metadata["fingerprint"] = fingerprint
-        return {"huggingface": json.dumps(metadata)}
 
     def _write(self, file_obj: BinaryIO, batch_size: int, **parquet_writer_kwargs) -> int:
         """Writes the pyarrow table as Parquet to a binary file handle.

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -1,7 +1,6 @@
 import os
 from typing import BinaryIO, Optional, Union
 
-import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .. import Dataset, Features, NamedSplit, config

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -1,14 +1,13 @@
-import os
 import json
+import os
 from typing import BinaryIO, Dict, Optional, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .. import Dataset, Features, NamedSplit, config
-from ..arrow_writer import ArrowWriter
-from ..info import DatasetInfo
 from ..formatting import query_table
+from ..info import DatasetInfo
 from ..packaged_modules import _PACKAGED_DATASETS_MODULES
 from ..packaged_modules.parquet.parquet import Parquet
 from ..utils import logging

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -114,13 +114,7 @@ class ParquetDatasetWriter:
         """
         written = 0
         _ = parquet_writer_kwargs.pop("path_or_buf", None)
-        schema = pa.schema(self.dataset.features.type)
-
-        schema = schema.with_metadata(
-            ArrowWriter._build_metadata(
-                info=DatasetInfo(features=self.dataset.features)
-            )
-        )
+        schema = self.dataset.features.arrow_schema
 
         writer = pq.ParquetWriter(file_obj, schema=schema, **parquet_writer_kwargs)
 

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -3,14 +3,10 @@ import pyarrow.parquet as pq
 import pytest
 
 from datasets import Dataset, DatasetDict, Features, NamedSplit, Value
-from datasets.io.parquet import ParquetDatasetReader, ParquetDatasetWriter
 from datasets.features.image import Image
+from datasets.io.parquet import ParquetDatasetReader, ParquetDatasetWriter
 
-from ..utils import (
-    assert_arrow_memory_doesnt_increase,
-    assert_arrow_memory_increases,
-    require_pil,
-)
+from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases, require_pil
 
 
 def _check_parquet_dataset(dataset, expected_features):
@@ -141,6 +137,7 @@ def test_parquer_write(dataset, tmp_path):
 @require_pil
 def test_dataset_to_parquet_keeps_features(shared_datadir, tmp_path):
     import PIL.Image
+
     image_path = str(shared_datadir / "test_image_rgb.jpg")
     PIL.Image.fromarray(np.zeros((5, 5), dtype=np.uint8)).save(image_path, format="png")
     data = {"image": [image_path]}

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pyarrow.parquet as pq
 import pytest
 

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -6,7 +6,7 @@ from datasets import Dataset, DatasetDict, Features, NamedSplit, Value
 from datasets.features.image import Image
 from datasets.io.parquet import ParquetDatasetReader, ParquetDatasetWriter
 
-from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases, require_pil
+from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases
 
 
 def _check_parquet_dataset(dataset, expected_features):
@@ -134,12 +134,8 @@ def test_parquer_write(dataset, tmp_path):
     assert dataset.data.table == output_table
 
 
-@require_pil
 def test_dataset_to_parquet_keeps_features(shared_datadir, tmp_path):
-    import PIL.Image
-
     image_path = str(shared_datadir / "test_image_rgb.jpg")
-    PIL.Image.fromarray(np.zeros((5, 5), dtype=np.uint8)).save(image_path, format="png")
     data = {"image": [image_path]}
     features = Features({"image": Image()})
     dataset = Dataset.from_dict(data, features=features)


### PR DESCRIPTION
Resolves #5482. 

Attaches feature metadata to parquet files serialised using `Dataset.to_parquet`. 

This allows retrieving data with "rich" feature types (e.g., `datasets.features.image.Image` or `datasets.features.audio.Audio`) from parquet files without cumbersome casting (for an example, see #5482).

@lhoestq It seems that it is sufficient to attach metadata to the schema prior to serialising and features are loaded back with correct types afterwards automatically. 

I used the following script to test the implementation:

```python
from pathlib import Path

import datasets

dataset_name = "Maysee/tiny-imagenet"
ds = datasets.load_dataset(dataset_name, split=datasets.Split.TRAIN)
output_directory_path = Path(__file__).parent.joinpath("example_test_outputs", dataset_name.replace("/", "_"))
output_directory_path.mkdir(exist_ok=True, parents=True)
output_filepath = output_directory_path.joinpath("ds.parquet")
ds.to_parquet(str(output_filepath))

reloaded_ds = datasets.load_dataset(str(output_directory_path), split=datasets.Split.TRAIN)

assert ds.features == reloaded_ds.features
```

Prior to the change in this PR this script raises an `AssertionError` and the `Image` features lose their type after serialisation. After the change in this PR, the assertion does not raise an error and manual inspection of the features shows type `Image` for the respective columns of `reloaded_ds `.

Some open questions:
* How/where can I best add new unit tests for this implementation?
* What dataset would I best use in the tests? I chose `Maysee/tiny-imagenet` mainly because it is small and contains an ?Image` feature that can be used to test, but I'd be happy for suggestions on a suitable data source to use.
* Currently I'm calling `datasets.arrow_writer.ArrowWriter._build_metadata` as I need the same logic. However, I'm not happy with the coupling between `datasets.io.parquet` and `datasets.arrow_writer` it leaves me with. Suggest to factor this common logic out into a helper function and reuse it from both of these. Do you agree and if yes, could you please guide me where I would best place this function?

Many thanks in advance and kind regards,
MFreidank


  