### PR TITLE
Improve skip take shuffling and distributed

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1361,7 +1361,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
                 split_when_sharding=self.split_when_sharding,
             )
         else:
-            self
+            return self
 
     @property
     def n_shards(self) -> int:


### PR DESCRIPTION
set the right behavior of skip/take depending on whether it's called after or before shuffle/split_by_node