### PR TITLE
Fix deprecation of errors in TextConfig

### DIFF
--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -29,7 +29,7 @@ class TextConfig(datasets.BuilderConfig):
     def __post_init__(self, errors):
         if errors != "deprecated":
             warnings.warn(
-                "'errors' was deprecated in favor of 'encoding_erros' in version 2.14.0 and will be removed in 3.0.0.\n"
+                "'errors' was deprecated in favor of 'encoding_errors' in version 2.14.0 and will be removed in 3.0.0.\n"
                 f"You can remove this warning by passing 'encoding_errors={errors}' instead.",
                 FutureWarning,
             )

--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -1,6 +1,6 @@
 import itertools
 import warnings
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from io import StringIO
 from typing import Optional
 
@@ -20,20 +20,20 @@ class TextConfig(datasets.BuilderConfig):
 
     features: Optional[datasets.Features] = None
     encoding: str = "utf-8"
-    errors = "deprecated"
+    errors: InitVar[Optional[str]] = "deprecated"
     encoding_errors: Optional[str] = None
     chunksize: int = 10 << 20  # 10MB
     keep_linebreaks: bool = False
     sample_by: str = "line"
 
-    def __post_init__(self):
-        if self.errors != "deprecated":
+    def __post_init__(self, errors):
+        if errors != "deprecated":
             warnings.warn(
                 "'errors' was deprecated in favor of 'encoding_erros' in version 2.14.0 and will be removed in 3.0.0.\n"
-                f"You can remove this warning by passing 'encoding_errors={self.errors}' instead.",
+                f"You can remove this warning by passing 'encoding_errors={errors}' instead.",
                 FutureWarning,
             )
-            self.encoding_errors = self.errors
+            self.encoding_errors = errors
 
 
 class Text(datasets.ArrowBasedBuilder):


### PR DESCRIPTION
This PR fixes an issue with the deprecation of `errors` in `TextConfig` introduced by:
- #5974

```python
In [1]: ds = load_dataset("text", data_files="test.txt", errors="strict")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-13-701c27131a5d> in <module>
----> 1 ds = load_dataset("text", data_files="test.txt", errors="strict")

~/huggingface/datasets/src/datasets/load.py in load_dataset(path, name, data_dir, data_files, split, cache_dir, features, download_config, download_mode, verification_mode, ignore_verifications, keep_in_memory, save_infos, revision, token, use_auth_token, task, streaming, num_proc, storage_options, **config_kwargs)
   2107 
   2108     # Create a dataset builder
-> 2109     builder_instance = load_dataset_builder(
   2110         path=path,
   2111         name=name,

~/huggingface/datasets/src/datasets/load.py in load_dataset_builder(path, name, data_dir, data_files, cache_dir, features, download_config, download_mode, revision, token, use_auth_token, storage_options, **config_kwargs)
   1830     builder_cls = get_dataset_builder_class(dataset_module, dataset_name=dataset_name)
   1831     # Instantiate the dataset builder
-> 1832     builder_instance: DatasetBuilder = builder_cls(
   1833         cache_dir=cache_dir,
   1834         dataset_name=dataset_name,

~/huggingface/datasets/src/datasets/builder.py in __init__(self, cache_dir, dataset_name, config_name, hash, base_path, info, features, token, use_auth_token, repo_id, data_files, data_dir, storage_options, writer_batch_size, name, **config_kwargs)
    371         if data_dir is not None:
    372             config_kwargs["data_dir"] = data_dir
--> 373         self.config, self.config_id = self._create_builder_config(
    374             config_name=config_name,
    375             custom_features=features,

~/huggingface/datasets/src/datasets/builder.py in _create_builder_config(self, config_name, custom_features, **config_kwargs)
    550             if "version" not in config_kwargs and hasattr(self, "VERSION") and self.VERSION:
    551                 config_kwargs["version"] = self.VERSION
--> 552             builder_config = self.BUILDER_CONFIG_CLASS(**config_kwargs)
    553 
    554         # otherwise use the config_kwargs to overwrite the attributes

TypeError: __init__() got an unexpected keyword argument 'errors'
```

Similar to:
- #6094