### PR TITLE
Fix push_to_hub with no dataset_infos

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5271,8 +5271,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             )
             dataset_metadata = DatasetMetadata.from_readme(Path(dataset_readme_path))
             dataset_infos: DatasetInfosDict = DatasetInfosDict.from_metadata(dataset_metadata)
-            repo_info = dataset_infos[next(iter(dataset_infos))]
-        # get the deprecated dataset_infos.json to uodate them
+            if dataset_infos:
+                repo_info = dataset_infos[next(iter(dataset_infos))]
+            else:
+                repo_info = None
+        # get the deprecated dataset_infos.json to update them
         elif config.DATASETDICT_INFOS_FILENAME in repo_files:
             dataset_metadata = DatasetMetadata()
             download_config = DownloadConfig()
@@ -5284,7 +5287,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             )
             with open(dataset_infos_path, encoding="utf-8") as f:
                 dataset_infos: DatasetInfosDict = json.load(f)
-                repo_info = DatasetInfo.from_dict(dataset_infos[next(iter(dataset_infos))])
+                if dataset_infos:
+                    repo_info = DatasetInfo.from_dict(dataset_infos[next(iter(dataset_infos))])
+                else:
+                    repo_info = None
         else:
             dataset_metadata = DatasetMetadata()
             repo_info = None

--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -403,7 +403,7 @@ class DatasetInfo:
 
 
 class DatasetInfosDict(Dict[str, DatasetInfo]):
-    def write_to_directory(self, dataset_infos_dir, overwrite=False, pretty_print=False):
+    def write_to_directory(self, dataset_infos_dir, overwrite=False, pretty_print=False) -> None:
         total_dataset_infos = {}
         dataset_infos_path = os.path.join(dataset_infos_dir, config.DATASETDICT_INFOS_FILENAME)
         dataset_readme_path = os.path.join(dataset_infos_dir, "README.md")
@@ -427,7 +427,7 @@ class DatasetInfosDict(Dict[str, DatasetInfo]):
             dataset_metadata.to_readme(Path(dataset_readme_path))
 
     @classmethod
-    def from_directory(cls, dataset_infos_dir):
+    def from_directory(cls, dataset_infos_dir) -> "DatasetInfosDict":
         logger.info(f"Loading Dataset Infos from {dataset_infos_dir}")
         # Load the info from the YAML part of README.md
         if os.path.exists(os.path.join(dataset_infos_dir, "README.md")):
@@ -447,7 +447,7 @@ class DatasetInfosDict(Dict[str, DatasetInfo]):
             return cls()
 
     @classmethod
-    def from_metadata(cls, dataset_metadata: DatasetMetadata):
+    def from_metadata(cls, dataset_metadata: DatasetMetadata) -> "DatasetInfosDict":
         if isinstance(dataset_metadata.get("dataset_info"), (list, dict)):
             if isinstance(dataset_metadata["dataset_info"], list):
                 return cls(


### PR DESCRIPTION
As reported in https://github.com/vijaydwivedi75/lrgb/issues/10, `push_to_hub` fails if the remote repository already exists and has a README.md without `dataset_info` in the YAML tags

cc @clefourrier 