### PR TITLE
 Add instructions to create `DataLoader` from augmented dataset in object detection guide

### DIFF
--- a/docs/source/object_detection.mdx
+++ b/docs/source/object_detection.mdx
@@ -158,6 +158,32 @@ You can verify the transform works by visualizing the 10th example:
     <img src="https://huggingface.co/datasets/nateraw/documentation-images/resolve/main/visualize_detection_example_transformed_2.png">
 </div>
 
+Finally, if you wish to create a [`torch.utils.data.DataLoader`](https://alband.github.io/doc_view/data.html?highlight=torch%20utils%20data%20dataloader#torch.utils.data.DataLoader), you can do so as follows:
+
+```py
+>>> from torch.utils.data import DataLoader
+
+# `transforms` already collates our data in batches
+# so we only pass along the batch
+>>> def collate_fn(batch):
+...     return batch
+
+>>> loader = DataLoader(ds['train'], batch_size=8, collate_fn=collate_fn)
+>>> example = next(iter(loader))[0]
+>>> to_pil_image(
+...     draw_bounding_boxes(
+...         example['image'],
+...         box_convert(example['bbox'], 'xywh', 'xyxy'),
+...         colors='red',
+...         labels=[categories.int2str(x) for x in example['category']]
+...     )
+... )
+```
+
+<div class="flex justify-center">
+    <img src="https://huggingface.co/datasets/nateraw/documentation-images/resolve/main/visualize_detection_example_transformed.png">
+</div>
+
 <Tip>
 
 Now that you know how to process a dataset for object detection, learn


### PR DESCRIPTION
The following adds instructions on how to create a `DataLoader` from the guide on how to use object detection with augmentations (#4710).

 I don't know if this is really the recommended way to create a `Dataloader` from a `Dataset` whose `Dataset.set_transform` is set. The added instructions could be simplified, since the main issue lies in the quirky `collate_fn`, which is necessary due to the behavior of the `transforms` function.

For example, the following works out of the box:
```py
>>> loader = DataLoader(ds['train'], batch_size=1)
>>> next(iter(loader))
{'image': tensor([[[[ 78,  78,  78,  ...,  86,  86,  86],
          [ 78,  78,  78,  ...,  85,  85,  85],
          [ 78,  78,  78,  ...,  84,  84,  84],
          ...,
          [  0,   0,   0,  ...,  41,  47,  52],
          [  0,   0,   0,  ...,  44,  49,  53],
          [ 12,   0,   0,  ...,  48,  50,  53]],

         [[ 79,  79,  79,  ...,  94,  94,  94],
          [ 79,  79,  79,  ...,  93,  93,  93],
          [ 79,  79,  79,  ...,  92,  92,  92],
          ...,
          [  0,   0,   0,  ...,  24,  30,  32],
          [  0,   0,   0,  ...,  28,  32,  34],
          [ 13,   0,   0,  ...,  31,  33,  34]],

         [[ 82,  82,  82,  ..., 101, 101, 101],
          [ 82,  82,  82,  ..., 100, 100, 100],
          [ 82,  82,  82,  ...,  99,  99,  99],
          ...,
          [  2,   5,   0,  ...,   0,   0,   0],
          [  0,   0,   0,  ...,   0,   0,   1],
          [ 19,   0,   0,  ...,   0,   0,   1]]]], dtype=torch.uint8), 'bbox': tensor([[[289.1198,  78.9140,  37.1580,  37.6471],
         [ 38.6850,  72.3982,  29.0138,  20.2715],
         [272.3224,  22.4434, 126.2354, 445.9729],
         [  0.0000,  49.2308, 102.8208, 290.3167]]], dtype=torch.float64), 'category': [tensor([4]), tensor([4]), tensor([0]), tensor([0])]}
```

But this doesn't:
```py
>>> loader = DataLoader(ds['train'], batch_size=2)
>>> next(iter(loader))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 628, in __next__
    data = self._next_data()
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 671, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 61, in fetch
    return self.collate_fn(data)
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/_utils/collate.py", line 265, in default_collate
    return collate(batch, collate_fn_map=default_collate_fn_map)
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/_utils/collate.py", line 128, in collate
    return elem_type({key: collate([d[key] for d in batch], collate_fn_map=collate_fn_map) for key in elem})
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/_utils/collate.py", line 128, in <dictcomp>
    return elem_type({key: collate([d[key] for d in batch], collate_fn_map=collate_fn_map) for key in elem})
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/_utils/collate.py", line 120, in collate
    return collate_fn_map[elem_type](batch, collate_fn_map=collate_fn_map)
  File "/home/laurent/.local/lib/python3.8/site-packages/torch/utils/data/_utils/collate.py", line 163, in collate_tensor_fn
    return torch.stack(batch, 0, out=out)
RuntimeError: stack expects each tensor to be equal size, but got [4, 4] at entry 0 and [11, 4] at entry 1
```

My solution is to define a "dummy" `collate_fn`:
```py
>>> def collate_fn(batch):
...     return batch
>>> loader = DataLoader(ds['train'], batch_size=2, collate_fn=collate_fn)
>>> next(iter(loader))
[{'image': tensor([[[100, 100, 100,  ..., 107, 107, 107],
         [100, 100, 100,  ..., 106, 106, 106],
         [100, 100, 100,  ..., 105, 105, 105],
         ...,
         [ 25,  28,  23,  ...,  67,  72,  77],
         [ 18,  16,  18,  ...,  70,  74,  78],
         [ 40,  22,  17,  ...,  73,  75,  78]],

        [[101, 101, 101,  ..., 114, 114, 114],
         [101, 101, 101,  ..., 113, 113, 113],
         [101, 101, 101,  ..., 112, 112, 112],
         ...,
         [ 26,  29,  24,  ...,  52,  57,  59],
         [ 19,  17,  19,  ...,  55,  59,  61],
         [ 41,  23,  18,  ...,  58,  60,  61]],

        [[103, 103, 103,  ..., 120, 120, 120],
         [103, 103, 103,  ..., 119, 119, 119],
         [103, 103, 103,  ..., 118, 118, 118],
         ...,
         [ 31,  34,  29,  ...,  22,  25,  29],
         [ 24,  22,  24,  ...,  25,  27,  30],
         [ 47,  27,  22,  ...,  28,  28,  30]]], dtype=torch.uint8), 'bbox': tensor([[289.1198,  78.9140,  37.1580,  37.6471],
        [ 38.6850,  72.3982,  29.0138,  20.2715],
        [272.3224,  22.4434, 126.2354, 445.9729],
        [  0.0000,  49.2308, 102.8208, 290.3167]], dtype=torch.float64), 'category': [4, 4, 0, 0]}, {'image': tensor([[[255, 255, 255,  ..., 255, 255, 255],
         [255, 255, 255,  ..., 255, 255, 255],
         [255, 255, 255,  ..., 255, 255, 255],
         ...,
         [ 92,  95,  93,  ...,  85,  81,  85],
         [ 93,  94,  95,  ...,  82,  85,  84],
         [ 93,  92,  94,  ...,  86,  84,  87]],

        [[255, 255, 255,  ..., 255, 255, 255],
         [255, 255, 255,  ..., 255, 255, 255],
         [255, 255, 255,  ..., 255, 255, 255],
         ...,
         [136, 139, 137,  ..., 122, 122, 124],
         [137, 138, 138,  ..., 119, 124, 123],
         [137, 137, 138,  ..., 123, 124, 126]],

        [[255, 255, 255,  ..., 255, 255, 255],
         [255, 255, 255,  ..., 255, 255, 255],
         [255, 255, 255,  ..., 255, 255, 255],
         ...,
         [191, 195, 190,  ..., 172, 172, 175],
         [191, 193, 191,  ..., 170, 173, 175],
         [192, 190, 191,  ..., 173, 173, 178]]], dtype=torch.uint8), 'bbox': tensor([[411.1843, 157.6502,  29.9199,  40.6943],
        [332.7516, 154.7664,  37.3998,  32.0427],
        [230.8103, 154.7664,  26.5004,  30.1202],
        [349.4212, 259.8665,  31.6296,  28.8385],
        [403.7044, 289.9866,  14.9599,   8.0107],
        [381.6919, 290.9479,  24.7907,  30.7610],
        [305.8237, 237.7570,  24.1496,  29.1589],
        [277.3998, 243.8451,  32.0570,  39.0921],
        [395.5833, 164.0587,  84.2030, 217.5701],
        [225.6812, 165.0200,  60.4809,  81.7089],
        [237.4354, 135.8611,  38.4684,  26.2750]], dtype=torch.float64), 'category': [4, 4, 4, 2, 2, 2, 2, 2, 0, 0, 3]}]
```

These instructions appears to be sub-optimal since it involves adding "boilerplate code". I am open to hearing any suggestions for improvement !