### PR TITLE
Fix multiprocessing with spawn in iterable datasets

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1954,28 +1954,7 @@ class IterableDataset(DatasetInfoMixin):
          'movie_review': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
-
-        def rename_column_fn(example):
-            if original_column_name not in example:
-                raise ValueError(
-                    f"Error when renaming {original_column_name} to {new_column_name}: column {original_column_name} is not in the dataset."
-                )
-            if new_column_name in example:
-                raise ValueError(
-                    f"Error when renaming {original_column_name} to {new_column_name}: column {new_column_name} is already in the dataset."
-                )
-            return {new_column_name: example[original_column_name]}
-
-        original_features = self._info.features.copy() if self._info.features else None
-        ds_iterable = self.map(rename_column_fn, remove_columns=[original_column_name])
-        if original_features is not None:
-            ds_iterable._info.features = Features(
-                {
-                    new_column_name if col == original_column_name else col: feature
-                    for col, feature in original_features.items()
-                }
-            )
-        return ds_iterable
+        return self.rename_columns({original_column_name: new_column_name})
 
     def rename_columns(self, column_mapping: Dict[str, str]) -> "IterableDataset":
         """

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -25,6 +25,7 @@ from .utils.logging import get_logger
 from .utils.py_utils import Literal
 from .utils.sharding import _merge_gen_kwargs, _number_of_shards_in_gen_kwargs, _shuffle_gen_kwargs, _split_gen_kwargs
 
+
 logger = get_logger(__name__)
 
 Key = Union[int, str]
@@ -105,9 +106,9 @@ class _HasNextIterator(Iterator):
 
 
 def _convert_to_arrow(
-        iterable: Iterable[Tuple[Key, dict]],
-        batch_size: int,
-        drop_last_batch: bool = False,
+    iterable: Iterable[Tuple[Key, dict]],
+    batch_size: int,
+    drop_last_batch: bool = False,
 ) -> Iterator[Tuple[Key, pa.Table]]:
     """Convert and group examples in Arrow tables of size `batch_size`.
 
@@ -136,9 +137,9 @@ def _convert_to_arrow(
 
 
 def _batch_arrow_tables(
-        iterable: Iterable[Tuple[Key, pa.Table]],
-        batch_size: Optional[int],
-        drop_last_batch: bool = False,
+    iterable: Iterable[Tuple[Key, pa.Table]],
+    batch_size: Optional[int],
+    drop_last_batch: bool = False,
 ) -> Iterator[Tuple[Key, pa.Table]]:
     """Iterate over sub-tables of size `batch_size`.
 
@@ -242,7 +243,7 @@ class ExamplesIterable(_BaseExamplesIterable):
 
 class ShuffledDataSourcesExamplesIterable(ExamplesIterable):
     def __init__(
-            self, generate_examples_fn: Callable[..., Tuple[Key, dict]], kwargs: dict, generator: np.random.Generator
+        self, generate_examples_fn: Callable[..., Tuple[Key, dict]], kwargs: dict, generator: np.random.Generator
     ):
         super().__init__(generate_examples_fn, kwargs)
         self.generator = deepcopy(generator)
@@ -297,10 +298,10 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
 
 class ShuffledDataSourcesArrowExamplesIterable(ArrowExamplesIterable):
     def __init__(
-            self,
-            generate_tables_fn: Callable[..., Tuple[Key, pa.Table]],
-            kwargs: dict,
-            generator: np.random.Generator,
+        self,
+        generate_tables_fn: Callable[..., Tuple[Key, pa.Table]],
+        kwargs: dict,
+        generator: np.random.Generator,
     ):
         super().__init__(generate_tables_fn, kwargs)
         self.generator = deepcopy(generator)
@@ -391,9 +392,9 @@ class StepExamplesIterable(_BaseExamplesIterable):
 
 class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterables: List[_BaseExamplesIterable],
-            stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
+        self,
+        ex_iterables: List[_BaseExamplesIterable],
+        stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
     ):
         super().__init__()
         self.ex_iterables = ex_iterables
@@ -482,7 +483,7 @@ class VerticallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable):
             yield from ex_iterable.iter_arrow()
 
     def shuffle_data_sources(
-            self, generator: np.random.Generator
+        self, generator: np.random.Generator
     ) -> "VerticallyConcatenatedMultiSourcesExamplesIterable":
         """Shuffle the list of examples iterable, as well as each underlying examples iterable."""
         rng = deepcopy(generator)
@@ -496,7 +497,7 @@ class VerticallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable):
         return min(ex_iterable.n_shards for ex_iterable in self.ex_iterables)
 
     def shard_data_sources(
-            self, worker_id: int, num_workers: int
+        self, worker_id: int, num_workers: int
     ) -> "VerticallyConcatenatedMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         return VerticallyConcatenatedMultiSourcesExamplesIterable(
@@ -559,7 +560,7 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
                 break
 
     def shuffle_data_sources(
-            self, generator: np.random.Generator
+        self, generator: np.random.Generator
     ) -> "HorizontallyConcatenatedMultiSourcesExamplesIterable":
         """Doesn't shuffle the wrapped examples iterable since it would break the alignment between them."""
         return self
@@ -569,7 +570,7 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
         return 1
 
     def shard_data_sources(
-            self, worker_id: int, num_workers: int
+        self, worker_id: int, num_workers: int
     ) -> "HorizontallyConcatenatedMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         return HorizontallyConcatenatedMultiSourcesExamplesIterable(
@@ -579,11 +580,11 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
 
 class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIterable):
     def __init__(
-            self,
-            ex_iterables: List[_BaseExamplesIterable],
-            generator: np.random.Generator,
-            probabilities: Optional[List[float]] = None,
-            stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
+        self,
+        ex_iterables: List[_BaseExamplesIterable],
+        generator: np.random.Generator,
+        probabilities: Optional[List[float]] = None,
+        stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
     ):
         super().__init__(ex_iterables, stopping_strategy)
         self.generator = deepcopy(generator)
