### PR TITLE
Add JAX device selection when formatting

### DIFF
--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -12,7 +12,8 @@ install them as `pip install datasets[jax]`.
 
 ## Dataset format
 
-By default, datasets return regular Python objects: integers, floats, strings, lists, etc.
+By default, datasets return regular Python objects: integers, floats, strings, lists, etc., and 
+string and binary objects are unchanged, since JAX only supports numbers.
 
 To get JAX arrays (numpy-like) instead, you can set the format of the dataset to `jax`:
 

--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -54,6 +54,28 @@ Another thing you'll need to take into consideration is that the formatting is n
 until you actually access the data. So if you want to get a JAX array out of a dataset,
 you'll need to access the data first, otherwise the format will remain the same.
 
+Finally, to load the data in the device of your choice, you can specify the `device` argument,
+but note that `jaxlib.xla_extension.Device` is not supported as it's not serializable with neither
+`pickle` not `dill`, so you'll need to use its string identifier instead:
+
+```py
+>>> import jax
+>>> from datasets import Dataset
+>>> data = [[1, 2], [3, 4]]
+>>> ds = Dataset.from_dict({"data": data})
+>>> device = str(jax.devices()[0])  # Not casting to `str` before passing it to `with_format` will raise a `ValueError`
+>>> ds = ds.with_format("jax", device=device)
+>>> ds[0]
+{'data': DeviceArray([1, 2], dtype=int32)}
+>>> ds[0]["data"].device()
+TFRT_CPU_0
+>>> assert ds[0]["data"].device() == jax.devices()[0]
+True
+```
+
+Note that if the `device` argument is not provided to `with_format` then it will use the default
+device which is `jax.devices()[0]`.
+
 ## N-dimensional arrays
 
 If your dataset consists of N-dimensional arrays, you will see that by default they are considered as nested lists.

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -42,7 +42,8 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         )
         self.jnp_array_kwargs = jnp_array_kwargs
 
-    def _map_devices_to_str(self) -> Dict[str, "jaxlib.xla_extension.Device"]:
+    @staticmethod
+    def _map_devices_to_str() -> Dict[str, "jaxlib.xla_extension.Device"]:
         import jax
 
         return {str(device): device for device in jax.devices()}

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -26,9 +26,10 @@ from .formatting import Formatter
 
 
 if TYPE_CHECKING:
+    from typing import Dict
+
     import jax
     import jaxlib
-    from typing import Dict
 
 
 class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -21,6 +21,7 @@ import numpy as np
 import pyarrow as pa
 
 from .. import config
+from ..utils.logging import get_logger
 from ..utils.py_utils import map_nested
 from .formatting import Formatter
 
@@ -28,6 +29,8 @@ from .formatting import Formatter
 if TYPE_CHECKING:
     import jax
     import jaxlib
+
+logger = get_logger()
 
 
 class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
@@ -40,6 +43,11 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         self.device = (
             device if isinstance(device, str) else str(device) if isinstance(device, Device) else str(jax.devices()[0])
         )
+        if self.device not in list(self.device_mapping.keys()):
+            logger.warning(
+                f"Device with string identifier {self.device} not listed among the available devices: {list(self.device_mapping.keys())}, so falling back to the default device: {str(jax.devices()[0])}."
+            )
+            self.device = str(jax.devices()[0])
         self.jnp_array_kwargs = jnp_array_kwargs
 
     @staticmethod

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -28,6 +28,7 @@ from .formatting import Formatter
 if TYPE_CHECKING:
     import jax
     import jaxlib
+    from typing import Dict
 
 
 class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
@@ -42,7 +43,7 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         )
         self.jnp_array_kwargs = jnp_array_kwargs
 
-    def _map_devices_to_str(self) -> Mapping[str, "jaxlib.xla_extension.Device"]:
+    def _map_devices_to_str() -> Dict[str, "jaxlib.xla_extension.Device"]:
         import jax
 
         return {str(device): device for device in jax.devices()}

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -15,7 +15,7 @@
 # Lint as: python3
 import sys
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
 import pyarrow as pa
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-DEVICE_MAPPING = {}
+DEVICE_MAPPING: Optional[dict] = None
 
 
 class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
@@ -52,7 +52,7 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         # using global variable since `jaxlib.xla_extension.Device` is not serializable neither
         # with `pickle` nor with `dill`, so we need to use a global variable instead
         global DEVICE_MAPPING
