### PR TITLE
Implement sharding on merged iterable datasets

### DIFF
--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -33,6 +33,11 @@ def interleave_datasets(
     The resulting dataset ends when one of the source datasets runs out of examples except when `oversampling` is `True`,
     in which case, the resulting dataset ends when all datasets have ran out of examples at least one time.
 
+    Note for iterable datasets:
+
+    In a distributed setup or in PyTorch DataLoader workers, the stopping strategy is applied per process.
+    Therefore the "first_exhausted" strategy on an sharded iterable dataset can generate less samples in total (up to 1 missing sample per subdataset per worker).
+
     Args:
         datasets (`List[Dataset]` or `List[IterableDataset]`):
             List of datasets to interleave.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -251,7 +251,7 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
 
     @property
     def n_shards(self) -> int:
-        return sum(ex_iterable.n_shards for ex_iterable in self.ex_iterables)
+        return min(ex_iterable.n_shards for ex_iterable in self.ex_iterables)
 
     def shard_data_sources(self, worker_id: int, num_workers: int) -> "CyclingMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
@@ -293,7 +293,7 @@ class VerticallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable):
 
     @property
     def n_shards(self) -> int:
-        return sum(ex_iterable.n_shards for ex_iterable in self.ex_iterables)
+        return min(ex_iterable.n_shards for ex_iterable in self.ex_iterables)
 
     def shard_data_sources(
         self, worker_id: int, num_workers: int

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -22,6 +22,7 @@ from .table import table_cast
 from .utils.logging import get_logger
 from .utils.sharding import _merge_gen_kwargs, _number_of_shards_in_gen_kwargs, _shuffle_gen_kwargs, _split_gen_kwargs
 
+
 logger = get_logger(__name__)
 
 
@@ -201,7 +202,7 @@ class StepExamplesIterable(_BaseExamplesIterable):
 
 class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self, ex_iterables: List[_BaseExamplesIterable], stopping_strategy: Optional[str] = "first_exhausted"
+        self, ex_iterables: List[_BaseExamplesIterable], stopping_strategy: Optional[str] = "first_exhausted"
     ):
         self.ex_iterables = ex_iterables
         self.stopping_strategy = stopping_strategy
@@ -281,7 +282,7 @@ class VerticallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable):
             yield from ex_iterable
 
     def shuffle_data_sources(
-            self, generator: np.random.Generator
+        self, generator: np.random.Generator
     ) -> "VerticallyConcatenatedMultiSourcesExamplesIterable":
         """Shuffle the list of examples iterable, as well as each underlying examples iterable."""
         rng = deepcopy(generator)
@@ -295,7 +296,7 @@ class VerticallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable):
         return min(ex_iterable.n_shards for ex_iterable in self.ex_iterables)
 
     def shard_data_sources(
-            self, worker_id: int, num_workers: int
+        self, worker_id: int, num_workers: int
     ) -> "VerticallyConcatenatedMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         return VerticallyConcatenatedMultiSourcesExamplesIterable(
@@ -356,7 +357,7 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
                 break
 
     def shuffle_data_sources(
-            self, generator: np.random.Generator
+        self, generator: np.random.Generator
     ) -> "HorizontallyConcatenatedMultiSourcesExamplesIterable":
         """Doesn't shuffle the wrapped examples iterable since it would break the alignment between them."""
         return self
@@ -366,7 +367,7 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
         return 1
 
     def shard_data_sources(
-            self, worker_id: int, num_workers: int
+        self, worker_id: int, num_workers: int
     ) -> "HorizontallyConcatenatedMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         return HorizontallyConcatenatedMultiSourcesExamplesIterable(
@@ -376,11 +377,11 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
 
 class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIterable):
     def __init__(
-            self,
-            ex_iterables,
-            generator: np.random.Generator,
-            probabilities: Optional[List[float]] = None,
-            stopping_strategy: Optional[str] = "first_exhausted",
+        self,
+        ex_iterables,
+        generator: np.random.Generator,
+        probabilities: Optional[List[float]] = None,
+        stopping_strategy: Optional[str] = "first_exhausted",
     ):
         super().__init__(ex_iterables, stopping_strategy)
         self.generator = deepcopy(generator)
