### PR TITLE
Document that to_json defaults to JSON Lines

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4984,6 +4984,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     ) -> int:
         """Export the dataset to JSON Lines or JSON.
 
+        The default output format is [JSON Lines](https://jsonlines.org/).
+        To export to [JSON](https://www.json.org), pass `lines=False` argument and the desired `orient`.
+
         Args:
             path_or_buf (`PathLike` or `FileOrBuffer`):
                 Either a path to a file (e.g. `file.json`), a remote URI (e.g. `hf://datasets/username/my_dataset_name/data.json`),
@@ -4992,7 +4995,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Size of the batch to load in memory and write at once.
                 Defaults to `datasets.config.DEFAULT_MAX_BATCH_SIZE`.
             num_proc (`int`, *optional*):
-                Number of processes for multiprocessing. By default it doesn't
+                Number of processes for multiprocessing. By default, it doesn't
                 use multiprocessing. `batch_size` in this case defaults to
                 `datasets.config.DEFAULT_MAX_BATCH_SIZE` but feel free to make it 5x or 10x of the default
                 value if you have sufficient compute power.
@@ -5002,10 +5005,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 <Added version="2.19.0"/>
             **to_json_kwargs (additional keyword arguments):
                 Parameters to pass to pandas's [`pandas.DataFrame.to_json`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html).
+                Default arguments are `lines=True` and `orient="records".
 
                 <Changed version="2.11.0">
 
-                Now, `index` defaults to `False` if `orient` is `"split"` or `"table"`.
+                The parameter `index` defaults to `False` if `orient` is `"split"` or `"table"`.
 
                 If you would like to write the index, pass `index=True`.
 
@@ -5017,7 +5021,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         Example:
 
         ```py
-        >>> ds.to_json("path/to/dataset/directory")
+        >>> ds.to_json("path/to/dataset/directory/filename.jsonl")
         ```
         """
         # Dynamic import to avoid circular dependency


### PR DESCRIPTION
Document that `Dataset.to_json` defaults to JSON Lines, by adding explanation in the corresponding docstring.

Fix #6894.