### PR TITLE
Make Image cast storage faster

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -561,8 +561,9 @@ class ArrowWriter:
             else:
                 col_try_type = try_features[col] if try_features is not None and col in try_features else None
                 typed_sequence = OptimizedTypedSequence(col_values, type=col_type, try_type=col_try_type, col=col)
-                arrays.append(pa.array(typed_sequence))
-                inferred_features[col] = typed_sequence.get_inferred_type()
+                array = pa.array(typed_sequence)
+                arrays.append(array)
+                inferred_features[col] = generate_from_arrow_type(array.type)
         schema = inferred_features.arrow_schema if self.pa_writer is None else self.schema
         pa_table = pa.Table.from_arrays(arrays, schema=schema)
         self.write_table(pa_table, writer_batch_size)

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -245,7 +245,7 @@ class Image:
                     [bytes_array, path_array], ["bytes", "path"], mask=storage.is_null()
                 )
             elif pa.types.is_list(storage.type):
-                from .features import Array3DExtensionType
+                from .features import Array2DExtensionType, Array3DExtensionType
 
                 arrays = []
                 for i, is_null in enumerate(storage.is_null()):
@@ -256,7 +256,10 @@ class Image:
                         shape = get_shapes_from_listarray(storage_part)
                         dtype = get_dtypes_from_listarray(storage_part)
 
-                        extension_type = Array3DExtensionType(shape=shape, dtype=str(dtype))
+                        if len(shape) == 2:
+                            extension_type = Array2DExtensionType(shape=shape, dtype=str(dtype))
+                        else:
+                            extension_type = Array3DExtensionType(shape=shape, dtype=str(dtype))
                         array = pa.ExtensionArray.from_storage(extension_type, storage_part)
                         arrays.append(array.to_numpy().squeeze(0))
 

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -225,31 +225,73 @@ class Image:
             `pa.StructArray`: Array in the Image arrow storage type, that is
                 `pa.struct({"bytes": pa.binary(), "path": pa.string()})`.
         """
-        if pa.types.is_string(storage.type):
-            bytes_array = pa.array([None] * len(storage), type=pa.binary())
-            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
-        elif pa.types.is_binary(storage.type):
-            path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([storage, path_array], ["bytes", "path"], mask=storage.is_null())
-        elif pa.types.is_struct(storage.type):
-            if storage.type.get_field_index("bytes") >= 0:
-                bytes_array = storage.field("bytes")
-            else:
+        if hasattr(storage, "type"):
+            if pa.types.is_string(storage.type):
                 bytes_array = pa.array([None] * len(storage), type=pa.binary())
-            if storage.type.get_field_index("path") >= 0:
-                path_array = storage.field("path")
-            else:
+                storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
+            elif pa.types.is_binary(storage.type):
                 path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
-        elif pa.types.is_list(storage.type):
+                storage = pa.StructArray.from_arrays([storage, path_array], ["bytes", "path"], mask=storage.is_null())
+            elif pa.types.is_struct(storage.type):
+                if storage.type.get_field_index("bytes") >= 0:
+                    bytes_array = storage.field("bytes")
+                else:
+                    bytes_array = pa.array([None] * len(storage), type=pa.binary())
+                if storage.type.get_field_index("path") >= 0:
+                    path_array = storage.field("path")
+                else:
+                    path_array = pa.array([None] * len(storage), type=pa.string())
+                storage = pa.StructArray.from_arrays(
+                    [bytes_array, path_array], ["bytes", "path"], mask=storage.is_null()
+                )
+            elif pa.types.is_list(storage.type):
+                from .features import Array2DExtensionType, Array3DExtensionType
+
+                def get_shapes(arr):
+                    shape = ()
+                    while isinstance(arr, pa.ListArray):
+                        len_curr = len(arr)
+                        arr = arr.flatten()
+                        len_new = len(arr)
+                        shape = shape + (len_new // len_curr,)
+                    return shape
+
+                def get_dtypes(arr):
+                    dtype = storage.type
+                    while hasattr(dtype, "value_type"):
+                        dtype = dtype.value_type
+                    return dtype
+
+                shapes = [get_shapes(storage.take([i])) for i in range(len(storage))]
+                dtypes = [get_dtypes(storage.take([i])) for i in range(len(storage))]
+
+                extension_types = [
+                    Array3DExtensionType(shape=shape, dtype=str(dtype))
+                    for shape, dtype in zip(shapes, dtypes, strict=True)
+                ]
+                arrays = [
+                    pa.ExtensionArray.from_storage(extension_type, storage.take([i])).to_numpy().squeeze(0)
+                    for i, extension_type in enumerate(extension_types)
+                ]
+
+                bytes_array = pa.array(
+                    [encode_np_array(arr)["bytes"] if arr is not None else None for arr in arrays],
+                    type=pa.binary(),
+                )
+                path_array = pa.array([None] * len(storage), type=pa.string())
+                storage = pa.StructArray.from_arrays(
+                    [bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null()
+                )
+        else:
             bytes_array = pa.array(
-                [encode_np_array(np.array(arr))["bytes"] if arr is not None else None for arr in storage.to_pylist()],
+                [encode_np_array(arr)["bytes"] if arr is not None else None for arr in storage],
                 type=pa.binary(),
             )
             path_array = pa.array([None] * len(storage), type=pa.string())
             storage = pa.StructArray.from_arrays(
                 [bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null()
             )
+
         return array_cast(storage, self.pa_type)
 
     def embed_storage(self, storage: pa.StructArray) -> pa.StructArray:


### PR DESCRIPTION
PR for issue #6782.
Makes `cast_storage` of the `Image` class faster by removing the slow call to `.pylist`.
Instead directly convert each `ListArray` item to either `Array2DExtensionType` or `Array3DExtensionType`.

This also preserves the `dtype` removing the warning if the array is already `uint8`.