@@ -388,10 +389,10 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
 
     @staticmethod
     def _iter_random_indices(
-            rng: np.random.Generator,
-            num_sources: int,
-            random_batch_size=1000,
-            p: Optional[List[float]] = None,
+        rng: np.random.Generator,
+        num_sources: int,
+        random_batch_size=1000,
+        p: Optional[List[float]] = None,
     ) -> Iterator[int]:
         """Get an infinite iterator that randomly samples the index of the source to pick examples from."""
         if p is None:
@@ -425,16 +426,16 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
 
 class MappedExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            function: Callable,
-            with_indices: bool = False,
-            input_columns: Optional[List[str]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
-            drop_last_batch: bool = False,
-            remove_columns: Optional[List[str]] = None,
-            fn_kwargs: Optional[dict] = None,
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        function: Callable,
+        with_indices: bool = False,
+        input_columns: Optional[List[str]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        remove_columns: Optional[List[str]] = None,
+        fn_kwargs: Optional[dict] = None,
     ):
         self.ex_iterable = ex_iterable
         self.function = function
@@ -460,10 +461,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
                 keys, examples = zip(*key_examples_list)
                 if (
-                        self.drop_last_batch
-                        and self.batch_size is not None
-                        and self.batch_size > 0
-                        and len(examples) < self.batch_size
+                    self.drop_last_batch
+                    and self.batch_size is not None
+                    and self.batch_size > 0
+                    and len(examples) < self.batch_size
                 ):  # ignore last batch
                     return
                 batch = _examples_to_batch(examples)
@@ -547,13 +548,13 @@ class MappedExamplesIterable(_BaseExamplesIterable):
 
 class FilteredExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            function: Callable,
-            with_indices: bool = False,
-            input_columns: Optional[List[str]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        function: Callable,
+        with_indices: bool = False,
+        input_columns: Optional[List[str]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
     ):
         self.ex_iterable = ex_iterable
         self.function = function
@@ -724,7 +725,7 @@ class TakeExamplesIterable(_BaseExamplesIterable):
 
 
 def _apply_feature_types_on_example(
-        example: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
+    example: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
 ) -> dict:
     example = dict(example)
     # add missing columns
@@ -739,7 +740,7 @@ def _apply_feature_types_on_example(
 
 
 def _apply_feature_types_on_batch(
-        batch: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
+    batch: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
 ) -> dict:
     batch = dict(batch)
     # add missing columns
@@ -756,10 +757,10 @@ def _apply_feature_types_on_batch(
 
 class TypedExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            features: Features,
-            token_per_repo_id: Dict[str, Union[str, bool, None]],
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        features: Features,
+        token_per_repo_id: Dict[str, Union[str, bool, None]],
     ):
         self.ex_iterable = ex_iterable
         self.features = features
@@ -830,14 +831,14 @@ class IterableDataset(DatasetInfoMixin):
     """A Dataset backed by an iterable."""
 
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            info: Optional[DatasetInfo] = None,
-            split: Optional[NamedSplit] = None,
-            format_type: Optional[str] = None,
-            shuffling: Optional[ShufflingConfig] = None,
-            distributed: Optional[DistributedConfig] = None,
-            token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None,
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        info: Optional[DatasetInfo] = None,
+        split: Optional[NamedSplit] = None,
+        format_type: Optional[str] = None,
+        shuffling: Optional[ShufflingConfig] = None,
+        distributed: Optional[DistributedConfig] = None,
+        token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None,
     ):
         if distributed and distributed.world_size > 1 and shuffling and shuffling._original_seed is None:
             raise RuntimeError(
@@ -1012,9 +1013,9 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_generator(
-            generator: Callable,
-            features: Optional[Features] = None,
-            gen_kwargs: Optional[dict] = None,
+        generator: Callable,
+        features: Optional[Features] = None,
+        gen_kwargs: Optional[dict] = None,
     ) -> "IterableDataset":
         """Create an Iterable Dataset from a generator.
 
@@ -1065,8 +1066,8 @@ class IterableDataset(DatasetInfoMixin):
         ).read()
 
     def with_format(
-            self,
-            type: Optional[str] = None,
+        self,
+        type: Optional[str] = None,
     ) -> "IterableDataset":
         """
         Return a dataset with the specified format.
@@ -1093,16 +1094,16 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def map(
-            self,
-            function: Optional[Callable] = None,
-            with_indices: bool = False,
-            input_columns: Optional[Union[str, List[str]]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
-            drop_last_batch: bool = False,
-            remove_columns: Optional[Union[str, List[str]]] = None,
-            features: Optional[Features] = None,
-            fn_kwargs: Optional[dict] = None,
+        self,
+        function: Optional[Callable] = None,
+        with_indices: bool = False,
+        input_columns: Optional[Union[str, List[str]]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        remove_columns: Optional[Union[str, List[str]]] = None,
+        features: Optional[Features] = None,
+        fn_kwargs: Optional[dict] = None,
     ) -> "IterableDataset":
         """
         Apply a function to all the examples in the iterable dataset (individually or in batches) and update them.
@@ -1205,12 +1206,12 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def filter(
-            self,
-            function: Optional[Callable] = None,
-            with_indices=False,
-            input_columns: Optional[Union[str, List[str]]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
+        self,
+        function: Optional[Callable] = None,
+        with_indices=False,
+        input_columns: Optional[Union[str, List[str]]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
     ) -> "IterableDataset":
         """Apply a filter function to all the elements so that the dataset only includes examples according to the filter function.
         The filtering is done on-the-fly when iterating over the dataset.
@@ -1278,7 +1279,7 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def shuffle(
-            self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000
+        self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000
     ) -> "IterableDataset":
         """
         Randomly shuffles the elements of this dataset.
@@ -1676,8 +1677,8 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def cast(
-            self,
-            features: Features,
+        self,
+        features: Features,
     ) -> "IterableDataset":
         """
         Cast the dataset to a new set of features.
@@ -1759,10 +1760,10 @@ class IterableDataset(DatasetInfoMixin):
 
 
 def _concatenate_iterable_datasets(
-        dsets: List[IterableDataset],
-        info: Optional[DatasetInfo] = None,
-        split: Optional[NamedSplit] = None,
-        axis: int = 0,
+    dsets: List[IterableDataset],
+    info: Optional[DatasetInfo] = None,
+    split: Optional[NamedSplit] = None,
+    axis: int = 0,
 ) -> IterableDataset:
     """
     Converts a list of `IterableDataset` with the same schema into a single `IterableDataset`.
@@ -1819,12 +1820,12 @@ def _concatenate_iterable_datasets(
 
 
 def _interleave_iterable_datasets(
-        datasets: List[IterableDataset],
-        probabilities: Optional[List[float]] = None,
-        seed: Optional[int] = None,
-        info: Optional[DatasetInfo] = None,
-        split: Optional[NamedSplit] = None,
-        stopping_strategy: Optional[str] = "first_exhausted",
+    datasets: List[IterableDataset],
+    probabilities: Optional[List[float]] = None,
+    seed: Optional[int] = None,
+    info: Optional[DatasetInfo] = None,
+    split: Optional[NamedSplit] = None,
+    stopping_strategy: Optional[str] = "first_exhausted",
 ) -> IterableDataset:
     """
     Interleave several iterable datasets (sources) into a single iterable dataset.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -951,8 +951,7 @@ class IterableDataset(DatasetInfoMixin):
                     logger.warning(
                         f"Assigning {n_shards_per_node} shard{plural} (or data source{plural}) of the dataset to each node."
                     )
-                shards_indices = list(range(rank, ex_iterable.n_shards, world_size))
-                ex_iterable = ex_iterable.shard_data_sources(shards_indices)
+                ex_iterable = ex_iterable.shard_data_sources(rank, world_size)
             else:
                 if self._is_main_process():
                     logger.warning(

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1285,5 +1285,6 @@ def test_interleave_dataset_with_sharding(n_shards1, nshards2, num_workers):
     expected_length = 2 * min(
         len([example for _, example in ex_iterable1]), len([example for _, example in ex_iterable2])
     )
+    # some samples may be missing because the stopping strategy is applied per process
     assert expected_length - num_workers <= len(result) <= expected_length
     assert len(result) == len({str(x) for x in result})


### PR DESCRIPTION
This PR allows sharding of merged iterable datasets.

Merged iterable datasets with for instance the `interleave_datasets` command are comprised of multiple sub-iterable, one for each dataset that has been merged.

With this PR, sharding a merged iterable will result in multiple merged datasets each comprised of sharded sub-iterable, ensuring that there is no duplication of data.

As a result it is now possible to set any amount of workers in the dataloader as long as it is lower or equal to the lowest amount of shards amongst the datasets. Before it had to be set to 0.

I previously talked about this issue on the forum [here](https://discuss.huggingface.co/t/interleaving-iterable-dataset-with-num-workers-0/35801) 