### PR TITLE
Support librosa and numpy 2.0 for Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ REQUIRED_PKGS = [
 AUDIO_REQUIRE = [
     "soundfile>=0.12.1",
     "librosa",
+    "soxr>=0.4.0b1; python_version>='3.10'",  # Supports numpy-2
 ]
 
 VISION_REQUIRE = [
@@ -192,7 +193,6 @@ TESTS_REQUIRE.extend(AUDIO_REQUIRE)
 
 NUMPY2_INCOMPATIBLE_LIBRARIES = [
     "faiss-cpu",
-    "librosa",
     "tensorflow",
     "transformers",
 ]


### PR DESCRIPTION
Support librosa and numpy 2.0 for Python 3.10 by installing soxr 0.4.0b1 pre-release:
- https://github.com/dofuuz/python-soxr/releases/tag/v0.4.0b1
- https://github.com/dofuuz/python-soxr/issues/28