### PR TITLE
Pass custom metadata filename to Image/Audio folders

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -27,6 +27,7 @@ class FolderBasedBuilderConfig(datasets.BuilderConfig):
     features: Optional[datasets.Features] = None
     drop_labels: bool = None
     drop_metadata: bool = None
+    metadata_filename: str = None
 
 
 class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
@@ -57,6 +58,9 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         if not self.config.data_files:
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+
+        if self.config.metadata_filename:
+            self.METADATA_FILENAMES = [self.config.metadata_filename]
 
         # Do an early pass if:
         # * `drop_labels` is None (default) or False, to infer the class labels
@@ -117,7 +121,6 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                 logger.info(f"Searching for labels and/or metadata files in {split_name} data files...")
                 analyze(files, downloaded_files, split_name)
                 analyze(archives, downloaded_dirs, split_name)
-
                 if metadata_files:
                     # add metadata if `metadata_files` are found and `drop_metadata` is None (default) or False
                     add_metadata = not self.config.drop_metadata


### PR DESCRIPTION
This is a quick fix. 
Now it requires to pass data via `data_files` parameters and include a required metadata file there and pass its filename as `metadata_filename` parameter.
For example, with the structure like:
```
data
   images_dir/
      im1.jpg
      im2.jpg
      ...
   metadata_dir/
      meta_file1.jsonl
      meta_file2.jsonl
      ...
```
to load data with `metadata_file1.jsonl` do:
```python
ds = load_dataset("imagefolder", data_files=["data/images_dir/**", "data/metadata_dir/meta_file1.jsonl"], metadata_filename="meta_file1.jsonl")
```