### PR TITLE
Install transformers with numpy-2 CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,6 @@ NUMPY2_INCOMPATIBLE_LIBRARIES = [
     "faiss-cpu",
     "librosa",  # librosa -> numba-0.60.0 requires numpy < 2.1 (see GH-7111)
     "tensorflow",
-    "transformers",
 ]
 TESTS_NUMPY2_REQUIRE = [
     library for library in TESTS_REQUIRE if library.partition(">")[0] not in NUMPY2_INCOMPATIBLE_LIBRARIES


### PR DESCRIPTION
Install transformers with numpy-2 CI.

Note that transformers no longer pins numpy < 2 since transformers-4.43.0:
- https://github.com/huggingface/transformers/pull/32018
- https://github.com/huggingface/transformers/releases/tag/v4.43.0