### PR TITLE
Temporarily pin tensorflow < 2.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ TESTS_REQUIRE = [
     "rarfile>=4.0",
     "sqlalchemy<2.0.0",
     "s3fs>=2021.11.1",  # aligned with fsspec[http]>=2021.11.1; test only on python 3.7 for now
-    "tensorflow>=2.3,!=2.6.0,!=2.6.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "tensorflow>=2.3,!=2.6.0,!=2.6.1,<2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'",  # Temporary upper pin
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "tiktoken",
     "torch",


### PR DESCRIPTION
Temporarily pin tensorflow < 2.14.0 until permanent solution is found.

Hot fix #6263.