### PR TITLE
Fix push_to_hub by not calling create_branch if branch exists

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5620,7 +5620,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         )
         repo_id = repo_url.repo_id
 
-        if revision is not None:
+        if revision is not None and not api.revision_exists(repo_id, revision, repo_type="dataset", token=token):
+            # We have checked revision_exists because create_branch raises 403 Forbidden error even if exist_ok
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
         if not data_dir:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5620,8 +5620,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         )
         repo_id = repo_url.repo_id
 
-        if revision is not None and not api.revision_exists(repo_id, revision, repo_type="dataset", token=token):
-            # We check revision_exists because create_branch raises 400/403 error even if branch exists and exist_ok
+        if revision is not None and not revision.startswith("refs/pr/"):
+            # We do not call create_branch for a PR reference: 400 Bad Request
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
         if not data_dir:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5621,7 +5621,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         repo_id = repo_url.repo_id
 
         if revision is not None and not api.revision_exists(repo_id, revision, repo_type="dataset", token=token):
-            # We have checked revision_exists because create_branch raises 403 Forbidden error even if exist_ok
+            # We check revision_exists because create_branch raises 400/403 error even if branch exists and exist_ok
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
         if not data_dir:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1710,7 +1710,7 @@ class DatasetDict(dict):
         repo_id = repo_url.repo_id
 
         if revision is not None and not api.revision_exists(repo_id, revision, repo_type="dataset", token=token):
-            # We have checked revision_exists because create_branch raises 403 Forbidden error even if exist_ok
+            # We check revision_exists because create_branch raises 400/403 error even if branch exists and exist_ok
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
         if not data_dir:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1709,7 +1709,8 @@ class DatasetDict(dict):
         )
         repo_id = repo_url.repo_id
 
-        if revision is not None:
+        if revision is not None and not api.revision_exists(repo_id, revision, repo_type="dataset", token=token):
+            # We have checked revision_exists because create_branch raises 403 Forbidden error even if exist_ok
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
         if not data_dir:

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1709,8 +1709,8 @@ class DatasetDict(dict):
         )
         repo_id = repo_url.repo_id
 
-        if revision is not None and not api.revision_exists(repo_id, revision, repo_type="dataset", token=token):
-            # We check revision_exists because create_branch raises 400/403 error even if branch exists and exist_ok
+        if revision is not None and not revision.startswith("refs/pr/"):
+            # We do not call create_branch for a PR reference: 400 Bad Request
             api.create_branch(repo_id, branch=revision, token=token, repo_type="dataset", exist_ok=True)
 
         if not data_dir:

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -66,9 +66,8 @@ def test_convert_to_parquet(temporary_repo, hf_api, hf_token, ci_hub_config, ci_
                         _ = convert_to_parquet(repo_id, token=hf_token, trust_remote_code=True)
     # mock_create_branch
     assert mock_create_branch.called
-    assert mock_create_branch.call_count == 2
-    for call_args, expected_branch in zip(mock_create_branch.call_args_list, ["refs/pr/1", "script"]):
-        assert call_args.kwargs.get("branch") == expected_branch
+    assert mock_create_branch.call_count == 1
+    assert mock_create_branch.call_args.kwargs.get("branch") == "script"
     # mock_create_commit
     assert mock_create_commit.called
     assert mock_create_commit.call_count == 2


### PR DESCRIPTION
Fix push_to_hub by not calling create_branch if branch exists.

Note that currently create_branch raises a 403 Forbidden error even if all these conditions are met:
- exist_ok is passed
- the branch already exists
- the user does not have WRITE permission

Fix #7067.

Related issue:
- https://github.com/huggingface/huggingface_hub/issues/2419