### PR TITLE
Fix CI mock filesystem fixtures

### DIFF
--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -23,12 +23,9 @@ COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
 ]
 
 
-def _register_custom_filesystems():
-    for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
-        fsspec.register_implementation(fs_class.protocol, fs_class)
-
-
-_register_custom_filesystems()
+# Register custom filesystems
+for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
+    fsspec.register_implementation(fs_class.protocol, fs_class)
 
 
 def extract_path_from_uri(dataset_path: str) -> str:

--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -22,9 +22,13 @@ COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
     compression.ZstdFileSystem,
 ]
 
-# Register custom filesystems
-for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
-    fsspec.register_implementation(fs_class.protocol, fs_class)
+
+def _register_custom_filesystems():
+    for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
+        fsspec.register_implementation(fs_class.protocol, fs_class)
+
+
+_register_custom_filesystems()
 
 
 def extract_path_from_uri(dataset_path: str) -> str:

--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -22,7 +22,6 @@ COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
     compression.ZstdFileSystem,
 ]
 
-
 # Register custom filesystems
 for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
     fsspec.register_implementation(fs_class.protocol, fs_class)

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 import fsspec
 import pytest
 from fsspec.implementations.local import AbstractFileSystem, LocalFileSystem, stringify_path
+from fsspec.registry import _registry as _fsspec_registry
+
+from datasets.filesystems import _register_custom_filesystems
 
 
 class MockFileSystem(AbstractFileSystem):
@@ -92,11 +95,11 @@ class TmpDirFileSystem(MockFileSystem):
 
 @pytest.fixture
 def mock_fsspec():
-    original_registry = fsspec.registry.copy()
     fsspec.register_implementation("mock", MockFileSystem)
     fsspec.register_implementation("tmp", TmpDirFileSystem)
     yield
-    fsspec.registry = original_registry
+    _fsspec_registry.clear()
+    _register_custom_filesystems()
 
 
 @pytest.fixture

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -2,7 +2,6 @@ import posixpath
 from pathlib import Path
 from unittest.mock import patch
 
-import fsspec
 import pytest
 from fsspec.implementations.local import AbstractFileSystem, LocalFileSystem, stringify_path
 from fsspec.registry import _registry as _fsspec_registry
@@ -93,8 +92,8 @@ class TmpDirFileSystem(MockFileSystem):
 
 @pytest.fixture
 def mock_fsspec():
-    fsspec.register_implementation("mock", MockFileSystem)
-    fsspec.register_implementation("tmp", TmpDirFileSystem)
+    _fsspec_registry["mock"] = MockFileSystem
+    _fsspec_registry["tmp"] = TmpDirFileSystem
     yield
     del _fsspec_registry["mock"]
     del _fsspec_registry["tmp"]

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -93,8 +93,8 @@ class TmpDirFileSystem(MockFileSystem):
 @pytest.fixture
 def mock_fsspec():
     original_registry = fsspec.registry.copy()
-    fsspec.register_implementation("mock", MockFileSystem, clobber=True)
-    fsspec.register_implementation("tmp", TmpDirFileSystem, clobber=True)
+    fsspec.register_implementation("mock", MockFileSystem)
+    fsspec.register_implementation("tmp", TmpDirFileSystem)
     yield
     fsspec.registry = original_registry
 

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -7,8 +7,6 @@ import pytest
 from fsspec.implementations.local import AbstractFileSystem, LocalFileSystem, stringify_path
 from fsspec.registry import _registry as _fsspec_registry
 
-from datasets.filesystems import _register_custom_filesystems
-
 
 class MockFileSystem(AbstractFileSystem):
     protocol = "mock"
@@ -98,8 +96,8 @@ def mock_fsspec():
     fsspec.register_implementation("mock", MockFileSystem)
     fsspec.register_implementation("tmp", TmpDirFileSystem)
     yield
