### PR TITLE
Fix expected splits when passing data_files or dir

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -2277,6 +2277,8 @@ def load_dataset_builder(
     )
     dataset_name = builder_kwargs.pop("dataset_name", None)
     info = dataset_module.dataset_infos.get(config_name) if dataset_module.dataset_infos else None
+    if data_dir or data_files:
+        info.splits = None
 
     if (
         path in _PACKAGED_DATASETS_MODULES

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1210,15 +1210,24 @@ def test_load_dataset_builder_for_community_dataset_with_script_no_parquet_expor
 
 
 @pytest.mark.integration
-def test_load_dataset_builder_use_parquet_export_if_dont_trust_remote_code_keeps_features():
+def test_load_dataset_builder_load_features_and_splits_info():
     dataset_name = "food101"
-    builder = datasets.load_dataset_builder(dataset_name, trust_remote_code=False)
+    builder = datasets.load_dataset_builder(dataset_name)
     assert isinstance(builder, DatasetBuilder)
     assert builder.name == "parquet"
     assert builder.dataset_name == dataset_name
     assert builder.config.name == "default"
     assert list(builder.info.features) == ["image", "label"]
     assert builder.info.features["image"] == Image()
+    assert builder.info.splits is not None
+    builder = datasets.load_dataset_builder(dataset_name, data_files="data/validation-00000-of-00003.parquet")
+    assert isinstance(builder, DatasetBuilder)
+    assert builder.name == "parquet"
+    assert builder.dataset_name == dataset_name
+    assert builder.config.name == "default"
+    assert list(builder.info.features) == ["image", "label"]
+    assert builder.info.features["image"] == Image()
+    assert builder.info.splits is None
 
 
 @pytest.mark.integration


### PR DESCRIPTION
reported on slack:

The following code snippet gives an error with v2.19 but not with v2.18:
from datasets import load_dataset
```
dataset = load_dataset(
    "lvwerra/stack-exchange-paired",
    split="train",
    cache_dir=None,
    data_dir="data/rl",
)
```
and the error is:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/datasets/load.py", line 2609, in load_dataset
    builder_instance.download_and_prepare(
  File "/usr/local/lib/python3.10/dist-packages/datasets/builder.py", line 1027, in download_and_prepare
    self._download_and_prepare(
  File "/usr/local/lib/python3.10/dist-packages/datasets/builder.py", line 1140, in _download_and_prepare
    verify_splits(self.info.splits, split_dict)
  File "/usr/local/lib/python3.10/dist-packages/datasets/utils/info_utils.py", line 92, in verify_splits
    raise ExpectedMoreSplits(str(set(expected_splits) - set(recorded_splits)))
datasets.utils.info_utils.ExpectedMoreSplits: {'test'}
```
