### PR TITLE
Add resampy dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ REQUIRED_PKGS = [
 
 AUDIO_REQUIRE = [
     "librosa",
-    "resampy",
+    "resampy",  # optional librosa dependency after 0.10 for resampling
 ]
 
 VISION_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ REQUIRED_PKGS = [
 
 AUDIO_REQUIRE = [
     "librosa",
+    "resampy",
 ]
 
 VISION_REQUIRE = [


### PR DESCRIPTION
In librosa 0.10 they removed the `resmpy` dependency and set it to optional.

However it is necessary for resampling. I added it to the "audio" extra dependencies.