### PR TITLE
Fix string-encoding, make `batch_size` optional, and minor improvements in `Dataset.to_tf_dataset`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -309,7 +309,7 @@ class TensorflowDatasetMixin:
 
     def to_tf_dataset(
         self,
-        batch_size: int,
+        batch_size: Optional[int] = None,
         columns: Optional[Union[str, List[str]]] = None,
         shuffle: bool = False,
         collate_fn: Optional[Callable] = None,
@@ -326,8 +326,9 @@ class TensorflowDatasetMixin:
         `tf.Tensor` is yielded instead.
 
         Args:
-            batch_size (`int`):
-                Size of batches to load from the dataset.
+            batch_size (`int`, *optional*):
+                Size of batches to load from the dataset. Defaults to `None`, which implies that the dataset won't be
+                batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
             columns (`List[str]` or `str`, *optional*):
                 Dataset column(s) to load in the `tf.data.Dataset`.
                 Column names that are created by the `collate_fn` and that do not exist in the original dataset can be used.
@@ -437,7 +438,7 @@ class TensorflowDatasetMixin:
             collate_fn=collate_fn,
             collate_fn_args=collate_fn_args,
             cols_to_retain=cols_to_retain,
-            batch_size=batch_size if drop_remainder else None,
+            batch_size=batch_size if drop_remainder and batch_size is not None else None,
             num_test_batches=num_test_batches,
         )
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -469,6 +469,11 @@ class TensorflowDatasetMixin:
                 drop_remainder=drop_remainder,
             )
         elif num_workers > 0:
+            if batch_size is None:
+                raise NotImplementedError(
+                    "`batch_size` must be specified when using multiple workers, as unbatched multiprocessing "
+                    "is not supported yet. Please provide a `batch_size` if `num_workers` is greater than 0."
+                )
             tf_dataset = multiprocess_dataset_to_tf(
                 dataset=dataset,
                 cols_to_retain=cols_to_retain,

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -426,7 +426,7 @@ class TensorflowDatasetMixin:
             cols_to_retain = None  # Indicates keeping all valid columns
             columns = []
 
-        if self.format["type"] != "custom":
+        if self.format["type"] not in ["custom", "numpy"]:
             dataset = self.with_format("numpy")
         else:
             dataset = self

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -262,7 +262,8 @@ class NumpyMultiprocessingGenerator:
         }
         self.output_signature = output_signature
         self.shuffle = shuffle
