### PR TITLE
Fix line-endings in tests on Windows

### DIFF
--- a/src/datasets/hub.py
+++ b/src/datasets/hub.py
@@ -70,7 +70,9 @@ def delete_from_hub(
             _ = dataset_card.data.pop("dataset_info", None)
     # Commit
     operations.append(
-        CommitOperationAdd(path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode())
+        CommitOperationAdd(
+            path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode(encoding="utf-8")
+        )
     )
     api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
     commit_info = api.create_commit(

--- a/src/datasets/hub.py
+++ b/src/datasets/hub.py
@@ -70,9 +70,7 @@ def delete_from_hub(
             _ = dataset_card.data.pop("dataset_info", None)
     # Commit
     operations.append(
-        CommitOperationAdd(
-            path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode(encoding="utf-8")
-        )
+        CommitOperationAdd(path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode())
     )
     api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
     commit_info = api.create_commit(

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -63,6 +63,11 @@ FILE_CONTENT = """\
 
 
 @pytest.fixture(scope="session")
+def text_file_content():
+    return FILE_CONTENT
+
+
+@pytest.fixture(scope="session")
 def text_file(tmp_path_factory):
     filename = tmp_path_factory.mktemp("data") / "file.txt"
     data = FILE_CONTENT

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -75,13 +75,13 @@ def temporary_repo(cleanup_repo):
 
 
 @pytest.fixture(scope="session")
-def hf_private_dataset_repo_txt_data_(hf_api: HfApi, hf_token, text_file):
+def hf_private_dataset_repo_txt_data_(hf_api: HfApi, hf_token, text_file_content):
     repo_name = f"repo_txt_data-{int(time.time() * 10e6)}"
     repo_id = f"{CI_HUB_USER}/{repo_name}"
     hf_api.create_repo(repo_id, token=hf_token, repo_type="dataset", private=True)
     hf_api.upload_file(
         token=hf_token,
-        path_or_fileobj=str(text_file),
+        path_or_fileobj=text_file_content.encode(),
         path_in_repo="data/text_data.txt",
         repo_id=repo_id,
         repo_type="dataset",

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -75,7 +75,9 @@ def test_delete_from_hub(
         CommitOperationDelete(path_in_repo="dogs/train/0000.csv", is_folder=False),
         CommitOperationAdd(
             path_in_repo="README.md",
-            path_or_fileobj=b"---\nconfigs:\n- config_name: cats\n  data_files:\n  - split: train\n    path: cats/train/*\n---\n",
+            path_or_fileobj="---\nconfigs:\n- config_name: cats\n  data_files:\n  - split: train\n    path: cats/train/*\n---\n".encode(
+                encoding="utf-8"
+            ),
         ),
     ]
     assert mock_method.call_args.kwargs.get("operations") == expected_operations

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -53,7 +53,8 @@ def test_delete_from_hub(
           - split: train
             path: dogs/train/*
         ---
-        """)
+        """),
+            encoding="utf-8",
         )
         hf_api.upload_file(
             token=hf_token,

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -76,7 +76,7 @@ def test_delete_from_hub(temporary_repo, hf_api, hf_token, csv_path, ci_hub_conf
               - split: train
                 path: cats/train/*
             ---
-            """).encode(encoding="utf-8"),
+            """).encode(),
         ),
     ]
     assert mock_method.call_args.kwargs.get("operations") == expected_operations

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -20,9 +20,7 @@ def test_dataset_url(repo_id, filename, revision):
     assert url == f"https://huggingface.co/datasets/{repo_id}/resolve/{revision or 'main'}/{quote(filename)}"
 
 
-def test_delete_from_hub(
-    temporary_repo, hf_api, hf_token, csv_path, tmp_path, ci_hub_config, ci_hfh_hf_hub_url
-) -> None:
+def test_delete_from_hub(temporary_repo, hf_api, hf_token, csv_path, ci_hub_config, ci_hfh_hf_hub_url) -> None:
     with temporary_repo() as repo_id:
         hf_api.create_repo(repo_id, token=hf_token, repo_type="dataset")
         hf_api.upload_file(
@@ -39,26 +37,21 @@ def test_delete_from_hub(
             repo_type="dataset",
             token=hf_token,
         )
-        readme_path = tmp_path / "README.md"
-        readme_path.write_text(
-            dedent(f"""\
-        ---
-        {METADATA_CONFIGS_FIELD}:
-        - config_name: cats
-          data_files:
-          - split: train
-            path: cats/train/*
-        - config_name: dogs
-          data_files:
-          - split: train
-            path: dogs/train/*
-        ---
-        """),
-            encoding="utf-8",
-        )
         hf_api.upload_file(
             token=hf_token,
-            path_or_fileobj=str(readme_path),
+            path_or_fileobj=dedent(f"""\
+            ---
+            {METADATA_CONFIGS_FIELD}:
+            - config_name: cats
+              data_files:
+              - split: train
+                path: cats/train/*
+            - config_name: dogs
+              data_files:
+              - split: train
+                path: dogs/train/*
+            ---
+            """).encode(),
             path_in_repo="README.md",
             repo_id=repo_id,
             repo_type="dataset",

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -68,9 +68,15 @@ def test_delete_from_hub(temporary_repo, hf_api, hf_token, csv_path, ci_hub_conf
         CommitOperationDelete(path_in_repo="dogs/train/0000.csv", is_folder=False),
         CommitOperationAdd(
             path_in_repo="README.md",
-            path_or_fileobj="---\nconfigs:\n- config_name: cats\n  data_files:\n  - split: train\n    path: cats/train/*\n---\n".encode(
-                encoding="utf-8"
-            ),
+            path_or_fileobj=dedent(f"""\
+            ---
+            {METADATA_CONFIGS_FIELD}:
+            - config_name: cats
+              data_files:
+              - split: train
+                path: cats/train/*
+            ---
+            """).encode(encoding="utf-8"),
         ),
     ]
     assert mock_method.call_args.kwargs.get("operations") == expected_operations


### PR DESCRIPTION
EDIT:
~~Fix test_delete_from_hub on Windows by passing explicit encoding.~~
Fix test_delete_from_hub and test_xgetsize_private by uploading the README file content directly (encoding the string), instead of writing a local file and uploading it.

Note that local files created on Windows will have "\r\n" line endings, instead of "\n".

Fix #6856.