### PR TITLE
Fix casting list array to fixed size list

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1919,7 +1919,7 @@ def array_cast(
                         )
                 else:
                     array_values = array.values[
-                        array.offset * pa_type.length : (array.offset + len(array)) * pa_type.length
+                        array.offset * pa_type.list_size : (array.offset + len(array)) * pa_type.list_size
                     ]
                     return pa.FixedSizeListArray.from_arrays(_c(array_values, pa_type.value_type), pa_type.list_size)
         elif pa.types.is_list(pa_type):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -19,6 +19,7 @@ from datasets.table import (
     _in_memory_arrow_table_from_file,
     _interpolation_search,
     _memory_mapped_arrow_table_from_file,
+    array_cast,
     cast_array_to_feature,
     concat_tables,
     embed_array_storage,
@@ -1323,3 +1324,12 @@ def test_table_iter(table, batch_size, drop_last_batch):
     if num_rows > 0:
         reloaded = pa.concat_tables(subtables)
         assert table.slice(0, num_rows).to_pydict() == reloaded.to_pydict()
+
+
+@pytest.mark.parametrize("to_type", ["list", "fixed_size_list"])
+@pytest.mark.parametrize("from_type", ["list", "fixed_size_list"])
+def test_array_cast(from_type, to_type):
+    array_type = {"list": pa.list_(pa.int64()), "fixed_size_list": pa.list_(pa.int64(), 2)}
+    arr = pa.array([[0, 1]], type=array_type[from_type])
+    cast_arr = array_cast(arr, array_type[to_type])
+    assert cast_arr.type == array_type[to_type]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1333,3 +1333,4 @@ def test_array_cast(from_type, to_type):
     arr = pa.array([[0, 1]], type=array_type[from_type])
     cast_arr = array_cast(arr, array_type[to_type])
     assert cast_arr.type == array_type[to_type]
+    assert cast_arr.values == arr.values


### PR DESCRIPTION
Fix casting list array to fixed size list.

This bug was introduced in [datasets-2.17.0](https://github.com/huggingface/datasets/releases/tag/2.17.0) by PR: https://github.com/huggingface/datasets/pull/6283/files#diff-1cb2b66aa9311d729cfd83013dad56cf5afcda35b39dfd0bfe9c3813a049eab0R1899
- #6283

Fix #7020.