-        self.batch_size = batch_size
+        # Make sure that we set the `batch_size=1` if `batch_size=None`
+        self.batch_size = batch_size or 1
         self.drop_remainder = drop_remainder
         self.num_workers = num_workers
         # Because strings are converted to characters, we need to add one extra dimension to the shape

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -136,27 +136,27 @@ def dataset_to_tf(
     """Create a tf.data.Dataset from the underlying Dataset. This is a single-process method - the multiprocess
     equivalent is multiprocess_dataset_to_tf.
 
-            Args:
-                dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
-                cols_to_retain (`List[str]`): Dataset column(s) to load in the
-                    tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
-                    that do not exist in the original dataset.
-                collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
-                    lists of samples into a batch.
-                collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
-                    `collate_fn`. Can be empty.
-                columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
-                output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
-                    `tf.TensorSpec` objects.
-                shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
-                    validation/evaluation.
-                batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that 
-                    the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
-                drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
-                    defaults to the same setting as shuffle.
+    Args:
+        dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
+        cols_to_retain (`List[str]`): Dataset column(s) to load in the
+            tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
+            that do not exist in the original dataset.
+        collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
+            lists of samples into a batch.
+        collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
+            `collate_fn`. Can be empty.
+        columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
+        output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
+            `tf.TensorSpec` objects.
+        shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
+            validation/evaluation.
+        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that 
+            the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
+        drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
+            defaults to the same setting as shuffle.
 
-            Returns:
-                `tf.data.Dataset`
+    Returns:
+        `tf.data.Dataset`
     """
     if config.TF_AVAILABLE:
         import tensorflow as tf
@@ -486,28 +486,28 @@ def multiprocess_dataset_to_tf(
     """Create a tf.data.Dataset from the underlying Dataset. This is a multi-process method - the single-process
     equivalent is dataset_to_tf.
 
-            Args:
-                dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
-                cols_to_retain (`List[str]`): Dataset column(s) to load in the
-                    tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
-                    that do not exist in the original dataset.
-                collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
-                    lists of samples into a batch.
-                collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
-                    `collate_fn`. Can be empty.
-                columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
-                output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
-                    `tf.TensorSpec` objects.
-                shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
-                    validation/evaluation.
-                batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that 
-                    the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
-                drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
-                    defaults to the same setting as shuffle.
-                num_workers (`int`): Number of workers to use for loading the dataset. Should be >= 1.
+    Args:
+        dataset (`Dataset`): Dataset to wrap with tf.data.Dataset.
+        cols_to_retain (`List[str]`): Dataset column(s) to load in the
+            tf.data.Dataset. It is acceptable to include column names that are created by the `collate_fn` and
+            that do not exist in the original dataset.
+        collate_fn(`Callable`): A function or callable object (such as a `DataCollator`) that will collate
+            lists of samples into a batch.
+        collate_fn_args (`Dict`): A  `dict` of keyword arguments to be passed to the
+            `collate_fn`. Can be empty.
+        columns_to_np_types (`Dict[str, np.dtype]`): A `dict` mapping column names to numpy dtypes.
+        output_signature (`Dict[str, tf.TensorSpec]`): A `dict` mapping column names to
+            `tf.TensorSpec` objects.
+        shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
+            validation/evaluation.
+        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that 
+            the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
+        drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
+            defaults to the same setting as shuffle.
+        num_workers (`int`): Number of workers to use for loading the dataset. Should be >= 1.
 
-            Returns:
-                `tf.data.Dataset`
+    Returns:
+        `tf.data.Dataset`
     """
     if config.TF_AVAILABLE:
         import tensorflow as tf

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -111,7 +111,7 @@ def np_get_batch(
         actual_size = len(list(batch.values())[0])  # Get the length of one of the arrays, assume all same
         # Our collators expect a list of dicts, not a dict of lists/arrays, so we invert
         batch = [{key: value[i] for key, value in batch.items()} for i in range(actual_size)]
-        batch = collate_fn(batch, **collate_fn_args)
+    batch = collate_fn(batch, **collate_fn_args)
 
     if return_dict:
         out_batch = {}

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -151,7 +151,7 @@ def dataset_to_tf(
             `tf.TensorSpec` objects.
         shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
             validation/evaluation.
-        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that 
+        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that
             the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
         drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
             defaults to the same setting as shuffle.
@@ -193,7 +193,7 @@ def dataset_to_tf(
 
     if batch_size is not None:
         tf_dataset = tf_dataset.batch(batch_size, drop_remainder=drop_remainder)
-    
+
     tf_dataset = tf_dataset.map(fetch_function)
 
     def ensure_shapes(input_dict):
@@ -503,7 +503,7 @@ def multiprocess_dataset_to_tf(
             `tf.TensorSpec` objects.
         shuffle(`bool`): Shuffle the dataset order when loading. Recommended True for training, False for
             validation/evaluation.
-        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that 
+        batch_size (`int`, default `None`): Size of batches to load from the dataset. Defaults to `None`, which implies that
             the dataset won't be batched, but the returned dataset can be batched later with `tf_dataset.batch(batch_size)`.
         drop_remainder(`bool`, default `None`): Drop the last incomplete batch when loading. If not provided,
             defaults to the same setting as shuffle.

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -173,13 +173,15 @@ def dataset_to_tf(
         return_dict=False,  # TF expects numpy_function to return a list and will not accept a dict
     )
 
+    # This works because dictionaries always output in the same order
+    tout = [tf.dtypes.as_dtype(dtype) for dtype in columns_to_np_types.values()]
+
     @tf.function(input_signature=[tf.TensorSpec(None, tf.int64)])
     def fetch_function(indices):
         output = tf.numpy_function(
             getter_fn,
             inp=[indices],
-            # This works because dictionaries always output in the same order
-            Tout=[tf.dtypes.as_dtype(dtype) for dtype in columns_to_np_types.values()],
+            Tout=tout,
         )
         return {key: output[i] for i, key in enumerate(columns_to_np_types.keys())}
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -33,7 +33,9 @@ from .. import config
 
 
 def minimal_tf_collate_fn(features):
-    if config.TF_AVAILABLE:
+    if isinstance(features, dict):  # case batch_size=None: nothing to collate
+        return features
+    elif config.TF_AVAILABLE:
         import tensorflow as tf
     else:
         raise ImportError("Called a Tensorflow-specific function but Tensorflow is not installed.")

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -86,7 +86,8 @@ def np_get_batch(
     indices, dataset, cols_to_retain, collate_fn, collate_fn_args, columns_to_np_types, return_dict=False
 ):
     # Optimization - if we're loading a sequential batch, do it with slicing instead of a list of indices
-    if isinstance(indices, (list, np.ndarray)):
+    indices = indices.numpy()
+    if isinstance(indices, np.ndarray):
         if np.all(np.diff(indices) == 1):
             batch = dataset[indices[0] : indices[-1] + 1]
         else:
@@ -170,7 +171,7 @@ def dataset_to_tf(
         collate_fn=collate_fn,
         collate_fn_args=collate_fn_args,
         columns_to_np_types=columns_to_np_types,
-        return_dict=False,  # TF expects numpy_function to return a list and will not accept a dict
+        return_dict=False,
     )
 
     # This works because dictionaries always output in the same order
@@ -178,7 +179,7 @@ def dataset_to_tf(
 
     @tf.function(input_signature=[tf.TensorSpec(None, tf.int64)])
     def fetch_function(indices):
-        output = tf.numpy_function(
+        output = tf.py_function(
             getter_fn,
             inp=[indices],
             Tout=tout,

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -198,8 +198,15 @@ def dataset_to_tf(
 
     tf_dataset = tf_dataset.map(fetch_function)
 
-    def ensure_shapes(input_dict):
-        return {key: tf.ensure_shape(val, output_signature[key].shape) for key, val in input_dict.items()}
+    if batch_size is not None:
+
+        def ensure_shapes(input_dict):
+            return {key: tf.ensure_shape(val, output_signature[key].shape) for key, val in input_dict.items()}
+
+    else:
+        # Ensure shape but remove batch dimension of output_signature[key].shape
+        def ensure_shapes(input_dict):
+            return {key: tf.ensure_shape(val, output_signature[key].shape[1:]) for key, val in input_dict.items()}
 
     return tf_dataset.map(ensure_shapes)
 

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -274,8 +274,7 @@ class NumpyMultiprocessingGenerator:
         }
         self.output_signature = output_signature
         self.shuffle = shuffle
-        # Make sure that we set the `batch_size=1` if `batch_size=None`
-        self.batch_size = batch_size or 1
+        self.batch_size = batch_size
         self.drop_remainder = drop_remainder
         self.num_workers = num_workers
         # Because strings are converted to characters, we need to add one extra dimension to the shape
@@ -547,7 +546,7 @@ def multiprocess_dataset_to_tf(
 
     tf_dataset = tf.data.Dataset.from_generator(data_generator, output_signature=output_signature)
     if drop_remainder:
-        dataset_length = int(len(dataset) // (batch_size or 1))
+        dataset_length = int(len(dataset) // (batch_size))
     else:
-        dataset_length = int(ceil(len(dataset) / (batch_size or 1)))
+        dataset_length = int(ceil(len(dataset) // (batch_size)))
     return tf_dataset.apply(tf.data.experimental.assert_cardinality(dataset_length))

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -85,8 +85,10 @@ def is_numeric_feature(feature):
 def np_get_batch(
     indices, dataset, cols_to_retain, collate_fn, collate_fn_args, columns_to_np_types, return_dict=False
 ):
+    if not isinstance(indices, np.ndarray):
+        indices = indices.numpy()
+
     # Optimization - if we're loading a sequential batch, do it with slicing instead of a list of indices
-    indices = indices.numpy()
     if isinstance(indices, np.ndarray):
         if np.all(np.diff(indices) == 1):
             batch = dataset[indices[0] : indices[-1] + 1]
@@ -295,7 +297,7 @@ class NumpyMultiprocessingGenerator:
         with SharedMemoryContext() as shm_ctx:
             for i in range(num_workers):
                 worker_random_id = str(uuid4())
-                worker_name = f"datasets_tf_worker_{i}_{worker_random_id}"
+                worker_name = f"dw_{i}_{worker_random_id}"[:10]
                 names.append(worker_name)
 
                 worker_shape_arrays = {

--- a/src/datasets/utils/tf_utils.py
+++ b/src/datasets/utils/tf_utils.py
@@ -546,7 +546,7 @@ def multiprocess_dataset_to_tf(
 
     tf_dataset = tf.data.Dataset.from_generator(data_generator, output_signature=output_signature)
     if drop_remainder:
-        dataset_length = int(len(dataset) // (batch_size))
+        dataset_length = int(len(dataset) // batch_size)
     else:
-        dataset_length = int(ceil(len(dataset) // (batch_size)))
+        dataset_length = int(ceil(len(dataset) / batch_size))
     return tf_dataset.apply(tf.data.experimental.assert_cardinality(dataset_length))

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2868,11 +2868,12 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(len(tf_dataset), 2)  # One batch of 3 and one batch of 1
             self.assertEqual(len(tf_dataset_with_drop), 1)  # Incomplete batch of 1 is dropped
         # Test that `NotImplementedError` is raised `batch_size` is None and `num_workers` is > 0
-        with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
-            with self.assertRaisesRegex(
-                NotImplementedError, "`batch_size` must be specified when using multiple workers"
-            ):
-                dset.to_tf_dataset(columns="col_1", batch_size=None, num_workers=2)
+        if sys.version_info >= (3, 8):
+            with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
+                with self.assertRaisesRegex(
+                    NotImplementedError, "`batch_size` must be specified when using multiple workers"
+                ):
+                    dset.to_tf_dataset(columns="col_1", batch_size=None, num_workers=2)
         del tf_dataset  # For correct cleanup
         del tf_dataset_with_drop
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2730,16 +2730,6 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(batch.shape.as_list(), [2])
                 self.assertEqual(batch.dtype.name, "int64")
                 del transform_dset
-            with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
-                tf_dataset = dset.to_tf_dataset(columns="col_3", num_workers=num_workers) # batch_size=None, optional
-                single_example = next(iter(tf_dataset))
-                self.assertEqual(single_example.shape.as_list(), [1])
-                self.assertEqual(single_example.dtype.name, "int64")
-                # Assert that we can easily batch it with `tf.data.Dataset.batch` method
-                batched_dataset = tf_dataset.batch(batch_size=2)
-                batch = next(iter(batched_dataset))
-                self.assertEqual(batch.shape.as_list(), [2, 1])
-                self.assertEqual(batch.dtype.name, "int64")
         del tf_dataset  # For correct cleanup
 
     @require_tf
@@ -2838,6 +2828,28 @@ class BaseDatasetTest(TestCase):
             batch = next(iter(tf_dataset))
             self.assertEqual(batch.shape.as_list(), [2, 4])
             self.assertEqual(batch.dtype.name, "int64")
+        # Test that batch_size=None (optional) works as expected
+        with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
+            tf_dataset = dset.to_tf_dataset(columns="col_3", batch_size=None)
+            single_example = next(iter(tf_dataset))
+            self.assertEqual(single_example.shape.as_list(), [1])
+            self.assertEqual(single_example.dtype.name, "int64")
+            # Assert that we can batch it with `tf.data.Dataset.batch` method
+            batched_dataset = tf_dataset.batch(batch_size=2)
+            batch = next(iter(batched_dataset))
+            self.assertEqual(batch.shape.as_list(), [2, 1])
+            self.assertEqual(batch.dtype.name, "int64")
+        # Test that batching a batch_size=None dataset produces the same results as using batch_size arg
+        with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
+            batch_size = 2
+            tf_dataset_no_batch = dset.to_tf_dataset(columns="col_3")
+            tf_dataset_batch = dset.to_tf_dataset(columns="col_3", batch_size=batch_size)
+            self.assertEqual(tf_dataset_no_batch.element_spec, tf_dataset_batch.element_spec)
+            self.assertEqual(tf_dataset_no_batch.cardinality(), tf_dataset_batch.cardinality() * batch_size)
+            for batch_1, batch_2 in zip(tf_dataset_no_batch.batch(batch_size=batch_size), tf_dataset_batch):
+                self.assertEqual(batch_1.shape, batch_2.shape)
+                self.assertEqual(batch_1.dtype, batch_2.dtype)
+                self.assertListEqual(batch_1.numpy().tolist(), batch_2.numpy().tolist())
         # Test that requesting label_cols works as expected
         with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
             tf_dataset = dset.to_tf_dataset(columns="col_1", label_cols=["col_2", "col_3"], batch_size=4)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2730,6 +2730,16 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(batch.shape.as_list(), [2])
                 self.assertEqual(batch.dtype.name, "int64")
                 del transform_dset
+            with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
+                tf_dataset = dset.to_tf_dataset(columns="col_3", num_workers=num_workers) # batch_size=None, optional
+                single_example = next(iter(tf_dataset))
+                self.assertEqual(single_example.shape.as_list(), [1])
+                self.assertEqual(single_example.dtype.name, "int64")
+                # Assert that we can easily batch it with `tf.data.Dataset.batch` method
+                batched_dataset = tf_dataset.batch(batch_size=2)
+                batch = next(iter(batched_dataset))
+                self.assertEqual(batch.shape.as_list(), [2, 1])
+                self.assertEqual(batch.dtype.name, "int64")
         del tf_dataset  # For correct cleanup
 
     @require_tf

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2869,7 +2869,9 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(len(tf_dataset_with_drop), 1)  # Incomplete batch of 1 is dropped
         # Test that `NotImplementedError` is raised `batch_size` is None and `num_workers` is > 0
         with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
-            with self.assertRaisesRegex(NotImplementedError, "`batch_size` must be specified when using multiple workers"):
+            with self.assertRaisesRegex(
+                NotImplementedError, "`batch_size` must be specified when using multiple workers"
+            ):
                 dset.to_tf_dataset(columns="col_1", batch_size=None, num_workers=2)
         del tf_dataset  # For correct cleanup
         del tf_dataset_with_drop

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2867,6 +2867,10 @@ class BaseDatasetTest(TestCase):
             tf_dataset_with_drop = dset.to_tf_dataset(columns="col_1", batch_size=3, drop_remainder=True)
             self.assertEqual(len(tf_dataset), 2)  # One batch of 3 and one batch of 1
             self.assertEqual(len(tf_dataset_with_drop), 1)  # Incomplete batch of 1 is dropped
+        # Test that `NotImplementedError` is raised `batch_size` is None and `num_workers` is > 0
+        with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
+            with self.assertRaisesRegex(NotImplementedError, "`batch_size` must be specified when using multiple workers"):
+                dset.to_tf_dataset(columns="col_1", batch_size=None, num_workers=2)
         del tf_dataset  # For correct cleanup
         del tf_dataset_with_drop
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2832,19 +2832,19 @@ class BaseDatasetTest(TestCase):
         with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
             tf_dataset = dset.to_tf_dataset(columns="col_3", batch_size=None)
             single_example = next(iter(tf_dataset))
-            self.assertEqual(single_example.shape.as_list(), [1])
+            self.assertEqual(single_example.shape.as_list(), [])
             self.assertEqual(single_example.dtype.name, "int64")
             # Assert that we can batch it with `tf.data.Dataset.batch` method
             batched_dataset = tf_dataset.batch(batch_size=2)
             batch = next(iter(batched_dataset))
-            self.assertEqual(batch.shape.as_list(), [2, 1])
+            self.assertEqual(batch.shape.as_list(), [2])
             self.assertEqual(batch.dtype.name, "int64")
         # Test that batching a batch_size=None dataset produces the same results as using batch_size arg
         with self._create_dummy_dataset(in_memory, tmp_dir.name, multiple_columns=True) as dset:
             batch_size = 2
             tf_dataset_no_batch = dset.to_tf_dataset(columns="col_3")
             tf_dataset_batch = dset.to_tf_dataset(columns="col_3", batch_size=batch_size)
-            self.assertEqual(tf_dataset_no_batch.element_spec, tf_dataset_batch.element_spec)
+            self.assertEqual(tf_dataset_no_batch.element_spec, tf_dataset_batch.unbatch().element_spec)
             self.assertEqual(tf_dataset_no_batch.cardinality(), tf_dataset_batch.cardinality() * batch_size)
             for batch_1, batch_2 in zip(tf_dataset_no_batch.batch(batch_size=batch_size), tf_dataset_batch):
                 self.assertEqual(batch_1.shape, batch_2.shape)


### PR DESCRIPTION
## What's in this PR?

This PR addresses some minor fixes and general improvements in the `to_tf_dataset` method of `datasets.Dataset`, to convert a 🤗HuggingFace Dataset as a TensorFlow Dataset.

The main bug solved in this PR comes with the string-encoding, since for safety purposes the internal conversion of `numpy.arrays` when `dtype` is unicode/string, is to convert it into `numpy.bytes`, more information in the docstring of https://github.com/tensorflow/tensorflow/blob/388d952114e59a1aeda440ed4737b29f8b7c6e8a/tensorflow/python/ops/script_ops.py#L210. That's triggered when using `tensorflow.numpy_function` as it's applying another type cast besides the one that `datasets` does, so the casting is applied at least twice per entry/batch. So this means that the definition of the `numpy.unicode_` dtype when the data in the batch is a string, is ignored, and replaced by `numpy.bytes_`.

Besides that, some other minor things have been fixed:

* Made `batch_size` an optional parameter in `to_tf_dataset`
* Map the `tensorflow` output dtypes just once, and not in every `tf.function` call during `map`
* Keep `numpy` formatting in the `datasets.Dataset` if already formatted like it, no need to format it again as `numpy`
* Docstring indentation in `dataset_to_tf` and `multiprocess_dataset_to_tf`

## What's missing in this PR?

I can include some integration tests if needed, to validate that `batch_size` is optional, and that the tensors in the TF-Dataset can be looped over with no issues as before.