### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -100,7 +100,8 @@ If your dataset consists of N-dimensional arrays, you will see that by default t
 {'data': [Array([1, 2], dtype=int32), Array([3], dtype=int32)]}
 ```
 
-However this logic often requires slow shape comparisons and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
+However this logic often requires slow shape comparisons and data copies.
+To avoid this, you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D

--- a/docs/source/use_with_jax.mdx
+++ b/docs/source/use_with_jax.mdx
@@ -100,7 +100,7 @@ If your dataset consists of N-dimensional arrays, you will see that by default t
 {'data': [Array([1, 2], dtype=int32), Array([3], dtype=int32)]}
 ```
 
-However this logic often requires slow shape comparisions and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
+However this logic often requires slow shape comparisons and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D

--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -61,7 +61,7 @@ If your dataset consists of N-dimensional arrays, you will see that by default t
 {'data': [tensor([1, 2]), tensor([3])]}
 ```
 
-However this logic often requires slow shape comparisions and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
+However this logic often requires slow shape comparisons and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D

--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -61,7 +61,8 @@ If your dataset consists of N-dimensional arrays, you will see that by default t
 {'data': [tensor([1, 2]), tensor([3])]}
 ```
 
-However this logic often requires slow shape comparisons and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
+However this logic often requires slow shape comparisons and data copies.
+To avoid this, you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D

--- a/docs/source/use_with_tensorflow.mdx
+++ b/docs/source/use_with_tensorflow.mdx
@@ -42,7 +42,6 @@ array([[1, 2],
 ## N-dimensional arrays
 
 If your dataset consists of N-dimensional arrays, you will see that by default they are considered as the same tensor if the shape is fixed:
-Otherwise, a TensorFlow formatted dataset outputs a `RaggedTensor` instead of a single tensor:
 
 ```py
 >>> from datasets import Dataset
@@ -54,6 +53,8 @@ Otherwise, a TensorFlow formatted dataset outputs a `RaggedTensor` instead of a 
  array([[1, 2],
         [3, 4]])>}
 ```
+
+Otherwise, a TensorFlow formatted dataset outputs a `RaggedTensor` instead of a single tensor:
 
 ```py
 >>> from datasets import Dataset

--- a/docs/source/use_with_tensorflow.mdx
+++ b/docs/source/use_with_tensorflow.mdx
@@ -64,7 +64,7 @@ Otherwise, a TensorFlow formatted dataset outputs a `RaggedTensor` instead of a 
 {'data': <tf.RaggedTensor [[1, 2], [3]]>}
 ```
 
-However this logic often requires slow shape comparisions and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
+However this logic often requires slow shape comparisons and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D

--- a/docs/source/use_with_tensorflow.mdx
+++ b/docs/source/use_with_tensorflow.mdx
@@ -65,7 +65,8 @@ Otherwise, a TensorFlow formatted dataset outputs a `RaggedTensor` instead of a 
 {'data': <tf.RaggedTensor [[1, 2], [3]]>}
 ```
 
-However this logic often requires slow shape comparisons and data copies, to avoid this you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
+However this logic often requires slow shape comparisons and data copies.
+To avoid this, you must explicitly use the [`Array`] feature type and specify the shape of your tensors:
 
 ```py
 >>> from datasets import Dataset, Features, Array2D


### PR DESCRIPTION
Fix typos in docs introduced by:
- #6956

Typos:
- `comparisions` => `comparisons`
- two consecutive sentences both ending in colon
- split one sentence into two

Sorry, I did not have time to review that PR.

CC: @lhoestq 