### PR TITLE
Fix CI by temporarily pinning tensorflow < 2.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ TESTS_REQUIRE = [
     "rarfile>=4.0",
     "sqlalchemy<2.0.0",
     "s3fs>=2021.11.1;python_version<'3.8'",  # aligned with fsspec[http]>=2021.11.1; test only on python 3.7 for now
-    "tensorflow>=2.3,!=2.6.0,!=2.6.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "tensorflow>=2.3,!=2.6.0,!=2.6.1,<2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'",  # temporary pin: see https://github.com/huggingface/datasets/issues/5663
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "tiktoken;python_version>='3.8'",
     "torch",


### PR DESCRIPTION
As a hotfix for our CI, temporarily pin `tensorflow` upper version:
- In Python 3.10, tensorflow-2.12.0 also installs `jax`

Fix #5663

Until root cause is fixed.