### PR TITLE
Fix sliced ConcatenationTable pickling with mixed schemas vertically

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -799,11 +799,12 @@ def test_concatenation_table_slice_mixed_schemas_vertically(arrow_file):
     blocks = [[t1], [t2]]
     table = ConcatenationTable.from_blocks(blocks)
     assert table.to_pydict() == expected.to_pydict()
-    assert table.slice(1, 2).to_pydict() == expected.slice(1, 2).to_pydict()
     assert isinstance(table, ConcatenationTable)
     reloaded = pickle.loads(pickle.dumps(table))
     assert reloaded.to_pydict() == expected.to_pydict()
-    assert reloaded.slice(1, 2).to_pydict() == expected.slice(1, 2).to_pydict()
+    assert isinstance(reloaded, ConcatenationTable)
+    reloaded = pickle.loads(pickle.dumps(table.slice(1, 2)))
+    assert reloaded.to_pydict() == expected.slice(1, 2).to_pydict()
     assert isinstance(reloaded, ConcatenationTable)
 
 


### PR DESCRIPTION
A sliced + pickled ConcatenationTable could end up with a different schema than the original schema, if the slice only contains blocks with only a subset of the columns.

This can lead to issues when saving datasets from a concatenation of datasets with mixed schemas

Reported in https://discuss.huggingface.co/t/datasetdict-save-to-disk-with-num-proc-1-seems-to-hang-with-error/75595