### PR TITLE
Validate name parameter in make_file_instructions

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -107,6 +107,10 @@ def make_file_instructions(
     Returns:
         file_intructions: FileInstructions instance
     """
+    if not isinstance(name, str):
+        raise TypeError(f"Expected str 'name', but got: {type(name).__name__}")
+    elif not name:
+        raise ValueError("Expected non-empty str 'name'")
     name2len = {info.name: info.num_examples for info in split_infos}
     name2shard_lengths = {info.name: info.shard_lengths for info in split_infos}
     name2filenames = {

--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -95,7 +95,7 @@ def make_file_instructions(
     instruction: Union[str, "ReadInstruction"],
     filetype_suffix: Optional[str] = None,
     prefix_path: Optional[str] = None,
-):
+) -> FileInstructions:
     """Returns instructions of the split dict.
 
     Args:

--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -99,13 +99,14 @@ def make_file_instructions(
     """Returns instructions of the split dict.
 
     Args:
-        name: Name of the dataset.
-        split_infos: `List[SplitInfo]`, Dataset splits information
-        instruction: `ReadInstruction` or `str`
-        filetype_suffix: :obj:`str`, optional suffix of dataset files, e.g. 'arrow' or 'parquet'
+        name (`str`): Name of the dataset.
+        split_infos (`list` of `[SplitInfo]`): Dataset splits information.
+        instruction ([`ReadInstruction`] or `str`): Reading instruction for a dataset.
+        filetype_suffix (`str`, *optional*): Suffix of dataset files, e.g. 'arrow' or 'parquet'.
+        prefix_path (`str`, *optional*): Prefix of dataset files, e.g. directory name.
 
     Returns:
-        file_intructions: FileInstructions instance
+        [`FileInstructions`]
     """
     if not isinstance(name, str):
         raise TypeError(f"Expected str 'name', but got: {type(name).__name__}")

--- a/tests/test_arrow_reader.py
+++ b/tests/test_arrow_reader.py
@@ -182,3 +182,13 @@ def test_make_file_instructions():
         {"filename": os.path.join(prefix_path, f"{name}-train-00002-of-00010.arrow"), "skip": 0, "take": -1},
         {"filename": os.path.join(prefix_path, f"{name}-train-00003-of-00010.arrow"), "skip": 0, "take": 3},
     ]
+
+
+@pytest.mark.parametrize("name, expected_exception", [(None, TypeError), ("", ValueError)])
+def test_make_file_instructions_raises(name, expected_exception):
+    split_infos = [SplitInfo(name="train", num_examples=100)]
+    instruction = "train"
+    filetype_suffix = "arrow"
+    prefix_path = "prefix_path"
+    with pytest.raises(expected_exception):
+        _ = make_file_instructions(name, split_infos, instruction, filetype_suffix, prefix_path)


### PR DESCRIPTION
Validate `name` parameter in `make_file_instructions`.

This way users get more informative error messages, instead of:
```stacktrace
.../huggingface/datasets/src/datasets/arrow_reader.py in make_file_instructions(name, split_infos, instruction, filetype_suffix, prefix_path)
    110     name2len = {info.name: info.num_examples for info in split_infos}
    111     name2shard_lengths = {info.name: info.shard_lengths for info in split_infos}
--> 112     name2filenames = {
    113         info.name: filenames_for_dataset_split(
    114             path=prefix_path,

.../huggingface/datasets/src/datasets/arrow_reader.py in <dictcomp>(.0)
    111     name2shard_lengths = {info.name: info.shard_lengths for info in split_infos}
    112     name2filenames = {
--> 113         info.name: filenames_for_dataset_split(
    114             path=prefix_path,
    115             dataset_name=name,

.../huggingface/datasets/src/datasets/naming.py in filenames_for_dataset_split(path, dataset_name, split, filetype_suffix, shard_lengths)
     68 
     69 def filenames_for_dataset_split(path, dataset_name, split, filetype_suffix=None, shard_lengths=None):
---> 70     prefix = filename_prefix_for_split(dataset_name, split)
     71     prefix = os.path.join(path, prefix)
     72 

.../huggingface/datasets/src/datasets/naming.py in filename_prefix_for_split(name, split)
     52 
     53 def filename_prefix_for_split(name, split):
---> 54     if os.path.basename(name) != name:
     55         raise ValueError(f"Should be a dataset name, not a path: {name}")
     56     if not re.match(_split_re, split):

.../lib/python3.9/posixpath.py in basename(p)
    140 def basename(p):
    141     """Returns the final component of a pathname"""
--> 142     p = os.fspath(p)
    143     sep = _get_sep(p)
    144     i = p.rfind(sep) + 1

TypeError: expected str, bytes or os.PathLike object, not NoneType
```

Related to #5895.