### PR TITLE
Fix deprecation of use_auth_token in DownloadConfig

### DIFF
--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -1,6 +1,6 @@
 import copy
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -74,19 +74,19 @@ class DownloadConfig:
     num_proc: Optional[int] = None
     max_retries: int = 1
     token: Optional[Union[str, bool]] = None
-    use_auth_token = "deprecated"
+    use_auth_token: InitVar[Optional[Union[str, bool]]] = "deprecated"
     ignore_url_params: bool = False
     storage_options: Dict[str, Any] = field(default_factory=dict)
     download_desc: Optional[str] = None
 
-    def __post_init__(self):
-        if self.use_auth_token != "deprecated":
+    def __post_init__(self, use_auth_token):
+        if use_auth_token != "deprecated":
             warnings.warn(
                 "'use_auth_token' was deprecated in favor of 'token' in version 2.14.0 and will be removed in 3.0.0.\n"
-                f"You can remove this warning by passing 'token={self.use_auth_token}' instead.",
+                f"You can remove this warning by passing 'token={use_auth_token}' instead.",
                 FutureWarning,
             )
-            self.token = self.use_auth_token
+            self.token = use_auth_token
         if "hf" not in self.storage_options:
             self.storage_options["hf"] = {"token": self.token, "endpoint": config.HF_ENDPOINT}
 


### PR DESCRIPTION
This PR fixes an issue with the deprecation of `use_auth_token` in `DownloadConfig` introduced by:
- #5996

```python
In [1]: from datasets import DownloadConfig

In [2]: DownloadConfig(use_auth_token=False)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-41927b449e72> in <module>
----> 1 DownloadConfig(use_auth_token=False)

TypeError: __init__() got an unexpected keyword argument 'use_auth_token'
```

```python
In [1]: from datasets import get_dataset_config_names
In [2]: get_dataset_config_names("squad", use_auth_token=False)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-22-4671992ead50> in <module>
----> 1 get_dataset_config_names("squad", use_auth_token=False)

~/huggingface/datasets/src/datasets/inspect.py in get_dataset_config_names(path, revision, download_config, download_mode, dynamic_modules_path, data_files, **download_kwargs)
    349     ```
    350     """
--> 351     dataset_module = dataset_module_factory(
    352         path,
    353         revision=revision,

~/huggingface/datasets/src/datasets/load.py in dataset_module_factory(path, revision, download_config, download_mode, dynamic_modules_path, data_dir, data_files, **download_kwargs)
   1374     """
   1375     if download_config is None:
-> 1376         download_config = DownloadConfig(**download_kwargs)
   1377     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
   1378     download_config.extract_compressed_file = True

TypeError: __init__() got an unexpected keyword argument 'use_auth_token'
```