### PR TITLE
Multithreaded downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo "installing pinned version of setuptools-scm to fix seqeval installation on 3.7" && pip install "setuptools-scm==6.4.2"
       - name: Install uv
-        run: pip install uv==0.1.29
+        run: pip install --upgrade uv
       - name: Install dependencies
         run: |
           uv pip install --system "datasets[tests,metrics-tests] @ ."
@@ -89,7 +89,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install uv
-        run: pip install uv==0.1.29
+        run: pip install --upgrade uv
       - name: Install dependencies
         run: uv pip install --system "datasets[tests] @ ."
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo "installing pinned version of setuptools-scm to fix seqeval installation on 3.7" && pip install "setuptools-scm==6.4.2"
       - name: Install uv
-        run: pip install --upgrade uv
+        run: pip install uv==0.1.29
       - name: Install dependencies
         run: |
           uv pip install --system "datasets[tests,metrics-tests] @ ."
@@ -89,7 +89,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install uv
-        run: pip install --upgrade uv
+        run: pip install uv==0.1.29
       - name: Install dependencies
         run: uv pip install --system "datasets[tests] @ ."
       - name: Test with pytest

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -182,6 +182,9 @@ HF_UPDATE_DOWNLOAD_COUNTS = (
     os.environ.get("HF_UPDATE_DOWNLOAD_COUNTS", "AUTO").upper() in ENV_VARS_TRUE_AND_AUTO_VALUES
 )
 
