### PR TITLE
Add `fsspec` version to the `datasets-cli env` command output

### DIFF
--- a/src/datasets/commands/env.py
+++ b/src/datasets/commands/env.py
@@ -1,6 +1,7 @@
 import platform
 from argparse import ArgumentParser
 
+import fsspec
 import huggingface_hub
 import pandas
 import pyarrow
@@ -24,9 +25,10 @@ class EnvironmentCommand(BaseDatasetsCLICommand):
             "`datasets` version": version,
             "Platform": platform.platform(),
             "Python version": platform.python_version(),
-            "Huggingface_hub version": huggingface_hub.__version__,
+            "`huggingface_hub` version": huggingface_hub.__version__,
             "PyArrow version": pyarrow.__version__,
             "Pandas version": pandas.__version__,
+            "`fsspec` version": fsspec.__version__,
         }
 
         print("\nCopy-and-paste the text below in your GitHub issue.\n")


### PR DESCRIPTION
... to make debugging issues easier, as `fsspec`'s releases often introduce breaking changes.