### PR TITLE
__add__ for Dataset, IterableDataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -131,6 +131,8 @@ from .utils.tf_utils import dataset_to_tf, minimal_tf_collate_fn, multiprocess_d
 from .utils.typing import ListLike, PathLike
 
 
+# from .combine import concatenate_datasets
+
 if TYPE_CHECKING:
     import sqlite3
 
@@ -726,6 +728,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         _check_column_names(self._data.column_names)
 
         self._data = update_metadata_with_features(self._data, self._info.features)
+
+    def __add__(self, other):
+        assert self.features.type == other.features.type
+        return concatenate_datasets([self, other])
 
     @property
     def features(self) -> Features:

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1224,6 +1224,10 @@ class IterableDataset(DatasetInfoMixin):
         self._token_per_repo_id: Dict[str, Union[str, bool, None]] = token_per_repo_id or {}
         _maybe_add_torch_iterable_dataset_parent_class(self.__class__)
 
+    def __add__(self, other):
+        assert self.features.type == other.features.type
+        return concatenate_datasets([self, other])
+
     def __repr__(self):
         return f"IterableDataset({{\n    features: {list(self._info.features.keys()) if self._info.features is not None else 'Unknown'},\n    n_shards: {self.n_shards}\n}})"
 


### PR DESCRIPTION
It's too cumbersome to write this command every time we perform a dataset merging operation. ```pythonfrom datasets import concatenate_datasets``` We have added a simple `__add__` magic method to each class using `concatenate_datasets.`

```python
from datasets import load_dataset

bookcorpus = load_dataset("bookcorpus", split="train")
wiki = load_dataset("wikimedia/wikipedia", "20231101.ab", split="train")
wiki = wiki.remove_columns([col for col in wiki.column_names if col != "text"])  # only keep the 'text' column

bookcorpus + wiki

#Dataset({
#   features: ['text'],
#   num_rows: 74004228
#})
#Dataset({
#    features: ['text'],
#    num_rows: 6152
#})
#Dataset({
#   features: ['text'],
#    num_rows: 74010380
#})
```