### PR TITLE
Ignore CI lint rule violation in Pickler.memoize

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -686,7 +686,7 @@ class Pickler(dill.Pickler):
 
     def memoize(self, obj):
         # don't memoize strings since two identical strings can have different python ids
-        if type(obj) != str:
+        if type(obj) != str:  # noqa: E721
             dill.Pickler.memoize(self, obj)
 
 


### PR DESCRIPTION
This PR ignores the violation of the lint rule E721 in `Pickler.memoize`.

The lint rule violation was introduced in this PR:
- #3182

@lhoestq is there a reason you did not use `isinstance` instead?

As a hotfix, we just ignore the violation of the lint rule.

Fix #6136.