### PR TITLE
BBox type

### DIFF
--- a/src/datasets/features/__init__.py
+++ b/src/datasets/features/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "Array3D",
     "Array4D",
     "Array5D",
+    "BBox",
     "ClassLabel",
     "Features",
     "Sequence",
@@ -16,5 +17,5 @@ __all__ = [
 ]
 from .audio import Audio
 from .features import Array2D, Array3D, Array4D, Array5D, ClassLabel, Features, Sequence, Value
-from .image import Image
+from .image import BBox, Image
 from .translation import Translation, TranslationVariableLanguages

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -41,7 +41,7 @@ from ..table import array_cast
 from ..utils import logging
 from ..utils.py_utils import asdict, first_non_null_value, zip_dict
 from .audio import Audio
-from .image import Image, encode_pil_image
+from .image import BBox, Image, encode_pil_image
 from .translation import Translation, TranslationVariableLanguages
 
 
@@ -1170,6 +1170,7 @@ FeatureType = Union[
     Array5D,
     Audio,
     Image,
+    BBox,
 ]
 
 
@@ -1294,7 +1295,7 @@ def encode_nested_example(schema, obj, level=0):
             return list(obj)
     # Object with special encoding:
     # ClassLabel will convert from string to int, TranslationVariableLanguages does some checks
-    elif isinstance(schema, (Audio, Image, ClassLabel, TranslationVariableLanguages, Value, _ArrayXD)):
+    elif isinstance(schema, (Audio, Image, BBox, ClassLabel, TranslationVariableLanguages, Value, _ArrayXD)):
         return schema.encode_example(obj) if obj is not None else None
     # Other object should be directly convertible to a native Arrow type (like Translation and Translation)
     return obj
@@ -1333,7 +1334,7 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[Dict[str, Uni
         else:
             return decode_nested_example([schema.feature], obj)
     # Object with special decoding:
-    elif isinstance(schema, (Audio, Image)):
+    elif isinstance(schema, (Audio, Image, BBox)):
         # we pass the token to read and decode files from private repositories in streaming mode
         if obj is not None and schema.decode:
             return schema.decode_example(obj, token_per_repo_id=token_per_repo_id)

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -398,7 +398,15 @@ class BBox:
         return self
 
     def encode_example(self, value: dict) -> dict:
-        return {"bbox": value["bbox"], "categories": value.get("label", value.get("category", value["categories"]))}
+        if "label" in value:
+            categories_field = "label"
+        elif "category" in value:
+            categories_field = "category"
+        elif "categories" in value:
+            categories_field = "categories"
+        else:
+            raise ValueError("Coudnl't find category field")
+        return {"bbox": value["bbox"], "categories": value[categories_field]}
 
     def decode_example(
         self, value: dict, token_per_repo_id: Optional[Dict[str, Union[str, bool, None]]] = None


### PR DESCRIPTION
see [internal discussion](https://huggingface.slack.com/archives/C02EK7C3SHW/p1703097195609209)

Draft to get some feedback on a possible `BBox` feature type that can be used to get object detection bounding boxes data in one format or another.

```python
>>> from datasets import load_dataset, BBox
>>> ds = load_dataset("svhn", "full_numbers", split="train")
>>> ds[0]
{
  'image': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=107x46 at 0x126409BE0>,
  'digits': {'bbox': [[38, 1, 21, 40], [57, 3, 16, 40]], 'label': [4, 6]}
}
>>> ds = ds.rename_column("digits", "annotations").cast_column("annotations", BBox(format="coco"))
>>> ds[0]
{
  'image': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=107x46 at 0x147730070>,
  'annotations': [{'bbox': [38, 1, 21, 40], 'category_id': 4}, {'bbox': [57, 3, 16, 40], 'category_id': 6}]
}
```

note that it's a type for a list of bounding boxes, not just one - which would be needed to switch from a format to another using type casting.