### PR TITLE
Fix deprecation warning when building conda package

### DIFF
--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Build conda packages
         run: |
           conda info
-          conda-build .github/conda
+          conda build .github/conda
 
       - name: Upload to Anaconda
         run: |
-          anaconda upload `conda-build .github/conda --output -c conda-forge` --force
+          anaconda upload `conda build .github/conda --output -c conda-forge` --force


### PR DESCRIPTION
When building/releasing conda package, we get this deprecation warning:
```
/usr/share/miniconda/envs/build-datasets/bin/conda-build:11: DeprecationWarning: conda_build.cli.main_build.main is deprecated and will be removed in 4.0.0. Use `conda build` instead.
```

This PR fixes the deprecation warning by using `conda build` instead.