### PR TITLE
Minor changes in JAX-formatting docstrings & type-hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.3.25 jaxlib==0.3.25
+        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.3.25
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1 jax==0.2.8 jaxlib==0.1.65
+        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1 jax==0.2.8
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill
+        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.4.1 jaxlib==0.4.1
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1
+        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1 jax==0.2.8 jaxlib==0.1.65
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.3.25
+        run: pip install --upgrade pyarrow huggingface-hub dill
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1 jax==0.2.8
+        run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.3.25 jaxlib==0.3.6
+        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.3.25 jaxlib==0.3.25
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
         run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1 jax==0.2.8 jaxlib==0.1.65

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.4.1 jaxlib==0.4.1
+        run: pip install --upgrade pyarrow huggingface-hub dill jax==0.3.25 jaxlib==0.3.6
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
         run: pip install pyarrow==6.0.1 huggingface-hub==0.2.0 transformers dill==0.3.1.1 jax==0.2.8 jaxlib==0.1.65

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ EXTRAS_REQUIRE = {
     ],
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
-    "jax": ["jax>=0.2.8,!=0.3.2,<=0.4.3", "jaxlib>=0.1.65,<=0.3.6"],
+    "jax": ["jax>=0.2.8,!=0.3.2,<0.4.0", "jaxlib>=0.1.65,<=0.3.6"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -227,6 +227,7 @@ EXTRAS_REQUIRE = {
     ],
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
+    "jax": ["jax", "jaxlib"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ EXTRAS_REQUIRE = {
     ],
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
-    "jax": ["jax>=0.4.1", "jaxlib>=0.4.1"],  # defines `jax.Array` unified type
+    "jax": ["jax>=0.2.8,!=0.3.2,<=0.4.3", "jaxlib>=0.1.65,<=0.3.6"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ EXTRAS_REQUIRE = {
     ],
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
-    "jax": ["jax>=0.2.8,!=0.3.2,<0.4.0", "jaxlib>=0.1.65,<=0.3.6"],
+    "jax": ["jax>=0.2.8,!=0.3.2,<=0.3.25", "jaxlib>=0.1.65,<=0.3.25"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ EXTRAS_REQUIRE = {
     ],
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
-    "jax": ["jax", "jaxlib"],
+    "jax": ["jax>=0.4.1", "jaxlib>=0.4.1"],  # defines `jax.Array` unified type
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2319,7 +2319,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         # Check that the format_type and format_kwargs are valid and make it possible to have a Formatter
         type = get_format_type_from_alias(type)
-        _ = get_formatter(type, features=self.features, **format_kwargs)
+        get_formatter(type, features=self.features, **format_kwargs)
 
         # Check filter column
         if isinstance(columns, str):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2248,7 +2248,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Args:
             type (`str`, *optional*):
-                Output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow']`.
+                Output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow', 'jax']`.
                 `None` means `__getitem__`` returns python objects (default).
             columns (`List[str]`, *optional*):
                 Columns to format in the output.
@@ -2282,7 +2282,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Args:
             type (`str`, *optional*):
-                Either output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow']`.
+                Either output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow', 'jax']`.
                 `None` means `__getitem__` returns python objects (default).
             columns (`List[str]`, *optional*):
                 Columns to format in the output.
@@ -2433,7 +2433,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         Args:
             type (`str`, *optional*):
-                Either output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow']`.
+                Either output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow', 'jax']`.
                 `None` means `__getitem__` returns python objects (default).
             columns (`List[str]`, *optional*):
                 Columns to format in the output.

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -476,8 +476,8 @@ class DatasetDict(dict):
         The transformation is applied to all the datasets of the dataset dictionary.
 
         Args:
-            type (`str`, optional):
-                Output type selected in `[None, numpy, torch, tensorflow, pandas, arrow]`.
+            type (`str`, *optional*):
+                Output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow', 'jax']`.
                 `None` means `__getitem__` returns python objects (default).
             columns (`List[str]`, *optional*):
                 Columns to format in the output.
@@ -513,7 +513,7 @@ class DatasetDict(dict):
 
         Args:
             type (`str`, *optional*):
-                Output type selected in `.[None, numpy, torch, tensorflow, pandas, arrow]`.
+                Output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow', 'jax']`.
                 `None` means `__getitem__` returns python objects (default).
             columns (`List[str]`, *optional*):
                 Columns to format in the output.
@@ -620,7 +620,7 @@ class DatasetDict(dict):
 
         Args:
             type (`str`, *optional*):
-                Either output type selected in `[None, numpy, torch, tensorflow, pandas, arrow]`.
+                Output type selected in `[None, 'numpy', 'torch', 'tensorflow', 'pandas', 'arrow', 'jax']`.
                 `None` means `__getitem__` returns python objects (default).
             columns (`List[str]`, *optional*):
                 Columns to format in the output.

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -41,8 +41,7 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
 
         if isinstance(column, list) and column:
             if all(
-                isinstance(x, jax.Array) and x.shape == column[0].shape and x.dtype == column[0].dtype
-                for x in column
+                isinstance(x, jax.Array) and x.shape == column[0].shape and x.dtype == column[0].dtype for x in column
             ):
                 return jnp.stack(column, axis=0)
         return column

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -18,6 +18,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pyarrow as pa
 
 from .. import config
 from ..utils.py_utils import map_nested
@@ -26,7 +27,6 @@ from .formatting import Formatter
 
 if TYPE_CHECKING:
     import jax
-    import pyarrow as pa
 
 
 class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
@@ -86,19 +86,19 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
     def recursive_tensorize(self, data_struct: dict):
         return map_nested(self._recursive_tensorize, data_struct)
 
-    def format_row(self, pa_table: "pa.Table") -> Mapping:
+    def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
         row = self.python_features_decoder.decode_row(row)
         return self.recursive_tensorize(row)
 
-    def format_column(self, pa_table: "pa.Table") -> "jax.Array":
+    def format_column(self, pa_table: pa.Table) -> "jax.Array":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
         column = self.recursive_tensorize(column)
         column = self._consolidate(column)
         return column
 
-    def format_batch(self, pa_table: "pa.Table") -> Mapping:
+    def format_batch(self, pa_table: pa.Table) -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
         batch = self.python_features_decoder.decode_batch(batch)
         batch = self.recursive_tensorize(batch)

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -43,7 +43,7 @@ class JaxFormatter(Formatter[Mapping, "jnp.ndarray", Mapping]):
                 isinstance(x, jnp.ndarray) and x.shape == column[0].shape and x.dtype == column[0].dtype
                 for x in column
             ):
-                return jnp.stack(column)
+                return jnp.stack(column, axis=0)
         return column
 
     def _tensorize(self, value):

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -18,7 +18,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import numpy as np
-import pyarrow as pa
 
 from .. import config
 from ..utils.py_utils import map_nested
@@ -27,6 +26,7 @@ from .formatting import Formatter
 
 if TYPE_CHECKING:
     import jax.numpy as jnp
+    import pyarrow as pa
 
 
 class JaxFormatter(Formatter[Mapping, "jnp.ndarray", Mapping]):
@@ -86,19 +86,19 @@ class JaxFormatter(Formatter[Mapping, "jnp.ndarray", Mapping]):
     def recursive_tensorize(self, data_struct: dict):
         return map_nested(self._recursive_tensorize, data_struct)
 
-    def format_row(self, pa_table: pa.Table) -> Mapping:
+    def format_row(self, pa_table: "pa.Table") -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
         row = self.python_features_decoder.decode_row(row)
         return self.recursive_tensorize(row)
 
-    def format_column(self, pa_table: pa.Table) -> "jnp.ndarray":
+    def format_column(self, pa_table: "pa.Table") -> "jnp.ndarray":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
         column = self.recursive_tensorize(column)
         column = self._consolidate(column)
         return column
 
-    def format_batch(self, pa_table: pa.Table) -> Mapping:
+    def format_batch(self, pa_table: "pa.Table") -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
         batch = self.python_features_decoder.decode_batch(batch)
         batch = self.recursive_tensorize(batch)

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -25,22 +25,23 @@ from .formatting import Formatter
 
 
 if TYPE_CHECKING:
-    import jax.numpy as jnp
+    import jax
     import pyarrow as pa
 
 
-class JaxFormatter(Formatter[Mapping, "jnp.ndarray", Mapping]):
+class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
     def __init__(self, features=None, **jnp_array_kwargs):
         super().__init__(features=features)
         self.jnp_array_kwargs = jnp_array_kwargs
-        import jax.numpy as jnp  # noqa import jax at initialization
+        import jax  # noqa import jax at initialization
 
     def _consolidate(self, column):
+        import jax
         import jax.numpy as jnp
 
         if isinstance(column, list) and column:
             if all(
-                isinstance(x, jnp.ndarray) and x.shape == column[0].shape and x.dtype == column[0].dtype
+                isinstance(x, jax.Array) and x.shape == column[0].shape and x.dtype == column[0].dtype
                 for x in column
             ):
                 return jnp.stack(column, axis=0)
@@ -91,7 +92,7 @@ class JaxFormatter(Formatter[Mapping, "jnp.ndarray", Mapping]):
         row = self.python_features_decoder.decode_row(row)
         return self.recursive_tensorize(row)
 
-    def format_column(self, pa_table: "pa.Table") -> "jnp.ndarray":
+    def format_column(self, pa_table: "pa.Table") -> "jax.Array":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
         column = self.recursive_tensorize(column)


### PR DESCRIPTION
Hi to whoever is reading this! 🤗

## What's in this PR?

I was exploring the code regarding the `JaxFormatter` implemented in 🤗`datasets`, and found some things that IMO could be changed. Those are mainly regarding the docstrings and the type-hints based on `jax`'s 0.4.1 release where `jax.Array` was introduced as the default type for JAX-arrays (instead of `jnp.DeviceArray`, `jnp.SharedDeviceArray`, and `jnp.GlobalDeviceArray`). Even though `isinstance(..., jax.Array)` also works with lower versions such as e.g. `0.3.25`.

More information about the latter at [`jax` v0.4.1 - Release Notes](https://github.com/google/jax/releases/tag/jax-v0.4.1) and [jax.Array migration - JAX documentation](https://jax.readthedocs.io/en/latest/jax_array_migration.html).

## What's missing?

* Do you want me to write an entry in the documentation on how to use 🤗`datasets` with JAX as https://huggingface.co/docs/datasets/use_with_pytorch with PyTorch?
* Do we need to actually include `pyarrow` under the `TYPE_CHECKING` when needed? I just did it for JAX, but if we are OK with that, I can do that with the rest of the formatters, just LMK.
* Should the License header be included in `datasets.formatting.np_formatter`? If so, do I include the one from 2020 e.g. https://github.com/huggingface/datasets/blob/b065547654efa0ec633cf373ac1512884c68b2e1/src/datasets/formatting/tf_formatter.py#L1-L13
* Is there any reason why `jnp.array` is being used instead of `jnp.asarray`? There's no difference between both, just that `jnp.asarray` has `copy=False` as default, even though `numpy` to `jax.numpy` conversion is not zero-copy, but just asking :)