### PR TITLE
Make CLI convert_to_parquet not raise error if no rights to create script branch

### DIFF
--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from typing import Optional
 
 from huggingface_hub import HfApi, create_branch, get_repo_discussions
+from huggingface_hub.utils import HfHubHTTPError
 
 from datasets import get_dataset_config_names, get_dataset_default_config_name, load_dataset
 from datasets.commands import BaseDatasetsCLICommand
@@ -91,7 +92,10 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
             time.sleep(5)
         delete_files(dataset_id, revision=pr_revision, token=token)
         if not revision:
-            create_branch(dataset_id, branch="script", repo_type="dataset", token=token, exist_ok=True)
+            try:
+                create_branch(dataset_id, branch="script", repo_type="dataset", token=token, exist_ok=True)
+            except HfHubHTTPError:
+                pass
         print(f"You can find your PR to convert the dataset to Parquet at: {pr_url}")
 
 


### PR DESCRIPTION
Make CLI convert_to_parquet not raise error if no rights to create script branch.

Fix #6901.