### PR TITLE
Avoid stuck map operation when subprocesses crashes

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -32,7 +32,7 @@ from multiprocessing import Manager
 from queue import Empty
 from shutil import disk_usage
 from types import CodeType, FunctionType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
 from urllib.parse import urlparse
 
 import dill
@@ -1331,7 +1331,7 @@ def _write_generator_to_queue(queue: queue.Queue, func: Callable[..., Iterable[Y
 
 
 def _get_pool_pid(pool: Union[multiprocessing.pool.Pool, multiprocess.pool.Pool]) -> Set[int]:
-    return set([f.pid for f in pool._pool])
+    return {f.pid for f in pool._pool}
 
 
 def iflatmap_unordered(

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -32,7 +32,7 @@ from multiprocessing import Manager
 from queue import Empty
 from shutil import disk_usage
 from types import CodeType, FunctionType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union, Set
 from urllib.parse import urlparse
 
 import dill
@@ -1330,18 +1330,24 @@ def _write_generator_to_queue(queue: queue.Queue, func: Callable[..., Iterable[Y
     return i
 
 
+def _get_pool_pid(pool: Union[multiprocessing.pool.Pool, multiprocess.pool.Pool]) -> Set[int]:
+    return set([f.pid for f in pool._pool])
+
+
 def iflatmap_unordered(
     pool: Union[multiprocessing.pool.Pool, multiprocess.pool.Pool],
     func: Callable[..., Iterable[Y]],
     *,
     kwargs_iterable: Iterable[dict],
 ) -> Iterable[Y]:
+    initial_pool_pid = _get_pool_pid(pool)
     manager_cls = Manager if isinstance(pool, multiprocessing.pool.Pool) else multiprocess.Manager
     with manager_cls() as manager:
         queue = manager.Queue()
         async_results = [
             pool.apply_async(_write_generator_to_queue, (queue, func, kwargs)) for kwargs in kwargs_iterable
         ]
+        subproc_killed = False
         try:
             while True:
                 try:
@@ -1349,6 +1355,14 @@ def iflatmap_unordered(
                 except Empty:
                     if all(async_result.ready() for async_result in async_results) and queue.empty():
                         break
+                if _get_pool_pid(pool) != initial_pool_pid:
+                    subproc_killed = True
+                    # One of the subprocesses has died. We should not wait forever.
+                    raise RuntimeError(
+                        "One of the subprocesses has abruptly died during map operation."
+                        "To debug the error, disable multiprocessing."
+                    )
         finally:
-            # we get the result in case there's an error to raise
-            [async_result.get(timeout=0.05) for async_result in async_results]
+            if not subproc_killed:
+                # we get the result in case there's an error to raise
+                [async_result.get(timeout=0.05) for async_result in async_results]

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -32,7 +32,7 @@ from multiprocessing import Manager
 from queue import Empty
 from shutil import disk_usage
 from types import CodeType, FunctionType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 from urllib.parse import urlparse
 
 import dill

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1631,6 +1631,18 @@ class BaseDatasetTest(TestCase):
                 ex_cnt = ExampleCounter(batched=True)
                 dset.map(ex_cnt)
                 self.assertEqual(ex_cnt.cnt, len(dset))
+    
+    def __test_map_crash_subprocess(self, in_memory):
+        # be sure that a crash in one of the subprocess will not 
+        # hang dataset.map() call forever
+
+        def do_crash(self, example):
+            raise SystemExit()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                with pytest.raises(ValueError):
+                    dset.map(do_crash)
 
     def test_filter(self, in_memory):
         # keep only first five examples

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1632,6 +1632,7 @@ class BaseDatasetTest(TestCase):
                 dset.map(ex_cnt)
                 self.assertEqual(ex_cnt.cnt, len(dset))
 
+    @require_not_windows
     def test_map_crash_subprocess(self, in_memory):
         # be sure that a crash in one of the subprocess will not
         # hang dataset.map() call forever

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1633,11 +1633,12 @@ class BaseDatasetTest(TestCase):
                 self.assertEqual(ex_cnt.cnt, len(dset))
 
     def test_map_crash_subprocess(self, in_memory):
-        # be sure that a crash in one of the subprocess will not 
+        # be sure that a crash in one of the subprocess will not
         # hang dataset.map() call forever
 
         def do_crash(row):
             import os
+
             os.kill(os.getpid(), 9)
             return row
 


### PR DESCRIPTION
I've been using Dataset.map() with `num_proc=os.cpu_count()` to leverage multicore processing for my datasets, but from time to time I get stuck processes waiting forever. Apparently, when one of the subprocesses is abruptly killed (OOM killer, segfault, SIGKILL, etc), the main process keeps waiting for the async task sent to that child process to finish.

It seems to be easy to reproduce the issue with the following script:

```
import os
from datasets import Dataset, Features, Value


def do_stuck(item):
    os.kill(os.getpid(), 9)

data = {
    "col1": list(range(5)),
    "col2": list(range(5)),
}

ds = Dataset.from_dict(
    data,
    features=Features({
        "col1": Value("int64"),
        "col2": Value("int64"),
    }),
)

print(ds.map(do_stuck, num_proc=4))
```

This is an old behavior in Python, which apparently was fixed a few years ago in `concurrent.futures.ProcessPoolExecutor` ([ref](https://bugs.python.org/issue9205)), but not in `multiprocessing.pool.Pool` / `multiprocess.pool.Pool`, which is used by `Dataset.map` ([ref](https://bugs.python.org/issue22393)).

This PR is an idea to try to detect when a child process gets killed, and raises a `RuntimeError` warning the dataset.map() caller.

EDIT: Related proposal for future improvement: https://github.com/huggingface/datasets/discussions/5977