@@ -592,10 +593,10 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
 
     @staticmethod
     def _iter_random_indices(
-            rng: np.random.Generator,
-            num_sources: int,
-            random_batch_size=1000,
-            p: Optional[List[float]] = None,
+        rng: np.random.Generator,
+        num_sources: int,
+        random_batch_size=1000,
+        p: Optional[List[float]] = None,
     ) -> Iterator[int]:
         """Get an infinite iterator that randomly samples the index of the source to pick examples from."""
         if p is None:
@@ -632,18 +633,18 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
 
 class MappedExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            function: Callable,
-            with_indices: bool = False,
-            input_columns: Optional[List[str]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
-            drop_last_batch: bool = False,
-            remove_columns: Optional[List[str]] = None,
-            fn_kwargs: Optional[dict] = None,
-            formatting: Optional["FormattingConfig"] = None,
-            format_type="deprecated",
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        function: Callable,
+        with_indices: bool = False,
+        input_columns: Optional[List[str]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        remove_columns: Optional[List[str]] = None,
+        fn_kwargs: Optional[dict] = None,
+        formatting: Optional["FormattingConfig"] = None,
+        format_type="deprecated",
     ):
         if format_type != "deprecated":
             warning_msg = "'format_type' is deprecated and will be removed in the next major version of datasets. "
@@ -693,10 +694,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 key_examples_list = [(key, example)] + [(key, example) for key, example in iterator_batch]
                 keys, examples = zip(*key_examples_list)
                 if (
-                        self.drop_last_batch
-                        and self.batch_size is not None
-                        and self.batch_size > 0
-                        and len(examples) < self.batch_size
+                    self.drop_last_batch
+                    and self.batch_size is not None
+                    and self.batch_size > 0
+                    and len(examples) < self.batch_size
                 ):  # ignore last batch
                     return
                 batch = _examples_to_batch(examples)
@@ -820,16 +821,16 @@ class MappedExamplesIterable(_BaseExamplesIterable):
 
 class FilteredExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            function: Callable,
-            with_indices: bool = False,
-            input_columns: Optional[List[str]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
-            fn_kwargs: Optional[dict] = None,
-            formatting: Optional["FormattingConfig"] = None,
-            format_type="deprecated",
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        function: Callable,
+        with_indices: bool = False,
+        input_columns: Optional[List[str]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        fn_kwargs: Optional[dict] = None,
+        formatting: Optional["FormattingConfig"] = None,
+        format_type="deprecated",
     ):
         if format_type != "deprecated":
             warning_msg = "'format_type' is deprecated and will be removed in the next major version of datasets. "
@@ -1057,7 +1058,7 @@ class TakeExamplesIterable(_BaseExamplesIterable):
 
 
 def _apply_feature_types_on_example(
-        example: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
+    example: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
 ) -> dict:
     example = dict(example)
     # add missing columns
@@ -1072,7 +1073,7 @@ def _apply_feature_types_on_example(
 
 
 def _apply_feature_types_on_batch(
-        batch: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
+    batch: dict, features: Features, token_per_repo_id: Dict[str, Union[str, bool, None]]
 ) -> dict:
     batch = dict(batch)
     # add missing columns
@@ -1089,10 +1090,10 @@ def _apply_feature_types_on_batch(
 
 class TypedExamplesIterable(_BaseExamplesIterable):
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            features: Features,
-            token_per_repo_id: Dict[str, Union[str, bool, None]],
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        features: Features,
+        token_per_repo_id: Dict[str, Union[str, bool, None]],
     ):
         super().__init__()
         self.ex_iterable = ex_iterable
@@ -1179,15 +1180,15 @@ class IterableDataset(DatasetInfoMixin):
     """A Dataset backed by an iterable."""
 
     def __init__(
-            self,
-            ex_iterable: _BaseExamplesIterable,
-            info: Optional[DatasetInfo] = None,
-            split: Optional[NamedSplit] = None,
-            formatting: Optional[FormattingConfig] = None,
-            shuffling: Optional[ShufflingConfig] = None,
-            distributed: Optional[DistributedConfig] = None,
-            token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None,
-            format_type="deprecated",
+        self,
+        ex_iterable: _BaseExamplesIterable,
+        info: Optional[DatasetInfo] = None,
+        split: Optional[NamedSplit] = None,
+        formatting: Optional[FormattingConfig] = None,
+        shuffling: Optional[ShufflingConfig] = None,
+        distributed: Optional[DistributedConfig] = None,
+        token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None,
+        format_type="deprecated",
     ):
         if distributed and distributed.world_size > 1 and shuffling and shuffling._original_seed is None:
             raise RuntimeError(
@@ -1422,9 +1423,9 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_generator(
-            generator: Callable,
-            features: Optional[Features] = None,
-            gen_kwargs: Optional[dict] = None,
+        generator: Callable,
+        features: Optional[Features] = None,
+        gen_kwargs: Optional[dict] = None,
     ) -> "IterableDataset":
         """Create an Iterable Dataset from a generator.
 
@@ -1476,10 +1477,10 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_spark(
-            df: "pyspark.sql.DataFrame",
-            split: Optional[NamedSplit] = None,
-            features: Optional[Features] = None,
-            **kwargs,
+        df: "pyspark.sql.DataFrame",
+        split: Optional[NamedSplit] = None,
+        features: Optional[Features] = None,
+        **kwargs,
     ) -> "IterableDataset":
         """Create an IterableDataset from Spark DataFrame. The dataset is streamed to the driver in batches.
 
@@ -1534,8 +1535,8 @@ class IterableDataset(DatasetInfoMixin):
         return IterableDataset(ex_iterable=ex_iterable, info=DatasetInfo(features=inferred_features))
 
     def with_format(
-            self,
-            type: Optional[str] = None,
+        self,
+        type: Optional[str] = None,
     ) -> "IterableDataset":
         """
         Return a dataset with the specified format.
@@ -1562,16 +1563,16 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def map(
-            self,
-            function: Optional[Callable] = None,
-            with_indices: bool = False,
-            input_columns: Optional[Union[str, List[str]]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
-            drop_last_batch: bool = False,
-            remove_columns: Optional[Union[str, List[str]]] = None,
-            features: Optional[Features] = None,
-            fn_kwargs: Optional[dict] = None,
+        self,
+        function: Optional[Callable] = None,
+        with_indices: bool = False,
+        input_columns: Optional[Union[str, List[str]]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        remove_columns: Optional[Union[str, List[str]]] = None,
+        features: Optional[Features] = None,
+        fn_kwargs: Optional[dict] = None,
     ) -> "IterableDataset":
         """
         Apply a function to all the examples in the iterable dataset (individually or in batches) and update them.
@@ -1675,13 +1676,13 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def filter(
-            self,
-            function: Optional[Callable] = None,
-            with_indices=False,
-            input_columns: Optional[Union[str, List[str]]] = None,
-            batched: bool = False,
-            batch_size: Optional[int] = 1000,
-            fn_kwargs: Optional[dict] = None,
+        self,
+        function: Optional[Callable] = None,
+        with_indices=False,
+        input_columns: Optional[Union[str, List[str]]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        fn_kwargs: Optional[dict] = None,
     ) -> "IterableDataset":
         """Apply a filter function to all the elements so that the dataset only includes examples according to the filter function.
         The filtering is done on-the-fly when iterating over the dataset.
@@ -1753,7 +1754,7 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def shuffle(
-            self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000
+        self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000
     ) -> "IterableDataset":
         """
         Randomly shuffles the elements of this dataset.
@@ -1969,7 +1970,9 @@ class IterableDataset(DatasetInfoMixin):
         """
 
         original_features = self._info.features.copy() if self._info.features else None
-        ds_iterable = self.map(partial(_rename_columns_fn, column_mapping=column_mapping), remove_columns=list(column_mapping))
+        ds_iterable = self.map(
+            partial(_rename_columns_fn, column_mapping=column_mapping), remove_columns=list(column_mapping)
+        )
         if original_features is not None:
             ds_iterable._info.features = Features(
                 {
@@ -2132,8 +2135,8 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def cast(
-            self,
-            features: Features,
+        self,
+        features: Features,
     ) -> "IterableDataset":
         """
         Cast the dataset to a new set of features.
@@ -2215,10 +2218,10 @@ class IterableDataset(DatasetInfoMixin):
 
 
 def _concatenate_iterable_datasets(
-        dsets: List[IterableDataset],
-        info: Optional[DatasetInfo] = None,
-        split: Optional[NamedSplit] = None,
-        axis: int = 0,
+    dsets: List[IterableDataset],
+    info: Optional[DatasetInfo] = None,
+    split: Optional[NamedSplit] = None,
+    axis: int = 0,
 ) -> IterableDataset:
     """
     Converts a list of `IterableDataset` with the same schema into a single `IterableDataset`.
@@ -2275,12 +2278,12 @@ def _concatenate_iterable_datasets(
 
 
 def _interleave_iterable_datasets(
-        datasets: List[IterableDataset],
-        probabilities: Optional[List[float]] = None,
-        seed: Optional[int] = None,
-        info: Optional[DatasetInfo] = None,
-        split: Optional[NamedSplit] = None,
-        stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
+    datasets: List[IterableDataset],
+    probabilities: Optional[List[float]] = None,
+    seed: Optional[int] = None,
+    info: Optional[DatasetInfo] = None,
+    split: Optional[NamedSplit] = None,
+    stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
 ) -> IterableDataset:
     """
     Interleave several iterable datasets (sources) into a single iterable dataset.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -50,6 +50,12 @@ def _rename_columns_fn(example: Dict, column_mapping: Dict[str, str]):
     }
 
 
+def add_column_fn(example: Dict, idx: int, name: str, column: List[Dict]):
+    if name in example:
+        raise ValueError(f"Error when adding {name}: column {name} is already in the dataset.")
+    return {name: column[idx]}
+
+
 def _infer_features_from_batch(batch: Dict[str, list], try_features: Optional[Features] = None) -> Features:
     pa_table = pa.Table.from_pydict(batch)
     if try_features is not None:
@@ -1919,13 +1925,7 @@ class IterableDataset(DatasetInfoMixin):
         Returns:
             `IterableDataset`
         """
-
-        def add_column_fn(example, idx):
-            if name in example:
-                raise ValueError(f"Error when adding {name}: column {name} is already in the dataset.")
-            return {name: column[idx]}
-
-        return self.map(add_column_fn, with_indices=True)
+        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
 
     def rename_column(self, original_column_name: str, new_column_name: str) -> "IterableDataset":
         """

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1943,4 +1943,7 @@ def test_pickle_after_many_transforms(dataset_with_several_columns):
     dataset = dataset.rename_column("metadata", "metadata1")
     dataset = dataset.rename_columns({"id": "id1", "metadata1": "metadata2"})
     dataset = dataset.select_columns(["id1", "additional_col"])
-    pickle.dumps(dataset)
+
+    unpickled_dataset = pickle.loads(pickle.dumps(dataset))
+
+    assert list(unpickled_dataset) == list(dataset)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -55,7 +55,6 @@ from .utils import (
     require_torch,
 )
 
-
 DEFAULT_N_EXAMPLES = 20
 DEFAULT_BATCH_SIZE = 4
 DEFAULT_FILEPATH = "file.txt"
@@ -363,7 +362,7 @@ def test_mapped_examples_iterable(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -403,7 +402,7 @@ def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             if len(examples) < batch_size:  # ignore last batch
                 break
             batch = _examples_to_batch(examples)
@@ -430,10 +429,10 @@ def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
     [
         (3, lambda x, index: {"id+idx": x["id"] + index}, False, None),  # add the index to the id
         (
-            25,
-            lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
-            True,
-            10,
+                25,
+                lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
+                True,
+                10,
         ),  # add the index to the id
         (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, None),  # same with bs=None
         (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, -1),  # same with bs<=0
@@ -454,7 +453,7 @@ def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             indices = list(range(batch_offset, batch_offset + len(examples)))
             transformed_batch = func(batch, indices)
@@ -472,11 +471,11 @@ def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size):
         (3, lambda x: {"id+1": x["id"] + 1}, False, None, ["extra_column"]),  # just add 1 to the id
         (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10, ["extra_column"]),  # same with bs=10
         (
-            50,
-            lambda x: {"foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)},
-            True,
-            8,
-            ["extra_column", "id"],
+                50,
+                lambda x: {"foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)},
+                True,
+                8,
+                ["extra_column", "id"],
         ),  # make a duplicate of each example
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None, ["extra_column"]),  # same with bs=None
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1, ["extra_column"]),  # same with bs<=0
@@ -498,7 +497,7 @@ def test_mapped_examples_iterable_remove_columns(n, func, batched, batch_size, r
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -536,7 +535,7 @@ def test_mapped_examples_iterable_fn_kwargs(n, func, batched, batch_size, fn_kwa
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch, **fn_kwargs)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -572,7 +571,7 @@ def test_mapped_examples_iterable_input_columns(n, func, batched, batch_size, in
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(*[batch[col] for col in columns_to_input])
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -613,7 +612,7 @@ def test_mapped_examples_iterable_arrow_format(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(batch).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -653,7 +652,7 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             if len(examples) < batch_size:  # ignore last batch
                 break
             batch = pa.Table.from_pylist(examples)
@@ -679,16 +678,16 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
     "n, func, batched, batch_size",
     [
         (
-            3,
-            lambda t, index: t.append_column("id+idx", pc.add(t["id"], index)),
-            False,
-            None,
+                3,
+                lambda t, index: t.append_column("id+idx", pc.add(t["id"], index)),
+                False,
+                None,
         ),  # add the index to the id
         (
-            25,
-            lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)),
-            True,
-            10,
+                25,
+                lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)),
+                True,
+                10,
         ),  # add the index to the id
         (5, lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)), True, None),  # same with bs=None
         (5, lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)), True, -1),  # same with bs<=0
@@ -713,7 +712,7 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(batch, list(range(batch_offset, batch_offset + len(batch)))).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -724,19 +723,19 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
     "n, func, batched, batch_size, remove_columns",
     [
         (
-            3,
-            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
-            False,
-            None,
-            ["extra_column"],
+                3,
+                lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+                False,
+                None,
+                ["extra_column"],
         ),  # just add 1 to the id
         (25, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10, ["extra_column"]),  # same with bs=10
         (
-            50,
-            lambda t: pa.table({"foo": ["bar"] * np.random.default_rng(t["id"][0].as_py()).integers(0, 10)}),
-            True,
-            8,
-            ["extra_column", "id"],
+                50,
+                lambda t: pa.table({"foo": ["bar"] * np.random.default_rng(t["id"][0].as_py()).integers(0, 10)}),
+                True,
+                8,
+                ["extra_column", "id"],
         ),  # make a duplicate of each example
         (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, None, ["extra_column"]),  # same with bs=None
         (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, -1, ["extra_column"]),  # same with bs<=0
@@ -765,7 +764,7 @@ def test_mapped_examples_iterable_remove_columns_arrow_format(n, func, batched, 
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(
                 [{k: v for k, v in x.items() if k not in columns_to_remove} for x in func(batch).to_pylist()]
@@ -805,7 +804,7 @@ def test_mapped_examples_iterable_fn_kwargs_and_arrow_format(n, func, batched, b
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(batch, **fn_kwargs).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -843,7 +842,7 @@ def test_mapped_examples_iterable_input_columns_and_arrow_format(n, func, batche
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(*[batch[col] for col in columns_to_input]).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -875,7 +874,7 @@ def test_filtered_examples_iterable(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             mask = func(batch)
             expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
@@ -908,7 +907,7 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             indices = list(range(batch_offset, batch_offset + len(examples)))
             mask = func(batch, indices)
@@ -942,7 +941,7 @@ def test_filtered_examples_iterable_input_columns(n, func, batched, batch_size, 
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset : batch_offset + batch_size]
+            examples = all_examples[batch_offset: batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             mask = func(*[batch[col] for col in columns_to_input])
             expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
@@ -957,7 +956,7 @@ def test_skip_examples_iterable():
     expected = list(generate_examples_fn(n=total))[count:]
     assert list(skip_ex_iterable) == expected
     assert (
-        skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable
+            skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable
     ), "skip examples makes the shards order fixed"
 
 
@@ -968,7 +967,7 @@ def test_take_examples_iterable():
     expected = list(generate_examples_fn(n=total))[:count]
     assert list(take_ex_iterable) == expected
     assert (
-        take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable
+            take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable
     ), "skip examples makes the shards order fixed"
 
 
@@ -1014,7 +1013,7 @@ def test_horizontally_concatenated_examples_iterable():
     expected = [{**x, **y} for (_, x), (_, y) in zip(ex_iterable1, ex_iterable2)]
     assert [x for _, x in concatenated_ex_iterable] == expected
     assert (
-        concatenated_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is concatenated_ex_iterable
+            concatenated_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is concatenated_ex_iterable
     ), "horizontally concatenated examples makes the shards order fixed"
 
 
@@ -1277,9 +1276,9 @@ def test_iterable_dataset_iter_batch(batch_size, drop_last_batch):
     all_examples = [ex for _, ex in generate_examples_fn(n=n)]
     expected = []
     for i in range(0, len(all_examples), batch_size):
-        if len(all_examples[i : i + batch_size]) < batch_size and drop_last_batch:
+        if len(all_examples[i: i + batch_size]) < batch_size and drop_last_batch:
             continue
-        expected.append(_examples_to_batch(all_examples[i : i + batch_size]))
+        expected.append(_examples_to_batch(all_examples[i: i + batch_size]))
     assert next(iter(dataset.iter(batch_size, drop_last_batch=drop_last_batch))) == expected[0]
     assert list(dataset.iter(batch_size, drop_last_batch=drop_last_batch)) == expected
 
@@ -1319,7 +1318,7 @@ def test_iterable_dataset_set_epoch_of_shuffled_dataset(dataset: IterableDataset
 
 
 def test_iterable_dataset_map(
-    dataset: IterableDataset,
+        dataset: IterableDataset,
 ):
     func = lambda x: {"id+1": x["id"] + 1}  # noqa: E731
     mapped_dataset = dataset.map(func)
@@ -1330,7 +1329,7 @@ def test_iterable_dataset_map(
 
 
 def test_iterable_dataset_map_batched(
-    dataset: IterableDataset,
+        dataset: IterableDataset,
 ):
     func = lambda x: {"id+1": [i + 1 for i in x["id"]]}  # noqa: E731
     batch_size = 3
@@ -1342,7 +1341,7 @@ def test_iterable_dataset_map_batched(
 
 
 def test_iterable_dataset_map_complex_features(
-    dataset: IterableDataset,
+        dataset: IterableDataset,
 ):
     # https://github.com/huggingface/datasets/issues/3505
     ex_iterable = ExamplesIterable(generate_examples_fn, {"label": "positive"})
@@ -1794,7 +1793,7 @@ def test_interleave_datasets(dataset: IterableDataset, probas, seed, expected_le
 
 
 def test_interleave_datasets_with_features(
-    dataset: IterableDataset,
+        dataset: IterableDataset,
 ):
     features = Features(
         {
@@ -1921,10 +1920,35 @@ def test_interleave_dataset_with_sharding(n_shards1, n_shards2, num_workers):
     assert expected_length - num_workers <= len(result) <= expected_length
     assert len(result) == len({str(x) for x in result})
 
+
+def filter_func(batch):
+    return batch["id"] == 4
+
+
+def map_func(batch):
+    batch["id"] *= 2
+    return batch
+
+
 def test_pickle_after_many_transforms(dataset_with_several_columns):
     def is_picklable(obj):
         try:
             pickle.dumps(obj)
             return True
-        except (pickle.PicklingError, TypeError):
+        except pickle.PicklingError:
             return False
+    dataset = dataset_with_several_columns
+    dataset = dataset.remove_columns(["filepath"])
+    dataset = dataset.take(5)
+    dataset = dataset.map(map_func)
+    dataset = dataset.shuffle()
+    dataset = dataset.skip(1)
+    dataset = dataset.filter(filter_func)
+    dataset = dataset.add_column("additional_col", ["something"])
+    dataset = dataset.rename_column("metadata", "metadata1")
+    dataset = dataset.rename_columns({
+        "id": "id1",
+        "metadata1": "metadata2"
+    })
+    dataset = dataset.select_columns(["id1", "additional_col"])
+    assert is_picklable(dataset)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -55,6 +55,7 @@ from .utils import (
     require_torch,
 )
 
+
 DEFAULT_N_EXAMPLES = 20
 DEFAULT_BATCH_SIZE = 4
 DEFAULT_FILEPATH = "file.txt"
@@ -362,7 +363,7 @@ def test_mapped_examples_iterable(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -402,7 +403,7 @@ def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             if len(examples) < batch_size:  # ignore last batch
                 break
             batch = _examples_to_batch(examples)
@@ -429,10 +430,10 @@ def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
     [
         (3, lambda x, index: {"id+idx": x["id"] + index}, False, None),  # add the index to the id
         (
-                25,
-                lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
-                True,
-                10,
+            25,
+            lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
+            True,
+            10,
         ),  # add the index to the id
         (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, None),  # same with bs=None
         (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, -1),  # same with bs<=0
@@ -453,7 +454,7 @@ def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             indices = list(range(batch_offset, batch_offset + len(examples)))
             transformed_batch = func(batch, indices)
@@ -471,11 +472,11 @@ def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size):
         (3, lambda x: {"id+1": x["id"] + 1}, False, None, ["extra_column"]),  # just add 1 to the id
         (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10, ["extra_column"]),  # same with bs=10
         (
-                50,
-                lambda x: {"foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)},
-                True,
-                8,
-                ["extra_column", "id"],
+            50,
+            lambda x: {"foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)},
+            True,
+            8,
+            ["extra_column", "id"],
         ),  # make a duplicate of each example
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None, ["extra_column"]),  # same with bs=None
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1, ["extra_column"]),  # same with bs<=0
@@ -497,7 +498,7 @@ def test_mapped_examples_iterable_remove_columns(n, func, batched, batch_size, r
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -535,7 +536,7 @@ def test_mapped_examples_iterable_fn_kwargs(n, func, batched, batch_size, fn_kwa
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch, **fn_kwargs)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -571,7 +572,7 @@ def test_mapped_examples_iterable_input_columns(n, func, batched, batch_size, in
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             transformed_batch = func(*[batch[col] for col in columns_to_input])
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
@@ -612,7 +613,7 @@ def test_mapped_examples_iterable_arrow_format(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(batch).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -652,7 +653,7 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             if len(examples) < batch_size:  # ignore last batch
                 break
             batch = pa.Table.from_pylist(examples)
@@ -678,16 +679,16 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
     "n, func, batched, batch_size",
     [
         (
-                3,
-                lambda t, index: t.append_column("id+idx", pc.add(t["id"], index)),
-                False,
-                None,
+            3,
+            lambda t, index: t.append_column("id+idx", pc.add(t["id"], index)),
+            False,
+            None,
         ),  # add the index to the id
         (
-                25,
-                lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)),
-                True,
-                10,
+            25,
+            lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)),
+            True,
+            10,
         ),  # add the index to the id
         (5, lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)), True, None),  # same with bs=None
         (5, lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)), True, -1),  # same with bs<=0
@@ -712,7 +713,7 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(batch, list(range(batch_offset, batch_offset + len(batch)))).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -723,19 +724,19 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
     "n, func, batched, batch_size, remove_columns",
     [
         (
-                3,
-                lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
-                False,
-                None,
-                ["extra_column"],
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            False,
+            None,
+            ["extra_column"],
         ),  # just add 1 to the id
         (25, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10, ["extra_column"]),  # same with bs=10
         (
-                50,
-                lambda t: pa.table({"foo": ["bar"] * np.random.default_rng(t["id"][0].as_py()).integers(0, 10)}),
-                True,
-                8,
-                ["extra_column", "id"],
+            50,
+            lambda t: pa.table({"foo": ["bar"] * np.random.default_rng(t["id"][0].as_py()).integers(0, 10)}),
+            True,
+            8,
+            ["extra_column", "id"],
         ),  # make a duplicate of each example
         (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, None, ["extra_column"]),  # same with bs=None
         (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, -1, ["extra_column"]),  # same with bs<=0
@@ -764,7 +765,7 @@ def test_mapped_examples_iterable_remove_columns_arrow_format(n, func, batched, 
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(
                 [{k: v for k, v in x.items() if k not in columns_to_remove} for x in func(batch).to_pylist()]
@@ -804,7 +805,7 @@ def test_mapped_examples_iterable_fn_kwargs_and_arrow_format(n, func, batched, b
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(batch, **fn_kwargs).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -842,7 +843,7 @@ def test_mapped_examples_iterable_input_columns_and_arrow_format(n, func, batche
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(func(*[batch[col] for col in columns_to_input]).to_pylist())
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -874,7 +875,7 @@ def test_filtered_examples_iterable(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             mask = func(batch)
             expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
@@ -907,7 +908,7 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             indices = list(range(batch_offset, batch_offset + len(examples)))
             mask = func(batch, indices)
@@ -941,7 +942,7 @@ def test_filtered_examples_iterable_input_columns(n, func, batched, batch_size, 
         if batch_size is None or batch_size <= 0:
             batch_size = len(all_examples)
         for batch_offset in range(0, len(all_examples), batch_size):
-            examples = all_examples[batch_offset: batch_offset + batch_size]
+            examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = _examples_to_batch(examples)
             mask = func(*[batch[col] for col in columns_to_input])
             expected.extend([x for x, to_keep in zip(examples, mask) if to_keep])
@@ -956,7 +957,7 @@ def test_skip_examples_iterable():
     expected = list(generate_examples_fn(n=total))[count:]
     assert list(skip_ex_iterable) == expected
     assert (
-            skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable
+        skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable
     ), "skip examples makes the shards order fixed"
 
 
@@ -967,7 +968,7 @@ def test_take_examples_iterable():
     expected = list(generate_examples_fn(n=total))[:count]
     assert list(take_ex_iterable) == expected
     assert (
-            take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable
+        take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable
     ), "skip examples makes the shards order fixed"
 
 
@@ -1013,7 +1014,7 @@ def test_horizontally_concatenated_examples_iterable():
     expected = [{**x, **y} for (_, x), (_, y) in zip(ex_iterable1, ex_iterable2)]
     assert [x for _, x in concatenated_ex_iterable] == expected
     assert (
-            concatenated_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is concatenated_ex_iterable
+        concatenated_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is concatenated_ex_iterable
     ), "horizontally concatenated examples makes the shards order fixed"
 
 
@@ -1276,9 +1277,9 @@ def test_iterable_dataset_iter_batch(batch_size, drop_last_batch):
     all_examples = [ex for _, ex in generate_examples_fn(n=n)]
     expected = []
     for i in range(0, len(all_examples), batch_size):
-        if len(all_examples[i: i + batch_size]) < batch_size and drop_last_batch:
+        if len(all_examples[i : i + batch_size]) < batch_size and drop_last_batch:
             continue
-        expected.append(_examples_to_batch(all_examples[i: i + batch_size]))
+        expected.append(_examples_to_batch(all_examples[i : i + batch_size]))
     assert next(iter(dataset.iter(batch_size, drop_last_batch=drop_last_batch))) == expected[0]
     assert list(dataset.iter(batch_size, drop_last_batch=drop_last_batch)) == expected
 
@@ -1318,7 +1319,7 @@ def test_iterable_dataset_set_epoch_of_shuffled_dataset(dataset: IterableDataset
 
 
 def test_iterable_dataset_map(
-        dataset: IterableDataset,
+    dataset: IterableDataset,
 ):
     func = lambda x: {"id+1": x["id"] + 1}  # noqa: E731
     mapped_dataset = dataset.map(func)
@@ -1329,7 +1330,7 @@ def test_iterable_dataset_map(
 
 
 def test_iterable_dataset_map_batched(
-        dataset: IterableDataset,
+    dataset: IterableDataset,
 ):
     func = lambda x: {"id+1": [i + 1 for i in x["id"]]}  # noqa: E731
     batch_size = 3
@@ -1341,7 +1342,7 @@ def test_iterable_dataset_map_batched(
 
 
 def test_iterable_dataset_map_complex_features(
-        dataset: IterableDataset,
+    dataset: IterableDataset,
 ):
     # https://github.com/huggingface/datasets/issues/3505
     ex_iterable = ExamplesIterable(generate_examples_fn, {"label": "positive"})
@@ -1793,7 +1794,7 @@ def test_interleave_datasets(dataset: IterableDataset, probas, seed, expected_le
 
 
 def test_interleave_datasets_with_features(
-        dataset: IterableDataset,
+    dataset: IterableDataset,
 ):
     features = Features(
         {
@@ -1940,9 +1941,6 @@ def test_pickle_after_many_transforms(dataset_with_several_columns):
     dataset = dataset.filter(filter_func)
     dataset = dataset.add_column("additional_col", ["something"])
     dataset = dataset.rename_column("metadata", "metadata1")
-    dataset = dataset.rename_columns({
-        "id": "id1",
-        "metadata1": "metadata2"
-    })
+    dataset = dataset.rename_columns({"id": "id1", "metadata1": "metadata2"})
     dataset = dataset.select_columns(["id1", "additional_col"])
     pickle.dumps(dataset)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1931,12 +1931,6 @@ def map_func(batch):
 
 
 def test_pickle_after_many_transforms(dataset_with_several_columns):
-    def is_picklable(obj):
-        try:
-            pickle.dumps(obj)
-            return True
-        except pickle.PicklingError:
-            return False
     dataset = dataset_with_several_columns
     dataset = dataset.remove_columns(["filepath"])
     dataset = dataset.take(5)
@@ -1951,4 +1945,4 @@ def test_pickle_after_many_transforms(dataset_with_several_columns):
         "metadata1": "metadata2"
     })
     dataset = dataset.select_columns(["id1", "additional_col"])
-    assert is_picklable(dataset)
+    pickle.dumps(dataset)


### PR DESCRIPTION
The "Spawn" method is preferred when multiprocessing on macOS or Windows systems, instead of the "Fork" method on linux systems.

This causes some methods of Iterable Datasets to break when using a dataloader with more than 0 workers.

I fixed the issue by replacing lambda and local methods which are not pickle-able.

See the example below:

```python
from datasets import load_dataset
from torch.utils.data import DataLoader


if __name__ == "__main__":
    dataset = load_dataset("lhoestq/demo1", split="train")
    dataset = dataset.to_iterable_dataset(num_shards=3)

    dataset = dataset.remove_columns(["package_name"])
    dataset = dataset.rename_columns({
        "review": "review1"
    })
    dataset = dataset.rename_column("date", "date1")
    for sample in DataLoader(dataset, batch_size=None, num_workers=3):
        print(sample)
```

To notice the fix on a linux system, adding these lines should do the trick:

```python
import multiprocessing
multiprocessing.set_start_method('spawn')
```

I also removed what looks like code duplication between rename_colums and rename_column
