### PR TITLE
Minor tqdm optim

### DIFF
--- a/src/datasets/utils/logging.py
+++ b/src/datasets/utils/logging.py
@@ -201,8 +201,8 @@ _tqdm_active = True
 
 
 class _tqdm_cls:
-    def __call__(self, *args, **kwargs):
-        if _tqdm_active:
+    def __call__(self, *args, disable=False, **kwargs):
+        if _tqdm_active and not disable:
             return tqdm_lib.tqdm(*args, **kwargs)
         else:
             return EmptyTqdm(*args, **kwargs)


### PR DESCRIPTION
Don't create a tqdm progress bar when `disable_tqdm` is passed to `map_nested`.

On my side it sped up some iterable datasets by ~30% when `map_nested` is used extensively to recursively tensorize python dicts.