### PR TITLE
Deprecate search API

### DIFF
--- a/docs/source/faiss_es.mdx
+++ b/docs/source/faiss_es.mdx
@@ -1,5 +1,11 @@
 # Search index
 
+<Tip warning={true}>
+
+Vector search is deprecated in 🤗 Datasets.
+
+</Tip>
+
 [FAISS](https://github.com/facebookresearch/faiss) and [ElasticSearch](https://www.elastic.co/elasticsearch/) enables searching for examples in a dataset. This can be useful when you want to retrieve specific examples from a dataset that are relevant to your NLP task. For example, if you are working on a Open Domain Question Answering task, you may want to only return examples that are relevant to answering your question.
 
 This guide will show you how to build an index for your dataset that will allow you to search it.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4386,7 +4386,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         from .dataset_dict import DatasetDict  # import here because of circular dependency
 
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if len(self.list_indexes()) > 0:
                 raise DatasetTransformationNotAllowedError(
                     "Using `.train_test_split` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1440,8 +1440,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         is_local = not is_remote_filesystem(fs)
         path_join = os.path.join if is_local else posixpath.join
 
-        if self.list_indexes():
-            raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if self.list_indexes():
+                raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
 
         if is_local:
             Path(dataset_path).resolve().mkdir(parents=True, exist_ok=True)
@@ -3453,6 +3454,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                             num_examples_progress_update = 0
                 else:
                     _time = time.time()
+                    with warnings.filterwarnings("ignore", category=FutureWarning):
+                        check_same_num_examples = len(shard.list_indexes()) > 0
                     for i, batch in shard_iterable:
                         num_examples_in_batch = len(batch)
                         indices = list(
@@ -3462,7 +3465,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                             batch = apply_function_on_filtered_inputs(
                                 batch,
                                 indices,
-                                check_same_num_examples=len(shard.list_indexes()) > 0,
+                                check_same_num_examples=check_same_num_examples,
                                 offset=offset,
                             )
                         except NumExamplesMismatchError:
@@ -3601,10 +3604,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         })
         ```
         """
-        if len(self.list_indexes()) > 0:
-            raise DatasetTransformationNotAllowedError(
-                "Using `.filter` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it.`"
-            )
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if len(self.list_indexes()) > 0:
+                raise DatasetTransformationNotAllowedError(
+                    "Using `.filter` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it.`"
+                )
 
         if function is None:
             function = lambda x: True  # noqa: E731
@@ -3762,10 +3766,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if keep_in_memory and indices_cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `indices_cache_file_name` but not both.")
 
-        if len(self.list_indexes()) > 0:
-            raise DatasetTransformationNotAllowedError(
-                "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
-            )
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if len(self.list_indexes()) > 0:
+                raise DatasetTransformationNotAllowedError(
+                    "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
+                )
 
         # If the array is empty we do nothing
         if len(self) == 0:
@@ -3900,10 +3905,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if keep_in_memory and indices_cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `indices_cache_file_name` but not both.")
 
-        if len(self.list_indexes()) > 0:
-            raise DatasetTransformationNotAllowedError(
-                "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
-            )
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if len(self.list_indexes()) > 0:
+                raise DatasetTransformationNotAllowedError(
+                    "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
+                )
 
         # If the array is empty we do nothing
         if len(self) == 0:
