### PR TITLE
Disable implicit token in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def set_test_cache_config(tmp_path_factory, monkeypatch):
     monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_PATH", str(test_extracted_datasets_path))
 
 
+@pytest.fixture(autouse=True)
+def disable_implicit_token(monkeypatch):
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", True)
+
+
 @pytest.fixture(autouse=True, scope="session")
 def disable_tqdm_output():
     datasets.disable_progress_bar()

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -33,7 +33,9 @@ def ci_hub_config(monkeypatch):
 
 
 @pytest.fixture
-def set_ci_hub_access_token(ci_hub_config):
+def set_ci_hub_access_token(ci_hub_config, monkeypatch):
+    # Enable implicit token
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", False)
     old_environ = dict(os.environ)
     os.environ["HF_TOKEN"] = CI_HUB_USER_TOKEN
     yield


### PR DESCRIPTION
Disable implicit token in CI.

This PR allows running CI tests locally without implicitly using the local user HF token. For example, run locally the tests in:
- #7124