### PR TITLE
Improve typing of Dataset.search, matching definition

### DIFF
--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -364,7 +364,7 @@ class FaissIndex(BaseIndex):
         if not queries.flags.c_contiguous:
             queries = np.asarray(queries, order="C")
         scores, indices = self.faiss_index.search(queries, k, **kwargs)
-        return SearchResults(scores[0], indices[0].astype(int))
+        return SearchResults(scores[0], indices[0].astype(int).tolist())
 
     def search_batch(self, queries: np.array, k=10, **kwargs) -> BatchedSearchResults:
         """Find the nearest examples indices to the queries.
@@ -382,7 +382,7 @@ class FaissIndex(BaseIndex):
         if not queries.flags.c_contiguous:
             queries = np.asarray(queries, order="C")
         scores, indices = self.faiss_index.search(queries, k, **kwargs)
-        return BatchedSearchResults(scores, indices.astype(int))
+        return BatchedSearchResults(scores, indices.astype(int).tolist())
 
     def save(self, file: Union[str, PurePath], storage_options: Optional[Dict] = None):
         """Serialize the FaissIndex on disk"""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -122,6 +122,8 @@ class FaissIndexTest(TestCase):
         self.assertRaises(ValueError, index.search, query.reshape(-1, 1))
         self.assertGreater(scores[0], 0)
         self.assertEqual(indices[0], 1)
+        self.assertIsInstance(indices, list)
+        self.assertIsInstance(indices[0], int)
 
         # batched queries
         queries = np.eye(5, dtype=np.float32)[::-1]
@@ -131,6 +133,8 @@ class FaissIndexTest(TestCase):
         best_indices = [indices[0] for indices in total_indices]
         self.assertGreater(np.min(best_scores), 0)
         self.assertListEqual([4, 3, 2, 1, 0], best_indices)
+        self.assertIsInstance(total_indices, list)
+        self.assertIsInstance(total_indices[0][0], int)
 
     def test_factory(self):
         import faiss


### PR DESCRIPTION
Previously, the output of `score, indices = Dataset.search(...)` would be numpy arrays.

The definition in `SearchResult` is a `List[int]` so this PR now matched the expected type.

The previous behavior is a bit annoying as `Dataset.__getitem__` doesn't support `numpy.int64` which forced me to convert `indices` to int eg:

```python
score, indices = ds.search(...)
item = ds[int(indices[0])]
```