@@ -4032,10 +4038,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         ```
         """
-        if len(self.list_indexes()) > 0:
-            raise DatasetTransformationNotAllowedError(
-                "Using `.sort` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
-            )
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if len(self.list_indexes()) > 0:
+                raise DatasetTransformationNotAllowedError(
+                    "Using `.sort` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
+                )
         # If the array is empty we do nothing
         if len(self) == 0:
             return self
@@ -4196,10 +4203,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         [1, 0, 1, 1, 0, 0, 0, 0, 0, 0]
         ```
         """
-        if len(self.list_indexes()) > 0:
-            raise DatasetTransformationNotAllowedError(
-                "Using `.shuffle` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
-            )
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if len(self.list_indexes()) > 0:
+                raise DatasetTransformationNotAllowedError(
+                    "Using `.shuffle` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
+                )
         # If the array is empty we do nothing
         if len(self) == 0:
             return self
@@ -4357,10 +4365,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         from .dataset_dict import DatasetDict  # import here because of circular dependency
 
-        if len(self.list_indexes()) > 0:
-            raise DatasetTransformationNotAllowedError(
-                "Using `.train_test_split` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
-            )
+        with warnings.filterwarnings("ignore", category=FutureWarning):
+            if len(self.list_indexes()) > 0:
+                raise DatasetTransformationNotAllowedError(
+                    "Using `.train_test_split` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
+                )
         # If the array is empty we do nothing
         if len(self) == 0:
             return DatasetDict({"train": self, "test": self})

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1440,7 +1440,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         is_local = not is_remote_filesystem(fs)
         path_join = os.path.join if is_local else posixpath.join
 
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if self.list_indexes():
                 raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
 
@@ -3454,7 +3455,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                             num_examples_progress_update = 0
                 else:
                     _time = time.time()
-                    with warnings.filterwarnings("ignore", category=FutureWarning):
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", FutureWarning)
                         check_same_num_examples = len(shard.list_indexes()) > 0
                     for i, batch in shard_iterable:
                         num_examples_in_batch = len(batch)
@@ -3604,7 +3606,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         })
         ```
         """
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if len(self.list_indexes()) > 0:
                 raise DatasetTransformationNotAllowedError(
                     "Using `.filter` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it.`"
@@ -3766,7 +3769,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if keep_in_memory and indices_cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `indices_cache_file_name` but not both.")
 
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if len(self.list_indexes()) > 0:
                 raise DatasetTransformationNotAllowedError(
                     "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
@@ -3905,7 +3909,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if keep_in_memory and indices_cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `indices_cache_file_name` but not both.")
 
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if len(self.list_indexes()) > 0:
                 raise DatasetTransformationNotAllowedError(
                     "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
@@ -4038,7 +4043,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         ```
         """
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if len(self.list_indexes()) > 0:
                 raise DatasetTransformationNotAllowedError(
                     "Using `.sort` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
@@ -4203,7 +4209,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         [1, 0, 1, 1, 0, 0, 0, 0, 0, 0]
         ```
         """
-        with warnings.filterwarnings("ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
             if len(self.list_indexes()) > 0:
                 raise DatasetTransformationNotAllowedError(
                     "Using `.shuffle` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -8,6 +8,7 @@ import fsspec
 import numpy as np
 
 from .utils import logging
+from .utils.deprecation_utils import deprecated
 
 
 if TYPE_CHECKING:
@@ -419,6 +420,7 @@ class IndexableMixin:
     def __getitem__(self, key):
         raise NotImplementedError
 
+    @deprecated()
     def is_index_initialized(self, index_name: str) -> bool:
         return index_name in self._indexes
 
@@ -428,10 +430,12 @@ class IndexableMixin:
                 f"Index with index_name '{index_name}' not initialized yet. Please make sure that you call `add_faiss_index` or `add_elasticsearch_index` first."
             )
 
+    @deprecated()
     def list_indexes(self) -> List[str]:
         """List the `colindex_nameumns`/identifiers of all the attached indexes."""
         return list(self._indexes)
 
+    @deprecated()
     def get_index(self, index_name: str) -> BaseIndex:
         """List the `index_name`/identifiers of all the attached indexes.
 
@@ -444,6 +448,7 @@ class IndexableMixin:
         self._check_index_is_initialized(index_name)
         return self._indexes[index_name]
 
+    @deprecated()
     def add_faiss_index(
         self,
         column: str,
@@ -485,6 +490,7 @@ class IndexableMixin:
         )
         self._indexes[index_name] = faiss_index
 
+    @deprecated()
     def add_faiss_index_from_external_arrays(
         self,
         external_arrays: np.array,
@@ -525,6 +531,7 @@ class IndexableMixin:
         )
         self._indexes[index_name] = faiss_index
 
+    @deprecated()
     def save_faiss_index(self, index_name: str, file: Union[str, PurePath], storage_options: Optional[Dict] = None):
         """Save a FaissIndex on disk.
 
@@ -543,6 +550,7 @@ class IndexableMixin:
         index.save(file, storage_options=storage_options)
         logger.info(f"Saved FaissIndex {index_name} at {file}")
 
+    @deprecated()
     def load_faiss_index(
         self,
         index_name: str,
@@ -575,6 +583,7 @@ class IndexableMixin:
         self._indexes[index_name] = index
         logger.info(f"Loaded FaissIndex {index_name} from {file}")
 
+    @deprecated()
     def add_elasticsearch_index(
         self,
         column: str,
@@ -627,6 +636,7 @@ class IndexableMixin:
         es_index.add_documents(self, column=column)
         self._indexes[index_name] = es_index
 
+    @deprecated()
     def load_elasticsearch_index(
         self,
         index_name: str,
@@ -674,6 +684,7 @@ class IndexableMixin:
             host=host, port=port, es_client=es_client, es_index_name=es_index_name, es_index_config=es_index_config
         )
 
+    @deprecated()
     def drop_index(self, index_name: str):
         """Drop the index with the specified column.
 
@@ -683,6 +694,7 @@ class IndexableMixin:
         """
         del self._indexes[index_name]
 
+    @deprecated()
     def search(self, index_name: str, query: Union[str, np.array], k: int = 10, **kwargs) -> SearchResults:
         """Find the nearest examples indices in the dataset to the query.
 
@@ -701,6 +713,7 @@ class IndexableMixin:
         self._check_index_is_initialized(index_name)
         return self._indexes[index_name].search(query, k, **kwargs)
 
+    @deprecated()
     def search_batch(
         self, index_name: str, queries: Union[List[str], np.array], k: int = 10, **kwargs
     ) -> BatchedSearchResults:
@@ -721,6 +734,7 @@ class IndexableMixin:
         self._check_index_is_initialized(index_name)
         return self._indexes[index_name].search_batch(queries, k, **kwargs)
 
+    @deprecated()
     def get_nearest_examples(
         self, index_name: str, query: Union[str, np.array], k: int = 10, **kwargs
     ) -> NearestExamplesResults:
@@ -743,6 +757,7 @@ class IndexableMixin:
         top_indices = [i for i in indices if i >= 0]
         return NearestExamplesResults(scores[: len(top_indices)], self[top_indices])
 
+    @deprecated()
     def get_nearest_examples_batch(
         self, index_name: str, queries: Union[List[str], np.array], k: int = 10, **kwargs
     ) -> BatchedNearestExamplesResults:


### PR DESCRIPTION
The Search API only supports Faiss and ElasticSearch as vector stores, is somewhat difficult to maintain (e.g., it still doesn't support ElasticSeach 8.0, difficult testing, ...), does not have the best design (adds a bunch of methods to the `Dataset` class that are only useful after creating an index), the usage doesn't seem to be significant and is not integrated with the Hub. Since we have no plans/bandwidth to improve it and better alternatives such as `langchain` and `docarray` exist, I think it should be deprecated (and eventually removed).

If we decide to deprecate/remove it, the following usage instances need to be addressed:
* [Course](https://github.com/huggingface/course/blob/0018bb434204d9750a03592cb0d4e846093218d8/chapters/en/chapter5/6.mdx#L342 ) and [Blog](https://github.com/huggingface/blog/blob/4897c6f73d4492a0955ade503281711d01840e09/image-search-datasets.md?plain=1#L252) - calling the FAISS API directly should be OK in these instances as it's pretty simple to use for basic scenarios. Alternatively, we can use `langchain`, but this adds an extra dependency
*  [Transformers](https://github.com/huggingface/transformers/blob/50726f9ea7afc6113da617f8f4ca1ab264a5e28a/src/transformers/models/rag/retrieval_rag.py#L183) - we can use the FAISS API directly and store the index as a separate attribute (and instead of building the `wiki_dpr` index each time the dataset is generated, we can generate it once and push it to the Hub repo, and then read it from there

cc @huggingface/datasets @LysandreJik for the opinion