### PR TITLE
Fix empty splitinfo json

### DIFF
--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -31,9 +31,15 @@ from .utils.py_utils import NonMutableDict, asdict
 
 @dataclass
 class SplitInfo:
-    name: str = ""
-    num_bytes: int = 0
-    num_examples: int = 0
+    name: str = dataclasses.field(
+        default="", metadata={"include_in_asdict_even_if_is_default": True}
+    )
+    num_bytes: int = dataclasses.field(
+        default=0, metadata={"include_in_asdict_even_if_is_default": True}
+    )
+    num_examples: int = dataclasses.field(
+        default=0, metadata={"include_in_asdict_even_if_is_default": True}
+    )
     shard_lengths: Optional[List[int]] = None
 
     # Deprecated

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -31,15 +31,9 @@ from .utils.py_utils import NonMutableDict, asdict
 
 @dataclass
 class SplitInfo:
-    name: str = dataclasses.field(
-        default="", metadata={"include_in_asdict_even_if_is_default": True}
-    )
-    num_bytes: int = dataclasses.field(
-        default=0, metadata={"include_in_asdict_even_if_is_default": True}
-    )
-    num_examples: int = dataclasses.field(
-        default=0, metadata={"include_in_asdict_even_if_is_default": True}
-    )
+    name: str = dataclasses.field(default="", metadata={"include_in_asdict_even_if_is_default": True})
+    num_bytes: int = dataclasses.field(default=0, metadata={"include_in_asdict_even_if_is_default": True})
+    num_examples: int = dataclasses.field(default=0, metadata={"include_in_asdict_even_if_is_default": True})
     shard_lengths: Optional[List[int]] = None
 
     # Deprecated


### PR DESCRIPTION
If a split is empty, then the JSON split info should mention num_bytes = 0 and num_examples = 0.

Until now they were omited because the JSON dumps ignore the fields that are equal to the default values.

This is needed in datasets-server since we parse this information to the viewer