### PR TITLE
Fix YAML error in README files appearing on GitHub

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,5 +1,5 @@
 ---
-TODO: Add YAML tags here. Copy-paste the tags obtained with the online tagging app: https://huggingface.co/spaces/huggingface/datasets-tagging
+TODO: "Add YAML tags here. Delete these instructions and copy-paste the YAML tags obtained with the online tagging app: https://huggingface.co/spaces/huggingface/datasets-tagging"
 ---
 
 # Dataset Card for [Dataset Name]

--- a/templates/README_guide.md
+++ b/templates/README_guide.md
@@ -1,6 +1,6 @@
 ---
-YAML tags (full spec here: https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1):
-- copy-paste the tags obtained with the online tagging app: https://huggingface.co/spaces/huggingface/datasets-tagging
+TODO: "Add YAML tags here. Delete these instructions and copy-paste the YAML tags obtained with the online tagging app: https://huggingface.co/spaces/huggingface/datasets-tagging"
+YAML tags: "Find the full spec here: https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1"
 ---
 
 # Dataset Card Creation Guide


### PR DESCRIPTION
Fix YAML error in README files appearing on GitHub.

See error message:
![Screenshot from 2024-05-14 06-58-02](https://github.com/huggingface/datasets/assets/8515462/7984cc4e-96ee-4e83-99a4-4c0c5791fa05)


Fix #6897.