### PR TITLE
adds early exit if url is `PathLike`

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -62,6 +62,8 @@ def init_hf_modules(hf_modules_cache: Optional[Union[Path, str]] = None) -> str:
 
 
 def is_remote_url(url_or_filename: str) -> bool:
+    if isinstance(url_or_filename, os.PathLike):
+        return False
     parsed = urlparse(url_or_filename)
     return parsed.scheme in ("http", "https", "s3", "gs", "hdfs", "ftp")
 


### PR DESCRIPTION
Closes #4864 

Should fix errors thrown when attempting to load `json` dataset using `pathlib.Path` in `data_files` argument.