### PR TITLE
Fix infer module for uppercase extensions

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -358,7 +358,7 @@ def infer_module_for_data_files(
             - builder kwargs
     """
     extensions_counter = Counter(
-        suffix[1:]
+        suffix[1:].lower()
         for filepath in data_files_list[: config.DATA_FILES_MAX_NUMBER_FOR_MODULE_INFERENCE]
         for suffix in Path(filepath).suffixes
     )

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -400,7 +400,9 @@ def infer_module_for_data_files_in_archives(
                     : config.ARCHIVED_DATA_FILES_MAX_NUMBER_FOR_MODULE_INFERENCE
                 ]
             ]
-    extensions_counter = Counter(suffix[1:] for filepath in archived_files for suffix in Path(filepath).suffixes)
+    extensions_counter = Counter(
+        suffix[1:].lower() for filepath in archived_files for suffix in Path(filepath).suffixes
+    )
     if extensions_counter:
         most_common = extensions_counter.most_common(1)[0][0]
         if most_common in _EXTENSION_TO_MODULE:

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -297,6 +297,15 @@ def zip_csv_path(csv_path, csv2_path, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def zip_uppercase_csv_path(csv_path, csv2_path, tmp_path_factory):
+    path = tmp_path_factory.mktemp("data") / "dataset.csv.zip"
+    with zipfile.ZipFile(path, "w") as f:
+        f.write(csv_path, arcname=os.path.basename(csv_path.replace(".csv", ".CSV")))
+        f.write(csv2_path, arcname=os.path.basename(csv2_path.replace(".csv", ".CSV")))
+    return path
+
+
+@pytest.fixture(scope="session")
 def zip_csv_with_dir_path(csv_path, csv2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.csv.zip"
     with zipfile.ZipFile(path, "w") as f:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -209,6 +209,7 @@ def metric_loading_script_dir(tmp_path):
         (["train.jsonl"], "json", {}),
         (["train.parquet"], "parquet", {}),
         (["train.txt"], "text", {}),
+        (["uppercase.TXT"], "text", {}),
         (["unsupported.ext"], None, {}),
         ([""], None, {}),
     ],

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -222,14 +222,20 @@ def test_infer_module_for_data_files(data_files, expected_module, expected_build
 
 @pytest.mark.parametrize(
     "data_file, expected_module",
-    [("zip_csv_path", "csv"), ("zip_csv_with_dir_path", "csv"), ("zip_unsupported_ext_path", None)],
+    [
+        ("zip_csv_path", "csv"),
+        ("zip_csv_with_dir_path", "csv"),
+        ("zip_uppercase_csv_path", "csv"),
+        ("zip_unsupported_ext_path", None),
+    ],
 )
 def test_infer_module_for_data_files_in_archives(
-    data_file, expected_module, zip_csv_path, zip_csv_with_dir_path, zip_unsupported_ext_path
+    data_file, expected_module, zip_csv_path, zip_csv_with_dir_path, zip_uppercase_csv_path, zip_unsupported_ext_path
 ):
     data_file_paths = {
         "zip_csv_path": zip_csv_path,
         "zip_csv_with_dir_path": zip_csv_with_dir_path,
+        "zip_uppercase_csv_path": zip_uppercase_csv_path,
         "zip_unsupported_ext_path": zip_unsupported_ext_path,
     }
     data_files = [str(data_file_paths[data_file])]


### PR DESCRIPTION
Fix the `infer_module_for_data_files` and `infer_module_for_data_files_in_archives` functions when passed a data file name with uppercase extension, e.g. `filename.TXT`.

Before, `None` module was returned.