### PR TITLE
Fix select_columns columns order

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1969,6 +1969,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             else:
                 break
         dataset.info.features = self._info.features.flatten(max_depth=max_depth)
+        dataset.info.features = Features({col: dataset.info.features[col] for col in dataset.data.column_names})
         dataset._data = update_metadata_with_features(dataset._data, dataset.features)
         logger.info(f'Flattened dataset from depth {depth} to depth {1 if depth + 1 < max_depth else "unknown"}.')
         dataset._fingerprint = new_fingerprint

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2333,8 +2333,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 )
 
         dataset = copy.deepcopy(self)
-        dataset._info.features = Features({k: v for k, v in dataset._info.features.items() if k in column_names})
         dataset._data = dataset._data.select(column_names)
+        dataset._info.features = Features({col: self._info.features[col] for col in dataset._data.column_names})
         dataset._data = update_metadata_with_features(dataset._data, dataset.features)
         dataset._fingerprint = new_fingerprint
         return dataset

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -105,7 +105,8 @@ def assert_arrow_metadata_are_synced_with_dataset_features(dataset: Dataset):
     features = DatasetInfo.from_dict(metadata["info"]).features
     assert features is not None
     assert dataset.features is not None
-    assert sorted(features) == sorted(field.name for field in dataset.data.schema)
+    assert list(features) == [field.name for field in dataset.data.schema]
+    assert list(dataset.features) == [field.name for field in dataset.data.schema]
 
 
 IN_MEMORY_PARAMETERS = [
@@ -648,6 +649,13 @@ class BaseDatasetTest(TestCase):
                 with dset.select_columns(column_names=["col_1", "col_2", "col_3"]) as new_dset:
                     self.assertEqual(new_dset.num_columns, 3)
                     self.assertListEqual(list(new_dset.column_names), ["col_1", "col_2", "col_3"])
+                    self.assertNotEqual(new_dset._fingerprint, fingerprint)
+                    assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
+
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
+                with dset.select_columns(column_names=["col_3", "col_2", "col_1"]) as new_dset:
+                    self.assertEqual(new_dset.num_columns, 3)
+                    self.assertListEqual(list(new_dset.column_names), ["col_3", "col_2", "col_1"])
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -106,8 +106,8 @@ def assert_arrow_metadata_are_synced_with_dataset_features(dataset: Dataset):
     assert features is not None
     assert features == dataset.features
     assert features == Features.from_arrow_schema(dataset.data.schema)
+    assert list(features) == dataset.data.column_names
     assert list(features) == list(dataset.features)
-    assert list(features) == list(Features.from_arrow_schema(dataset.data.schema))
 
 
 IN_MEMORY_PARAMETERS = [

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -104,9 +104,10 @@ def assert_arrow_metadata_are_synced_with_dataset_features(dataset: Dataset):
     assert "info" in metadata
     features = DatasetInfo.from_dict(metadata["info"]).features
     assert features is not None
-    assert dataset.features is not None
-    assert list(features) == [field.name for field in dataset.data.schema]
-    assert list(dataset.features) == [field.name for field in dataset.data.schema]
+    assert features == dataset.features
+    assert features == Features.from_arrow_schema(dataset.data.schema)
+    assert list(features) == list(dataset.features)
+    assert list(features) == list(Features.from_arrow_schema(dataset.data.schema))
 
 
 IN_MEMORY_PARAMETERS = [


### PR DESCRIPTION
Fix the order of the columns in dataset.features when the order changes with `dataset.select_columns()`.

I also fixed the same issue for `dataset.flatten()`

Close https://github.com/huggingface/datasets/issues/5993