### PR TITLE
Replace metadata utils with `huggingface_hub`'s RepoCard API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: pip install --upgrade pyarrow huggingface-hub dill
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: pip install pyarrow==8.0.0 huggingface-hub==0.11.0 transformers dill==0.3.1.1
+        run: pip install pyarrow==8.0.0 huggingface-hub==0.13.0 transformers dill==0.3.1.1
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/setup.py
+++ b/setup.py
@@ -132,8 +132,8 @@ REQUIRED_PKGS = [
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
-    # minimum 0.11.0 to fix 400 Client Error issues
-    "huggingface-hub>=0.11.0,<1.0.0",
+    # minimum 0.13.0 to support dict-like modification of DatasetCard
+    "huggingface-hub>=0.13.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     # To parse YAML metadata from dataset cards

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5422,7 +5422,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             )
             dataset_card = DatasetCard.load(Path(dataset_readme_path))
             dataset_card_data = dataset_card.data
-            dataset_infos: DatasetInfosDict = DatasetInfosDict.from_metadata(dataset_card_data)
+            dataset_infos: DatasetInfosDict = DatasetInfosDict.from_dataset_card_data(dataset_card_data)
             if dataset_infos:
                 repo_info = dataset_infos[next(iter(dataset_infos))]
             else:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5409,8 +5409,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 download_config=download_config,
             )
             dataset_card = DatasetCard.load(Path(dataset_readme_path))
-            dataset_metadata = dataset_card.data
-            dataset_infos: DatasetInfosDict = DatasetInfosDict.from_metadata(dataset_metadata)
+            dataset_card_data = dataset_card.data
+            dataset_infos: DatasetInfosDict = DatasetInfosDict.from_metadata(dataset_card_data)
             if dataset_infos:
                 repo_info = dataset_infos[next(iter(dataset_infos))]
             else:
@@ -5418,7 +5418,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # get the deprecated dataset_infos.json to update them
         elif config.DATASETDICT_INFOS_FILENAME in repo_files:
             dataset_card = None
-            dataset_metadata = DatasetCardData()
+            dataset_card_data = DatasetCardData()
             download_config = DownloadConfig()
             download_config.download_desc = "Downloading metadata"
             download_config.use_auth_token = token
@@ -5434,7 +5434,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     repo_info = None
         else:
             dataset_card = None
-            dataset_metadata = DatasetCardData()
+            dataset_card_data = DatasetCardData()
             repo_info = None
         # update the total info to dump from existing info
         if repo_info is not None:
@@ -5472,11 +5472,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 revision=branch,
             )
         # push to README
