### PR TITLE
Improve default patterns resolution

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -501,7 +501,6 @@ def get_data_patterns(base_path: str, download_config: Optional[DownloadConfig] 
     """
     resolver = partial(resolve_pattern, base_path=base_path, download_config=download_config)
     try:
-        # import pdb; pdb.set_trace()
         return _get_data_files_patterns(resolver)
     except FileNotFoundError:
         raise EmptyDatasetError(f"The directory at {base_path} doesn't contain any data files") from None

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -635,6 +635,8 @@ def mock_fs(file_paths: List[str]):
         {"test": "my test file.txt"},
         {"test": "my-test_file.txt"},
         {"test": "test00001.txt"},
+        # <split>.<split> case
+        {"test": "test/train.txt"},
     ],
 )
 def test_get_data_files_patterns(base_path, data_file_per_split):


### PR DESCRIPTION
Separate the default patterns that match directories from the ones matching files and ensure directories are checked first (reverts the change from https://github.com/huggingface/datasets/pull/6244, which merged these patterns). Also, ensure that the glob patterns do not overlap to avoid duplicates in the result.

fix https://github.com/huggingface/datasets/issues/6259
fix https://github.com/huggingface/datasets/issues/6272

TODO:
- [ ] optimize repeated `LocalFileSystem.ls` calls when resolving the default patterns