### PR TITLE
Fix data_files when passing data_dir

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1021,7 +1021,7 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         base_path = Path(self.path, self.data_dir or "").expanduser().resolve().as_posix()
         if self.data_files is not None:
             patterns = sanitize_patterns(self.data_files)
-        elif metadata_configs and "data_files" in next(iter(metadata_configs.values())):
+        elif metadata_configs and not self.data_dir and "data_files" in next(iter(metadata_configs.values())):
             patterns = sanitize_patterns(next(iter(metadata_configs.values()))["data_files"])
         else:
             patterns = get_data_patterns(base_path)
@@ -1073,6 +1073,8 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             "base_path": self.path,
             "dataset_name": camelcase_to_snakecase(Path(self.path).name),
         }
+        if self.data_dir:
+            builder_kwargs["data_files"] = data_files
         # this file is deprecated and was created automatically in old versions of push_to_hub
         if os.path.isfile(os.path.join(self.path, config.DATASETDICT_INFOS_FILENAME)):
             with open(os.path.join(self.path, config.DATASETDICT_INFOS_FILENAME), encoding="utf-8") as f:
@@ -1227,7 +1229,7 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
         # because we need to infer module name by files extensions
         if self.data_files is not None:
             patterns = sanitize_patterns(self.data_files)
-        elif metadata_configs and "data_files" in next(iter(metadata_configs.values())):
+        elif metadata_configs and not self.data_dir and "data_files" in next(iter(metadata_configs.values())):
             patterns = sanitize_patterns(next(iter(metadata_configs.values()))["data_files"])
         else:
             patterns = get_data_patterns(base_path, download_config=self.download_config)
@@ -1285,6 +1287,8 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             "repo_id": self.name,
             "dataset_name": camelcase_to_snakecase(Path(self.name).name),
         }
+        if self.data_dir:
+            builder_kwargs["data_files"] = data_files
         download_config = self.download_config.copy()
         if download_config.download_desc is None:
             download_config.download_desc = "Downloading metadata"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -194,7 +194,7 @@ def data_dir_with_single_config_in_metadata(tmp_path):
 
 @pytest.fixture
 def data_dir_with_config_and_data_files(tmp_path):
-    data_dir = tmp_path / "data_dir_with_one_default_config_in_metadata"
+    data_dir = tmp_path / "data_dir_with_config_and_data_files"
 
     cats_data_dir = data_dir / "data" / "cats"
     cats_data_dir.mkdir(parents=True)


### PR DESCRIPTION
This code should not return empty data files

```python
from datasets import load_dataset_builder

revision = "3d406e70bc21c3ca92a9a229b4c6fc3ed88279fd"
b = load_dataset_builder("bigcode/the-stack-v2-dedup", data_dir="data/Dockerfile", revision=revision)
print(b.config.data_files)
```

Previously it would return no data files because it would apply the YAML `data_files: data/**/train-*` pattern to this directory

cc @anton-l 