### PR TITLE
Fix `fsspec.open` when using an HTTP proxy

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -440,7 +440,10 @@ def _prepare_http_url_kwargs(url: str, use_auth_token: Optional[Union[str, bool]
 
     In particular it resolves google drive URLs and it adds the authentication headers for the Hugging Face Hub.
     """
-    kwargs = {"headers": get_authentication_headers_for_url(url, use_auth_token=use_auth_token)}
+    kwargs = {
+        "headers": get_authentication_headers_for_url(url, use_auth_token=use_auth_token),
+        "client_kwargs": {"trust_env": True},  # Enable reading proxy env variables.
+    }
     if "drive.google.com" in url:
         response = http_head(url)
         cookies = None

--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -42,6 +42,7 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
             client_kwargs={
                 "requote_redirect_url": False,  # see https://github.com/huggingface/datasets/pull/5459
                 "trust_env": True,  # Enable reading proxy env variables.
+                **(target_options or {}).pop("client_kwargs", {}),  # To avoid issues if it was already passed.
             },
             **(target_options or {}),
         )

--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -39,7 +39,10 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
             mode="rb",
             protocol=target_protocol,
             compression=self.compression,
-            client_kwargs={"requote_redirect_url": False},  # see https://github.com/huggingface/datasets/pull/5459
+            client_kwargs={
+                "requote_redirect_url": False,  # see https://github.com/huggingface/datasets/pull/5459
+                "trust_env": True,  # Enable reading proxy env variables.
+            },
             **(target_options or {}),
         )
         self.compressed_name = os.path.basename(self.file.path.split("::")[0])

--- a/src/datasets/filesystems/hffilesystem.py
+++ b/src/datasets/filesystems/hffilesystem.py
@@ -66,6 +66,7 @@ class HfFileSystem(AbstractFileSystem):
             url,
             mode=mode,
             headers=get_authentication_headers_for_url(url, use_auth_token=self.token),
+            client_kwargs={"trust_env": True},  # Enable reading proxy env variables.
         ).open()
 
     def info(self, path, **kwargs):


### PR DESCRIPTION
Most HTTP(S) downloads from this library support proxy automatically by reading the `HTTP_PROXY` environment variable (et al.) because `requests` is widely used. However, in some parts of the code, `fsspec` is used, which in turn uses `aiohttp` for HTTP(S) requests (as opposed to `requests`), which in turn doesn't support reading proxy env variables by default. This PR enables reading them automatically.

Read [aiohttp docs on using proxies](https://docs.aiohttp.org/en/stable/client_advanced.html?highlight=trust_env#proxy-support).

For context, [the Python library requests](https://requests.readthedocs.io/en/latest/user/advanced/?highlight=http_proxy#proxies) and [the official Python library via `urllib.urlopen` support this automatically by default](https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen). Many (most common ones?) programs also do the same, including cURL, APT, Wget, and many others.