### PR TITLE
Remove `os.path.relpath` in `resolve_patterns`

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -372,9 +372,7 @@ def resolve_pattern(
     else:
         base_path = ""
     pattern, storage_options = _prepare_path_and_storage_options(pattern, download_config=download_config)
-    fs, *_ = url_to_fs(pattern, **storage_options)
-    fs_base_path = base_path.split("::")[0].split("://")[-1] or fs.root_marker
-    fs_pattern = pattern.split("::")[0].split("://")[-1]
+    fs, fs_pattern = url_to_fs(pattern, **storage_options)
     files_to_ignore = set(FILES_TO_IGNORE) - {xbasename(pattern)}
     protocol = fs.protocol if isinstance(fs.protocol, str) else fs.protocol[0]
     protocol_prefix = protocol + "://" if protocol != "file" else ""
@@ -387,12 +385,8 @@ def resolve_pattern(
         for filepath, info in fs.glob(pattern, detail=True, **glob_kwargs).items()
         if info["type"] == "file"
         and (xbasename(filepath) not in files_to_ignore)
-        and not _is_inside_unrequested_special_dir(
-            os.path.relpath(filepath, fs_base_path), os.path.relpath(fs_pattern, fs_base_path)
-        )
-        and not _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir(
-            os.path.relpath(filepath, fs_base_path), os.path.relpath(fs_pattern, fs_base_path)
-        )
+        and not _is_inside_unrequested_special_dir(filepath, fs_pattern)
+        and not _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir(filepath, fs_pattern)
     ]  # ignore .ipynb and __pycache__, but keep /../
     if allowed_extensions is not None:
         out = [


### PR DESCRIPTION
... to save a few seconds when resolving repos with many data files.