### PR TITLE
Support streaming Beam datasets from HF GCS preprocessed data

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1245,9 +1245,6 @@ class DatasetBuilder:
         split: Optional[str] = None,
         base_path: Optional[str] = None,
     ) -> Union[Dict[str, IterableDataset], IterableDataset]:
-        if not isinstance(self, (GeneratorBasedBuilder, ArrowBasedBuilder)):
-            raise ValueError(f"Builder {self.name} is not streamable.")
-
         is_local = not is_remote_filesystem(self._fs)
         if not is_local:
             raise NotImplementedError(

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -2100,7 +2100,7 @@ class BeamBasedBuilder(DatasetBuilder):
     def _get_examples_iterable_for_split(self, split: str) -> ExamplesIterable:
         return ExamplesIterable(self._generate_examples_from_hf_gcs, {"split": split})
 
-    def _generate_examples_from_hf_gcs(self, split):  # , split_name):
+    def _generate_examples_from_hf_gcs(self, split):
         import pyarrow as pa
 
         from .download.streaming_download_manager import xopen

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Mapping, Optional, Tuple, Union
 
 import fsspec
+import pyarrow as pa
 from multiprocess import Pool
 from tqdm.contrib.concurrent import thread_map
 
@@ -50,7 +51,7 @@ from .dataset_dict import DatasetDict, IterableDatasetDict
 from .download.download_config import DownloadConfig
 from .download.download_manager import DownloadManager, DownloadMode
 from .download.mock_download_manager import MockDownloadManager
-from .download.streaming_download_manager import StreamingDownloadManager
+from .download.streaming_download_manager import StreamingDownloadManager, xopen
 from .features import Features
 from .filesystems import is_remote_filesystem
 from .fingerprint import Hasher
@@ -2101,10 +2102,6 @@ class BeamBasedBuilder(DatasetBuilder):
         return ExamplesIterable(self._generate_examples_from_hf_gcs, {"split": split})
 
     def _generate_examples_from_hf_gcs(self, split):
-        import pyarrow as pa
-
-        from .download.streaming_download_manager import xopen
-
         remote_prepared_filename = f"{self._remote_cache_dir_from_hf_gcs}/{self.name}-{split}.arrow"
         with xopen(remote_prepared_filename, "rb") as f:
             with pa.ipc.open_stream(f) as reader:

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -2114,7 +2114,7 @@ class BeamBasedBuilder(DatasetBuilder):
     def _request_info_from_hf_gcs(self):
         from .download.streaming_download_manager import xopen
 
-        remote_dataset_info = f"{self._remote_cache_dir_from_hf_gcs}/dataset_info.json"
+        remote_dataset_info = f"{self._remote_cache_dir_from_hf_gcs}/{config.DATASET_INFO_FILENAME}"
         try:
             with xopen(remote_dataset_info) as f:
                 import json
@@ -2126,5 +2126,5 @@ class BeamBasedBuilder(DatasetBuilder):
 
     @property
     def _remote_cache_dir_from_hf_gcs(self):
-        relative_data_dir = self._relative_data_dir(with_version=True, with_hash=False)
+        relative_data_dir = self._relative_data_dir(with_hash=False)
         return HF_GCP_BASE_URL + "/" + relative_data_dir.replace(os.sep, "/")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -938,7 +938,7 @@ def test_builder_as_streaming_dataset(tmp_path):
 
 @require_beam
 def test_beam_based_builder_as_streaming_dataset(tmp_path):
-    builder = DummyBeamBasedBuilder(cache_dir=tmp_path, beam_runner="DirectRunner")
+    builder = DummyBeamBasedBuilder(cache_dir=tmp_path)
     check_streaming(builder)
     with pytest.raises(DatasetNotOnHfGcsError):
         builder.as_streaming_dataset()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -15,6 +15,7 @@ import pytest
 from multiprocess.pool import Pool
 
 from datasets.arrow_dataset import Dataset
+from datasets.arrow_reader import DatasetNotOnHfGcsError
 from datasets.arrow_writer import ArrowWriter
 from datasets.builder import ArrowBasedBuilder, BeamBasedBuilder, BuilderConfig, DatasetBuilder, GeneratorBasedBuilder
 from datasets.dataset_dict import DatasetDict, IterableDatasetDict
@@ -933,6 +934,14 @@ def test_builder_as_streaming_dataset(tmp_path):
     dset = dummy_builder.as_streaming_dataset(split="train")
     assert isinstance(dset, IterableDataset)
     assert len(list(dset)) == 100
+
+
+@require_beam
+def test_beam_based_builder_as_streaming_dataset(tmp_path):
+    builder = DummyBeamBasedBuilder(cache_dir=tmp_path, beam_runner="DirectRunner")
+    check_streaming(builder)
+    with pytest.raises(DatasetNotOnHfGcsError):
+        builder.as_streaming_dataset()
 
 
 def _run_test_builder_streaming_works_in_subprocesses(builder):

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -64,31 +64,28 @@ class TestDatasetOnHfGcp(TestCase):
                 hash=dataset_module.hash,
             )
 
