### PR TITLE
Call fs.makedirs in save_to_disk

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1378,6 +1378,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 raise PermissionError(
                     f"Tried to overwrite {Path(dataset_path).resolve()} but a dataset can't overwrite itself."
                 )
+        else:
+            fs.makedirs(dataset_path, exist_ok=True)
 
         # Get json serializable state
         state = {

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1217,6 +1217,8 @@ class DatasetDict(dict):
 
         if is_local:
             Path(dataset_dict_path).resolve().mkdir(parents=True, exist_ok=True)
+        else:
+            fs.makedirs(dataset_dict_path, exist_ok=True)
 
         with fs.open(path_join(dataset_dict_path, config.DATASETDICT_JSON_FILENAME), "w", encoding="utf-8") as f:
             json.dump({"splits": list(self)}, f)


### PR DESCRIPTION
We need to call `fs.makedirs` when saving a dataset using `save_to_disk`, because some fs implementations have actual directories (S3 and others don't)

Close https://github.com/huggingface/datasets/issues/5775