### PR TITLE
Overwrite legacy default config name in `dataset_infos.json` in packaged datasets

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1728,6 +1728,9 @@ class DatasetDict(dict):
             )
             with open(dataset_infos_path, encoding="utf-8") as f:
                 dataset_infos: dict = json.load(f)
+            legacy_config_name = "--".join(repo_id.split("/"))
+            if config_name == "default" and legacy_config_name in dataset_infos:
+                dataset_infos.pop(legacy_config_name)
             dataset_infos[config_name] = asdict(info_to_dump)
             buffer = BytesIO()
             buffer.write(json.dumps(dataset_infos, indent=4).encode("utf-8"))

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1728,9 +1728,9 @@ class DatasetDict(dict):
             )
             with open(dataset_infos_path, encoding="utf-8") as f:
                 dataset_infos: dict = json.load(f)
-            legacy_config_name = "--".join(repo_id.split("/"))
-            if config_name == "default" and legacy_config_name in dataset_infos:
-                dataset_infos.pop(legacy_config_name)
+            legacy_default_config_name = repo_id.replace("/", "--")
+            if config_name == "default" and legacy_default_config_name in dataset_infos:
+                dataset_infos.pop(legacy_default_config_name)
             dataset_infos[config_name] = asdict(info_to_dump)
             buffer = BytesIO()
             buffer.write(json.dumps(dataset_infos, indent=4).encode("utf-8"))

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -912,10 +912,9 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                         for config_name, dataset_info_dict in json.load(f).items()
                     }
                 )
-                if len(legacy_dataset_infos) == 1:
-                    # old config e.g. named "username--dataset_name"
-                    legacy_config_name = next(iter(legacy_dataset_infos))
-                    legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
+                legacy_default_config_name = os.path.basename(self.path.rstrip("/"))
+                if legacy_default_config_name in legacy_dataset_infos:
+                    legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_default_config_name)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
         if default_config_name is None and len(dataset_infos) == 1:
@@ -1113,10 +1112,9 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                         for config_name, dataset_info_dict in json.load(f).items()
                     }
                 )
-                if len(legacy_dataset_infos) == 1:
-                    # old config e.g. named "username--dataset_name"
-                    legacy_config_name = next(iter(legacy_dataset_infos))
-                    legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_config_name)
+                legacy_default_config_name = self.name.replace("/", "--")
+                if legacy_default_config_name in legacy_dataset_infos:
+                    legacy_dataset_infos["default"] = legacy_dataset_infos.pop(legacy_default_config_name)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
         except FileNotFoundError:


### PR DESCRIPTION
Currently if we push data as default config with `.push_to_hub` to a repo that has a legacy `dataset_infos.json` file containing a legacy default config name like `{username}--{dataset_name}`, new key `"default"` is added to `dataset_infos.json` along with the legacy one. I think the legacy one should be dropped in this case.