### PR TITLE
Fix typo in docs (upload CLI)

### DIFF
--- a/docs/source/share.mdx
+++ b/docs/source/share.mdx
@@ -87,7 +87,7 @@ The default usage for this command is:
 To upload the current directory at the root of the repo, use:
 
 ```bash
->>> huggingface-cli upload my-cool-dataset --repo-type=dataset . .
+>>> huggingface-cli upload my-cool-dataset . . --repo-type=dataset
 https://huggingface.co/datasets/Wauplin/my-cool-dataset/tree/main/
 ```
 


### PR DESCRIPTION
Related to https://huggingface.slack.com/archives/C04RG8YRVB8/p1712643948574129 (interal)

Positional args must be placed before optional args.

Feel free to merge whenever it's ready.