### PR TITLE
Add decorator as explicit test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ BENCHMARKS_REQUIRE = [
 TESTS_REQUIRE = [
     # test dependencies
     "absl-py",
+    "decorator",
     "joblib<1.3.0",  # joblibspark doesn't support recent joblib versions
     "joblibspark",
     "pytest",


### PR DESCRIPTION
Add decorator as explicit test dependency.

We use `decorator` library in our CI test since PR:
- #4845

However we did not add it as an explicit test requirement, and we depended on it indirectly through other libraries' dependencies.

I discovered this while testing Numpy 2.0 and removing incompatible libraries.