### PR TITLE
Deterministic set hash

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -738,6 +738,29 @@ def pklregister(t):
 
 if config.DILL_VERSION < version.parse("0.3.6"):
 
+    @pklregister(set)
+    def _save_set(pickler, obj):
+        dill._dill.log.info(f"Se: {obj}")
+        from datasets.fingerprint import Hasher
+
+        args = (sorted(obj, key=Hasher.hash),)
+        pickler.save_reduce(set, args, obj=obj)
+        dill._dill.log.info("# Se")
+
+elif config.DILL_VERSION.release[:3] in [version.parse("0.3.6").release, version.parse("0.3.7").release]:
+
+    @pklregister(set)
+    def _save_set(pickler, obj):
+        dill._dill.logger.trace(pickler, "Se: %s", obj)
+        from datasets.fingerprint import Hasher
+
+        args = (sorted(obj, key=Hasher.hash),)
+        pickler.save_reduce(set, args, obj=obj)
+        dill._dill.logger.trace(pickler, "# Se")
+
+
+if config.DILL_VERSION < version.parse("0.3.6"):
+
     @pklregister(CodeType)
     def _save_code(pickler, obj):
         """


### PR DESCRIPTION
Sort the items in a set according to their `datasets.fingerprint.Hasher.hash` hash to get a deterministic hash of sets.

This is useful to get deterministic hashes of tokenizers that use a trie based on python sets.

reported in https://github.com/huggingface/datasets/issues/3847