### PR TITLE
Use new hffs

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - dataclasses
     - multiprocess
     - fsspec
-    - huggingface_hub >=0.13.0,<1.0.0
+    - huggingface_hub >=0.14.0,<1.0.0
     - packaging
     - aiohttp
   run:
@@ -40,7 +40,7 @@ requirements:
     - dataclasses
     - multiprocess
     - fsspec
-    - huggingface_hub >=0.13.0,<1.0.0
+    - huggingface_hub >=0.14.0,<1.0.0
     - packaging
     - aiohttp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: pip install --upgrade pyarrow huggingface-hub dill
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: pip install pyarrow==8.0.0 huggingface-hub==0.13.0 transformers dill==0.3.1.1
+        run: pip install pyarrow==8.0.0 huggingface-hub==0.14.0 transformers dill==0.3.1.1
       - name: Test with pytest
         run: |
           python -m pytest -rfExX -m ${{ matrix.test }} -n 2 --dist loadfile -sv ./tests/

--- a/setup.py
+++ b/setup.py
@@ -130,8 +130,8 @@ REQUIRED_PKGS = [
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
-    # minimum 0.13.0 to support dict-like modification of DatasetCard
-    "huggingface-hub>=0.13.0,<1.0.0",
+    # minimum 0.14.0 to support HfFileSystem
+    "huggingface-hub>=0.14.0,<1.0.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     # To parse YAML metadata from dataset cards

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5315,7 +5315,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             for data_file in data_files
             if data_file.startswith(f"data/{split}-") and data_file not in shards_path_in_repo
         ]
-        deleted_size = sum(xgetsize(hf_hub_url(repo_id, data_file), token=token) for data_file in data_files_to_delete)
+        download_config = DownloadConfig(use_auth_token=token)
+        deleted_size = sum(
+            xgetsize(hf_hub_url(repo_id, data_file), download_config=download_config)
+            for data_file in data_files_to_delete
+        )
 
         def delete_file(file):
             api.delete_file(file, repo_id=repo_id, token=token, repo_type="dataset", revision=branch)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5330,7 +5330,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             for data_file in data_files
             if data_file.startswith(f"{data_dir}/{split}-") and data_file not in shards_path_in_repo
         ]
