### PR TITLE
Suggest scikit-learn instead of sklearn

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -218,6 +218,8 @@ def _download_additional_modules(
     if needs_to_be_installed:
         _dependencies_str = "dependencies" if len(needs_to_be_installed) > 1 else "dependency"
         _them_str = "them" if len(needs_to_be_installed) > 1 else "it"
+        if "sklearn" in needs_to_be_installed.keys():
+            needs_to_be_installed["sklearn"] = "scikit-learn"
         raise ImportError(
             f"To be able to use {name}, you need to install the following {_dependencies_str}: "
             f"{', '.join(needs_to_be_installed)}.\nPlease install {_them_str} using 'pip install "


### PR DESCRIPTION
This is kinda unimportant fix but, the suggested `pip install sklearn` does not work.

The current error message if sklearn is not installed:

```
ImportError: To be able to use [dataset name], you need to install the following dependency: sklearn.
Please install it using 'pip install sklearn' for instance.
```
