### PR TITLE
add kwargs to index search

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -190,7 +190,7 @@ class ElasticSearchIndex(BaseIndex):
         response = self.es_client.search(
             index=self.es_index_name,
             body={"query": {"multi_match": {"query": query, "fields": ["text"], "type": "cross_fields"}}, "size": k},
-            **kwargs
+            **kwargs,
         )
         hits = response["hits"]["hits"]
         return SearchResults([hit["_score"] for hit in hits], [int(hit["_id"]) for hit in hits])
@@ -686,7 +686,9 @@ class IndexableMixin:
         self._check_index_is_initialized(index_name)
         return self._indexes[index_name].search(query, k, **kwargs)
 
-    def search_batch(self, index_name: str, queries: Union[List[str], np.array], k: int = 10, **kwargs) -> BatchedSearchResults:
+    def search_batch(
+        self, index_name: str, queries: Union[List[str], np.array], k: int = 10, **kwargs
+    ) -> BatchedSearchResults:
         """Find the nearest examples indices in the dataset to the query.
 
         Args:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -188,10 +188,26 @@ class ElasticSearchIndexTest(TestCase):
             self.assertEqual(scores[0], 1)
             self.assertEqual(indices[0], 0)
 
+            # single query with timeout
+            query = "foo"
+            mocked_search.return_value = {"hits": {"hits": [{"_score": 1, "_id": 0}]}}
+            scores, indices = index.search(query, request_timeout=30)
+            self.assertEqual(scores[0], 1)
+            self.assertEqual(indices[0], 0)
+
             # batched queries
             queries = ["foo", "bar", "foobar"]
             mocked_search.return_value = {"hits": {"hits": [{"_score": 1, "_id": 1}]}}
             total_scores, total_indices = index.search_batch(queries)
+            best_scores = [scores[0] for scores in total_scores]
+            best_indices = [indices[0] for indices in total_indices]
+            self.assertGreater(np.min(best_scores), 0)
+            self.assertListEqual([1, 1, 1], best_indices)
+
+            # batched queries with timeout
+            queries = ["foo", "bar", "foobar"]
+            mocked_search.return_value = {"hits": {"hits": [{"_score": 1, "_id": 1}]}}
+            total_scores, total_indices = index.search_batch(queries, request_timeout=30)
             best_scores = [scores[0] for scores in total_scores]
             best_indices = [indices[0] for indices in total_indices]
             self.assertGreater(np.min(best_scores), 0)


### PR DESCRIPTION
This PR proposes to add kwargs to index search methods.

This is particularly useful for setting the timeout of a query on elasticsearch.

A typical use case would be:
```python
dset.add_elasticsearch_index("filename", es_client=es_client)
scores, examples = dset.get_nearest_examples("filename", "my_name-train_29", request_timeout=60)
```