-        download_config = DownloadConfig(use_auth_token=token)
+        download_config = DownloadConfig(token=token)
         deleted_size = sum(
             xgetsize(hf_hub_url(repo_id, data_file), download_config=download_config)
             for data_file in data_files_to_delete

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -360,7 +360,7 @@ class DatasetBuilder:
             data_files = DataFilesDict.from_local_or_remote(
                 sanitize_patterns(data_files),
                 base_path=base_path,
-                download_config=DownloadConfig(token=token, storage_options=storage_options),
+                download_config=DownloadConfig(token=token, storage_options=self.storage_options),
             )
 
         # Prepare config: DatasetConfig contains name, version and description but can be extended by each dataset

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -357,7 +357,7 @@ class DatasetBuilder:
         self._writer_batch_size = writer_batch_size or self.DEFAULT_WRITER_BATCH_SIZE
 
         if data_files is not None and not isinstance(data_files, DataFilesDict):
-            data_files = DataFilesDict.from_local_or_remote(
+            data_files = DataFilesDict.from_patterns(
                 sanitize_patterns(data_files),
                 base_path=base_path,
                 download_config=DownloadConfig(token=token, storage_options=self.storage_options),

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -347,12 +347,14 @@ class DatasetBuilder:
         # For backwards compatibility (e.g. if accessed in a dataset script)
         self.use_auth_token = token
         self.repo_id = repo_id
-        self.storage_options = storage_options
+        self.storage_options = storage_options or {}
         self._writer_batch_size = writer_batch_size or self.DEFAULT_WRITER_BATCH_SIZE
 
         if data_files is not None and not isinstance(data_files, DataFilesDict):
             data_files = DataFilesDict.from_local_or_remote(
-                sanitize_patterns(data_files), base_path=base_path, token=token
+                sanitize_patterns(data_files),
+                base_path=base_path,
+                download_config=DownloadConfig(token=token, storage_options=storage_options),
             )
 
         # Prepare config: DatasetConfig contains name, version and description but can be extended by each dataset

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -287,7 +287,7 @@ def resolve_pattern(
     fs_base_path = base_path.split("::")[0].split("://")[-1] or fs.root_marker
     fs_pattern = pattern.split("::")[0].split("://")[-1]
     protocol_prefix = fs.protocol + "://" if fs.protocol != "file" else ""
-    files_to_ignore = set(FILES_TO_IGNORE) - set(xbasename(pattern))
+    files_to_ignore = set(FILES_TO_IGNORE) - {xbasename(pattern)}
     matched_paths = [
         filepath if filepath.startswith(protocol_prefix) else protocol_prefix + filepath
         for filepath in fs.glob(pattern)

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -614,7 +614,7 @@ class DataFilesDict(Dict[str, DataFilesList]):
     @classmethod
     def from_patterns(
         cls,
-        patterns: List[str],
+        patterns: Dict[str, Union[List[str], DataFilesList]],
         base_path: Optional[str] = None,
         allowed_extensions: Optional[List[str]] = None,
         download_config: Optional[DownloadConfig] = None,

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -405,7 +405,7 @@ def get_data_patterns(base_path: str, download_config: Optional[DownloadConfig] 
 
     Output:
 
-        {"train": [**train*], "test": ["**test*"]}
+        {"train": ["**train*"], "test": ["**test*"]}
 
     Input:
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -16,8 +16,6 @@ from .download.streaming_download_manager import _prepare_path_and_storage_optio
 from .splits import Split
 from .utils import logging
 from .utils.file_utils import is_local_path, is_relative_path
-from .utils.py_utils import string_to_dict
-from .utils.file_utils import is_relative_path
 from .utils.py_utils import glob_pattern_to_regex, string_to_dict
 
 
@@ -242,14 +240,14 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], List[str]]) -> Di
     for patterns_dict in ALL_DEFAULT_PATTERNS:
         non_empty_splits = []
         for split, patterns in patterns_dict.items():
-            try:
-                for pattern in patterns:
+            for pattern in patterns:
+                try:
                     data_files = pattern_resolver(pattern)
-                    if len(data_files) > 0:
-                        non_empty_splits.append(split)
-                        break
-            except FileNotFoundError:
-                pass
+                except FileNotFoundError:
+                    continue
+                if len(data_files) > 0:
+                    non_empty_splits.append(split)
+                    break
         if non_empty_splits:
             return {split: patterns_dict[split] for split in non_empty_splits}
     raise FileNotFoundError(f"Couldn't resolve pattern {pattern} with resolver {pattern_resolver}")

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -335,7 +335,6 @@ def resolve_pattern(
         filepath if filepath.startswith(protocol_prefix) else protocol_prefix + filepath
         for filepath, info in fs.glob(pattern, detail=True).items()
         if info["type"] == "file"
-        
         and (xbasename(filepath) not in files_to_ignore)
         and not _is_inside_unrequested_special_dir(
             os.path.relpath(filepath, fs_base_path), os.path.relpath(fs_pattern, fs_base_path)

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -333,8 +333,9 @@ def resolve_pattern(
     files_to_ignore = set(FILES_TO_IGNORE) - {xbasename(pattern)}
     matched_paths = [
         filepath if filepath.startswith(protocol_prefix) else protocol_prefix + filepath
-        for filepath in fs.glob(pattern)
-        if fs.isfile(filepath)
+        for filepath, info in fs.glob(pattern, detail=True).items()
+        if info["type"] == "file"
+        
         and (xbasename(filepath) not in files_to_ignore)
         and not _is_inside_unrequested_special_dir(
             os.path.relpath(filepath, fs_base_path), os.path.relpath(fs_pattern, fs_base_path)
@@ -352,7 +353,7 @@ def resolve_pattern(
         if len(out) < len(matched_paths):
             invalid_matched_files = list(set(matched_paths) - set(out))
             logger.info(
-                f"Some files matched the pattern '{pattern}'but don't have valid data file extensions: {invalid_matched_files}"
+                f"Some files matched the pattern '{pattern}' but don't have valid data file extensions: {invalid_matched_files}"
             )
     else:
         out = matched_paths

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -1,8 +1,10 @@
 import copy
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
+
+from .. import config
 
 
 @dataclass
@@ -74,7 +76,7 @@ class DownloadConfig:
     token: Optional[Union[str, bool]] = None
     use_auth_token = "deprecated"
     ignore_url_params: bool = False
-    storage_options: Optional[Dict] = None
+    storage_options: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     download_desc: Optional[str] = None
 
     def __post_init__(self):
@@ -85,8 +87,8 @@ class DownloadConfig:
                 FutureWarning,
             )
             self.token = self.use_auth_token
-        if self.storage_options is None and self.token is not None:
-            self.storage_options = {"hf": {"token": self.token}}
+        if "hf" not in self.storage_options:
+            self.storage_options["hf"] = {"token": self.token, "endpoint": config.HF_ENDPOINT}
 
     def copy(self) -> "DownloadConfig":
         return self.__class__(**{k: copy.deepcopy(v) for k, v in self.__dict__.items()})

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -85,6 +85,8 @@ class DownloadConfig:
                 FutureWarning,
             )
             self.token = self.use_auth_token
+        if self.storage_options is None and self.token is not None:
+            self.storage_options = {"hf": {"token": self.token}}
 
     def copy(self) -> "DownloadConfig":
         return self.__class__(**{k: copy.deepcopy(v) for k, v in self.__dict__.items()})

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -417,10 +417,8 @@ def _prepare_single_hop_path_and_storage_options(
     """
     Prepare the URL and the kwargs that must be passed to the HttpFileSystem or to requests.get/head
 
-    In particular it resolves google drive URLs and it adds the authentication headers for the Hugging Face Hub.
-
-    it also needs to resolve the S3 file system specifically due to the S3 file system stores it parameters in
-     storage_options field.
+    In particular it resolves google drive URLs
+    It also adds the authentication headers for the Hugging Face Hub, for both https:// and hf:// paths.
     """
     token = None if download_config is None else download_config.token
     protocol = urlpath.split("://")[0] if "://" in urlpath else "file"

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -77,6 +77,8 @@ MAGIC_NUMBER_MAX_LENGTH = max(
     for magic_number in chain(MAGIC_NUMBER_TO_COMPRESSION_PROTOCOL, MAGIC_NUMBER_TO_UNSUPPORTED_COMPRESSION_PROTOCOL)
 )
 
+SUPPORTED_REMOTE_SERVER_TYPE = ["http", "https", "s3"]
+
 
 class NonStreamableDatasetError(Exception):
     pass
@@ -140,13 +142,12 @@ def xdirname(a):
     return "::".join([a] + b)
 
 
-def xexists(urlpath: str, token: Optional[Union[str, bool]] = None):
+def xexists(urlpath: str, download_config: Optional[DownloadConfig] = None):
     """Extend `os.path.exists` function to support both local and remote files.
 
     Args:
         urlpath (`str`): URL path.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `bool`
@@ -156,16 +157,7 @@ def xexists(urlpath: str, token: Optional[Union[str, bool]] = None):
     if is_local_path(main_hop):
         return os.path.exists(main_hop)
     else:
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            main_hop, http_kwargs = _prepare_http_url_kwargs(main_hop, token=token)
-            storage_options = http_kwargs
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, http_kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": http_kwargs}
-            urlpath = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        urlpath, storage_options = _prepare_server_config(urlpath, download_config=download_config)
         fs, *_ = fsspec.get_fs_token_paths(urlpath, storage_options=storage_options)
         return fs.exists(main_hop)
 
@@ -250,13 +242,12 @@ def xsplitext(a):
         return "::".join([a] + b), ext
 
 
-def xisfile(path, token: Optional[Union[str, bool]] = None) -> bool:
+def xisfile(path, download_config: Optional[DownloadConfig] = None) -> bool:
     """Extend `os.path.isfile` function to support remote files.
 
     Args:
         path (`str`): URL path.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `bool`
@@ -265,27 +256,17 @@ def xisfile(path, token: Optional[Union[str, bool]] = None) -> bool:
     if is_local_path(main_hop):
         return os.path.isfile(path)
     else:
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            main_hop, http_kwargs = _prepare_http_url_kwargs(main_hop, token=token)
-            storage_options = http_kwargs
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, http_kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": http_kwargs}
-            path = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        path, storage_options = _prepare_server_config(path, download_config=download_config)
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
         return fs.isfile(main_hop)
 
 
-def xgetsize(path, token: Optional[Union[str, bool]] = None) -> int:
+def xgetsize(path, download_config: Optional[DownloadConfig] = None) -> int:
     """Extend `os.path.getsize` function to support remote files.
 
     Args:
         path (`str`): URL path.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `int`: optional
@@ -294,32 +275,22 @@ def xgetsize(path, token: Optional[Union[str, bool]] = None) -> int:
     if is_local_path(main_hop):
         return os.path.getsize(path)
     else:
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            main_hop, http_kwargs = _prepare_http_url_kwargs(main_hop, token=token)
-            storage_options = http_kwargs
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, http_kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": http_kwargs}
-            path = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        path, storage_options = _prepare_server_config(path, download_config=download_config)
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
         size = fs.size(main_hop)
         if size is None:
             # use xopen instead of fs.open to make data fetching more robust
-            with xopen(path, token=token) as f:
+            with xopen(path, download_config=download_config) as f:
                 size = len(f.read())
         return size
 
 
-def xisdir(path, token: Optional[Union[str, bool]] = None) -> bool:
+def xisdir(path, download_config: Optional[DownloadConfig] = None) -> bool:
     """Extend `os.path.isdir` function to support remote files.
 
     Args:
         path (`str`): URL path.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `bool`
@@ -328,15 +299,7 @@ def xisdir(path, token: Optional[Union[str, bool]] = None) -> bool:
     if is_local_path(main_hop):
         return os.path.isdir(path)
     else:
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            raise NotImplementedError("os.path.isdir is not extended to support URLs in streaming mode")
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, http_kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": http_kwargs}
-            path = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        path, storage_options = _prepare_server_config(path, download_config=download_config, implemented=False)
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
         inner_path = main_hop.split("://")[1]
         if not inner_path.strip("/"):
@@ -412,7 +375,7 @@ def _get_extraction_protocol_with_magic_number(f) -> Optional[str]:
             raise NotImplementedError(f"Compression protocol '{compression}' not implemented.")
 
 
-def _get_extraction_protocol(urlpath: str, token: Optional[Union[str, bool]] = None) -> Optional[str]:
+def _get_extraction_protocol(urlpath: str, download_config: Optional[DownloadConfig] = None) -> Optional[str]:
     # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://train-00000.json.gz
     urlpath = str(urlpath)
     path = urlpath.split("::")[0]
@@ -427,7 +390,7 @@ def _get_extraction_protocol(urlpath: str, token: Optional[Union[str, bool]] = N
         return COMPRESSION_EXTENSION_TO_PROTOCOL[extension]
     if is_remote_url(urlpath):
         # get headers and cookies for authentication on the HF Hub and for Google Drive
-        urlpath, kwargs = _prepare_http_url_kwargs(urlpath, token=token)
+        urlpath, kwargs = _prepare_http_url_kwargs(urlpath, download_config=download_config)
     else:
         urlpath, kwargs = urlpath, {}
     try:
@@ -442,12 +405,40 @@ def _get_extraction_protocol(urlpath: str, token: Optional[Union[str, bool]] = N
             raise
 
 
-def _prepare_http_url_kwargs(url: str, token: Optional[Union[str, bool]] = None) -> Tuple[str, dict]:
+def _validate_servers(urlpath: str):
+    server = urlpath.split("://")[0]
+    return server in SUPPORTED_REMOTE_SERVER_TYPE
+
+
+def _prepare_server_config(
+    path: str, download_config: Optional[DownloadConfig] = None, implemented: bool = True
+) -> Tuple[str, dict]:
+    main_hop, *rest_hops = str(path).split("::")
+    if not rest_hops and _validate_servers(main_hop):
+        if not implemented:
+            raise NotImplementedError("Currently not extended to support URLs in streaming mode")
+        main_hop, http_kwargs = _prepare_http_url_kwargs(main_hop, download_config=download_config)
+        storage_options = http_kwargs
+    elif rest_hops and _validate_servers(rest_hops[0]):
+        url = rest_hops[0]
+        url, http_kwargs = _prepare_http_url_kwargs(url, download_config=download_config)
+        storage_options = {"https": http_kwargs}
+        path = "::".join([main_hop, url, *rest_hops[1:]])
+    else:
+        storage_options = None
+    return path, storage_options
+
+
+def _prepare_http_url_kwargs(url: str, download_config: Optional[DownloadConfig] = None) -> Tuple[str, dict]:
     """
     Prepare the URL and the kwargs that must be passed to the HttpFileSystem or to requests.get/head
 
     In particular it resolves google drive URLs and it adds the authentication headers for the Hugging Face Hub.
+
+    it also needs to resolve the S3 file system specifically due to the S3 file system stores it parameters in
+     storage_options field.
     """
+    use_auth_token = None if download_config is None else download_config.use_auth_token
     kwargs = {
         "headers": get_authentication_headers_for_url(url, token=token),
         "client_kwargs": {"trust_env": True},  # Enable reading proxy env variables.
@@ -466,10 +457,13 @@ def _prepare_http_url_kwargs(url: str, token: Optional[Union[str, bool]] = None)
     if url.startswith("https://raw.githubusercontent.com/"):
         # Workaround for served data with gzip content-encoding: https://github.com/fsspec/filesystem_spec/issues/389
         kwargs["block_size"] = 0
+    # Fix S3 file system
+    if url.startswith("s3://"):
+        kwargs = None if download_config is None else download_config.storage_options
     return url, kwargs
 
 
-def xopen(file: str, mode="r", *args, token: Optional[Union[str, bool]] = None, **kwargs):
+def xopen(file: str, mode="r", *args, download_config: Optional[DownloadConfig] = None, **kwargs):
     """Extend `open` function to support remote files using `fsspec`.
 
     It also has a retry mechanism in case connection fails.
@@ -479,8 +473,7 @@ def xopen(file: str, mode="r", *args, token: Optional[Union[str, bool]] = None, 
         file (`str`): Path name of the file to be opened.
         mode (`str`, *optional*, default "r"): Mode in which the file is opened.
         *args: Arguments to be passed to `fsspec.open`.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
         **kwargs: Keyword arguments to be passed to `fsspec.open`.
 
     Returns:
@@ -492,14 +485,8 @@ def xopen(file: str, mode="r", *args, token: Optional[Union[str, bool]] = None, 
     if is_local_path(main_hop):
         return open(main_hop, mode, *args, **kwargs)
     # add headers and cookies for authentication on the HF Hub and for Google Drive
-    if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-        file, new_kwargs = _prepare_http_url_kwargs(file_str, token=token)
-    elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-        url = rest_hops[0]
-        url, http_kwargs = _prepare_http_url_kwargs(url, token=token)
-        new_kwargs = {"https": http_kwargs}
-        file = "::".join([main_hop, url, *rest_hops[1:]])
-    else:
+    file, new_kwargs = _prepare_server_config(file_str, download_config=download_config)
+    if new_kwargs is None:
         new_kwargs = {}
     kwargs = {**kwargs, **new_kwargs}
     try:
@@ -523,13 +510,12 @@ def xopen(file: str, mode="r", *args, token: Optional[Union[str, bool]] = None, 
     return file_obj
 
 
-def xlistdir(path: str, token: Optional[Union[str, bool]] = None) -> List[str]:
+def xlistdir(path: str, download_config: Optional[DownloadConfig] = None) -> List[str]:
     """Extend `os.listdir` function to support remote files.
 
     Args:
         path (`str`): URL path.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `list` of `str`
@@ -539,15 +525,7 @@ def xlistdir(path: str, token: Optional[Union[str, bool]] = None) -> List[str]:
         return os.listdir(path)
     else:
         # globbing inside a zip in a private repo requires authentication
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            raise NotImplementedError("os.listdir is not extended to support URLs in streaming mode")
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, http_kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": http_kwargs}
-            path = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        path, storage_options = _prepare_server_config(path, download_config=download_config, implemented=False)
         fs, *_ = fsspec.get_fs_token_paths(path, storage_options=storage_options)
         inner_path = main_hop.split("://")[1]
         if inner_path.strip("/") and not fs.isdir(inner_path):
@@ -556,15 +534,14 @@ def xlistdir(path: str, token: Optional[Union[str, bool]] = None) -> List[str]:
         return [os.path.basename(obj["name"]) for obj in objects]
 
 
-def xglob(urlpath, *, recursive=False, token: Optional[Union[str, bool]] = None):
+def xglob(urlpath, *, recursive=False, download_config: Optional[DownloadConfig] = None):
     """Extend `glob.glob` function to support remote files.
 
     Args:
         urlpath (`str`): URL path with shell-style wildcard patterns.
         recursive (`bool`, default `False`): Whether to match the "**" pattern recursively to zero or more
             directories or subdirectories.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `list` of `str`
@@ -574,15 +551,7 @@ def xglob(urlpath, *, recursive=False, token: Optional[Union[str, bool]] = None)
         return glob.glob(main_hop, recursive=recursive)
     else:
         # globbing inside a zip in a private repo requires authentication
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            raise NotImplementedError("glob.glob is not extended to support URLs in streaming mode")
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": kwargs}
-            urlpath = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        urlpath, storage_options = _prepare_server_config(urlpath, download_config=download_config, implemented=False)
         fs, *_ = fsspec.get_fs_token_paths(urlpath, storage_options=storage_options)
         # - If there's no "*" in the pattern, get_fs_token_paths() doesn't do any pattern matching
         #   so to be able to glob patterns like "[0-9]", we have to call `fs.glob`.
@@ -594,13 +563,12 @@ def xglob(urlpath, *, recursive=False, token: Optional[Union[str, bool]] = None)
         return ["::".join([f"{protocol}://{globbed_path}"] + rest_hops) for globbed_path in globbed_paths]
 
 
-def xwalk(urlpath, token: Optional[Union[str, bool]] = None, **kwargs):
+def xwalk(urlpath, download_config: Optional[DownloadConfig] = None, **kwargs):
     """Extend `os.walk` function to support remote files.
 
     Args:
         urlpath (`str`): URL root path.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
         **kwargs: Additional keyword arguments forwarded to the underlying filesystem.
 
 
@@ -612,15 +580,7 @@ def xwalk(urlpath, token: Optional[Union[str, bool]] = None, **kwargs):
         yield from os.walk(main_hop, **kwargs)
     else:
         # walking inside a zip in a private repo requires authentication
-        if not rest_hops and (main_hop.startswith("http://") or main_hop.startswith("https://")):
-            raise NotImplementedError("os.walk is not extended to support URLs in streaming mode")
-        elif rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
-            url = rest_hops[0]
-            url, kwargs = _prepare_http_url_kwargs(url, token=token)
-            storage_options = {"https": kwargs}
-            urlpath = "::".join([main_hop, url, *rest_hops[1:]])
-        else:
-            storage_options = None
+        urlpath, storage_options = _prepare_server_config(urlpath, download_config=download_config, implemented=False)
         fs, *_ = fsspec.get_fs_token_paths(urlpath, storage_options=storage_options)
         inner_path = main_hop.split("://")[1]
         if inner_path.strip("/") and not fs.isdir(inner_path):
@@ -643,25 +603,23 @@ class xPath(type(Path())):
         path_as_posix += "//" if path_as_posix.endswith(":") else ""  # Add slashes to root of the protocol
         return path_as_posix
 
-    def exists(self, token: Optional[Union[str, bool]] = None):
+    def exists(self, download_config: Optional[DownloadConfig] = None):
         """Extend `pathlib.Path.exists` method to support both local and remote files.
 
         Args:
-            token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-                Hugging Face Hub for private remote files.
+            download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
         Returns:
             `bool`
         """
-        return xexists(str(self), token=token)
+        return xexists(str(self), download_config=download_config)
 
-    def glob(self, pattern, token: Optional[Union[str, bool]] = None):
+    def glob(self, pattern, download_config: Optional[DownloadConfig] = None):
         """Glob function for argument of type :obj:`~pathlib.Path` that supports both local paths end remote URLs.
 
         Args:
             pattern (`str`): Pattern that resulting paths must match.
-            token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-                Hugging Face Hub for private remote files.
+            download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
         Yields:
             [`xPath`]
@@ -672,9 +630,9 @@ class xPath(type(Path())):
             yield from Path(main_hop).glob(pattern)
         else:
             # globbing inside a zip in a private repo requires authentication
-            if rest_hops and (rest_hops[0].startswith("http://") or rest_hops[0].startswith("https://")):
+            if rest_hops and _validate_servers(rest_hops[0]):
                 url = rest_hops[0]
-                url, kwargs = _prepare_http_url_kwargs(url, token=token)
+                url, kwargs = _prepare_http_url_kwargs(url, download_config=download_config)
                 storage_options = {"https": kwargs}
                 posix_path = "::".join([main_hop, url, *rest_hops[1:]])
             else:
@@ -772,27 +730,27 @@ def _as_str(path: Union[str, Path, xPath]):
     return str(path) if isinstance(path, xPath) else str(xPath(str(path)))
 
 
-def xgzip_open(filepath_or_buffer, *args, token: Optional[Union[str, bool]] = None, **kwargs):
+def xgzip_open(filepath_or_buffer, *args, download_config: Optional[DownloadConfig] = None, **kwargs):
     import gzip
 
     if hasattr(filepath_or_buffer, "read"):
         return gzip.open(filepath_or_buffer, *args, **kwargs)
     else:
         filepath_or_buffer = str(filepath_or_buffer)
-        return gzip.open(xopen(filepath_or_buffer, "rb", token=token), *args, **kwargs)
+        return gzip.open(xopen(filepath_or_buffer, "rb", download_config=download_config), *args, **kwargs)
 
 
-def xnumpy_load(filepath_or_buffer, *args, token: Optional[Union[str, bool]] = None, **kwargs):
+def xnumpy_load(filepath_or_buffer, *args, download_config: Optional[DownloadConfig] = None, **kwargs):
     import numpy as np
 
     if hasattr(filepath_or_buffer, "read"):
         return np.load(filepath_or_buffer, *args, **kwargs)
     else:
         filepath_or_buffer = str(filepath_or_buffer)
-        return np.load(xopen(filepath_or_buffer, "rb", token=token), *args, **kwargs)
+        return np.load(xopen(filepath_or_buffer, "rb", download_config=download_config), *args, **kwargs)
 
 
-def xpandas_read_csv(filepath_or_buffer, token: Optional[Union[str, bool]] = None, **kwargs):
+def xpandas_read_csv(filepath_or_buffer, download_config: Optional[DownloadConfig] = None, **kwargs):
     import pandas as pd
 
     if hasattr(filepath_or_buffer, "read"):
@@ -800,11 +758,11 @@ def xpandas_read_csv(filepath_or_buffer, token: Optional[Union[str, bool]] = Non
     else:
         filepath_or_buffer = str(filepath_or_buffer)
         if kwargs.get("compression", "infer") == "infer":
-            kwargs["compression"] = _get_extraction_protocol(filepath_or_buffer, token=token)
-        return pd.read_csv(xopen(filepath_or_buffer, "rb", token=token), **kwargs)
+            kwargs["compression"] = _get_extraction_protocol(filepath_or_buffer, download_config=download_config)
+        return pd.read_csv(xopen(filepath_or_buffer, "rb", download_config=download_config), **kwargs)
 
 
-def xpandas_read_excel(filepath_or_buffer, token: Optional[Union[str, bool]] = None, **kwargs):
+def xpandas_read_excel(filepath_or_buffer, download_config: Optional[DownloadConfig] = None, **kwargs):
     import pandas as pd
 
     if hasattr(filepath_or_buffer, "read"):
@@ -815,28 +773,29 @@ def xpandas_read_excel(filepath_or_buffer, token: Optional[Union[str, bool]] = N
     else:
         filepath_or_buffer = str(filepath_or_buffer)
         try:
-            return pd.read_excel(xopen(filepath_or_buffer, "rb", token=token), **kwargs)
+            return pd.read_excel(xopen(filepath_or_buffer, "rb", download_config=download_config), **kwargs)
         except ValueError:  # Cannot seek streaming HTTP file
-            return pd.read_excel(BytesIO(xopen(filepath_or_buffer, "rb", token=token).read()), **kwargs)
+            return pd.read_excel(
+                BytesIO(xopen(filepath_or_buffer, "rb", download_config=download_config).read()), **kwargs
+            )
 
 
-def xsio_loadmat(filepath_or_buffer, token: Optional[Union[str, bool]] = None, **kwargs):
+def xsio_loadmat(filepath_or_buffer, download_config: Optional[DownloadConfig] = None, **kwargs):
     import scipy.io as sio
 
     if hasattr(filepath_or_buffer, "read"):
         return sio.loadmat(filepath_or_buffer, **kwargs)
     else:
-        return sio.loadmat(xopen(filepath_or_buffer, "rb", token=token), **kwargs)
+        return sio.loadmat(xopen(filepath_or_buffer, "rb", download_config=download_config), **kwargs)
 
 
-def xet_parse(source, parser=None, token: Optional[Union[str, bool]] = None):
+def xet_parse(source, parser=None, download_config: Optional[DownloadConfig] = None):
     """Extend `xml.etree.ElementTree.parse` function to support remote files.
 
     Args:
         source: File path or file object.
         parser (`XMLParser`, *optional*, default `XMLParser`): Parser instance.
-        token (`bool` or `str`, optional): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
 
     Returns:
         `xml.etree.ElementTree.Element`: Root element of the given source document.
@@ -844,17 +803,16 @@ def xet_parse(source, parser=None, token: Optional[Union[str, bool]] = None):
     if hasattr(source, "read"):
         return ET.parse(source, parser=parser)
     else:
-        with xopen(source, "rb", token=token) as f:
+        with xopen(source, "rb", download_config=download_config) as f:
             return ET.parse(f, parser=parser)
 
 
-def xxml_dom_minidom_parse(filename_or_file, token: Optional[Union[str, bool]] = None, **kwargs):
+def xxml_dom_minidom_parse(filename_or_file, download_config: Optional[DownloadConfig] = None, **kwargs):
     """Extend `xml.dom.minidom.parse` function to support remote files.
 
     Args:
         filename_or_file (`str` or file): File path or file object.
-        token (`bool` or `str`, *optional*): Whether to use token or token to authenticate on the
-            Hugging Face Hub for private remote files.
+        download_config : mainly use use_auth_token or storage_options to support different platforms and auth types.
         **kwargs (optional): Additional keyword arguments passed to `xml.dom.minidom.parse`.
 
     Returns:
@@ -863,7 +821,7 @@ def xxml_dom_minidom_parse(filename_or_file, token: Optional[Union[str, bool]] =
     if hasattr(filename_or_file, "read"):
         return xml.dom.minidom.parse(filename_or_file, **kwargs)
     else:
-        with xopen(filename_or_file, "rb", token=token) as f:
+        with xopen(filename_or_file, "rb", download_config=download_config) as f:
             return xml.dom.minidom.parse(f, **kwargs)
 
 
@@ -924,10 +882,10 @@ class ArchiveIterable(_IterableFromGenerator):
 
     @classmethod
     def _iter_from_urlpath(
-        cls, urlpath: str, token: Optional[Union[str, bool]] = None
+        cls, urlpath: str, download_config: Optional[DownloadConfig] = None
     ) -> Generator[Tuple, None, None]:
-        compression = _get_extraction_protocol(urlpath, token=token)
-        with xopen(urlpath, "rb", token=token) as f:
+        compression = _get_extraction_protocol(urlpath, download_config=download_config)
+        with xopen(urlpath, "rb", download_config=download_config) as f:
             if compression == "zip":
                 yield from cls._iter_zip(f)
             else:
@@ -938,8 +896,8 @@ class ArchiveIterable(_IterableFromGenerator):
         return cls(cls._iter_from_fileobj, fileobj)
 
     @classmethod
-    def from_urlpath(cls, urlpath_or_buf, token: Optional[Union[str, bool]] = None) -> "ArchiveIterable":
-        return cls(cls._iter_from_urlpath, urlpath_or_buf, token)
+    def from_urlpath(cls, urlpath_or_buf, download_config: Optional[DownloadConfig] = None) -> "ArchiveIterable":
+        return cls(cls._iter_from_urlpath, urlpath_or_buf, download_config)
 
 
 class FilesIterable(_IterableFromGenerator):
@@ -947,18 +905,18 @@ class FilesIterable(_IterableFromGenerator):
 
     @classmethod
     def _iter_from_urlpaths(
-        cls, urlpaths: Union[str, List[str]], token: Optional[Union[str, bool]] = None
+        cls, urlpaths: Union[str, List[str]], download_config: Optional[DownloadConfig] = None
     ) -> Generator[str, None, None]:
         if not isinstance(urlpaths, list):
             urlpaths = [urlpaths]
         for urlpath in urlpaths:
-            if xisfile(urlpath, token=token):
+            if xisfile(urlpath, download_config=download_config):
                 if xbasename(urlpath).startswith((".", "__")):
                     # skipping hidden files
                     return
                 yield urlpath
-            elif xisdir(urlpath, token=token):
-                for dirpath, dirnames, filenames in xwalk(urlpath, token=token):
+            elif xisdir(urlpath, download_config=download_config):
+                for dirpath, dirnames, filenames in xwalk(urlpath, download_config=download_config):
                     # skipping hidden directories; prune the search
                     # [:] for the in-place list modification required by os.walk
                     # (only works for local paths as fsspec's walk doesn't support the in-place modification)
@@ -975,8 +933,8 @@ class FilesIterable(_IterableFromGenerator):
                 raise FileNotFoundError(urlpath)
 
     @classmethod
-    def from_urlpaths(cls, urlpaths, token: Optional[Union[str, bool]] = None) -> "FilesIterable":
-        return cls(cls._iter_from_urlpaths, urlpaths, token)
+    def from_urlpaths(cls, urlpaths, download_config: Optional[DownloadConfig] = None) -> "FilesIterable":
+        return cls(cls._iter_from_urlpaths, urlpaths, download_config)
 
 
 class StreamingDownloadManager:
@@ -1056,7 +1014,7 @@ class StreamingDownloadManager:
 
     def _extract(self, urlpath: str) -> str:
         urlpath = str(urlpath)
-        protocol = _get_extraction_protocol(urlpath, token=self.download_config.token)
+        protocol = _get_extraction_protocol(urlpath, download_config=self.download_config)
         # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://train-00000.json.gz
         path = urlpath.split("::")[0]
         extension = _get_path_extension(path)
@@ -1124,7 +1082,7 @@ class StreamingDownloadManager:
         if hasattr(urlpath_or_buf, "read"):
             return ArchiveIterable.from_buf(urlpath_or_buf)
         else:
-            return ArchiveIterable.from_urlpath(urlpath_or_buf, token=self.download_config.token)
+            return ArchiveIterable.from_urlpath(urlpath_or_buf, download_config=self.download_config)
 
     def iter_files(self, urlpaths: Union[str, List[str]]) -> Iterable[str]:
         """Iterate over files.
@@ -1143,4 +1101,4 @@ class StreamingDownloadManager:
         >>> files = dl_manager.iter_files(files)
         ```
         """
-        return FilesIterable.from_urlpaths(urlpaths, token=self.download_config.token)
+        return FilesIterable.from_urlpaths(urlpaths, download_config=self.download_config)

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -428,8 +428,10 @@ def _prepare_single_hop_path_and_storage_options(
         storage_options = {}
     if protocol in ["http", "https"]:
         storage_options[protocol] = {
-            "headers": get_authentication_headers_for_url(urlpath, token=token)
-            | {"user-agent": get_datasets_user_agent()},
+            "headers": {
+                **get_authentication_headers_for_url(urlpath, token=token),
+                "user-agent": get_datasets_user_agent(),
+            },
             "client_kwargs": {"trust_env": True},  # Enable reading proxy env variables.
             **(storage_options.get(protocol, {})),
         }

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -957,7 +957,7 @@ class FilesIterable(_IterableFromGenerator):
                     # skipping hidden files
                     return
                 yield urlpath
-            else:
+            elif xisdir(urlpath, token=token):
                 for dirpath, dirnames, filenames in xwalk(urlpath, token=token):
                     # skipping hidden directories; prune the search
                     # [:] for the in-place list modification required by os.walk
@@ -971,6 +971,8 @@ class FilesIterable(_IterableFromGenerator):
                             # skipping hidden files
                             continue
                         yield xjoin(dirpath, filename)
+            else:
+                raise FileNotFoundError(urlpath)
 
     @classmethod
     def from_urlpaths(cls, urlpaths, token: Optional[Union[str, bool]] = None) -> "FilesIterable":

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -7,6 +7,7 @@ import numpy as np
 import pyarrow as pa
 
 from .. import config
+from ..download.download_config import DownloadConfig
 from ..download.streaming_download_manager import xopen, xsplitext
 from ..table import array_cast
 from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
@@ -178,7 +179,8 @@ class Audio:
             except (ValueError, KeyError):
                 token = None
 
-            with xopen(path, "rb", token=token) as f:
+            download_config = DownloadConfig(token=token)
+            with xopen(path, "rb", download_config=download_config) as f:
                 array, sampling_rate = sf.read(f)
 
         else:

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -9,6 +9,7 @@ import numpy as np
 import pyarrow as pa
 
 from .. import config
+from ..download.download_config import DownloadConfig
 from ..download.streaming_download_manager import xopen
 from ..table import array_cast
 from ..utils.file_utils import is_local_path
@@ -170,7 +171,8 @@ class Image:
                         token = token_per_repo_id.get(repo_id)
                     except ValueError:
                         token = None
-                    with xopen(path, "rb", token=token) as f:
+                    download_config = DownloadConfig(token=token)
+                    with xopen(path, "rb", download_config=download_config) as f:
                         bytes_ = BytesIO(f.read())
                     image = PIL.Image.open(bytes_)
         else:

--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -8,7 +8,6 @@ import fsspec
 import fsspec.asyn
 
 from . import compression
-from .hffilesystem import HfFileSystem
 
 
 _has_s3fs = importlib.util.find_spec("s3fs") is not None
@@ -25,7 +24,7 @@ COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
 ]
 
 # Register custom filesystems
-for fs_class in COMPRESSION_FILESYSTEMS + [HfFileSystem]:
+for fs_class in COMPRESSION_FILESYSTEMS:
     if fs_class.protocol in fsspec.registry and fsspec.registry[fs_class.protocol] is not fs_class:
         warnings.warn(f"A filesystem protocol was already set for {fs_class.protocol} and will be overwritten.")
     fsspec.register_implementation(fs_class.protocol, fs_class, clobber=True)

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -61,8 +61,11 @@ def extend_module_for_streaming(module_path, download_config: Optional[DownloadC
 
     module = importlib.import_module(module_path)
 
-    # TODO(QL): always update the module to add subsequent new authentication
+    # TODO(QL): always update the module to add subsequent new authentication without removing old ones
     if hasattr(module, "_patched_for_streaming") and module._patched_for_streaming:
+        if isinstance(module._patched_for_streaming, DownloadConfig):
+            module._patched_for_streaming.token = download_config.token
+            module._patched_for_streaming.storage_options = download_config.storage_options
         return
 
     def wrap_auth(function):
@@ -99,7 +102,7 @@ def extend_module_for_streaming(module_path, download_config: Optional[DownloadC
     patch_submodule(module, "scipy.io.loadmat", wrap_auth(xsio_loadmat), attrs=["__version__"]).start()
     patch_submodule(module, "xml.etree.ElementTree.parse", wrap_auth(xet_parse)).start()
     patch_submodule(module, "xml.dom.minidom.parse", wrap_auth(xxml_dom_minidom_parse)).start()
-    module._patched_for_streaming = True
+    module._patched_for_streaming = download_config
 
 
 def extend_dataset_builder_for_streaming(builder: "DatasetBuilder"):

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -110,3 +110,4 @@ def tmpfs(tmp_path_factory, mock_fsspec):
     tmp_fs_dir = tmp_path_factory.mktemp("tmpfs")
     with patch.object(TmpDirFileSystem, "tmp_dir", tmp_fs_dir):
         yield TmpDirFileSystem()
+        TmpDirFileSystem.clear_instance_cache()

--- a/tests/packaged_modules/test_audiofolder.py
+++ b/tests/packaged_modules/test_audiofolder.py
@@ -7,7 +7,7 @@ import pytest
 import soundfile as sf
 
 from datasets import Audio, ClassLabel, Features, Value
-from datasets.data_files import DataFilesDict, get_data_patterns_locally
+from datasets.data_files import DataFilesDict, get_data_patterns
 from datasets.download.streaming_download_manager import StreamingDownloadManager
 from datasets.packaged_modules.audiofolder.audiofolder import AudioFolder
 
@@ -33,8 +33,8 @@ def data_files_with_labels_no_metadata(tmp_path, audio_file):
     audio_filename2 = subdir_class_1 / "audio_uk.wav"
     shutil.copyfile(audio_file, audio_filename2)
 
-    data_files_with_labels_no_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
+    data_files_with_labels_no_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
 
     return data_files_with_labels_no_metadata
@@ -123,8 +123,8 @@ def data_files_with_one_split_and_metadata(tmp_path, audio_file):
     )
     with open(audio_metadata_filename, "w", encoding="utf-8") as f:
         f.write(audio_metadata)
-    data_files_with_one_split_and_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
+    data_files_with_one_split_and_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
     assert len(data_files_with_one_split_and_metadata) == 1
     assert len(data_files_with_one_split_and_metadata["train"]) == 4
@@ -183,8 +183,8 @@ def data_files_with_two_splits_and_metadata(request, tmp_path, audio_file):
     )
     with open(test_audio_metadata_filename, "w", encoding="utf-8") as f:
         f.write(audio_metadata)
-    data_files_with_two_splits_and_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
+    data_files_with_two_splits_and_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
     assert len(data_files_with_two_splits_and_metadata) == 2
     assert len(data_files_with_two_splits_and_metadata["train"]) == 3
@@ -223,9 +223,7 @@ def data_files_with_zip_archives(tmp_path, audio_file):
     shutil.make_archive(str(archive_dir), "zip", archive_dir)
     shutil.rmtree(str(archive_dir))
 
-    data_files_with_zip_archives = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
-    )
+    data_files_with_zip_archives = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
 
     assert len(data_files_with_zip_archives) == 1
     assert len(data_files_with_zip_archives["train"]) == 1
@@ -446,9 +444,7 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, audio_fil
     with open(audio_metadata_filename, "w", encoding="utf-8") as f:
         f.write(audio_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
-    )
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     audiofolder = AudioFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     audiofolder.download_and_prepare()
     dataset = audiofolder.as_dataset(split="train")
@@ -470,9 +466,7 @@ def test_data_files_with_wrong_audio_file_name_column_in_metadata_file(cache_dir
     with open(audio_metadata_filename, "w", encoding="utf-8") as f:
         f.write(audio_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
-    )
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     audiofolder = AudioFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     with pytest.raises(ValueError) as exc_info:
         audiofolder.download_and_prepare()
@@ -502,7 +496,7 @@ def test_data_files_with_with_metadata_in_different_formats(cache_dir, tmp_path,
     with open(audio_metadata_filename_csv, "w", encoding="utf-8") as f:
         f.write(audio_metadata_csv)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     audiofolder = AudioFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     with pytest.raises(ValueError) as exc_info:
         audiofolder.download_and_prepare()

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 
 from datasets import ClassLabel, DownloadManager, Features, Value
-from datasets.data_files import DataFilesDict, get_data_patterns_locally
+from datasets.data_files import DataFilesDict, get_data_patterns
 from datasets.download.streaming_download_manager import StreamingDownloadManager
 from datasets.packaged_modules.folder_based_builder.folder_based_builder import (
     FolderBasedBuilder,
@@ -54,8 +54,8 @@ def data_files_with_labels_no_metadata(tmp_path, auto_text_file):
     filename2 = subdir_class_1 / "file1.txt"
     shutil.copyfile(auto_text_file, filename2)
 
-    data_files_with_labels_no_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
+    data_files_with_labels_no_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
 
     return data_files_with_labels_no_metadata
@@ -75,8 +75,8 @@ def data_files_with_different_levels_no_metadata(tmp_path, auto_text_file):
     filename2 = subdir_class_1 / "file1.txt"
     shutil.copyfile(auto_text_file, filename2)
 
-    data_files_with_different_levels = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
+    data_files_with_different_levels = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
 
     return data_files_with_different_levels
@@ -93,9 +93,7 @@ def data_files_with_one_label_no_metadata(tmp_path, auto_text_file):
     filename2 = data_dir / "file1.txt"
     shutil.copyfile(auto_text_file, filename2)
 
-    data_files_with_one_label = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
-    )
+    data_files_with_one_label = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
 
     return data_files_with_one_label
 
@@ -183,8 +181,8 @@ def data_files_with_one_split_and_metadata(tmp_path, auto_text_file):
     )
     with open(metadata_filename, "w", encoding="utf-8") as f:
         f.write(metadata)
-    data_files_with_one_split_and_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(data_dir), data_dir
+    data_files_with_one_split_and_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
     assert len(data_files_with_one_split_and_metadata) == 1
     assert len(data_files_with_one_split_and_metadata["train"]) == 4
@@ -224,8 +222,8 @@ def data_files_with_two_splits_and_metadata(tmp_path, auto_text_file):
     )
     with open(test_metadata_filename, "w", encoding="utf-8") as f:
         f.write(test_metadata)
-    data_files_with_two_splits_and_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(data_dir), data_dir
+    data_files_with_two_splits_and_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
     assert len(data_files_with_two_splits_and_metadata) == 2
     assert len(data_files_with_two_splits_and_metadata["train"]) == 3
@@ -260,7 +258,7 @@ def data_files_with_zip_archives(tmp_path, auto_text_file):
     shutil.make_archive(archive_dir, "zip", archive_dir)
     shutil.rmtree(str(archive_dir))
 
-    data_files_with_zip_archives = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_zip_archives = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
 
     assert len(data_files_with_zip_archives) == 1
     assert len(data_files_with_zip_archives["train"]) == 1
@@ -505,7 +503,7 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, auto_text
     with open(metadata_filename, "w", encoding="utf-8") as f:
         f.write(metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     autofolder = DummyFolderBasedBuilder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     gen_kwargs = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
     generator = autofolder._generate_examples(**gen_kwargs)
@@ -525,7 +523,7 @@ def test_data_files_with_wrong_file_name_column_in_metadata_file(cache_dir, tmp_
     with open(metadata_filename, "w", encoding="utf-8") as f:
         f.write(metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     autofolder = DummyFolderBasedBuilder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     with pytest.raises(ValueError) as exc_info:
         _ = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from datasets import ClassLabel, Features, Image, Value
-from datasets.data_files import DataFilesDict, get_data_patterns_locally
+from datasets.data_files import DataFilesDict, get_data_patterns
 from datasets.download.streaming_download_manager import StreamingDownloadManager
 from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder
 
@@ -31,8 +31,8 @@ def data_files_with_labels_no_metadata(tmp_path, image_file):
     image_filename2 = subdir_class_1 / "image_dog.jpg"
     shutil.copyfile(image_file, image_filename2)
 
-    data_files_with_labels_no_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(str(data_dir)), str(data_dir)
+    data_files_with_labels_no_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
 
     return data_files_with_labels_no_metadata
@@ -132,8 +132,8 @@ def data_files_with_one_split_and_metadata(request, tmp_path, image_file):
     )
     with open(image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
-    data_files_with_one_split_and_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(data_dir), data_dir
+    data_files_with_one_split_and_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
     assert len(data_files_with_one_split_and_metadata) == 1
     assert len(data_files_with_one_split_and_metadata["train"]) == 4
@@ -192,8 +192,8 @@ def data_files_with_two_splits_and_metadata(request, tmp_path, image_file):
     )
     with open(test_image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
-    data_files_with_two_splits_and_metadata = DataFilesDict.from_local_or_remote(
-        get_data_patterns_locally(data_dir), data_dir
+    data_files_with_two_splits_and_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
     )
     assert len(data_files_with_two_splits_and_metadata) == 2
     assert len(data_files_with_two_splits_and_metadata["train"]) == 3
@@ -232,7 +232,7 @@ def data_files_with_zip_archives(tmp_path, image_file):
     shutil.make_archive(archive_dir, "zip", archive_dir)
     shutil.rmtree(str(archive_dir))
 
-    data_files_with_zip_archives = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_zip_archives = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
 
     assert len(data_files_with_zip_archives) == 1
     assert len(data_files_with_zip_archives["train"]) == 1
@@ -450,7 +450,7 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, image_fil
     with open(image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     imagefolder = ImageFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     imagefolder.download_and_prepare()
     dataset = imagefolder.as_dataset(split="train")
@@ -472,7 +472,7 @@ def test_data_files_with_wrong_image_file_name_column_in_metadata_file(cache_dir
     with open(image_metadata_filename, "w", encoding="utf-8") as f:
         f.write(image_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     imagefolder = ImageFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     with pytest.raises(ValueError) as exc_info:
         imagefolder.download_and_prepare()
@@ -502,7 +502,7 @@ def test_data_files_with_with_metadata_in_different_formats(cache_dir, tmp_path,
     with open(image_metadata_filename_csv, "w", encoding="utf-8") as f:
         f.write(image_metadata_csv)
 
-    data_files_with_bad_metadata = DataFilesDict.from_local_or_remote(get_data_patterns_locally(data_dir), data_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
     imagefolder = ImageFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
     with pytest.raises(ValueError) as exc_info:
         imagefolder.download_and_prepare()

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -96,7 +96,7 @@ def pattern_results(complex_data_dir):
 
     return {
         pattern: sorted(
-            str(Path(os.path.abspath(path)))
+            Path(os.path.abspath(path)).as_posix()
             for path in fsspec.filesystem("file").glob(os.path.join(complex_data_dir, pattern))
             if Path(path).name not in _FILES_TO_IGNORE
             and not any(

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -6,21 +6,17 @@ from unittest.mock import patch
 import fsspec
 import pytest
 from fsspec.spec import AbstractFileSystem
-from huggingface_hub.hf_api import DatasetInfo
 
 from datasets.data_files import (
     DataFilesDict,
     DataFilesList,
-    Url,
     _get_data_files_patterns,
     _get_metadata_files_patterns,
     _is_inside_unrequested_special_dir,
     _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir,
-    resolve_patterns_in_dataset_repository,
-    resolve_patterns_locally_or_by_urls,
+    resolve_pattern,
 )
 from datasets.fingerprint import Hasher
-from datasets.utils.hub import hf_hub_url
 
 
 _TEST_PATTERNS = ["*", "**", "**/*", "*.txt", "data/*", "**/*.txt", "**/train.txt"]
@@ -113,25 +109,19 @@ def pattern_results(complex_data_dir):
 
 
 @pytest.fixture
-def hub_dataset_info(complex_data_dir):
-    return DatasetInfo(
-        siblings=[
-            {"rfilename": path.relative_to(complex_data_dir).as_posix()}
-            for path in Path(complex_data_dir).rglob("*")
-            if path.is_file()
-        ],
-        sha="foobarfoobar",
-        id="foo",
-    )
+def hub_dataset_repo_path(tmpfs, complex_data_dir):
+    for path in Path(complex_data_dir).rglob("*"):
+        if path.is_file():
+            with tmpfs.open(path.relative_to(complex_data_dir).as_posix(), "wb") as f:
+                f.write(path.read_bytes())
+    yield "tmp://"
 
 
 @pytest.fixture
-def hub_dataset_info_patterns_results(hub_dataset_info, complex_data_dir, pattern_results):
+def hub_dataset_repo_patterns_results(hub_dataset_repo_path, complex_data_dir, pattern_results):
     return {
         pattern: [
-            hf_hub_url(
-                hub_dataset_info.id, Path(path).relative_to(complex_data_dir).as_posix(), revision=hub_dataset_info.sha
-            )
+            hub_dataset_repo_path + Path(path).relative_to(complex_data_dir).as_posix()
             for path in pattern_results[pattern]
         ]
         for pattern in pattern_results
@@ -181,241 +171,210 @@ def test_pattern_results_fixture(pattern_results, pattern):
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_resolve_patterns_locally_or_by_urls(complex_data_dir, pattern, pattern_results):
+def test_resolve_pattern_locally(complex_data_dir, pattern, pattern_results):
     try:
-        resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, [pattern])
+        resolved_data_files = resolve_pattern(pattern, complex_data_dir)
         assert sorted(str(f) for f in resolved_data_files) == pattern_results[pattern]
-        assert all(isinstance(path, Path) for path in resolved_data_files)
     except FileNotFoundError:
         assert len(pattern_results[pattern]) == 0
 
 
-def test_resolve_patterns_locally_or_by_urls_with_dot_in_base_path(complex_data_dir):
+def test_resolve_pattern_locally_with_dot_in_base_path(complex_data_dir):
     base_path_with_dot = os.path.join(complex_data_dir, "data", ".dummy_subdir")
-    resolved_data_files = resolve_patterns_locally_or_by_urls(
-        base_path_with_dot, [os.path.join(base_path_with_dot, "train.txt")]
-    )
+    resolved_data_files = resolve_pattern(os.path.join(base_path_with_dot, "train.txt"), base_path_with_dot)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_with_absolute_path(tmp_path, complex_data_dir):
+def test_resolve_pattern_locally_with_absolute_path(tmp_path, complex_data_dir):
     abs_path = os.path.join(complex_data_dir, "data", "train.txt")
-    resolved_data_files = resolve_patterns_locally_or_by_urls(str(tmp_path / "blabla"), [abs_path])
+    resolved_data_files = resolve_pattern(abs_path, str(tmp_path / "blabla"))
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_with_double_dots(tmp_path, complex_data_dir):
+def test_resolve_pattern_locally_with_double_dots(tmp_path, complex_data_dir):
     path_with_double_dots = os.path.join(complex_data_dir, "data", "subdir", "..", "train.txt")
-    resolved_data_files = resolve_patterns_locally_or_by_urls(str(tmp_path / "blabla"), [path_with_double_dots])
+    resolved_data_files = resolve_pattern(path_with_double_dots, str(tmp_path / "blabla"))
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_returns_hidden_file_only_if_requested(complex_data_dir):
+def test_resolve_pattern_locally_returns_hidden_file_only_if_requested(complex_data_dir):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_locally_or_by_urls(complex_data_dir, ["*dummy"])
-    resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, [".dummy"])
+        resolve_pattern("*dummy", complex_data_dir)
+    resolved_data_files = resolve_pattern(".dummy", complex_data_dir)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_hidden_base_path(tmp_path):
+def test_resolve_pattern_locally_hidden_base_path(tmp_path):
     hidden = tmp_path / ".test_hidden_base_path"
     hidden.mkdir()
     (tmp_path / ".test_hidden_base_path" / "a.txt").touch()
-    resolved_data_files = resolve_patterns_locally_or_by_urls(str(hidden), ["*"])
+    resolved_data_files = resolve_pattern("*", str(hidden))
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_returns_hidden_dir_only_if_requested(complex_data_dir):
+def test_resolve_pattern_locallyreturns_hidden_dir_only_if_requested(complex_data_dir):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_locally_or_by_urls(complex_data_dir, ["data/*dummy_subdir/train.txt"])
-    resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, ["data/.dummy_subdir/train.txt"])
+        resolve_pattern("data/*dummy_subdir/train.txt", complex_data_dir)
+    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", complex_data_dir)
     assert len(resolved_data_files) == 1
-    resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, ["*/.dummy_subdir/train.txt"])
+    resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", complex_data_dir)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_returns_special_dir_only_if_requested(complex_data_dir):
+def test_resolve_pattern_locally_returns_special_dir_only_if_requested(complex_data_dir):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_locally_or_by_urls(complex_data_dir, ["data/*dummy_subdir/train.txt"])
-    resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, ["data/.dummy_subdir/train.txt"])
+        resolve_pattern("data/*dummy_subdir/train.txt", complex_data_dir)
+    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", complex_data_dir)
     assert len(resolved_data_files) == 1
-    resolved_data_files = resolve_patterns_locally_or_by_urls(complex_data_dir, ["*/.dummy_subdir/train.txt"])
+    resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", complex_data_dir)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_locally_or_by_urls_special_base_path(tmp_path):
+def test_resolve_pattern_locally_special_base_path(tmp_path):
     special = tmp_path / "__test_special_base_path__"
     special.mkdir()
     (tmp_path / "__test_special_base_path__" / "a.txt").touch()
-    resolved_data_files = resolve_patterns_locally_or_by_urls(str(special), ["*"])
+    resolved_data_files = resolve_pattern("*", str(special))
     assert len(resolved_data_files) == 1
 
 
 @pytest.mark.parametrize("pattern,size,extensions", [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])])
-def test_resolve_patterns_locally_or_by_urls_with_extensions(complex_data_dir, pattern, size, extensions):
+def test_resolve_pattern_locally_with_extensions(complex_data_dir, pattern, size, extensions):
     if size > 0:
-        resolved_data_files = resolve_patterns_locally_or_by_urls(
-            complex_data_dir, [pattern], allowed_extensions=extensions
-        )
+        resolved_data_files = resolve_pattern(pattern, complex_data_dir, allowed_extensions=extensions)
         assert len(resolved_data_files) == size
     else:
         with pytest.raises(FileNotFoundError):
-            resolve_patterns_locally_or_by_urls(complex_data_dir, [pattern], allowed_extensions=extensions)
+            resolve_pattern(pattern, complex_data_dir, allowed_extensions=extensions)
 
 
-def test_fail_resolve_patterns_locally_or_by_urls(complex_data_dir):
+def test_fail_resolve_pattern_locally(complex_data_dir):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_locally_or_by_urls(complex_data_dir, ["blablabla"])
+        resolve_pattern(complex_data_dir, ["blablabla"])
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Windows does not support symlinks in the default mode")
-def test_resolve_patterns_locally_or_by_urls_does_not_resolve_symbolic_links(tmp_path, complex_data_dir):
+def test_resolve_pattern_locally_does_not_resolve_symbolic_links(tmp_path, complex_data_dir):
     (tmp_path / "train_data_symlink.txt").symlink_to(os.path.join(complex_data_dir, "data", "train.txt"))
-    resolved_data_files = resolve_patterns_locally_or_by_urls(str(tmp_path), ["train_data_symlink.txt"])
+    resolved_data_files = resolve_pattern("train_data_symlink.txt", str(tmp_path))
     assert len(resolved_data_files) == 1
-    assert resolved_data_files[0] == tmp_path / "train_data_symlink.txt"
+    assert Path(resolved_data_files[0]) == tmp_path / "train_data_symlink.txt"
 
 
-def test_resolve_patterns_locally_or_by_urls_sorted_files(tmp_path_factory):
+def test_resolve_pattern_locally_sorted_files(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("unsorted_text_files"))
     unsorted_names = ["0.txt", "2.txt", "3.txt"]
     for name in unsorted_names:
         with open(os.path.join(path, name), "w"):
             pass
-    resolved_data_files = resolve_patterns_locally_or_by_urls(path, ["*"])
+    resolved_data_files = resolve_pattern("*", path)
     resolved_names = [os.path.basename(data_file) for data_file in resolved_data_files]
     assert resolved_names == sorted(unsorted_names)
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_resolve_patterns_in_dataset_repository(hub_dataset_info, pattern, hub_dataset_info_patterns_results):
+def test_resolve_pattern_in_dataset_repository(hub_dataset_repo_path, pattern, hub_dataset_repo_patterns_results):
     try:
-        resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, [pattern])
-        assert sorted(str(f) for f in resolved_data_files) == hub_dataset_info_patterns_results[pattern]
-        assert all(isinstance(url, Url) for url in resolved_data_files)
+        resolved_data_files = resolve_pattern(pattern, hub_dataset_repo_path)
+        assert sorted(str(f) for f in resolved_data_files) == hub_dataset_repo_patterns_results[pattern]
     except FileNotFoundError:
-        assert len(hub_dataset_info_patterns_results[pattern]) == 0
+        assert len(hub_dataset_repo_patterns_results[pattern]) == 0
 
 
 @pytest.mark.parametrize(
     "pattern,size,base_path", [("**", 4, None), ("**", 4, "data"), ("**", 2, "data/subdir"), ("**", 0, "data/subdir2")]
 )
-def test_resolve_patterns_in_dataset_repository_with_base_path(hub_dataset_info, pattern, size, base_path):
+def test_resolve_pattern_in_dataset_repository_with_base_path(hub_dataset_repo_path, pattern, size, base_path):
+    base_path = hub_dataset_repo_path + (base_path or "")
     if size > 0:
-        resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, [pattern], base_path=base_path)
+        resolved_data_files = resolve_pattern(pattern, base_path)
         assert len(resolved_data_files) == size
     else:
         with pytest.raises(FileNotFoundError):
-            resolved_data_files = resolve_patterns_in_dataset_repository(
-                hub_dataset_info, [pattern], base_path=base_path
-            )
+            resolve_pattern(pattern, base_path)
 
 
 @pytest.mark.parametrize("pattern,size,extensions", [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])])
-def test_resolve_patterns_in_dataset_repository_with_extensions(hub_dataset_info, pattern, size, extensions):
+def test_resolve_pattern_in_dataset_repository_with_extensions(hub_dataset_repo_path, pattern, size, extensions):
     if size > 0:
-        resolved_data_files = resolve_patterns_in_dataset_repository(
-            hub_dataset_info, [pattern], allowed_extensions=extensions
-        )
+        resolved_data_files = resolve_pattern(pattern, hub_dataset_repo_path, allowed_extensions=extensions)
         assert len(resolved_data_files) == size
     else:
         with pytest.raises(FileNotFoundError):
-            resolved_data_files = resolve_patterns_in_dataset_repository(
-                hub_dataset_info, [pattern], allowed_extensions=extensions
-            )
+            resolved_data_files = resolve_pattern(pattern, hub_dataset_repo_path, allowed_extensions=extensions)
 
 
-def test_fail_resolve_patterns_in_dataset_repository(hub_dataset_info):
+def test_fail_resolve_pattern_in_dataset_repository(hub_dataset_repo_path):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_in_dataset_repository(hub_dataset_info, "blablabla")
+        resolve_pattern("blablabla", hub_dataset_repo_path)
 
 
-def test_resolve_patterns_in_dataset_repository_sorted_files():
-    unsorted_names = ["0.txt", "2.txt", "3.txt"]
-    siblings = [{"rfilename": name} for name in unsorted_names]
-    datasets_infos = DatasetInfo(id="test_unsorted_files", siblings=siblings, sha="foobar")
-    resolved_data_files = resolve_patterns_in_dataset_repository(datasets_infos, ["*"])
-    resolved_names = [os.path.basename(data_file) for data_file in resolved_data_files]
-    assert resolved_names == sorted(unsorted_names)
-
-
-def test_resolve_patterns_in_dataset_repository_returns_hidden_file_only_if_requested(hub_dataset_info):
+def test_resolve_pattern_in_dataset_repository_returns_hidden_file_only_if_requested(hub_dataset_repo_path):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_in_dataset_repository(hub_dataset_info, ["*dummy"])
-    resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, [".dummy"])
+        resolve_pattern("*dummy", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern(".dummy", hub_dataset_repo_path)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_in_dataset_repository_hidden_base_path():
-    siblings = [{"rfilename": ".hidden/a.txt"}]
-    datasets_infos = DatasetInfo(id="test_hidden_base_path", siblings=siblings, sha="foobar")
-    resolved_data_files = resolve_patterns_in_dataset_repository(datasets_infos, ["*"], base_path=".hidden")
+def test_resolve_pattern_in_dataset_repository_hidden_base_path(tmpfs):
+    tmpfs.touch(".hidden/a.txt")
+    resolved_data_files = resolve_pattern("*", base_path="tmp://.hidden")
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_in_dataset_repository_returns_hidden_dir_only_if_requested(hub_dataset_info):
+def test_resolve_pattern_in_dataset_repository_returns_hidden_dir_only_if_requested(hub_dataset_repo_path):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_in_dataset_repository(hub_dataset_info, ["data/*dummy_subdir/train.txt"])
-    resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, ["data/.dummy_subdir/train.txt"])
+        resolve_pattern("data/*dummy_subdir/train.txt", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", hub_dataset_repo_path)
     assert len(resolved_data_files) == 1
-    resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, ["*/.dummy_subdir/train.txt"])
+    resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", hub_dataset_repo_path)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_in_dataset_repository_returns_special_dir_only_if_requested(hub_dataset_info):
+def test_resolve_pattern_in_dataset_repository_returns_special_dir_only_if_requested(hub_dataset_repo_path):
     with pytest.raises(FileNotFoundError):
-        resolve_patterns_in_dataset_repository(hub_dataset_info, ["data/*dummy_subdir/train.txt"])
-    resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, ["data/.dummy_subdir/train.txt"])
+        resolve_pattern("data/*dummy_subdir/train.txt", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", hub_dataset_repo_path)
     assert len(resolved_data_files) == 1
-    resolved_data_files = resolve_patterns_in_dataset_repository(hub_dataset_info, ["*/.dummy_subdir/train.txt"])
+    resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", hub_dataset_repo_path)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_patterns_in_dataset_repository_special_base_path():
-    siblings = [{"rfilename": "__special__/a.txt"}]
-    datasets_infos = DatasetInfo(id="test_hidden_base_path", siblings=siblings, sha="foobar")
-    resolved_data_files = resolve_patterns_in_dataset_repository(datasets_infos, ["*"], base_path="__special__")
+def test_resolve_pattern_in_dataset_repository_special_base_path(tmpfs):
+    tmpfs.touch("__special__/a.txt")
+    resolved_data_files = resolve_pattern("*", base_path="tmp://__special__")
     assert len(resolved_data_files) == 1
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_DataFilesList_from_hf_repo(hub_dataset_info, hub_dataset_info_patterns_results, pattern):
+def test_DataFilesList_from_patterns_in_dataset_repository_(
+    hub_dataset_repo_path, hub_dataset_repo_patterns_results, pattern
+):
     try:
-        data_files_list = DataFilesList.from_hf_repo([pattern], hub_dataset_info)
-        assert sorted(str(f) for f in data_files_list) == hub_dataset_info_patterns_results[pattern]
-        assert all(isinstance(url, Url) for url in data_files_list)
-        assert len(data_files_list.origin_metadata) > 0
+        data_files_list = DataFilesList.from_patterns([pattern], hub_dataset_repo_path)
+        assert sorted(data_files_list) == hub_dataset_repo_patterns_results[pattern]
+        assert len(data_files_list.origin_metadata) == len(data_files_list)
     except FileNotFoundError:
-        assert len(hub_dataset_info_patterns_results[pattern]) == 0
+        assert len(hub_dataset_repo_patterns_results[pattern]) == 0
 
 
-@pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_DataFilesList_from_local_or_remote(complex_data_dir, pattern_results, pattern):
-    try:
-        data_files_list = DataFilesList.from_local_or_remote([pattern], complex_data_dir)
-        assert sorted(str(f) for f in data_files_list) == pattern_results[pattern]
-        assert all(isinstance(path, Path) for path in data_files_list)
-        assert len(data_files_list.origin_metadata) > 0
-    except FileNotFoundError:
-        assert len(pattern_results[pattern]) == 0
-
-
-def test_DataFilesList_from_local_or_remote_with_extra_files(complex_data_dir, text_file):
-    data_files_list = DataFilesList.from_local_or_remote([_TEST_URL, str(text_file)], complex_data_dir)
-    assert list(data_files_list) == [Url(_TEST_URL), Path(text_file)]
+def test_DataFilesList_from_patterns_locally_with_extra_files(complex_data_dir, text_file):
+    data_files_list = DataFilesList.from_patterns([_TEST_URL, str(text_file)], complex_data_dir)
+    assert list(data_files_list) == [_TEST_URL, str(text_file)]
     assert len(data_files_list.origin_metadata) == 2
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_DataFilesDict_from_hf_repo(hub_dataset_info, hub_dataset_info_patterns_results, pattern):
+def test_DataFilesDict_from_patterns_in_dataset_repository(
+    hub_dataset_repo_path, hub_dataset_repo_patterns_results, pattern
+):
     split_name = "train"
     try:
-        data_files = DataFilesDict.from_hf_repo({split_name: [pattern]}, hub_dataset_info)
+        data_files = DataFilesDict.from_patterns({split_name: [pattern]}, hub_dataset_repo_path)
         assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
-        assert sorted(str(f) for f in data_files[split_name]) == hub_dataset_info_patterns_results[pattern]
-        assert all(isinstance(url, Url) for url in data_files[split_name])
+        assert sorted(data_files[split_name]) == hub_dataset_repo_patterns_results[pattern]
     except FileNotFoundError:
-        assert len(hub_dataset_info_patterns_results[pattern]) == 0
+        assert len(hub_dataset_repo_patterns_results[pattern]) == 0
 
 
 @pytest.mark.parametrize(
@@ -429,74 +388,72 @@ def test_DataFilesDict_from_hf_repo(hub_dataset_info, hub_dataset_info_patterns_
         ("**", 0, "data/subdir2", "train"),
     ],
 )
-def test_DataFilesDict_from_hf_repo_with_base_path(hub_dataset_info, pattern, size, base_path, split_name):
+def test_DataFilesDict_from_patterns_in_dataset_repository_with_base_path(
+    hub_dataset_repo_path, pattern, size, base_path, split_name
+):
+    base_path = hub_dataset_repo_path + (base_path or "")
     if size > 0:
-        data_files = DataFilesDict.from_hf_repo({split_name: [pattern]}, hub_dataset_info, base_path=base_path)
+        data_files = DataFilesDict.from_patterns({split_name: [pattern]}, base_path=base_path)
         assert len(data_files[split_name]) == size
     else:
         with pytest.raises(FileNotFoundError):
-            data_files = DataFilesDict.from_hf_repo({split_name: [pattern]}, hub_dataset_info, base_path=base_path)
+            resolve_pattern(pattern, base_path)
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_DataFilesDict_from_local_or_remote(complex_data_dir, pattern_results, pattern):
+def test_DataFilesDict_from_patterns_locally(complex_data_dir, pattern_results, pattern):
     split_name = "train"
     try:
         data_files = DataFilesDict.from_local_or_remote({split_name: [pattern]}, complex_data_dir)
         assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
-        assert sorted(str(f) for f in data_files[split_name]) == pattern_results[pattern]
-        assert all(isinstance(url, Path) for url in data_files[split_name])
+        assert sorted(data_files[split_name]) == pattern_results[pattern]
     except FileNotFoundError:
         assert len(pattern_results[pattern]) == 0
 
 
-def test_DataFilesDict_from_hf_repo_hashing(hub_dataset_info):
+def test_DataFilesDict_from_patterns_in_dataset_repository_hashing(hub_dataset_repo_path):
     patterns = {"train": ["**/train.txt"], "test": ["**/test.txt"]}
-    data_files1 = DataFilesDict.from_hf_repo(patterns, hub_dataset_info)
-    data_files2 = DataFilesDict.from_hf_repo(patterns, hub_dataset_info)
+    data_files1 = DataFilesDict.from_patterns(patterns, hub_dataset_repo_path)
+    data_files2 = DataFilesDict.from_patterns(patterns, hub_dataset_repo_path)
     assert Hasher.hash(data_files1) == Hasher.hash(data_files2)
 
     data_files2 = DataFilesDict(sorted(data_files1.items(), reverse=True))
     assert Hasher.hash(data_files1) == Hasher.hash(data_files2)
 
     patterns2 = {"train": ["data/**train.txt"], "test": ["data/**test.txt"]}
-    data_files2 = DataFilesDict.from_hf_repo(patterns2, hub_dataset_info)
+    data_files2 = DataFilesDict.from_patterns(patterns2, hub_dataset_repo_path)
     assert Hasher.hash(data_files1) == Hasher.hash(data_files2)
 
     patterns2 = {"train": ["data/**train.txt"], "test": ["data/**train.txt"]}
-    data_files2 = DataFilesDict.from_hf_repo(patterns2, hub_dataset_info)
+    data_files2 = DataFilesDict.from_patterns(patterns2, hub_dataset_repo_path)
     assert Hasher.hash(data_files1) != Hasher.hash(data_files2)
 
-    with patch.object(hub_dataset_info, "id", "blabla"):
-        data_files2 = DataFilesDict.from_hf_repo(patterns, hub_dataset_info)
+    # the tmpfs used to mock the hub repo is based on a local directory
+    # therefore os.stat is used to get the mtime of the data files
+    with patch("os.stat", return_value=os.stat(__file__)):
+        data_files2 = DataFilesDict.from_patterns(patterns, hub_dataset_repo_path)
         assert Hasher.hash(data_files1) != Hasher.hash(data_files2)
 
-    with patch.object(hub_dataset_info, "sha", "blabla"):
-        data_files2 = DataFilesDict.from_hf_repo(patterns, hub_dataset_info)
-        assert Hasher.hash(data_files1) != Hasher.hash(data_files2)
 
-
-def test_DataFilesDict_from_hf_local_or_remote_hashing(text_file):
+def test_DataFilesDict_from_patterns_locally_or_remote_hashing(text_file):
     patterns = {"train": [_TEST_URL], "test": [str(text_file)]}
-    data_files1 = DataFilesDict.from_local_or_remote(patterns)
-    data_files2 = DataFilesDict.from_local_or_remote(patterns)
+    data_files1 = DataFilesDict.from_patterns(patterns)
+    data_files2 = DataFilesDict.from_patterns(patterns)
     assert Hasher.hash(data_files1) == Hasher.hash(data_files2)
 
     data_files2 = DataFilesDict(sorted(data_files1.items(), reverse=True))
     assert Hasher.hash(data_files1) == Hasher.hash(data_files2)
 
     patterns2 = {"train": [_TEST_URL], "test": [_TEST_URL]}
-    data_files2 = DataFilesDict.from_local_or_remote(patterns2)
+    data_files2 = DataFilesDict.from_patterns(patterns2)
     assert Hasher.hash(data_files1) != Hasher.hash(data_files2)
 
-    with patch("datasets.data_files.request_etag") as mock_request_etag:
-        mock_request_etag.return_value = "blabla"
-        data_files2 = DataFilesDict.from_local_or_remote(patterns)
+    with patch("fsspec.implementations.http._file_info", return_value={}):
+        data_files2 = DataFilesDict.from_patterns(patterns)
         assert Hasher.hash(data_files1) != Hasher.hash(data_files2)
 
-    with patch("datasets.data_files.os.path.getmtime") as mock_getmtime:
-        mock_getmtime.return_value = 123
-        data_files2 = DataFilesDict.from_local_or_remote(patterns)
+    with patch("os.stat", return_value=os.stat(__file__)):
+        data_files2 = DataFilesDict.from_patterns(patterns)
         assert Hasher.hash(data_files1) != Hasher.hash(data_files2)
 
 
@@ -616,12 +573,12 @@ def test_get_data_files_patterns(data_file_per_split):
     fs = mock_fs(file_paths)
 
     def resolver(pattern):
-        return [PurePath(file_path) for file_path in fs.glob(pattern) if fs.isfile(file_path)]
+        return [file_path for file_path in fs.glob(pattern) if fs.isfile(file_path)]
 
     patterns_per_split = _get_data_files_patterns(resolver)
     assert list(patterns_per_split.keys()) == list(data_file_per_split.keys())  # Test split order with list()
     for split, patterns in patterns_per_split.items():
-        matched = [file_path.as_posix() for pattern in patterns for file_path in resolver(pattern)]
+        matched = [file_path for pattern in patterns for file_path in resolver(pattern)]
         assert matched == data_file_per_split[split]
 
 

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -359,8 +359,8 @@ def test_DataFilesList_from_patterns_in_dataset_repository_(
 
 
 def test_DataFilesList_from_patterns_locally_with_extra_files(complex_data_dir, text_file):
-    data_files_list = DataFilesList.from_patterns([_TEST_URL, str(text_file)], complex_data_dir)
-    assert list(data_files_list) == [_TEST_URL, str(text_file)]
+    data_files_list = DataFilesList.from_patterns([_TEST_URL, text_file.as_posix()], complex_data_dir)
+    assert list(data_files_list) == [_TEST_URL, text_file.as_posix()]
     assert len(data_files_list.origin_metadata) == 2
 
 

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -404,7 +404,7 @@ def test_DataFilesDict_from_patterns_in_dataset_repository_with_base_path(
 def test_DataFilesDict_from_patterns_locally(complex_data_dir, pattern_results, pattern):
     split_name = "train"
     try:
-        data_files = DataFilesDict.from_local_or_remote({split_name: [pattern]}, complex_data_dir)
+        data_files = DataFilesDict.from_patterns({split_name: [pattern]}, complex_data_dir)
         assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
         assert sorted(data_files[split_name]) == pattern_results[pattern]
     except FileNotFoundError:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -6,7 +6,7 @@ import pytest
 from fsspec import register_implementation
 from fsspec.registry import _registry as _fsspec_registry
 
-from datasets.filesystems import COMPRESSION_FILESYSTEMS, HfFileSystem, extract_path_from_uri, is_remote_filesystem
+from datasets.filesystems import COMPRESSION_FILESYSTEMS, extract_path_from_uri, is_remote_filesystem
 
 from .utils import require_lz4, require_zstandard
 
@@ -71,17 +71,6 @@ def test_fs_isfile(protocol, zip_jsonl_path, jsonl_gz_path):
     fs, *_ = fsspec.get_fs_token_paths(path)
     assert fs.isfile(member_file_path)
     assert not fs.isfile("non_existing_" + member_file_path)
-
-
-@pytest.mark.integration
-def test_hf_filesystem(hf_token, hf_api, hf_private_dataset_repo_txt_data, text_file):
-    repo_info = hf_api.dataset_info(hf_private_dataset_repo_txt_data, token=hf_token)
-    hffs = HfFileSystem(repo_info=repo_info, token=hf_token)
-    assert sorted(hffs.glob("*")) == [".gitattributes", "data"]
-    assert hffs.isdir("data")
-    assert hffs.isfile(".gitattributes") and hffs.isfile("data/text_data.txt")
-    with open(text_file) as f:
-        assert hffs.open("data/text_data.txt", "r").read() == f.read()
 
 
 def test_fs_overwrites():

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -261,7 +261,7 @@ def test_infer_module_for_data_files_in_archives(
         "zip_unsupported_ext_path": zip_unsupported_ext_path,
     }
     data_files = [str(data_file_paths[data_file])]
-    inferred_module, _ = infer_module_for_data_files_in_archives(data_files, False)
+    inferred_module, _ = infer_module_for_data_files_in_archives(data_files)
     assert inferred_module == expected_module
 
 
@@ -367,11 +367,11 @@ class ModuleFactoryTest(TestCase):
             and len(module_factory_result.builder_kwargs["data_files"]["test"]) > 0
         )
         assert any(
-            data_file.name == "metadata.jsonl"
+            Path(data_file).name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
         )
         assert any(
-            data_file.name == "metadata.jsonl"
+            Path(data_file).name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )
 
@@ -412,11 +412,11 @@ class ModuleFactoryTest(TestCase):
             self._data_dir_with_metadata
         )
         assert any(
-            data_file.name == "metadata.jsonl"
+            Path(data_file).name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["train"]
         )
         assert any(
-            data_file.name == "metadata.jsonl"
+            Path(data_file).name == "metadata.jsonl"
             for data_file in module_factory_result.builder_kwargs["data_files"]["test"]
         )
 
@@ -651,7 +651,7 @@ class LoadTest(TestCase):
             with offline(offline_simulation_mode):
                 with self.assertRaises(ConnectionError) as context:
                     datasets.load_dataset("lhoestq/_dummy")
-                self.assertIn("lhoestq/_dummy", str(context.exception))
+                self.assertIn("lhoestq/_dummy", str(context.exception), msg=offline_simulation_mode)
 
 
 def test_load_dataset_builder_for_absolute_script_dir(dataset_loading_script_dir, data_dir):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1309,8 +1309,8 @@ def test_load_hub_dataset_without_script_with_metadata_config_in_parallel():
 
 @require_pil
 @pytest.mark.integration
-@pytest.mark.parametrize("implicit_token", [False, True])
-@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("implicit_token", [True])
+@pytest.mark.parametrize("streaming", [True])
 def test_load_dataset_private_zipped_images(
     hf_private_dataset_repo_zipped_img_data, hf_token, streaming, implicit_token
 ):

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -7,6 +7,7 @@ import pytest
 from fsspec.registry import _registry as _fsspec_registry
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 
+from datasets.download.download_config import DownloadConfig
 from datasets.download.streaming_download_manager import (
     StreamingDownloadManager,
     _get_extraction_protocol,
@@ -236,8 +237,9 @@ def test_xexists(input_path, exists, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xexists_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_txt_data, "")
-    assert xexists(root_url + "data/text_data.txt", token=hf_token)
-    assert not xexists(root_url + "file_that_doesnt_exist.txt", token=hf_token)
+    download_config = DownloadConfig(token=hf_token)
+    assert xexists(root_url + "data/text_data.txt", download_config=download_config)
+    assert not xexists(root_url + "file_that_doesnt_exist.txt", download_config=download_config)
 
 
 @pytest.mark.parametrize(
@@ -320,12 +322,13 @@ def test_xlistdir(input_path, expected_paths, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xlistdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
-    assert len(xlistdir("zip://::" + root_url, token=hf_token)) == 1
-    assert len(xlistdir("zip://main_dir::" + root_url, token=hf_token)) == 2
+    download_config = DownloadConfig(token=hf_token)
+    assert len(xlistdir("zip://::" + root_url, download_config=download_config)) == 1
+    assert len(xlistdir("zip://main_dir::" + root_url, download_config=download_config)) == 2
     with pytest.raises(FileNotFoundError):
-        xlistdir("zip://qwertyuiop::" + root_url, token=hf_token)
+        xlistdir("zip://qwertyuiop::" + root_url, download_config=download_config)
     with pytest.raises(NotImplementedError):
-        xlistdir(root_url, token=hf_token)
+        xlistdir(root_url, download_config=download_config)
 
 
 @pytest.mark.parametrize(
@@ -348,11 +351,12 @@ def test_xisdir(input_path, isdir, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xisdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
-    assert xisdir("zip://::" + root_url, token=hf_token) is True
-    assert xisdir("zip://main_dir::" + root_url, token=hf_token) is True
-    assert xisdir("zip://qwertyuiop::" + root_url, token=hf_token) is False
+    download_config = DownloadConfig(token=hf_token)
+    assert xisdir("zip://::" + root_url, download_config=download_config) is True
+    assert xisdir("zip://main_dir::" + root_url, download_config=download_config) is True
+    assert xisdir("zip://qwertyuiop::" + root_url, download_config=download_config) is False
     with pytest.raises(NotImplementedError):
-        xisdir(root_url, token=hf_token)
+        xisdir(root_url, download_config=download_config)
 
 
 @pytest.mark.parametrize(
@@ -374,8 +378,9 @@ def test_xisfile(input_path, isfile, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xisfile_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_txt_data, "")
-    assert xisfile(root_url + "data/text_data.txt", token=hf_token) is True
-    assert xisfile(root_url + "qwertyuiop", token=hf_token) is False
+    download_config = DownloadConfig(token=hf_token)
+    assert xisfile(root_url + "data/text_data.txt", download_config=download_config) is True
+    assert xisfile(root_url + "qwertyuiop", download_config=download_config) is False
 
 
 @pytest.mark.parametrize(
@@ -397,9 +402,10 @@ def test_xgetsize(input_path, size, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xgetsize_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_txt_data, "")
-    assert xgetsize(root_url + "data/text_data.txt", token=hf_token) == 39
+    download_config = DownloadConfig(token=hf_token)
+    assert xgetsize(root_url + "data/text_data.txt", download_config=download_config) == 39
     with pytest.raises(FileNotFoundError):
-        xgetsize(root_url + "qwertyuiop", token=hf_token)
+        xgetsize(root_url + "qwertyuiop", download_config=download_config)
 
 
 @pytest.mark.parametrize(
@@ -440,8 +446,9 @@ def test_xglob(input_path, expected_paths, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xglob_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
-    assert len(xglob("zip://**::" + root_url, token=hf_token)) == 3
-    assert len(xglob("zip://qwertyuiop/*::" + root_url, token=hf_token)) == 0
+    download_config = DownloadConfig(token=hf_token)
+    assert len(xglob("zip://**::" + root_url, download_config=download_config)) == 3
+    assert len(xglob("zip://qwertyuiop/*::" + root_url, download_config=download_config)) == 0
 
 
 @pytest.mark.parametrize(
@@ -478,9 +485,10 @@ def test_xwalk(input_path, expected_outputs, tmp_path, mock_fsspec):
 @pytest.mark.integration
 def test_xwalk_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_hub_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
-    assert len(list(xwalk("zip://::" + root_url, token=hf_token))) == 2
-    assert len(list(xwalk("zip://main_dir::" + root_url, token=hf_token))) == 1
-    assert len(list(xwalk("zip://qwertyuiop::" + root_url, token=hf_token))) == 0
+    download_config = DownloadConfig(token=hf_token)
+    assert len(list(xwalk("zip://::" + root_url, download_config=download_config))) == 2
+    assert len(list(xwalk("zip://main_dir::" + root_url, download_config=download_config))) == 1
+    assert len(list(xwalk("zip://qwertyuiop::" + root_url, download_config=download_config))) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -327,7 +327,7 @@ def test_xlistdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     assert len(xlistdir("zip://main_dir::" + root_url, download_config=download_config)) == 2
     with pytest.raises(FileNotFoundError):
         xlistdir("zip://qwertyuiop::" + root_url, download_config=download_config)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(FileNotFoundError):
         xlistdir(root_url, download_config=download_config)
 
 
@@ -355,8 +355,7 @@ def test_xisdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     assert xisdir("zip://::" + root_url, download_config=download_config) is True
     assert xisdir("zip://main_dir::" + root_url, download_config=download_config) is True
     assert xisdir("zip://qwertyuiop::" + root_url, download_config=download_config) is False
-    with pytest.raises(NotImplementedError):
-        xisdir(root_url, download_config=download_config)
+    assert xisdir(root_url, download_config=download_config) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Thanks to @janineguo 's work in https://github.com/huggingface/datasets/pull/5919 which was needed to support HfFileSystem.

Switching to `HfFileSystem` will help implementing optimization in data files resolution

## Implementation details

I replaced all the from_hf_repo and from_local_or_remote in data_files.py to only use a new `from_patterns` which works for any fsspec path, including hf:// paths, https:// URLs and local paths. This simplifies the codebase since there is no logic duplication anymore when it comes to data files resolution.

I added `_prepare_path_and_storage_options` which returns the right storage_options to use given a path and a `DownloadConfig`. This is the only place where the logic depends on the filesystem type that must be used.

I also removed the `get_metadata_data_files_list ` and `get_patterns_and_data_files` functions added recently, since data files resolution is now handled using a common interface.

## New features

hf:// paths are now supported in data_files

## Breaking changes

DataFilesList and DataFilesDict:
- use `str` paths instead of `Union[Path, Url]`
- require posix paths for windows paths

close https://github.com/huggingface/datasets/issues/6017