### PR TITLE
Don't skip hidden files in `dl_manager.iter_files` when they are given as input

### DIFF
--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -231,8 +231,7 @@ class FilesIterable(_IterableFromGenerator):
                 yield urlpath
             else:
                 for dirpath, dirnames, filenames in os.walk(urlpath):
-                    # skipping hidden directories; prune the search
-                    # [:] for the in-place list modification required by os.walk
+                    # in-place modification to prune the search
                     dirnames[:] = sorted([dirname for dirname in dirnames if not dirname.startswith((".", "__"))])
                     if os.path.basename(dirpath).startswith((".", "__")):
                         # skipping hidden directories

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -228,9 +228,6 @@ class FilesIterable(_IterableFromGenerator):
             urlpaths = [urlpaths]
         for urlpath in urlpaths:
             if os.path.isfile(urlpath):
-                if os.path.basename(urlpath).startswith((".", "__")):
-                    # skipping hidden files
-                    continue
                 yield urlpath
             else:
                 for dirpath, dirnames, filenames in os.walk(urlpath):

--- a/src/datasets/download/mock_download_manager.py
+++ b/src/datasets/download/mock_download_manager.py
@@ -232,8 +232,6 @@ class MockDownloadManager:
             paths = [paths]
         for path in paths:
             if os.path.isfile(path):
-                if os.path.basename(path).startswith((".", "__")):
-                    return
                 yield path
             else:
                 for dirpath, dirnames, filenames in os.walk(path):

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -914,9 +914,6 @@ class FilesIterable(_IterableFromGenerator):
             urlpaths = [urlpaths]
         for urlpath in urlpaths:
             if xisfile(urlpath, download_config=download_config):
-                if xbasename(urlpath).startswith((".", "__")):
-                    # skipping hidden files
-                    continue
                 yield urlpath
             elif xisdir(urlpath, download_config=download_config):
                 for dirpath, dirnames, filenames in xwalk(urlpath, download_config=download_config):

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -917,9 +917,7 @@ class FilesIterable(_IterableFromGenerator):
                 yield urlpath
             elif xisdir(urlpath, download_config=download_config):
                 for dirpath, dirnames, filenames in xwalk(urlpath, download_config=download_config):
-                    # skipping hidden directories; prune the search
-                    # [:] for the in-place list modification required by os.walk
-                    # (only works for local paths as fsspec's walk doesn't support the in-place modification)
+                    # in-place modification to prune the search
                     dirnames[:] = sorted([dirname for dirname in dirnames if not dirname.startswith((".", "__"))])
                     if xbasename(dirpath).startswith((".", "__")):
                         # skipping hidden directories


### PR DESCRIPTION
Required for `load_dataset(<format>, data_files=["path/to/.hidden_file"])` to work as expected