### PR TITLE
Do no write index by default when exporting a dataset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ TESTS_REQUIRE = [
     "lz4",
     "py7zr",
     "rarfile>=4.0",
+    "sqlalchemy<2.0.0",
     "s3fs>=2021.11.1;python_version<'3.8'",  # aligned with fsspec[http]>=2021.11.1; test only on python 3.7 for now
     "tensorflow>=2.3,!=2.6.0,!=2.6.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
@@ -196,7 +197,6 @@ METRICS_TESTS_REQUIRE = [
     "scipy",
     "sentencepiece",  # for bleurt
     "seqeval",
-    "sqlalchemy<2.0.0",
     "spacy>=3.0.0",
     "tldextract",
     # to speed up pip backtracking

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4597,7 +4597,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         path_or_buf: Union[PathLike, BinaryIO],
         batch_size: Optional[int] = None,
         num_proc: Optional[int] = None,
-        index: bool = False,
         **to_csv_kwargs,
     ) -> int:
         """Exports the dataset to csv
@@ -4613,19 +4612,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 use multiprocessing. `batch_size` in this case defaults to
                 `datasets.config.DEFAULT_MAX_BATCH_SIZE` but feel free to make it 5x or 10x of the default
                 value if you have sufficient compute power.
-            index (`bool`, default `False`): Write row names (index).
+            **to_csv_kwargs (additional keyword arguments):
+                Parameters to pass to pandas's [`pandas.DataFrame.to_csv`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html).
 
                 <Changed version="2.10.0">
 
-                Now, `index` defaults to `False`.
+                Now, `index` defaults to `False` if not specified.
 
-                If you would like to write the index, set it to `True` and also set a name for the index column by
+                If you would like to write the index, pass `index=True` and also set a name for the index column by
                 passing `index_label`.
 
                 </Changed>
-
-            **to_csv_kwargs (additional keyword arguments):
-                Parameters to pass to pandas's `pandas.DataFrame.to_csv`.
 
         Returns:
             `int`: The number of characters or bytes written.
@@ -4639,9 +4636,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Dynamic import to avoid circular dependency
         from .io.csv import CsvDatasetWriter
 
-        return CsvDatasetWriter(
-            self, path_or_buf, batch_size=batch_size, num_proc=num_proc, index=index, **to_csv_kwargs
-        ).write()
+        return CsvDatasetWriter(self, path_or_buf, batch_size=batch_size, num_proc=num_proc, **to_csv_kwargs).write()
 
     def to_dict(self, batch_size: Optional[int] = None, batched: bool = False) -> Union[dict, Iterator[dict]]:
         """Returns the dataset as a Python dict. Can also return a generator for large datasets.
@@ -4699,21 +4694,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 use multiprocessing. `batch_size` in this case defaults to
                 `datasets.config.DEFAULT_MAX_BATCH_SIZE` but feel free to make it 5x or 10x of the default
                 value if you have sufficient compute power.
-            lines (`bool`, defaults to `True`):
-                Whether output JSON lines format.
-                Only possible if `orient="records"`. It will throw ValueError with `orient` different from
-                `"records"`, since the others are not list-like.
-            orient (`str`, defaults to `"records"`):
-                Format of the JSON:
-
-                - `"records"`: list like `[{column -> value}, … , {column -> value}]`
-                - `"split"`: dict like `{"index" -> [index], "columns" -> [columns], "data" -> [values]}`
-                - `"index"`: dict like `{index -> {column -> value}}`
-                - `"columns"`: dict like `{column -> {index -> value}}`
-                - `"values"`: just the values array
-                - `"table"`: dict like `{"schema": {schema}, "data": {data}}`
             **to_json_kwargs (additional keyword arguments):
                 Parameters to pass to pandas's [`pandas.DataFrame.to_json`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html).
+
+                <Changed version="2.11.0">
+
+                Now, `index` defaults to `False` if `orint` is  `"split"` or `"table"` is  specified.
+
+                If you would like to write the index, pass `index=True`.
+
+                </Changed>
 
         Returns:
             `int`: The number of characters or bytes written.
@@ -4817,7 +4807,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Size of the batch to load in memory and write at once.
                 Defaults to `datasets.config.DEFAULT_MAX_BATCH_SIZE`.
             **sql_writer_kwargs (additional keyword arguments):
-                Parameters to pass to pandas's [`Dataframe.to_sql`].
+                Parameters to pass to pandas's [`pandas.DataFrame.to_sql`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_sql.html).
+
+                <Changed version="2.11.0">
+
+                Now, `index` defaults to `False` if not specified.
+
+                If you would like to write the index, pass `index=True` and also set a name for the index column by
+                passing `index_label`.
+
+                </Changed>
 
         Returns:
             `int`: The number of records written.

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -188,7 +188,7 @@ class TestJsonDatasetWriter:
         "orient, container, keys, len_at",
         [
             ("records", list, {"tokens", "labels", "answers", "id"}, None),
-            ("split", dict, {"index", "columns", "data"}, "data"),
+            ("split", dict, {"columns", "data"}, "data"),
             ("index", dict, set("0123456789"), None),
             ("columns", dict, {"tokens", "labels", "answers", "id"}, "tokens"),
             ("values", list, None, None),
@@ -227,7 +227,7 @@ class TestJsonDatasetWriter:
         "orient, container, keys, len_at",
         [
             ("records", list, {"tokens", "labels", "answers", "id"}, None),
-            ("split", dict, {"index", "columns", "data"}, "data"),
+            ("split", dict, {"columns", "data"}, "data"),
             ("index", dict, set("0123456789"), None),
             ("columns", dict, {"tokens", "labels", "answers", "id"}, "tokens"),
             ("values", list, None, None),

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -66,7 +66,7 @@ def test_dataset_to_sql(sqlite_path, tmp_path):
     cache_dir = tmp_path / "cache"
     output_sqlite_path = os.path.join(cache_dir, "tmp.sql")
     dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
-    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, index=False, num_proc=1).write()
+    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=1).write()
 
     original_sql = iter_sql_file(sqlite_path)
     expected_sql = iter_sql_file(output_sqlite_path)
@@ -80,7 +80,7 @@ def test_dataset_to_sql_multiproc(sqlite_path, tmp_path):
     cache_dir = tmp_path / "cache"
     output_sqlite_path = os.path.join(cache_dir, "tmp.sql")
     dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
-    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, index=False, num_proc=2).write()
+    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=2).write()
 
     original_sql = iter_sql_file(sqlite_path)
     expected_sql = iter_sql_file(output_sqlite_path)
