### PR TITLE
Fix xnumpy_load for .npz files

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -774,8 +774,7 @@ def xnumpy_load(filepath_or_buffer, *args, use_auth_token: Optional[Union[str, b
         return np.load(filepath_or_buffer, *args, **kwargs)
     else:
         filepath_or_buffer = str(filepath_or_buffer)
-        with xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token) as f:
-            return np.load(f, *args, **kwargs)
+        return np.load(xopen(filepath_or_buffer, "rb", use_auth_token=use_auth_token), *args, **kwargs)
 
 
 def xpandas_read_csv(filepath_or_buffer, use_auth_token: Optional[Union[str, bool]] = None, **kwargs):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -18,6 +18,7 @@ from datasets.download.streaming_download_manager import (
     xisfile,
     xjoin,
     xlistdir,
+    xnumpy_load,
     xopen,
     xPath,
     xrelpath,
@@ -914,3 +915,19 @@ def test_iter_files(data_dir_with_hidden_files):
     for num_file, file in enumerate(dl_manager.iter_files(data_dir_with_hidden_files), start=1):
         assert os.path.basename(file) == ("test.txt" if num_file == 1 else "train.txt")
     assert num_file == 2
+
+
+def test_xnumpy_load(tmp_path):
+    import numpy as np
+
+    expected_x = np.arange(10)
+    npy_path = tmp_path / "data-x.npy"
+    np.save(npy_path, expected_x)
+    x = xnumpy_load(npy_path)
+    assert np.array_equal(x, expected_x)
+
+    npz_path = tmp_path / "data.npz"
+    np.savez(npz_path, x=expected_x)
+    with xnumpy_load(npz_path) as f:
+        x = f["x"]
+    assert np.array_equal(x, expected_x)


### PR DESCRIPTION
PR:
- #5626 

implemented support for streaming `.npy` files by using `numpy.load`.

However, it introduced a bug when used with `.npz` files, within a context manager:
```
ValueError: seek of closed file
```
or in streaming mode:
```
ValueError: I/O operation on closed file.
```

This PR fixes the bug and tests for both `.npy` and `.npz` files.

Fix #5711.