### PR TITLE
Support returning dataframe in map transform

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -510,6 +510,8 @@ class ArrowWriter:
         Args:
             row: the row to add.
         """
+        if len(row) != 1:
+            raise ValueError(f"Only single-row pyarrow tables are allowed but got table with {len(row)} rows.")
         self.current_rows.append(row)
         if writer_batch_size is None:
             writer_batch_size = self.writer_batch_size

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -115,13 +115,13 @@ def data_dir_with_arrow(tmp_path):
     data_dir.mkdir()
     output_train = os.path.join(data_dir, "train.arrow")
     with ArrowWriter(path=output_train) as writer:
-        writer.write_row(pa.Table.from_pydict({"col_1": ["foo"] * 10}))
+        writer.write_table(pa.Table.from_pydict({"col_1": ["foo"] * 10}))
         num_examples, num_bytes = writer.finalize()
     assert num_examples == 10
     assert num_bytes > 0
     output_test = os.path.join(data_dir, "test.arrow")
     with ArrowWriter(path=output_test) as writer:
-        writer.write_row(pa.Table.from_pydict({"col_1": ["bar"] * 10}))
+        writer.write_table(pa.Table.from_pydict({"col_1": ["bar"] * 10}))
         num_examples, num_bytes = writer.finalize()
     assert num_examples == 10
     assert num_bytes > 0


### PR DESCRIPTION
Allow returning Pandas DataFrames in `map` transforms.

(Plus, raise an error in the non-batched mode if a returned PyArrow table/Pandas DataFrame has more than one row)

