### PR TITLE
Fix webdataset pickling

### DIFF
--- a/src/datasets/exceptions.py
+++ b/src/datasets/exceptions.py
@@ -7,7 +7,7 @@ from huggingface_hub import HfFileSystem
 from . import config
 from .table import CastError
 from .utils.deprecation_utils import deprecated
-from .utils.track import TrackedIterable, tracked_list, tracked_str
+from .utils.track import TrackedIterableFromGenerator, tracked_list, tracked_str
 
 
 class DatasetsError(Exception):
@@ -65,9 +65,11 @@ class DatasetGenerationCastError(DatasetGenerationError):
         )
         formatted_tracked_gen_kwargs: List[str] = []
         for gen_kwarg in gen_kwargs.values():
-            if not isinstance(gen_kwarg, (tracked_str, tracked_list, TrackedIterable)):
+            if not isinstance(gen_kwarg, (tracked_str, tracked_list, TrackedIterableFromGenerator)):
                 continue
-            while isinstance(gen_kwarg, (tracked_list, TrackedIterable)) and gen_kwarg.last_item is not None:
+            while (
+                isinstance(gen_kwarg, (tracked_list, TrackedIterableFromGenerator)) and gen_kwarg.last_item is not None
+            ):
                 gen_kwarg = gen_kwarg.last_item
             if isinstance(gen_kwarg, tracked_str):
                 gen_kwarg = gen_kwarg.get_origin()

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1567,17 +1567,19 @@ def xxml_dom_minidom_parse(filename_or_file, download_config: Optional[DownloadC
 class _IterableFromGenerator(TrackedIterable):
     """Utility class to create an iterable from a generator function, in order to reset the generator when needed."""
 
-    def __init__(self, generator: Callable, *args, **kwargs):
+    def __init__(self, generator: Callable, *args):
         super().__init__()
         self.generator = generator
         self.args = args
-        self.kwargs = kwargs
 
     def __iter__(self):
-        for x in self.generator(*self.args, **self.kwargs):
+        for x in self.generator(*self.args):
             self.last_item = x
             yield x
         self.last_item = None
+
+    def __reduce__(self):
+        return (self.__class__, (self.generator, *self.args))
 
 
 class ArchiveIterable(_IterableFromGenerator):

--- a/src/datasets/utils/track.py
+++ b/src/datasets/utils/track.py
@@ -37,9 +37,19 @@ class tracked_list(list):
             return f"{self.__class__.__name__}(current={self.last_item})"
 
 
-class TrackedIterable(Iterable):
-    def __init__(self) -> None:
+class TrackedIterableFromGenerator(Iterable):
+    """Utility class to create an iterable from a generator function, in order to reset the generator when needed."""
+
+    def __init__(self, generator, *args):
         super().__init__()
+        self.generator = generator
+        self.args = args
+        self.last_item = None
+
+    def __iter__(self):
+        for x in self.generator(*self.args):
+            self.last_item = x
+            yield x
         self.last_item = None
 
     def __repr__(self) -> str:
@@ -47,3 +57,6 @@ class TrackedIterable(Iterable):
             return super().__repr__()
         else:
             return f"{self.__class__.__name__}(current={self.last_item})"
+
+    def __reduce__(self):
+        return (self.__class__, (self.generator, *self.args))

--- a/src/datasets/utils/track.py
+++ b/src/datasets/utils/track.py
@@ -44,6 +44,6 @@ class TrackedIterable(Iterable):
 
     def __repr__(self) -> str:
         if self.last_item is None:
-            super().__repr__()
+            return super().__repr__()
         else:
             return f"{self.__class__.__name__}(current={self.last_item})"


### PR DESCRIPTION
...by making tracked iterables picklable.

This is important to make streaming datasets compatible with multiprocessing e.g. for parallel data loading