### PR TITLE
No gzip encoding from github

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -448,7 +448,7 @@ def _prepare_single_hop_path_and_storage_options(
             urlpath += "&confirm=t"
         if urlpath.startswith("https://raw.githubusercontent.com/"):
             # Workaround for served data with gzip content-encoding: https://github.com/fsspec/filesystem_spec/issues/389
-            storage_options[protocol] = {"block_size": 0, **storage_options.get(protocol, {})}
+            storage_options[protocol]["headers"]["Accept-Encoding"] = "identity"
     elif protocol == "hf":
         storage_options = {"token": token, "endpoint": config.HF_ENDPOINT, **(storage_options or {})}
     return urlpath, storage_options


### PR DESCRIPTION
Don't accept gzip encoding from github, otherwise some files are not streamable + seekable.

fix https://huggingface.co/datasets/code_x_glue_cc_code_to_code_trans/discussions/2#64c0e0c1a04a514ba6303e84

and making sure https://github.com/huggingface/datasets/issues/2918 works as well