### PR TITLE
Rename old push_to_hub configs to "default" in dataset_infos

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -913,9 +913,9 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                     }
                 )
                 if len(legacy_dataset_infos) == 1:
+                    # old config e.g. named "username--dataset_name"
                     legacy_config_name = next(iter(legacy_dataset_infos))
-                    if "--" in legacy_config_name:  # old config named "username--dataset_name"
-                        legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
+                    legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
         if default_config_name is None and len(dataset_infos) == 1:
@@ -1114,9 +1114,9 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                     }
                 )
                 if len(legacy_dataset_infos) == 1:
+                    # old config e.g. named "username--dataset_name"
                     legacy_config_name = next(iter(legacy_dataset_infos))
-                    if "--" in legacy_config_name:  # old config named "username--dataset_name"
-                        legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
+                    legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
         except FileNotFoundError:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -903,6 +903,7 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         if self.data_files is not None or not metadata_configs:
             builder_kwargs["data_files"] = data_files
             builder_kwargs.update(default_builder_kwargs)  # from _EXTENSION_TO_MODULE
+        # this file is deprecated and was created automatically in old versions of push_to_hub
         if os.path.isfile(os.path.join(self.path, config.DATASETDICT_INFOS_FILENAME)):
             with open(os.path.join(self.path, config.DATASETDICT_INFOS_FILENAME), encoding="utf-8") as f:
                 legacy_dataset_infos = DatasetInfosDict(
@@ -911,6 +912,10 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                         for config_name, dataset_info_dict in json.load(f).items()
                     }
                 )
+                if len(legacy_dataset_infos) == 1:
+                    legacy_config_name = next(iter(legacy_dataset_infos))
+                    if "--" in legacy_config_name:  # old config named "username--dataset_name"
+                        legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
         if default_config_name is None and len(dataset_infos) == 1:
@@ -1096,6 +1101,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         if download_config.download_desc is None:
             download_config.download_desc = "Downloading metadata"
         try:
+            # this file is deprecated and was created automatically in old versions of push_to_hub
             dataset_infos_path = cached_path(
                 hf_hub_url(self.name, config.DATASETDICT_INFOS_FILENAME, revision=self.revision),
                 download_config=download_config,
@@ -1107,6 +1113,10 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                         for config_name, dataset_info_dict in json.load(f).items()
                     }
                 )
+                if len(legacy_dataset_infos) == 1:
+                    legacy_config_name = next(iter(legacy_dataset_infos))
+                    if "--" in legacy_config_name:  # old config named "username--dataset_name"
+                        legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
         except FileNotFoundError:


### PR DESCRIPTION
Fix

```python
from datasets import load_dataset_builder

b = load_dataset_builder("lambdalabs/pokemon-blip-captions", "default")
print(b.info)
```

which should return

```
DatasetInfo(
  features={'image': Image(decode=True, id=None), 'text': Value(dtype='string', id=None)}, 
  dataset_name='pokemon-blip-captions',
  config_name='default', 
  version=0.0.0,
  splits={'train': SplitInfo(name='train', num_bytes=119417410.0, num_examples=833, shard_lengths=None, dataset_name='pokemon-blip-captions')},
  download_checksums=None,
  download_size=99672355,
  dataset_size=119417410.0,
  size_in_bytes=219089765.0,
  ...
)
```

instead of and empty dataset info.

The dataset has a dataset_infos.json file with a deprecated config name "lambdalabs--pokemon-blip-captions". We switched those config names to "default" in 2.14, so the builder.info should take this into account.