### PR TITLE
Support data_dir parameter in push_to_hub

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5247,6 +5247,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         config_name: str = "default",
         set_default: Optional[bool] = None,
         split: Optional[str] = None,
+        data_dir: Optional[str] = None,
         commit_message: Optional[str] = None,
         commit_description: Optional[str] = None,
         private: Optional[bool] = False,
@@ -5277,6 +5278,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 named "default".
             split (`str`, *optional*):
                 The name of the split that will be given to that dataset. Defaults to `self.split`.
+            data_dir (`str`, *optional*):
+                Directory name that will contain the uploaded data files. Defaults to the `config_name` if different
+                from "default", else "data".
+
+                <Added version="2.17.0"/>
             commit_message (`str`, *optional*):
                 Message to commit while pushing. Will default to `"Upload dataset"`.
             commit_description (`str`, *optional*):
@@ -5389,7 +5395,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if revision is not None:
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
-        data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
+        if not data_dir:
+            data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
         additions, uploaded_size, dataset_nbytes = self._push_parquet_shards_to_hub(
             repo_id=repo_id,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1566,6 +1566,7 @@ class DatasetDict(dict):
         repo_id,
         config_name: str = "default",
         set_default: Optional[bool] = None,
+        data_dir: Optional[str] = None,
         commit_message: Optional[str] = None,
         commit_description: Optional[str] = None,
         private: Optional[bool] = False,
@@ -1596,6 +1597,11 @@ class DatasetDict(dict):
             set_default (`bool`, *optional*):
                 Whether to set this configuration as the default one. Otherwise, the default configuration is the one
                 named "default".
+            data_dir (`str`, *optional*):
+                Directory name that will contain the uploaded data files. Defaults to the `config_name` if different
+                from "default", else "data".
+
+                <Added version="2.17.0"/>
             commit_message (`str`, *optional*):
                 Message to commit while pushing. Will default to `"Upload dataset"`.
             commit_description (`str`, *optional*):
@@ -1704,7 +1710,8 @@ class DatasetDict(dict):
         if revision is not None:
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
-        data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
+        if not data_dir:
+            data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
         additions = []
         for split in self.keys():


### PR DESCRIPTION
Support `data_dir` parameter in `push_to_hub`.

This allows users to organize the data files according to their specific needs. For example, "wikimedia/wikipedia" files could be organized by year and/or date, e.g. "2024/20240101/20240101.en".