### PR TITLE
Support parallelized downloading in load_dataset with Spark

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -641,6 +641,7 @@ class DatasetBuilder:
         max_shard_size: Optional[Union[int, str]] = None,
         num_proc: Optional[int] = None,
         storage_options: Optional[dict] = None,
+        use_spark: bool = False,
         **download_and_prepare_kwargs,
     ):
         """Downloads and prepares dataset for reading.
@@ -705,6 +706,8 @@ class DatasetBuilder:
                 Key/value pairs to be passed on to the caching file-system backend, if any.
 
                 <Added version="2.5.0"/>
+            use_spark (`bool`, defaults to `False`):
+                If set to `True`, uses Spark to download/extract files in parallel.
             **download_and_prepare_kwargs (additional keyword arguments): Keyword arguments.
 
         Example:
@@ -782,6 +785,7 @@ class DatasetBuilder:
                     num_proc=num_proc,
                     use_auth_token=use_auth_token,
                     storage_options=self.storage_options,
+                    use_spark=use_spark,
                 )  # We don't use etag for data files to speed up the process
 
             dl_manager = DownloadManager(

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -46,6 +46,8 @@ class DownloadConfig:
             Key/value pairs to be passed on to the dataset file-system backend, if any.
         download_desc (`str`, *optional*):
             A description to be displayed alongside with the progress bar while downloading the files.
+        use_spark (`bool`, defaults to `False`):
+            Whether to use Spark for parallelized downloading
     """
 
     cache_dir: Optional[Union[str, Path]] = None
@@ -64,6 +66,7 @@ class DownloadConfig:
     ignore_url_params: bool = False
     storage_options: Optional[Dict] = None
     download_desc: Optional[str] = None
+    use_spark: bool = False
 
     def copy(self) -> "DownloadConfig":
         return self.__class__(**{k: copy.deepcopy(v) for k, v in self.__dict__.items()})

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -421,6 +421,10 @@ class DownloadManager:
         if download_config.download_desc is None:
             download_config.download_desc = "Downloading data"
 
+        if download_config.use_spark:
+            # TODO: probe and set download_config=False if multi-node with non-NFS cache_dir
+            pass
+
         download_func = partial(self._download, download_config=download_config)
 
         start_time = datetime.now()
@@ -431,6 +435,7 @@ class DownloadManager:
             num_proc=download_config.num_proc,
             disable_tqdm=not is_progress_bar_enabled(),
             desc="Downloading data files",
+            use_spark=download_config.use_spark,
         )
         duration = datetime.now() - start_time
         logger.info(f"Downloading took {duration.total_seconds() // 60} min")
@@ -533,12 +538,18 @@ class DownloadManager:
         # Extract downloads the file first if it is not already downloaded
         if download_config.download_desc is None:
             download_config.download_desc = "Downloading data"
