### PR TITLE
Remove set_access_token usage + fail tests if FutureWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 license_file = LICENSE
 
 [tool:pytest]
+# -Werror::FutureWarning -> test fails if a FutureWarning is thrown
+addopts = -Werror::FutureWarning
 markers =
     unit: unit test
     integration: integration test

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,9 @@
 license_file = LICENSE
 
 [tool:pytest]
-# -Werror::FutureWarning -> test fails if a FutureWarning is thrown
-addopts = -Werror::FutureWarning
+# Test fails if a FutureWarning is thrown by `huggingface_hub`
+filterwarnings =
+    error::FutureWarning:huggingface_hub*
 markers =
     unit: unit test
     integration: integration test

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -39,12 +39,9 @@ def ci_hub_token_path(monkeypatch):
 
 @pytest.fixture
 def set_ci_hub_access_token(ci_hub_config, ci_hub_token_path):
-    _api = HfApi(endpoint=CI_HUB_ENDPOINT)
-    _api.set_access_token(CI_HUB_USER_TOKEN)
     HfFolder.save_token(CI_HUB_USER_TOKEN)
     yield
     HfFolder.delete_token()
-    _api.unset_access_token()
 
 
 @pytest.fixture(scope="session")
@@ -54,14 +51,10 @@ def hf_api():
 
 @pytest.fixture(scope="session")
 def hf_token(hf_api: HfApi):
-    hf_api.set_access_token(CI_HUB_USER_TOKEN)
+    previous_token = HfFolder.get_token()
     HfFolder.save_token(CI_HUB_USER_TOKEN)
-
     yield CI_HUB_USER_TOKEN
-    try:
-        hf_api.unset_access_token()
-    except requests.exceptions.HTTPError:
-        pass
+    HfFolder.save_token(previous_token)
 
 
 @pytest.fixture

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -54,7 +54,8 @@ def hf_token(hf_api: HfApi):
     previous_token = HfFolder.get_token()
     HfFolder.save_token(CI_HUB_USER_TOKEN)
     yield CI_HUB_USER_TOKEN
-    HfFolder.save_token(previous_token)
+    if previous_token is not None:
+        HfFolder.save_token(previous_token)
 
 
 @pytest.fixture


### PR DESCRIPTION
`set_access_token` is deprecated and will be removed in `huggingface_hub>=0.14`.

This PR removes it from the tests (it was not used in `datasets` source code itself). FYI, it was not needed since `set_access_token` was just setting git credentials and `datasets` doesn't seem to use git anywhere.

In the future, use `set_git_credential` if needed. It is a git-credential-agnostic helper, i.e. you can store your git token in `git-credential-cache`, `git-credential-store`, `osxkeychain`, etc. The legacy `set_access_token` could only set in `git-credential-store` no matter the user preference.

(for context, I found out about this while working on https://github.com/huggingface/huggingface_hub/pull/1381)

---

In addition to this, I have added

```
filterwarnings =
    error::FutureWarning:huggingface_hub*
```

to the `setup.cfg` config file to fail on future warnings from `huggingface_hub`. In `hfh`'s CI we trigger on FutureWarning from any package but it's less robust (any package update leads can lead to a failure). No obligation to keep it like that (I can remove it if you prefer) but I think it's a good idea in order to track future FutureWarnings.

FYI, in `huggingface_hub` tests we use `-Werror::FutureWarning --log-cli-level=INFO -sv --durations=0`
- FutureWarning are processed as error
- verbose mode / INFO logs (and above) are captured for easier debugging in github report
- track each test duration, just to see where we can improve. We have a quite long CI (~10min) so it helped improve that.