### PR TITLE
Fix authentication issues

### DIFF
--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -24,6 +24,7 @@ REPO_METRICS_URL = "https://raw.githubusercontent.com/huggingface/datasets/{revi
 # Hub
 HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
 HUB_DATASETS_URL = HF_ENDPOINT + "/datasets/{repo_id}/resolve/{revision}/{path}"
+HUB_DATASETS_HFFS_URL = "hf://datasets/{repo_id}@{revision}/{path}"
 HUB_DEFAULT_VERSION = "main"
 
 PY_VERSION = version.parse(platform.python_version())

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -92,3 +92,11 @@ class DownloadConfig:
 
     def copy(self) -> "DownloadConfig":
         return self.__class__(**{k: copy.deepcopy(v) for k, v in self.__dict__.items()})
+
+    def __setattr__(self, name, value):
+        if name == "token" and getattr(self, "storage_options", None) is not None:
+            if "hf" not in self.storage_options:
+                self.storage_options["hf"] = {"token": value, "endpoint": config.HF_ENDPOINT}
+            elif getattr(self.storage_options["hf"], "token", None) is None:
+                self.storage_options["hf"]["token"] = value
+        super().__setattr__(name, value)

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -173,8 +173,11 @@ class Audio:
         if file is None:
             token_per_repo_id = token_per_repo_id or {}
             source_url = path.split("::")[-1]
+            pattern = (
+                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+            )
             try:
-                repo_id = string_to_dict(source_url, config.HUB_DATASETS_URL)["repo_id"]
+                repo_id = string_to_dict(source_url, pattern)["repo_id"]
                 token = token_per_repo_id[repo_id]
             except (ValueError, KeyError):
                 token = None

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -166,8 +166,13 @@ class Image:
                     image = PIL.Image.open(path)
                 else:
                     source_url = path.split("::")[-1]
+                    pattern = (
+                        config.HUB_DATASETS_URL
+                        if source_url.startswith(config.HF_ENDPOINT)
+                        else config.HUB_DATASETS_HFFS_URL
+                    )
                     try:
-                        repo_id = string_to_dict(source_url, config.HUB_DATASETS_URL)["repo_id"]
+                        repo_id = string_to_dict(source_url, pattern)["repo_id"]
                         token = token_per_repo_id.get(repo_id)
                     except ValueError:
                         token = None

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -539,6 +539,7 @@ def create_builder_configs_from_metadata_configs(
     base_path: Optional[str] = None,
     default_builder_kwargs: Dict[str, Any] = None,
     allowed_extensions: Optional[List[str]] = None,
+    download_config: Optional[DownloadConfig] = None,
 ) -> Tuple[List[BuilderConfig], str]:
     builder_cls = import_main_class(module_path)
     builder_config_cls = builder_cls.BUILDER_CONFIG_CLASS
@@ -560,6 +561,7 @@ def create_builder_configs_from_metadata_configs(
                 config_patterns,
                 base_path=config_base_path,
                 allowed_extensions=ALL_ALLOWED_EXTENSIONS,
+                download_config=download_config,
             )
         except EmptyDatasetError as e:
             raise EmptyDatasetError(
@@ -1070,6 +1072,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                 base_path=base_path,
                 supports_metadata=supports_metadata,
                 default_builder_kwargs=default_builder_kwargs,
+                download_config=self.download_config,
             )
         else:
             builder_configs, default_config_name = None, None

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -48,12 +48,8 @@ def hf_api():
 
 
 @pytest.fixture(scope="session")
-def hf_token(hf_api: HfApi):
-    previous_token = HfFolder.get_token()
-    HfFolder.save_token(CI_HUB_USER_TOKEN)
+def hf_token():
     yield CI_HUB_USER_TOKEN
-    if previous_token is not None:
-        HfFolder.save_token(previous_token)
 
 
 @pytest.fixture

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -47,6 +47,11 @@ def test_get_dataset_config_info(path, config_name, expected_splits):
     assert list(info.splits.keys()) == expected_splits
 
 
+def test_get_dataset_config_info_private(hf_token, hf_private_dataset_repo_txt_data):
+    info = get_dataset_config_info(hf_private_dataset_repo_txt_data, config_name="default", token=hf_token)
+    assert list(info.splits.keys()) == ["train"]
+
+
 @pytest.mark.parametrize(
     "path, config_name, expected_exception",
     [

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -38,6 +38,7 @@ from datasets.load import (
     PackagedDatasetModuleFactory,
     infer_module_for_data_files_list,
     infer_module_for_data_files_list_in_archives,
+    load_dataset_builder,
 )
 from datasets.packaged_modules.audiofolder.audiofolder import AudioFolder, AudioFolderConfig
 from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder, ImageFolderConfig
@@ -1225,6 +1226,12 @@ def test_loading_from_the_datasets_hub_with_token():
 def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_data):
     ds = load_dataset(hf_private_dataset_repo_txt_data, streaming=True, token=hf_token)
     assert next(iter(ds)) is not None
+
+
+@pytest.mark.integration
+def test_load_dataset_builder_private_dataset(hf_token, hf_private_dataset_repo_txt_data):
+    builder = load_dataset_builder(hf_private_dataset_repo_txt_data, token=hf_token)
+    assert isinstance(builder, DatasetBuilder)
 
 
 @pytest.mark.integration

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1310,9 +1310,7 @@ def test_load_hub_dataset_without_script_with_metadata_config_in_parallel():
 @require_pil
 @pytest.mark.integration
 @pytest.mark.parametrize("streaming", [True])
-def test_load_dataset_private_zipped_images(
-    hf_private_dataset_repo_zipped_img_data, hf_token, streaming
-):
+def test_load_dataset_private_zipped_images(hf_private_dataset_repo_zipped_img_data, hf_token, streaming):
     ds = load_dataset(hf_private_dataset_repo_zipped_img_data, split="train", streaming=streaming, token=hf_token)
     assert isinstance(ds, IterableDataset if streaming else Dataset)
     ds_items = list(ds)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1223,13 +1223,13 @@ def test_loading_from_the_datasets_hub_with_token():
 
 @pytest.mark.integration
 def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_data):