-        DatasetInfosDict({"default": info_to_dump}).to_metadata(dataset_metadata)
+        DatasetInfosDict({"default": info_to_dump}).to_dataset_card_data(dataset_card_data)
         dataset_card = (
             DatasetCard(
                 "---\n"
-                + str(dataset_metadata)
+                + str(dataset_card_data)
                 + "\n---\n"
                 + f'# Dataset Card for "{repo_id.split("/")[-1]}"\n\n[More Information needed](https://github.com/huggingface/datasets/blob/main/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)'
             )

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -328,8 +328,8 @@ def resolve_patterns_locally_or_by_urls(
 
         >>> from datasets.data_files import resolve_patterns_locally_or_by_urls
         >>> base_path = "."
-        >>> resolve_patterns_locally_or_by_urls(base_path, ["src/**/*.yaml"])
-        [PosixPath('/Users/quentinlhoest/Desktop/hf/datasets/src/datasets/utils/resources/readme_structure.yaml')]
+        >>> resolve_patterns_locally_or_by_urls(base_path, ["docs/**/*.py"])
+        [PosixPath('/Users/mariosasko/Desktop/projects/datasets/docs/source/_config.py')]
 
     Args:
         base_path (str): Base path to use when resolving relative paths.

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1623,16 +1623,16 @@ class DatasetDict(dict):
                 download_config=download_config,
             )
             dataset_card = DatasetCard.load(Path(dataset_readme_path))
-            dataset_metadata = dataset_card.data
+            dataset_card_data = dataset_card.data
         else:
             dataset_card = None
-            dataset_metadata = DatasetCardData()
+            dataset_card_data = DatasetCardData()
 
-        DatasetInfosDict({"default": info_to_dump}).to_metadata(dataset_metadata)
+        DatasetInfosDict({"default": info_to_dump}).to_dataset_card_data(dataset_card_data)
         dataset_card = (
             DatasetCard(
                 "---\n"
-                + str(dataset_metadata)
+                + str(dataset_card_data)
                 + "\n---\n"
                 + f'# Dataset Card for "{repo_id.split("/")[-1]}"\n\n[More Information needed](https://github.com/huggingface/datasets/blob/main/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)'
             )

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1633,7 +1633,7 @@ class DatasetDict(dict):
             DatasetCard(
                 "---\n"
                 + str(dataset_metadata)
-                + "---\n"
+                + "\n---\n"
                 + f'# Dataset Card for "{repo_id.split("/")[-1]}"\n\n[More Information needed](https://github.com/huggingface/datasets/blob/main/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)'
             )
             if dataset_card is None

--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -438,7 +438,7 @@ class DatasetInfosDict(Dict[str, DatasetInfo]):
         if os.path.exists(os.path.join(dataset_infos_dir, "README.md")):
             dataset_card_data = DatasetCard.load(Path(dataset_infos_dir) / "README.md").data
             if "dataset_info" in dataset_card_data:
-                return cls.from_metadata(dataset_card_data)
+                return cls.from_dataset_card_data(dataset_card_data)
         if os.path.exists(os.path.join(dataset_infos_dir, config.DATASETDICT_INFOS_FILENAME)):
             # this is just to have backward compatibility with dataset_infos.json files
             with open(os.path.join(dataset_infos_dir, config.DATASETDICT_INFOS_FILENAME), encoding="utf-8") as f:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -30,7 +30,7 @@ from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import fsspec
 import requests
-from huggingface_hub import HfApi
+from huggingface_hub import DatasetCard, HfApi
 
 from . import config
 from .arrow_dataset import Dataset
@@ -79,7 +79,6 @@ from .utils.filelock import FileLock
 from .utils.hub import hf_hub_url
 from .utils.info_utils import VerificationMode, is_small_dataset
 from .utils.logging import get_logger
-from .utils.metadata import DatasetMetadata
 from .utils.py_utils import get_imports
 from .utils.version import Version
 
@@ -672,7 +671,7 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                 builder_kwargs["config_name"] = next(iter(dataset_infos))
                 builder_kwargs["info"] = DatasetInfo.from_dict(next(iter(dataset_infos.values())))
         if os.path.isfile(os.path.join(self.path, "README.md")):
-            dataset_metadata = DatasetMetadata.from_readme(Path(self.path) / "README.md")
+            dataset_metadata = DatasetCard.load(Path(self.path) / "README.md").data
             if isinstance(dataset_metadata.get("dataset_info"), list) and dataset_metadata["dataset_info"]:
                 dataset_info_dict = dataset_metadata["dataset_info"][0]
                 builder_kwargs["info"] = DatasetInfo._from_yaml_dict(dataset_info_dict)
@@ -832,7 +831,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                 hf_hub_url(self.name, "README.md", revision=self.revision),
                 download_config=download_config,
             )
-            dataset_metadata = DatasetMetadata.from_readme(Path(dataset_readme_path))
+            dataset_metadata = DatasetCard.load(Path(dataset_readme_path)).data
             if isinstance(dataset_metadata.get("dataset_info"), list) and dataset_metadata["dataset_info"]:
                 dataset_info_dict = dataset_metadata["dataset_info"][0]
                 builder_kwargs["info"] = DatasetInfo._from_yaml_dict(dataset_info_dict)

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -671,14 +671,14 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                 builder_kwargs["config_name"] = next(iter(dataset_infos))
                 builder_kwargs["info"] = DatasetInfo.from_dict(next(iter(dataset_infos.values())))
         if os.path.isfile(os.path.join(self.path, "README.md")):
-            dataset_metadata = DatasetCard.load(Path(self.path) / "README.md").data
-            if isinstance(dataset_metadata.get("dataset_info"), list) and dataset_metadata["dataset_info"]:
-                dataset_info_dict = dataset_metadata["dataset_info"][0]
+            dataset_card_data = DatasetCard.load(Path(self.path) / "README.md").data
+            if isinstance(dataset_card_data.get("dataset_info"), list) and dataset_card_data["dataset_info"]:
+                dataset_info_dict = dataset_card_data["dataset_info"][0]
                 builder_kwargs["info"] = DatasetInfo._from_yaml_dict(dataset_info_dict)
                 if "config_name" in dataset_info_dict:
                     builder_kwargs["config_name"] = dataset_info_dict["config_name"]
-            elif isinstance(dataset_metadata.get("dataset_info"), dict) and dataset_metadata["dataset_info"]:
-                dataset_info_dict = dataset_metadata["dataset_info"]
+            elif isinstance(dataset_card_data.get("dataset_info"), dict) and dataset_card_data["dataset_info"]:
+                dataset_info_dict = dataset_card_data["dataset_info"]
                 builder_kwargs["info"] = DatasetInfo._from_yaml_dict(dataset_info_dict)
                 if "config_name" in dataset_info_dict:
                     builder_kwargs["config_name"] = dataset_info_dict["config_name"]
@@ -831,14 +831,14 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                 hf_hub_url(self.name, "README.md", revision=self.revision),
                 download_config=download_config,
             )
