### PR TITLE
Pin `joblib` to avoid `joblibspark` test failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ BENCHMARKS_REQUIRE = [
 TESTS_REQUIRE = [
     # test dependencies
     "absl-py",
+    "joblib<0.13.0",  # joblibspark doesn't support recent joblib versions
     "joblibspark",
     "pytest",
     "pytest-datadir",

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ BENCHMARKS_REQUIRE = [
 TESTS_REQUIRE = [
     # test dependencies
     "absl-py",
-    "joblib<0.13.0",  # joblibspark doesn't support recent joblib versions
+    "joblib<1.3.0",  # joblibspark doesn't support recent joblib versions
     "joblibspark",
     "pytest",
     "pytest-datadir",


### PR DESCRIPTION
`joblibspark` doesn't support the latest `joblib` release.

See https://github.com/huggingface/datasets/actions/runs/5401870932/jobs/9812337078 for the errors