### PR TITLE
Fix dl_manager.extract returning FileNotFoundError

### DIFF
--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -531,10 +531,6 @@ class DownloadManager:
             )
         download_config = self.download_config.copy()
         download_config.extract_compressed_file = True
-        # Extract downloads the file first if it is not already downloaded
-        if download_config.download_desc is None:
-            download_config.download_desc = "Downloading data"
-
         extract_func = partial(self._download, download_config=download_config)
         extracted_paths = map_nested(
             extract_func,

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -218,7 +218,7 @@ def cached_path(
             output_path, force_extract=download_config.force_extract
         )
 
-    return output_path
+    return relative_to_absolute_path(output_path)
 
 
 def get_datasets_user_agent(user_agent: Optional[Union[str, dict]] = None) -> str:


### PR DESCRIPTION
The dl_manager base path is remote (e.g. a hf:// path), so local cached paths should be passed as absolute paths.
This could happen if users provide a relative path as `cache_dir`

fix https://github.com/huggingface/datasets/issues/6536