-            dataset_metadata = DatasetCard.load(Path(dataset_readme_path)).data
-            if isinstance(dataset_metadata.get("dataset_info"), list) and dataset_metadata["dataset_info"]:
-                dataset_info_dict = dataset_metadata["dataset_info"][0]
+            dataset_card_data = DatasetCard.load(Path(dataset_readme_path)).data
+            if isinstance(dataset_card_data.get("dataset_info"), list) and dataset_card_data["dataset_info"]:
+                dataset_info_dict = dataset_card_data["dataset_info"][0]
                 builder_kwargs["info"] = DatasetInfo._from_yaml_dict(dataset_info_dict)
                 if "config_name" in dataset_info_dict:
                     builder_kwargs["config_name"] = dataset_info_dict["config_name"]
-            elif isinstance(dataset_metadata.get("dataset_info"), dict) and dataset_metadata["dataset_info"]:
-                dataset_info_dict = dataset_metadata["dataset_info"]
+            elif isinstance(dataset_card_data.get("dataset_info"), dict) and dataset_card_data["dataset_info"]:
+                dataset_info_dict = dataset_card_data["dataset_info"]
                 builder_kwargs["info"] = DatasetInfo._from_yaml_dict(dataset_info_dict)
                 if "config_name" in dataset_info_dict:
                     builder_kwargs["config_name"] = dataset_info_dict["config_name"]

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -4,6 +4,8 @@ from typing import Optional, Tuple
 
 import yaml
 
+from .deprecation_utils import deprecated
+
 
 class _NoDuplicateSafeLoader(yaml.SafeLoader):
     def _check_no_duplicates_on_constructed_node(self, node):
@@ -30,6 +32,7 @@ def _split_yaml_from_readme(readme_content: str) -> Tuple[Optional[str], str]:
     return None, "\n".join(full_content)
 
 
+@deprecated("Use `huggingface_hub.DatasetCardData` instead.")
 class DatasetMetadata(dict):
     # class attributes
     _FIELDS_WITH_DASHES = {"train_eval_index"}  # train-eval-index in the YAML metadata

--- a/src/datasets/utils/readme.py
+++ b/src/datasets/utils/readme.py
@@ -4,6 +4,8 @@ from typing import Any, List, Tuple
 
 import yaml
 
+from .deprecation_utils import deprecated
+
 
 # loading package files: https://stackoverflow.com/a/20885799
 try:
@@ -173,6 +175,7 @@ class Section:
         }
 
 
+@deprecated("Use `huggingface_hub.DatasetCard` instead.")
 class ReadMe(Section):  # Level 0
     def __init__(self, name: str, lines: List[str], structure: dict = None, suppress_parsing_errors: bool = False):
         super().__init__(name=name, level="")  # Not using lines here as we need to use a child class parse


### PR DESCRIPTION
Use `huggingface_hub`'s RepoCard API instead of `DatasetMetadata` for modifying the card's YAML, and deprecate `datasets.utils.metadata` and `datasets.utils.readme`.

After removing these modules, we can also delete `datasets.utils.resources` since the moon landing repo now stores its own version of these resources for the metadata UI.

PS: this change requires bumping `huggingface_hub` to 0.13.0 (Transformers requires 0.14.0, so should be ok)