-    ds = load_dataset(hf_private_dataset_repo_txt_data, streaming=True)
+    ds = load_dataset(hf_private_dataset_repo_txt_data, streaming=True, token=hf_token)
     assert next(iter(ds)) is not None
 
 
 @pytest.mark.integration
 def test_load_streaming_private_dataset_with_zipped_data(hf_token, hf_private_dataset_repo_zipped_txt_data):
-    ds = load_dataset(hf_private_dataset_repo_zipped_txt_data, streaming=True)
+    ds = load_dataset(hf_private_dataset_repo_zipped_txt_data, streaming=True, token=hf_token)
     assert next(iter(ds)) is not None
 
 
@@ -1309,13 +1309,11 @@ def test_load_hub_dataset_without_script_with_metadata_config_in_parallel():
 
 @require_pil
 @pytest.mark.integration
-@pytest.mark.parametrize("implicit_token", [True])
 @pytest.mark.parametrize("streaming", [True])
 def test_load_dataset_private_zipped_images(
-    hf_private_dataset_repo_zipped_img_data, hf_token, streaming, implicit_token
+    hf_private_dataset_repo_zipped_img_data, hf_token, streaming
 ):
-    token = None if implicit_token else hf_token
-    ds = load_dataset(hf_private_dataset_repo_zipped_img_data, split="train", streaming=streaming, token=token)
+    ds = load_dataset(hf_private_dataset_repo_zipped_img_data, split="train", streaming=streaming, token=hf_token)
     assert isinstance(ds, IterableDataset if streaming else Dataset)
     ds_items = list(ds)
     assert len(ds_items) == 2

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -38,7 +38,7 @@ class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)
     _token = CI_HUB_USER_TOKEN
 
-    def test_push_dataset_dict_to_hub_no_token(self, temporary_repo):
+    def test_push_dataset_dict_to_hub_no_token(self, temporary_repo, set_ci_hub_access_token):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
         local_ds = DatasetDict({"train": ds})

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.integration
 
 
 @for_all_test_methods(xfail_if_500_502_http_error)
-@pytest.mark.usefixtures("set_ci_hub_access_token", "ci_hfh_hf_hub_url")
+@pytest.mark.usefixtures("ci_hub_config", "ci_hfh_hf_hub_url")
 class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)
     _token = CI_HUB_USER_TOKEN
@@ -778,6 +778,7 @@ class TestPushToHub:
                 path_in_repo="data/train-00000-of-00001.parquet",
                 repo_id=ds_name,
                 repo_type="dataset",
+                token=self._token,
             )
             ds_another_config.push_to_hub(ds_name, "another_config", token=self._token)
             ds_builder = load_dataset_builder(ds_name, download_mode="force_redownload")
@@ -811,6 +812,7 @@ class TestPushToHub:
                 path_in_repo="data/random-00000-of-00001.parquet",
                 repo_id=ds_name,
                 repo_type="dataset",
+                token=self._token,
             )
             local_ds_another_config.push_to_hub(ds_name, "another_config", token=self._token)
             ds_builder = load_dataset_builder(ds_name, download_mode="force_redownload")


### PR DESCRIPTION
This PR fixes 3 authentication issues:
- Fix authentication when passing `token`.
- Fix authentication in `Audio.decode_example` and `Image.decode_example`.
- Fix authentication to resolve `data_files` in repositories without script.

This PR also fixes our CI so that we properly test when passing `token` and we do not use the token stored in `HfFolder`.

Fix #6126.

## Details


### Fix authentication when passing `token`

See c0a77dc943de68a17f23f141517028c734c78623

The root issue was caused when the `token` was set in an already instantiated `DownloadConfig` and thus not propagated to `self._storage_options`:

  ```python
  download_config.token = token
  ```

As this usage is very common, the fix consists in overriding `DownloadConfig.__setattr__`.

This fixes authentication issues in the following functions:
- `load_dataset` and `load_dataset_builder`
- `Dataset.push_to_hub` and `Dataset.push_to_hub`
- `inspect.get_dataset_config_info`, `inspect.get_dataset_infos` and `inspect.get_dataset_split_names`

### Fix authentication in `Audio.decode_example` and `Image.decode_example`. 

See: 58e62af004b6b8b84dcfd897a4bc71637cfa6c3f

The `token` was not set because the `repo_id` was wrongly tried to be parsed from an HTTP URL (`"http://..."`), instead of an HFFileSystem URL (`"hf://"`)

### Fix authentication to resolve `data_files` in repositories without script

See: e4684fc1032321abf0d494b0c130ea7c82ebda80

This is fixed by passing `download_config` to the function `create_builder_configs_from_metadata_configs`