### PR TITLE
Better row group size in push_to_hub

### DIFF
--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -186,6 +186,11 @@ MAX_TABLE_NBYTES_FOR_PICKLING = 4 << 30
 # Max shard size in bytes (e.g. to shard parquet datasets in push_to_hub or download_and_prepare)
 MAX_SHARD_SIZE = "500MB"
 
+# Parquet configuration
+PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS = 100
+PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS = 100
+PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS = 100
+
 # Offline mode
 HF_DATASETS_OFFLINE = os.environ.get("HF_DATASETS_OFFLINE", "AUTO").upper() in ENV_VARS_TRUE_VALUES
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -23,7 +23,7 @@ from collections.abc import Sequence as SequenceABC
 from dataclasses import InitVar, dataclass, field, fields
 from functools import reduce, wraps
 from operator import mul
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
 from typing import Sequence as Sequence_
 
 import numpy as np
@@ -1457,6 +1457,25 @@ def to_pyarrow_listarray(data: Any, pa_type: _ArrayXDExtensionType) -> pa.Array:
         return any_np_array_to_pyarrow_listarray(data, type=pa_type.value_type)
     else:
         return pa.array(data, pa_type.storage_dtype)
+
+
+def _visit(feature: FeatureType, func: Callable[[FeatureType], Optional[FeatureType]]) -> FeatureType:
+    """Visit a (possibly nested) feature.
+
+    Args:
+        feature (FeatureType): the feature type to be checked
+    Returns:
+        visited feature (FeatureType)
+    """
+    if isinstance(feature, dict):
+        out = func({k: _visit(f, func) for k, f in feature.items()})
+    elif isinstance(feature, (list, tuple)):
+        out = func([_visit(feature[0], func)])
+    elif isinstance(feature, Sequence):
+        out = func(Sequence(_visit(feature.feature, func), length=feature.length))
+    else:
+        out = func(feature)
+    return feature if out is None else out
 
 
 def require_decoding(feature: FeatureType, ignore_decode_attribute: bool = False) -> bool:

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -1,9 +1,11 @@
 import os
 from typing import BinaryIO, Optional, Union
 
+import numpy as np
 import pyarrow.parquet as pq
 
-from .. import Dataset, DatasetInfo, Features, NamedSplit, config
+from .. import Audio, Dataset, Features, Image, NamedSplit, Value, config
+from ..features.features import FeatureType, _visit
 from ..formatting import query_table
 from ..packaged_modules import _PACKAGED_DATASETS_MODULES
 from ..packaged_modules.parquet.parquet import Parquet
@@ -12,17 +14,16 @@ from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
 
 
-PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS = 100
-PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS = 100
-PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS = 100
-
-
-def get_writer_batch_size(ds_config_info: DatasetInfo) -> Optional[int]:
+def get_writer_batch_size(features: Features) -> Optional[int]:
     """
     Get the writer_batch_size that defines the maximum row group size in the parquet files.
     The default in `datasets` is 1,000 but we lower it to 100 for image datasets.
     This allows to optimize random access to parquet file, since accessing 1 row requires
     to read its entire row group.
+
+    This can be improved to get optimized size for querying/iterating
+    but at least it matches the dataset viewer expectations on HF.
+
     Args:
         ds_config_info (`datasets.info.DatasetInfo`):
             Dataset info from `datasets`.
@@ -31,14 +32,21 @@ def get_writer_batch_size(ds_config_info: DatasetInfo) -> Optional[int]:
             Writer batch size to pass to a dataset builder.
             If `None`, then it will use the `datasets` default.
     """
-    if "Audio(" in str(ds_config_info.features):
-        return PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS
-    elif "Image(" in str(ds_config_info.features):
-        return PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS
-    elif "'binary'" in str(ds_config_info.features):
-        return PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS
-    else:
-        return None
+
+    batch_size = np.inf
+
+    def set_batch_size(feature: FeatureType) -> None:
+        nonlocal batch_size
+        if isinstance(feature, Image):
+            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS)
+        elif isinstance(feature, Audio):
+            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS)
+        elif isinstance(feature, Value) and feature.dtype == "binary":
+            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS)
+
+    _visit(features, set_batch_size)
+
+    return None if batch_size is np.inf else batch_size
 
 
 class ParquetDatasetReader(AbstractDatasetReader):
@@ -108,7 +116,7 @@ class ParquetDatasetWriter:
     ):
         self.dataset = dataset
         self.path_or_buf = path_or_buf
-        self.batch_size = batch_size or get_writer_batch_size(dataset.info)
+        self.batch_size = batch_size or get_writer_batch_size(dataset.features)
         self.parquet_writer_kwargs = parquet_writer_kwargs
 
     def write(self) -> int:

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -3,13 +3,42 @@ from typing import BinaryIO, Optional, Union
 
 import pyarrow.parquet as pq
 
-from .. import Dataset, Features, NamedSplit, config
+from .. import Dataset, DatasetInfo, Features, NamedSplit, config
 from ..formatting import query_table
 from ..packaged_modules import _PACKAGED_DATASETS_MODULES
 from ..packaged_modules.parquet.parquet import Parquet
 from ..utils import logging
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
+
+
+PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS = 100
+PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS = 100
+PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS = 100
+
+
+def get_writer_batch_size(ds_config_info: DatasetInfo) -> Optional[int]:
+    """
+    Get the writer_batch_size that defines the maximum row group size in the parquet files.
+    The default in `datasets` is 1,000 but we lower it to 100 for image datasets.
+    This allows to optimize random access to parquet file, since accessing 1 row requires
+    to read its entire row group.
+    Args:
+        ds_config_info (`datasets.info.DatasetInfo`):
+            Dataset info from `datasets`.
+    Returns:
+        writer_batch_size (`Optional[int]`):
+            Writer batch size to pass to a dataset builder.
+            If `None`, then it will use the `datasets` default.
+    """
+    if "Audio(" in str(ds_config_info.features):
+        return PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS
+    elif "Image(" in str(ds_config_info.features):
+        return PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS
+    elif "'binary'" in str(ds_config_info.features):
+        return PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS
+    else:
+        return None
 
 
 class ParquetDatasetReader(AbstractDatasetReader):
@@ -79,7 +108,7 @@ class ParquetDatasetWriter:
     ):
         self.dataset = dataset
         self.path_or_buf = path_or_buf
-        self.batch_size = batch_size
+        self.batch_size = batch_size or get_writer_batch_size(dataset.info)
         self.parquet_writer_kwargs = parquet_writer_kwargs
 
     def write(self) -> int:


### PR DESCRIPTION
This is a very simple change that improves `to_parquet` to use a more reasonable row group size for image and audio datasets.

This is especially useful for `push_to_hub` and will provide a better experience with the dataset viewer on HF