### PR TITLE
Fix prepare_single_hop_path_and_storage_options

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1173,9 +1173,9 @@ def _prepare_single_hop_path_and_storage_options(
                     urlpath += "&confirm=" + v
                     cookies = response.cookies
                     storage_options[protocol] = {"cookies": cookies, **storage_options.get(protocol, {})}
-        # Fix Google Drive URL to avoid Virus scan warning
-        if "drive.google.com" in urlpath and "confirm=" not in urlpath:
-            urlpath += "&confirm=t"
+            # Fix Google Drive URL to avoid Virus scan warning
+            if "confirm=" not in urlpath:
+                urlpath += "&confirm=t"
         if urlpath.startswith("https://raw.githubusercontent.com/"):
             # Workaround for served data with gzip content-encoding: https://github.com/fsspec/filesystem_spec/issues/389
             headers = storage_options[protocol].setdefault("headers", {})

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1160,10 +1160,8 @@ def _prepare_single_hop_path_and_storage_options(
     else:
         storage_options = {}
     if protocol in {"http", "https"}:
-        storage_options = {
-            "client_kwargs": {"trust_env": True},  # Enable reading proxy env variables.
-            **storage_options,
-        }
+        client_kwargs = storage_options.setdefault("client_kwargs", {})
+        _ = client_kwargs.setdefault("trust_env", True)  # Enable reading proxy env variables
         if "drive.google.com" in urlpath:
             response = http_head(urlpath)
             for k, v in response.cookies.items():

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1146,7 +1146,7 @@ def _prepare_single_hop_path_and_storage_options(
     Storage options are formatted in the form {protocol: storage_options_for_protocol}
     """
     token = None if download_config is None else download_config.token
-    if urlpath.startswith(config.HF_ENDPOINT):
+    if urlpath.startswith(config.HF_ENDPOINT) and "/resolve/" in urlpath:
         urlpath = "hf://" + urlpath[len(config.HF_ENDPOINT) + 1 :].replace("/resolve/", "@", 1)
     protocol = urlpath.split("://")[0] if "://" in urlpath else "file"
     if download_config is not None and protocol in download_config.storage_options:

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1168,7 +1168,6 @@ def _prepare_single_hop_path_and_storage_options(
         }
         if "drive.google.com" in urlpath:
             response = http_head(urlpath)
-            cookies = None
             for k, v in response.cookies.items():
                 if k.startswith("download_warning"):
                     urlpath += "&confirm=" + v

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1179,7 +1179,8 @@ def _prepare_single_hop_path_and_storage_options(
             urlpath += "&confirm=t"
         if urlpath.startswith("https://raw.githubusercontent.com/"):
             # Workaround for served data with gzip content-encoding: https://github.com/fsspec/filesystem_spec/issues/389
-            storage_options[protocol]["headers"]["Accept-Encoding"] = "identity"
+            headers = storage_options[protocol].setdefault("headers", {})
+            headers["Accept-Encoding"] = "identity"
     elif protocol == "hf":
         storage_options[protocol] = {
             "token": token,

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1161,7 +1161,7 @@ def _prepare_single_hop_path_and_storage_options(
         storage_options = {}
     if storage_options:
         storage_options = {protocol: storage_options}
-    if protocol in ["http", "https"]:
+    if protocol in {"http", "https"}:
         storage_options[protocol] = {
             "client_kwargs": {"trust_env": True},  # Enable reading proxy env variables.
             **(storage_options.get(protocol, {})),

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1146,7 +1146,7 @@ def _prepare_single_hop_path_and_storage_options(
     Storage options are formatted in the form {protocol: storage_options_for_protocol}
     """
     token = None if download_config is None else download_config.token
-    if urlpath.startswith(config.HF_ENDPOINT) and "/resolve/" in urlpath:
+    if urlpath.startswith(config.HF_ENDPOINT):
         urlpath = "hf://" + urlpath[len(config.HF_ENDPOINT) + 1 :].replace("/resolve/", "@", 1)
     protocol = urlpath.split("://")[0] if "://" in urlpath else "file"
     if download_config is not None and protocol in download_config.storage_options:

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1161,10 +1161,7 @@ def _prepare_single_hop_path_and_storage_options(
         storage_options = {}
     if protocol in {"http", "https"}:
         client_kwargs = storage_options.pop("client_kwargs", {})
-        storage_options = {
-            "client_kwargs": {"trust_env": True, **client_kwargs},  # Enable reading proxy env variables
-            **storage_options,
-        }
+        storage_options["client_kwargs"] = {"trust_env": True, **client_kwargs}  # Enable reading proxy env variables
         if "drive.google.com" in urlpath:
             response = http_head(urlpath)
             for k, v in response.cookies.items():

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1163,10 +1163,6 @@ def _prepare_single_hop_path_and_storage_options(
         storage_options = {protocol: storage_options}
     if protocol in ["http", "https"]:
         storage_options[protocol] = {
-            "headers": {
-                **get_authentication_headers_for_url(urlpath, token=token),
-                "user-agent": get_datasets_user_agent(),
-            },
             "client_kwargs": {"trust_env": True},  # Enable reading proxy env variables.
             **(storage_options.get(protocol, {})),
         }

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1174,8 +1174,8 @@ def _prepare_single_hop_path_and_storage_options(
                 urlpath += "&confirm=t"
         if urlpath.startswith("https://raw.githubusercontent.com/"):
             # Workaround for served data with gzip content-encoding: https://github.com/fsspec/filesystem_spec/issues/389
-            headers = storage_options.setdefault("headers", {})
-            headers["Accept-Encoding"] = "identity"
+            headers = storage_options.pop("headers", {})
+            storage_options["headers"] = {"Accept-Encoding": "identity", **headers}
     elif protocol == "hf":
         storage_options = {
             "token": token,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -242,6 +242,17 @@ def test_fsspec_offline(tmp_path_factory):
             "https://domain.org/data.txt",
             {"https": {"client_kwargs": {"trust_env": False}}},
         ),
+        (
+            "https://raw.githubusercontent.com/data.txt",
+            DownloadConfig(storage_options={"https": {"headers": {"x-test": "true"}}}),
+            "https://raw.githubusercontent.com/data.txt",
+            {
+                "https": {
+                    "client_kwargs": {"trust_env": True},
+                    "headers": {"x-test": "true", "Accept-Encoding": "identity"},
+                }
+            },
+        ),
     ],
 )
 def test_prepare_single_hop_path_and_storage_options(

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -247,9 +247,12 @@ def test_fsspec_offline(tmp_path_factory):
 def test_prepare_single_hop_path_and_storage_options(
     urlpath, download_config, expected_urlpath, expected_storage_options
 ):
+    original_download_config_storage_options = str(download_config.storage_options)
     prepared_urlpath, storage_options = _prepare_single_hop_path_and_storage_options(urlpath, download_config)
     assert prepared_urlpath == expected_urlpath
     assert storage_options == expected_storage_options
+    # Check that DownloadConfig.storage_options are not modified:
+    assert str(download_config.storage_options) == original_download_config_storage_options
 
 
 class DummyTestFS(AbstractFileSystem):

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -47,7 +47,7 @@ FILE_CONTENT = """\
 
 FILE_PATH = "file"
 
-TEST_URL = "https://huggingface.co/datasets/hf-internal-testing/dataset_with_script/raw/main/some_text.txt"
+TEST_URL = "https://huggingface.co/datasets/hf-internal-testing/dataset_with_script/resolve/main/some_text.txt"
 TEST_URL_CONTENT = "foo\nbar\nfoobar"
 
 TEST_GG_DRIVE_FILENAME = "train.tsv"


### PR DESCRIPTION
Fix `_prepare_single_hop_path_and_storage_options`:
- Do not pass HF authentication headers and HF user-agent to non-HF HTTP URLs
- Do not overwrite passed `storage_options` nested values:
  - Before, when passed 
    ```DownloadConfig(storage_options={"https": {"client_kwargs": {"raise_for_status": True}}})```, 
    it was overwritten to 
    ```{"https": {"client_kwargs": {"trust_env": True}}}```
  - Now, the result combines both: 
    ```{"https": {"client_kwargs": {"trust_env": True, "raise_for_status": True}}}```