### PR TITLE
Unpin fsspec

### DIFF
--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -93,8 +93,8 @@ class TmpDirFileSystem(MockFileSystem):
 @pytest.fixture
 def mock_fsspec():
     original_registry = fsspec.registry.copy()
-    fsspec.register_implementation("mock", MockFileSystem)
-    fsspec.register_implementation("tmp", TmpDirFileSystem)
+    fsspec.register_implementation("mock", MockFileSystem, clobber=True)
+    fsspec.register_implementation("tmp", TmpDirFileSystem, clobber=True)
     yield
     fsspec.registry = original_registry
 

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -131,7 +131,7 @@ class DummyTestFS(AbstractFileSystem):
 @pytest.fixture
 def mock_fsspec():
     original_registry = fsspec.registry.copy()
-    fsspec.register_implementation("mock", DummyTestFS)
+    fsspec.register_implementation("mock", DummyTestFS, clobber=True)
     yield
     fsspec.registry = original_registry
 


### PR DESCRIPTION
In `fsspec--2023.4.0` default value for clobber when registering an implementation was changed from True to False. See:
- https://github.com/fsspec/filesystem_spec/pull/1237

This PR recovers previous behavior by passing clobber True when registering mock implementations.