### PR TITLE
Use more efficient and idiomatic way to construct list.

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -736,7 +736,7 @@ class DataFilesList(List[Union[Path, Url]]):
         allowed_extensions: Optional[List[str]] = None,
     ) -> "DataFilesList":
         data_files = resolve_patterns_in_dataset_repository(dataset_info, patterns, base_path, allowed_extensions)
-        origin_metadata = [(dataset_info.id, dataset_info.sha) for _ in patterns]
+        origin_metadata = [(dataset_info.id, dataset_info.sha)] * len(patterns)
         return cls(data_files, origin_metadata)
 
     @classmethod


### PR DESCRIPTION
Using `*` is ~2X faster according to [benchmark](https://colab.research.google.com/gist/ttsugriy/c964a2604edf70c41911b10335729b6a/for-vs-mult.ipynb) with just 4 patterns. This doesn't matter much since this tiny difference is not going to be noticeable, but why not?