### PR TITLE
Improved the tutorial by adding a link for loading datasets

### DIFF
--- a/docs/source/create_dataset.mdx
+++ b/docs/source/create_dataset.mdx
@@ -61,6 +61,8 @@ squirtle.png, When it retracts its long neck into its shell, it squirts out wate
 
 To learn more about each of these folder-based builders, check out the and <a href="https://huggingface.co/docs/datasets/image_dataset#imagefolder"><span class="underline decoration-yellow-400 decoration-2 font-semibold">ImageFolder</span></a> or <a href="https://huggingface.co/docs/datasets/audio_dataset#audiofolder"><span class="underline decoration-pink-400 decoration-2 font-semibold">AudioFolder</span></a> guides.
 
+For similiar builders to load data from common formats such as `csv`, `json/jsonl`, `parquet`, and `txt` follow this guide [here](https://huggingface.co/docs/datasets/loading#local-and-remote-files)
+
 ## From local files
 
 You can also create a dataset from local files by specifying the path to the data files. There are two ways you can create a dataset using the `from_` methods:


### PR DESCRIPTION
Improved the tutorial by letting readers know about loading datasets with common files and including a link. I left the local files section alone because the methods were already listed with code snippets.