### PR TITLE
Don't compute checksums if not necessary in `datasets-cli test`

### DIFF
--- a/src/datasets/commands/test.py
+++ b/src/datasets/commands/test.py
@@ -140,7 +140,9 @@ class TestCommand(BaseDatasetsCLICommand):
 
         for j, builder in enumerate(get_builders()):
             print(f"Testing builder '{builder.config.name}' ({j + 1}/{n_builders})")
-            builder._record_infos = True
+            builder._record_infos = os.path.exists(
+                os.path.join(builder.get_imported_module_dir(), datasets.config.DATASETDICT_INFOS_FILENAME)
+            )  # record checksums only if we need to update a (deprecated) dataset_infos.json
             builder.download_and_prepare(
                 download_mode=DownloadMode.REUSE_CACHE_IF_EXISTS
                 if not self._force_redownload


### PR DESCRIPTION
we only need them if there exists a `dataset_infos.json`