### PR TITLE
Fix CI test_convert_to_parquet

### DIFF
--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -45,8 +45,6 @@ def test_dataset_url(repo_id, filename, revision):
     assert url == f"https://huggingface.co/datasets/{repo_id}/resolve/{revision or 'main'}/{quote(filename)}"
 
 
-# Temporarily mark this test as expected to fail: GH-7073
-@pytest.mark.xfail
 def test_convert_to_parquet(temporary_repo, hf_api, hf_token, ci_hub_config, ci_hfh_hf_hub_url):
     with temporary_repo() as repo_id:
         hf_api.create_repo(repo_id, token=hf_token, repo_type="dataset")

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -62,7 +62,8 @@ def test_convert_to_parquet(temporary_repo, hf_api, hf_token, ci_hub_config, ci_
         with patch.object(datasets.hub.HfApi, "create_commit", return_value=commit_info) as mock_create_commit:
             with patch.object(datasets.hub.HfApi, "create_branch") as mock_create_branch:
                 with patch.object(datasets.hub.HfApi, "list_repo_tree", return_value=[]):  # not needed
-                    _ = convert_to_parquet(repo_id, token=hf_token, trust_remote_code=True)
+                    with patch.object(datasets.hub.HfApi, "preupload_lfs_files", return_value=None):  # not needed
+                        _ = convert_to_parquet(repo_id, token=hf_token, trust_remote_code=True)
     # mock_create_branch
     assert mock_create_branch.called
     assert mock_create_branch.call_count == 2


### PR DESCRIPTION
Fix `test_convert_to_parquet` by patching `HfApi.preupload_lfs_files` and revert temporary fix:
- #7074