### PR TITLE
Adding option for multipart achive download

### DIFF
--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -78,6 +78,7 @@ class DownloadConfig:
     ignore_url_params: bool = False
     storage_options: Dict[str, Any] = field(default_factory=dict)
     download_desc: Optional[str] = None
+    multi_part: bool = False
 
     def __post_init__(self, use_auth_token):
         if use_auth_token != "deprecated":

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -567,6 +567,14 @@ class DownloadManager:
         Returns:
             extracted_path(s): `str`, extracted paths of given URL(s).
         """
+        if self.download_config.multi_part:
+            paths = self.download(url_or_urls)
+            concatenated_archive = os.path.join(self.download_config.cache_dir, "final_archive.tar")
+            with open(concatenated_archive, mode="wb") as final:
+                for pth in paths:
+                    with open(pth, mode="rb") as part:
+                        final.write(part.read())
+            return self.extract(concatenated_archive)
         return self.extract(self.download(url_or_urls))
 
     def get_recorded_sizes_checksums(self):


### PR DESCRIPTION
Right now we can only download multiple separate archives or a single file archive, but not multipart archives, such as those produced by `tar --multi-volume`. This PR allows for downloading and extraction of archives split into multiple parts.

With the new `multi_part` field of the `DownloadConfig` set, the downloader will first retrieve all the files and attempt to concatenate them before starting extraction. This will obviously fail if files retrieved are actually multiple separate archives, so the option is set to `False` by default.

Tests and docs incoming. 