### PR TITLE
Fix dependency conflict within CI build documentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,7 @@ TESTS_REQUIRE = [
     "torch",
     "soundfile>=0.12.1",
     "transformers",
+    "typing-extensions>=4.6.1",  # due to conflict between apache-beam and pydantic
     "zstandard",
 ]
 


### PR DESCRIPTION
Manually fix dependency conflict on `typing-extensions` version originated by `apache-beam` + `pydantic` (now a dependency of `huggingface-hub`).
This is a temporary hot fix of our CI build documentation until we stop using `apache-beam`.
Fix #6406.