### PR TITLE
Improve error message for missing function parameters

### DIFF
--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -466,7 +466,7 @@ def fingerprint_transform(
 
     def _fingerprint(func):
         if not inplace and not all(name in func.__code__.co_varnames for name in fingerprint_names):
-            raise ValueError(f"function {func.__name__} is missing parameters {fingerprint_names} in signature")
+            raise ValueError(f"function {func.__qualname__} is missing parameters {fingerprint_names} in signature")
 
         if randomized_function:  # randomized function have seed and generator parameters
             if "seed" not in func.__code__.co_varnames:

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -466,7 +466,7 @@ def fingerprint_transform(
 
     def _fingerprint(func):
         if not inplace and not all(name in func.__code__.co_varnames for name in fingerprint_names):
-            raise ValueError("function {func} is missing parameters {fingerprint_names} in signature")
+            raise ValueError(f"function {func.__name__} is missing parameters {fingerprint_names} in signature")
 
         if randomized_function:  # randomized function have seed and generator parameters
             if "seed" not in func.__code__.co_varnames:

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -466,7 +466,7 @@ def fingerprint_transform(
 
     def _fingerprint(func):
         if not inplace and not all(name in func.__code__.co_varnames for name in fingerprint_names):
-            raise ValueError(f"function {func.__qualname__} is missing parameters {fingerprint_names} in signature")
+            raise ValueError(f"function {func} is missing parameters {fingerprint_names} in signature")
 
         if randomized_function:  # randomized function have seed and generator parameters
             if "seed" not in func.__code__.co_varnames:


### PR DESCRIPTION
The error message in the fingerprint module was missing the f-string 'f' symbol, so the error message returned by fingerprint.py, line 469 was literally "function {func} is missing parameters {fingerprint_names} in signature."

This has been fixed.