### PR TITLE
Fix parquet columns argument in streaming mode

### DIFF
--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -49,13 +49,12 @@ class Parquet(datasets.ArrowBasedBuilder):
             if self.info.features is None:
                 for file in itertools.chain.from_iterable(files):
                     with open(file, "rb") as f:
-                        features = datasets.Features.from_arrow_schema(pq.read_schema(f))
-                        if self.config.columns is not None:
-                            features = datasets.Features(
-                                {col: feat for col, feat in features.items() if col in self.config.columns}
-                            )
-                        self.info.features = features
+                        self.info.features = datasets.Features.from_arrow_schema(pq.read_schema(f))
                     break
+            if self.config.columns is not None:
+                self.info.features = datasets.Features(
+                    {col: feat for col, feat in self.info.features.items() if col in self.config.columns}
+                )
             splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -1,7 +1,7 @@
 import pyarrow.parquet as pq
 import pytest
 
-from datasets import Audio, Dataset, DatasetDict, Features, NamedSplit, Sequence, Value, config
+from datasets import Audio, Dataset, DatasetDict, Features, IterableDatasetDict, NamedSplit, Sequence, Value, config
 from datasets.features.image import Image
 from datasets.io.parquet import ParquetDatasetReader, ParquetDatasetWriter, get_writer_batch_size
 
@@ -69,12 +69,12 @@ def test_dataset_from_parquet_path_type(path_type, parquet_path, tmp_path):
 
 
 def _check_parquet_datasetdict(dataset_dict, expected_features, splits=("train",)):
-    assert isinstance(dataset_dict, DatasetDict)
+    assert isinstance(dataset_dict, (DatasetDict, IterableDatasetDict))
     for split in splits:
         dataset = dataset_dict[split]
-        assert dataset.num_rows == 4
-        assert dataset.num_columns == 3
-        assert dataset.column_names == ["col_1", "col_2", "col_3"]
+        assert len(list(dataset)) == 4
+        assert dataset.features is not None
+        assert set(dataset.features) == set(expected_features)
         for feature, expected_dtype in expected_features.items():
             assert dataset.features[feature].dtype == expected_dtype
 
@@ -90,6 +90,7 @@ def test_parquet_datasetdict_reader_keep_in_memory(keep_in_memory, parquet_path,
     _check_parquet_datasetdict(dataset, expected_features)
 
 
+@pytest.mark.parametrize("streaming", [False, True])
 @pytest.mark.parametrize(
     "features",
     [
@@ -100,14 +101,30 @@ def test_parquet_datasetdict_reader_keep_in_memory(keep_in_memory, parquet_path,
         {"col_1": "float32", "col_2": "float32", "col_3": "float32"},
     ],
 )
-def test_parquet_datasetdict_reader_features(features, parquet_path, tmp_path):
+def test_parquet_datasetdict_reader_features(streaming, features, parquet_path, tmp_path):
     cache_dir = tmp_path / "cache"
     default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     expected_features = features.copy() if features else default_expected_features
     features = (
         Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
     )
-    dataset = ParquetDatasetReader({"train": parquet_path}, features=features, cache_dir=cache_dir).read()
+    dataset = ParquetDatasetReader(
+        {"train": parquet_path}, features=features, cache_dir=cache_dir, streaming=streaming
+    ).read()
+    _check_parquet_datasetdict(dataset, expected_features)
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("columns", [None, ["col_1"]])
+def test_parquet_datasetdict_reader_columns(streaming, columns, parquet_path, tmp_path):
+    cache_dir = tmp_path / "cache"
+    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    expected_features = (
+        {col: default_expected_features[col] for col in columns} if columns else default_expected_features
+    )
+    dataset = ParquetDatasetReader(
+        {"train": parquet_path}, columns=columns, cache_dir=cache_dir, streaming=streaming
+    ).read()
     _check_parquet_datasetdict(dataset, expected_features)
 
 


### PR DESCRIPTION
It was failing when there's a DatasetInfo with non-None info.features from the YAML (therefore containing columns that should be ignored)

Fix https://github.com/huggingface/datasets/issues/6293