### PR TITLE
Expand no-code dataset info with datasets-server info

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1223,6 +1223,21 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             pass
         metadata_configs = MetadataConfigs.from_dataset_card_data(dataset_card_data)
         dataset_infos = DatasetInfosDict.from_dataset_card_data(dataset_card_data)
+        try:
+            exported_dataset_infos = _datasets_server.get_exported_dataset_infos(
+                dataset=self.name, revision=self.revision, token=self.download_config.token
+            )
+        except _datasets_server.DatasetsServerError:
+            pass
+        else:
+            exported_dataset_infos = DatasetInfosDict(
+                {
+                    config_name: DatasetInfo.from_dict(exported_dataset_infos[config_name])
+                    for config_name in exported_dataset_infos
+                }
+            )
+            exported_dataset_infos.update(dataset_infos)
+            dataset_infos = exported_dataset_infos
         # we need a set of data files to find which dataset builder to use
         # because we need to infer module name by files extensions
         if self.data_files is not None:

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1227,15 +1227,15 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             exported_dataset_infos = _datasets_server.get_exported_dataset_infos(
                 dataset=self.name, revision=self.revision, token=self.download_config.token
             )
-        except _datasets_server.DatasetsServerError:
-            pass
-        else:
             exported_dataset_infos = DatasetInfosDict(
                 {
                     config_name: DatasetInfo.from_dict(exported_dataset_infos[config_name])
                     for config_name in exported_dataset_infos
                 }
             )
+        except _datasets_server.DatasetsServerError:
+            exported_dataset_infos = None
+        if exported_dataset_infos:
             exported_dataset_infos.update(dataset_infos)
             dataset_infos = exported_dataset_infos
         # we need a set of data files to find which dataset builder to use


### PR DESCRIPTION
E.g., to have info about a dataset's number of examples for more informative TQDM bars.