### PR TITLE
Add return_file_name in load_dataset

### DIFF
--- a/src/datasets/packaged_modules/pandas/pandas.py
+++ b/src/datasets/packaged_modules/pandas/pandas.py
@@ -15,6 +15,7 @@ class PandasConfig(datasets.BuilderConfig):
     """BuilderConfig for Pandas."""
 
     features: Optional[datasets.Features] = None
+    include_file_name: bool = False
 
     def __post_init__(self):
         super().__post_init__()
@@ -62,4 +63,10 @@ class Pandas(datasets.ArrowBasedBuilder):
         for i, file in enumerate(itertools.chain.from_iterable(files)):
             with open(file, "rb") as f:
                 pa_table = pa.Table.from_pandas(pd.read_pickle(f))
-                yield i, self._cast_table(pa_table)
+                if self.config.include_file_name:
+                    if "file_name" in pa_table.schema.names:
+                        raise ValueError(
+                            "Column 'file_name' already present in data therefore include_file_name should be False."
+                        )
+                    pa_table = pa_table.append_column("file_name", pa.array([file] * len(pa_table)))
+                yield i, pa_table

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -248,3 +248,22 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
     generator = builder._generate_tables([[request.getfixturevalue(file_fixture)]])
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa_table.column_names == ["ID", "Language", "Topic"]
+
+
+@pytest.mark.parametrize(
+    "file_fixture, config_kwargs",
+    [
+        ("jsonl_file", {"include_file_name": True}),
+        ("json_file_with_list_of_dicts", {"include_file_name": True}),
+    ],
+)
+def test_json_generate_tables_include_file_name(file_fixture, config_kwargs, request):
+    json = Json(**config_kwargs)
+    fixture_value = request.getfixturevalue(file_fixture)
+    generator = json._generate_tables([[fixture_value]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.to_pydict() == {
+        "col_1": [-1, 1, 10],
+        "col_2": [None, 2, 20],
+        "file_name": [fixture_value] * len(pa_table),
+    }


### PR DESCRIPTION
Proposition to fix #5806.

Added an optional parameter `return_file_name` in the dataset builder config. When set to `True`, the function will include the file name corresponding to the sample in the returned output.

There is a difference between arrow-based and folder-based datasets to return the file name:
- for arrow-based: a column is concatenated after the table is cast.
- for folder-based: `dataset.info.features` has the entry `file_name` and the original file name is passed to the `sample_metadata` dictionary. 

The difference in behavior might be a concern, also I do not know whether the `file_name` should return the original file path or the downloaded one for folder-based datasets.

I added some tests for the datasets that already had a test file.