### PR TITLE
Support cloud storage in load_dataset via fsspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ EXTRAS_REQUIRE = {
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
     "jax": ["jax>=0.2.8,!=0.3.2,<=0.3.25", "jaxlib>=0.1.65,<=0.3.25"],
+    "gcsfs": ["gcsfs"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -230,8 +230,6 @@ EXTRAS_REQUIRE = {
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
     "jax": ["jax>=0.2.8,!=0.3.2,<=0.3.25", "jaxlib>=0.1.65,<=0.3.25"],
-    "gcs": ["gcsfs"],
-    "gs": ["gcsfs"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,8 @@ EXTRAS_REQUIRE = {
     "tensorflow_gpu": ["tensorflow-gpu>=2.2.0,!=2.6.0,!=2.6.1"],
     "torch": ["torch"],
     "jax": ["jax>=0.2.8,!=0.3.2,<=0.3.25", "jaxlib>=0.1.65,<=0.3.25"],
-    "gcsfs": ["gcsfs"],
+    "gcs": ["gcsfs"],
+    "gs": ["gcsfs"],
     "s3": ["s3fs"],
     "streaming": [],  # for backward compatibility
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE + DOCS_REQUIRE,

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -330,24 +330,24 @@ def _request_with_retry(
 
 def fsspec_head(url, timeout=10.0):
     _raise_if_offline_mode_is_enabled(f"Tried to reach {url}")
-    fs, _, paths = fsspec.get_fs_token_paths(url)
+    fs, _, paths = fsspec.get_fs_token_paths(url, storage_options={"requests_timeout": timeout})
     if len(paths) > 1:
-        raise ValueError("HEAD can be called with at most one path but was called with {paths}")
-    return fs.info(paths[0], timeout=timeout)
+        raise ValueError(f"HEAD can be called with at most one path but was called with {paths}")
+    return fs.info(paths[0])
 
 
 def fsspec_get(url, temp_file, timeout=10.0, desc=None):
     _raise_if_offline_mode_is_enabled(f"Tried to reach {url}")
-    fs, _, paths = fsspec.get_fs_token_paths(url)
+    fs, _, paths = fsspec.get_fs_token_paths(url, storage_options={"requests_timeout": timeout})
     if len(paths) > 1:
-        raise ValueError("GET can be called with at most one path but was called with {paths}")
+        raise ValueError(f"GET can be called with at most one path but was called with {paths}")
     callback = fsspec.callbacks.TqdmCallback(
         tqdm_kwargs={
             "desc": desc or "Downloading",
             "disable": logging.is_progress_bar_enabled(),
         }
     )
-    fs.get(paths[0], temp_file, timeout=timeout, callback=callback)
+    fs.get_file(paths[0], temp_file.name, callback=callback)
 
 
 def ftp_head(url, timeout=10.0):

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -500,7 +500,6 @@ def get_from_cache(
             connected = ftp_head(url)
         elif scheme not in ("http", "https"):
             response = fsspec_head(url)
-            # use the hash of the response as a pseudo ETag to detect changes
             # s3fs uses "ETag", gcsfs uses "etag"
             etag = (response.get("ETag", None) or response.get("etag", None)) if use_etag else None
             connected = True

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -344,7 +344,7 @@ def fsspec_get(url, temp_file, timeout=10.0, desc=None):
     callback = fsspec.callbacks.TqdmCallback(
         tqdm_kwargs={
             "desc": desc or "Downloading",
-            "disable": logging.is_progress_bar_enabled(),
+            "disable": not logging.is_progress_bar_enabled(),
         }
     )
     fs.get_file(paths[0], temp_file.name, callback=callback)

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -501,7 +501,8 @@ def get_from_cache(
         elif scheme not in ("http", "https"):
             response = fsspec_head(url)
             # use the hash of the response as a pseudo ETag to detect changes
-            etag = json.dumps(response, sort_keys=True) if use_etag else None
+            # s3fs uses "ETag", gcsfs uses "etag"
+            etag = (response.get("ETag", None) or response.get("etag", None)) if use_etag else None
             connected = True
         try:
             response = http_head(

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -40,6 +40,10 @@ class MockFileSystem(AbstractFileSystem):
         out["name"] = out["name"][len(self.local_root_dir) :]
         return out
 
+    def get_file(self, rpath, lpath, *args, **kwargs):
+        rpath = posixpath.join(self.local_root_dir, self._strip_protocol(rpath))
+        return self._fs.get_file(rpath, lpath, *args, **kwargs)
+
     def cp_file(self, path1, path2, *args, **kwargs):
         path1 = posixpath.join(self.local_root_dir, self._strip_protocol(path1))
         path2 = posixpath.join(self.local_root_dir, self._strip_protocol(path2))

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -36,10 +36,10 @@ def zstd_path(tmp_path_factory):
 
 
 @pytest.fixture
-def mockfs_file(mockfs):
-    with open(os.path.join(mockfs.local_root_dir, FILE_PATH), "w") as f:
+def tmpfs_file(tmpfs):
+    with open(os.path.join(tmpfs.local_root_dir, FILE_PATH), "w") as f:
         f.write(FILE_CONTENT)
-    return mockfs
+    return FILE_PATH
 
 
 @pytest.mark.parametrize("compression_format", ["gzip", "xz", "zstd"])
@@ -99,13 +99,11 @@ def test_cached_path_missing_local(tmp_path):
         cached_path(missing_file)
 
 
-def test_get_from_cache_fsspec(mockfs_file):
-    with patch("datasets.utils.file_utils.fsspec.get_fs_token_paths") as mock_get_fs_token_paths:
-        mock_get_fs_token_paths.return_value = (mockfs_file, "", [FILE_PATH])
-        output_path = get_from_cache("mock://huggingface.co")
-        with open(output_path) as f:
-            output_file_content = f.read()
-        assert output_file_content == FILE_CONTENT
+def test_get_from_cache_fsspec(tmpfs_file):
+    output_path = get_from_cache(f"tmp://{tmpfs_file}")
+    with open(output_path) as f:
+        output_file_content = f.read()
+    assert output_file_content == FILE_CONTENT
 
 
 @patch("datasets.config.HF_DATASETS_OFFLINE", True)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -6,7 +6,16 @@ import pytest
 import zstandard as zstd
 
 from datasets.download.download_config import DownloadConfig
-from datasets.utils.file_utils import OfflineModeIsEnabled, cached_path, ftp_get, ftp_head, http_get, http_head
+from datasets.utils.file_utils import (
+    OfflineModeIsEnabled,
+    cached_path,
+    fsspec_get,
+    fsspec_head,
+    ftp_get,
+    ftp_head,
+    http_get,
+    http_head,
+)
 
 
 FILE_CONTENT = """\
@@ -102,3 +111,12 @@ def test_ftp_offline(tmp_path_factory):
         ftp_get("ftp://huggingface.co", temp_file=filename)
     with pytest.raises(OfflineModeIsEnabled):
         ftp_head("ftp://huggingface.co")
+
+
+@patch("datasets.config.HF_DATASETS_OFFLINE", True)
+def test_fsspec_offline(tmp_path_factory):
+    filename = tmp_path_factory.mktemp("data") / "file.html"
+    with pytest.raises(OfflineModeIsEnabled):
+        fsspec_get("s3://huggingface.co", temp_file=filename)
+    with pytest.raises(OfflineModeIsEnabled):
+        fsspec_head("s3://huggingface.co")

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -28,7 +28,7 @@ FILE_PATH = "file"
 
 @pytest.fixture(scope="session")
 def zstd_path(tmp_path_factory):
-    path = tmp_path_factory.mktemp("data") / FILE_PATH
+    path = tmp_path_factory.mktemp("data") / (FILE_PATH + ".zstd")
     data = bytes(FILE_CONTENT, "utf-8")
     with zstd.open(path, "wb") as f:
         f.write(data)


### PR DESCRIPTION
Closes https://github.com/huggingface/datasets/issues/5281

This PR uses fsspec to support datasets on cloud storage (tested manually with GCS). ETags are currently unsupported for cloud storage. In general, a much larger refactor could be done to just use fsspec for all schemes (ftp, http/s, s3, gcs) to unify the interfaces here, but I ultimately opted to leave that out of this PR

I didn't create a GCS filesystem class in `datasets.filesystems` since the S3 one appears to be a wrapper around `s3fs.S3FileSystem` and mainly used to generate docs.