### PR TITLE
IterableDataset Arrow formatting

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -56,7 +56,7 @@ from .features import Features
 from .filesystems import is_remote_filesystem
 from .fingerprint import Hasher
 from .info import DatasetInfo, DatasetInfosDict, PostProcessedInfo
-from .iterable_dataset import ExamplesIterable, IterableDataset, _generate_examples_from_tables_wrapper
+from .iterable_dataset import ArrowExamplesIterable, ExamplesIterable, IterableDataset
 from .keyhash import DuplicatedKeysError
 from .naming import INVALID_WINDOWS_CHARACTERS_IN_PATH, camelcase_to_snakecase
 from .splits import Split, SplitDict, SplitGenerator, SplitInfo
@@ -1895,9 +1895,7 @@ class ArrowBasedBuilder(DatasetBuilder):
         yield job_id, True, (total_num_examples, total_num_bytes, writer._features, num_shards, shard_lengths)
 
     def _get_examples_iterable_for_split(self, split_generator: SplitGenerator) -> ExamplesIterable:
-        return ExamplesIterable(
-            _generate_examples_from_tables_wrapper(self._generate_tables), kwargs=split_generator.gen_kwargs
-        )
+        return ArrowExamplesIterable(self._generate_tables, kwargs=split_generator.gen_kwargs)
 
 
 class MissingBeamOptions(ValueError):

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -864,7 +864,7 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                 else:
                     function_args.append(current_idx)
             # then apply the transform
-            mask = self.function(*function_args)
+            mask = self.function(*function_args, **self.fn_kwargs)
             # yield the filtered table
             if self.batched:
                 yield key, pa_table.filter(mask)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1420,7 +1420,8 @@ class IterableDataset(DatasetInfoMixin):
     ) -> "IterableDataset":
         """
         Return a dataset with the specified format.
-        This method only supports the "torch" format for now.
+        Supported formats: "arrow", or None for regular python objects.
+        The other formats are currently not implemented.
 
         Args:
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -87,9 +87,9 @@ class _HasNextIterator(Iterator):
 def _convert_to_arrow(
     iterable: Iterable[Tuple[Key, dict]],
     batch_size: int,
-    drop_last_batch=False,
+    drop_last_batch: bool = False,
 ) -> Iterator[Tuple[Key, pa.Table]]:
-    """Iterate over sub-tables of size `batch_size`.
+    """Convert and group examples in Arrow tables of size `batch_size`.
 
     Args:
         iterable (`Iterable[Tuple[Key, dict]]`):
@@ -116,7 +116,7 @@ def _convert_to_arrow(
 def _batch_arrow_tables(
     iterable: Iterable[Tuple[Key, pa.Table]],
     batch_size: Optional[int],
-    drop_last_batch=False,
+    drop_last_batch: bool = False,
 ) -> Iterator[Tuple[Key, pa.Table]]:
     """Iterate over sub-tables of size `batch_size`.
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1043,17 +1043,6 @@ class TypedExamplesIterable(_BaseExamplesIterable):
         return self.ex_iterable.n_shards
 
 
-def _generate_examples_from_tables_wrapper(generate_tables_fn):
-    def wrapper(**kwargs):
-        python_formatter = PythonFormatter()
-        for key, table in generate_tables_fn(**kwargs):
-            batch = python_formatter.format_batch(table)
-            for i, example in enumerate(_batch_to_examples(batch)):
-                yield f"{key}_{i}", example
-
-    return wrapper
-
-
 @dataclass
 class ShufflingConfig:
     generator: np.random.Generator

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -5,7 +5,7 @@ from collections import Counter
 from copy import deepcopy
 from dataclasses import dataclass
 from itertools import cycle, islice
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
@@ -24,6 +24,8 @@ from .utils.sharding import _merge_gen_kwargs, _number_of_shards_in_gen_kwargs, 
 
 
 logger = get_logger(__name__)
+
+Key = Union[int, str]
 
 
 def _infer_features_from_batch(batch: Dict[str, list], try_features: Optional[Features] = None) -> Features:
@@ -81,23 +83,57 @@ class HasNextIterator(Iterator):
         return self._hasnext
 
 
-def _batch_arrow_tables(
-    iterator: Iterator[Tuple[Any, pa.Table]],
+def _convert_to_arrow(
+    iterable: Iterable[Tuple[Key, dict]],
     batch_size: int,
     drop_last_batch=False,
-) -> Iterator[Tuple[Any, pa.Table]]:
+) -> Iterator[Tuple[Key, pa.Table]]:
     """Iterate over sub-tables of size `batch_size`.
 
     Args:
-        batch_size (`int`):
-            Size of each sub-table to yield.
+        iterable (`Iterable[Tuple[Key, dict]]`):
+            An examples iterable containing tuples (example_key, example) of type (int/str, dict)
+        batch_size (`Optional[int]`):
+            Size of each sub-table to yield. If None or <= 0, yields the full table.
         drop_last_batch (`bool`, defaults to `False`):
             Drop the last batch if it is smaller than `batch_size`.
     """
