### PR TITLE
Support indexable objects in `Dataset.__getitem__`

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -75,11 +75,6 @@ def _query_table_with_indices_mapping(
     if isinstance(key, Iterable):
         return _query_table(table, [indices.fast_slice(i, 1).column(0)[0].as_py() for i in key])
 
-    try:
-        return operator.index(key)
-    except TypeError:
-        pass
-
     _raise_bad_key_type(key)
 
 
@@ -104,11 +99,6 @@ def _query_table(table: Table, key: Union[int, slice, range, str, Iterable]) -> 
             return table.table.slice(0, 0)
         # don't use pyarrow.Table.take even for pyarrow >=1.0 (see https://issues.apache.org/jira/browse/ARROW-9773)
         return table.fast_gather(key % table.num_rows)
-
-    try:
-        return operator.index(key)
-    except TypeError:
-        pass
 
     _raise_bad_key_type(key)
 


### PR DESCRIPTION
As discussed in https://github.com/huggingface/datasets/pull/6816, this is needed to support objects that implement `__index__` such as `np.int64` in `Dataset.__getitem__`.