### PR TITLE
Support working_dir in from_spark

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1248,7 +1248,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Whether to copy the data in-memory.
             working_dir (`str`, *optional*)
                 Intermediate directory for each Spark worker to write data to before moving it to `cache_dir`. Setting
-                a non-NFS intermediate directory may improve performance. Can also be set via env var HF_WORKING_DIR.
+                a non-NFS intermediate directory may improve performance.
             load_from_cache_file (`bool`):
                 Whether to load the dataset from the cache if possible.
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1228,6 +1228,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
         cache_dir: str = None,
+        working_dir: str = None,
         load_from_cache_file: bool = True,
         **kwargs,
     ):
@@ -1245,6 +1246,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 workers and the driver.
             keep_in_memory (`bool`):
                 Whether to copy the data in-memory.
+            working_dir (`str`, *optional*)
+                Intermediate directory for each Spark worker to write data to before moving it to `cache_dir`. Setting
+                a non-NFS intermediate directory may improve performance.
             load_from_cache_file (`bool`):
                 Whether to load the dataset from the cache if possible.
 
@@ -1274,6 +1278,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             streaming=False,
             cache_dir=cache_dir,
             keep_in_memory=keep_in_memory,
+            working_dir=working_dir,
             load_from_cache_file=load_from_cache_file,
             **kwargs,
         ).read()

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1248,7 +1248,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Whether to copy the data in-memory.
             working_dir (`str`, *optional*)
                 Intermediate directory for each Spark worker to write data to before moving it to `cache_dir`. Setting
-                a non-NFS intermediate directory may improve performance.
+                a non-NFS intermediate directory may improve performance. Can also be set via env var HF_WORKING_DIR.
             load_from_cache_file (`bool`):
                 Whether to load the dataset from the cache if possible.
 

--- a/src/datasets/io/spark.py
+++ b/src/datasets/io/spark.py
@@ -23,6 +23,7 @@ class SparkDatasetReader(AbstractDatasetReader):
         streaming: bool = True,
         cache_dir: str = None,
         keep_in_memory: bool = False,
+        working_dir: str = None,
         load_from_cache_file: bool = True,
         file_format: str = "arrow",
         **kwargs,
@@ -41,6 +42,7 @@ class SparkDatasetReader(AbstractDatasetReader):
             df=df,
             features=features,
             cache_dir=cache_dir,
+            working_dir=working_dir,
             **kwargs,
         )
 

--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -91,7 +91,6 @@ class Spark(datasets.DatasetBuilder):
 
         self._spark = pyspark.sql.SparkSession.builder.getOrCreate()
         self.df = df
