### PR TITLE
datasets.filesystems: fix is_remote_filesystems

### DIFF
--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -51,10 +51,11 @@ def is_remote_filesystem(fs: fsspec.AbstractFileSystem) -> bool:
         fs (`fsspec.spec.AbstractFileSystem`):
             An abstract super-class for pythonic file-systems, e.g. `fsspec.filesystem(\'file\')` or [`datasets.filesystems.S3FileSystem`].
     """
-    if fs is not None and fs.protocol != "file":
-        return True
-    else:
-        return False
+    if fs is not None:
+        protocols = (p,) if isinstance(p := fs.protocol, str) else p
+        if "file" not in protocols:
+            return True
+    return False
 
 
 def rename(fs: fsspec.AbstractFileSystem, src: str, dst: str):


### PR DESCRIPTION
Close #6330

`fsspec.implementations.LocalFilesystem.protocol`
was changed from `str` "file" to `tuple[str,...]` ("file", "local") in `fsspec>=2023.10.0`

This commit supports both styles.