### PR TITLE
Preserve split order in DataFilesDict

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -682,17 +682,6 @@ class DataFilesDict(Dict[str, DataFilesList]):
             )
         return out
 
-    def __reduce__(self):
-        """
-        To make sure the order of the keys doesn't matter when pickling and hashing:
-
-        >>> from datasets.data_files import DataFilesDict
-        >>> from datasets.fingerprint import Hasher
-        >>> assert Hasher.hash(DataFilesDict(a=[], b=[])) == Hasher.hash(DataFilesDict(b=[], a=[]))
-
-        """
-        return DataFilesDict, (dict(sorted(self.items())),)
-
     def filter_extensions(self, extensions: List[str]) -> "DataFilesDict":
         out = type(self)()
         for key, data_files_list in self.items():

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -760,10 +760,6 @@ class BuilderTest(TestCase):
             )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
-                cache_dir=tmp_dir, data_files={"test": dummy_data2, "train": dummy_data1}
-            )
-            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(
                 cache_dir=tmp_dir, data_files={"train": dummy_data1, "validation": dummy_data2}
             )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from pathlib import Path, PurePath
 from typing import List
@@ -383,6 +384,13 @@ def test_DataFilesList_from_patterns_locally_with_extra_files(complex_data_dir, 
 def test_DataFilesList_from_patterns_raises_FileNotFoundError(complex_data_dir):
     with pytest.raises(FileNotFoundError):
         DataFilesList.from_patterns(["file_that_doesnt_exist.txt"], complex_data_dir)
+
+
+class TestDataFilesDict:
+    def test_key_order_after_copy(self):
+        data_files = DataFilesDict({"train": "train.csv", "test": "test.csv"})
+        copied_data_files = copy.deepcopy(data_files)
+        assert list(copied_data_files.keys()) == list(data_files.keys())  # test split order with list()
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)


### PR DESCRIPTION
After investigation, I have found that this copy forces the splits to be sorted alphabetically: https://github.com/huggingface/datasets/blob/029227a116c14720afca71b9b22e78eb2a1c09a6/src/datasets/builder.py#L556

This PR removes the alphabetically sort of `DataFilesDict` keys.
- Note that for a `dict`, the order of keys is relevant when hashing:
  ```python
  hash1 = Hasher.hash({'train': 'train.csv', 'test': 'test.csv'})
  hash2 = Hasher.hash({'test': 'test.csv', 'train': 'train.csv'})
  assert hash1 != hash2
  ```
- The `DataFilesDict` is a subclass of `dict`, thus the order should be relevant as well
  ```python
  hash1 = Hasher.hash(DataFilesDict({'train': 'train.csv', 'test': 'test.csv'}))
  hash2 = Hasher.hash(DataFilesDict({'test': 'test.csv', 'train': 'train.csv'}))
  assert hash1 != hash2
  ```

Fix #6196.