### PR TITLE
Fix key error in webdataset

### DIFF
--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -29,7 +29,7 @@ class WebDataset(datasets.GeneratorBasedBuilder):
         streaming_download_manager = datasets.StreamingDownloadManager()
         for filename, f in tar_iterator:
             if "." in filename:
-                example_key, field_name = filename.split(".", 1)
+                example_key, field_name = filename.rsplit(".", 1)
                 if current_example and current_example["__key__"] != example_key:
                     yield current_example
                     current_example = {}


### PR DESCRIPTION
I was running into

```
example[field_name] = {"path": example["__key__"] + "." + field_name, "bytes": example[field_name]}
KeyError: 'png'
```

The issue is that a filename may have multiple "." e.g. `22.05.png`. Changing `split` to `rsplit` fixes it.

Related https://github.com/huggingface/datasets/issues/6880