### PR TITLE
Validate config name and data_files in packaged modules

### DIFF
--- a/src/datasets/packaged_modules/arrow/arrow.py
+++ b/src/datasets/packaged_modules/arrow/arrow.py
@@ -17,6 +17,9 @@ class ArrowConfig(datasets.BuilderConfig):
 
     features: Optional[datasets.Features] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class Arrow(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = ArrowConfig

--- a/src/datasets/packaged_modules/audiofolder/audiofolder.py
+++ b/src/datasets/packaged_modules/audiofolder/audiofolder.py
@@ -15,6 +15,9 @@ class AudioFolderConfig(folder_based_builder.FolderBasedBuilderConfig):
     drop_labels: bool = None
     drop_metadata: bool = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class AudioFolder(folder_based_builder.FolderBasedBuilder):
     BASE_FEATURE = datasets.Audio

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -68,6 +68,7 @@ class CsvConfig(datasets.BuilderConfig):
     date_format: Optional[str] = None
 
     def __post_init__(self):
+        super().__post_init__()
         if self.delimiter is not None:
             self.sep = self.delimiter
         if self.column_names is not None:

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -28,6 +28,9 @@ class FolderBasedBuilderConfig(datasets.BuilderConfig):
     drop_labels: bool = None
     drop_metadata: bool = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
     """

--- a/src/datasets/packaged_modules/generator/generator.py
+++ b/src/datasets/packaged_modules/generator/generator.py
@@ -11,7 +11,9 @@ class GeneratorConfig(datasets.BuilderConfig):
     features: Optional[datasets.Features] = None
 
     def __post_init__(self):
-        assert self.generator is not None, "generator must be specified"
+        super().__post_init__()
+        if self.generator is None:
+            raise ValueError("generator must be specified")
 
         if self.gen_kwargs is None:
             self.gen_kwargs = {}

--- a/src/datasets/packaged_modules/imagefolder/imagefolder.py
+++ b/src/datasets/packaged_modules/imagefolder/imagefolder.py
@@ -15,6 +15,9 @@ class ImageFolderConfig(folder_based_builder.FolderBasedBuilderConfig):
     drop_labels: bool = None
     drop_metadata: bool = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class ImageFolder(folder_based_builder.FolderBasedBuilder):
     BASE_FEATURE = datasets.Image

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -36,6 +36,9 @@ class JsonConfig(datasets.BuilderConfig):
     chunksize: int = 10 << 20  # 10MB
     newlines_in_values: Optional[bool] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class Json(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = JsonConfig

--- a/src/datasets/packaged_modules/pandas/pandas.py
+++ b/src/datasets/packaged_modules/pandas/pandas.py
@@ -16,6 +16,9 @@ class PandasConfig(datasets.BuilderConfig):
 
     features: Optional[datasets.Features] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class Pandas(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = PandasConfig

--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -20,6 +20,9 @@ class ParquetConfig(datasets.BuilderConfig):
     columns: Optional[List[str]] = None
     features: Optional[datasets.Features] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class Parquet(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = ParquetConfig

--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -30,6 +30,9 @@ class SparkConfig(datasets.BuilderConfig):
 
     features: Optional[datasets.Features] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 def _reorder_dataframe_by_partition(df: "pyspark.sql.DataFrame", new_partition_order: List[int]):
     df_combined = df.select("*").where(f"part_id = {new_partition_order[0]}")

--- a/src/datasets/packaged_modules/sql/sql.py
+++ b/src/datasets/packaged_modules/sql/sql.py
@@ -35,6 +35,7 @@ class SqlConfig(datasets.BuilderConfig):
     features: Optional[datasets.Features] = None
 
     def __post_init__(self):
+        super().__post_init__()
         if self.sql is None:
             raise ValueError("sql must be specified")
         if self.con is None:

--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -27,6 +27,7 @@ class TextConfig(datasets.BuilderConfig):
     sample_by: str = "line"
 
     def __post_init__(self, errors):
+        super().__post_init__()
         if errors != "deprecated":
             warnings.warn(
                 "'errors' was deprecated in favor of 'encoding_errors' in version 2.14.0 and will be removed in 3.0.0.\n"


### PR DESCRIPTION
Validate the config attributes `name` and `data_files` in packaged modules by making the derived classes call their parent `__post_init__` method.

Note that their parent `BuilderConfig` validates its attributes `name` and `data_files` in its `__post_init__` method: https://github.com/huggingface/datasets/blob/60d21efbc01e15d0b596ac1072750cbecd91548a/src/datasets/builder.py#L128-L137

This PR makes the derived config classes call their parent `__post_init__` method to validate their `name` and `data_files` attributes.