### PR TITLE
Filter unsupported extensions

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -751,7 +751,7 @@ class DataFilesList(List[Union[Path, Url]]):
 
     def filter_extensions(self, extensions: List[str]) -> "DataFilesList":
         pattern = "|".join("\\" + ext for ext in extensions)
-        pattern = re.compile(f".*({pattern})(\\..+)?")
+        pattern = re.compile(f".*({pattern})(\\..+)?$")
         return DataFilesList(
             [
                 data_file

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -1,4 +1,5 @@
 import os
+import re
 from functools import partial
 from pathlib import Path, PurePath
 from typing import Callable, Dict, List, Optional, Set, Tuple, Union
@@ -748,6 +749,18 @@ class DataFilesList(List[Union[Path, Url]]):
         origin_metadata = _get_origin_metadata_locally_or_by_urls(data_files, use_auth_token=use_auth_token)
         return cls(data_files, origin_metadata)
 
+    def filter_extensions(self, extensions: List[str]) -> "DataFilesList":
+        pattern = "|".join("\\" + ext for ext in extensions)
+        pattern = re.compile(f".*({pattern})(\\..+)?")
+        return DataFilesList(
+            [
+                data_file
+                for data_file in self
+                if pattern.match(data_file.name if isinstance(data_file, Path) else data_file)
+            ],
+            origin_metadata=self.origin_metadata,
+        )
+
 
 class DataFilesDict(Dict[str, DataFilesList]):
     """
@@ -819,3 +832,9 @@ class DataFilesDict(Dict[str, DataFilesList]):
 
         """
         return DataFilesDict, (dict(sorted(self.items())),)
+
+    def filter_extensions(self, extensions: List[str]) -> "DataFilesDict":
+        out = type(self)()
+        for key, data_files_list in self.items():
+            out[key] = data_files_list.filter_extensions(extensions)
+        return out

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -39,6 +39,7 @@ _PACKAGED_DATASETS_MODULES = {
     "audiofolder": (audiofolder.__name__, _hash_python_lines(inspect.getsource(audiofolder).splitlines())),
 }
 
+# Used to infer the module to use based on the data files extensions
 _EXTENSION_TO_MODULE = {
     ".csv": ("csv", {}),
     ".tsv": ("csv", {"sep": "\t"}),
@@ -54,6 +55,10 @@ _EXTENSION_TO_MODULE.update({ext: ("audiofolder", {}) for ext in audiofolder.Aud
 _EXTENSION_TO_MODULE.update({ext.upper(): ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS})
 _MODULE_SUPPORTS_METADATA = {"imagefolder", "audiofolder"}
 
+# Used to filter data files based on extensions given a module name
 _MODULE_TO_EXTENSIONS: Dict[str, List[str]] = {}
 for _ext, (_module, _) in _EXTENSION_TO_MODULE.items():
     _MODULE_TO_EXTENSIONS.setdefault(_module, []).append(_ext)
+
+_MODULE_TO_EXTENSIONS["imagefolder"].append(".zip")
+_MODULE_TO_EXTENSIONS["audiofolder"].append(".zip")

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 from hashlib import sha256
-from typing import List
+from typing import Dict, List
 
 from .arrow import arrow
 from .audiofolder import audiofolder
@@ -53,3 +53,7 @@ _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefo
 _EXTENSION_TO_MODULE.update({ext: ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS})
 _MODULE_SUPPORTS_METADATA = {"imagefolder", "audiofolder"}
+
+_MODULE_TO_EXTENSIONS: Dict[str, List[str]] = {}
+for _ext, (_module, _) in _EXTENSION_TO_MODULE.items():
+    _MODULE_TO_EXTENSIONS.setdefault(_module, []).append(_ext)

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -472,6 +472,16 @@ def text2_path(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def text_dir_with_unsupported_extension(tmp_path_factory):
+    data = ["0", "1", "2", "3"]
+    path = tmp_path_factory.mktemp("data") / "dataset.abc"
+    with open(path, "w") as f:
+        for item in data:
+            f.write(item + "\n")
+    return path
+
+
+@pytest.fixture(scope="session")
 def zip_text_path(text_path, text2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset.text.zip"
     with zipfile.ZipFile(path, "w") as f:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -899,6 +899,12 @@ def test_load_dataset_text_with_unicode_new_lines(text_path_with_unicode_new_lin
     assert ds.num_rows == 3
 
 
+def test_load_dataset_with_unsupported_extensions(text_dir_with_unsupported_extension):
+    data_files = str(text_dir_with_unsupported_extension)
+    ds = load_dataset("text", split="train", data_files=data_files)
+    assert ds.num_rows == 4
+
+
 @pytest.mark.integration
 def test_loading_from_the_datasets_hub():
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
I used a regex to filter the data files based on their extension for packaged builders.

I tried and a regex is 10x faster that using `in` to check if the extension is in the list of supported extensions.

Supersedes https://github.com/huggingface/datasets/pull/5850

Close https://github.com/huggingface/datasets/issues/5849

I also did a small change to favor the parquet module in case of a draw in the extension counter.