### PR TITLE
Don't require trust_remote_code in inspect_dataset

### DIFF
--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -19,11 +19,12 @@ import inspect
 import os
 import shutil
 import warnings
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Dict, List, Mapping, Optional, Sequence, Union
 
 import huggingface_hub
 
+from . import config
 from .download.download_config import DownloadConfig
 from .download.download_manager import DownloadMode
 from .download.streaming_download_manager import StreamingDownloadManager
@@ -141,24 +142,19 @@ def inspect_dataset(path: str, local_path: str, download_config: Optional[Downlo
             Optional arguments for [`DownloadConfig`] which will override
             the attributes of `download_config` if supplied.
     """
-    dataset_module = dataset_module_factory(path, download_config=download_config, **download_kwargs)
-    builder_cls = get_dataset_builder_class(dataset_module)
-    module_source_path = inspect.getsourcefile(builder_cls)
-    module_source_dirpath = os.path.dirname(module_source_path)
-    for dirpath, dirnames, filenames in os.walk(module_source_dirpath):
-        dst_dirpath = os.path.join(local_path, os.path.relpath(dirpath, module_source_dirpath))
-        os.makedirs(dst_dirpath, exist_ok=True)
-        # skipping hidden directories; prune the search
-        # [:] for the in-place list modification required by os.walk
-        dirnames[:] = [dirname for dirname in dirnames if not dirname.startswith((".", "__"))]
-        for filename in filenames:
-            shutil.copy2(os.path.join(dirpath, filename), os.path.join(dst_dirpath, filename))
-        shutil.copystat(dirpath, dst_dirpath)
-    local_path = relative_to_absolute_path(local_path)
+    if download_config is None:
+        download_config = DownloadConfig(**download_kwargs)
+    if os.path.isfile(path):
+        path = str(Path(path).parent)
+    if os.path.isdir(path):
+        shutil.copytree(path, local_path, dirs_exist_ok=True)
+    else:
+        huggingface_hub.HfApi(endpoint=config.HF_ENDPOINT, token=download_config.token).snapshot_download(
+            repo_id=path, repo_type="dataset", local_dir=local_path, force_download=download_config.force_download
+        )
     print(
-        f"The processing script for dataset {path} can be inspected at {local_path}. "
-        f"The main class is in {module_source_dirpath}. "
-        f'You can modify this processing script and use it with `datasets.load_dataset("{PurePath(local_path).as_posix()}")`.'
+        f"The dataset {path} can be inspected at {local_path}. "
+        f'You can modify this loading script  if it has one and use it with `datasets.load_dataset("{PurePath(local_path).as_posix()}")`.'
     )
 
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -10,17 +11,17 @@ from datasets import (
     inspect_dataset,
     inspect_metric,
 )
+from datasets.packaged_modules.csv import csv
 
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.parametrize("path", ["paws", "csv"])
+@pytest.mark.parametrize("path", ["paws", csv.__file__])
 def test_inspect_dataset(path, tmp_path):
     inspect_dataset(path, tmp_path)
-    script_name = path + ".py"
+    script_name = Path(path).stem + ".py"
     assert script_name in os.listdir(tmp_path)
-    assert "__pycache__" not in os.listdir(tmp_path)
 
 
 @pytest.mark.filterwarnings("ignore:inspect_metric is deprecated:FutureWarning")


### PR DESCRIPTION
don't require `trust_remote_code` in (deprecated) `inspect_dataset` (it defeats its purpose)

(not super important but we might as well keep it until the next major release)

this is needed to fix the tests in https://github.com/huggingface/datasets/pull/6448