### PR TITLE
Fallback on dataset script if user wants to load default config

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, Un
 
 import fsspec
 import requests
-from huggingface_hub import DatasetCard, DatasetCardData, HfApi
+from huggingface_hub import DatasetCard, DatasetCardData, HfApi, HfFileSystem
 
 from . import config
 from .arrow_dataset import Dataset
@@ -1621,6 +1621,7 @@ def dataset_module_factory(
     data_dir: Optional[str] = None,
     data_files: Optional[Union[Dict, List, str, DataFilesDict]] = None,
     trust_remote_code: Optional[bool] = None,
+    _ignore_default_config=False,
     **download_kwargs,
 ) -> DatasetModule:
     """
@@ -1772,8 +1773,15 @@ def dataset_module_factory(
                 else:
                     raise e
             if filename in [sibling.rfilename for sibling in dataset_info.siblings]:  # contains a dataset script
-                if config.USE_PARQUET_EXPORT:
+                fs = HfFileSystem(endpoint=config.HF_ENDPOINT, token=download_config.token)
+                with fs.open(f"datasets/{path}/{filename}", "r", revision=revision) as f:
+                    can_load_config_from_parquet_export = (
+                        "DEFAULT_CONFIG_NAME" not in f.read() or _ignore_default_config
+                    )
+                if config.USE_PARQUET_EXPORT and can_load_config_from_parquet_export:
                     # If the parquet export is ready (parquet files + info available for the current sha), we can use it instead
+                    # This fails when the dataset has multiple configs and a default config and
+                    # the user didn't specify a configuration name (_ignore_default_config=False).
                     try:
                         return HubDatasetModuleFactoryWithParquetExport(
                             path, download_config=download_config, revision=dataset_info.sha
@@ -1781,22 +1789,14 @@ def dataset_module_factory(
                     except _datasets_server.DatasetsServerError:
                         pass
                 # Otherwise we must use the dataset script if the user trusts it
-                trust_remote_code = resolve_trust_remote_code(trust_remote_code, path)
-                if trust_remote_code:
-                    return HubDatasetModuleFactoryWithScript(
-                        path,
-                        revision=revision,
-                        download_config=download_config,
-                        download_mode=download_mode,
-                        dynamic_modules_path=dynamic_modules_path,
-                        trust_remote_code=trust_remote_code,
-                    ).get_module()
-                else:
-                    raise ValueError(
-                        f"Loading {path} requires you to execute the dataset script in that"
-                        " repo on your local machine. Make sure you have read the code there to avoid malicious use, then"
-                        " set the option `trust_remote_code=True` to remove this error."
-                    )
+                return HubDatasetModuleFactoryWithScript(
+                    path,
+                    revision=revision,
+                    download_config=download_config,
+                    download_mode=download_mode,
+                    dynamic_modules_path=dynamic_modules_path,
+                    trust_remote_code=trust_remote_code,
+                ).get_module()
             else:
                 return HubDatasetModuleFactoryWithoutScript(
                     path,
@@ -2053,6 +2053,7 @@ def load_dataset_builder(
     use_auth_token="deprecated",
     storage_options: Optional[Dict] = None,
     trust_remote_code: Optional[bool] = None,
+    _ignore_default_config=False,
     **config_kwargs,
 ) -> DatasetBuilder:
     """Load a dataset builder from the Hugging Face Hub, or a local dataset. A dataset builder can be used to inspect general information that is required to build a dataset (cache directory, config, dataset info, etc.)
@@ -2177,6 +2178,7 @@ def load_dataset_builder(
         data_dir=data_dir,
         data_files=data_files,
         trust_remote_code=trust_remote_code,
+        _ignore_default_config=_ignore_default_config,
     )
     # Get dataset builder class from the processing script
     builder_kwargs = dataset_module.builder_kwargs
@@ -2510,6 +2512,7 @@ def load_dataset(
         token=token,
         storage_options=storage_options,
         trust_remote_code=trust_remote_code,
+        _ignore_default_config=name is not None,
         **config_kwargs,
     )
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1774,7 +1774,7 @@ def dataset_module_factory(
                     raise e
             if filename in [sibling.rfilename for sibling in dataset_info.siblings]:  # contains a dataset script
                 fs = HfFileSystem(endpoint=config.HF_ENDPOINT, token=download_config.token)
-                with fs.open(f"datasets/{path}/{filename}", "r", revision=revision) as f:
+                with fs.open(f"datasets/{path}/{filename}", "r", revision=revision, encoding="utf-8") as f:
                     can_load_config_from_parquet_export = (
                         "DEFAULT_CONFIG_NAME" not in f.read() or _ignore_default_config
                     )


### PR DESCRIPTION
Right now this code is failing on `main`:

```python
load_dataset("openbookqa")
```

This is because it tries to load the dataset from the Parquet export but the dataset has multiple configurations and the Parquet export doesn't know which one is the default one.

I fixed this by simply falling back on using the dataset script (which tells the user to pass `trust_remote_code=True`):

```python
load_dataset("openbookqa", trust_remote_code=True)
```

Note that if the user happened to specify a config name I don't fall back on the script since we can use the Parquet export in this case (no need to know which config is the default)


```python
load_dataset("openbookqa", "main")
```