### PR TITLE
Add `accelerate` as metric's test dependency to fix CI error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ TESTS_REQUIRE = [
 
 METRICS_TESTS_REQUIRE = [
     # metrics dependencies
+    "accelerate",  # for frugalscore (calls transformers' Trainer)
     "bert_score>=0.3.6",
     "jiwer",
     "langdetect",


### PR DESCRIPTION
The `frugalscore` metric uses Transformers' Trainer, which requires `accelerate` (as of recently).

Fixes the following [CI error](https://github.com/huggingface/datasets/actions/runs/4950900048/jobs/8855148703?pr=5845).