### PR TITLE
Pass through information about location of cache directory.

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -297,7 +297,9 @@ class BaseReader:
         remote_cache_dir = HF_GCP_BASE_URL + "/" + relative_data_dir.replace(os.sep, "/")
         try:
             remote_dataset_info = os.path.join(remote_cache_dir, "dataset_info.json")
-            downloaded_dataset_info = cached_path(remote_dataset_info.replace(os.sep, "/"))
+            downloaded_dataset_info = cached_path(
+                remote_dataset_info.replace(os.sep, "/"), download_config=download_config
+            )
             shutil.move(downloaded_dataset_info, os.path.join(self._path, "dataset_info.json"))
             if self._info is not None:
                 self._info.update(self._info.from_directory(self._path))


### PR DESCRIPTION
If cache directory is set, information is not passed through.
Pass download config in as an arg too.