### PR TITLE
Avoid redundant warning when encoding NumPy array as `Image`

### DIFF
--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -321,32 +321,34 @@ def encode_np_array(array: np.ndarray) -> dict:
 
     dest_dtype = None
 
+    # import pdb; pdb.set_trace()
+
     # Multi-channel array case (only np.dtype("|u1") is allowed)
     if array.shape[2:]:
-        dest_dtype = np.dtype("|u1")
         if dtype_kind not in ["u", "i"]:
             raise TypeError(
                 f"Unsupported array dtype {dtype} for image encoding. Only {dest_dtype} is supported for multi-channel arrays."
             )
-        if dtype is not dest_dtype:
+        dest_dtype = np.dtype("|u1")
+        if dtype != dest_dtype:
             warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
     # Exact match
     elif dtype in _VALID_IMAGE_ARRAY_DTPYES:
         dest_dtype = dtype
     else:  # Downcast the type within the kind (np.can_cast(from_type, to_type, casting="same_kind") doesn't behave as expected, so do it manually)
         while dtype_itemsize >= 1:
-            dest_dtype_str = dtype_byteorder + dtype_kind + str(dtype_itemsize)
-            dest_dtype = np.dtype(dest_dtype_str)
-            if dest_dtype in _VALID_IMAGE_ARRAY_DTPYES:
+            dtype_str = dtype_byteorder + dtype_kind + str(dtype_itemsize)
+            if np.dtype(dtype_str) in _VALID_IMAGE_ARRAY_DTPYES:
+                dest_dtype = np.dtype(dtype_str)
                 warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
                 break
             else:
                 dtype_itemsize //= 2
+        if dest_dtype is None:
+            raise TypeError(
+                f"Cannot downcast dtype {dtype} to a valid image dtype. Valid image dtypes: {_VALID_IMAGE_ARRAY_DTPYES}"
+            )
 
-    if dest_dtype is None:
-        raise TypeError(
-            f"Cannot convert dtype {dtype} to a valid image dtype. Valid image dtypes: {_VALID_IMAGE_ARRAY_DTPYES}"
-        )
     image = PIL.Image.fromarray(array.astype(dest_dtype))
     return {"path": None, "bytes": image_to_bytes(image)}
 

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -321,8 +321,6 @@ def encode_np_array(array: np.ndarray) -> dict:
 
     dest_dtype = None
 
-    # import pdb; pdb.set_trace()
-
     # Multi-channel array case (only np.dtype("|u1") is allowed)
     if array.shape[2:]:
         if dtype_kind not in ["u", "i"]:

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -677,6 +677,7 @@ def test_image_embed_storage(shared_datadir):
         (np.arange(16).reshape(4, 4).astype(np.uint8), "exact_match", "PNG"),
         (np.arange(16).reshape(4, 4).astype(np.uint16), "exact_match", "TIFF"),
         (np.arange(16).reshape(4, 4).astype(np.int64), "downcast->|i4", "TIFF"),
+        (np.arange(16).reshape(4, 4).astype(np.complex128), "error", None),
         (np.arange(16).reshape(2, 2, 4).astype(np.uint8), "exact_match", "PNG"),
         (np.arange(16).reshape(2, 2, 4), "downcast->|u1", "PNG"),
         (np.arange(16).reshape(2, 2, 4).astype(np.float64), "error", None),


### PR DESCRIPTION
Avoid a redundant warning in `encode_np_array` by removing the identity check as NumPy `dtype`s can be equal without having identical `id`s.

Additionally, fix "unreachable" checks in `encode_np_array`.