### PR TITLE
Check builder cls default config name in inspect

### DIFF
--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -358,7 +358,9 @@ def get_dataset_config_names(
         **download_kwargs,
     )
     builder_cls = get_dataset_builder_class(dataset_module, dataset_name=os.path.basename(path))
-    return list(builder_cls.builder_configs.keys()) or [dataset_module.builder_kwargs.get("config_name", builder_cls.DEFAULT_CONFIG_NAME or "default")]
+    return list(builder_cls.builder_configs.keys()) or [
+        dataset_module.builder_kwargs.get("config_name", builder_cls.DEFAULT_CONFIG_NAME or "default")
+    ]
 
 
 def get_dataset_config_info(

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -358,7 +358,7 @@ def get_dataset_config_names(
         **download_kwargs,
     )
     builder_cls = get_dataset_builder_class(dataset_module, dataset_name=os.path.basename(path))
-    return list(builder_cls.builder_configs.keys()) or [dataset_module.builder_kwargs.get("config_name", "default")]
+    return list(builder_cls.builder_configs.keys()) or [dataset_module.builder_kwargs.get("config_name", builder_cls.DEFAULT_CONFIG_NAME or "default")]
 
 
 def get_dataset_config_info(


### PR DESCRIPTION
Fix https://github.com/huggingface/datasets-server/issues/1812

this was causing this issue:

```ipython
In [1]: from datasets import *

In [2]: inspect.get_dataset_config_names("aakanksha/udpos")
Out[2]: ['default']

In [3]: load_dataset_builder("aakanksha/udpos").config.name
Out[3]: 'en'
```