### PR TITLE
Fix commit message formatting in multi-commit uploads

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5513,11 +5513,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         dataset_card = DatasetCard(f"---\n{dataset_card_data}\n---\n") if dataset_card is None else dataset_card
         additions.append(CommitOperationAdd(path_in_repo="README.md", path_or_fileobj=str(dataset_card).encode()))
 
+        commit_message = commit_message if commit_message is not None else "Upload dataset"
         if len(additions) <= config.UPLOADS_MAX_NUMBER_PER_COMMIT:
             api.create_commit(
                 repo_id,
                 operations=additions + deletions,
-                commit_message=commit_message if commit_message is not None else "Upload dataset",
+                commit_message=commit_message,
                 token=token,
                 repo_type="dataset",
                 revision=revision,
@@ -5532,13 +5533,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 operations = additions[
                     i * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1) * config.UPLOADS_MAX_NUMBER_PER_COMMIT
                 ] + (deletions if i == 0 else [])
-                commit_message = (
-                    commit_message if commit_message is not None else "Upload dataset"
-                ) + f" (part {i:05d}-of-{num_commits:05d})"
                 api.create_commit(
                     repo_id,
                     operations=operations,
-                    commit_message=commit_message,
+                    commit_message=commit_message + f" (part {i:05d}-of-{num_commits:05d})",
                     token=token,
                     repo_type="dataset",
                     revision=revision,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1801,13 +1801,13 @@ class DatasetDict(dict):
                 f"Number of files to upload is larger than {config.UPLOADS_MAX_NUMBER_PER_COMMIT}. Splitting the push into multiple commits."
             )
             num_commits = math.ceil(len(additions) / config.UPLOADS_MAX_NUMBER_PER_COMMIT)
+            commit_message = commit_message if commit_message is not None else "Upload dataset"
             for i in range(0, num_commits):
                 operations = additions[
                     i * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1) * config.UPLOADS_MAX_NUMBER_PER_COMMIT
                 ] + (deletions if i == 0 else [])
-                commit_message = (
-                    commit_message if commit_message is not None else "Upload dataset"
-                ) + f" (part {i:05d}-of-{num_commits:05d})"
+                part_number = f"{i:05d}-of-{num_commits:05d}"
+                commit_message = f"{commit_message} (part {part_number})"
                 api.create_commit(
                     repo_id,
                     operations=operations,
@@ -1822,6 +1822,7 @@ class DatasetDict(dict):
                     + (f" (still {num_commits - i - 1} to go)" if num_commits - i - 1 else "")
                     + "."
                 )
+
 
 
 class IterableDatasetDict(dict):

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1809,7 +1809,7 @@ class DatasetDict(dict):
                 api.create_commit(
                     repo_id,
                     operations=operations,
-                    commit_message=commit_message + f"{i:05d}-of-{num_commits:05d}",
+                    commit_message=commit_message + f" (part {i:05d}-of-{num_commits:05d})",
                     token=token,
                     repo_type="dataset",
                     revision=revision,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1786,11 +1786,12 @@ class DatasetDict(dict):
         dataset_card = DatasetCard(f"---\n{dataset_card_data}\n---\n") if dataset_card is None else dataset_card
         additions.append(CommitOperationAdd(path_in_repo="README.md", path_or_fileobj=str(dataset_card).encode()))
 
+        commit_message = commit_message if commit_message is not None else "Upload dataset"
         if len(additions) <= config.UPLOADS_MAX_NUMBER_PER_COMMIT:
             api.create_commit(
                 repo_id,
                 operations=additions + deletions,
-                commit_message=commit_message if commit_message is not None else "Upload dataset",
+                commit_message=commit_message,
                 token=token,
                 repo_type="dataset",
                 revision=revision,
@@ -1801,16 +1802,14 @@ class DatasetDict(dict):
                 f"Number of files to upload is larger than {config.UPLOADS_MAX_NUMBER_PER_COMMIT}. Splitting the push into multiple commits."
             )
             num_commits = math.ceil(len(additions) / config.UPLOADS_MAX_NUMBER_PER_COMMIT)
-            commit_message = commit_message if commit_message is not None else "Upload dataset"
             for i in range(0, num_commits):
                 operations = additions[
                     i * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1) * config.UPLOADS_MAX_NUMBER_PER_COMMIT
                 ] + (deletions if i == 0 else [])
-                part_number = f"{i:05d}-of-{num_commits:05d}"
                 api.create_commit(
                     repo_id,
                     operations=operations,
-                    commit_message=f"{commit_message} (part {part_number})",
+                    commit_message=commit_message + f"{i:05d}-of-{num_commits:05d}",
                     token=token,
                     repo_type="dataset",
                     revision=revision,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1807,11 +1807,10 @@ class DatasetDict(dict):
                     i * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1) * config.UPLOADS_MAX_NUMBER_PER_COMMIT
                 ] + (deletions if i == 0 else [])
                 part_number = f"{i:05d}-of-{num_commits:05d}"
-                commit_message = f"{commit_message} (part {part_number})"
                 api.create_commit(
                     repo_id,
                     operations=operations,
-                    commit_message=commit_message,
+                    commit_message=f"{commit_message} (part {part_number})",
                     token=token,
                     repo_type="dataset",
                     revision=revision,
@@ -1822,7 +1821,6 @@ class DatasetDict(dict):
                     + (f" (still {num_commits - i - 1} to go)" if num_commits - i - 1 else "")
                     + "."
                 )
-
 
 
 class IterableDatasetDict(dict):


### PR DESCRIPTION
Currently, the commit message keeps on adding:

- `Upload dataset (part 00000-of-00002)`
- `Upload dataset (part 00000-of-00002) (part 00001-of-00002)`

Introduced in https://github.com/huggingface/datasets/pull/6269

This PR fixes this issue to have

- `Upload dataset (part 00000-of-00002)`
- `Upload dataset (part 00001-of-00002)`