### PR TITLE
Fix inferring module for unsupported data files

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -368,6 +368,7 @@ def infer_module_for_data_files(
                 return _EXTENSION_TO_MODULE[ext]
             elif ext == "zip":
                 return infer_module_for_data_files_in_archives(data_files_list, use_auth_token=use_auth_token)
+    return None, {}
 
 
 def infer_module_for_data_files_in_archives(
@@ -404,6 +405,7 @@ def infer_module_for_data_files_in_archives(
         most_common = extensions_counter.most_common(1)[0][0]
         if most_common in _EXTENSION_TO_MODULE:
             return _EXTENSION_TO_MODULE[most_common]
+    return None, {}
 
 
 @dataclass

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -626,7 +626,9 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
 
     def get_module(self) -> DatasetModule:
         base_path = os.path.join(self.path, self.data_dir) if self.data_dir else self.path
-        patterns = sanitize_patterns(self.data_files) if self.data_files else get_data_patterns_locally(base_path)
+        patterns = (
+            sanitize_patterns(self.data_files) if self.data_files is not None else get_data_patterns_locally(base_path)
+        )
         data_files = DataFilesDict.from_local_or_remote(
             patterns,
             base_path=base_path,
@@ -763,7 +765,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         )
         patterns = (
             sanitize_patterns(self.data_files)
-            if self.data_files
+            if self.data_files is not None
             else get_data_patterns_in_dataset_repository(hfh_dataset_info, self.data_dir)
         )
         data_files = DataFilesDict.from_hf_repo(

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -634,14 +634,14 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             base_path=base_path,
             allowed_extensions=ALL_ALLOWED_EXTENSIONS,
         )
-        module_names = {
-            key: infer_module_for_data_files(data_files_list) for key, data_files_list in data_files.items()
+        split_modules = {
+            split: infer_module_for_data_files(data_files_list) for split, data_files_list in data_files.items()
         }
-        if len(set(list(zip(*module_names.values()))[0])) > 1:
-            raise ValueError(f"Couldn't infer the same data file format for all splits. Got {module_names}")
-        module_name, builder_kwargs = next(iter(module_names.values()))
+        module_name, builder_kwargs = next(iter(split_modules.values()))
+        if any((module_name, builder_kwargs) != split_module for split_module in split_modules.values()):
+            raise ValueError(f"Couldn't infer the same data file format for all splits. Got {split_modules}")
         if not module_name:
-            raise FileNotFoundError(f"No data files or dataset script found in {self.path}")
+            raise FileNotFoundError(f"No (supported) data files or dataset script found in {self.path}")
         # Collect metadata files if the module supports them
         if self.data_files is None and module_name in _MODULE_SUPPORTS_METADATA and patterns != DEFAULT_PATTERNS_ALL:
             try:
@@ -774,15 +774,15 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             base_path=self.data_dir,
             allowed_extensions=ALL_ALLOWED_EXTENSIONS,
         )
-        module_names = {
-            key: infer_module_for_data_files(data_files_list, use_auth_token=self.download_config.use_auth_token)
-            for key, data_files_list in data_files.items()
+        split_modules = {
+            split: infer_module_for_data_files(data_files_list, use_auth_token=self.download_config.use_auth_token)
+            for split, data_files_list in data_files.items()
         }
-        if len(set(list(zip(*module_names.values()))[0])) > 1:
-            raise ValueError(f"Couldn't infer the same data file format for all splits. Got {module_names}")
-        module_name, builder_kwargs = next(iter(module_names.values()))
+        module_name, builder_kwargs = next(iter(split_modules.values()))
+        if any((module_name, builder_kwargs) != split_module for split_module in split_modules.values()):
+            raise ValueError(f"Couldn't infer the same data file format for all splits. Got {split_modules}")
         if not module_name:
-            raise FileNotFoundError(f"No data files or dataset script found in {self.name}")
+            raise FileNotFoundError(f"No (supported) data files or dataset script found in {self.name}")
         # Collect metadata files if the module supports them
         if self.data_files is None and module_name in _MODULE_SUPPORTS_METADATA and patterns != DEFAULT_PATTERNS_ALL:
             try:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -626,9 +626,7 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
 
     def get_module(self) -> DatasetModule:
         base_path = os.path.join(self.path, self.data_dir) if self.data_dir else self.path
-        patterns = (
-            sanitize_patterns(self.data_files) if self.data_files is not None else get_data_patterns_locally(base_path)
-        )
+        patterns = sanitize_patterns(self.data_files) if self.data_files else get_data_patterns_locally(base_path)
         data_files = DataFilesDict.from_local_or_remote(
             patterns,
             base_path=base_path,
@@ -765,7 +763,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         )
         patterns = (
             sanitize_patterns(self.data_files)
-            if self.data_files is not None
+            if self.data_files
             else get_data_patterns_in_dataset_repository(hfh_dataset_info, self.data_dir)
         )
         data_files = DataFilesDict.from_hf_repo(

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -481,6 +481,15 @@ def zip_text_with_dir_path(text_path, text2_path, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def zip_unsupported_ext_path(text_path, text2_path, tmp_path_factory):
+    path = tmp_path_factory.mktemp("data") / "dataset.ext.zip"
+    with zipfile.ZipFile(path, "w") as f:
+        f.write(text_path, arcname=os.path.basename("unsupported.ext"))
+        f.write(text2_path, arcname=os.path.basename("unsupported_2.ext"))
+    return path
+
+
+@pytest.fixture(scope="session")
 def text_path_with_unicode_new_lines(tmp_path_factory):
     text = "\n".join(["First", "Second\u2029with Unicode new line", "Third"])
     path = str(tmp_path_factory.mktemp("data") / "dataset_with_unicode_new_lines.txt")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -209,6 +209,8 @@ def metric_loading_script_dir(tmp_path):
         (["train.jsonl"], "json", {}),
         (["train.parquet"], "parquet", {}),
         (["train.txt"], "text", {}),
+        (["unsupported.ext"], None, {}),
+        ([""], None, {}),
     ],
 )
 def test_infer_module_for_data_files(data_files, expected_module, expected_builder_kwargs):
@@ -217,9 +219,18 @@ def test_infer_module_for_data_files(data_files, expected_module, expected_build
     assert builder_kwargs == expected_builder_kwargs
 
 
-@pytest.mark.parametrize("data_file, expected_module", [("zip_csv_path", "csv"), ("zip_csv_with_dir_path", "csv")])
-def test_infer_module_for_data_files_in_archives(data_file, expected_module, zip_csv_path, zip_csv_with_dir_path):
-    data_file_paths = {"zip_csv_path": zip_csv_path, "zip_csv_with_dir_path": zip_csv_with_dir_path}
+@pytest.mark.parametrize(
+    "data_file, expected_module",
+    [("zip_csv_path", "csv"), ("zip_csv_with_dir_path", "csv"), ("zip_unsupported_ext_path", None)],
+)
+def test_infer_module_for_data_files_in_archives(
+    data_file, expected_module, zip_csv_path, zip_csv_with_dir_path, zip_unsupported_ext_path
+):
+    data_file_paths = {
+        "zip_csv_path": zip_csv_path,
+        "zip_csv_with_dir_path": zip_csv_with_dir_path,
+        "zip_unsupported_ext_path": zip_unsupported_ext_path,
+    }
     data_files = [str(data_file_paths[data_file])]
     inferred_module, _ = infer_module_for_data_files_in_archives(data_files, False)
     assert inferred_module == expected_module


### PR DESCRIPTION
This PR raises a FileNotFoundError instead:
```
FileNotFoundError: No (supported) data files or dataset script found in <dataset_name>
```

Fix #5785.