### PR TITLE
Temporarily pin fsspec < 2023.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ REQUIRED_PKGS = [
     "multiprocess",
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0",
+    "fsspec[http]>=2023.1.0<2023.10.0",  # Temporary upper pin: https://github.com/huggingface/datasets/issues/6330
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co


### PR DESCRIPTION
Temporarily pin fsspec < 2023.10.0 until permanent solution is found.

Hot fix #6330.