+    if batch_size is None or batch_size <= 0:
+        yield "all", pa.Table.from_pylist([example for _, example in iterable])
+        return
+    iterator = iter(iterable)
+    for key, example in iterator:
+        iterator_batch = islice(iterator, batch_size - 1)
+        key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
+        if len(key_examples_list) < batch_size and drop_last_batch:
+            return
+        keys, examples = zip(*key_examples_list)
+        new_key = "_".join(str(key) for key in keys)
+        yield new_key, pa.Table.from_pylist(examples)
+
+
+def _batch_arrow_tables(
+    iterable: Iterable[Tuple[Key, pa.Table]],
+    batch_size: Optional[int],
+    drop_last_batch=False,
+) -> Iterator[Tuple[Key, pa.Table]]:
+    """Iterate over sub-tables of size `batch_size`.
+
+    Args:
+        iterable (`Iterable[Tuple[Key, pa.Table]]`):
+            A tables iterable containing tuples (table_key, table) of type (int/str, pa.Table)
+        batch_size (`Optional[int]`):
+            Size of each sub-table to yield. If None or <= 0, yields the full table.
+        drop_last_batch (`bool`, defaults to `False`):
+            Drop the last batch if it is smaller than `batch_size`.
+    """
+    if batch_size is None or batch_size <= 0:
+        yield "all", pa.concat_tables([pa_table for _, pa_table in iterable])
+        return
     keys_buffer = []
     chunks_buffer = []
     chunks_buffer_size = 0
-    for key, pa_table in iterator:
+    for key, pa_table in iterable:
         for chunk in pa_table.to_reader(max_chunksize=batch_size):
             if len(chunk) == 0:
                 continue
@@ -132,9 +168,9 @@ class _BaseExamplesIterable:
     """Base class for the examples iterable used by an IterableDataset"""
 
     def __init__(self) -> None:
-        self.iter_arrow: Optional[Callable[[], Iterator[Tuple[Any, pa.Table]]]] = None
+        self.iter_arrow: Optional[Callable[[], Iterator[Tuple[Key, pa.Table]]]] = None
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Tuple[Key, dict]]:
         """An examples iterable should yield tuples (example_key, example) of type (int/str, dict)"""
         raise NotImplementedError(f"{type(self)} doesn't implement __iter__ yet")
 
@@ -155,7 +191,7 @@ class _BaseExamplesIterable:
 
 
 class ExamplesIterable(_BaseExamplesIterable):
-    def __init__(self, generate_examples_fn: Callable, kwargs: dict):
+    def __init__(self, generate_examples_fn: Callable[..., Tuple[Key, dict]], kwargs: dict):
         super().__init__()
         self.generate_examples_fn = generate_examples_fn
         self.kwargs = kwargs
@@ -178,7 +214,9 @@ class ExamplesIterable(_BaseExamplesIterable):
 
 
 class ShuffledDataSourcesExamplesIterable(ExamplesIterable):
-    def __init__(self, generate_examples_fn: Callable, kwargs: dict, generator: np.random.Generator):
+    def __init__(
+        self, generate_examples_fn: Callable[..., Tuple[Key, dict]], kwargs: dict, generator: np.random.Generator
+    ):
         super().__init__(generate_examples_fn, kwargs)
         self.generator = deepcopy(generator)
 
@@ -198,7 +236,7 @@ class ShuffledDataSourcesExamplesIterable(ExamplesIterable):
 
 
 class ArrowExamplesIterable(_BaseExamplesIterable):
-    def __init__(self, generate_tables_fn: Callable, kwargs: dict):
+    def __init__(self, generate_tables_fn: Callable[..., Tuple[Key, pa.Table]], kwargs: dict):
         super().__init__()
         self.generate_tables_fn = generate_tables_fn
         self.kwargs = kwargs
@@ -234,7 +272,7 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
 class ShuffledDataSourcesArrowExamplesIterable(ArrowExamplesIterable):
     def __init__(
         self,
-        generate_tables_fn: Callable,
+        generate_tables_fn: Callable[..., Tuple[Key, pa.Table]],
         kwargs: dict,
         generator: np.random.Generator,
     ):
@@ -266,36 +304,6 @@ class ShuffledDataSourcesArrowExamplesIterable(ArrowExamplesIterable):
         )
 
 
