### PR TITLE
Support HTTP authentication in non-streaming mode

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -194,7 +194,7 @@ def cached_path(
             url_or_filename, download_config=download_config
         )
         # get_from_cache uses storage_options only if scheme not in {"http", "https"}
-        if next(iter(storage_options)) in {"http", "https"}:
+        if storage_options.get("http", storage_options.get("https")):
             storage_options = {}
         output_path = get_from_cache(
             url_or_filename,

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -193,6 +193,9 @@ def cached_path(
         url_or_filename, storage_options = _prepare_path_and_storage_options(
             url_or_filename, download_config=download_config
         )
+        # get_from_cache uses storage_options only if scheme not in {"http", "https"}
+        if next(iter(storage_options)) in {"http", "https"}:
+            storage_options = {}
         output_path = get_from_cache(
             url_or_filename,
             cache_dir=cache_dir,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -78,24 +79,62 @@ def tmpfs_file(tmpfs):
     return FILE_PATH
 
 
-@pytest.mark.parametrize("protocol", ["hf", "s3"])
-def test_cached_path_protocols(protocol, monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "protocol, download_config_storage_options, expected_fsspec_called",
+    [
+        ("hf", {}, True),
+        ("s3", {"s3": {"anon": True}}, True),
+        # HTTP calls fsspec only if passed HTTP download_config.storage_options:
+        ("https", {"https": {"block_size": "omit"}}, True),
+        ("https", {}, False),
+    ],
+)
+def test_cached_path_calls_fsspec_for_protocols(
+    protocol, download_config_storage_options, expected_fsspec_called, monkeypatch, tmp_path
+):
     # GH-6598: Test no TypeError: __init__() got an unexpected keyword argument 'hf'
+    # fsspec_head/get:
     mock_fsspec_head = MagicMock(return_value={})
     mock_fsspec_get = MagicMock(return_value=None)
     monkeypatch.setattr("datasets.utils.file_utils.fsspec_head", mock_fsspec_head)
     monkeypatch.setattr("datasets.utils.file_utils.fsspec_get", mock_fsspec_get)
+
+    # http_head_get:
+    @dataclass
+    class Response:
+        status_code: int
+        headers: dict = field(default_factory=dict)
+        cookies: dict = field(default_factory=dict)
+
+    mock_http_head = MagicMock(return_value=Response(status_code=200))
+    mock_http_get = MagicMock(return_value=None)
+    monkeypatch.setattr("datasets.utils.file_utils.http_head", mock_http_head)
+    monkeypatch.setattr("datasets.utils.file_utils.http_get", mock_http_get)
+    # Test:
     cache_dir = tmp_path / "cache"
-    storage_options = {} if protocol == "hf" else {"s3": {"anon": True}}
-    download_config = DownloadConfig(cache_dir=cache_dir, storage_options=storage_options)
-    urls = {"hf": "hf://datasets/org-name/ds-name@main/filename.ext", "s3": "s3://bucket-name/filename.ext"}
+    download_config = DownloadConfig(cache_dir=cache_dir, storage_options=download_config_storage_options)
+    urls = {
+        "hf": "hf://datasets/org-name/ds-name@main/filename.ext",
+        "https": "https://doamin.org/filename.ext",
+        "s3": "s3://bucket-name/filename.ext",
+    }
     url = urls[protocol]
     _ = cached_path(url, download_config=download_config)
-    for mock in [mock_fsspec_head, mock_fsspec_get]:
-        assert mock.called
-        assert mock.call_count == 1
-        assert mock.call_args.args[0] == url
-        assert list(mock.call_args.kwargs["storage_options"].keys()) == [protocol]
+    if expected_fsspec_called:
+        for mock in [mock_fsspec_head, mock_fsspec_get]:
+            assert mock.called
+            assert mock.call_count == 1
+            assert mock.call_args.args[0] == url
+            assert list(mock.call_args.kwargs["storage_options"].keys()) == [protocol]
+        for mock in [mock_http_head, mock_http_get]:
+            assert not mock.called
+    else:
+        for mock in [mock_fsspec_head, mock_fsspec_get]:
+            assert not mock.called
+        for mock in [mock_http_head, mock_http_get]:
+            assert mock.called
+            assert mock.call_count == 1
+            assert mock.call_args.args[0] == url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Support HTTP authentication in non-streaming mode, by support passing HTTP storage_options in non-streaming mode.
- Note that currently, HTTP authentication is supported only in streaming mode.

For example, this is necessary if a remote HTTP host requires authentication to download the data.