### PR TITLE
Support push_to_hub without org/user to default to logged-in user

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5365,13 +5365,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
 
-        _ = api.create_repo(
+        repo_url = api.create_repo(
             repo_id,
             token=token,
             repo_type="dataset",
             private=private,
             exist_ok=True,
         )
+        repo_id = repo_url.repo_id
 
         if revision is not None:
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1685,13 +1685,14 @@ class DatasetDict(dict):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
 
-        _ = api.create_repo(
+        repo_url = api.create_repo(
             repo_id,
             token=token,
             repo_type="dataset",
             private=private,
             exist_ok=True,
         )
+        repo_id = repo_url.repo_id
 
         if revision is not None:
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -13,7 +13,6 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 from huggingface_hub import DatasetCard, HfApi
-from huggingface_hub.utils import RepositoryNotFoundError
 
 from datasets import (
     Audio,
@@ -71,9 +70,16 @@ class TestPushToHub:
         local_ds = DatasetDict({"train": ds})
 
         with temporary_repo() as ds_name:
-            # cannot create a repo without namespace
-            with pytest.raises(RepositoryNotFoundError):
-                local_ds.push_to_hub(ds_name.split("/")[-1], token=self._token)
+            local_ds.push_to_hub(ds_name.split("/")[-1], token=self._token)
+            hub_ds = load_dataset(ds_name, download_mode="force_redownload")
+
+            assert local_ds.column_names == hub_ds.column_names
+            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert local_ds["train"].features == hub_ds["train"].features
+
+            # Ensure that there is a single file on the repository that has the correct name
+            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
+            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
 
     def test_push_dataset_dict_to_hub_datasets_with_different_features(self, cleanup_repo):
         ds_train = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})


### PR DESCRIPTION
This behavior is aligned with:
- the behavior of `datasets` before merging #6519
  - the behavior described in the corresponding docstring
- the behavior of `huggingface_hub.create_repo`

Revert "Support push_to_hub canonical datasets (#6519)"
- This reverts commit a887ee78835573f5d80f9e414e8443b4caff3541.

Fix #6597.