### PR TITLE
Avoid parallel redownload in cache

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -580,6 +580,10 @@ def get_from_cache(
     # Prevent parallel downloads of the same file with a lock.
     lock_path = cache_path + ".lock"
     with FileLock(lock_path):
+        # Retry in case previously locked processes just enter after the first process releases the lock
+        if os.path.exists(cache_path) and not force_download:
+            return cache_path
+
         if resume_download:
             incomplete_path = cache_path + ".incomplete"
 


### PR DESCRIPTION
Avoid parallel redownload in cache by retrying inside the lock if path exists.