### PR TITLE
Temporarily pin numpy<2.1 to fix CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ REQUIRED_PKGS = [
     # For file locking
     "filelock",
     # We use numpy>=1.17 to have np.random.Generator (Dataset shuffling)
-    "numpy>=1.17",
+    "numpy>=1.17,<2.1",  # Temporarily pin <2.1 (see GH-7111)
     # Backend and serialization.
     # Minimum 15.0.0 to be able to cast dictionary types to their underlying types
     "pyarrow>=15.0.0",


### PR DESCRIPTION
Temporarily pin numpy<2.1 to fix CI.

Fix #7111.