### PR TITLE
Fix decoding multi part extension

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1250,6 +1250,8 @@ def encode_nested_example(schema, obj, level=0):
         sub_schema = schema[0]
         if obj is None:
             return None
+        elif isinstance(obj, np.ndarray):
+            return encode_nested_example(schema, obj.tolist())
         else:
             if len(obj) > 0:
                 for first_elmt in obj:

--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -31,8 +31,8 @@ class WebDataset(datasets.GeneratorBasedBuilder):
                 current_example["__key__"] = example_key
                 current_example["__url__"] = tar_path
                 current_example[field_name.lower()] = f.read()
-                if field_name in cls.DECODERS:
-                    current_example[field_name] = cls.DECODERS[field_name](current_example[field_name])
+                if field_name.split(".")[-1] in cls.DECODERS:
+                    current_example[field_name] = cls.DECODERS[field_name.split(".")[-1]](current_example[field_name])
         if current_example:
             yield current_example
 


### PR DESCRIPTION
e.g. a field named `url.txt` should be a treated as text

I also included a small fix to support .npz correctly