-class PythonToArrowExamplesIterable(_BaseExamplesIterable):
-    def __init__(self, ex_iterable: _BaseExamplesIterable):
-        super().__init__()
-        self.ex_iterable = ex_iterable
-        self.iter_arrow = self._iter_arrow
-
-    def __iter__(self):
-        yield from self.ex_iterable
-
-    def _iter_arrow(self) -> Iterator[Tuple[Any, pa.Table]]:
-        iterator = iter(self.ex_iterable)
-        batch_size = config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER
-        for key, example in iterator:
-            iterator_batch = islice(iterator, batch_size - 1)
-            key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
-            keys, examples = zip(*key_examples_list)
-            new_key = "_".join(str(key) for key in keys)
-            yield new_key, pa.Table.from_pylist(examples)
-
-    def shuffle_data_sources(self, generator: np.random.Generator) -> "PythonToArrowExamplesIterable":
-        return PythonToArrowExamplesIterable(self.ex_iterable.shuffle_data_sources(generator))
-
-    def shard_data_sources(self, shard_indices: List[int]) -> "PythonToArrowExamplesIterable":
-        return PythonToArrowExamplesIterable(self.ex_iterable.shard_data_sources(shard_indices))
-
-    @property
-    def n_shards(self) -> int:
-        return self.ex_iterable.n_shards
-
-
 class SelectColumnsIterable(_BaseExamplesIterable):
     def __init__(self, ex_iterable: _BaseExamplesIterable, column_names: List[str]):
         super().__init__()
@@ -308,7 +316,7 @@ class SelectColumnsIterable(_BaseExamplesIterable):
         for idx, row in self.ex_iterable:
             yield idx, {c: row[c] for c in self.column_names}
 
-    def _iter_arrow(self) -> Iterator[Tuple[Any, pa.Table]]:
+    def _iter_arrow(self) -> Iterator[Tuple[Key, pa.Table]]:
         for idx, pa_table in self.ex_iterable.iter_arrow():
             yield idx, pa_table.select(self.column_names)
 
@@ -677,11 +685,19 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 yield key, transformed_example
                 current_idx += 1
 
-    def _iter_arrow(self) -> Iterator[Tuple[Any, pa.Table]]:
-        ex_iterable = (
-            self.ex_iterable if self.ex_iterable.iter_arrow else PythonToArrowExamplesIterable(self.ex_iterable)
-        )
-        iterator = _batch_arrow_tables(ex_iterable.iter_arrow(), batch_size=self.batch_size if self.batched else 1)
+    def _iter_arrow(self) -> Iterator[Tuple[Key, pa.Table]]:
+        if self.ex_iterable.iter_arrow:
+            iterator = _batch_arrow_tables(
+                self.ex_iterable.iter_arrow(),
+                batch_size=self.batch_size if self.batched else 1,
+                drop_last_batch=self.drop_last_batch,
+            )
+        else:
+            iterator = _convert_to_arrow(
+                self.ex_iterable,
+                batch_size=self.batch_size if self.batched else 1,
+                drop_last_batch=self.drop_last_batch,
+            )
         current_idx = 0
         for key, pa_table in iterator:
             # first build the batch
@@ -692,22 +708,18 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 else:
                     function_args.append(current_idx)
             # then apply the transform
-            transformed_table = self.function(*function_args, **self.fn_kwargs)
-            if not isinstance(transformed_table, pa.Table):
+            output_table = self.function(*function_args, **self.fn_kwargs)
+            if not isinstance(output_table, pa.Table):
                 raise TypeError(
-                    f"Provided `function` which is applied to pyarrow tables returns a variable of type {type(transformed_table)}. Make sure provided `function` returns a a pyarrow table to update the dataset."
+                    f"Provided `function` which is applied to pyarrow tables returns a variable of type {type(output_table)}. Make sure provided `function` returns a a pyarrow table to update the dataset."
                 )
-            # merge results
-            merged_output = dict(zip(pa_table.column_names, pa_table.itercolumns()))
-            merged_output.update(dict(zip(transformed_table.column_names, transformed_table.itercolumns())))
+            # we don't need to merge results for consistency with Dataset.map which merges iif both input and output are dicts
             # then remove the unwanted columns
             if self.remove_columns:
                 for column in self.remove_columns:
-                    if column in merged_output:
-                        del merged_output[column]
+                    if column in output_table.column_names:
+                        output_table = output_table.remove_column(output_table.column_names.index(column))
             # return output
-            names, arrays = zip(*merged_output.items())
-            output_table = pa.Table.from_arrays(arrays=arrays, names=names)
             yield key, output_table
             current_idx += len(pa_table)
 
@@ -808,10 +820,12 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                 current_idx += 1
 
     def _iter_arrow(self):
