### PR TITLE
Export to_iterable_dataset to document

### DIFF
--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -61,6 +61,7 @@ The base class [`Dataset`] implements a Dataset backed by an Apache Arrow table.
     - to_json
     - to_parquet
     - to_sql
+    - to_iterable_dataset
     - add_faiss_index
     - add_faiss_index_from_external_arrays
     - save_faiss_index


### PR DESCRIPTION
Fix the export of a missing method of `Dataset`