### PR TITLE
Re-enable raising error from huggingface-hub FutureWarning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ known-first-party = ["datasets"]
 
 [tool.pytest.ini_options]
 # Test fails if a FutureWarning is thrown by `huggingface_hub`
-# Temporarily disabled because transformers 4.41.1 calls deprecated code from `huggingface_hub` that causes FutureWarning
-# filterwarnings = [
-#     "error::FutureWarning:huggingface_hub*",
-# ]
+filterwarnings = [
+    "error::FutureWarning:huggingface_hub*",
+]
 markers = [
     "unit: unit test",
     "integration: integration test",


### PR DESCRIPTION
Re-enable raising error from huggingface-hub FutureWarning in tests, once that the fix in transformers
- https://github.com/huggingface/transformers/pull/31007

was just released yesterday in transformers-4.42.0: https://github.com/huggingface/transformers/releases/tag/v4.42.0


Fix #7010.