### PR TITLE
Fix CI by temporarily pinning ruff < 0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ METRICS_TESTS_REQUIRE = [
 TESTS_REQUIRE.extend(VISION_REQUIRE)
 TESTS_REQUIRE.extend(AUDIO_REQUIRE)
 
-QUALITY_REQUIRE = ["ruff>=0.3.0"]
+QUALITY_REQUIRE = ["ruff>=0.3.0,<0.5.0"]
 
 DOCS_REQUIRE = [
     # Might need to add doc-builder and some specific deps in the future


### PR DESCRIPTION
As a hotfix for CI, temporarily pin ruff upper version < 0.5.0.

Fix #7006.

Revert once root cause is fixed.