### PR TITLE
Expanduser in save_to_disk()

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1459,15 +1459,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
 
         if is_local:
-            Path(dataset_path).expanduser().resolve().mkdir(parents=True, exist_ok=True)
+            resolved_path = Path(dataset_path).expanduser().resolve()
+            resolved_path.mkdir(parents=True, exist_ok=True)
             parent_cache_files_paths = {
                 Path(cache_filename["filename"]).resolve().parent for cache_filename in self.cache_files
             }
             # Check that the dataset doesn't overwrite iself. It can cause a permission error on Windows and a segfault on linux.
-            if Path(dataset_path).resolve() in parent_cache_files_paths:
-                raise PermissionError(
-                    f"Tried to overwrite {Path(dataset_path).resolve()} but a dataset can't overwrite itself."
-                )
+            if resolved_path in parent_cache_files_paths:
+                raise PermissionError(f"Tried to overwrite {resolved_path} but a dataset can't overwrite itself.")
         else:
             fs.makedirs(dataset_path, exist_ok=True)
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1459,7 +1459,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
 
         if is_local:
-            Path(dataset_path).resolve().mkdir(parents=True, exist_ok=True)
+            Path(dataset_path).expanduser().resolve().mkdir(parents=True, exist_ok=True)
             parent_cache_files_paths = {
                 Path(cache_filename["filename"]).resolve().parent for cache_filename in self.cache_files
             }

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1652,7 +1652,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             path_join = posixpath.join
         else:
             fs = fsspec.filesystem("file")
-            dest_dataset_path = dataset_path
+            dest_dataset_path = Path(dataset_path).expanduser().resolve()
             path_join = os.path.join
 
         dataset_dict_json_path = path_join(dest_dataset_path, config.DATASETDICT_JSON_FILENAME)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1459,14 +1459,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
 
         if is_local:
-            resolved_path = Path(dataset_path).expanduser().resolve()
-            resolved_path.mkdir(parents=True, exist_ok=True)
+            save_path = Path(dataset_path).expanduser().resolve()
+            save_path.mkdir(parents=True, exist_ok=True)
             parent_cache_files_paths = {
                 Path(cache_filename["filename"]).resolve().parent for cache_filename in self.cache_files
             }
             # Check that the dataset doesn't overwrite iself. It can cause a permission error on Windows and a segfault on linux.
-            if resolved_path in parent_cache_files_paths:
-                raise PermissionError(f"Tried to overwrite {resolved_path} but a dataset can't overwrite itself.")
+            if save_path in parent_cache_files_paths:
+                raise PermissionError(f"Tried to overwrite {save_path} but a dataset can't overwrite itself.")
         else:
             fs.makedirs(dataset_path, exist_ok=True)
 

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1269,7 +1269,7 @@ class DatasetDict(dict):
             )
 
         if is_local:
-            Path(dataset_dict_path).resolve().mkdir(parents=True, exist_ok=True)
+            Path(dataset_dict_path).expanduser().resolve().mkdir(parents=True, exist_ok=True)
         else:
             fs.makedirs(dataset_dict_path, exist_ok=True)
 

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1343,7 +1343,7 @@ class DatasetDict(dict):
             path_join = posixpath.join
         else:
             fs = fsspec.filesystem("file")
-            dest_dataset_dict_path = dataset_dict_path
+            dest_dataset_dict_path = Path(dataset_dict_path).expanduser().resolve()
             path_join = os.path.join
 
         dataset_dict_json_path = path_join(dest_dataset_dict_path, config.DATASETDICT_JSON_FILENAME)

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -2217,7 +2217,7 @@ def load_from_disk(
         path_join = posixpath.join
     else:
         fs = fsspec.filesystem("file")
-        dest_dataset_path = dataset_path
+        dest_dataset_path = Path(dataset_path).expanduser().resolve()
         path_join = os.path.join
 
     if not fs.exists(dest_dataset_path):


### PR DESCRIPTION
Fixes #5651. The same problem occurs when loading from disk so I fixed it there too.

I am not sure why the case distinction between local and remote filesystems is even necessary for `DatasetDict` when saving to disk. Imo this could be removed (leaving only `fs.makedirs(dataset_dict_path, exist_ok=True)`).