### PR TITLE
Temporarily pin pyarrow < 14.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill
+        run: pip install --upgrade "pyarrow<14.0.0" huggingface-hub dill
       - name: Install depencencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
         run: pip install pyarrow==8.0.0 huggingface-hub==0.18.0 transformers dill==0.3.1.1

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ REQUIRED_PKGS = [
     "numpy>=1.17",
     # Backend and serialization.
     # Minimum 8.0.0 to be able to use .to_reader()
-    "pyarrow>=8.0.0",
+    "pyarrow>=8.0.0,<14.0.0",  # temporary upper pin
     # For smart caching dataset processing
     "dill>=0.3.0,<0.3.8",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
     # For performance gains with apache arrow


### PR DESCRIPTION
Temporarily pin `pyarrow` < 14.0.0 until permanent solution is found.

Hot fix #6374.