### PR TITLE
Use default audio resampling type

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -290,7 +290,7 @@ class Audio:
             array = librosa.to_mono(array)
         if self.sampling_rate and self.sampling_rate != sampling_rate:
             array = librosa.resample(
-                array, orig_sr=sampling_rate, target_sr=self.sampling_rate, res_type="kaiser_best"
+                array, orig_sr=sampling_rate, target_sr=self.sampling_rate
             )
             sampling_rate = self.sampling_rate
         return array, sampling_rate

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -289,9 +289,7 @@ class Audio:
         if self.mono:
             array = librosa.to_mono(array)
         if self.sampling_rate and self.sampling_rate != sampling_rate:
-            array = librosa.resample(
-                array, orig_sr=sampling_rate, target_sr=self.sampling_rate
-            )
+            array = librosa.resample(array, orig_sr=sampling_rate, target_sr=self.sampling_rate)
             sampling_rate = self.sampling_rate
         return array, sampling_rate
 


### PR DESCRIPTION
...instead of relying on the optional librosa dependency `resampy`.

It was only used for `_decode_non_mp3_file_like` anyway and not for the other ones - removing it fixes consistency between decoding methods (except torchaudio decoding)

Therefore I think it is a better solution than adding `resampy` as a dependency in https://github.com/huggingface/datasets/pull/5554

cc @polinaeterna 