### PR TITLE
docs: resolving namespace conflict, refactored variable 

### DIFF
--- a/docs/source/about_arrow.md
+++ b/docs/source/about_arrow.md
@@ -43,8 +43,8 @@ Iterating over a memory-mapped dataset using Arrow is fast. Iterating over Wikip
 ...     ...
 ... """
 
->>> time = timeit.timeit(stmt=s, number=1, globals=globals())
->>> print(f"Time to iterate over the {wiki.dataset_size >> 30} GB dataset: {time:.1f} sec, "
-...       f"ie. {float(wiki.dataset_size >> 27)/time:.1f} Gb/s")
+>>> elapsed_time = timeit.timeit(stmt=s, number=1, globals=globals())
+>>> print(f"Time to iterate over the {wiki.dataset_size >> 30} GB dataset: {elapsed_time:.1f} sec, "
+...       f"ie. {float(wiki.dataset_size >> 27)/elapsed_time:.1f} Gb/s")
 Time to iterate over the 18 GB dataset: 31.8 sec, ie. 4.8 Gb/s
 ```


### PR DESCRIPTION
In docs of about_arrow.md, in the below example code
![image](https://github.com/huggingface/datasets/assets/74114936/fc70e152-e15f-422e-949a-1c4c4c9aa116)
The variable name 'time' was being used in a way that could potentially lead to a namespace conflict with Python's built-in 'time' module. It is not a good convention and can lead to unintended variable shadowing for any user re-using the example code.
To ensure code clarity, and prevent potential naming conflicts renamed the variable 'time' to 'elapsed_time' in the example  code.