### PR TITLE
Create DefunctDatasetError

### DIFF
--- a/src/datasets/exceptions.py
+++ b/src/datasets/exceptions.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 The HuggingFace Authors.
+
+
+class DatasetsError(Exception):
+    """Base class for exceptions in this library."""
+
+    pass
+
+
+class DefunctDatasetError(DatasetsError):
+    """The dataset has been defunct."""
+
+    pass


### PR DESCRIPTION
Create `DefunctDatasetError` as a specific error to be raised when a dataset is defunct and no longer accessible.