### PR TITLE
Register `.zstd` extension for zstd-compressed files

### DIFF
--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -16,7 +16,7 @@ _has_s3fs = importlib.util.find_spec("s3fs") is not None
 if _has_s3fs:
     from .s3filesystem import S3FileSystem
 
-COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
+COMPRESSION_FILESYSTEMS: List[type[compression.BaseCompressedFileFileSystem]] = [
     compression.Bz2FileSystem,
     compression.GzipFileSystem,
     compression.Lz4FileSystem,

--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -16,7 +16,7 @@ _has_s3fs = importlib.util.find_spec("s3fs") is not None
 if _has_s3fs:
     from .s3filesystem import S3FileSystem
 
-COMPRESSION_FILESYSTEMS: List[type[compression.BaseCompressedFileFileSystem]] = [
+COMPRESSION_FILESYSTEMS: List[compression.BaseCompressedFileFileSystem] = [
     compression.Bz2FileSystem,
     compression.GzipFileSystem,
     compression.Lz4FileSystem,

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -751,6 +751,7 @@ COMPRESSION_EXTENSION_TO_PROTOCOL = {
     **{fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS},
     # archive compression
     "zip": "zip",
+    "zstd": "zstd",
 }
 SINGLE_FILE_COMPRESSION_EXTENSION_TO_PROTOCOL = {
     fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -749,9 +749,9 @@ BASE_KNOWN_EXTENSIONS = [
 COMPRESSION_EXTENSION_TO_PROTOCOL = {
     # single file compression
     **{fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS},
+    "zstd": "zstd",  # in addition to `zst`, see ZstdFileSystem.extension
     # archive compression
     "zip": "zip",
-    "zstd": "zstd",
 }
 SINGLE_FILE_COMPRESSION_EXTENSION_TO_PROTOCOL = {
     fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -754,7 +754,8 @@ COMPRESSION_EXTENSION_TO_PROTOCOL = {
     "zip": "zip",
 }
 SINGLE_FILE_COMPRESSION_EXTENSION_TO_PROTOCOL = {
-    fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS
+    **{fs_class.extension.lstrip("."): fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS},
+    "zstd": "zstd",  # in addition to `zst`, see ZstdFileSystem.extension
 }
 SINGLE_FILE_COMPRESSION_PROTOCOLS = {fs_class.protocol for fs_class in COMPRESSION_FILESYSTEMS}
 SINGLE_SLASH_AFTER_PROTOCOL_PATTERN = re.compile(r"(?<!:):/")


### PR DESCRIPTION
For example, https://huggingface.co/datasets/mlfoundations/dclm-baseline-1.0 dataset files have `.zstd` extension which is currently ignored (only `.zst` is registered).