### PR TITLE
Make JSON builder support file with an array of strings

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -145,12 +145,20 @@ class Json(datasets.ArrowBasedBuilder):
                             except json.JSONDecodeError:
                                 logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")
                                 raise e
-                            # If possible, parse the file as a list of json objects and exit the loop
+                            # If possible, parse the file as a list of json objects/strings and exit the loop
                             if isinstance(dataset, list):  # list is the only sequence type supported in JSON
                                 try:
-                                    keys = set().union(*[row.keys() for row in dataset])
-                                    mapping = {col: [row.get(col) for row in dataset] for col in keys}
-                                    pa_table = pa.Table.from_pydict(mapping)
+                                    if dataset and isinstance(dataset[0], str):
+                                        pa_table_names = (
+                                            list(self.config.features)
+                                            if self.config.features is not None
+                                            else ["text"]
+                                        )
+                                        pa_table = pa.Table.from_arrays([pa.array(dataset)], names=pa_table_names)
+                                    else:
+                                        keys = set().union(*[row.keys() for row in dataset])
+                                        mapping = {col: [row.get(col) for row in dataset] for col in keys}
+                                        pa_table = pa.Table.from_pydict(mapping)
                                 except (pa.ArrowInvalid, AttributeError) as e:
                                     logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")
                                     raise ValueError(f"Not able to read records in the JSON file at {file}.") from None


### PR DESCRIPTION
Support JSON file with an array of strings.

Fix #6695.