### PR TITLE
Pin supported upper version of fsspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ REQUIRED_PKGS = [
     "multiprocess",
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0",
+    "fsspec[http]>=2023.1.0,<=2023.10.0",
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co


### PR DESCRIPTION
Pin upper version of `fsspec` to avoid disruptions introduced by breaking changes (and the need of urgent patch releases with hotfixes) on each release on their side. See:
- #6331
- #6210 
- #5731
- #5617
- #5447

I propose that we explicitly test, introduce fixes and support each new `fsspec` version release.

CC: @LysandreJik 