### PR TITLE
Fix doc generation when NamedSplit is used as parameter default value

### DIFF
--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -376,7 +376,7 @@ class NamedSplit(SplitBase):
         elif isinstance(other, str):  # Other should be string
             return self._name == other
         else:
-            raise ValueError(f"Equality not supported between split {self} and {other}")
+            return False
 
     def __lt__(self, other):
         return self._name < other._name  # pylint: disable=protected-access

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -1,6 +1,8 @@
+import inspect
+
 import pytest
 
-from datasets.splits import SplitDict, SplitInfo
+from datasets.splits import Split, SplitDict, SplitInfo
 from datasets.utils.py_utils import asdict
 
 
@@ -34,3 +36,8 @@ def test_split_dict_asdict_has_dataset_name(split_info):
     split_dict_asdict = asdict(SplitDict({"train": split_info}))
     assert "dataset_name" in split_dict_asdict["train"]
     assert split_dict_asdict["train"]["dataset_name"] == split_info.dataset_name
+
+
+def test_named_split_inequality():
+    # Used while building the docs, when set as a default parameter value in a function signature
+    assert Split.TRAIN != inspect.Parameter.empty


### PR DESCRIPTION
Fix doc generation when `NamedSplit` is used as parameter default value.

Fix #7035.