### PR TITLE
[docs] Update return statement of index search

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -697,7 +697,7 @@ class IndexableMixin:
         Returns:
             `(scores, indices)`:
                 A tuple of `(scores, indices)` where:
-                - **scores** (`List[List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples
+                - **scores** (`List[List[float]`): the retrieval scores from either FAISS (`IndexFlatL2` by default) or ElasticSearch of the retrieved examples
                 - **indices** (`List[List[int]]`): the indices of the retrieved examples
         """
         self._check_index_is_initialized(index_name)
@@ -719,7 +719,7 @@ class IndexableMixin:
         Returns:
             `(total_scores, total_indices)`:
                 A tuple of `(total_scores, total_indices)` where:
-                - **total_scores** (`List[List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples per query
+                - **total_scores** (`List[List[float]`): the retrieval scores from either FAISS (`IndexFlatL2` by default) or ElasticSearch of the retrieved examples per query
                 - **total_indices** (`List[List[int]]`): the indices of the retrieved examples per query
         """
         self._check_index_is_initialized(index_name)
@@ -741,7 +741,7 @@ class IndexableMixin:
         Returns:
             `(scores, examples)`:
                 A tuple of `(scores, examples)` where:
-                - **scores** (`List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples
+                - **scores** (`List[float]`): the retrieval scores from either FAISS (`IndexFlatL2` by default) or ElasticSearch of the retrieved examples
                 - **examples** (`dict`): the retrieved examples
         """
         self._check_index_is_initialized(index_name)
@@ -765,8 +765,8 @@ class IndexableMixin:
         Returns:
             `(total_scores, total_examples)`:
                 A tuple of `(total_scores, total_examples)` where:
-                - **total_scores** (`List[List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples per query
-                - **total_samples** (`List[dict]`): the retrieved examples per query
+                - **total_scores** (`List[List[float]`): the retrieval scores from either FAISS (`IndexFlatL2` by default) or ElasticSearch of the retrieved examples per query
+                - **total_examples** (`List[dict]`): the retrieved examples per query
         """
         self._check_index_is_initialized(index_name)
         total_scores, total_indices = self.search_batch(index_name, queries, k, **kwargs)

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -695,8 +695,10 @@ class IndexableMixin:
                 The number of examples to retrieve.
 
         Returns:
-            - scores (`List[List[float]`): The retrieval scores of the retrieved examples.
-            - indices (`List[List[int]]`): The indices of the retrieved examples.
+            `(scores, indices)`:
+                A tuple of `(scores, indices)` where:
+                - **scores** (`List[List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples
+                - **indices** (`List[List[int]]`): the indices of the retrieved examples
         """
         self._check_index_is_initialized(index_name)
         return self._indexes[index_name].search(query, k, **kwargs)
@@ -715,8 +717,10 @@ class IndexableMixin:
                 The number of examples to retrieve per query.
 
         Returns:
-            - total_scores (`List[List[float]`): The retrieval scores of the retrieved examples per query.
-            - total_indices (`List[List[int]]`): The indices of the retrieved examples per query.
+            `(total_scores, total_indices)`:
+                A tuple of `(total_scores, total_indices)` where:
+                - **total_scores** (`List[List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples per query
+                - **total_indices** (`List[List[int]]`): the indices of the retrieved examples per query
         """
         self._check_index_is_initialized(index_name)
         return self._indexes[index_name].search_batch(queries, k, **kwargs)
@@ -735,8 +739,10 @@ class IndexableMixin:
                 The number of examples to retrieve.
 
         Returns:
-            - scores (`List[float]`): The retrieval scores of the retrieved examples.
-            - examples (`dict`): The retrieved examples.
+            `(scores, examples)`:
+                A tuple of `(scores, examples)` where:
+                - **scores** (`List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples
+                - **examples** (`dict`): the retrieved examples
         """
         self._check_index_is_initialized(index_name)
         scores, indices = self.search(index_name, query, k, **kwargs)
@@ -757,8 +763,10 @@ class IndexableMixin:
                 The number of examples to retrieve per query.
 
         Returns:
-            - total_scores (`List[List[float]`): The retrieval scores of the retrieved examples per query.
-            - total_examples (`List[dict]`): The retrieved examples per query.
+            `(total_scores, total_examples)`:
+                A tuple of `(total_scores, total_examples)` where:
+                - **total_scores** (`List[List[float]`): the retrieval scores (`IndexFlatL2` score by default) of the retrieved examples per query
+                - **total_samples** (`List[dict]`): the retrieved examples per query
         """
         self._check_index_is_initialized(index_name)
         total_scores, total_indices = self.search_batch(index_name, queries, k, **kwargs)


### PR DESCRIPTION
Clarifies in the return statement of the docstring that the retrieval score is `IndexFlatL2` by default (see [PR](https://github.com/huggingface/transformers/issues/24739) and internal Slack [convo](https://huggingface.slack.com/archives/C01229B19EX/p1689105179711689)), and fixes the formatting because multiple return values are not supported.