-        ex_iterable = (
-            self.ex_iterable if self.ex_iterable.iter_arrow else PythonToArrowExamplesIterable(self.ex_iterable)
-        )
-        iterator = _batch_arrow_tables(ex_iterable.iter_arrow(), batch_size=self.batch_size if self.batched else 1)
+        if self.ex_iterable.iter_arrow:
+            iterator = _batch_arrow_tables(
+                self.ex_iterable.iter_arrow(), batch_size=self.batch_size if self.batched else 1
+            )
+        else:
+            iterator = _convert_to_arrow(self.ex_iterable, batch_size=self.batch_size if self.batched else 1)
         current_idx = 0
         for key, pa_table in iterator:
             # first build the batch
@@ -995,7 +1009,7 @@ class TypedExamplesIterable(_BaseExamplesIterable):
                 example, self.features, token_per_repo_id=self.token_per_repo_id
             )
 
-    def _iter_arrow(self) -> Iterator[Tuple[Any, pa.Table]]:
+    def _iter_arrow(self) -> Iterator[Tuple[Key, pa.Table]]:
         schema = self.features.arrow_schema
         for key, pa_table in self.ex_iterable.iter_arrow():
             columns = set(pa_table.column_names)
@@ -1237,10 +1251,13 @@ class IterableDataset(DatasetInfoMixin):
         """
         ex_iterable = self._prepare_ex_iterable_for_iteration()
         if self._format_type == "arrow":
-            ex_iterable = ex_iterable if ex_iterable.iter_arrow else PythonToArrowExamplesIterable(ex_iterable)
-            for key, pa_table in _batch_arrow_tables(
-                ex_iterable.iter_arrow(), batch_size=batch_size, drop_last_batch=drop_last_batch
-            ):
+            if ex_iterable.iter_arrow:
+                iterator = _batch_arrow_tables(
+                    ex_iterable.iter_arrow(), batch_size=batch_size, drop_last_batch=drop_last_batch
+                )
+            else:
+                iterator = _convert_to_arrow(ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch)
+            for key, pa_table in iterator:
                 if self.features:
                     columns = set(pa_table.colum_names)
                     # add missing columns

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -113,15 +113,15 @@ def test_batch_arrow_tables(tables, batch_size, drop_last_batch):
     full_table = pa.concat_tables(tables)
     num_rows = len(full_table) if not drop_last_batch else len(full_table) // batch_size * batch_size
     num_batches = (num_rows // batch_size) + 1 if num_rows % batch_size else num_rows // batch_size
-    subtables = list(_batch_arrow_tables(tables, batch_size=batch_size, drop_last_batch=drop_last_batch))
+    subtables = list(_batch_arrow_tables([(i, table) for i, table in enumerate(tables)], batch_size=batch_size, drop_last_batch=drop_last_batch))
     assert len(subtables) == num_batches
     if drop_last_batch:
-        assert all(len(subtable) == batch_size for subtable in subtables)
+        assert all(len(subtable) == batch_size for _, subtable in subtables)
     else:
-        assert all(len(subtable) == batch_size for subtable in subtables[:-1])
-        assert len(subtables[-1]) <= batch_size
+        assert all(len(subtable) == batch_size for _, subtable in subtables[:-1])
+        assert len(subtables[-1][1]) <= batch_size
     if num_rows > 0:
-        reloaded = pa.concat_tables(subtables)
+        reloaded = pa.concat_tables([subtable for _, subtable in subtables])
         assert full_table.slice(0, num_rows).to_pydict() == reloaded.to_pydict()
 
 


### PR DESCRIPTION
Adding an optional `.iter_arrow` to examples iterable. This allows to use Arrow formatting in map/filter.

This will also be useful for torch formatting, since we can reuse the TorchFormatter that converts Arrow data to torch tensors

Related to https://github.com/huggingface/datasets/issues/5793 and https://github.com/huggingface/datasets/issues/3444

Required for https://github.com/huggingface/datasets/pull/5852

### Example: 

Speed x10 in map

```python
from datasets import Dataset
import pyarrow.compute as pc
import time


ds = Dataset.from_dict({"a": range(100_000)})


ids = ds.to_iterable_dataset()
ids = ids.map(lambda x: {"a": [a + 10 for a in x["a"]]}, batched=True)

_start = time.time()
print(f"Python ({sum(1 for _ in ids)} items):\t{(time.time() - _start) * 1000:.1f}ms")
# Python (100000 items):  695.7ms

ids = ds.to_iterable_dataset().with_format("arrow")
ids = ids.map(lambda t: t.set_column(0, "a", pc.add(t[0], 10)), batched=True)
ids = ids.with_format(None)

_start = time.time()
print(f"Arrow ({sum(1 for _ in ids)} items):\t{(time.time() - _start) * 1000:.1f}ms)")
# Arrow (100000 items):   81.0ms)
```


### Implementation details

I added an optional `iter_arrow` method to examples iterable. If an example iterable has this method, then it can be used to iterate on the examples by batch of arrow tables.