### PR TITLE
Always return list in `list_datasets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,20 +86,18 @@ For more details on using the library with NumPy, pandas, PyTorch or TensorFlow,
 
 # Usage
 
-🤗 Datasets is made to be very simple to use. The main methods are:
-
-- `datasets.list_datasets()` to list the available datasets
-- `datasets.load_dataset(dataset_name, **kwargs)` to instantiate a dataset
+🤗 Datasets is made to be very simple to use - the API is centered around a single function, `datasets.load_dataset(dataset_name, **kwargs)`, that instantiates a dataset.
 
 This library can be used for text/image/audio/etc. datasets. Here is an example to load a text dataset:
 
 Here is a quick example:
 
 ```python
-from datasets import list_datasets, load_dataset
+from datasets import load_dataset
 
 # Print all the available datasets
-print(list_datasets())
+from huggingface_hub import list_datasets
+print([dataset.id for dataset in list_datasets()])
 
 # Load a dataset and print the first example in the training set
 squad_dataset = load_dataset('squad')
@@ -152,7 +150,6 @@ You can find:
 If you are familiar with the great TensorFlow Datasets, here are the main differences between 🤗 Datasets and `tfds`:
 
 - the scripts in 🤗 Datasets are not provided within the library but are queried, downloaded/cached and dynamically loaded upon request
-- 🤗 Datasets also provides evaluation metrics in a similar fashion to the datasets, i.e. as dynamically installed scripts with a unified API. This gives access to the pair of a benchmark dataset and a benchmark metric for instance for benchmarks like [SQuAD](https://rajpurkar.github.io/SQuAD-explorer/) or [GLUE](https://gluebenchmark.com/).
 - the backend serialization of 🤗 Datasets is based on [Apache Arrow](https://arrow.apache.org/) instead of TF Records and leverage python dataclasses for info and features with some diverging features (we mostly don't do encoding and store the raw data as much as possible in the backend serialization cache).
 - the user-facing dataset object of 🤗 Datasets is not a `tf.data.Dataset` but a built-in framework-agnostic dataset class with methods inspired by what we like in `tf.data` (like a `map()` method). It basically wraps a memory-mapped Arrow table cache.
 

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -41,6 +41,7 @@ class SplitsNotFoundError(ValueError):
     pass
 
 
+@deprecated("Use 'huggingface_hub.list_datasets' instead.")
 def list_datasets(with_community_datasets=True, with_details=False):
     """List all the datasets scripts available on the Hugging Face Hub.
 
@@ -70,7 +71,7 @@ def list_datasets(with_community_datasets=True, with_details=False):
         datasets = [dataset for dataset in datasets if "/" not in dataset.id]
     if not with_details:
         datasets = [dataset.id for dataset in datasets]
-    return datasets
+    return list(datasets)
 
 
 @deprecated(
@@ -112,6 +113,7 @@ def list_metrics(with_community_metrics=True, with_details=False):
     return metrics
 
 
+@deprecated("Clone the dataset repository from the Hugging Face Hub instead.")
 def inspect_dataset(path: str, local_path: str, download_config: Optional[DownloadConfig] = None, **download_kwargs):
     """
     Allow inspection/modification of a dataset script by copying on local drive at local_path.

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1075,7 +1075,7 @@ def dataset_module_factory(
               -> load the dataset builder from the dataset script
               e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``.
 
-            For datasets on the Hugging Face Hub (list all available datasets and ids with ``datasets.list_datasets()``)
+            For datasets on the Hugging Face Hub (list all available datasets with ``huggingface_hub.list_datasets()``)
 
             - if ``path`` is a dataset repository on the HF hub (containing data files only)
               -> load a generic dataset builder (csv, text etc.) based on the content of the repository
@@ -1421,7 +1421,7 @@ def load_dataset_builder(
     """Load a dataset builder from the Hugging Face Hub, or a local dataset. A dataset builder can be used to inspect general information that is required to build a dataset (cache directory, config, dataset info, etc.)
     without downloading the dataset itself.
 
-    You can find the list of datasets on the [Hub](https://huggingface.co/datasets) or with [`datasets.list_datasets`].
+    You can find the list of datasets on the [Hub](https://huggingface.co/datasets) or with [`huggingface_hub.list_datasets`].
 
     A dataset is a directory that contains:
 
@@ -1445,7 +1445,7 @@ def load_dataset_builder(
               -> load the dataset builder from the dataset script
               e.g. `'./dataset/squad'` or `'./dataset/squad/squad.py'`.
 
-            For datasets on the Hugging Face Hub (list all available datasets and ids with [`datasets.list_datasets`])
+            For datasets on the Hugging Face Hub (list all available datasets with [`huggingface_hub.list_datasets`])
 
             - if `path` is a dataset repository on the HF hub (containing data files only)
               -> load a generic dataset builder (csv, text etc.) based on the content of the repository
@@ -1567,7 +1567,7 @@ def load_dataset(
 ) -> Union[DatasetDict, Dataset, IterableDatasetDict, IterableDataset]:
     """Load a dataset from the Hugging Face Hub, or a local dataset.
 
-    You can find the list of datasets on the [Hub](https://huggingface.co/datasets) or with [`datasets.list_datasets`].
+    You can find the list of datasets on the [Hub](https://huggingface.co/datasets) or with [`huggingface_hub.list_datasets`].
 
     A dataset is a directory that contains:
 
@@ -1615,7 +1615,7 @@ def load_dataset(
               -> load the dataset builder from the dataset script
               e.g. `'./dataset/squad'` or `'./dataset/squad/squad.py'`.
 
-            For datasets on the Hugging Face Hub (list all available datasets and ids with [`datasets.list_datasets`])
+            For datasets on the Hugging Face Hub (list all available datasets with [`huggingface_hub.list_datasets`])
 
             - if `path` is a dataset repository on the HF hub (containing data files only)
               -> load a generic dataset builder (csv, text etc.) based on the content of the repository


### PR DESCRIPTION
Fix #5925 

Plus, deprecate `list_datasets`/`inspect_dataset` in favor of `huggingface_hub.list_datasets`/"git clone workflow" (downloads data files)