### PR TITLE
Consistent ArrayXD Python formatting + better NumPy/Pandas formatting

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -815,7 +815,8 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         """
         if dtype == object:
             out = np.empty(len(self._data), dtype=object)
-            out[:] = self._data
+            for i in range(len(self._data)):
+                out[i] = self._data[i]
             return out
         if dtype is None:
             return self._data
@@ -847,7 +848,7 @@ class PandasArrayExtensionArray(PandasExtensionArray):
             data = np.vstack([va._data for va in to_concat])
         else:
             data = np.empty(len(to_concat), dtype=object)
-            data[:] = to_concat
+            data[:] = [va._data for va in to_concat]
         return cls(data, copy=False)
 
     @property

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -755,7 +755,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
     def to_pylist(self):
         zero_copy_only = _is_zero_copy_only(self.storage.type, unnest=True)
         if self.type.shape[0] is None:
-            return self.to_list_of_numpy(zero_copy_only=zero_copy_only)
+            return [numpy_arr.tolist() for numpy_arr in self.to_list_of_numpy(zero_copy_only=zero_copy_only)]
         else:
             return self.to_numpy(zero_copy_only=zero_copy_only).tolist()
 

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -168,16 +168,9 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
             if isinstance(pa_array.type, _ArrayXDExtensionType):
                 # don't call to_pylist() to preserve dtype of the fixed-size array
                 zero_copy_only = _is_zero_copy_only(pa_array.type.storage_dtype, unnest=True)
-                if pa_array.type.shape[0] is None:
-                    array: List = [
-                        row
-                        for chunk in pa_array.chunks
-                        for row in chunk.to_list_of_numpy(zero_copy_only=zero_copy_only)
-                    ]
-                else:
-                    array: List = [
-                        row for chunk in pa_array.chunks for row in chunk.to_numpy(zero_copy_only=zero_copy_only)
-                    ]
+                array: List = [
+                    row for chunk in pa_array.chunks for row in chunk.to_numpy(zero_copy_only=zero_copy_only)
+                ]
             else:
                 zero_copy_only = _is_zero_copy_only(pa_array.type) and all(
                     not _is_array_with_nulls(chunk) for chunk in pa_array.chunks
@@ -189,10 +182,7 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
             if isinstance(pa_array.type, _ArrayXDExtensionType):
                 # don't call to_pylist() to preserve dtype of the fixed-size array
                 zero_copy_only = _is_zero_copy_only(pa_array.type.storage_dtype, unnest=True)
-                if pa_array.type.shape[0] is None:
-                    array: List = pa_array.to_list_of_numpy(zero_copy_only=zero_copy_only)
-                else:
-                    array: List = pa_array.to_numpy(zero_copy_only=zero_copy_only)
+                array: List = pa_array.to_numpy(zero_copy_only=zero_copy_only)
             else:
                 zero_copy_only = _is_zero_copy_only(pa_array.type) and not _is_array_with_nulls(pa_array)
                 array: List = pa_array.to_numpy(zero_copy_only=zero_copy_only).tolist()

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -267,8 +267,8 @@ class ArrayXDDynamicTest(unittest.TestCase):
         pylist = arr_xd.to_pylist()
 
         for first_dim, single_arr in zip(first_dim_list, pylist):
-            self.assertIsInstance(single_arr, np.ndarray)
-            self.assertTupleEqual(single_arr.shape, (first_dim, *fixed_shape))
+            self.assertIsInstance(single_arr, list)
+            self.assertTupleEqual(np.array(single_arr).shape, (first_dim, *fixed_shape))
 
     def test_iter_dataset(self):
         fixed_shape = (2, 2)
@@ -277,8 +277,8 @@ class ArrayXDDynamicTest(unittest.TestCase):
 
         for first_dim, ds_row in zip(first_dim_list, dataset):
             single_arr = ds_row["image"]
-            self.assertIsInstance(single_arr, np.ndarray)
-            self.assertTupleEqual(single_arr.shape, (first_dim, *fixed_shape))
+            self.assertIsInstance(single_arr, list)
+            self.assertTupleEqual(np.array(single_arr).shape, (first_dim, *fixed_shape))
 
     def test_to_pandas_fail(self):
         fixed_shape = (2, 2)
@@ -297,8 +297,8 @@ class ArrayXDDynamicTest(unittest.TestCase):
         # check also if above function resulted with 2x bigger first dim
         for first_dim, ds_row in zip(first_dim_list, dataset):
             single_arr = ds_row["image"]
-            self.assertIsInstance(single_arr, np.ndarray)
-            self.assertTupleEqual(single_arr.shape, (first_dim * 2, *fixed_shape))
+            self.assertIsInstance(single_arr, list)
+            self.assertTupleEqual(np.array(single_arr).shape, (first_dim * 2, *fixed_shape))
 
 
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -314,12 +314,34 @@ class ArrayXDDynamicTest(unittest.TestCase):
             self.assertIsInstance(single_arr, list)
             self.assertTupleEqual(np.array(single_arr).shape, (first_dim, *fixed_shape))
 
-    def test_to_pandas_fail(self):
+    def test_to_pandas(self):
         fixed_shape = (2, 2)
+
+        # ragged
         first_dim_list = [1, 3, 10]
         dataset = self.get_one_col_dataset(first_dim_list, fixed_shape)
-        with self.assertRaises(NotImplementedError):
-            dataset.to_pandas()
+        df = dataset.to_pandas()
+        self.assertEqual(type(df.image.dtype), PandasArrayExtensionDtype)
+        numpy_arr = df.image.to_numpy()
+
+        self.assertIsInstance(numpy_arr, np.ndarray)
+        self.assertEqual(numpy_arr.dtype, object)
+        for first_dim, single_arr in zip(first_dim_list, numpy_arr):
+            self.assertIsInstance(single_arr, np.ndarray)
+            self.assertTupleEqual(single_arr.shape, (first_dim, *fixed_shape))
+
+        # non-ragged
+        first_dim_list = [4, 4, 4]
+        dataset = self.get_one_col_dataset(first_dim_list, fixed_shape)
+        df = dataset.to_pandas()
+        self.assertEqual(type(df.image.dtype), PandasArrayExtensionDtype)
+        numpy_arr = df.image.to_numpy()
+
+        self.assertIsInstance(numpy_arr, np.ndarray)
+        self.assertNotEqual(numpy_arr.dtype, object)
+        for first_dim, single_arr in zip(first_dim_list, numpy_arr):
+            self.assertIsInstance(single_arr, np.ndarray)
+            self.assertTupleEqual(single_arr.shape, (first_dim, *fixed_shape))
 
     def test_map_dataset(self):
         fixed_shape = (2, 2)


### PR DESCRIPTION
Return a list of lists instead of a list of NumPy arrays when converting the variable-shaped `ArrayXD` to Python. Additionally, improve the NumPy conversion by returning a numeric NumPy array when the offsets are equal or a NumPy object array when they aren't, and allow converting the variable-shaped `ArrayXD` to Pandas.

(Reported in https://github.com/huggingface/datasets/issues/5719#issuecomment-1507579671)