### PR TITLE
Disable benchmarks in PRs

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,5 +1,8 @@
 name: benchmarks
-on: [push]
+on:
+  push:
+    branches:
+      - main
 jobs:
   run:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
In order to keep PR pages less spammy / more readable.
Having the benchmarks on commits on `main` is enough imo