### PR TITLE
Use parquet export if possible

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -335,6 +335,8 @@ def resolve_pattern(
     Returns:
         List[str]: List of paths or URLs to the local or remote files that match the patterns.
     """
+    if pattern.startswith(config.HF_ENDPOINT) and not has_magic(pattern):
+        return ["hf://" + pattern[len(config.HF_ENDPOINT) + 1 :].replace("/resolve/", "@", 1)]
     if is_relative_path(pattern):
         pattern = xjoin(base_path, pattern)
     elif is_local_path(pattern):

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -389,8 +389,7 @@ def ftp_get(url, temp_file, timeout=10.0):
 
 def http_get(
     url, temp_file, proxies=None, resume_size=0, headers=None, cookies=None, timeout=100.0, max_retries=0, desc=None
-):
-    headers = copy.deepcopy(headers) or {}
+) -> Optional[requests.Response]:
     headers["user-agent"] = get_datasets_user_agent(user_agent=headers.get("user-agent"))
     if resume_size > 0:
         headers["Range"] = f"bytes={resume_size:d}-"
@@ -404,6 +403,8 @@ def http_get(
         max_retries=max_retries,
         timeout=timeout,
     )
+    if temp_file is None:
+        return response
     if response.status_code == 416:  # Range not satisfiable
         return
     content_length = response.headers.get("Content-Length")
@@ -643,7 +644,7 @@ def get_from_cache(
             else:
                 http_get(
                     url,
-                    temp_file,
+                    temp_file=temp_file,
                     proxies=proxies,
                     resume_size=resume_size,
                     headers=headers,


### PR DESCRIPTION
The idea is to make this code work for dataset with scripts if they have a Parquet export

```python
ds = load_dataset("squad", trust_remote_code=False)
```

And more generally, it means we use the Parquet export whenever it's possible (it's safer and faster than dataset scripts).

Needs https://github.com/huggingface/datasets/pull/6429 to be merged first