### PR TITLE
Align `column_names` type check with type hint in `sort`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4051,7 +4051,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             )
 
         # Check proper format of and for duplicates in column_names
-        if not isinstance(column_names, list):
+        if not isinstance(column_names, Sequence_):
             column_names = [column_names]
 
         # Check proper format and length of reverse

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4051,7 +4051,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             )
 
         # Check proper format of and for duplicates in column_names
-        if not isinstance(column_names, Sequence_):
+        if isinstance(column_names, str):
             column_names = [column_names]
 
         # Check proper format and length of reverse


### PR DESCRIPTION
Fix #5998 