+
+        if download_config.use_spark:
+            # TODO: probe and set download_config=False if multi-node with non-NFS cache_dir
+            pass
+
         extracted_paths = map_nested(
             partial(cached_path, download_config=download_config),
             path_or_paths,
             num_proc=download_config.num_proc,
             disable_tqdm=not is_progress_bar_enabled(),
             desc="Extracting data files",
+            use_spark=download_config.use_spark,
         )
         path_or_paths = NestedDataStructure(path_or_paths)
         extracted_paths = NestedDataStructure(extracted_paths)

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1561,6 +1561,7 @@ def load_dataset(
     streaming: bool = False,
     num_proc: Optional[int] = None,
     storage_options: Optional[Dict] = None,
+    use_spark: bool = False,
     **config_kwargs,
 ) -> Union[DatasetDict, Dataset, IterableDatasetDict, IterableDataset]:
     """Load a dataset from the Hugging Face Hub, or a local dataset.
@@ -1686,6 +1687,8 @@ def load_dataset(
             **Experimental**. Key/value pairs to be passed on to the dataset file-system backend, if any.
 
             <Added version="2.11.0"/>
+        use_spark (`bool`, defaults to `False`):
+            If set to `True`, uses Spark to download/extract files in parallel.
         **config_kwargs (additional keyword arguments):
             Keyword arguments to be passed to the `BuilderConfig`
             and used in the [`DatasetBuilder`].
@@ -1801,6 +1804,7 @@ def load_dataset(
         try_from_hf_gcs=try_from_hf_gcs,
         num_proc=num_proc,
         storage_options=storage_options,
+        use_spark=use_spark,
     )
 
     # Build dataset for splits

--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -43,7 +43,7 @@ class Spark(datasets.DatasetBuilder):
         self._spark = pyspark.sql.SparkSession.builder.getOrCreate()
         self.df = df
 
-        validate_cache_dir(cache_dir, "Dataset.from_spark")
+        validate_cache_dir(cache_dir, "Dataset.from_spark", self._spark)
 
         super().__init__(
             cache_dir=cache_dir,

--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -1,6 +1,5 @@
 import os
 import posixpath
-import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Union
 
@@ -14,6 +13,7 @@ from datasets.filesystems import (
     rename,
 )
 from datasets.utils.py_utils import convert_file_size_to_int
+from datasets.utils.spark_utils import validate_cache_dir
 
 
 logger = datasets.utils.logging.get_logger(__name__)
@@ -42,41 +42,13 @@ class Spark(datasets.DatasetBuilder):
 
         self._spark = pyspark.sql.SparkSession.builder.getOrCreate()
         self.df = df
-        self._validate_cache_dir(cache_dir)
+
+        validate_cache_dir(cache_dir, "Dataset.from_spark")
 
         super().__init__(
             cache_dir=cache_dir,
             config_name=str(self.df.semanticHash()),
             **config_kwargs,
-        )
-
-    def _validate_cache_dir(self, cache_dir):
-        # Returns the path of the created file.
-        def create_cache_and_write_probe(context):
-            # makedirs with exist_ok will recursively create the directory. It will not throw an error if directories
-            # already exist.
-            os.makedirs(cache_dir, exist_ok=True)
-            probe_file = os.path.join(cache_dir, "fs_test" + uuid.uuid4().hex)
-            # Opening the file in append mode will create a new file unless it already exists, in which case it will not
-            # change the file contents.
-            open(probe_file, "a")
-            return [probe_file]
-
-        if self._spark.conf.get("spark.master", "").startswith("local"):
-            return
-
-        # If the cluster is multi-node, make sure that the user provided a cache_dir and that it is on an NFS
-        # accessible to the driver.
-        # TODO: Stream batches to the driver using ArrowCollectSerializer instead of throwing an error.
-        if cache_dir:
-            probe = (
-                self._spark.sparkContext.parallelize(range(1), 1).mapPartitions(create_cache_and_write_probe).collect()
-            )
-            if os.path.isfile(probe[0]):
-                return
-
-        raise ValueError(
-            "When using Dataset.from_spark on a multi-node cluster, the driver and all workers should be able to access cache_dir"
         )
 
     def _info(self):

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -459,6 +459,7 @@ def map_nested(
 
         except ImportError:
             # No parallelization
+            logger.warning("pyspark module is not found, running single process without Spark parallelization")
             mapped = [
                 _single_map_nested((function, obj, types, None, True, None))
                 for obj in logging.tqdm(iterable, disable=disable_tqdm, desc=desc)

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -457,7 +457,7 @@ def map_nested(
                 .collect()
             )
 
-        except Exception:
+        except ImportError:
             # No parallelization
             mapped = [
                 _single_map_nested((function, obj, types, None, True, None))

--- a/src/datasets/utils/spark_utils.py
+++ b/src/datasets/utils/spark_utils.py
@@ -1,6 +1,8 @@
 import os
 import uuid
 
+import pyspark
+
 
 def validate_cache_dir(cache_dir, spark_function_name):
     # Returns the path of the created file.
@@ -13,8 +15,6 @@ def validate_cache_dir(cache_dir, spark_function_name):
         # change the file contents.
         open(probe_file, "a")
         return [probe_file]
-
-    import pyspark
 
     spark = pyspark.sql.SparkSession.builder.getOrCreate()
 

--- a/src/datasets/utils/spark_utils.py
+++ b/src/datasets/utils/spark_utils.py
@@ -1,1 +1,35 @@
-# TODO: move probe function here & pass test_arrow_dataset test_from_spark
+import os
+import uuid
+
+
+def validate_cache_dir(cache_dir, spark_function_name):
+    # Returns the path of the created file.
+    def create_cache_and_write_probe(context):
+        # makedirs with exist_ok will recursively create the directory. It will not throw an error if directories
+        # already exist.
+        os.makedirs(cache_dir, exist_ok=True)
+        probe_file = os.path.join(cache_dir, "fs_test" + uuid.uuid4().hex)
+        # Opening the file in append mode will create a new file unless it already exists, in which case it will not
+        # change the file contents.
+        open(probe_file, "a")
+        return [probe_file]
+
+    import pyspark
+
+    spark = pyspark.sql.SparkSession.builder.getOrCreate()
+
+    if spark.conf.get("spark.master", "").startswith("local"):
+        return
+
+    # If the cluster is multi-node, make sure that the user provided a cache_dir and that it is on an NFS
+    # accessible to the driver.
+    # TODO: Stream batches to the driver using ArrowCollectSerializer instead of throwing an error.
+    if cache_dir:
+        probe = spark.sparkContext.parallelize(range(1), 1).mapPartitions(create_cache_and_write_probe).collect()
+        if os.path.isfile(probe[0]):
+            return
+
+    raise ValueError(
+        f"When using {spark_function_name} on a multi-node cluster, the driver and all workers should be able to access "
+        "cache_dir "
+    )

--- a/src/datasets/utils/spark_utils.py
+++ b/src/datasets/utils/spark_utils.py
@@ -2,7 +2,11 @@ import os
 import uuid
 from typing import Optional
 
-import pyspark
+
+try:
+    import pyspark
+except ImportError:
+    pass
 
 
 def validate_cache_dir(cache_dir: str, spark_function_name: str, spark: Optional[pyspark.sql.SparkSession] = None):

--- a/src/datasets/utils/spark_utils.py
+++ b/src/datasets/utils/spark_utils.py
@@ -1,0 +1,1 @@
+# TODO: move probe function here & pass test_arrow_dataset test_from_spark

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -31,6 +31,8 @@ def mock_request(*args, **kwargs):
 
 
 def mock_internal_download(*args, **kwargs):
+    # The patch scope of Spark map function is not as direct as normal functions, so we need to patch request here
+    # https://stackoverflow.com/questions/69936939/pyspark-rdd-map-function-mock-scope
     with patch("requests.request") as request_mock:
         request_mock.return_value = MockResponse()
         return DownloadManager._download(*args, **kwargs)
@@ -86,8 +88,6 @@ def test_download_manager_download(urls_type, tmp_path, monkeypatch):
 @require_pyspark
 @pytest.mark.parametrize("urls_type", [list, dict])
 def test_download_manager_download_with_spark(urls_type, tmp_path, monkeypatch):
-
-    # monkeypatch.setattr(requests, "request", mock_request)
     monkeypatch.setattr(DownloadManager, "_download", mock_internal_download)
 
     url = URL

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -9,7 +9,11 @@ from datasets.download.download_config import DownloadConfig
 from datasets.download.download_manager import DownloadManager
 from datasets.utils.file_utils import hash_url_to_filename
 
-from .utils import require_pyspark
+from .utils import (
+    require_dill_gt_0_3_2,
+    require_not_windows,
+    require_pyspark,
+)
 
 
 URL = "http://www.mocksite.com/file1.txt"
@@ -85,6 +89,8 @@ def test_download_manager_download(urls_type, tmp_path, monkeypatch):
             assert metadata_content == {"url": URL, "etag": None}
 
 
+@require_not_windows
+@require_dill_gt_0_3_2
 @require_pyspark
 @pytest.mark.parametrize("urls_type", [list, dict])
 def test_download_manager_download_with_spark(urls_type, tmp_path, monkeypatch):


### PR DESCRIPTION
As proposed in https://github.com/huggingface/datasets/issues/5798, this adds support to parallelized downloading in `load_dataset` with Spark, which can speed up the process by distributing the workload to worker nodes.

Parallelizing dataset processing is not supported in this PR.