### PR TITLE
fix os.listdir return name is empty string

### DIFF
--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -545,7 +545,7 @@ def xlistdir(path: str, download_config: Optional[DownloadConfig] = None) -> Lis
         if inner_path.strip("/") and not fs.isdir(inner_path):
             raise FileNotFoundError(f"Directory doesn't exist: {path}")
         objects = fs.listdir(inner_path)
-        return [os.path.basename(obj["name"]) for obj in objects]
+        return [os.path.basename(obj["name"].strip("/")) for obj in objects]
 
 
 def xglob(urlpath, *, recursive=False, download_config: Optional[DownloadConfig] = None):


### PR DESCRIPTION
fix #6588

xlistdir return name is empty string

for example：
`
from datasets.download.streaming_download_manager import xjoin
from datasets.download.streaming_download_manager import xlistdir
config = DownloadConfig(storage_options=options)
manger = StreamingDownloadManager("ILSVRC2012",download_config=config)
input_path = "lakefs://datalab/main/imagenet/ILSVRC2012.zip"


download_files = manger.download_and_extract(input_path)

current_dir = xjoin(download_files,"ILSVRC2012/Images/ILSVRC2012_img_train")
folder_list = xlistdir(current_dir)

`
