### PR TITLE
Revert the changes in `arrow_writer.py` from #6636

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -426,8 +426,7 @@ class ArrowWriter:
         """Write stored examples from the write-pool of examples. It makes a table out of the examples and write it."""
         if not self.current_examples:
             return
-
-        # order the columns properly
+        # preserve the order the columns
         if self.schema:
             schema_cols = set(self.schema.names)
             examples_cols = self.current_examples[0][0].keys()  # .keys() preserves the order (unlike set)
@@ -545,7 +544,8 @@ class ArrowWriter:
         try_features = self._features if self.pa_writer is None and self.update_features else None
         arrays = []
         inferred_features = Features()
-         if self.schema:
+        # preserve the order the columns
+        if self.schema:
             schema_cols = set(self.schema.names)
             batch_cols = batch_examples.keys()  # .keys() preserves the order (unlike set)
             common_cols = [col for col in self.schema.names if col in batch_cols]

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -428,18 +428,12 @@ class ArrowWriter:
             return
 
         # order the columns properly
-        if self.schema:
-            schema_cols = set(self.schema.names)
-            common_cols, extra_cols = [], []
-            for col in self.current_examples[0][0]:
-                if col in schema_cols:
-                    common_cols.append(col)
-                else:
-                    extra_cols.append(col)
-            cols = common_cols + extra_cols
-        else:
-            cols = list(self.current_examples[0][0])
-
+        cols = (
+            [col for col in self.schema.names if col in self.current_examples[0][0]]
+            + [col for col in self.current_examples[0][0].keys() if col not in self.schema.names]
+            if self.schema
+            else self.current_examples[0][0].keys()
+        )
         batch_examples = {}
         for col in cols:
             # We use row[0][col] since current_examples contains (example, key) tuples.
@@ -549,17 +543,12 @@ class ArrowWriter:
         try_features = self._features if self.pa_writer is None and self.update_features else None
         arrays = []
         inferred_features = Features()
-        if self.schema:
-            schema_cols = set(self.schema.names)
-            common_cols, extra_cols = [], []
-            for col in batch_examples:
-                if col in schema_cols:
-                    common_cols.append(col)
-                else:
-                    extra_cols.append(col)
-            cols = common_cols + extra_cols
-        else:
-            cols = list(batch_examples)
+        cols = (
+            [col for col in self.schema.names if col in batch_examples]
+            + [col for col in batch_examples.keys() if col not in self.schema.names]
+            if self.schema
+            else batch_examples.keys()
+        )
         for col in cols:
             col_values = batch_examples[col]
             col_type = features[col] if features else None

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -87,7 +87,13 @@ def _check_output(output, expected_num_chunks: int):
 
 @pytest.mark.parametrize("writer_batch_size", [None, 1, 10])
 @pytest.mark.parametrize(
-    "fields", [None, {"col_1": pa.string(), "col_2": pa.int64()}, {"col_1": pa.string(), "col_2": pa.int32()}]
+    "fields",
+    [
+        None,
+        {"col_1": pa.string(), "col_2": pa.int64()},
+        {"col_1": pa.string(), "col_2": pa.int32()},
+        {"col_2": pa.int64(), "col_1": pa.string()},
+    ],
 )
 def test_write(fields, writer_batch_size):
     output = pa.BufferOutputStream()


### PR DESCRIPTION
#6636 broke `write_examples_on_file` and `write_batch` from the class `ArrowWriter`. I'm undoing these changes. See #6663.

Note the current implementation doesn't keep the order of the columns and the schema, thus setting a wrong schema for each column.