### PR TITLE
Fix CI

### DIFF
--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3980,7 +3980,7 @@ def _check_sql_dataset(dataset, expected_features):
 
 @require_sqlalchemy
 @pytest.mark.parametrize("con_type", ["string", "engine"])
-def test_dataset_from_sql_con_type(con_type, sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning):
+def test_dataset_from_sql_con_type(con_type, sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning, caplog):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
     if con_type == "string":
@@ -3989,17 +3989,17 @@ def test_dataset_from_sql_con_type(con_type, sqlite_path, tmp_path, set_sqlalche
         import sqlalchemy
 
         con = sqlalchemy.create_engine("sqlite:///" + sqlite_path)
-    # # https://github.com/huggingface/datasets/issues/2832 needs to be fixed first for this to work
-    # with caplog.at_level(INFO):
-    #     dataset = Dataset.from_sql(
-    #         "dataset",
-    #         con,
-    #         cache_dir=cache_dir,
-    #     )
-    # if con_type == "string":
-    #     assert "couldn't be hashed properly" not in caplog.text
-    # elif con_type == "engine":
-    #     assert "couldn't be hashed properly" in caplog.text
+    # https://github.com/huggingface/datasets/issues/2832 needs to be fixed first for this to work
+    with caplog.at_level(INFO, logger=get_logger().name):
+        dataset = Dataset.from_sql(
+            "dataset",
+            con,
+            cache_dir=cache_dir,
+        )
+    if con_type == "string":
+        assert "couldn't be hashed properly" not in caplog.text
+    elif con_type == "engine":
+        assert "couldn't be hashed properly" in caplog.text
     dataset = Dataset.from_sql(
         "dataset",
         con,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3989,7 +3989,6 @@ def test_dataset_from_sql_con_type(con_type, sqlite_path, tmp_path, set_sqlalche
         import sqlalchemy
 
         con = sqlalchemy.create_engine("sqlite:///" + sqlite_path)
-    # https://github.com/huggingface/datasets/issues/2832 needs to be fixed first for this to work
     with caplog.at_level(INFO, logger=get_logger().name):
         dataset = Dataset.from_sql(
             "dataset",

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -18,7 +18,7 @@ from datasets.packaged_modules.csv import csv
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.parametrize("path", ["lhoestq/test", csv.__file__])
+@pytest.mark.parametrize("path", ["hf-internal-testing/dataset_with_script", csv.__file__])
 def test_inspect_dataset(path, tmp_path):
     inspect_dataset(path, tmp_path)
     script_name = Path(path).stem + ".py"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -418,24 +418,28 @@ class ModuleFactoryTest(TestCase):
         )
 
     def test_HubDatasetModuleFactoryWithScript_dont_trust_remote_code(self):
-        # "lhoestq/test" has a dataset script
         factory = HubDatasetModuleFactoryWithScript(
-            "lhoestq/test", download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+            "hf-internal-testing/dataset_with_script",
+            download_config=self.download_config,
+            dynamic_modules_path=self.dynamic_modules_path,
         )
         with patch.object(config, "HF_DATASETS_TRUST_REMOTE_CODE", None):  # this will be the default soon
             self.assertRaises(ValueError, factory.get_module)
         factory = HubDatasetModuleFactoryWithScript(
-            "lhoestq/test",
+            "hf-internal-testing/dataset_with_script",
             download_config=self.download_config,
             dynamic_modules_path=self.dynamic_modules_path,
             trust_remote_code=False,
         )
         self.assertRaises(ValueError, factory.get_module)
 
-    def test_HubDatasetModuleFactoryWithScript_with_github_dataset(self):
+    def test_HubDatasetModuleFactoryWithScript_with_hub_dataset(self):
         # "wmt_t2t" has additional imports (internal)
         factory = HubDatasetModuleFactoryWithScript(
-            "wmt_t2t", download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+            "wmt_t2t",
+            download_config=self.download_config,
+            dynamic_modules_path=self.dynamic_modules_path,
+            revision="861aac88b2c6247dd93ade8b1c189ce714627750",
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None


### PR DESCRIPTION
Updates the `wmt_t2t` test to pin the `revision` to the version with a loading script (cc @albertvillanova). 

Additionally, it replaces the occurrences of the `lhoestq/test` repo id with `hf-internal-testing/dataset_with_script` and re-enables logging checks in the `Dataset.from_sql` tests.