### PR TITLE
Fix CI 404 errors

### DIFF
--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -43,7 +43,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -65,7 +65,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name.split("/")[-1], token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -88,7 +88,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds_train, "test": ds_test})
 
-        ds_name = f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}"
+        ds_name = f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}"
         try:
             with pytest.raises(ValueError):
                 local_ds.push_to_hub(ds_name.split("/")[-1], token=self._token)
@@ -101,7 +101,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, private=True)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload", token=self._token)
 
@@ -123,7 +123,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -145,7 +145,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             with patch("datasets.config.MAX_SHARD_SIZE", "16KB"):
                 local_ds.push_to_hub(ds_name, token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
@@ -174,7 +174,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, max_shard_size="16KB")
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -202,7 +202,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, num_shards={"train": 2})
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -231,7 +231,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"train": ds, "random": ds2})
 
-        ds_name = f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}"
+        ds_name = f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}"
 
         # Push to hub two times, but the second time with a larger amount of files.
         # Verify that the new files contain the correct dataset.
@@ -332,7 +332,7 @@ class TestPushToHub:
     def test_push_dataset_to_hub(self, temporary_repo):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, split="train", token=self._token)
             local_ds_dict = {"train": local_ds}
             hub_ds_dict = load_dataset(ds_name, download_mode="force_redownload")
@@ -350,7 +350,7 @@ class TestPushToHub:
         features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [0, 0, 1]}, features=features)
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds.push_to_hub(ds_name, token=self._token)
             hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
 
@@ -367,7 +367,7 @@ class TestPushToHub:
         ds = Dataset.from_dict(data, features=features)
 
         for embed_external_files in [True, False]:
-            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
                 ds.push_to_hub(ds_name, embed_external_files=embed_external_files, token=self._token)
                 hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
 
@@ -391,7 +391,7 @@ class TestPushToHub:
         ds = Dataset.from_dict(data, features=features)
 
         for embed_external_files in [True, False]:
-            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
                 ds.push_to_hub(ds_name, embed_external_files=embed_external_files, token=self._token)
                 hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
 
@@ -413,7 +413,7 @@ class TestPushToHub:
         ds = Dataset.from_dict(data, features=features)
 
         for embed_external_files in [True, False]:
-            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
                 ds.push_to_hub(ds_name, embed_external_files=embed_external_files, token=self._token)
                 hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
 
@@ -433,7 +433,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"test": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -444,7 +444,7 @@ class TestPushToHub:
     def test_push_dataset_to_hub_custom_splits(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds.push_to_hub(ds_name, split="random", token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -454,7 +454,7 @@ class TestPushToHub:
 
     def test_push_dataset_to_hub_skip_identical_files(self, temporary_repo):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             with patch("datasets.arrow_dataset.HfApi.upload_file", side_effect=self._api.upload_file) as mock_hf_api:
                 # Initial push
                 ds.push_to_hub(ds_name, token=self._token, max_shard_size="1KB")
@@ -479,7 +479,7 @@ class TestPushToHub:
 
     def test_push_dataset_to_hub_multiple_splits_one_by_one(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds.push_to_hub(ds_name, split="train", token=self._token)
             ds.push_to_hub(ds_name, split="test", token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
@@ -493,7 +493,7 @@ class TestPushToHub:
 
         local_ds = DatasetDict({"random": ds})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token)
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -509,7 +509,7 @@ class TestPushToHub:
             local_ds.save_to_disk(tmp)
             local_ds = load_dataset(tmp, streaming=True)
 
-            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+            with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
                 local_ds.push_to_hub(ds_name, token=self._token)
                 hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
@@ -522,7 +522,7 @@ class TestPushToHub:
         ds_config1 = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_config2 = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
@@ -556,7 +556,7 @@ class TestPushToHub:
         ds_config1 = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_config2 = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
@@ -600,7 +600,7 @@ class TestPushToHub:
         ds_config1 = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_config2 = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
@@ -639,7 +639,7 @@ class TestPushToHub:
         ds_config1 = DatasetDict({"random": ds_config1})
         ds_config2 = DatasetDict({"random": ds_config2})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
@@ -676,7 +676,7 @@ class TestPushToHub:
         ds_config1 = DatasetDict({"train": ds_config1, "random": ds_config1})
         ds_config2 = DatasetDict({"train": ds_config2, "random": ds_config2})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
@@ -729,7 +729,7 @@ class TestPushToHub:
         ds_config1 = DatasetDict({"train": ds_config1, "random": ds_config1})
         ds_config2 = DatasetDict({"train": ds_config2, "random": ds_config2})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
@@ -770,7 +770,7 @@ class TestPushToHub:
         ds.to_parquet(parquet_buf)
         parquet_content = parquet_buf.getvalue()
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             self._api.create_repo(ds_name, token=self._token, repo_type="dataset")
             # old push_to_hub was uploading the parquet files only - without metadata configs
             self._api.upload_file(
@@ -804,7 +804,7 @@ class TestPushToHub:
 
         local_ds_another_config = DatasetDict({"random": ds_another_config})
 
-        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e6)}") as ds_name:
             self._api.create_repo(ds_name, token=self._token, repo_type="dataset")
             # old push_to_hub was uploading the parquet files only - without metadata configs
             self._api.upload_file(


### PR DESCRIPTION
Currently our CI usually raises 404 errors when trying to delete temporary repositories. See, e.g.: https://github.com/huggingface/datasets/actions/runs/6314980985/job/17146507884
```
FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_dict_to_hub_multiple_files_with_max_shard_size - huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error. (Request ID: Root=1-6512fb99-4a52c561752ece3d77eb6d57;2b61cae4-613d-4a73-bbb1-2faf9e32b02d)
Repository Not Found for url: https://hub-ci.huggingface.co/api/repos/delete.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.

FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_to_hub_custom_features_audio - huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error. (Request ID: Root=1-6512fbb2-0333dd666d42f0e173c2bb68;dfdc4271-b49b-4008-8c49-f05cf7c1d53d)
Repository Not Found for url: https://hub-ci.huggingface.co/api/repos/delete.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.

FAILED tests/test_upstream_hub.py::TestPushToHub::test_push_dataset_dict_to_hub_custom_splits - huggingface_hub.utils._errors.RepositoryNotFoundError: 404 Client Error. (Request ID: Root=1-6512fbca-167690694f39770a5b3a444e;baeaa905-0a57-4585-ac97-9aaae12dd47d)
Repository Not Found for url: https://hub-ci.huggingface.co/api/repos/delete.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
```

I think this can be caused by collisions in temporary repository IDs because we create them in multiprocessing:
```python
with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
```

This PR tries to fix this issue by increasing the precision of the number on the repository ID: `10e6` instead of `10e3`.
