### PR TITLE
Ignore `dataset_info.json` in data files resolution

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -80,7 +80,14 @@ METADATA_PATTERNS = [
     "**/metadata.jsonl",
 ]  # metadata file for ImageFolder and AudioFolder
 WILDCARD_CHARACTERS = "*[]"
-FILES_TO_IGNORE = ["README.md", "config.json", "dataset_infos.json", "dummy_data.zip", "dataset_dict.json"]
+FILES_TO_IGNORE = [
+    "README.md",
+    "config.json",
+    "dataset_info.json",
+    "dataset_infos.json",
+    "dummy_data.zip",
+    "dataset_dict.json",
+]
 
 
 def contains_wildcards(pattern: str) -> bool:


### PR DESCRIPTION
`save_to_disk` creates this file, but also [`HugginFaceDatasetSever`](https://github.com/gradio-app/gradio/blob/26fef8c7f85a006c7e25cdbed1792df19c512d02/gradio/flagging.py#L214), so this is needed to avoid issues such as [this one](https://discord.com/channels/879548962464493619/1149295819938349107/1149295819938349107).