### PR TITLE
Revert "pass the dataset features to the IterableDataset.from_generator"

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4974,9 +4974,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 self.shard(num_shards=num_shards, index=shard_idx, contiguous=True) for shard_idx in range(num_shards)
             ]
         )
-        return IterableDataset.from_generator(
-            Dataset._iter_shards, features=self.features, gen_kwargs={"shards": shards}
-        )
+        return IterableDataset.from_generator(Dataset._iter_shards, gen_kwargs={"shards": shards})
 
     def _push_parquet_shards_to_hub(
         self,


### PR DESCRIPTION
This reverts commit b91070b9c09673e2e148eec458036ab6a62ac042 (temporarily)

It hurts iterable dataset performance a lot (e.g. x4 slower because it encodes+decodes images unnecessarily). I think we need to fix this before re-adding it

cc @mariosasko @Hubert-Bonisseur 