### PR TITLE
Improve features decoding in to_iterable_dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -88,7 +88,7 @@ from .fingerprint import (
     update_fingerprint,
     validate_fingerprint,
 )
-from .formatting import format_table, get_format_type_from_alias, get_formatter, query_table
+from .formatting import PythonFormatter, format_table, get_format_type_from_alias, get_formatter, query_table
 from .formatting.formatting import LazyDict, _is_range_contiguous
 from .info import DatasetInfo, DatasetInfosDict
 from .naming import _split_re
@@ -4874,9 +4874,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return dataset_nbytes
 
     @staticmethod
-    def _iter_shards(shards: List["Dataset"]):
-        for shard in shards:
-            yield from shard
+    def _generate_examples_from_shards(shards: List["Dataset"]):
+        python_formatter = PythonFormatter()
+        for shards_idx, shard in enumerate(shards):
+            example_idx = 0
+            for pa_table in shard.with_format("arrow").iter(config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER):
+                batch = python_formatter.format_batch(pa_table)
+                for i in range(len(pa_table)):
+                    example = {col: array[i] for col, array in batch.items()}
+                    yield f"{shards_idx}_{example_idx}", example
+                    example_idx += 1
 
     def to_iterable_dataset(self, num_shards: Optional[int] = 1) -> "IterableDataset":
         """Get an [`datasets.IterableDataset`] from a map-style [`datasets.Dataset`].
@@ -4969,8 +4976,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         Feel free to also use [`IterableDataset.set_epoch`] when using a PyTorch DataLoader or in distributed setups.
         """
-        from .iterable_dataset import IterableDataset
+        from .iterable_dataset import ExamplesIterable, IterableDataset
 
+        if self._format_type is not None:
+            raise NotImplementedError(
+                "Converting a formatted dataset to a formatted iterable dataset is not implemented yet. Please run `my_dataset = my_dataset.with_format(None)` before calling to_iterable_dataset"
+            )
         if num_shards > len(self):
             raise ValueError(
                 f"Unable to shard a dataset of size {len(self)} into {num_shards} shards (the number of shards exceeds the number of samples)."
@@ -4987,9 +4998,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 self.shard(num_shards=num_shards, index=shard_idx, contiguous=True) for shard_idx in range(num_shards)
             ]
         )
-        return IterableDataset.from_generator(
-            Dataset._iter_shards, features=self.features, gen_kwargs={"shards": shards}
-        )
+        ex_iterable = ExamplesIterable(Dataset._generate_examples_from_shards, kwargs={"shards": shards})
+        return IterableDataset(ex_iterable, info=DatasetInfo(features=self.features))
 
     def _push_parquet_shards_to_hub(
         self,

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -218,7 +218,7 @@ class PandasArrowExtractor(BaseArrowExtractor[pd.DataFrame, pd.Series, pd.DataFr
 
 
 class PythonFeaturesDecoder:
-    def __init__(self, features: Features):
+    def __init__(self, features: Optional[Features]):
         self.features = features
 
     def decode_row(self, row: dict) -> dict:
@@ -232,7 +232,7 @@ class PythonFeaturesDecoder:
 
 
 class PandasFeaturesDecoder:
-    def __init__(self, features: Features):
+    def __init__(self, features: Optional[Features]):
         self.features = features
 
     def decode_row(self, row: pd.DataFrame) -> pd.DataFrame:
@@ -396,7 +396,7 @@ class Formatter(Generic[RowFormat, ColumnFormat, BatchFormat]):
     numpy_arrow_extractor = NumpyArrowExtractor
     pandas_arrow_extractor = PandasArrowExtractor
 
-    def __init__(self, features=None):
+    def __init__(self, features: Optional[Features] = None):
         self.features = features
         self.python_features_decoder = PythonFeaturesDecoder(self.features)
         self.pandas_features_decoder = PandasFeaturesDecoder(self.features)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4309,16 +4309,20 @@ def test_dataset_estimate_nbytes():
     assert 0.9 * ds._estimate_nbytes() < 100 * 100, "must be smaller than one chunk"
 
 
-def test_dataset_to_iterable_dataset(dataset):
+def test_dataset_to_iterable_dataset(dataset: Dataset):
     iterable_dataset = dataset.to_iterable_dataset()
     assert isinstance(iterable_dataset, IterableDataset)
     assert list(iterable_dataset) == list(dataset)
+    assert iterable_dataset.features == dataset.features
     iterable_dataset = dataset.to_iterable_dataset(num_shards=3)
     assert isinstance(iterable_dataset, IterableDataset)
     assert list(iterable_dataset) == list(dataset)
+    assert iterable_dataset.features == dataset.features
     assert iterable_dataset.n_shards == 3
     with pytest.raises(ValueError):
         dataset.to_iterable_dataset(num_shards=len(dataset) + 1)
+    with pytest.raises(NotImplementedError):
+        dataset.with_format("torch").to_iterable_dataset()
 
 
 @pytest.mark.parametrize("batch_size", [1, 4])


### PR DESCRIPTION
Following discussion at https://github.com/huggingface/datasets/pull/5589

Right now `to_iterable_dataset` on images/audio hurts iterable dataset performance a lot (e.g. x4 slower because it encodes+decodes images/audios unnecessarily).

I fixed it by providing a generator that yields undecoded examples