### PR TITLE
Use a new low-memory approach for tf dataset index shuffling

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -115,7 +115,7 @@ from .utils.info_utils import is_small_dataset
 from .utils.metadata import DatasetMetadata
 from .utils.py_utils import Literal, asdict, convert_file_size_to_int, iflatmap_unordered, unique_values
 from .utils.stratify import stratified_shuffle_split_generate_indices
-from .utils.tf_utils import minimal_tf_collate_fn, multiprocess_dataset_to_tf
+from .utils.tf_utils import dataset_to_tf, minimal_tf_collate_fn, multiprocess_dataset_to_tf
 from .utils.typing import ListLike, PathLike
 
 
@@ -457,20 +457,33 @@ class TensorflowDatasetMixin:
             if col not in output_signature:
                 raise ValueError(f"Label column {col} not found in dataset!")
 
-        if num_workers <= 0:
-            num_workers = 1
-        tf_dataset = multiprocess_dataset_to_tf(
-            dataset=dataset,
-            cols_to_retain=cols_to_retain,
-            collate_fn=collate_fn,
-            collate_fn_args=collate_fn_args,
-            columns_to_np_types=columns_to_np_types,
-            output_signature=output_signature,
-            shuffle=shuffle,
-            batch_size=batch_size,
-            drop_remainder=drop_remainder,
-            num_workers=num_workers,
-        )
+        if num_workers == 0:
+            tf_dataset = dataset_to_tf(
+                dataset=dataset,
+                cols_to_retain=cols_to_retain,
+                collate_fn=collate_fn,
+                collate_fn_args=collate_fn_args,
+                columns_to_np_types=columns_to_np_types,
+                output_signature=output_signature,
+                shuffle=shuffle,
+                batch_size=batch_size,
+                drop_remainder=drop_remainder,
+            )
+        elif num_workers > 0:
+            tf_dataset = multiprocess_dataset_to_tf(
+                dataset=dataset,
+                cols_to_retain=cols_to_retain,
+                collate_fn=collate_fn,
+                collate_fn_args=collate_fn_args,
+                columns_to_np_types=columns_to_np_types,
+                output_signature=output_signature,
+                shuffle=shuffle,
+                batch_size=batch_size,
+                drop_remainder=drop_remainder,
+                num_workers=num_workers,
+            )
+        else:
+            raise ValueError("num_workers must be >= 0")
 
         def split_features_and_labels(input_batch):
             # TODO(Matt, QL): deprecate returning the dict content when there's only one key

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -470,6 +470,11 @@ class TensorflowDatasetMixin:
                 drop_remainder=drop_remainder,
             )
         elif num_workers > 0:
