### PR TITLE
Fix streaming xnli

### DIFF
--- a/src/datasets/features/translation.py
+++ b/src/datasets/features/translation.py
@@ -98,7 +98,9 @@ class TranslationVariableLanguages:
 
     def encode_example(self, translation_dict):
         lang_set = set(self.languages)
-        if self.languages and set(translation_dict) - lang_set:
+        if set(translation_dict) == {"language", "translation"}:
+            return translation_dict
+        elif self.languages and set(translation_dict) - lang_set:
             raise ValueError(
                 f'Some languages in example ({", ".join(sorted(set(translation_dict) - lang_set))}) are not in valid set ({", ".join(lang_set)}).'
             )


### PR DESCRIPTION
This code was failing

```python

In [1]: from datasets import load_dataset

In [2]: 
   ...:         ds = load_dataset("xnli", "all_languages", split="test", streaming=True)
   ...: 
   ...:         sample_data = next(iter(ds))["premise"]  # pick up one data
   ...:         input_text = list(sample_data.values())
```

```
File ~/hf/datasets/src/datasets/features/translation.py:104, in TranslationVariableLanguages.encode_example(self, translation_dict)
    102     return translation_dict
    103 elif self.languages and set(translation_dict) - lang_set:
--> 104     raise ValueError(
    105         f'Some languages in example ({", ".join(sorted(set(translation_dict) - lang_set))}) are not in valid set ({", ".join(lang_set)}).'
    106     )
    108 # Convert dictionary into tuples, splitting out cases where there are
    109 # multiple translations for a single language.
    110 translation_tuples = []

ValueError: Some languages in example (language, translation) are not in valid set (ur, fr, hi, sw, vi, el, de, th, en, tr, zh, ar, bg, ru, es).
```

because in streaming mode we expect features encode methods to be no-ops if the example is already encoded.

I fixed `TranslationVariableLanguages` to account for that