### PR TITLE
Support streaming datasets with pyarrow.parquet.read_table

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -783,6 +783,16 @@ def xpandas_read_excel(filepath_or_buffer, download_config: Optional[DownloadCon
             )
 
 
+def xpyarrow_parquet_read_table(filepath_or_buffer, download_config: Optional[DownloadConfig] = None, **kwargs):
+    import pyarrow.parquet as pq
+
+    if hasattr(filepath_or_buffer, "read"):
+        return pq.read_table(filepath_or_buffer, **kwargs)
+    else:
+        filepath_or_buffer = str(filepath_or_buffer)
+        return pq.read_table(xopen(filepath_or_buffer, mode="rb", download_config=download_config), **kwargs)
+
+
 def xsio_loadmat(filepath_or_buffer, download_config: Optional[DownloadConfig] = None, **kwargs):
     import scipy.io as sio
 

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -21,6 +21,7 @@ from .download.streaming_download_manager import (
     xpandas_read_csv,
     xpandas_read_excel,
     xPath,
+    xpyarrow_parquet_read_table,
     xrelpath,
     xsio_loadmat,
     xsplit,
@@ -99,6 +100,7 @@ def extend_module_for_streaming(module_path, download_config: Optional[DownloadC
     patch_submodule(module, "numpy.load", wrap_auth(xnumpy_load)).start()
     patch_submodule(module, "pandas.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
     patch_submodule(module, "pandas.read_excel", wrap_auth(xpandas_read_excel), attrs=["__version__"]).start()
+    patch_submodule(module, "pyarrow.parquet.read_table", wrap_auth(xpyarrow_parquet_read_table)).start()
     patch_submodule(module, "scipy.io.loadmat", wrap_auth(xsio_loadmat), attrs=["__version__"]).start()
     patch_submodule(module, "xml.etree.ElementTree.parse", wrap_auth(xet_parse)).start()
     patch_submodule(module, "xml.dom.minidom.parse", wrap_auth(xxml_dom_minidom_parse)).start()

--- a/src/datasets/streaming.py
+++ b/src/datasets/streaming.py
@@ -100,10 +100,12 @@ def extend_module_for_streaming(module_path, download_config: Optional[DownloadC
     patch_submodule(module, "numpy.load", wrap_auth(xnumpy_load)).start()
     patch_submodule(module, "pandas.read_csv", wrap_auth(xpandas_read_csv), attrs=["__version__"]).start()
     patch_submodule(module, "pandas.read_excel", wrap_auth(xpandas_read_excel), attrs=["__version__"]).start()
-    patch_submodule(module, "pyarrow.parquet.read_table", wrap_auth(xpyarrow_parquet_read_table)).start()
     patch_submodule(module, "scipy.io.loadmat", wrap_auth(xsio_loadmat), attrs=["__version__"]).start()
     patch_submodule(module, "xml.etree.ElementTree.parse", wrap_auth(xet_parse)).start()
     patch_submodule(module, "xml.dom.minidom.parse", wrap_auth(xxml_dom_minidom_parse)).start()
+    # pyarrow: do not patch pyarrow attribute in packaged modules
+    if not module.__name__.startswith("datasets.packaged_modules."):
+        patch_submodule(module, "pyarrow.parquet.read_table", wrap_auth(xpyarrow_parquet_read_table)).start()
     module._patched_for_streaming = download_config
 
 


### PR DESCRIPTION
Support streaming datasets with `pyarrow.parquet.read_table`.

See: https://huggingface.co/datasets/uonlp/CulturaX/discussions/2

CC: @AndreaFrancis 