### PR TITLE
Disable `tqdm` bars in non-interactive environments

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1711,7 +1711,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 [posixpath.join(dest_dataset_path, data_file["filename"]) for data_file in state["_data_files"]],
                 tqdm_class=hf_tqdm,
                 desc="Loading dataset from disk",
-                disable=len(state["_data_files"]) <= 16,
+                # set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
+                disable=len(state["_data_files"]) <= 16 or None,
             )
         )
 

--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -204,7 +204,8 @@ class BaseReader:
             files,
             tqdm_class=hf_tqdm,
             desc="Loading dataset shards",
-            disable=len(files) <= 16,
+            # set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
+            disable=len(files) <= 16 or None,
         )
         pa_tables = [t for t in pa_tables if len(t) > 0]
         if not pa_tables and (self._info is None or self._info.features is None):

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -522,6 +522,7 @@ def _get_origin_metadata(
         max_workers=max_workers,
         tqdm_class=hf_tqdm,
         desc="Resolving data files",
+        # set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
         disable=len(data_files) <= 16,
     )
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -523,7 +523,7 @@ def _get_origin_metadata(
         tqdm_class=hf_tqdm,
         desc="Resolving data files",
         # set `disable=None` rather than `disable=False` by default to disable progress bar when no TTY attached
-        disable=len(data_files) <= 16,
+        disable=len(data_files) <= 16 or None,
     )
 
 


### PR DESCRIPTION
Replace `disable=False` with `disable=None` in the `tqdm` bars to disable them in non-interactive environments (by default).

For more info, see a [similar PR](https://github.com/huggingface/huggingface_hub/pull/2000) in `huggingface_hub`.