### PR TITLE
Raise FileNotFoundError when passing data_files that don't exist

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -573,14 +573,18 @@ class DataFilesList(List[str]):
         base_path = base_path if base_path is not None else Path().resolve().as_posix()
         data_files = []
         for pattern in patterns:
-            data_files.extend(
-                resolve_pattern(
-                    pattern,
-                    base_path=base_path,
-                    allowed_extensions=allowed_extensions,
-                    download_config=download_config,
+            try:
+                data_files.extend(
+                    resolve_pattern(
+                        pattern,
+                        base_path=base_path,
+                        allowed_extensions=allowed_extensions,
+                        download_config=download_config,
+                    )
                 )
-            )
+            except FileNotFoundError:
+                if "*" not in pattern and "[" not in pattern and "?" not in pattern:
+                    raise
         origin_metadata = _get_origin_metadata(data_files, download_config=download_config)
         return cls(data_files, origin_metadata)
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -320,7 +320,7 @@ def resolve_pattern(
         allowed_extensions (Optional[list], optional): White-list of file extensions to use. Defaults to None (all extensions).
             For example: allowed_extensions=[".csv", ".json", ".txt", ".parquet"]
     Returns:
-        List[Union[Path, Url]]: List of paths or URLs to the local or remote files that match the patterns.
+        List[str]: List of paths or URLs to the local or remote files that match the patterns.
     """
     if is_relative_path(pattern):
         pattern = xjoin(base_path, pattern)
@@ -573,17 +573,14 @@ class DataFilesList(List[str]):
         base_path = base_path if base_path is not None else Path().resolve().as_posix()
         data_files = []
         for pattern in patterns:
-            try:
-                data_files.extend(
-                    resolve_pattern(
-                        pattern,
-                        base_path=base_path,
-                        allowed_extensions=allowed_extensions,
-                        download_config=download_config,
-                    )
+            data_files.extend(
+                resolve_pattern(
+                    pattern,
+                    base_path=base_path,
+                    allowed_extensions=allowed_extensions,
+                    download_config=download_config,
                 )
-            except FileNotFoundError:
-                pass
+            )
         origin_metadata = _get_origin_metadata(data_files, download_config=download_config)
         return cls(data_files, origin_metadata)
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -1,6 +1,7 @@
 import os
 import re
 from functools import partial
+from glob import has_magic
 from pathlib import Path, PurePath
 from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
@@ -583,7 +584,7 @@ class DataFilesList(List[str]):
                     )
                 )
             except FileNotFoundError:
-                if "*" not in pattern and "[" not in pattern and "?" not in pattern:
+                if not has_magic(pattern):
                     raise
         origin_metadata = _get_origin_metadata(data_files, download_config=download_config)
         return cls(data_files, origin_metadata)

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -380,6 +380,11 @@ def test_DataFilesList_from_patterns_locally_with_extra_files(complex_data_dir, 
     assert len(data_files_list.origin_metadata) == 2
 
 
+def test_DataFilesList_from_patterns_raises_FileNotFoundError(complex_data_dir):
+    with pytest.raises(FileNotFoundError):
+        DataFilesList.from_patterns(["file_that_doesnt_exist.txt"], complex_data_dir)
+
+
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
 def test_DataFilesDict_from_patterns_in_dataset_repository(
     hub_dataset_repo_path, hub_dataset_repo_patterns_results, pattern


### PR DESCRIPTION
e.g. when running `load_dataset("parquet", data_files="doesnt_exist.parquet")`