### PR TITLE
Remove instructions for `ffmpeg` system package installation on Colab

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -323,7 +323,7 @@ class Audio:
                     import librosa
                 except ImportError as err:
                     raise ImportError(
-                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, make sure you have `ffmpeg` system package of at least version 4 installed. "
+                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, make sure you have `ffmpeg` system package with at least version 4 installed. "
                         "\tpip install \"torchaudio<0.12\".\n\nTo decode 'mp3' files without `torchaudio`, please install `librosa`:\n\n"
                         "\tpip install librosa\n\nNote that decoding might be extremely slow in that case."
                     ) from err

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -313,7 +313,7 @@ class Audio:
                 global _ffmpeg_warned
                 if not _ffmpeg_warned:
                     warnings.warn(
-                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, make sure you have `ffmpeg` system package of at least version 4 installed. "
+                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, make sure you have `ffmpeg` system package with at least version 4 installed. "
                         "Alternatively, you can downgrade `torchaudio`:\n\n"
                         "\tpip install \"torchaudio<0.12\".\n\nOtherwise 'mp3' files will be decoded with `librosa`."
                     )

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -313,10 +313,9 @@ class Audio:
                 global _ffmpeg_warned
                 if not _ffmpeg_warned:
                     warnings.warn(
-                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
-                        "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
-                        "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
-                        "\tpip install \"torchaudio<0.12\"`.\n\nOtherwise 'mp3' files will be decoded with `librosa`."
+                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, make sure you have `ffmpeg` system package of at least version 4 installed. "
+                        "Alternatively, you can downgrade `torchaudio`:\n\n"
+                        "\tpip install \"torchaudio<0.12\".\n\nOtherwise 'mp3' files will be decoded with `librosa`."
                     )
                     _ffmpeg_warned = True
                 try:
@@ -324,9 +323,7 @@ class Audio:
                     import librosa
                 except ImportError as err:
                     raise ImportError(
-                        "To support 'mp3' decoding with `torchaudio>=0.12.0`, please install `ffmpeg4` system package. On Google Colab you can run:\n\n"
-                        "\t!add-apt-repository -y ppa:jonathonf/ffmpeg-4 && apt update && apt install -y ffmpeg\n\n"
-                        "and restart your runtime. Alternatively, you can downgrade `torchaudio`:\n\n"
+                        "\nTo support 'mp3' decoding with `torchaudio>=0.12.0`, make sure you have `ffmpeg` system package of at least version 4 installed. "
                         "\tpip install \"torchaudio<0.12\".\n\nTo decode 'mp3' files without `torchaudio`, please install `librosa`:\n\n"
                         "\tpip install librosa\n\nNote that decoding might be extremely slow in that case."
                     ) from err


### PR DESCRIPTION
Colab now has Ubuntu 20.04 which already has `ffmpeg` of required (>4) version. 