### PR TITLE
Update yanked version of minimum requests requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ REQUIRED_PKGS = [
     # For performance gains with apache arrow
     "pandas",
     # for downloading datasets over HTTPS
-    "requests>=2.32.1",
+    "requests>=2.32.2",
     # progress bars in download and scripts
     "tqdm>=4.66.3",
     # for fast hashing


### PR DESCRIPTION
Update yanked version of minimum requests requirement.

Version 2.32.1 was yanked: https://pypi.org/project/requests/2.32.1/