### PR TITLE
Add JAX-formatting documentation

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -34,6 +34,8 @@
       title: Use with TensorFlow
     - local: use_with_pytorch
       title: Use with PyTorch
+    - local: use_with_jax
+      title: Use with JAX
     - local: cache
       title: Cache management
     - local: filesystems

--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -102,7 +102,7 @@ To use the [`Image`] feature type, you'll need to install the `vision` extra as
 >>> ds = Dataset.from_dict({"image": images}, features=features)
 >>> ds = ds.with_format("jax")
 >>> ds[0]["image"].shape
-torch.Size([512, 512, 3])
+(512, 512, 3)
 >>> ds[0]
 {'image': DeviceArray([[[ 255, 255, 255],
               [ 255, 255, 255],
@@ -110,7 +110,7 @@ torch.Size([512, 512, 3])
               [ 255, 255, 255],
               [ 255, 255, 255]]], dtype=uint8)}
 >>> ds[:2]["image"].shape
-torch.Size([2, 512, 512, 3])
+(2, 512, 512, 3)
 >>> ds[:2]
 {'image': DeviceArray([[[[ 255, 255, 255],
               [ 255, 255, 255],

--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -1,0 +1,98 @@
+# Use with JAX
+
+This document is a quick introduction to using `datasets` with JAX, with a particular focus on how to get
+`jax.Array` objects out of our datasets, and how to use them to train JAX models.
+
+<Tip>
+
+`jax` and `jaxlib` are required to reproduce to code above, so please make sure you
+install them as `pip install datasets[jax]`.
+
+</Tip>
+
+## Dataset format
+
+By default, datasets return regular Python objects: integers, floats, strings, lists, etc.
+
+To get JAX arrays (numpy-like) instead, you can set the format of the dataset to `jax`:
+
+```py
+>>> from datasets import Dataset
+>>> data = [[1, 2], [3, 4]]
+>>> ds = Dataset.from_dict({"data": [[1, 2], [3, 4]]})
+>>> ds = ds.with_format("jax")
+>>> ds[0]
+{'data': DeviceArray([1, 2], dtype=int32)}
+>>> ds[:2]
+{'data': DeviceArray([
+    [1, 2],
+    [3, 4]], dtype=int32)}
+```
+
+<Tip>
+
+A [`Dataset`] object is a wrapper of an Arrow table, which allows fast reads from arrays in the dataset to JAX tensors.
+
+</Tip>
+
+Note that the exact same procedure applies to `DatasetDict` objects, so that
+when setting the format of a `DatasetDict` to `jax`, all the `Dataset`s there
+will be formatted as `jax`:
+
+```py
+>>> from datasets import DatasetDict
+>>> data = {"train": {"data": [[1, 2], [3, 4]]}, "test": {"data": [[5, 6], [7, 8]]}}
+>>> dds = DatasetDict.from_dict(data)
+>>> dds = dds.with_format("jax")
+>>> dds["train"][:2]
+{'data': DeviceArray([
+    [1, 2],
+    [3, 4]], dtype=int32)}
+```
+
+Another thing you'll need to take into consideration is that the formatting is not applied
+until you actually access the data. So if you want to get a JAX array out of a dataset,
+you'll need to access the data first, otherwise the format will remain the same.
+
+## Data loading
+
+JAX doesn't have any built-in data loading capabilities, so you'll need to use a library such
+as [PyTorch](https://pytorch.org/) to load your data using a `DataLoader` or [TensorFlow](https://www.tensorflow.org/)
+using a `tf.data.Dataset`. Citing the [JAX documentation](https://jax.readthedocs.io/en/latest/notebooks/Neural_Network_and_Data_Loading.html#data-loading-with-pytorch) on this topic:
+"JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don’t
+include data loading or munging in the JAX library. There are already a lot of great data loaders
+out there, so let’s just use them instead of reinventing anything. We’ll grab PyTorch’s data loader,
+and make a tiny shim to make it work with NumPy arrays.".
+
+So that's the reason why JAX-formatting in `datasets` is so useful, because it lets you use
+any model from the HuggingFace Hub with JAX, without having to worry about the data loading
+part.
+
+### Using `with_format('jax')`
+
+The easiest way to get JAX arrays out of a dataset is to use the `with_format('jax')` method. Lets assume
+that we want to train a neural network on the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) available
+at the HuggingFace Hub at https://huggingface.co/datasets/mnist.
+
+```py
+>>> from datasets import load_dataset
+>>> ds = load_dataset("mnist")
+>>> ds = ds.with_format("jax")
+>>> ds["train"][0]
+{'image': DeviceArray([[  0,   0,   0, ...],
+                       [  0,   0,   0, ...],
+                       ...,
+                       [  0,   0,   0, ...],
+                       [  0,   0,   0, ...]], dtype=uint8),
+ 'label': DeviceArray(5, dtype=int32)}
+```
+
+Once the format is set we can feed the dataset to the JAX model in batches using the `Dataset.iter()`
+method:
+
+```py
+>>> for epoch in range(epochs):
+...     for batch in ds["train"].iter(batch_size=32):
+...         x, y = batch["image"], batch["label"]
+...         ...
+```

--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -19,7 +19,7 @@ To get JAX arrays (numpy-like) instead, you can set the format of the dataset to
 ```py
 >>> from datasets import Dataset
 >>> data = [[1, 2], [3, 4]]
->>> ds = Dataset.from_dict({"data": [[1, 2], [3, 4]]})
+>>> ds = Dataset.from_dict({"data": data})
 >>> ds = ds.with_format("jax")
 >>> ds[0]
 {'data': DeviceArray([1, 2], dtype=int32)}
@@ -31,7 +31,7 @@ To get JAX arrays (numpy-like) instead, you can set the format of the dataset to
 
 <Tip>
 
-A [`Dataset`] object is a wrapper of an Arrow table, which allows fast reads from arrays in the dataset to JAX tensors.
+A [`Dataset`] object is a wrapper of an Arrow table, which allows fast reads from arrays in the dataset to JAX arrays.
 
 </Tip>
 
@@ -53,6 +53,91 @@ will be formatted as `jax`:
 Another thing you'll need to take into consideration is that the formatting is not applied
 until you actually access the data. So if you want to get a JAX array out of a dataset,
 you'll need to access the data first, otherwise the format will remain the same.
+
+## N-dimensional arrays
+
+If your dataset consists of N-dimensional arrays, you will see that by default they are considered as nested lists.
+In particular, a JAX formatted dataset outputs a `DeviceArray` object, which is a numpy-like array, so it does not
+need the [`Array`] feature type to be specified as opposed to PyTorch or TensorFlow formatters.
+
+```py
+>>> from datasets import Dataset
+>>> data = [[[1, 2],[3, 4]], [[5, 6],[7, 8]]]
+>>> ds = Dataset.from_dict({"data": data})
+>>> ds = ds.with_format("jax")
+>>> ds[0]
+{'data': DeviceArray([[1, 2],
+             [3, 4]], dtype=int32)}
+```
+
+## Other feature types
+
+[`ClassLabel`] data is properly converted to arrays:
+
+```py
+>>> from datasets import Dataset, Features, ClassLabel
+>>> labels = [0, 0, 1]
+>>> features = Features({"label": ClassLabel(names=["negative", "positive"])})
+>>> ds = Dataset.from_dict({"label": labels}, features=features)
+>>> ds = ds.with_format("jax")
+>>> ds[:3]
+{'label': DeviceArray([0, 0, 1], dtype=int32)}
+```
+
+String and binary objects are unchanged, since JAX only supports numbers.
+
+The [`Image`] and [`Audio`] feature types are also supported.
+
+<Tip>
+
+To use the [`Image`] feature type, you'll need to install the `vision` extra as
+`pip install datasets[vision]`.
+
+</Tip>
+
+```py
+>>> from datasets import Dataset, Features, Image
+>>> images = ["path/to/image.png"] * 10
+>>> features = Features({"image": Image()})
+>>> ds = Dataset.from_dict({"image": images}, features=features)
+>>> ds = ds.with_format("jax")
+>>> ds[0]["image"].shape
+torch.Size([512, 512, 3])
+>>> ds[0]
+{'image': DeviceArray([[[ 255, 255, 255],
+              [ 255, 255, 255],
+              ...,
+              [ 255, 255, 255],
+              [ 255, 255, 255]]], dtype=uint8)}
+>>> ds[:2]["image"].shape
+torch.Size([2, 512, 512, 3])
+>>> ds[:2]
+{'image': DeviceArray([[[[ 255, 255, 255],
+              [ 255, 255, 255],
+              ...,
+              [ 255, 255, 255],
+              [ 255, 255, 255]]]], dtype=uint8)}
+```
+
+<Tip>
+
+To use the [`Audio`] feature type, you'll need to install the `audio` extra as
+`pip install datasets[audio]`.
+
+</Tip>
+
+```py
+>>> from datasets import Dataset, Features, Audio
+>>> audio = ["path/to/audio.wav"] * 10
+>>> features = Features({"audio": Audio()})
+>>> ds = Dataset.from_dict({"audio": audio}, features=features)
+>>> ds = ds.with_format("jax")
+>>> ds[0]["audio"]["array"]
+DeviceArray([-0.059021  , -0.03894043, -0.00735474, ...,  0.0133667 ,
+              0.01809692,  0.00268555], dtype=float32)
+>>> ds[0]["audio"]["sampling_rate"]
+DeviceArray(44100, dtype=int32, weak_type=True)
+```
 
 ## Data loading
 

--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -88,7 +88,14 @@ To get a single tensor, you must explicitly use the [`Array`] feature type and s
 
 String and binary objects are unchanged, since PyTorch only supports numbers.
 
-The [`Image`] and [`Audio`] feature types are also supported:
+The [`Image`] and [`Audio`] feature types are also supported.
+
+<Tip>
+
+To use the [`Image`] feature type, you'll need to install the `vision` extra as
+`pip install datasets[vision]`.
+
+</Tip>
 
 ```py
 >>> from datasets import Dataset, Features, Audio, Image
@@ -113,6 +120,13 @@ torch.Size([2, 512, 512, 4])
           [255, 255, 255, 255],
           [255, 255, 255, 255]]]], dtype=torch.uint8)}
 ```
+
+<Tip>
+
+To use the [`Audio`] feature type, you'll need to install the `audio` extra as
+`pip install datasets[audio]`.
+
+</Tip>
 
 ```py
 >>> from datasets import Dataset, Features, Audio, Image

--- a/docs/source/use_with_tensorflow.mdx
+++ b/docs/source/use_with_tensorflow.mdx
@@ -13,7 +13,7 @@ To get TensorFlow tensors instead, you can set the format of the dataset to `tf`
 ```py
 >>> from datasets import Dataset
 >>> data = [[1, 2],[3, 4]]
->>> ds = Dataset.from_dict({"data": [[1, 2],[3, 4]]})
+>>> ds = Dataset.from_dict({"data": data})
 >>> ds = ds.with_format("tf")
 >>> ds[0]
 {'data': <tf.Tensor: shape=(2,), dtype=int64, numpy=array([1, 2])>}
@@ -53,7 +53,7 @@ In particular, a TensorFlow formatted dataset outputs a `RaggedTensor` instead o
 {'data': <tf.RaggedTensor [[1, 2], [3, 4]]>}
 ```
 
-To get a single tensor, you must explicitly use the Array feature type and specify the shape of your tensors:
+To get a single tensor, you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D
@@ -113,7 +113,14 @@ You can also explicitly format certain columns and leave the other columns unfor
 
 String and binary objects are unchanged, since PyTorch only supports numbers.
 
-The [`Image`] and [`Audio`] feature types are also supported:
+The [`Image`] and [`Audio`] feature types are also supported.
+
+<Tip>
+
+To use the [`Image`] feature type, you'll need to install the `vision` extra as
+`pip install datasets[vision]`.
+
+</Tip>
 
 ```py
 >>> from datasets import Dataset, Features, Audio, Image
@@ -136,6 +143,13 @@ The [`Image`] and [`Audio`] feature types are also supported:
           [255, 255, 255, 255],
           [255, 255, 255, 255]]]], dtype=uint8)>}
 ```
+
+<Tip>
+
+To use the [`Audio`] feature type, you'll need to install the `audio` extra as
+`pip install datasets[audio]`.
+
+</Tip>
 
 ```py
 >>> from datasets import Dataset, Features, Audio, Image


### PR DESCRIPTION
## What's in this PR?

As a follow-up of #5522, I've created this entry in the documentation to explain how to use `.with_format("jax")` and why is it useful.

@lhoestq Feel free to drop any feedback and/or suggestion, as probably more useful features can be included there!