### PR TITLE
Ignore parallel warning in map_nested

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -25,6 +25,7 @@ import os
 import queue
 import re
 import types
+import warnings
 from contextlib import contextmanager
 from dataclasses import fields, is_dataclass
 from io import BytesIO as StringIO
@@ -465,7 +466,13 @@ def map_nested(
             for obj in logging.tqdm(iterable, disable=disable_tqdm, desc=desc)
         ]
     else:
-        mapped = parallel_map(function, iterable, num_proc, types, disable_tqdm, desc, _single_map_nested)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=".* is experimental and might be subject to breaking changes in the future\\.$",
+                category=UserWarning,
+            )
+            mapped = parallel_map(function, iterable, num_proc, types, disable_tqdm, desc, _single_map_nested)
 
     if isinstance(data_struct, dict):
         return dict(zip(data_struct.keys(), mapped))


### PR DESCRIPTION
This warning message was shown every time you pass num_proc to `load_dataset` because of `map_nested`

```
parallel_map is experimental and might be subject to breaking changes in the future
```

This PR removes it for `map_nested`. If someone uses another parallel backend they're already warned when `parallel_backend` is called anyway