+            if batch_size is None:
+                raise NotImplementedError(
+                    "`batch_size` must be specified when using multiple workers, as unbatched multiprocessing "
+                    "is not supported yet. Please provide a `batch_size` if `num_workers` is greater than 0."
+                )
             tf_dataset = multiprocess_dataset_to_tf(
                 dataset=dataset,
                 cols_to_retain=cols_to_retain,

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -199,7 +199,7 @@ def dataset_to_tf(
     tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
 
     if shuffle:
-        base_seed = tf.fill((3,), value=-1, dtype=tf.int64)
+        base_seed = tf.fill((3,), value=tf.cast(-1, dtype=tf.int64))
 
         def scan_random_indices(state, indices):
             if tf.reduce_all(state == -1):

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -220,8 +220,7 @@ def dataset_to_tf(
                 # This generates a new random seed once per epoch only,
                 # to ensure that we iterate over each sample exactly once per epoch
                 state = tf.random.uniform(shape=(3,), maxval=2**62, dtype=tf.int64)
-            state = tf.ensure_shape(state, (3,))
-            shuffled_indices = tf.random_index_shuffle(index=indices, seed=state, max_index=len(dataset) - 1)
+            shuffled_indices = random_index_shuffle(index=indices, seed=state, max_index=len(dataset) - 1)
             return state, shuffled_indices
 
         tf_dataset = tf_dataset.scan(base_seed, scan_random_indices)

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -161,7 +161,8 @@ def dataset_to_tf(
             `tf.TensorSpec` objects.
         shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
             validation/evaluation.
-        batch_size (`int`): Size of batches to load from the dataset.
+        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that
+            the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
         drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
             defaults to the same setting as shuffle.
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -174,10 +174,8 @@ def dataset_to_tf(
     else:
         raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
 
-    # Matt: There are a few version dependencies here - ideally we'd move everything to the multiprocessing path for
-    # simplicity, but that depends on SharedMemory that only arrived in Py3.8. We also have a reasonably efficient
-    # solution without Python multiprocessing, but it depends on TF >= 2.9. If we're on an older version of TF,
-    # we fall back to the slowest path. Hopefully when our minimum versions move up a bit more we can clean this all up.
+    # TODO Matt: When our minimum Python version is 3.8 or higher, we can delete all of this and move everything
+    #            to the NumPy multiprocessing path.
     if hasattr(tf, "random_index_shuffle"):
         random_index_shuffle = tf.random_index_shuffle
     elif hasattr(tf.random.experimental, "index_shuffle"):

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -15,8 +15,6 @@
 """TF-specific utils import."""
 
 import os
-import warnings
-from functools import partial
 from math import ceil
 from uuid import uuid4
 
@@ -131,121 +129,6 @@ def np_get_batch(
             array = array.astype(cast_dtype)
             out_batch.append(array)
     return out_batch
-
-
-def dataset_to_tf(
-    dataset,
-    cols_to_retain,
-    collate_fn,
-    collate_fn_args,
-    columns_to_np_types,
-    output_signature,
-    shuffle,
-    batch_size,
-    drop_remainder,
-):
-    """Create a tf.data.Dataset from the underlying Dataset. This is a single-process method - the multiprocess
-    equivalent is multiprocess_dataset_to_tf.
-
-    Args:
-        dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
-        cols_to_retain (`List[str]`): Dataset column(s) to load in the
-            tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
-            that do not exist in the original dataset.
-        collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
-            lists of samples into a batch.
-        collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
-            `collate_fn`. Can be empty.
-        columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
-        output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
-            `tf.TensorSpec` objects.
-        shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
-            validation/evaluation.
-        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that
-            the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
-        drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
-            defaults to the same setting as shuffle.
-
-    Returns:
-        `tf.data.Dataset`
-    """
-    if config.TF_AVAILABLE:
-        import tensorflow as tf
-    else:
-        raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
-
-    if hasattr(tf, "random_index_shuffle"):
-        random_index_shuffle = tf.random_index_shuffle
-    elif hasattr(tf.random.experimental, "index_shuffle"):
-        random_index_shuffle = tf.random.experimental.index_shuffle
-    else:
-        if len(dataset) > 10_000_000:
-            warnings.warn(
-                "to_tf_dataset() can be memory-inefficient on versions of TensorFlow older than 2.9. "
-                "If you are iterating over a dataset with a very large number of samples, consider "
-                "upgrading to TF >= 2.9."
-            )
-        random_index_shuffle = None
-
-    getter_fn = partial(
-        np_get_batch,
-        dataset=dataset,
-        cols_to_retain=cols_to_retain,
-        collate_fn=collate_fn,
-        collate_fn_args=collate_fn_args,
-        columns_to_np_types=columns_to_np_types,
-        return_dict=False,
-    )
-
-    # This works because dictionaries always output in the same order
-    tout = [tf.dtypes.as_dtype(dtype) for dtype in columns_to_np_types.values()]
-
-    @tf.function(input_signature=[tf.TensorSpec(None, tf.int64)])
-    def fetch_function(indices):
-        output = tf.py_function(
-            getter_fn,
-            inp=[indices],
-            Tout=tout,
-        )
-        return {key: output[i] for i, key in enumerate(columns_to_np_types.keys())}
-
-    tf_dataset = tf.data.Dataset.range(len(dataset))
-
-    if shuffle and random_index_shuffle is not None:
-        tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
-        base_seed = tf.fill((3,), value=tf.cast(-1, dtype=tf.int64))
-
-        def scan_random_indices(state, indices):
-            if tf.reduce_all(state == -1):
-                # This generates a new random seed once per epoch only,
-                # to ensure that we iterate over each sample exactly once per epoch
-                state = tf.random.uniform(shape=(3,), maxval=2**62, dtype=tf.int64)
-            shuffled_indices = random_index_shuffle(index=indices, seed=state, max_index=len(dataset) - 1)
-            return state, shuffled_indices
-
-        tf_dataset = tf_dataset.scan(base_seed, scan_random_indices)
-    elif shuffle:
-        tf_dataset = tf_dataset.shuffle(len(tf_dataset))
-        tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
-    else:
-        tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
-
-    if batch_size is not None:
-        tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
-
-    tf_dataset = tf_dataset.map(fetch_function)
-
-    if batch_size is not None:
-
-        def ensure_shapes(input_dict):
-            return {key: tf.ensure_shape(val, output_signature[key].shape) for key, val in input_dict.items()}
-
-    else:
-        # Ensure shape but remove batch dimension of output_signature[key].shape
-        def ensure_shapes(input_dict):
-            return {key: tf.ensure_shape(val, output_signature[key].shape[1:]) for key, val in input_dict.items()}
-
-    return tf_dataset.map(ensure_shapes)
 
 
 class SharedMemoryContext:

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -216,15 +216,15 @@ def dataset_to_tf(
     if shuffle and random_index_shuffle is not None:
         base_seed = tf.fill((3,), value=tf.cast(-1, dtype=tf.int64))
 
-        def scan_random_indices(state, indices):
+        def scan_random_index(state, index):
             if tf.reduce_all(state == -1):
                 # This generates a new random seed once per epoch only,
                 # to ensure that we iterate over each sample exactly once per epoch
                 state = tf.random.uniform(shape=(3,), maxval=2**62, dtype=tf.int64)
-            shuffled_indices = random_index_shuffle(index=indices, seed=state, max_index=len(dataset) - 1)
-            return state, shuffled_indices
+            shuffled_index = random_index_shuffle(index=index, seed=state, max_index=len(dataset) - 1)
+            return state, shuffled_index
 
-        tf_dataset = tf_dataset.scan(base_seed, scan_random_indices)
+        tf_dataset = tf_dataset.scan(base_seed, scan_random_index)
     elif shuffle:
         tf_dataset = tf_dataset.shuffle(tf_dataset.cardinality())
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -226,7 +226,7 @@ def dataset_to_tf(
 
         tf_dataset = tf_dataset.scan(base_seed, scan_random_indices)
     elif shuffle:
-        tf_dataset = tf_dataset.shuffle(len(tf_dataset))
+        tf_dataset = tf_dataset.shuffle(tf_dataset.cardinality())
         tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
     else:
         tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -199,7 +199,7 @@ def dataset_to_tf(
     tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
 
     if shuffle:
-        base_seed = tf.fill((3,), fill_value=-1, dtype=tf.int64)
+        base_seed = tf.fill((3,), value=-1, dtype=tf.int64)
 
         def scan_random_indices(state, indices):
             if tf.reduce_all(state == -1):

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -147,26 +147,26 @@ def dataset_to_tf(
     """Create a tf.data.Dataset from the underlying Dataset. This is a single-process method - the multiprocess
     equivalent is multiprocess_dataset_to_tf.
 
-            Args:
-                dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
-                cols_to_retain (`List[str]`): Dataset column(s) to load in the
-                    tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
-                    that do not exist in the original dataset.
-                collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
-                    lists of samples into a batch.
-                collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
-                    `collate_fn`. Can be empty.
-                columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
-                output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
-                    `tf.TensorSpec` objects.
-                shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
-                    validation/evaluation.
-                batch_size (`int`): Size of batches to load from the dataset.
-                drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
-                    defaults to the same setting as shuffle.
+    Args:
+        dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
+        cols_to_retain (`List[str]`): Dataset column(s) to load in the
+            tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
+            that do not exist in the original dataset.
+        collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
+            lists of samples into a batch.
+        collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
+            `collate_fn`. Can be empty.
+        columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
+        output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
+            `tf.TensorSpec` objects.
+        shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
+            validation/evaluation.
+        batch_size (`int`): Size of batches to load from the dataset.
+        drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
+            defaults to the same setting as shuffle.
 
-            Returns:
-                `tf.data.Dataset`
+    Returns:
+        `tf.data.Dataset`
     """
     if config.TF_AVAILABLE:
         import tensorflow as tf

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -173,6 +173,10 @@ def dataset_to_tf(
     else:
         raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")
 
+    # Matt: There are a few version dependencies here - ideally we'd move everything to the multiprocessing path for
+    # simplicity, but that depends on SharedMemory that only arrived in Py3.8. We also have a reasonably efficient
+    # solution without Python multiprocessing, but it depends on TF >= 2.9. If we're on an older version of TF,
+    # we fall back to the slowest path. Hopefully when our minimum versions move up a bit more we can clean this all up.
     if hasattr(tf, "random_index_shuffle"):
         random_index_shuffle = tf.random_index_shuffle
     elif hasattr(tf.random.experimental, "index_shuffle"):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2755,6 +2755,8 @@ class BaseDatasetTest(TestCase):
                     second_indices.append(batch["col_1"])
                 second_indices = np.concatenate([arr.numpy() for arr in second_indices])
                 self.assertFalse(np.array_equal(indices, second_indices))
+                self.assertEqual(len(indices), len(np.unique(indices)))
+                self.assertEqual(len(second_indices), len(np.unique(second_indices)))
 
                 tf_dataset = dset.to_tf_dataset(batch_size=1, shuffle=False, num_workers=num_workers)
                 for i, batch in enumerate(tf_dataset):


### PR DESCRIPTION
This PR tries out a new approach to generating the index tensor in `to_tf_dataset`, which should reduce memory usage for very large datasets. I'll need to do some testing before merging it!

Fixes #5855