### PR TITLE
Use soundfile for mp3 decoding instead of torchaudio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install libsndfile1 sox
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -112,13 +111,3 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/
-      - name: Install dependencies to test torchaudio>=0.12 on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          pip uninstall -y torchaudio torch
-          pip install "torchaudio>=0.12"
-          sudo apt-get -y install ffmpeg
-      - name: Test torchaudio>=0.12 on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          python -m pytest -rfExX -m torchaudio_latest -n 2 --dist loadfile -sv ./tests/features/test_audio.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,6 @@ jobs:
     continue-on-error: ${{ matrix.test == 'integration' }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install OS dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install libsndfile1 sox
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -72,16 +67,6 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/
-      - name: Install dependencies to test torchaudio>=0.12 on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          pip uninstall -y torchaudio torch
-          pip install "torchaudio>=0.12"
-          sudo apt-get -y install ffmpeg
-      - name: Test torchaudio>=0.12 on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          python -m pytest -rfExX -m torchaudio_latest -n 2 --dist loadfile -sv ./tests/features/test_audio.py
 
   test_py310:
     needs: check_code_quality
@@ -93,10 +78,6 @@ jobs:
     continue-on-error: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install OS dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get -y update
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -1,7 +1,7 @@
 # Load audio data
 
 You can load an audio dataset using the [`Audio`] feature that automatically decodes and resamples the audio files when you access the examples.
-Audio decoding is based on `librosa` in general, and `torchaudio` for MP3.
+Audio decoding is based on the [`soundfile`](https://github.com/bastibe/python-soundfile) python package, which uses the [`libsndfile`](https://github.com/libsndfile/libsndfile) C library under the hood.
 
 ## Installation
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -68,7 +68,7 @@ pip install datasets[audio]
 <Tip warning={true}>
 
 To decode mp3 files you should have the `libsndfile` system library of at least version 1.1.0. Normally, it's bundled into the python [`soundfile`](https://github.com/bastibe/python-soundfile) package which is installed as an extra audio dependency of 🤗 Datasets.
-On Linux, the required version of `libsndfile` is bundled into the `soundfile` wheel since version 0.12.0 of `soundfile`. You can check which version of `libsndfile` is used by `soundfile` running the following code:
+On Linux, the required version of `libsndfile` is bundled into the `soundfile` wheel since version 0.12.0 of `soundfile`. You can run the following command to check which version of `libsndfile` is used by `soundfile`:
 
 ```bash
 python -c "import soundfile; print(soundfile.__libsndfile_version__)"

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -67,8 +67,8 @@ pip install datasets[audio]
 
 <Tip warning={true}>
 
-To decode mp3 files you should have the `libsndfile` system library of at least version 1.1.0. Normally, it's bundled into the python [`soundfile`](https://github.com/bastibe/python-soundfile) package which is installed as an extra audio dependency of 🤗 Datasets.
-On Linux, the required version of `libsndfile` is bundled into the `soundfile` wheel since version 0.12.0 of `soundfile`. You can run the following command to check which version of `libsndfile` is used by `soundfile`:
+To decode mp3 files, you need to have at least version 1.1.0 of the `libsndfile` system library. Usually, it's bundled with the python [`soundfile`](https://github.com/bastibe/python-soundfile) package, which is installed as an extra audio dependency for 🤗 Datasets.
+For Linux, the required version of `libsndfile` is bundled with `soundfile` starting from version 0.12.0. You can run the following command to determine which version of `libsndfile` is being used by `soundfile`:
 
 ```bash
 python -c "import soundfile; print(soundfile.__libsndfile_version__)"

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -67,31 +67,15 @@ pip install datasets[audio]
 
 <Tip warning={true}>
 
-On Linux, non-Python dependency on `libsndfile` package must be installed manually, using your distribution package manager, for example:
+To decode mp3 files you should have the `libsndfile` system library of at least version 1.1.0. Normally, it's bundled into the python [`soundfile`](https://github.com/bastibe/python-soundfile) package which is installed as an extra audio dependency of 🤗 Datasets.
+On Linux, the required version of `libsndfile` is bundled into the `soundfile` wheel since version 0.12.0 of `soundfile`. You can check which version of `libsndfile` is used by `soundfile` running the following code:
 
 ```bash
-sudo apt-get install libsndfile1
+python -c "import soundfile; print(soundfile.__libsndfile_version__)"
 ```
 
 </Tip>
 
-To support loading audio datasets containing MP3 files, users should also install [torchaudio](https://pytorch.org/audio/stable/index.html) to handle the audio data with high performance:
-
-```bash
-pip install 'torchaudio<0.12.0'
-```
-
-<Tip warning={true}>
-
-torchaudio's `sox_io` [backend](https://pytorch.org/audio/stable/backend.html#) supports decoding MP3 files. Unfortunately, the `sox_io` backend is only available on Linux/macOS and isn't supported by Windows.
-
-You need to install it using your distribution package manager, for example:
-
-```bash
-sudo apt-get install sox
-```
-
-</Tip>
 
 ## Vision
 

--- a/setup.py
+++ b/setup.py
@@ -174,8 +174,6 @@ TESTS_REQUIRE = [
     "tensorflow>=2.3,!=2.6.0,!=2.6.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "tiktoken;python_version>='3.8'",
-    "torch",
-    "torchaudio<0.12.0",
     "soundfile",
     "transformers",
     "zstandard",

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,8 @@ REQUIRED_PKGS = [
 ]
 
 AUDIO_REQUIRE = [
-    "soundfile>=0.12.1" "librosa",
+    "soundfile>=0.12.1",
+    "librosa",
 ]
 
 VISION_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ REQUIRED_PKGS = [
 ]
 
 AUDIO_REQUIRE = [
-    "librosa",
+    "soundfile>=0.12.1" "librosa",
 ]
 
 VISION_REQUIRE = [
@@ -175,7 +175,7 @@ TESTS_REQUIRE = [
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "tiktoken;python_version>='3.8'",
     "torch",
-    "soundfile",
+    "soundfile>=0.12.1",
     "transformers",
     "zstandard",
 ]

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ TESTS_REQUIRE = [
     "tensorflow>=2.3,!=2.6.0,!=2.6.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "tiktoken;python_version>='3.8'",
+    "torch",
     "soundfile",
     "transformers",
     "zstandard",

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -130,7 +130,12 @@ SQLALCHEMY_AVAILABLE = importlib.util.find_spec("sqlalchemy") is not None
 
 # Optional tools for feature decoding
 PIL_AVAILABLE = importlib.util.find_spec("PIL") is not None
-
+IS_OPUS_SUPPORTED = importlib.util.find_spec("soundfile") is not None and version.parse(
+    importlib.import_module("soundfile").__libsndfile_version__
+) >= version.parse("1.0.31")
+IS_MP3_SUPPORTED = importlib.util.find_spec("soundfile") is not None and version.parse(
+    importlib.import_module("soundfile").__libsndfile_version__
+) >= version.parse("1.1.0")
 
 # Optional compression tools
 RARFILE_AVAILABLE = importlib.util.find_spec("rarfile") is not None

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -252,16 +252,14 @@ class Audio:
         if format == "opus":
             if version.parse(sf.__libsndfile_version__) < version.parse("1.0.31"):
                 raise RuntimeError(
-                    "Decoding .opus files requires 'libsndfile'>=1.0.31, "
-                    "You can try to update `soundfile`: `pip install soundfile` or install `libsndfile` with your"
-                    "system package manager or compile it from source.`"
+                    "Decoding 'opus' files requires system library 'libsndfile'>=1.0.31, "
+                    'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
                 )
         if format == "mp3":
             if version.parse(sf.__libsndfile_version__) < version.parse("1.1.0"):
                 raise RuntimeError(
-                    "Decoding 'mp3' files requires 'libsndfile'>=1.1.0, "
-                    "You can try to update `soundfile`: `pip install soundfile` or install `libsndfile` with your"
-                    "system package manager or compile it from source.`"
+                    "Decoding 'mp3' files requires system library 'libsndfile'>=1.1.0, "
+                    'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
                 )
 
         if not is_file:

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union
 
 import numpy as np
 import pyarrow as pa
-from packaging import version
 
 from .. import config
 from ..download.streaming_download_manager import xopen
@@ -158,13 +157,13 @@ class Audio:
 
         audio_format = os.path.splitext(path)[1].lstrip(".").lower() if path is not None else None
         if audio_format == "opus":
-            if version.parse(sf.__libsndfile_version__) < version.parse("1.0.31"):
+            if not config.IS_OPUS_SUPPORTED:
                 raise RuntimeError(
                     "Decoding 'opus' files requires system library 'libsndfile'>=1.0.31, "
                     'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
                 )
         if audio_format == "mp3":
-            if version.parse(sf.__libsndfile_version__) < version.parse("1.1.0"):
+            if not config.IS_MP3_SUPPORTED:
                 raise RuntimeError(
                     "Decoding 'mp3' files requires system library 'libsndfile'>=1.1.0, "
                     'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -156,7 +156,7 @@ class Audio:
         except ImportError as err:
             raise ImportError("To support decoding audio files, please install 'librosa' and 'soundfile'.") from err
 
-        audio_format = path.split(".")[-1] if path is not None else None
+        audio_format = os.path.splitext(path)[1].lstrip(".").lower() if path is not None else None
         if audio_format == "opus":
             if version.parse(sf.__libsndfile_version__) < version.parse("1.0.31"):
                 raise RuntimeError(

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -165,7 +165,7 @@ class Audio:
             raise RuntimeError(
                 "Decoding 'mp3' files requires system library 'libsndfile'>=1.1.0, "
                 'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
-                )
+            )
 
         if file is None:
             token_per_repo_id = token_per_repo_id or {}

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -7,7 +7,7 @@ import numpy as np
 import pyarrow as pa
 
 from .. import config
-from ..download.streaming_download_manager import xopen
+from ..download.streaming_download_manager import xopen, xsplitext
 from ..table import array_cast
 from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
 

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -155,18 +155,16 @@ class Audio:
         except ImportError as err:
             raise ImportError("To support decoding audio files, please install 'librosa' and 'soundfile'.") from err
 
-        audio_format = os.path.splitext(path)[1].lstrip(".").lower() if path is not None else None
-        if audio_format == "opus":
-            if not config.IS_OPUS_SUPPORTED:
-                raise RuntimeError(
-                    "Decoding 'opus' files requires system library 'libsndfile'>=1.0.31, "
-                    'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
-                )
-        if audio_format == "mp3":
-            if not config.IS_MP3_SUPPORTED:
-                raise RuntimeError(
-                    "Decoding 'mp3' files requires system library 'libsndfile'>=1.1.0, "
-                    'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
+        audio_format = xsplitext(path)[1][1:].lower() if path is not None else None
+        if not config.IS_OPUS_SUPPORTED and audio_format == "opus":
+            raise RuntimeError(
+                "Decoding 'opus' files requires system library 'libsndfile'>=1.0.31, "
+                'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
+            )
+        elif not config.IS_MP3_SUPPORTED and audio_format == "mp3":
+            raise RuntimeError(
+                "Decoding 'mp3' files requires system library 'libsndfile'>=1.1.0, "
+                'You can try to update `soundfile` python library: `pip install "soundfile>=0.12.1"`. '
                 )
 
         if file is None:

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -640,9 +640,13 @@ class Pickler(dill.Pickler):
 
                     @pklregister(obj_type)
                     def _save_tensor(pickler, obj):
+                        # `torch.from_numpy` is not picklable in `torch>=1.11.0`
+                        def _create_tensor(np_array):
+                            return torch.from_numpy(np_array)
+
                         dill_log(pickler, f"To: {obj}")
                         args = (obj.detach().cpu().numpy(),)
-                        pickler.save_reduce(torch.from_numpy, args, obj=obj)
+                        pickler.save_reduce(_create_tensor, args, obj=obj)
                         dill_log(pickler, "# To")
                         return
 

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -8,7 +8,6 @@ from datasets import Dataset, concatenate_datasets, load_dataset
 from datasets.features import Audio, Features, Sequence, Value
 
 from ..utils import (
-    require_libsndfile_with_opus,
     require_sndfile,
 )
 
@@ -137,7 +136,7 @@ def test_audio_decode_example_mp3(shared_datadir):
     assert decoded_example["sampling_rate"] == 44100
 
 
-@require_libsndfile_with_opus
+@require_sndfile
 def test_audio_decode_example_opus(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_48000.opus")
     audio = Audio()

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -1,7 +1,5 @@
 import os
 import tarfile
-from contextlib import nullcontext
-from unittest.mock import patch
 
 import pyarrow as pa
 import pytest
@@ -12,9 +10,6 @@ from datasets.features import Audio, Features, Sequence, Value
 from ..utils import (
     require_libsndfile_with_opus,
     require_sndfile,
-    require_sox,
-    require_torchaudio,
-    require_torchaudio_latest,
 )
 
 
@@ -131,33 +126,15 @@ def test_audio_resampling(shared_datadir):
     assert decoded_example["sampling_rate"] == 16000
 
 
-@require_sox
-@require_torchaudio
+@require_sndfile
 def test_audio_decode_example_mp3(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_44100.mp3")
     audio = Audio()
     decoded_example = audio.decode_example(audio.encode_example(audio_path))
     assert decoded_example.keys() == {"path", "array", "sampling_rate"}
     assert decoded_example["path"] == audio_path
-    assert decoded_example["array"].shape == (109440,)
+    assert decoded_example["array"].shape == (110592,)
     assert decoded_example["sampling_rate"] == 44100
-
-
-@pytest.mark.torchaudio_latest
-@require_torchaudio_latest
-@pytest.mark.parametrize("torchaudio_failed", [False, True])
-def test_audio_decode_example_mp3_torchaudio_latest(shared_datadir, torchaudio_failed):
-    audio_path = str(shared_datadir / "test_audio_44100.mp3")
-    audio = Audio()
-
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
-        if torchaudio_failed:
-            load_mock.side_effect = RuntimeError()
-
-        decoded_example = audio.decode_example(audio.encode_example(audio_path))
-        assert decoded_example["path"] == audio_path
-        assert decoded_example["array"].shape == (110592,)
-        assert decoded_example["sampling_rate"] == 44100
 
 
 @require_libsndfile_with_opus
@@ -183,8 +160,7 @@ def test_audio_decode_example_pcm(shared_datadir, sampling_rate):
     assert decoded_example["sampling_rate"] == sampling_rate
 
 
-@require_sox
-@require_torchaudio
+@require_sndfile
 def test_audio_resampling_mp3_different_sampling_rates(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_44100.mp3")
     audio_path2 = str(shared_datadir / "test_audio_16000.mp3")
@@ -193,40 +169,14 @@ def test_audio_resampling_mp3_different_sampling_rates(shared_datadir):
     decoded_example = audio.decode_example(audio.encode_example(audio_path))
     assert decoded_example.keys() == {"path", "array", "sampling_rate"}
     assert decoded_example["path"] == audio_path
-    assert decoded_example["array"].shape == (119119,)
+    assert decoded_example["array"].shape == (120373,)
     assert decoded_example["sampling_rate"] == 48000
 
     decoded_example = audio.decode_example(audio.encode_example(audio_path2))
     assert decoded_example.keys() == {"path", "array", "sampling_rate"}
     assert decoded_example["path"] == audio_path2
-    assert decoded_example["array"].shape == (120960,)
+    assert decoded_example["array"].shape == (122688,)
     assert decoded_example["sampling_rate"] == 48000
-
-
-@pytest.mark.torchaudio_latest
-@require_torchaudio_latest
-@pytest.mark.parametrize("torchaudio_failed", [False, True])
-def test_audio_resampling_mp3_different_sampling_rates_torchaudio_latest(shared_datadir, torchaudio_failed):
-    audio_path = str(shared_datadir / "test_audio_44100.mp3")
-    audio_path2 = str(shared_datadir / "test_audio_16000.mp3")
-    audio = Audio(sampling_rate=48000)
-
-    # if torchaudio>=0.12 failed, mp3 must be decoded anyway (with librosa)
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
-        if torchaudio_failed:
-            load_mock.side_effect = RuntimeError()
-
-        decoded_example = audio.decode_example(audio.encode_example(audio_path))
-        assert decoded_example.keys() == {"path", "array", "sampling_rate"}
-        assert decoded_example["path"] == audio_path
-        assert decoded_example["array"].shape == (120373,)
-        assert decoded_example["sampling_rate"] == 48000
-
-        decoded_example = audio.decode_example(audio.encode_example(audio_path2))
-        assert decoded_example.keys() == {"path", "array", "sampling_rate"}
-        assert decoded_example["path"] == audio_path2
-        assert decoded_example["array"].shape == (122688,)
-        assert decoded_example["sampling_rate"] == 48000
 
 
 @require_sndfile
@@ -286,41 +236,8 @@ def test_dataset_with_audio_feature_tar_wav(tar_wav_path):
     assert column[0]["sampling_rate"] == 44100
 
 
-@require_sox
-@require_torchaudio
+@require_sndfile
 def test_dataset_with_audio_feature_tar_mp3(tar_mp3_path):
-    audio_filename = "test_audio_44100.mp3"
-    data = {"audio": []}
-    for file_path, file_obj in iter_archive(tar_mp3_path):
-        data["audio"].append({"path": file_path, "bytes": file_obj.read()})
-        break
-    features = Features({"audio": Audio()})
-    dset = Dataset.from_dict(data, features=features)
-    item = dset[0]
-    assert item.keys() == {"audio"}
-    assert item["audio"].keys() == {"path", "array", "sampling_rate"}
-    assert item["audio"]["path"] == audio_filename
-    assert item["audio"]["array"].shape == (109440,)
-    assert item["audio"]["sampling_rate"] == 44100
-    batch = dset[:1]
-    assert batch.keys() == {"audio"}
-    assert len(batch["audio"]) == 1
-    assert batch["audio"][0].keys() == {"path", "array", "sampling_rate"}
-    assert batch["audio"][0]["path"] == audio_filename
-    assert batch["audio"][0]["array"].shape == (109440,)
-    assert batch["audio"][0]["sampling_rate"] == 44100
-    column = dset["audio"]
-    assert len(column) == 1
-    assert column[0].keys() == {"path", "array", "sampling_rate"}
-    assert column[0]["path"] == audio_filename
-    assert column[0]["array"].shape == (109440,)
-    assert column[0]["sampling_rate"] == 44100
-
-
-@pytest.mark.torchaudio_latest
-@require_torchaudio_latest
-def test_dataset_with_audio_feature_tar_mp3_torchaudio_latest(tar_mp3_path):
-    # no test for librosa here because it doesn't support file-like objects, only paths
     audio_filename = "test_audio_44100.mp3"
     data = {"audio": []}
     for file_path, file_obj in iter_archive(tar_mp3_path):
@@ -410,8 +327,7 @@ def test_resampling_at_loading_dataset_with_audio_feature(shared_datadir):
     assert column[0]["sampling_rate"] == 16000
 
 
-@require_sox
-@require_torchaudio
+@require_sndfile
 def test_resampling_at_loading_dataset_with_audio_feature_mp3(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_44100.mp3")
     data = {"audio": [audio_path]}
@@ -421,56 +337,21 @@ def test_resampling_at_loading_dataset_with_audio_feature_mp3(shared_datadir):
     assert item.keys() == {"audio"}
     assert item["audio"].keys() == {"path", "array", "sampling_rate"}
     assert item["audio"]["path"] == audio_path
-    assert item["audio"]["array"].shape == (39707,)
+    assert item["audio"]["array"].shape == (40125,)
     assert item["audio"]["sampling_rate"] == 16000
     batch = dset[:1]
     assert batch.keys() == {"audio"}
     assert len(batch["audio"]) == 1
     assert batch["audio"][0].keys() == {"path", "array", "sampling_rate"}
     assert batch["audio"][0]["path"] == audio_path
-    assert batch["audio"][0]["array"].shape == (39707,)
+    assert batch["audio"][0]["array"].shape == (40125,)
     assert batch["audio"][0]["sampling_rate"] == 16000
     column = dset["audio"]
     assert len(column) == 1
     assert column[0].keys() == {"path", "array", "sampling_rate"}
     assert column[0]["path"] == audio_path
-    assert column[0]["array"].shape == (39707,)
+    assert column[0]["array"].shape == (40125,)
     assert column[0]["sampling_rate"] == 16000
-
-
-@pytest.mark.torchaudio_latest
-@require_torchaudio_latest
-@pytest.mark.parametrize("torchaudio_failed", [False, True])
-def test_resampling_at_loading_dataset_with_audio_feature_mp3_torchaudio_latest(shared_datadir, torchaudio_failed):
-    audio_path = str(shared_datadir / "test_audio_44100.mp3")
-    data = {"audio": [audio_path]}
-    features = Features({"audio": Audio(sampling_rate=16000)})
-    dset = Dataset.from_dict(data, features=features)
-
-    # if torchaudio>=0.12 failed, mp3 must be decoded anyway (with librosa)
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
-        if torchaudio_failed:
-            load_mock.side_effect = RuntimeError()
-
-        item = dset[0]
-        assert item.keys() == {"audio"}
-        assert item["audio"].keys() == {"path", "array", "sampling_rate"}
-        assert item["audio"]["path"] == audio_path
-        assert item["audio"]["array"].shape == (40125,)
-        assert item["audio"]["sampling_rate"] == 16000
-        batch = dset[:1]
-        assert batch.keys() == {"audio"}
-        assert len(batch["audio"]) == 1
-        assert batch["audio"][0].keys() == {"path", "array", "sampling_rate"}
-        assert batch["audio"][0]["path"] == audio_path
-        assert batch["audio"][0]["array"].shape == (40125,)
-        assert batch["audio"][0]["sampling_rate"] == 16000
-        column = dset["audio"]
-        assert len(column) == 1
-        assert column[0].keys() == {"path", "array", "sampling_rate"}
-        assert column[0]["path"] == audio_path
-        assert column[0]["array"].shape == (40125,)
-        assert column[0]["sampling_rate"] == 16000
 
 
 @require_sndfile
@@ -503,8 +384,7 @@ def test_resampling_after_loading_dataset_with_audio_feature(shared_datadir):
     assert column[0]["sampling_rate"] == 16000
 
 
-@require_sox
-@require_torchaudio
+@require_sndfile
 def test_resampling_after_loading_dataset_with_audio_feature_mp3(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_44100.mp3")
     data = {"audio": [audio_path]}
@@ -517,59 +397,21 @@ def test_resampling_after_loading_dataset_with_audio_feature_mp3(shared_datadir)
     assert item.keys() == {"audio"}
     assert item["audio"].keys() == {"path", "array", "sampling_rate"}
     assert item["audio"]["path"] == audio_path
-    assert item["audio"]["array"].shape == (39707,)
+    assert item["audio"]["array"].shape == (40125,)
     assert item["audio"]["sampling_rate"] == 16000
     batch = dset[:1]
     assert batch.keys() == {"audio"}
     assert len(batch["audio"]) == 1
     assert batch["audio"][0].keys() == {"path", "array", "sampling_rate"}
     assert batch["audio"][0]["path"] == audio_path
-    assert batch["audio"][0]["array"].shape == (39707,)
+    assert batch["audio"][0]["array"].shape == (40125,)
     assert batch["audio"][0]["sampling_rate"] == 16000
     column = dset["audio"]
     assert len(column) == 1
     assert column[0].keys() == {"path", "array", "sampling_rate"}
     assert column[0]["path"] == audio_path
-    assert column[0]["array"].shape == (39707,)
+    assert column[0]["array"].shape == (40125,)
     assert column[0]["sampling_rate"] == 16000
-
-
-@pytest.mark.torchaudio_latest
-@require_torchaudio_latest
-@pytest.mark.parametrize("torchaudio_failed", [False, True])
-def test_resampling_after_loading_dataset_with_audio_feature_mp3_torchaudio_latest(shared_datadir, torchaudio_failed):
-    audio_path = str(shared_datadir / "test_audio_44100.mp3")
-    data = {"audio": [audio_path]}
-    features = Features({"audio": Audio()})
-    dset = Dataset.from_dict(data, features=features)
-
-    # if torchaudio>=0.12 failed, mp3 must be decoded anyway (with librosa)
-    with patch("torchaudio.load") if torchaudio_failed else nullcontext() as load_mock:
-        if torchaudio_failed:
-            load_mock.side_effect = RuntimeError()
-
-        item = dset[0]
-        assert item["audio"]["sampling_rate"] == 44100
-        dset = dset.cast_column("audio", Audio(sampling_rate=16000))
-        item = dset[0]
-        assert item.keys() == {"audio"}
-        assert item["audio"].keys() == {"path", "array", "sampling_rate"}
-        assert item["audio"]["path"] == audio_path
-        assert item["audio"]["array"].shape == (40125,)
-        assert item["audio"]["sampling_rate"] == 16000
-        batch = dset[:1]
-        assert batch.keys() == {"audio"}
-        assert len(batch["audio"]) == 1
-        assert batch["audio"][0].keys() == {"path", "array", "sampling_rate"}
-        assert batch["audio"][0]["path"] == audio_path
-        assert batch["audio"][0]["array"].shape == (40125,)
-        assert batch["audio"][0]["sampling_rate"] == 16000
-        column = dset["audio"]
-        assert len(column) == 1
-        assert column[0].keys() == {"path", "array", "sampling_rate"}
-        assert column[0]["path"] == audio_path
-        assert column[0]["array"].shape == (40125,)
-        assert column[0]["sampling_rate"] == 16000
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,10 +6,8 @@ import tempfile
 import unittest
 from contextlib import contextmanager
 from copy import deepcopy
-from ctypes.util import find_library
 from distutils.util import strtobool
 from enum import Enum
-from importlib import import_module
 from importlib.util import find_spec
 from pathlib import Path
 from unittest.mock import patch
@@ -56,31 +54,8 @@ require_zstandard = pytest.mark.skipif(not config.ZSTANDARD_AVAILABLE, reason="t
 # Audio
 require_sndfile = pytest.mark.skipif(
     # On Windows and OS X, soundfile installs sndfile
-    (sys.platform != "linux" and find_spec("soundfile") is None)
-    # On Linux, soundfile throws RuntimeError if sndfile OS dependency not installed with distribution package manager
-    or (sys.platform == "linux" and find_library("sndfile") is None),
-    reason="test requires sndfile: 'pip install soundfile'; "
-    "on Linux, test requires sndfile OS dependency: 'sudo apt-get install libsndfile1'",
-)
-require_libsndfile_with_opus = pytest.mark.skipif(
-    version.parse(import_module("soundfile").__libsndfile_version__) < version.parse("1.0.30")
-    if (sys.platform != "linux" and find_spec("soundfile")) or (sys.platform == "linux" and find_library("sndfile"))
-    else True,
-    reason="test requires libsndfile>=1.0.30: 'conda install -c conda-forge libsndfile>=1.0.30'",
-)
-require_sox = pytest.mark.skipif(
-    find_library("sox") is None,
-    reason="test requires sox OS dependency; only available on non-Windows: 'sudo apt-get install sox'",
-)
-require_torchaudio = pytest.mark.skipif(
-    find_spec("torchaudio") is None
-    or version.parse(importlib_metadata.version("torchaudio")) >= version.parse("0.12.0"),
-    reason="test requires torchaudio<0.12",
-)
-require_torchaudio_latest = pytest.mark.skipif(
-    find_spec("torchaudio") is None
-    or version.parse(importlib_metadata.version("torchaudio")) < version.parse("0.12.0"),
-    reason="test requires torchaudio>=0.12",
+    find_spec("soundfile") is None or version.parse(importlib_metadata.version("soundfile")) < version.parse("0.12.0"),
+    reason="test requires sndfile>=0.12.1: 'pip install \"soundfile>=0.12.1\"'; ",
 )
 
 # Beam


### PR DESCRIPTION
I've removed `torchaudio` completely and switched to use `soundfile` for everything. With the new version of `soundfile` package this should work smoothly because the `libsndfile` C library is bundled, in Linux wheels too. 

Let me know if you think it's too harsh and we should continue to support `torchaudio` decoding.

I decided that we can drop it completely because:
1. it's always something wrong with `torchaudio` (for example recently https://github.com/huggingface/datasets/issues/5488 )
2. the results of mp3 decoding are different depending on `torchaudio` version 
3. `soundfile` is slightly faster then the latest `torchaudio`
4. anyway users can pass any custom decoding function with any library they want if needed (worth putting a snippet in the docs).

cc @sanchit-gandhi @vaibhavad  