### PR TITLE
Fix missing info when loading some datasets from Parquet export

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -252,10 +252,8 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
 
     def get_default_config_name(self) -> Optional[str]:
         default_config_name = None
-        if len(self) == 1:
-            return next(iter(self))
         for config_name, metadata_config in self.items():
-            if config_name == "default" or metadata_config.get("default"):
+            if len(self) == 1 or config_name == "default" or metadata_config.get("default"):
                 if default_config_name is None:
                     default_config_name = config_name
                 else:

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -252,6 +252,8 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
 
     def get_default_config_name(self) -> Optional[str]:
         default_config_name = None
+        if len(self) == 1:
+            return next(iter(self))
         for config_name, metadata_config in self.items():
             if config_name == "default" or metadata_config.get("default"):
                 if default_config_name is None:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -523,7 +523,7 @@ class ModuleFactoryTest(TestCase):
         assert module_builder_configs[0].drop_labels is True  # parameter is passed from metadata
 
         # config named "default" is automatically considered to be a default config
-        assert module_factory_result.builder_configs_parameters.default_config_name is None
+        assert module_factory_result.builder_configs_parameters.default_config_name == "custom"
 
         # we don't pass config params to builder in builder_kwargs, they are stored in builder_configs directly
         assert "drop_labels" not in module_factory_result.builder_kwargs

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -695,7 +695,7 @@ class ModuleFactoryTest(TestCase):
         assert module_builder_configs[0].drop_labels is True  # parameter is passed from metadata
 
         # config named "default" is automatically considered to be a default config
-        assert module_factory_result.builder_configs_parameters.default_config_name is None
+        assert module_factory_result.builder_configs_parameters.default_config_name == "custom"
 
         # we don't pass config params to builder in builder_kwargs, they are stored in builder_configs directly
         assert "drop_labels" not in module_factory_result.builder_kwargs

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -224,7 +224,7 @@ class TestMetadataUtils(unittest.TestCase):
 @pytest.mark.parametrize(
     "readme_content, expected_metadata_configs_dict, expected_default_config_name",
     [
-        (README_METADATA_SINGLE_CONFIG, EXPECTED_METADATA_SINGLE_CONFIG, None),
+        (README_METADATA_SINGLE_CONFIG, EXPECTED_METADATA_SINGLE_CONFIG, "custom"),
         (README_METADATA_TWO_CONFIGS_WITH_DEFAULT_FLAG, EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_FLAG, "v2"),
         (README_METADATA_TWO_CONFIGS_WITH_DEFAULT_NAME, EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_NAME, "default"),
     ],


### PR DESCRIPTION
Fix getting the info for script-based datasets with Parquet export with a single config not named "default".

E.g.

```python
from datasets import load_dataset_builder

b = load_dataset_builder("bookcorpus")
print(b.info.features)
# should print {'text': Value(dtype='string', id=None)}
```

I fixed this by setting the default config name when there is only one config.