### PR TITLE
Implement get dataset default config name

### DIFF
--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -31,6 +31,7 @@ from .info import DatasetInfo, MetricInfo
 from .inspect import (
     get_dataset_config_info,
     get_dataset_config_names,
+    get_dataset_default_config_name,
     get_dataset_infos,
     get_dataset_split_names,
     inspect_dataset,

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -359,6 +359,73 @@ def get_dataset_config_names(
     ]
 
 
+def get_dataset_default_config_name(
+    path: str,
+    revision: Optional[Union[str, Version]] = None,
+    download_config: Optional[DownloadConfig] = None,
+    download_mode: Optional[Union[DownloadMode, str]] = None,
+    dynamic_modules_path: Optional[str] = None,
+    data_files: Optional[Union[Dict, List, str]] = None,
+    **download_kwargs,
+) -> Optional[str]:
+    """Get the default config name for a particular dataset.
+
+    Args:
+        path (`str`): path to the dataset processing script with the dataset builder. Can be either:
+
+            - a local path to processing script or the directory containing the script (if the script has the same name as the directory),
+                e.g. `'./dataset/squad'` or `'./dataset/squad/squad.py'`
+            - a dataset identifier on the Hugging Face Hub (list all available datasets and ids with [`datasets.list_datasets`])
+                e.g. `'squad'`, `'glue'` or `'openai/webtext'`
+        revision (`Union[str, datasets.Version]`, *optional*):
+            If specified, the dataset module will be loaded from the datasets repository at this version.
+            By default:
+            - it is set to the local version of the lib.
+            - it will also try to load it from the main branch if it's not available at the local version of the lib.
+            Specifying a version that is different from your local version of the lib might cause compatibility issues.
+        download_config ([`DownloadConfig`], *optional*):
+            Specific download configuration parameters.
+        download_mode ([`DownloadMode`] or `str`, defaults to `REUSE_DATASET_IF_EXISTS`):
+            Download/generate mode.
+        dynamic_modules_path (`str`, defaults to `~/.cache/huggingface/modules/datasets_modules`):
+            Optional path to the directory in which the dynamic modules are saved. It must have been initialized with `init_dynamic_modules`.
+            By default the datasets and metrics are stored inside the `datasets_modules` module.
+        data_files (`Union[Dict, List, str]`, *optional*):
+            Defining the data_files of the dataset configuration.
+        **download_kwargs (additional keyword arguments):
+            Optional attributes for [`DownloadConfig`] which will override the attributes in `download_config` if supplied,
+            for example `token`.
+
+    Returns:
+        Optional[str]
+
+    Example:
+
+    ```py
+    >>> from datasets import get_dataset_default_config_name
+    >>> get_dataset_default_config_name("openbookqa")
+    'main'
+    ```
+    """
+    dataset_module = dataset_module_factory(
+        path,
+        revision=revision,
+        download_config=download_config,
+        download_mode=download_mode,
+        dynamic_modules_path=dynamic_modules_path,
+        data_files=data_files,
+        **download_kwargs,
+    )
+    builder_cls = get_dataset_builder_class(dataset_module, dataset_name=os.path.basename(path))
+    builder_configs = list(builder_cls.builder_configs.keys())
+    # default_config_name = builder_configs[0] if len(builder_configs) == 1 else None if builder_configs else "default"
+    if builder_configs:
+        default_config_name = builder_configs[0] if len(builder_configs) == 1 else None
+    else:
+        default_config_name = "default"
+    return builder_cls.DEFAULT_CONFIG_NAME or default_config_name
+
+
 def get_dataset_config_info(
     path: str,
     config_name: Optional[str] = None,

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -418,7 +418,6 @@ def get_dataset_default_config_name(
     )
     builder_cls = get_dataset_builder_class(dataset_module, dataset_name=os.path.basename(path))
     builder_configs = list(builder_cls.builder_configs.keys())
-    # default_config_name = builder_configs[0] if len(builder_configs) == 1 else None if builder_configs else "default"
     if builder_configs:
         default_config_name = builder_configs[0] if len(builder_configs) == 1 else None
     else:

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from datasets import (
+from datasets.inspect import (
     get_dataset_config_info,
     get_dataset_config_names,
+    get_dataset_default_config_name,
     get_dataset_infos,
     get_dataset_split_names,
     inspect_dataset,
@@ -80,6 +81,27 @@ def test_get_dataset_config_info_error(path, config_name, expected_exception):
 def test_get_dataset_config_names(path, expected):
     config_names = get_dataset_config_names(path)
     assert config_names == expected
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("acronym_identification", "default"),
+        ("squad", "plain_text"),
+        ("hf-internal-testing/dataset_with_script", "default"),
+        ("dalle-mini/wit", "default"),
+        ("hf-internal-testing/librispeech_asr_dummy", None),
+        ("hf-internal-testing/audiofolder_no_configs_in_metadata", "default"),
+        ("hf-internal-testing/audiofolder_single_config_in_metadata", "custom"),
+        ("hf-internal-testing/audiofolder_two_configs_in_metadata", None),
+    ],
+)
+def test_get_dataset_default_config_name(path, expected):
+    default_config_name = get_dataset_default_config_name(path)
+    if expected:
+        assert default_config_name == expected
+    else:
+        assert default_config_name is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implement `get_dataset_default_config_name`.

Now that we support setting a configuration as default in `push_to_hub` (see #6500), we need a programmatically way to know in advance which is the default configuration. This will be used in the Space to convert script-datasets to Parquet: https://huggingface.co/spaces/albertvillanova/convert-dataset-to-parquet

Follow-up of:
- #6500

CC: @severo 