### PR TITLE
Fix custom configs from script

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -572,16 +572,18 @@ class DatasetBuilder:
                 logger.info(f"No config specified, defaulting to: {self.dataset_name}/{builder_config.name}")
             else:
                 if len(self.BUILDER_CONFIGS) > 1:
-                    example_of_usage = f"load_dataset('{self.dataset_name}', '{self.BUILDER_CONFIGS[0].name}')"
-                    raise ValueError(
-                        "Config name is missing."
-                        f"\nPlease pick one among the available configs: {list(self.builder_configs.keys())}"
-                        + f"\nExample of usage:\n\t`{example_of_usage}`"
+                    if not config_kwargs:
+                        example_of_usage = f"load_dataset('{self.dataset_name}', '{self.BUILDER_CONFIGS[0].name}')"
+                        raise ValueError(
+                            "Config name is missing."
+                            f"\nPlease pick one among the available configs: {list(self.builder_configs.keys())}"
+                            + f"\nExample of usage:\n\t`{example_of_usage}`"
+                        )
+                else:
+                    builder_config = self.BUILDER_CONFIGS[0]
+                    logger.info(
+                        f"No config specified, defaulting to the single config: {self.dataset_name}/{builder_config.name}"
                     )
-                builder_config = self.BUILDER_CONFIGS[0]
-                logger.info(
-                    f"No config specified, defaulting to the single config: {self.dataset_name}/{builder_config.name}"
-                )
 
         # try to get config by name
         if isinstance(config_name, str):

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1634,6 +1634,7 @@ def dataset_module_factory(
     cache_dir: Optional[str] = None,
     trust_remote_code: Optional[bool] = None,
     _require_default_config_name=True,
+    _require_custom_configs=False,
     **download_kwargs,
 ) -> DatasetModule:
     """
@@ -1790,7 +1791,9 @@ def dataset_module_factory(
                     raise e
             if filename in [sibling.rfilename for sibling in dataset_info.siblings]:  # contains a dataset script
                 fs = HfFileSystem(endpoint=config.HF_ENDPOINT, token=download_config.token)
-                if _require_default_config_name:
+                if _require_custom_configs:
+                    can_load_config_from_parquet_export = False
+                elif _require_default_config_name:
                     with fs.open(f"datasets/{path}/{filename}", "r", revision=revision, encoding="utf-8") as f:
                         can_load_config_from_parquet_export = "DEFAULT_CONFIG_NAME" not in f.read()
                 else:
@@ -2199,6 +2202,7 @@ def load_dataset_builder(
         cache_dir=cache_dir,
         trust_remote_code=trust_remote_code,
         _require_default_config_name=_require_default_config_name,
+        _require_custom_configs=bool(config_kwargs),
     )
     # Get dataset builder class from the processing script
     builder_kwargs = dataset_module.builder_kwargs


### PR DESCRIPTION
We should not use the parquet export when the user is passing config_kwargs

I also fixed a regression that would disallow creating a custom config when a dataset has multiple predefined configs

fix https://github.com/huggingface/datasets/issues/6533