### PR TITLE
Fix UnboundLocalError if preprocessing doesn't returns an empty list

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -734,9 +734,8 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 new_key = "_".join(str(key) for key in keys)
                 # yield one example at a time from the transformed batch
                 for example in _batch_to_examples(transformed_batch):
-                    current_idx += 1
                     yield new_key, example
-                        
+                    current_idx += 1
         else:
             for key, example in iterator:
                 # If not batched, we can apply the transform and yield the example directly
@@ -894,9 +893,8 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                 # yield one example at a time from the batch
                 for (key_example, to_keep) in zip(key_examples_list, mask):
                     if to_keep:
-                        current_idx += 1
                         yield key_example
-                        
+                    current_idx += 1    
         else:
             for key, example in iterator:
                 # If not batched, we can apply the filtering function direcly

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -891,7 +891,7 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                     function_args.append([current_idx + i for i in range(len(key_examples_list))])
                 mask = self.function(*function_args, **self.fn_kwargs)
                 # yield one example at a time from the batch
-                for (key_example, to_keep) in zip(key_examples_list, mask):
+                for key_example, to_keep in zip(key_examples_list, mask):
                     if to_keep:
                         yield key_example
                     current_idx += 1

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -894,7 +894,7 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                 for (key_example, to_keep) in zip(key_examples_list, mask):
                     if to_keep:
                         yield key_example
-                    current_idx += 1    
+                    current_idx += 1
         else:
             for key, example in iterator:
                 # If not batched, we can apply the filtering function direcly

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -735,7 +735,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 # yield one example at a time from the transformed batch
                 for batch_idx, example in enumerate(_batch_to_examples(transformed_batch)):
                     yield new_key, example
-                current_idx += batch_idx + 1
+                try:
+                    current_idx += batch_idx + 1
+                except:
+                    current_idx += 1
         else:
             for key, example in iterator:
                 # If not batched, we can apply the transform and yield the example directly
@@ -894,7 +897,10 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                 for batch_idx, (key_example, to_keep) in enumerate(zip(key_examples_list, mask)):
                     if to_keep:
                         yield key_example
-                current_idx += batch_idx + 1
+                try:
+                    current_idx += batch_idx + 1
+                except:
+                    current_idx += 1
         else:
             for key, example in iterator:
                 # If not batched, we can apply the filtering function direcly

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -733,9 +733,10 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 # the new key is the concatenation of the examples keys from the batch
                 new_key = "_".join(str(key) for key in keys)
                 # yield one example at a time from the transformed batch
-                for batch_idx, example in enumerate(_batch_to_examples(transformed_batch)):
+                for example in _batch_to_examples(transformed_batch):
+                    current_idx += 1
                     yield new_key, example
-                        current_idx += 1
+                        
         else:
             for key, example in iterator:
                 # If not batched, we can apply the transform and yield the example directly
@@ -891,10 +892,11 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                     function_args.append([current_idx + i for i in range(len(key_examples_list))])
                 mask = self.function(*function_args, **self.fn_kwargs)
                 # yield one example at a time from the batch
-                for batch_idx, (key_example, to_keep) in enumerate(zip(key_examples_list, mask)):
+                for (key_example, to_keep) in zip(key_examples_list, mask):
                     if to_keep:
-                        yield key_example
                         current_idx += 1
+                        yield key_example
+                        
         else:
             for key, example in iterator:
                 # If not batched, we can apply the filtering function direcly

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -735,10 +735,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 # yield one example at a time from the transformed batch
                 for batch_idx, example in enumerate(_batch_to_examples(transformed_batch)):
                     yield new_key, example
-                try:
-                    current_idx += batch_idx + 1
-                except:
-                    current_idx += 1
+                        current_idx += 1
         else:
             for key, example in iterator:
                 # If not batched, we can apply the transform and yield the example directly
@@ -897,10 +894,7 @@ class FilteredExamplesIterable(_BaseExamplesIterable):
                 for batch_idx, (key_example, to_keep) in enumerate(zip(key_examples_list, mask)):
                     if to_keep:
                         yield key_example
-                try:
-                    current_idx += batch_idx + 1
-                except:
-                    current_idx += 1
+                        current_idx += 1
         else:
             for key, example in iterator:
                 # If not batched, we can apply the filtering function direcly


### PR DESCRIPTION
If this tokenization function is used with IterableDatasets and no sample is as big as the context length, `input_batch` will be an empty list.
```
def tokenize(batch, tokenizer, context_length):
    outputs = tokenizer(
        batch["text"],
        truncation=True,
        max_length=context_length,
        return_overflowing_tokens=True,
        return_length=True
    )
    input_batch = []
    for length, input_ids in zip(outputs["length"], outputs["input_ids"]):
        if length == context_length:
            input_batch.append(input_ids)
    return {"input_ids": input_batch}

dataset.map(tokenize, batched=True, batch_size=batch_size, fn_kwargs={"context_length": context_length, "tokenizer": tokenizer}, remove_columns=dataset.column_names)
```

This will throw the following error: UnboundLocalError: local variable 'batch_idx' referenced before assignment, because the for loop was not executed a single time

```
for batch_idx, example in enumerate(_batch_to_examples(transformed_batch)):
     yield new_key, example
current_idx += batch_idx + 1
```

Some of the possible solutions

```
for batch_idx, example in enumerate(_batch_to_examples(transformed_batch)):
     yield new_key, example
try:
     current_idx += batch_idx + 1
except:
     current_idx += 1
```

or 

```
batch_idx = 0
for batch_idx, example in enumerate(_batch_to_examples(transformed_batch)):
     yield new_key, example
current_idx += batch_idx + 1
```