@@ -95,4 +95,4 @@ def test_dataset_to_sql_invalidproc(sqlite_path, tmp_path):
     output_sqlite_path = os.path.join(cache_dir, "tmp.sql")
     dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
     with pytest.raises(ValueError):
-        SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, index=False, num_proc=0).write()
+        SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=0).write()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2259,7 +2259,7 @@ class BaseDatasetTest(TestCase):
             # Destionation specified as database URI string
             with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 file_path = os.path.join(tmp_dir, "test_path.sqlite")
-                _ = dset.to_sql("data", "sqlite:///" + file_path, index=False)
+                _ = dset.to_sql("data", "sqlite:///" + file_path)
 
                 self.assertTrue(os.path.isfile(file_path))
                 sql_dset = pd.read_sql("data", "sqlite:///" + file_path)
@@ -2273,7 +2273,7 @@ class BaseDatasetTest(TestCase):
 
                 file_path = os.path.join(tmp_dir, "test_path.sqlite")
                 with contextlib.closing(sqlite3.connect(file_path)) as con:
-                    _ = dset.to_sql("data", con, index=False, if_exists="replace")
+                    _ = dset.to_sql("data", con, if_exists="replace")
 
                 self.assertTrue(os.path.isfile(file_path))
                 sql_dset = pd.read_sql("data", "sqlite:///" + file_path)
@@ -2284,7 +2284,7 @@ class BaseDatasetTest(TestCase):
             # Test writing to a database in chunks
             with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 file_path = os.path.join(tmp_dir, "test_path.sqlite")
-                _ = dset.to_sql("data", "sqlite:///" + file_path, batch_size=1, index=False, if_exists="replace")
+                _ = dset.to_sql("data", "sqlite:///" + file_path, batch_size=1, if_exists="replace")
 
                 self.assertTrue(os.path.isfile(file_path))
                 sql_dset = pd.read_sql("data", "sqlite:///" + file_path)
@@ -2296,7 +2296,7 @@ class BaseDatasetTest(TestCase):
             with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
                 dset = dset.select(range(0, len(dset), 2)).shuffle()
                 file_path = os.path.join(tmp_dir, "test_path.sqlite")
-                _ = dset.to_sql("data", "sqlite:///" + file_path, index=False, if_exists="replace")
+                _ = dset.to_sql("data", "sqlite:///" + file_path, if_exists="replace")
 
                 self.assertTrue(os.path.isfile(file_path))
                 sql_dset = pd.read_sql("data", "sqlite:///" + file_path)
@@ -2307,7 +2307,7 @@ class BaseDatasetTest(TestCase):
             # With array features
             with self._create_dummy_dataset(in_memory, tmp_dir, array_features=True) as dset:
                 file_path = os.path.join(tmp_dir, "test_path.sqlite")
-                _ = dset.to_sql("data", "sqlite:///" + file_path, index=False, if_exists="replace")
+                _ = dset.to_sql("data", "sqlite:///" + file_path, if_exists="replace")
 
                 self.assertTrue(os.path.isfile(file_path))
                 sql_dset = pd.read_sql("data", "sqlite:///" + file_path)


### PR DESCRIPTION
Ensures all the writers that use Pandas for conversion (JSON, CSV, SQL) do not export `index` by default (https://github.com/huggingface/datasets/pull/5490 only did this for CSV)