### PR TITLE
Remove token arg from CLI examples

### DIFF
--- a/docs/source/cli.mdx
+++ b/docs/source/cli.mdx
@@ -56,7 +56,7 @@ For example:
 
 Do not forget that you need to log in first to your Hugging Face account:
 ```bash
-huggingface-cli login
+>>> huggingface-cli login
 ```
 
 </Tip>

--- a/docs/source/cli.mdx
+++ b/docs/source/cli.mdx
@@ -49,5 +49,5 @@ Note that you should pass the `--trust_remote_code` argument only if you trust t
 
 For example:
 ```bash
->>> datasets-cli convert_to_parquet USERNAME/DATASET_NAME --token USER_ACCESS_TOKEN
+>>> datasets-cli convert_to_parquet USERNAME/DATASET_NAME
 ```

--- a/docs/source/cli.mdx
+++ b/docs/source/cli.mdx
@@ -51,3 +51,12 @@ For example:
 ```bash
 >>> datasets-cli convert_to_parquet USERNAME/DATASET_NAME
 ```
+
+<Tip>
+
+Do not forget that you need to log in first to your Hugging Face account:
+```bash
+huggingface-cli login
+```
+
+</Tip>

--- a/docs/source/cli.mdx
+++ b/docs/source/cli.mdx
@@ -34,7 +34,7 @@ positional arguments:
 
 optional arguments:
   -h, --help           show this help message and exit
-  --token TOKEN        access token to the Hugging Face Hub
+  --token TOKEN        access token to the Hugging Face Hub (defaults to logged-in user's one)
   --revision REVISION  source revision
   --trust_remote_code  whether to trust the code execution of the load script
 ```

--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -24,7 +24,7 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
         parser.add_argument(
             "dataset_id", help="source dataset ID, e.g. USERNAME/DATASET_NAME or ORGANIZATION/DATASET_NAME"
         )
-        parser.add_argument("--token", help="access token to the Hugging Face Hub")
+        parser.add_argument("--token", help="access token to the Hugging Face Hub (defaults to logged-in user's one)")
         parser.add_argument("--revision", help="source revision")
         parser.add_argument(
             "--trust_remote_code", action="store_true", help="whether to trust the code execution of the load script"


### PR DESCRIPTION
Remove token arg from CLI examples.

Fix #6838.

CC: @Wauplin 