### PR TITLE
Fix for continuation behaviour on broken dataset archives on starving download connections via HTTP-GET

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -416,9 +416,15 @@ def http_get(
         desc=desc or "Downloading",
         disable=not logging.is_progress_bar_enabled(),
     ) as progress:
+        received_bytes = 0
         for chunk in response.iter_content(chunk_size=1024):
-            progress.update(len(chunk))
+            chunk_size = len(chunk)
+            received_bytes += chunk_size
+            progress.update(chunk_size)
             temp_file.write(chunk)
+        # Check received vs total
+        if (resume_size + received_bytes) < total:
+            raise RuntimeError("data received is incomplete")
 
 
 def http_head(
@@ -641,16 +647,32 @@ def get_from_cache(
             elif scheme not in ("http", "https"):
                 fsspec_get(url, temp_file, storage_options=storage_options, desc=download_desc)
             else:
-                http_get(
-                    url,
-                    temp_file,
-                    proxies=proxies,
-                    resume_size=resume_size,
-                    headers=headers,
-                    cookies=cookies,
-                    max_retries=max_retries,
-                    desc=download_desc,
-                )
+                tries, success = 0, False
+                while not success:
+                    tries += 1
+                    try:
+                        http_get(
+                            url,
+                            temp_file,
+                            proxies=proxies,
+                            resume_size=resume_size,
+                            headers=headers,
+                            cookies=cookies,
+                            max_retries=max_retries,
+                            desc=download_desc,
+                        )
+                        success = True
+                    except RuntimeError as err:
+                        if tries > max_retries:
+                            raise err
+                        else:
+                            # Timeout before retry
+                            base_wait_time, max_wait_time = 0.5, 2
+                            logger.info(f"{scheme} request to {url} timed out, retrying... [{tries / max_retries}]")
+                            sleep_time = min(max_wait_time, base_wait_time * 2 ** (tries - 1))  # Exponential backoff
+                            time.sleep(sleep_time)
+                            # Update resume size
+                            resume_size = os.stat(temp_file.name).st_size
 
         logger.info(f"storing {url} in cache at {cache_path}")
         shutil.move(temp_file.name, cache_path)


### PR DESCRIPTION
This PR proposes a (slightly hacky) fix for an Issue that can occur when downloading large dataset parts over unstable connections.
The underlying issue is also being discussed in https://github.com/huggingface/datasets/issues/5594.

Issue Symptoms & Behaviour:
- Download of a large archive file during dataset download via HTTP-GET fails.
- An silent net exception (which I was unable to identify) is thrown within the `tqdm` download progress.
- Due to missing exception catch code, the above process just continues processing, assuming `http_get` completed successfully.
- Pending Archive file gets renamed to remove the `.incomplete` extension, despite not all data has been downloaded. 
- Also, for reasons I did not investigate, there seems to be no real integrity check for the downloaded files; or it does not detect this problem. This is especially problematic, since the downloader script won't retry downloading this archive after CRC-Checking, even if it is being manually restarted / executed again after running into errors on extraction.

Fix proposal: Adding a retry mechanic for HTTP-GET downloads, which adds the following behaviour:
- Download Progress Thread checks for download size validity in case the HTTP connection starves mid download. If the check fails, a RuntimeError is thrown
- Cache Downloader code with retry mechanic monitors for an exception thrown by the download progress thread, and retries download with updated `resume_size`.
- Cache Downloader will not mark incomplete files which have thrown an exception during download, and exceeded retries, as complete.