### PR TITLE
Load cached dataset as iterable 

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5013,15 +5013,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     example = {col: array[i] for col, array in batch.items()}
                     yield i, example
 
-    @staticmethod
-    def _generate_examples_from_table(arrow_table: Table):
-        python_formatter = PythonFormatter()
-        for pa_table in arrow_table.to_reader(max_chunksize=config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER):
-            batch = python_formatter.format_batch(pa_table)
-            for i in range(len(pa_table)):
-                example = {col: array[i] for col, array in batch.items()}
-                yield i, example
-
     def to_iterable_dataset(self, num_shards: Optional[int] = 1) -> "IterableDataset":
         """Get an [`datasets.IterableDataset`] from a map-style [`datasets.Dataset`].
         This is equivalent to loading a dataset in streaming mode with [`datasets.load_dataset`], but much faster since the data is streamed from local files.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5000,6 +5000,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             for pa_table in shard.with_format("arrow").iter(batch_size):
                 yield shard_idx, pa_table
 
+    @staticmethod
+    def _generate_examples_from_table(arrow_table: Table):
+        python_formatter = PythonFormatter()
+        for pa_table in arrow_table.to_reader(max_chunksize=config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER):
+            batch = python_formatter.format_batch(pa_table)
+            for i in range(len(pa_table)):
+                example = {col: array[i] for col, array in batch.items()}
+                yield i, example
+
     def to_iterable_dataset(self, num_shards: Optional[int] = 1) -> "IterableDataset":
         """Get an [`datasets.IterableDataset`] from a map-style [`datasets.Dataset`].
         This is equivalent to loading a dataset in streaming mode with [`datasets.load_dataset`], but much faster since the data is streamed from local files.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -88,7 +88,7 @@ from .fingerprint import (
     update_fingerprint,
     validate_fingerprint,
 )
