### PR TITLE
Fix: Missing a MetadataConfigs init when the repo has a `datasets_info.json` but no README

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5462,6 +5462,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             dataset_card = None
             dataset_card_data = DatasetCardData()
             download_config = DownloadConfig()
+            metadata_configs = MetadataConfigs()
             download_config.download_desc = "Downloading metadata"
             download_config.token = token
             dataset_infos_path = cached_path(


### PR DESCRIPTION
When I try to push to an arrow repo (can provide the link on Slack), it uploads the files but fails to update the metadata, with
```
  File "app.py", line 123, in add_new_eval
    eval_results[level].push_to_hub(my_repo, token=TOKEN, split=SPLIT)
  File "blabla_my_env_path/lib/python3.10/site-packages/datasets/arrow_dataset.py", line 5501, in push_to_hub
    if not metadata_configs:
UnboundLocalError: local variable 'metadata_configs' referenced before assignment
```

This fixes it.