-            dataset_info_url = os.path.join(
-                HF_GCP_BASE_URL, builder_instance._relative_data_dir(with_hash=False), config.DATASET_INFO_FILENAME
-            ).replace(os.sep, "/")
+            dataset_info_url = "/".join(
+                [HF_GCP_BASE_URL, builder_instance._relative_data_dir(with_hash=False), config.DATASET_INFO_FILENAME]
+            )
             datset_info_path = cached_path(dataset_info_url, cache_dir=tmp_dir)
             self.assertTrue(os.path.exists(datset_info_path))
 
 
 @pytest.mark.integration
-def test_wikipedia_frr(tmp_path_factory):
+def test_as_dataset_from_hf_gcs(tmp_path_factory):
     tmp_dir = tmp_path_factory.mktemp("test_hf_gcp") / "test_wikipedia_simple"
     dataset_module = dataset_module_factory("wikipedia", cache_dir=tmp_dir)
-
-    builder_cls = import_main_class(dataset_module.module_path, dataset=True)
-
+    builder_cls = import_main_class(dataset_module.module_path)
     builder_instance: DatasetBuilder = builder_cls(
         cache_dir=tmp_dir,
         config_name="20220301.frr",
         hash=dataset_module.hash,
     )
-
     # use the HF cloud storage, not the original download_and_prepare that uses apache-beam
     builder_instance._download_and_prepare = None
     builder_instance.download_and_prepare()
     ds = builder_instance.as_dataset()
-    assert ds is not None
+    assert ds
 
 
 @pytest.mark.integration

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -65,7 +65,11 @@ class TestDatasetOnHfGcp(TestCase):
             )
 
             dataset_info_url = "/".join(
-                [HF_GCP_BASE_URL, builder_instance._relative_data_dir(with_hash=False), config.DATASET_INFO_FILENAME]
+                [
+                    HF_GCP_BASE_URL,
+                    builder_instance._relative_data_dir(with_hash=False).replace(os.sep, "/"),
+                    config.DATASET_INFO_FILENAME,
+                ]
             )
             datset_info_path = cached_path(dataset_info_url, cache_dir=tmp_dir)
             self.assertTrue(os.path.exists(datset_info_path))


### PR DESCRIPTION
This PR implements streaming Apache Beam datasets that are already preprocessed by us and stored in the HF Google Cloud Storage:
- natural_questions
- wiki40b
- wikipedia

This is done by streaming from the prepared Arrow files in HF Google Cloud Storage.

This will fix their corresponding dataset viewers. Related to:
- https://github.com/huggingface/datasets-server/pull/988#discussion_r1150767138

Related to:
- https://huggingface.co/datasets/natural_questions/discussions/4
- https://huggingface.co/datasets/wiki40b/discussions/2
- https://huggingface.co/datasets/wikipedia/discussions/9

CC: @severo 