-        self._validate_cache_dir(cache_dir)
         self._working_dir = working_dir
 
         super().__init__(
@@ -169,7 +168,8 @@ class Spark(datasets.DatasetBuilder):
         import pyspark
 
         writer_class = ParquetWriter if file_format == "parquet" else ArrowWriter
-        working_fpath = os.path.join(self._working_dir, os.path.basename(fpath)) if self._working_dir else fpath
+        working_dir = self._working_dir or os.environ.get("HF_WORKING_DIR")
+        working_fpath = os.path.join(working_dir, os.path.basename(fpath)) if working_dir else fpath
         embed_local_files = file_format == "parquet"
 
         # Define these so that we don't reference self in write_arrow, which will result in a pickling error due to

--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -168,8 +168,7 @@ class Spark(datasets.DatasetBuilder):
         import pyspark
 
         writer_class = ParquetWriter if file_format == "parquet" else ArrowWriter
-        working_dir = self._working_dir or os.environ.get("HF_WORKING_DIR")
-        working_fpath = os.path.join(working_dir, os.path.basename(fpath)) if working_dir else fpath
+        working_fpath = os.path.join(self._working_dir, os.path.basename(fpath)) if self._working_dir else fpath
         embed_local_files = file_format == "parquet"
 
         # Define these so that we don't reference self in write_arrow, which will result in a pickling error due to
@@ -228,7 +227,7 @@ class Spark(datasets.DatasetBuilder):
             if working_fpath != fpath:
                 for file in os.listdir(os.path.dirname(working_fpath)):
                     dest = os.path.join(os.path.dirname(fpath), os.path.basename(file))
-                    os.rename(file, dest)
+                    shutil.move(file, dest)
 
         stats = (
             self.df.mapInArrow(write_arrow, "task_id: long, num_examples: long, num_bytes: long")

--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -84,12 +84,15 @@ class Spark(datasets.DatasetBuilder):
         self,
         df: "pyspark.sql.DataFrame",
         cache_dir: str = None,
+        working_dir: str = None,
         **config_kwargs,
     ):
         import pyspark
 
         self._spark = pyspark.sql.SparkSession.builder.getOrCreate()
         self.df = df
+        self._validate_cache_dir(cache_dir)
+        self._working_dir = working_dir
 
         super().__init__(
             cache_dir=cache_dir,

--- a/tests/packaged_modules/test_spark.py
+++ b/tests/packaged_modules/test_spark.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pyspark
 
 from datasets.packaged_modules.spark.spark import (
+    Spark,
     SparkExamplesIterable,
     _generate_iterable_examples,
 )
@@ -20,6 +21,18 @@ def _get_expected_row_ids_and_row_dicts_for_partition_order(df, partition_order)
         for row_idx, row in enumerate(partition):
             expected_row_ids_and_row_dicts.append((f"{part_id}_{row_idx}", row.asDict()))
     return expected_row_ids_and_row_dicts
+
+@require_not_windows
+@require_dill_gt_0_3_2
+def test_repartition_df_if_needed():
+    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    df = spark.range(100).repartition(1)
+    spark_builder = Spark(df)
+    # The id ints will be converted to Pyarrow int64s, so each row will be 8 bytes. Setting a max_shard_size of 16 means
+    # that each partition can hold 2 rows.
+    spark_builder._repartition_df_if_needed(max_shard_size=16)
+    # Given that the dataframe has 100 rows and each partition has 2 rows, we expect 50 partitions.
+    assert spark_builder.df.rdd.getNumPartitions() == 50
 
 
 @require_not_windows
@@ -90,3 +103,12 @@ def test_spark_examples_iterable_shard():
         expected_row_id, expected_row_dict = expected_row_ids_and_row_dicts_2[i]
         assert row_id == expected_row_id
         assert row_dict == expected_row_dict
+
+def test_repartition_df_if_needed_max_num_df_rows():
+    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    df = spark.range(100).repartition(1)
+    spark_builder = Spark(df)
+    # Choose a small max_shard_size for maximum partitioning.
+    spark_builder._repartition_df_if_needed(max_shard_size=1)
+    # The new number of partitions should not be greater than the number of rows.
+    assert spark_builder.df.rdd.getNumPartitions() == 100

--- a/tests/packaged_modules/test_spark.py
+++ b/tests/packaged_modules/test_spark.py
@@ -22,6 +22,7 @@ def _get_expected_row_ids_and_row_dicts_for_partition_order(df, partition_order)
             expected_row_ids_and_row_dicts.append((f"{part_id}_{row_idx}", row.asDict()))
     return expected_row_ids_and_row_dicts
 
+
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_repartition_df_if_needed():
@@ -104,6 +105,9 @@ def test_spark_examples_iterable_shard():
         assert row_id == expected_row_id
         assert row_dict == expected_row_dict
 
+
+@require_not_windows
+@require_dill_gt_0_3_2
 def test_repartition_df_if_needed_max_num_df_rows():
     spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
     df = spark.range(100).repartition(1)


### PR DESCRIPTION
Accept `working_dir` as an argument to `Dataset.from_spark`. Setting a non-NFS working directory for Spark workers to materialize to will improve write performance.