### PR TITLE
packaging: Remove useless dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ Steps to make a release:
      ```
    Check that you can install it in a virtualenv/notebook by running:
      ```
-     pip install huggingface-hub fsspec aiohttp pyarrow-hotfix
+     pip install huggingface-hub fsspec aiohttp
      pip install -U tqdm
      pip install -i https://testpypi.python.org/pypi datasets
      ```
@@ -115,8 +115,6 @@ REQUIRED_PKGS = [
     # Backend and serialization.
     # Minimum 15.0.0 to be able to cast dictionary types to their underlying types
     "pyarrow>=15.0.0",
-    # As long as we allow pyarrow < 14.0.1, to fix vulnerability CVE-2023-47248
-    "pyarrow-hotfix",
     # For smart caching dataset processing
     "dill>=0.3.0,<0.3.9",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
     # For performance gains with apache arrow

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -32,7 +32,6 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.types
-import pyarrow_hotfix  # noqa: F401  # to fix vulnerability on pyarrow<14.0.1
 from pandas.api.extensions import ExtensionArray as PandasExtensionArray
 from pandas.api.extensions import ExtensionDtype as PandasExtensionDtype
 


### PR DESCRIPTION
Revert changes in #6396 and #6404. CVE-2023-47248 has been fixed since PyArrow v14.0.1. Meanwhile Python requirements requires `pyarrow>=15.0.0`.