### PR TITLE
Fix a description error for interleave_datasets.

### DIFF
--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -88,7 +88,7 @@ def interleave_datasets(
         [0, 10, 20, 1, 11, 21, 2, 12, 22]
         >>> dataset = interleave_datasets([d1, d2, d3], stopping_strategy="all_exhausted")
         >>> dataset["a"]
-        [0, 10, 20, 1, 11, 21, 2, 12, 22, 0, 13, 23, 1, 0, 24]
+        [0, 10, 20, 1, 11, 21, 2, 12, 22, 0, 13, 23, 1, 10, 24]
         >>> dataset = interleave_datasets([d1, d2, d3], probabilities=[0.7, 0.2, 0.1], seed=42)
         >>> dataset["a"]
         [10, 0, 11, 1, 2]


### PR DESCRIPTION
There is a description mistake in the annotation of interleave_dataset with "all_exhausted" stopping_strategy.
``` python
d1 = Dataset.from_dict({"a": [0, 1, 2]})
d2 = Dataset.from_dict({"a": [10, 11, 12, 13]})
d3 = Dataset.from_dict({"a": [20, 21, 22, 23, 24]})
dataset = interleave_datasets([d1, d2, d3], stopping_strategy="all_exhausted")
```
According to the interleave way, the correct output of `dataset["a"]` is `[0, 10, 20, 1, 11, 21, 2, 12, 22, 0, 13, 23, 1, 10, 24]`, not `[0, 10, 20, 1, 11, 21, 2, 12, 22, 0, 13, 23, 1, 0, 24]`