### PR TITLE
Fix dataset name for community Hub script-datasets

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1545,6 +1545,7 @@ class HubDatasetModuleFactoryWithScript(_DatasetModuleFactory):
         builder_kwargs = {
             "base_path": hf_dataset_url(self.name, "", revision=self.revision).rstrip("/"),
             "repo_id": self.name,
+            "dataset_name": self.name,
         }
         return DatasetModule(module_path, hash, builder_kwargs, importable_file_path=importable_file_path)
 


### PR DESCRIPTION
Fix dataset name for community Hub script-datasets by passing explicit dataset_name to HubDatasetModuleFactoryWithScript.

Fix #6854.

CC: @Wauplin 