### PR TITLE
fix typo: "mow" -> "now"

### DIFF
--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -152,5 +152,5 @@ The distinction between a Hub dataset within or without a namespace only comes f
 
 </Tip>
 
-Those datasets are mow maintained on the Hub: if you think a fix is needed, please use their "Community" tab to open a discussion or create a Pull Request.
+Those datasets are now maintained on the Hub: if you think a fix is needed, please use their "Community" tab to open a discussion or create a Pull Request.
 The code of these datasets is reviewed by the Hugging Face team.


### PR DESCRIPTION
I noticed a typo as I was reading the datasets documentation. This PR contains a trivial fix changing "mow" to "now."