### PR TITLE
Validate non-empty data_files

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1748,6 +1748,8 @@ def load_dataset(
             f"You can remove this warning by passing 'verification_mode={verification_mode.value}' instead.",
             FutureWarning,
         )
+    if data_files is not None and not data_files:
+        raise ValueError(f"Empty 'data_files': '{data_files}'. It should be either non-empty or None (default).")
     if Path(path, config.DATASET_STATE_JSON_FILENAME).exists():
         raise ValueError(
             "You are trying to load a dataset that was saved using `save_to_disk`. "


### PR DESCRIPTION
This PR adds validation of `data_files`, so that they are non-empty (str, list, or dict) or `None` (default).

See: https://github.com/huggingface/datasets/pull/5787#discussion_r1178862327