-from .formatting import format_table, get_format_type_from_alias, get_formatter, query_table
+from .formatting import PythonFormatter, format_table, get_format_type_from_alias, get_formatter, query_table
 from .formatting.formatting import LazyDict, _is_range_contiguous
 from .info import DatasetInfo, DatasetInfosDict
 from .naming import _split_re

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -98,7 +98,7 @@ from .table import (
     InMemoryTable,
     MemoryMappedTable,
     Table,
-    arrow_table_batches_from_file,
+    _memory_mapped_record_batch_reader_from_file,
     cast_array_to_feature,
     concat_tables,
     embed_table_storage,
@@ -5004,7 +5004,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @staticmethod
     def _generate_examples_from_cache_file(filename: str):
         python_formatter = PythonFormatter()
-        with arrow_table_batches_from_file(
+        with _memory_mapped_record_batch_reader_from_file(
             filename=filename, max_chunksize=config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER
         ) as batches:
             for pa_table in batches:

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -12,14 +12,13 @@ import pyarrow as pa
 
 from . import config
 from .arrow_dataset import Dataset, DatasetInfoMixin
-from .arrow_reader import ArrowReader
 from .features import Features
 from .features.features import FeatureType, _align_features, _check_if_features_can_be_aligned
 from .filesystems import _reset_fsspec_lock
 from .formatting import PythonFormatter, get_format_type_from_alias
 from .info import DatasetInfo
 from .splits import NamedSplit
-from .table import cast_table_to_features, table_cast
+from .table import arrow_table_schema_from_file, cast_table_to_features, table_cast
 from .utils.logging import get_logger
 from .utils.py_utils import Literal
 from .utils.sharding import _merge_gen_kwargs, _number_of_shards_in_gen_kwargs, _shuffle_gen_kwargs, _split_gen_kwargs
@@ -1416,21 +1415,19 @@ class IterableDataset(DatasetInfoMixin):
         ).read()
 
     @staticmethod
-    def from_file(filename: str, in_memory: bool = False) -> "IterableDataset":
+    def from_file(filename: str) -> "IterableDataset":
         """Instantiate a IterableDataset from Arrow table at filename.
 
         Args:
             filename (`str`):
                 File name of the dataset.
-            in_memory (`bool`, defaults to `False`):
-                Whether to copy the data in-memory.
 
         Returns:
             [`IterableDataset`]
         """
-        pa_table = ArrowReader.read_table(filename, in_memory=in_memory)
-        inferred_features = Features.from_arrow_schema(pa_table.schema)
-        ex_iterable = ExamplesIterable(Dataset._generate_examples_from_table, kwargs={"arrow_table": pa_table})
+        pa_table_schema = arrow_table_schema_from_file(filename)
+        inferred_features = Features.from_arrow_schema(pa_table_schema)
+        ex_iterable = ExamplesIterable(Dataset._generate_examples_from_cache_file, kwargs={"filename": filename})
         return IterableDataset(ex_iterable=ex_iterable, info=DatasetInfo(features=inferred_features))
 
     def with_format(

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyarrow as pa
 
 from . import config
-from .arrow_dataset import DatasetInfoMixin, Dataset
+from .arrow_dataset import Dataset, DatasetInfoMixin
 from .arrow_reader import ArrowReader
 from .features import Features
 from .features.features import FeatureType, _align_features, _check_if_features_can_be_aligned

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -57,8 +57,9 @@ def arrow_table_schema_from_file(filename: str) -> pa.Schema:
 
 
 def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
-    with pa.memory_map(filename) as memory_mapped_stream:
-        pa_table = pa.ipc.open_stream(memory_mapped_stream).read_all()
+    memory_mapped_stream = pa.memory_map(filename)
+    opened_stream = pa.ipc.open_stream(memory_mapped_stream)
+    pa_table = opened_stream.read_all()
     return pa_table
 
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -46,28 +46,18 @@ def _in_memory_arrow_table_from_buffer(buffer: pa.Buffer) -> pa.Table:
     return table
 
 
-def _memory_mapped_arrow_stream_from_file(filename: str):
-    # To more efficiently read big data from disk, we can memory map the file,
-    # so that Arrow can directly reference the data mapped from disk and avoid
-    # having to allocate its own memory. In such case the operating system will
-    # be able to page in the mapped memory lazily and page it out without any
-    # write back cost when under pressure, allowing to more easily read arrays
-    # bigger than the total memory.
-    return pa.memory_map(filename)
-
-
 def arrow_table_schema_from_file(filename: str) -> pa.Schema:
     """
     Infer arrow table schema from file without loading whole file into memory.
     Usefull especially while having very big files.
     """
-    with _memory_mapped_arrow_stream_from_file(filename) as memory_mapped_stream:
+    with pa.memory_map(filename) as memory_mapped_stream:
         schema = pa.ipc.open_stream(memory_mapped_stream).schema
     return schema
 
 
 def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
-    with _memory_mapped_arrow_stream_from_file(filename) as memory_mapped_stream:
+    with pa.memory_map(filename) as memory_mapped_stream:
         pa_table = pa.ipc.open_stream(memory_mapped_stream).read_all()
     return pa_table
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -46,11 +46,33 @@ def _in_memory_arrow_table_from_buffer(buffer: pa.Buffer) -> pa.Table:
     return table
 
 
+def _memory_mapped_arrow_stream_from_file(filename: str):
+    # To more efficiently read big data from disk, we can memory map the file,
+    # so that Arrow can directly referee able to page in the mapped memory lazily and page it out without
+    # any write back cost when under pressure,nce the data mapped from disk and avoid having to allocate its own memory.
+    # In such case the operating system will b allowing to more easily read arrays bigger than the total memory
+    return pa.memory_map(filename)
+
+
+def arrow_table_schema_from_file(filename: str) -> pa.Schema:
+    """
+    Infer arrow table schema from file without loading whole file into memory.
+    Usefull especially while having very big files.
+    """
+    with _memory_mapped_arrow_stream_from_file(filename) as memory_mapped_stream:
+        schema = pa.ipc.open_stream(memory_mapped_stream).schema
+    return schema
+
+
 def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
-    memory_mapped_stream = pa.memory_map(filename)
-    opened_stream = pa.ipc.open_stream(memory_mapped_stream)
-    pa_table = opened_stream.read_all()
+    with _memory_mapped_arrow_stream_from_file(filename) as memory_mapped_stream:
+        pa_table = pa.ipc.open_stream(memory_mapped_stream).read_all()
     return pa_table
+
+
+def arrow_table_batches_from_file(filename: str, max_chunksize: Optional[int] = None):
+    pa_table = _memory_mapped_arrow_table_from_file(filename)
+    return pa_table.to_reader(max_chunksize=config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER)
 
 
 def _write_table_to_file(table: pa.Table, filename: str) -> int:

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -72,7 +72,7 @@ def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
     return pa_table
 
 
-def arrow_table_batches_from_file(filename: str, max_chunksize: Optional[int] = None):
+def _memory_mapped_record_batch_reader_from_file(filename: str, max_chunksize: Optional[int] = None):
     pa_table = _memory_mapped_arrow_table_from_file(filename)
     return pa_table.to_reader(max_chunksize=config.ARROW_READER_BATCH_SIZE_IN_DATASET_ITER)
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -48,9 +48,11 @@ def _in_memory_arrow_table_from_buffer(buffer: pa.Buffer) -> pa.Table:
 
 def _memory_mapped_arrow_stream_from_file(filename: str):
     # To more efficiently read big data from disk, we can memory map the file,
-    # so that Arrow can directly referee able to page in the mapped memory lazily and page it out without
-    # any write back cost when under pressure,nce the data mapped from disk and avoid having to allocate its own memory.
-    # In such case the operating system will b allowing to more easily read arrays bigger than the total memory
+    # so that Arrow can directly reference the data mapped from disk and avoid
+    # having to allocate its own memory. In such case the operating system will
+    # be able to page in the mapped memory lazily and page it out without any
+    # write back cost when under pressure, allowing to more easily read arrays
+    # bigger than the total memory.
     return pa.memory_map(filename)
 
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4400,11 +4400,10 @@ def test_dataset_to_iterable_dataset(dataset: Dataset):
         dataset.with_format("torch").to_iterable_dataset()
 
 
-@pytest.mark.parametrize("in_memory", [False, True])
-def test_iterable_dataset_from_file(in_memory, dataset, arrow_file):
+def test_iterable_dataset_from_file(dataset, arrow_file):
     filename = arrow_file
-    with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
-        dataset_from_file = IterableDataset.from_file(filename, in_memory=in_memory)
+    with assert_arrow_memory_doesnt_increase():
+        dataset_from_file = IterableDataset.from_file(filename)
     assert dataset_from_file.features.type == dataset.features.type
     assert dataset_from_file.features == dataset.features
     assert isinstance(dataset_from_file, IterableDataset)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4400,6 +4400,17 @@ def test_dataset_to_iterable_dataset(dataset: Dataset):
         dataset.with_format("torch").to_iterable_dataset()
 
 
+@pytest.mark.parametrize("in_memory", [False, True])
+def test_iterable_dataset_from_file(in_memory, dataset, arrow_file):
+    filename = arrow_file
+    with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
+        dataset_from_file = IterableDataset.from_file(filename, in_memory=in_memory)
+    assert dataset_from_file.features.type == dataset.features.type
+    assert dataset_from_file.features == dataset.features
+    assert isinstance(dataset_from_file, IterableDataset)
+    assert list(dataset_from_file) == list(dataset)
+
+
 @pytest.mark.parametrize("batch_size", [1, 4])
 @require_torch
 def test_dataset_with_torch_dataloader(dataset, batch_size):


### PR DESCRIPTION
To be used to train models it allows to load an IterableDataset from the cached Arrow file.  
See https://github.com/huggingface/datasets/issues/5481