### PR TITLE
Change downloaded file permission based on umask

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -621,6 +621,9 @@ def get_from_cache(
 
         logger.info(f"storing {url} in cache at {cache_path}")
         shutil.move(temp_file.name, cache_path)
+        umask = os.umask(0o666)
+        os.umask(umask)
+        os.chmod(cache_path, 0o666 & ~umask)
 
         logger.info(f"creating metadata file for {cache_path}")
         meta = {"url": url, "etag": etag}


### PR DESCRIPTION
This PR changes the permission of downloaded files to cache, so that the umask is taken into account.

Related to:
- #2157

Fix #5799.

CC: @stas00 