### PR TITLE
Fix parallel downloads for datasets without scripts

### DIFF
--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -30,7 +30,14 @@ from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
 from .. import config
 from ..utils import tqdm as hf_tqdm
 from ..utils.deprecation_utils import DeprecatedEnum, deprecated
-from ..utils.file_utils import cached_path, get_from_cache, hash_url_to_filename, is_relative_path, url_or_path_join
+from ..utils.file_utils import (
+    cached_path,
+    get_from_cache,
+    hash_url_to_filename,
+    is_relative_path,
+    stack_multiprocessing_download_progress_bars,
+    url_or_path_join,
+)
 from ..utils.info_utils import get_size_checksum_dict
 from ..utils.logging import get_logger
 from ..utils.py_utils import NestedDataStructure, map_nested, size_str
@@ -423,13 +430,14 @@ class DownloadManager:
         download_func = partial(self._download, download_config=download_config)
 
         start_time = datetime.now()
-        downloaded_path_or_paths = map_nested(
-            download_func,
-            url_or_urls,
-            map_tuple=True,
-            num_proc=download_config.num_proc,
-            desc="Downloading data files",
-        )
+        with stack_multiprocessing_download_progress_bars():
+            downloaded_path_or_paths = map_nested(
+                download_func,
+                url_or_urls,
+                map_tuple=True,
+                num_proc=download_config.num_proc,
+                desc="Downloading data files",
+            )
         duration = datetime.now() - start_time
         logger.info(f"Downloading took {duration.total_seconds() // 60} min")
         url_or_urls = NestedDataStructure(url_or_urls)

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -343,7 +343,7 @@ def fsspec_get(url, temp_file, storage_options=None, desc=None):
             "desc": desc or "Downloading",
             "unit": "B",
             "unit_scale": True,
-            "position": multiprocessing.current_process()._identity[-1]
+            "position": multiprocessing.current_process()._identity[-1]  # contains the ranks of subprocesses
             if os.environ.get("HF_DATASETS_STACK_MULTIPROCESSING_DOWNLOAD_PROGRESS_BARS") == "1"
             and multiprocessing.current_process()._identity
             else None,
@@ -401,7 +401,7 @@ def http_get(
         total=total,
         initial=resume_size,
         desc=desc or "Downloading",
-        position=multiprocessing.current_process()._identity[-1]
+        position=multiprocessing.current_process()._identity[-1]  # contains the ranks of subprocesses
         if os.environ.get("HF_DATASETS_STACK_MULTIPROCESSING_DOWNLOAD_PROGRESS_BARS") == "1"
         and multiprocessing.current_process()._identity
         else None,

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -462,7 +462,18 @@ def map_nested(
 
     if num_proc is None:
         num_proc = 1
-    if num_proc != -1 and num_proc <= 1 or len(iterable) < parallel_min_length:
+    if any(isinstance(v, types) and len(v) > len(iterable) for v in iterable):
+        mapped = [
+            map_nested(
+                function=function,
+                data_struct=obj,
+                num_proc=num_proc,
+                parallel_min_length=parallel_min_length,
+                types=types,
+            )
+            for obj in iterable
+        ]
+    elif num_proc != -1 and num_proc <= 1 or len(iterable) < parallel_min_length:
         mapped = [
             _single_map_nested((function, obj, types, None, True, None))
             for obj in hf_tqdm(iterable, disable=disable_tqdm, desc=desc)


### PR DESCRIPTION
Enable parallel downloads using multiprocessing when `num_proc` is passed to `load_dataset`.

It was enabled for datasets with scripts already (if they passed lists to `dl_manager.download`) but not for no-script datasets (we pass dicts {split: [list of files]} to `dl_manager.download` for those ones).

I fixed this by parallelising on the lists contained in the data files dicts when possible.

I also added a context manager `stack_multiprocessing_download_progress_bars` in `DownloadManager` to stack the progress bard of the downloads (from `cached_path(...)` calls). Otherwise the progress bars overlap each other with an annoying flickering effect.