### PR TITLE
Use schema metadata only if it matches features

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1672,7 +1672,9 @@ class Features(dict):
         if pa_schema.metadata is not None and "huggingface".encode("utf-8") in pa_schema.metadata:
             metadata = json.loads(pa_schema.metadata["huggingface".encode("utf-8")].decode())
             if "info" in metadata and "features" in metadata["info"] and metadata["info"]["features"] is not None:
-                return Features.from_dict(metadata["info"]["features"])
+                features = Features.from_dict(metadata["info"]["features"])
+                if features.arrow_schema == pa_schema:
+                    return features
         obj = {field.name: generate_from_arrow_type(field.type) for field in pa_schema}
         return cls(**obj)
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1669,13 +1669,20 @@ class Features(dict):
             [`Features`]
         """
         # try to load features from the arrow schema metadata
+        metadata_features = Features()
         if pa_schema.metadata is not None and "huggingface".encode("utf-8") in pa_schema.metadata:
             metadata = json.loads(pa_schema.metadata["huggingface".encode("utf-8")].decode())
             if "info" in metadata and "features" in metadata["info"] and metadata["info"]["features"] is not None:
-                features = Features.from_dict(metadata["info"]["features"])
-                if features.arrow_schema == pa_schema:
-                    return features
-        obj = {field.name: generate_from_arrow_type(field.type) for field in pa_schema}
+                metadata_features = Features.from_dict(metadata["info"]["features"])
+        metadata_features_schema = metadata_features.arrow_schema
+        obj = {
+            field.name: (
+                metadata_features[field.name]
+                if field.name in metadata_features and metadata_features_schema.field(field.name) == field
+                else generate_from_arrow_type(field.type)
+            )
+            for field in pa_schema
+        }
         return cls(**obj)
 
     @classmethod


### PR DESCRIPTION
e.g. if we use `map` in arrow format and transform the table, the returned table might have new columns but the metadata might be wrong