### PR TITLE
Unpin `tensorflow` maximum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ TESTS_REQUIRE = [
     "rarfile>=4.0",
     "sqlalchemy<2.0.0",
     "s3fs>=2021.11.1",  # aligned with fsspec[http]>=2021.11.1; test only on python 3.7 for now
-    "tensorflow>=2.3,!=2.6.0,!=2.6.1,<2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'",  # Temporary upper pin
+    "tensorflow>=2.3,!=2.6.0,!=2.6.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "tensorflow-macos; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "tiktoken",
     "torch",

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -254,7 +254,7 @@ def temp_seed(seed: int, set_pytorch=False, set_tensorflow=False):
 
     if set_tensorflow and config.TF_AVAILABLE:
         import tensorflow as tf
-        from tensorflow.python import context as tfpycontext
+        from tensorflow.python.eager import context as tfpycontext
 
         tf_state = tf.random.get_global_generator()
         temp_gen = tf.random.Generator.from_seed(seed)


### PR DESCRIPTION
Removes the temporary pin introduced in #6264 