### PR TITLE
Raise error in `DatasetBuilder.as_dataset` when `file_format` is not `"arrow"`

### DIFF
--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -599,25 +599,26 @@ You can also use the [`~Dataset.set_transform`] function to decode formats not s
 The example below uses the [`pydub`](http://pydub.com/) package to open an audio format not supported by `soundfile`:
 
 ```py
-import numpy as np
-from pydub import AudioSegment
+>>> import numpy as np
+>>> from pydub import AudioSegment
 
-audio_dataset_amr = Dataset.from_dict({"audio": ["audio_samples/audio.amr"]})
+>>> audio_dataset_amr = Dataset.from_dict({"audio": ["audio_samples/audio.amr"]})
 
-def decode_audio_with_pydub(batch, sampling_rate=16_000):
-    def pydub_decode_file(audio_path):
-      sound = AudioSegment.from_file(audio_path)
-      if sound.frame_rate != sampling_rate:
-        sound = sound.set_frame_rate(sampling_rate)
-      channel_sounds = sound.split_to_mono()
-      samples = [s.get_array_of_samples() for s in channel_sounds]
-      fp_arr = np.array(samples).T.astype(np.float32)
-      fp_arr /= np.iinfo(samples[0].typecode).max
-      return fp_arr
-    batch["audio"] = [pydub_decode_file(audio_path) for audio_path in batch["audio"]]
-    return batch
+>>> def decode_audio_with_pydub(batch, sampling_rate=16_000):
+...     def pydub_decode_file(audio_path):
+...         sound = AudioSegment.from_file(audio_path)
+...         if sound.frame_rate != sampling_rate:
+...             sound = sound.set_frame_rate(sampling_rate)
+...         channel_sounds = sound.split_to_mono()
+...         samples = [s.get_array_of_samples() for s in channel_sounds]
+...         fp_arr = np.array(samples).T.astype(np.float32)
+...         fp_arr /= np.iinfo(samples[0].typecode).max
+...         return fp_arr
+...
+...     batch["audio"] = [pydub_decode_file(audio_path) for audio_path in batch["audio"]]
+...     return batch
 
-audio_dataset_amr.set_transform(decode_audio_with_pydub)
+>>> audio_dataset_amr.set_transform(decode_audio_with_pydub)
 ```
 
 ## Save

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -100,6 +100,10 @@ class DatasetGenerationError(DatasetBuildError):
     pass
 
 
+class FileFormatError(DatasetBuildError):
+    pass
+
+
 @dataclass
 class BuilderConfig:
     """Base class for `DatasetBuilder` data configuration.
@@ -402,6 +406,9 @@ class DatasetBuilder:
 
         # Set to True by "datasets-cli test" to generate file checksums for (deprecated) dataset_infos.json independently of verification_mode value.
         self._record_infos = False
+
+        # Set in `.download_and_prepare` once the format of the generated dataset is known
+        self._file_format = None
 
         # Enable streaming (e.g. it patches "open" to work with remote files)
         extend_dataset_builder_for_streaming(self)
@@ -718,7 +725,7 @@ class DatasetBuilder:
         ```py
         >>> from datasets import load_dataset_builder
         >>> builder = load_dataset_builder("rotten_tomatoes")
-        >>> ds = builder.download_and_prepare()
+        >>> builder.download_and_prepare()
         ```
 
         Download and prepare the dataset as sharded Parquet files locally:
@@ -726,7 +733,7 @@ class DatasetBuilder:
         ```py
         >>> from datasets import load_dataset_builder
         >>> builder = load_dataset_builder("rotten_tomatoes")
-        >>> ds = builder.download_and_prepare("./output_dir", file_format="parquet")
+        >>> builder.download_and_prepare("./output_dir", file_format="parquet")
         ```
 
         Download and prepare the dataset as sharded Parquet files in a cloud storage:
@@ -735,7 +742,7 @@ class DatasetBuilder:
         >>> from datasets import load_dataset_builder
         >>> storage_options = {"key": aws_access_key_id, "secret": aws_secret_access_key}
         >>> builder = load_dataset_builder("rotten_tomatoes")
-        >>> ds = builder.download_and_prepare("s3://my-bucket/my_rotten_tomatoes", storage_options=storage_options, file_format="parquet")
+        >>> builder.download_and_prepare("s3://my-bucket/my_rotten_tomatoes", storage_options=storage_options, file_format="parquet")
         ```
         """
         if ignore_verifications != "deprecated":
@@ -766,6 +773,7 @@ class DatasetBuilder:
 
         if file_format is not None and file_format not in ["arrow", "parquet"]:
             raise ValueError(f"Unsupported file_format: {file_format}. Expected 'arrow' or 'parquet'")
+        self._file_format = file_format
 
         if self._fs._strip_protocol(self._output_dir) == "":
             # We don't support the root directory, because it has no dirname,
@@ -1090,7 +1098,7 @@ class DatasetBuilder:
         ```py
         >>> from datasets import load_dataset_builder
         >>> builder = load_dataset_builder('rotten_tomatoes')
-        >>> ds = builder.download_and_prepare()
+        >>> builder.download_and_prepare()
         >>> ds = builder.as_dataset(split='train')
         >>> ds
         Dataset({
@@ -1106,6 +1114,8 @@ class DatasetBuilder:
                 f"You can remove this warning by passing 'verification_mode={verification_mode.value}' instead.",
                 FutureWarning,
             )
+        if self._file_format != "arrow":
+            raise FileFormatError('Loading a dataset not written in the "arrow" format is not supported.')
         is_local = not is_remote_filesystem(self._fs)
         if not is_local:
             raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1114,7 +1114,7 @@ class DatasetBuilder:
                 f"You can remove this warning by passing 'verification_mode={verification_mode.value}' instead.",
                 FutureWarning,
             )
-        if self._file_format != "arrow":
+        if self._file_format is not None and self._file_format != "arrow":
             raise FileFormatError('Loading a dataset not written in the "arrow" format is not supported.')
         is_local = not is_remote_filesystem(self._fs)
         if not is_local:


### PR DESCRIPTION
Raise an error in  `DatasetBuilder.as_dataset` when `file_format != "arrow"` (and fix the docstring)

Fix #5874 