### PR TITLE
Add `fn_kwargs` to `map` and `filter` of `IterableDataset` and `IterableDatasetDict`

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1680,6 +1680,7 @@ class IterableDatasetDict(dict):
         batch_size: int = 1000,
         drop_last_batch: bool = False,
         remove_columns: Optional[Union[str, List[str]]] = None,
+        fn_kwargs: Optional[dict] = None,
     ) -> "IterableDatasetDict":
         """
         Apply a function to all the examples in the iterable dataset (individually or in batches) and update them.
@@ -1726,6 +1727,8 @@ class IterableDatasetDict(dict):
                 Remove a selection of columns while doing the mapping.
                 Columns will be removed before updating the examples with the output of `function`, i.e. if `function` is adding
                 columns with names in `remove_columns`, these columns will be kept.
+            fn_kwargs (`Dict`, *optional*, defaults to `None`):
+                Keyword arguments to be passed to `function`
 
         Example:
 
@@ -1751,6 +1754,7 @@ class IterableDatasetDict(dict):
                     batch_size=batch_size,
                     drop_last_batch=drop_last_batch,
                     remove_columns=remove_columns,
+                    fn_kwargs=fn_kwargs,
                 )
                 for k, dataset in self.items()
             }
@@ -1763,6 +1767,7 @@ class IterableDatasetDict(dict):
         input_columns: Optional[Union[str, List[str]]] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
+        fn_kwargs: Optional[dict] = None,
     ) -> "IterableDatasetDict":
         """Apply a filter function to all the elements so that the dataset only includes examples according to the filter function.
         The filtering is done on-the-fly when iterating over the dataset.
@@ -1787,6 +1792,8 @@ class IterableDatasetDict(dict):
                 Provide batch of examples to `function`
             batch_size (`int`, *optional*, defaults to `1000`):
                 Number of examples per batch provided to `function` if `batched=True`.
+            fn_kwargs (`Dict`, *optional*, defaults to `None`):
+                Keyword arguments to be passed to `function`
 
         Example:
 
@@ -1810,6 +1817,7 @@ class IterableDatasetDict(dict):
                     input_columns=input_columns,
                     batched=batched,
                     batch_size=batch_size,
+                    fn_kwargs=fn_kwargs,
                 )
                 for k, dataset in self.items()
             }

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1237,6 +1237,8 @@ class IterableDataset(DatasetInfoMixin):
                 Provide batch of examples to `function`.
             batch_size (`int`, *optional*, default `1000`):
                 Number of examples per batch provided to `function` if `batched=True`.
+            fn_kwargs (`Dict`, *optional*, default `None`):
+                Keyword arguments to be passed to `function`.
 
         Example:
 
@@ -1269,6 +1271,7 @@ class IterableDataset(DatasetInfoMixin):
             input_columns=input_columns,
             batched=batched,
             batch_size=batch_size,
+            fn_kwargs=fn_kwargs,
         )
         return IterableDataset(
             ex_iterable=ex_iterable,

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -8,9 +8,9 @@ import pytest
 
 from datasets import load_from_disk
 from datasets.arrow_dataset import Dataset
-from datasets.iterable_dataset import IterableDataset
 from datasets.dataset_dict import DatasetDict, IterableDatasetDict
 from datasets.features import ClassLabel, Features, Sequence, Value
+from datasets.iterable_dataset import IterableDataset
 from datasets.splits import NamedSplit
 
 from .utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases, require_tf, require_torch

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -311,7 +311,7 @@ class DatasetDictTest(TestCase):
         mapped_example = next(iter(mapped_dsets["train"]))
         self.assertListEqual(list(example.keys()), list(mapped_example.keys()))
         self.assertListEqual(mapped_dsets["train"].column_names, ["filename", "foo"])
-        self.assertLessEqual(len(mapped_example["foo"]), 3)
+        self.assertLessEqual(mapped_example["foo"][0], 3)
         del dsets, mapped_dsets
 
     def test_filter(self):
@@ -348,7 +348,7 @@ class DatasetDictTest(TestCase):
         )
         filtered_example = next(iter(filtered_dsets["train"]))
         self.assertListEqual(list(example.keys()), list(filtered_example.keys()))
