### PR TITLE
Fix `to_numpy` when None values in the sequence

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -714,10 +714,11 @@ class ArrayExtensionArray(pa.ExtensionArray):
 
     def to_numpy(self, zero_copy_only=True):
         storage: pa.ListArray = self.storage
+        null_mask = storage.is_null().to_numpy(zero_copy_only=False)
 
         if self.type.shape[0] is not None:
             size = 1
-            null_indices = np.arange(len(storage))[storage.is_null().to_numpy(zero_copy_only=False)]
+            null_indices = np.arange(len(storage))[null_mask] - np.arange(np.sum(null_mask))
 
             for i in range(self.type.ndims):
                 size *= self.type.shape[i]
@@ -733,7 +734,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
             ndims = self.type.ndims
             arrays = []
             first_dim_offsets = np.array([off.as_py() for off in storage.offsets])
-            for i, is_null in enumerate(storage.is_null().to_numpy(zero_copy_only=False)):
+            for i, is_null in enumerate(null_mask):
                 if is_null:
                     arrays.append(np.nan)
                 else:

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -380,9 +380,9 @@ def test_array_xd_with_none():
     # Fixed shape
     features = datasets.Features({"foo": datasets.Array2D(dtype="int32", shape=(2, 2))})
     dummy_array = np.array([[1, 2], [3, 4]], dtype="int32")
-    dataset = datasets.Dataset.from_dict({"foo": [dummy_array, None, dummy_array]}, features=features)
+    dataset = datasets.Dataset.from_dict({"foo": [dummy_array, None, dummy_array, None]}, features=features)
     arr = NumpyArrowExtractor().extract_column(dataset._data)
-    assert isinstance(arr, np.ndarray) and arr.dtype == np.float64 and arr.shape == (3, 2, 2)
+    assert isinstance(arr, np.ndarray) and arr.dtype == np.float64 and arr.shape == (4, 2, 2)
     assert np.allclose(arr[0], dummy_array) and np.allclose(arr[2], dummy_array)
     assert np.all(np.isnan(arr[1]))  # broadcasted np.nan - use np.all
 


### PR DESCRIPTION
Closes #5927 
I've realized that the error was overlooked during testing due to the presence of only one None value in the sequence.
Unfortunately, it was the only case where the function works as expected. When the sequence contains more than one None value, the function fails. Consequently, I've updated the tests to include sequences with multiple None values.