### PR TITLE
Pass datasets-cli additional args as kwargs to DatasetBuilder in `run_beam.py`

### DIFF
--- a/docs/source/beam.mdx
+++ b/docs/source/beam.mdx
@@ -19,12 +19,25 @@ BUCKET=your_bucket
 REGION=your_region
 ```
 
+If you have never done so, don't forget to create a `default_applications_credentials.json` file (full docs [here](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login))
+
+```
+gcloud auth application-default login
+```
+
+This will create a file in `~/.config/gcloud/application_default_credentials.json` which the gcfs library will use to authenticate to Google Cloud Platform.
+
 3. Specify your Python requirements:
+
+Here are the dependpencies for the wikipedia dataset Beam pipeline:
 
 ```
 echo "datasets" > /tmp/beam_requirements.txt
-echo "apache_beam" >> /tmp/beam_requirements.txt
+echo "apache_beam[gcp,dataframe]" >> /tmp/beam_requirements.txt
+echo "git+https://github.com/earwig/mwparserfromhell.git@0f89f44" >> /tmp/beam_requirements.txt
 ```
+
+The version of mwparserfromhell is currently quite precise because otherwise the production version (currently `0.6`) has a bug which crashes the pipeline. This is fixed on the `main` branch (see [Datasets issue #577](https://github.com/huggingface/datasets/issues/577) for details), and the next release of mwparserfromhell will likely contain this bugfix.
 
 4. Run the pipeline:
 
@@ -44,3 +57,20 @@ datasets-cli run_beam datasets/$DATASET_NAME \
 When you run your pipeline, you can adjust the parameters to change the runner (Flink or Spark), output location (S3 bucket or HDFS), and the number of workers.
 
 </Tip>
+
+5. Example: running the wikipedia datasets pipeline on DataFlow
+
+```
+datasets-cli run_beam ${DATASET_NAME} \
+--name 20220301.fr \
+--language fr \
+--date 20230601 \
+--save_info \
+--cache_dir gs://$BUCKET/cache/datasets \
+--beam_pipeline_options=\
+"runner=DataflowRunner,project=${PROJECT},job_name=${DATASET_NAME}-gen,"\
+"staging_location=gs://${BUCKET}/binaries,temp_location=gs://${BUCKET}/temp,"\
+"region=${REGION},requirements_file=/tmp/beam_requirements.txt"
+```
+
+Maybe a bit counter-intuitive is that you have to specify the current config name (`20220301.fr`) and then override it with the `language` and `date` arguments. This allows the dataset script [wikipedia](https://huggingface.co/datasets/wikipedia/blob/main/wikipedia.py) to have a valid config. That script allows a specific date and language to be specified, but only on top of a valid configuration.

--- a/src/datasets/commands/run_beam.py
+++ b/src/datasets/commands/run_beam.py
@@ -112,6 +112,7 @@ class RunBeamCommand(BaseDatasetsCLICommand):
                         beam_options=beam_options,
                         cache_dir=self._cache_dir,
                         base_path=dataset_module.builder_kwargs.get("base_path"),
+                        **self._config_kwargs,
                     )
                 )
         else:


### PR DESCRIPTION
Hi,

Following this <https://discuss.huggingface.co/t/how-to-preprocess-a-wikipedia-dataset-using-dataflowrunner/41991/3>, here is a simple PR to pass any additional args to datasets-cli as kwargs in the DatasetBuilder in `run_beam.py`.

I also took the liberty to add missing setup steps to the `beam.mdx` docs in order to help everyone.