-        self.assertEqual(filtered_example["filename"].split("_")[-1], 3)
+        self.assertEqual(len(filtered_example["filename"]), 3)
         del dsets, filtered_dsets
 
     def test_sort(self):

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -339,17 +339,16 @@ class DatasetDictTest(TestCase):
             del dsets, filtered_dsets_1, filtered_dsets_2, filtered_dsets_3
 
     def test_iterable_filter(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            dsets = self._create_dummy_iterable_dataset_dict()
-            example = next(iter(dsets))
-            fn_kwargs = {"n": 3}
-            filtered_dsets: IterableDatasetDict = dsets.filter(
-                lambda ex, n: int(ex["filename"].split("_")[-1]) < n, fn_kwargs=fn_kwargs
-            )
-            filtered_example = next(iter(filtered_dsets["train"]))
-            self.assertListEqual(list(example.keys()), list(filtered_example.keys()))
-            self.assertEqual(filtered_example["filename"].split("_")[-1], 3)
-            del dsets, filtered_dsets
+        dsets = self._create_dummy_iterable_dataset_dict()
+        example = next(iter(dsets))
+        fn_kwargs = {"n": 3}
+        filtered_dsets: IterableDatasetDict = dsets.filter(
+            lambda ex, n: int(ex["filename"].split("_")[-1]) < n, fn_kwargs=fn_kwargs
+        )
+        filtered_example = next(iter(filtered_dsets["train"]))
+        self.assertListEqual(list(example.keys()), list(filtered_example.keys()))
+        self.assertEqual(filtered_example["filename"].split("_")[-1], 3)
+        del dsets, filtered_dsets
 
     def test_sort(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -7,7 +7,8 @@ import pandas as pd
 import pytest
 
 from datasets import load_from_disk
-from datasets.arrow_dataset import Dataset, IterableDataset
+from datasets.arrow_dataset import Dataset
+from datasets.iterable_dataset import IterableDataset
 from datasets.dataset_dict import DatasetDict, IterableDatasetDict
 from datasets.features import ClassLabel, Features, Sequence, Value
 from datasets.splits import NamedSplit

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -521,7 +521,7 @@ def test_filtered_examples_iterable_with_fn_kwargs(n, func, batched, batch_size,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
-        expected = [x for x in enumerate(all_examples) if func(x, **fn_kwargs)]
+        expected = [x for x in all_examples if func(x, **fn_kwargs)]
     else:
         # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         expected = []
@@ -883,7 +883,7 @@ def test_iterable_dataset_map_with_fn_kwargs(dataset: IterableDataset) -> None:
     assert next(iter(mapped_dataset)) == {"id": 0, "id+y": 1}
     batch_size = 3
     mapped_dataset = dataset.map(
-        lambda x, y: {"id+y": x["id"] + y}, batched=True, batch_size=batch_size, fn_kwargs=fn_kwargs
+        lambda x, y: {"id+y": [i + y for i in x["id"]]}, batched=True, batch_size=batch_size, fn_kwargs=fn_kwargs
     )
     assert isinstance(mapped_dataset._ex_iterable, MappedExamplesIterable)
     assert mapped_dataset._ex_iterable.batch_size == batch_size
@@ -892,9 +892,9 @@ def test_iterable_dataset_map_with_fn_kwargs(dataset: IterableDataset) -> None:
 
 def test_iterable_dataset_filter(dataset: IterableDataset) -> None:
     fn_kwargs = {"y": 1}
-    with dataset.filter(lambda x, y: x["id"] == y, fn_kwargs=fn_kwargs) as filtered_dataset:
-        assert filtered_dataset._ex_iterable.batched is False
-        assert next(iter(filtered_dataset)) == {"id": 1}
+    filtered_dataset = dataset.filter(lambda x, y: x["id"] == y, fn_kwargs=fn_kwargs)
+    assert filtered_dataset._ex_iterable.batched is False
+    assert next(iter(filtered_dataset)) == {"id": 1}
 
 
 @pytest.mark.parametrize("seed", [42, 1337, 101010, 123456])

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -511,6 +511,7 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
             expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
     assert next(iter(ex_iterable))[1] == expected[0]
     assert [x for _, x in ex_iterable] == expected
+    
 
 
 @pytest.mark.parametrize(

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -507,8 +507,7 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
     [
         (3, lambda x, y: x["id"] == y, False, None, {"y": 1}),  # keep even number
         (25, lambda x, y: [i == y for i in x["id"]], True, 10, {"y": 1}),  # same with bs=10
-        (5, lambda x, y: [i == 0 for i in x["id"]], True, None, {"y": 1}),  # same with bs=None
-        (5, lambda x, y: [i == 0 for i in x["id"]], True, -1, {"y": 1}),  # same with bs<=0
+        (5, lambda x, y: [i == y for i in x["id"]], True, None, {"y": 1}),  # same with bs=None
     ],
 )
 def test_filtered_examples_iterable_with_fn_kwargs(n, func, batched, batch_size, fn_kwargs):

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -505,7 +505,7 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
 @pytest.mark.parametrize(
     "n, func, batched, batch_size, fn_kwargs",
     [
-        (3, lambda x, y: x["id"] == y, False, None, {"y": 1}),  # keep even number
+        (3, lambda x, y: x["id"] == y, False, None, {"y": 1}),
         (25, lambda x, y: [i == y for i in x["id"]], True, 10, {"y": 1}),  # same with bs=10
         (5, lambda x, y: [i == y for i in x["id"]], True, None, {"y": 1}),  # same with bs=None
     ],

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -878,16 +878,16 @@ def test_iterable_dataset_map_with_features(dataset: IterableDataset) -> None:
 
 def test_iterable_dataset_map_with_fn_kwargs(dataset: IterableDataset) -> None:
     fn_kwargs = {"y": 1}
-    with dataset.map(lambda x, y: {"id+y": x["id"] + y}, fn_kwargs=fn_kwargs) as mapped_dataset:
-        assert mapped_dataset._ex_iterable.batched is False
-        assert next(iter(mapped_dataset)) == {"id": 0, "id+y": 1}
+    mapped_dataset = dataset.map(lambda x, y: {"id+y": x["id"] + y}, fn_kwargs=fn_kwargs)
+    assert mapped_dataset._ex_iterable.batched is False
+    assert next(iter(mapped_dataset)) == {"id": 0, "id+y": 1}
     batch_size = 3
-    with dataset.map(
+    mapped_dataset = dataset.map(
         lambda x, y: {"id+y": x["id"] + y}, batched=True, batch_size=batch_size, fn_kwargs=fn_kwargs
-    ) as mapped_dataset:
-        assert isinstance(mapped_dataset._ex_iterable, MappedExamplesIterable)
-        assert mapped_dataset._ex_iterable.batch_size == batch_size
-        assert next(iter(mapped_dataset)) == {"id": 0, "id+y": 1}
+    )
+    assert isinstance(mapped_dataset._ex_iterable, MappedExamplesIterable)
+    assert mapped_dataset._ex_iterable.batch_size == batch_size
+    assert next(iter(mapped_dataset)) == {"id": 0, "id+y": 1}
 
 
 def test_iterable_dataset_filter(dataset: IterableDataset) -> None:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -514,41 +514,6 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
 
 
 @pytest.mark.parametrize(
-    "n, func, batched, batch_size, fn_kwargs",
-    [
-        (3, lambda x, y: x["id"] == y, False, None, {"y": 1}),
-        (25, lambda x, y: [i == y for i in x["id"]], True, 10, {"y": 1}),  # same with bs=10
-        (5, lambda x, y: [i == y for i in x["id"]], True, None, {"y": 1}),  # same with bs=None
-    ],
-)
-def test_filtered_examples_iterable_with_fn_kwargs(n, func, batched, batch_size, fn_kwargs):
-    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = FilteredExamplesIterable(
-        base_ex_iterable,
-        func,
-        batched=batched,
-        batch_size=batch_size,
-        fn_kwargs=fn_kwargs,
-    )
-    all_examples = [x for _, x in generate_examples_fn(n=n)]
-    if batched is False:
-        expected = [x for x in all_examples if func(x, **fn_kwargs)]
-    else:
-        # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
-        expected = []
-        # If batch_size is None or <=0, we use the whole dataset as a single batch
-        if batch_size is None or batch_size <= 0:
-            batch_size = len(all_examples)
-        for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
-            batch = _examples_to_batch(examples)
-            mask = func(batch, **fn_kwargs)
-            expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
-    assert next(iter(ex_iterable))[1] == expected[0]
-    assert [x for _, x in ex_iterable] == expected
-
-
-@pytest.mark.parametrize(
     "n, func, batched, batch_size, input_columns",
     [
         (3, lambda id_: id_ % 2 == 0, False, None, ["id"]),  # keep even number

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -511,7 +511,6 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
             expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
     assert next(iter(ex_iterable))[1] == expected[0]
     assert [x for _, x in ex_iterable] == expected
-    
 
 
 @pytest.mark.parametrize(

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -503,6 +503,42 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
 
 
 @pytest.mark.parametrize(
+    "n, func, batched, batch_size, fn_kwargs",
+    [
+        (3, lambda x, y: x["id"] == y, False, None, {"y": 1}),  # keep even number
+        (25, lambda x, y: [i == y for i in x["id"]], True, 10, {"y": 1}),  # same with bs=10
+        (5, lambda x, y: [i == 0 for i in x["id"]], True, None, {"y": 1}),  # same with bs=None
+        (5, lambda x, y: [i == 0 for i in x["id"]], True, -1, {"y": 1}),  # same with bs<=0
+    ],
+)
+def test_filtered_examples_iterable_with_fn_kwargs(n, func, batched, batch_size, fn_kwargs):
+    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
+    ex_iterable = FilteredExamplesIterable(
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        fn_kwargs=fn_kwargs,
+    )
+    all_examples = [x for _, x in generate_examples_fn(n=n)]
+    if batched is False:
+        expected = [x for x in enumerate(all_examples) if func(x, **fn_kwargs)]
+    else:
+        # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
+        expected = []
+        # If batch_size is None or <=0, we use the whole dataset as a single batch
+        if batch_size is None or batch_size <= 0:
+            batch_size = len(all_examples)
+        for batch_offset in range(0, len(all_examples), batch_size):
+            examples = all_examples[batch_offset : batch_offset + batch_size]
+            batch = _examples_to_batch(examples)
+            mask = func(batch, **fn_kwargs)
+            expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
+    assert next(iter(ex_iterable))[1] == expected[0]
+    assert [x for _, x in ex_iterable] == expected
+
+
+@pytest.mark.parametrize(
     "n, func, batched, batch_size, input_columns",
     [
         (3, lambda id_: id_ % 2 == 0, False, None, ["id"]),  # keep even number


### PR DESCRIPTION
# Overview
I've added an argument`fn_kwargs` for map and filter methods of `IterableDataset` and `IterableDatasetDict` classes.

# Details
Currently, the map and filter methods of some classes related to `IterableDataset` do not allow specifing the arguments passed to the function. This pull request adds `fn_kwargs` to pass arguments to the mapping function. This allows users to preprocess data more flexibly.

Added `fn_kwargs` to the following classes and methods (description of the argument is also added).
1. class `FilteredExamplesIterable`
2. method `filter` of class `IterableDataset`
3. method `map` of class `IterableDatasetDict`
4. method `filter` of class `IterableDatasetDict`

# Example of changes
Here's an example of how to use the new functionality:
```python
from datasets import IterableDatasetDict

def preprocess_function(example, a=None, b=None):
    # do something
    return example

dataset = IterableDatasetDict(...)
dataset = dataset.map(preprocess_function, fn_kwargs={"a": 1, "b": 2})
```
# Related Issues
This pull request is related to the following issue:
https://github.com/huggingface/datasets/issues/3444 .

# Testing
I have added unit tests to test the new functionality.

In test_iterable_dataset.py  
- Added `test_filtered_examples_iterable_with_fn_kwargs` for [1](#details).
- Added `test_iterable_dataset_filter` for [2](#details).
- Added `test_iterable_dataset_map_with_fn_kwargs`. This is not a newly added feature, but was added because it was not tested.

In test_dataset_dict.py  
- Added `_create_dummy_iterable_dataset` for [3](#details) and [4](#details).
- Added `_create_dummy_iterable_dataset_dict` for [3](#details) and [4](#details).
- Added `test_iterable_map` for [3](#details).
- Added `test_iterable_filter` for [4](#details).

Note that, there is no test for `IterableDatasetDict` at the current main branch. I thought about writing tests for `IterableDatasetDict` in a new file, but I decided to add them in the test file for `DatasetDict` (test_dataset_dict.py).

# Checklist
- [x] Format the code.
- [x] Added tests.
- [x] Passed tests locally.