+# For downloads and to check remote files metadata
+HF_DATASETS_MULTITHREADING_MAX_WORKERS = 16
+
 # Remote dataset scripts support
 __HF_DATASETS_TRUST_REMOTE_CODE = os.environ.get("HF_DATASETS_TRUST_REMOTE_CODE", "1")
 HF_DATASETS_TRUST_REMOTE_CODE: Optional[bool] = (

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -545,7 +545,7 @@ def _get_single_origin_metadata(
 def _get_origin_metadata(
     data_files: List[str],
     download_config: Optional[DownloadConfig] = None,
-    max_workers: int = 16,
+    max_workers: int = config.HF_DATASETS_MULTITHREADING_MAX_WORKERS,
 ) -> Tuple[str]:
     return thread_map(
         partial(_get_single_origin_metadata, download_config=download_config),

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 import re
 from functools import partial
@@ -546,7 +545,7 @@ def _get_single_origin_metadata(
 def _get_origin_metadata(
     data_files: List[str],
     download_config: Optional[DownloadConfig] = None,
-    max_workers: int = max(32, multiprocessing.cpu_count() + 4),
+    max_workers: int = 16,
 ) -> Tuple[str]:
     return thread_map(
         partial(_get_single_origin_metadata, download_config=download_config),

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -545,8 +545,9 @@ def _get_single_origin_metadata(
 def _get_origin_metadata(
     data_files: List[str],
     download_config: Optional[DownloadConfig] = None,
-    max_workers: int = config.HF_DATASETS_MULTITHREADING_MAX_WORKERS,
+    max_workers: Optional[int] = None,
 ) -> Tuple[str]:
+    max_workers = max_workers if max_workers is not None else config.HF_DATASETS_MULTITHREADING_MAX_WORKERS
     return thread_map(
         partial(_get_single_origin_metadata, download_config=download_config),
         data_files,

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import re
 from functools import partial
@@ -544,8 +545,8 @@ def _get_single_origin_metadata(
 
 def _get_origin_metadata(
     data_files: List[str],
-    max_workers=64,
     download_config: Optional[DownloadConfig] = None,
+    max_workers: int = max(32, multiprocessing.cpu_count() + 4),
 ) -> Tuple[str]:
     return thread_map(
         partial(_get_single_origin_metadata, download_config=download_config),

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -59,6 +59,8 @@ class DownloadConfig:
             Key/value pairs to be passed on to the dataset file-system backend, if any.
         download_desc (`str`, *optional*):
             A description to be displayed alongside with the progress bar while downloading the files.
+        disable_tqdm (`bool`, defaults to `False`):
+            Whether to disable the individual files download progress bar
     """
 
     cache_dir: Optional[Union[str, Path]] = None
@@ -78,6 +80,7 @@ class DownloadConfig:
     ignore_url_params: bool = False
     storage_options: Dict[str, Any] = field(default_factory=dict)
     download_desc: Optional[str] = None
+    disable_tqdm: bool = False
 
     def __post_init__(self, use_auth_token):
         if use_auth_token != "deprecated":

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -1002,10 +1002,10 @@ class StreamingDownloadManager:
         >>> downloaded_files = dl_manager.download('https://storage.googleapis.com/seldon-datasets/sentence_polarity_v1/rt-polaritydata.tar.gz')
         ```
         """
-        url_or_urls = map_nested(self._download, url_or_urls, map_tuple=True)
+        url_or_urls = map_nested(self._download_single, url_or_urls, map_tuple=True)
         return url_or_urls
 
-    def _download(self, urlpath: str) -> str:
+    def _download_single(self, urlpath: str) -> str:
         urlpath = str(urlpath)
         if is_relative_path(urlpath):
             # append the relative path to the base_path

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -363,11 +363,18 @@ class classproperty(property):  # pylint: disable=invalid-name
 
 def _single_map_nested(args):
     """Apply a function recursively to each element of a nested data struct."""
-    function, data_struct, types, rank, disable_tqdm, desc = args
+    function, data_struct, batched, batch_size, types, rank, disable_tqdm, desc = args
 
     # Singleton first to spare some computation
     if not isinstance(data_struct, dict) and not isinstance(data_struct, types):
         return function(data_struct)
+    if (
+        batched
+        and not isinstance(data_struct, dict)
+        and isinstance(data_struct, types)
+        and all(not isinstance(v, types) for v in data_struct)
+    ):
+        return [mapped_item for batch in iter_batched(data_struct, batch_size) for mapped_item in function(batch)]
 
     # Reduce logging to keep things readable in multiprocessing with tqdm
     if rank is not None and logging.get_verbosity() < logging.WARNING:
@@ -402,6 +409,8 @@ def map_nested(
     map_numpy: bool = False,
     num_proc: Optional[int] = None,
     parallel_min_length: int = 2,
+    batched: bool = False,
+    batch_size: Optional[int] = 1000,
     types: Optional[tuple] = None,
     disable_tqdm: bool = True,
     desc: Optional[str] = None,
@@ -432,9 +441,18 @@ def map_nested(
         map_numpy (`bool, default `False`): Whether also apply `function` recursively to `numpy.array` elements (besides
             `dict` values).
         num_proc (`int`, *optional*): Number of processes.
+            The level in the data struct used for multiprocessing is the first level that has smaller sub-structs,
+            starting from the root.
         parallel_min_length (`int`, default `2`): Minimum length of `data_struct` required for parallel
             processing.
             <Added version="2.5.0"/>
+        batched (`bool`, defaults to `False`):
+            Provide batch of items to `function`.
+            <Added version="2.18.1"/>
+        batch_size (`int`, *optional*, defaults to `1000`):
+            Number of items per batch provided to `function` if `batched=True`.
+            If `batch_size <= 0` or `batch_size == None`, provide the full iterable as a single batch to `function`.
+            <Added version="2.18.1"/>
         types (`tuple`, *optional*): Additional types (besides `dict` values) to apply `function` recursively to their
             elements.
         disable_tqdm (`bool`, default `True`): Whether to disable the tqdm progressbar.
@@ -474,10 +492,16 @@ def map_nested(
             for obj in iterable
         ]
     elif num_proc != -1 and num_proc <= 1 or len(iterable) < parallel_min_length:
+        if batched:
+            if batch_size is None or batch_size <= 0:
+                batch_size = len(iterable) // num_proc + int(len(iterable) % num_proc > 0)
+            iterable = list(iter_batched(iterable, batch_size))
         mapped = [
-            _single_map_nested((function, obj, types, None, True, None))
+            _single_map_nested((function, obj, batched, batch_size, types, None, True, None))
             for obj in hf_tqdm(iterable, disable=disable_tqdm, desc=desc)
         ]
+        if batched:
+            mapped = [mapped_item for mapped_batch in mapped for mapped_item in mapped_batch]
     else:
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -485,7 +509,16 @@ def map_nested(
                 message=".* is experimental and might be subject to breaking changes in the future\\.$",
                 category=UserWarning,
             )
-            mapped = parallel_map(function, iterable, num_proc, types, disable_tqdm, desc, _single_map_nested)
+            if batched:
+                if batch_size is None or batch_size <= 0:
+                    batch_size = len(iterable) // num_proc + int(len(iterable) % num_proc > 0)
+                iterable = list(iter_batched(iterable, batch_size))
+            print(iterable)
+            mapped = parallel_map(
+                function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, _single_map_nested
+            )
+            if batched:
+                mapped = [mapped_item for mapped_batch in mapped for mapped_item in mapped_batch]
 
     if isinstance(data_struct, dict):
         return dict(zip(data_struct.keys(), mapped))
@@ -672,3 +705,18 @@ def iflatmap_unordered(
             if not pool_changed:
                 # we get the result in case there's an error to raise
                 [async_result.get(timeout=0.05) for async_result in async_results]
+
+
+T = TypeVar("T")
+
+
+def iter_batched(iterable: Iterable[T], n: int) -> Iterable[List[T]]:
+    batch = []
+    for item in iterable:
+        if len(batch) == n:
+            yield batch
+            batch = []
+        else:
+            batch.append(item)
+    if batch:
+        yield batch

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -496,7 +496,7 @@ def map_nested(
     elif num_proc != -1 and num_proc <= 1 or len(iterable) < parallel_min_length:
         if batched:
             if batch_size is None or batch_size <= 0:
-                batch_size = len(iterable) // num_proc + int(len(iterable) % num_proc > 0)
+                batch_size = max(len(iterable) // num_proc + int(len(iterable) % num_proc > 0), 1)
             iterable = list(iter_batched(iterable, batch_size))
         mapped = [
             _single_map_nested((function, obj, batched, batch_size, types, None, True, None))

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -476,7 +476,12 @@ def map_nested(
 
     # Singleton
     if not isinstance(data_struct, dict) and not isinstance(data_struct, types):
-        return function(data_struct)
+        if batched:
+            data_struct = [data_struct]
+        mapped = function(data_struct)
+        if batched:
+            mapped = mapped[0]
+        return mapped
 
     iterable = list(data_struct.values()) if isinstance(data_struct, dict) else data_struct
 

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -494,6 +494,8 @@ def map_nested(
                 data_struct=obj,
                 num_proc=num_proc,
                 parallel_min_length=parallel_min_length,
+                batched=batched,
+                batch_size=batch_size,
                 types=types,
             )
             for obj in iterable

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -842,10 +842,10 @@ class ModuleFactoryTest(TestCase):
         )
         assert module_factory_result.builder_configs_parameters.builder_configs[0].data_files == {
             "train": [
-                "hf://datasets/hf-internal-testing/dataset_with_script@8f965694d611974ef8661618ada1b5aeb1072915/default/train/0000.parquet"
+                "hf://datasets/hf-internal-testing/dataset_with_script@0c97cd1168f31e683059ddcf0703e3f45d9007c4/default/train/0000.parquet"
             ],
             "validation": [
-                "hf://datasets/hf-internal-testing/dataset_with_script@8f965694d611974ef8661618ada1b5aeb1072915/default/validation/0000.parquet"
+                "hf://datasets/hf-internal-testing/dataset_with_script@0c97cd1168f31e683059ddcf0703e3f45d9007c4/default/validation/0000.parquet"
             ],
         }
 


### PR DESCRIPTION
...for faster dataset download when there are many many small files (e.g. imagefolder, audiofolder)

### Behcnmark

for example on [lhoestq/tmp-images-writer_batch_size](https://hf.co/datasets/lhoestq/tmp-images-writer_batch_size) (128 images)

|    | duration of the download step in `load_dataset()` |
|--| ----------------------------------------------------------------------|
| Before | 58s |
| Now | 3s |

This should fix issues with the Dataset Viewer taking too much time to show up for imagefolder/audiofolder datasets.

### Implementation details

The main change is in the `DownloadManager`:

```diff
- download_func = partial(self._download, download_config=download_config)
+ download_func = partial(self._download_batched, download_config=download_config)
downloaded_path_or_paths = map_nested(
    download_func,
    url_or_urls,
    map_tuple=True,
    num_proc=download_config.num_proc,
    desc="Downloading data files",
+   batched=True,
+   batch_size=-1,
)
```

and `_download_batched` is a multithreaded function.

I only enable multithreading if there are more than 16 files and files are small though, otherwise the progress bar that counts the number of downloaded files is not fluid (updating when a big batch of big files are done downloading). To do so I simply check if the first file is smaller than 20MB.

I also had to tweak `map_nested` to support batching. In particular it slices the data correctly if the user also enables multiprocessing.