### PR TITLE
Change default compression argument for JsonDatasetWriter

### DIFF
--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -95,7 +95,7 @@ class JsonDatasetWriter:
         lines = self.to_json_kwargs.pop("lines", True if orient == "records" else False)
         if "index" not in self.to_json_kwargs and orient in ["split", "table"]:
             self.to_json_kwargs["index"] = False
-        compression = self.to_json_kwargs.pop("compression", None)
+        compression = self.to_json_kwargs.pop("compression", "infer")
 
         if compression not in [None, "infer", "gzip", "bz2", "xz"]:
             raise NotImplementedError(f"`datasets` currently does not support {compression} compression")


### PR DESCRIPTION
Change default compression type from `None` to "infer", to align with pandas' defaults.

Documentation asks the user to supply `to_json_kwargs` with arguments suitable for pandas' `to_json` method. At the same time, while pandas' by default uses ["infer"](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html) for compression, datasets enforce `None` as default. This, likely, confuses user, as they expect the same behaviour, i.e they expect that if they name their output file as "dataset.jsonl.zst" then the compression would be inferred as "zstd" and file will be compressed before writing.

Moreover, while it is probably outside of the scope of this pull request, `compression` argument needs to be capable of taking `dict` as input (along with `str`), as it does in pandas, in order to allow user to specify compression parameters. Current implementation will likely fail with `NotImplementedError`, as it expects either `None` or `str` specifying compression algo.