### PR TITLE
Fix `fsspec` download

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -332,7 +332,8 @@ def resolve_pattern(
     fs, _, _ = get_fs_token_paths(pattern, storage_options=storage_options)
     fs_base_path = base_path.split("::")[0].split("://")[-1] or fs.root_marker
     fs_pattern = pattern.split("::")[0].split("://")[-1]
-    protocol_prefix = fs.protocol + "://" if fs.protocol != "file" else ""
+    fs_protocol = fs.protocol[0] if not isinstance(fs.protocol, str) else fs.protocol
+    protocol_prefix = fs_protocol + "://" if fs_protocol != "file" else ""
     files_to_ignore = set(FILES_TO_IGNORE) - {xbasename(pattern)}
     matched_paths = [
         filepath if filepath.startswith(protocol_prefix) else protocol_prefix + filepath


### PR DESCRIPTION
Testing `ds = load_dataset("audiofolder", data_files="s3://datasets.huggingface.co/SpeechCommands/v0.01/v0.01_test.tar.gz", storage_options={"anon": True})` and trying to fix the issues raised by `fsspec` ...

TODO: fix
```
    self.session = aiobotocore.session.AioSession(**self.kwargs)
TypeError: __init__() got an unexpected keyword argument 'hf'
```
by "preparing `storage_options`" for the `fsspec` head/get