### PR TITLE
Support PyArrow arrays as column values in `from_dict`

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1808,6 +1808,22 @@ class Features(dict):
         example = cast_to_python_objects(example)
         return encode_nested_example(self, example)
 
+    def encode_column(self, column, column_name: str):
+        """
+        Encode column into a format for Arrow.
+
+        Args:
+            column (`list[Any]`):
+                Data in a Dataset column.
+            column_name (`str`):
+                Dataset column name.
+
+        Returns:
+            `list[Any]`
+        """
+        column = cast_to_python_objects(column)
+        return [encode_nested_example(self[column_name], obj) for obj in column]
+
     def encode_batch(self, batch):
         """
         Encode batch into a format for Arrow.

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2867,36 +2867,48 @@ class MiscellaneousDatasetTest(TestCase):
         self.assertRaises(TypeError, Dataset.from_pandas, df, features=features)
 
     def test_from_dict(self):
-        data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}
+        data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"], "col_3": pa.array([True, False, True, False])}
         with Dataset.from_dict(data) as dset:
             self.assertListEqual(dset["col_1"], data["col_1"])
             self.assertListEqual(dset["col_2"], data["col_2"])
-            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
-            self.assertDictEqual(dset.features, Features({"col_1": Value("int64"), "col_2": Value("string")}))
+            self.assertListEqual(dset["col_3"], data["col_3"].to_pylist())
+            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2", "col_3"])
+            self.assertDictEqual(
+                dset.features, Features({"col_1": Value("int64"), "col_2": Value("string"), "col_3": Value("bool")})
+            )
 
-        features = Features({"col_1": Value("int64"), "col_2": Value("string")})
+        features = Features({"col_1": Value("int64"), "col_2": Value("string"), "col_3": Value("bool")})
         with Dataset.from_dict(data, features=features) as dset:
             self.assertListEqual(dset["col_1"], data["col_1"])
             self.assertListEqual(dset["col_2"], data["col_2"])
-            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
-            self.assertDictEqual(dset.features, Features({"col_1": Value("int64"), "col_2": Value("string")}))
+            self.assertListEqual(dset["col_3"], data["col_3"].to_pylist())
+            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2", "col_3"])
+            self.assertDictEqual(
+                dset.features, Features({"col_1": Value("int64"), "col_2": Value("string"), "col_3": Value("bool")})
+            )
 
-        features = Features({"col_1": Value("int64"), "col_2": Value("string")})
+        features = Features({"col_1": Value("int64"), "col_2": Value("string"), "col_3": Value("bool")})
         with Dataset.from_dict(data, features=features, info=DatasetInfo(features=features)) as dset:
             self.assertListEqual(dset["col_1"], data["col_1"])
             self.assertListEqual(dset["col_2"], data["col_2"])
-            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
-            self.assertDictEqual(dset.features, Features({"col_1": Value("int64"), "col_2": Value("string")}))
+            self.assertListEqual(dset["col_3"], data["col_3"].to_pylist())
+            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2", "col_3"])
+            self.assertDictEqual(
+                dset.features, Features({"col_1": Value("int64"), "col_2": Value("string"), "col_3": Value("bool")})
+            )
 
-        features = Features({"col_1": Value("string"), "col_2": Value("string")})
+        features = Features({"col_1": Value("string"), "col_2": Value("string"), "col_3": Value("int32")})
         with Dataset.from_dict(data, features=features) as dset:
             # the integers are converted to strings
             self.assertListEqual(dset["col_1"], [str(x) for x in data["col_1"]])
             self.assertListEqual(dset["col_2"], data["col_2"])
-            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2"])
-            self.assertDictEqual(dset.features, Features({"col_1": Value("string"), "col_2": Value("string")}))
+            self.assertListEqual(dset["col_3"], [int(x) for x in data["col_3"].to_pylist()])
+            self.assertListEqual(list(dset.features.keys()), ["col_1", "col_2", "col_3"])
+            self.assertDictEqual(
+                dset.features, Features({"col_1": Value("string"), "col_2": Value("string"), "col_3": Value("int32")})
+            )
 
-        features = Features({"col_1": Value("int64"), "col_2": Value("int64")})
+        features = Features({"col_1": Value("int64"), "col_2": Value("int64"), "col_3": Value("bool")})
         self.assertRaises(ValueError, Dataset.from_dict, data, features=features)
 
     def test_concatenate_mixed_memory_and_disk(self):


### PR DESCRIPTION
For consistency with `pa.Table.from_pydict`, which supports both Python lists and PyArrow arrays as column values.

"Fixes" https://discuss.huggingface.co/t/pyarrow-lib-floatarray-did-not-recognize-python-value-type-when-inferring-an-arrow-data-type/33417