### PR TITLE
Fix `sort` with indices mapping

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3994,7 +3994,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         sort_table = query_table(
             table=self._data,
-            key=range(self._data.num_rows),
+            key=slice(0, len(self)),
             indices=self._indices if self._indices is not None else None,
         )
 


### PR DESCRIPTION
Fixes the `key` range in the `query_table` call in `sort` to account for an indices mapping

Fix #5586 