-        if not DEVICE_MAPPING:
+        if DEVICE_MAPPING is None:
             DEVICE_MAPPING = self._map_devices_to_str()
         if self.device not in list(DEVICE_MAPPING.keys()):
             logger.warning(
@@ -109,7 +109,7 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         # using global variable since `jaxlib.xla_extension.Device` is not serializable neither
         # with `pickle` nor with `dill`, so we need to use a global variable instead
         global DEVICE_MAPPING
-        if not DEVICE_MAPPING:
+        if DEVICE_MAPPING is None:
             DEVICE_MAPPING = self._map_devices_to_str()
 
         with jax.default_device(DEVICE_MAPPING[self.device]):

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -39,13 +39,20 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         import jax
         from jaxlib.xla_client import Device
 
+        if isinstance(device, Device):
+            raise ValueError(
+                f"Expected {device} to be a `str` not {type(device)}, as `jaxlib.xla_extension.Device` "
+                "is not serializable neither with `pickle` nor with `dill`. Instead you can surround "
+                "the device with `str()` to get its string identifier that will be internally mapped "
+                "to the actual `jaxlib.xla_extension.Device`."
+            )
+        self.device = device if isinstance(device, str) else str(jax.devices()[0])
         self.device_mapping = self._map_devices_to_str()
-        self.device = (
-            device if isinstance(device, str) else str(device) if isinstance(device, Device) else str(jax.devices()[0])
-        )
         if self.device not in list(self.device_mapping.keys()):
             logger.warning(
-                f"Device with string identifier {self.device} not listed among the available devices: {list(self.device_mapping.keys())}, so falling back to the default device: {str(jax.devices()[0])}."
+                f"Device with string identifier {self.device} not listed among the available "
+                "devices: {list(self.device_mapping.keys())}, so falling back to the default "
+                f"device: {str(jax.devices()[0])}."
             )
             self.device = str(jax.devices()[0])
         self.jnp_array_kwargs = jnp_array_kwargs

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -42,7 +42,7 @@ class JaxFormatter(Formatter[Mapping, "jax.Array", Mapping]):
         )
         self.jnp_array_kwargs = jnp_array_kwargs
 
-    def _map_devices_to_str() -> Dict[str, "jaxlib.xla_extension.Device"]:
+    def _map_devices_to_str(self) -> Dict[str, "jaxlib.xla_extension.Device"]:
         import jax
 
         return {str(device): device for device in jax.devices()}

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -15,7 +15,7 @@
 # Lint as: python3
 import sys
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 import numpy as np
 import pyarrow as pa
@@ -26,8 +26,6 @@ from .formatting import Formatter
 
 
 if TYPE_CHECKING:
-    from typing import Dict
-
     import jax
     import jaxlib
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -504,6 +504,22 @@ class FormatterTest(TestCase):
         batch = formatter.format_batch(pa_table)
         self.assertEqual(batch["audio"][0]["array"].dtype, jnp.float32)
 
+    @require_jax
+    def test_jax_formatter_device(self):
+        import jax
+
+        from datasets.formatting import JaxFormatter
+
+        pa_table = self._create_dummy_table()
+        device = jax.devices()[0]
+        formatter = JaxFormatter(device=str(device))
+        row = formatter.format_row(pa_table)
+        assert row["a"].device() == device
+        assert row["c"].device() == device
+        batch = formatter.format_batch(pa_table)
+        assert batch["a"].device() == device
+        assert batch["c"].device() == device
+
 
 class QueryTest(TestCase):
     def _create_dummy_table(self):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -516,6 +516,8 @@ class FormatterTest(TestCase):
         row = formatter.format_row(pa_table)
         assert row["a"].device() == device
         assert row["c"].device() == device
+        col = formatter.format_column(pa_table)
+        assert col.device() == device
         batch = formatter.format_batch(pa_table)
         assert batch["a"].device() == device
         assert batch["c"].device() == device


### PR DESCRIPTION
## What's in this PR?

After exploring for a while the JAX integration in 🤗`datasets`, I found out that, even though JAX prioritizes the TPU and GPU as the default device when available, the `JaxFormatter` doesn't let you specify the device where you want to place the `jax.Array`s in case you don't want to rely on JAX's default array placement.

So on, I've included the `device` param in `JaxFormatter` but there are some things to take into consideration:
* A formatted `Dataset` is copied with `copy.deepcopy` which means that if one adds the param `device` in `JaxFormatter` as a `jaxlib.xla_extension.Device`, it "fails" because that object cannot be serialized (instead of serializing the param adds a random hash instead). That's the reason why I added a function `_map_devices_to_str` to basically create a mapping of strings to `jaxlib.xla_extension.Device`s so that `self.device` is a string and not a `jaxlib.xla_extension.Device`.
* To create a `jax.Array` in a device you need to either create it in the default device and then move it to the desired device with `jax.device_put` or directly create it in the device you want with `jax.default_device()` context manager.
* JAX will create an array by default in `jax.devices()[0]`

More information on JAX device management is available at https://jax.readthedocs.io/en/latest/faq.html#controlling-data-and-computation-placement-on-devices

## What's missing in this PR?

I've tested it both locally in CPU (Mac M2 and Mac M1, as no GPU support for Mac yet), and in GPU and TPU in Google Colab, let me know if you want me to provide you the Notebook for the latter.

But I did not implement any integration test as I wanted to get your feedback first.