### PR TITLE
Raise error on bad split name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           python -m spacy download fr_core_news_sm
       - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
-        run: pip install --upgrade pyarrow huggingface-hub dill
+        run: pip install --upgrade pyarrow huggingface-hub "dill<0.3.8"
       - name: Install dependencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
         run: pip install pyarrow==8.0.0 huggingface-hub==0.19.4 transformers dill==0.3.1.1

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -15,6 +15,7 @@ from tqdm.contrib.concurrent import thread_map
 from . import config
 from .download import DownloadConfig
 from .download.streaming_download_manager import _prepare_path_and_storage_options, xbasename, xjoin
+from .naming import _split_re
 from .splits import Split
 from .utils import logging
 from .utils import tqdm as hf_tqdm
@@ -247,6 +248,8 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], List[str]]) -> Di
                 string_to_dict(xbasename(p), glob_pattern_to_regex(xbasename(split_pattern)))["split"]
                 for p in data_files
             }
+            if any(not re.match(_split_re, split) for split in splits):
+                raise ValueError(f"Split name should match '{_split_re}'' but got '{splits}'.")
             sorted_splits = [str(split) for split in DEFAULT_SPLITS if split in splits] + sorted(
                 splits - set(DEFAULT_SPLITS)
             )

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from collections import Counter
 from itertools import groupby
@@ -10,6 +11,7 @@ from huggingface_hub import DatasetCardData
 
 from ..config import METADATA_CONFIGS_FIELD
 from ..info import DatasetInfo, DatasetInfosDict
+from ..naming import _split_re
 from ..utils.logging import get_logger
 from .deprecation_utils import deprecated
 
@@ -155,6 +157,8 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
                       - train/part2/*
                     - split: test
                       path: test/*
+
+                PS: some symbols like dashes '-' are not allowed in split names
                 """
             )
             if not isinstance(yaml_data_files, (list, str)):
@@ -167,6 +171,7 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
                         and not (
                             len(yaml_data_files_item) == 2
                             and "split" in yaml_data_files_item
+                            and re.match(_split_re, yaml_data_files_item["split"])
                             and isinstance(yaml_data_files_item.get("path"), (str, list))
                         )
                     ):


### PR DESCRIPTION
e.g. dashes '-' are not allowed in split names

This should add an error message on datasets with unsupported split names like https://huggingface.co/datasets/open-source-metrics/test

cc @AndreaFrancis 