### PR TITLE
Better error handling in `dataset_module_factory`

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1844,9 +1844,12 @@ def dataset_module_factory(
             ) as e:
                 raise ConnectionError(f"Couldn't reach '{path}' on the Hub ({e.__class__.__name__})") from e
             except GatedRepoError as e:
-                raise DatasetNotFoundError(
-                    f"Dataset '{path}' is a gated dataset on the Hub. Visit the dataset page at https://huggingface.co/datasets/{path} to ask for access."
-                ) from e
+                message = f"Dataset '{path}' is a gated dataset on the Hub."
+                if "401 Client Error" in str(e):
+                    message += " You must be authenticated to access it."
+                elif "403 Client Error" in str(e):
+                    message += f" Visit the dataset page at https://huggingface.co/datasets/{path} to ask for access."
+                raise DatasetNotFoundError(message) from e
             except RevisionNotFoundError as e:
                 raise DatasetNotFoundError(
                     f"Revision '{revision}' doesn't exist for dataset '{path}' on the Hub."

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1048,13 +1048,9 @@ class LoadTest(TestCase):
             str(context.exception),
         )
         with self.assertRaises(DatasetNotFoundError) as context:
-            datasets.load_dataset("_dummy", revision="0.0.0")
+            datasets.load_dataset("HuggingFaceFW/fineweb-edu", revision="0.0.0")
         self.assertIn(
-            "Dataset '_dummy' doesn't exist on the Hub",
-            str(context.exception),
-        )
-        self.assertIn(
-            "at revision '0.0.0'",
+            "Revision '0.0.0' doesn't exist for dataset 'HuggingFaceFW/fineweb-edu' on the Hub.",
             str(context.exception),
         )
         for offline_simulation_mode in list(OfflineSimulationMode):


### PR DESCRIPTION
cc @cakiki who reported it on [slack](https://huggingface.slack.com/archives/C039P47V1L5/p1717754405578539) (private link)

This PR updates how errors are handled in `dataset_module_factory` when the  `dataset_info` cannot be accessed:
1. Use multiple `except ... as e` instead of using `isinstance(e, ...)`
2. Always raise `DatasetNotFoundError` with `from e` so that the initial error is explicitly logged in the stacktrace.
3. Differentiate `RepoNotFoundError` / `GatedRepoError` / `RevisionNotFoundError` cases