-    _fsspec_registry.clear()
-    _register_custom_filesystems()
+    del _fsspec_registry["mock"]
+    del _fsspec_registry["tmp"]
 
 
 @pytest.fixture

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -2,10 +2,21 @@ import os
 
 import fsspec
 import pytest
+from fsspec.registry import _registry as _fsspec_registry
 
 from datasets.filesystems import COMPRESSION_FILESYSTEMS, HfFileSystem, extract_path_from_uri, is_remote_filesystem
 
 from .utils import require_lz4, require_zstandard
+
+
+def test_mockfs(mockfs):
+    assert "mock" in _fsspec_registry
+    assert "bz2" in _fsspec_registry
+
+
+def test_non_mockfs():
+    assert "mock" not in _fsspec_registry
+    assert "bz2" in _fsspec_registry
 
 
 def test_extract_path_from_uri():

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -131,7 +131,7 @@ class DummyTestFS(AbstractFileSystem):
 @pytest.fixture
 def mock_fsspec():
     original_registry = fsspec.registry.copy()
-    fsspec.register_implementation("mock", DummyTestFS, clobber=True)
+    fsspec.register_implementation("mock", DummyTestFS)
     yield
     fsspec.registry = original_registry
 

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -3,7 +3,6 @@ import os
 import re
 from pathlib import Path
 
-import fsspec
 import pytest
 from fsspec.registry import _registry as _fsspec_registry
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
@@ -131,7 +130,7 @@ class DummyTestFS(AbstractFileSystem):
 
 @pytest.fixture
 def mock_fsspec():
-    fsspec.register_implementation("mock", DummyTestFS)
+    _fsspec_registry["mock"] = DummyTestFS
     yield
     del _fsspec_registry["mock"]
 

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import fsspec
 import pytest
+from fsspec.registry import _registry as _fsspec_registry
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 
 from datasets.download.streaming_download_manager import (
@@ -26,7 +27,7 @@ from datasets.download.streaming_download_manager import (
     xsplitext,
     xwalk,
 )
-from datasets.filesystems import COMPRESSION_FILESYSTEMS
+from datasets.filesystems import COMPRESSION_FILESYSTEMS, _register_custom_filesystems
 from datasets.utils.hub import hf_hub_url
 
 from .utils import require_lz4, require_zstandard, slow
@@ -130,10 +131,10 @@ class DummyTestFS(AbstractFileSystem):
 
 @pytest.fixture
 def mock_fsspec():
-    original_registry = fsspec.registry.copy()
     fsspec.register_implementation("mock", DummyTestFS)
     yield
-    fsspec.registry = original_registry
+    _fsspec_registry.clear()
+    _register_custom_filesystems()
 
 
 def _readd_double_slash_removed_by_path(path_as_posix: str) -> str:

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -27,7 +27,7 @@ from datasets.download.streaming_download_manager import (
     xsplitext,
     xwalk,
 )
-from datasets.filesystems import COMPRESSION_FILESYSTEMS, _register_custom_filesystems
+from datasets.filesystems import COMPRESSION_FILESYSTEMS
 from datasets.utils.hub import hf_hub_url
 
 from .utils import require_lz4, require_zstandard, slow
@@ -133,8 +133,7 @@ class DummyTestFS(AbstractFileSystem):
 def mock_fsspec():
     fsspec.register_implementation("mock", DummyTestFS)
     yield
-    _fsspec_registry.clear()
-    _register_custom_filesystems()
+    del _fsspec_registry["mock"]
 
 
 def _readd_double_slash_removed_by_path(path_as_posix: str) -> str:


### PR DESCRIPTION
This PR fixes the fixtures of our CI mock filesystems.

Before, we had to pass `clobber=True` to `fsspec.register_implementation` to overwrite the still present previously added "mock" filesystem. That meant that the mock filesystem fixture was not working properly, because the previously added "mock" filesystem, should have been deleted by the fixture.

This PR fixes the mock filesystem fixtures, so that the "mock" filesystem is properly deleted from the inner `fsspec` registry.

Tests were added to check the correct behavior of the mock filesystem fixtures.

Related to:
- #5733