### PR TITLE
Fix CI: ignore C901 ("some_func" is to complex) in `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         stages: [commit]
         args: ["--config", "pyproject.toml", "tests", "src", "benchmarks", "metrics"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.247'
+    rev: 'v0.0.255'
     hooks:
     - id: ruff
       stages: [commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ target_version = ['py37']
 # Ignored rules:
 #   "E501" -> line length violation
 #   "F821" -> undefined named in type annotation (e.g. Literal["something"])
-#   "C901" -> `function_name` is too complex (introduced in version 0.0.255)
+#   "C901" -> `function_name` is too complex
 ignore = ["E501", "F821", "C901"]
 select = ["C", "E", "F", "I", "W"]
 line-length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.black]
 line-length = 119
 target_version = ['py37']
-ignore = ["C901"]
 
 [tool.ruff]
 # Ignored rules:
 #   "E501" -> line length violation
 #   "F821" -> undefined named in type annotation (e.g. Literal["something"])
+#   "C901" -> `function_name` is too complex (introduced in version 0.0.255)
 ignore = ["E501", "F821", "C901"]
 select = ["C", "E", "F", "I", "W"]
 line-length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [tool.black]
 line-length = 119
 target_version = ['py37']
+ignore = ["C901"]
 
 [tool.ruff]
 # Ignored rules:
 #   "E501" -> line length violation
 #   "F821" -> undefined named in type annotation (e.g. Literal["something"])
-ignore = ["E501", "F821"]
+ignore = ["E501", "F821", "C901"]
 select = ["C", "E", "F", "I", "W"]
 line-length = 119
 


### PR DESCRIPTION
idk if I should have added this ignore to `ruff` too, but I added :) 