### PR TITLE
Ensure last tqdm update in `map`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2955,6 +2955,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                         transformed_dataset = content
                     else:
                         pbar.update(content)
+                pbar.close()
             assert transformed_dataset is not None, "Failed to retrieve the result from map"
             # update fingerprint if the dataset changed
             if transformed_dataset._fingerprint != self._fingerprint:
@@ -3050,6 +3051,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                             transformed_shards[rank] = content
                         else:
                             pbar.update(content)
+                    pbar.close()
                 # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:
                     del kwargs["shard"]

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3338,6 +3338,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                         if os.path.exists(tmp_file.name):
                             os.remove(tmp_file.name)
                 raise
+            else:
+                yield rank, False, num_examples_progress_update
 
         if update_data and tmp_file is not None:
             tmp_file.close()

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2929,9 +2929,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 fn_kwargs=fn_kwargs,
                 new_fingerprint=new_fingerprint,
             )
+            transformed_dataset = None
             try:
                 transformed_dataset = load_processed_shard_from_cache(dataset_kwargs)
             except NonExistentDatasetError:
+                pass
+            if transformed_dataset is None:
                 pbar = logging.tqdm(
                     disable=not logging.is_progress_bar_enabled(),
                     unit=" examples",
@@ -3338,9 +3341,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                         if os.path.exists(tmp_file.name):
                             os.remove(tmp_file.name)
                 raise
-            else:
-                yield rank, False, num_examples_progress_update
 
+        yield rank, False, num_examples_progress_update
         if update_data and tmp_file is not None:
             tmp_file.close()
             shutil.move(tmp_file.name, cache_file_name)

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -356,18 +356,17 @@ def _single_map_nested(args):
     # Loop over single examples or batches and write to buffer/file if examples are to be updated
     pbar_iterable = data_struct.items() if isinstance(data_struct, dict) else data_struct
     pbar_desc = (desc + " " if desc is not None else "") + "#" + str(rank) if rank is not None else desc
-    pbar = logging.tqdm(pbar_iterable, disable=disable_tqdm, position=rank, unit="obj", desc=pbar_desc)
-
-    if isinstance(data_struct, dict):
-        return {k: _single_map_nested((function, v, types, None, True, None)) for k, v in pbar}
-    else:
-        mapped = [_single_map_nested((function, v, types, None, True, None)) for v in pbar]
-        if isinstance(data_struct, list):
-            return mapped
-        elif isinstance(data_struct, tuple):
-            return tuple(mapped)
+    with logging.tqdm(pbar_iterable, disable=disable_tqdm, position=rank, unit="obj", desc=pbar_desc) as pbar:
+        if isinstance(data_struct, dict):
+            return {k: _single_map_nested((function, v, types, None, True, None)) for k, v in pbar}
         else:
-            return np.array(mapped)
+            mapped = [_single_map_nested((function, v, types, None, True, None)) for v in pbar]
+            if isinstance(data_struct, list):
+                return mapped
+            elif isinstance(data_struct, tuple):
+                return tuple(mapped)
+            else:
+                return np.array(mapped)
 
 
 def map_nested(


### PR DESCRIPTION
This PR modifies `map` to:
* ensure the TQDM bar gets the last progress update
* when a map function fails, avoid throwing a chained exception in the single-proc mode