### PR TITLE
Support ndjson data files

### DIFF
--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -61,6 +61,7 @@ _EXTENSION_TO_MODULE: Dict[str, Tuple[str, dict]] = {
     ".tsv": ("csv", {"sep": "\t"}),
     ".json": ("json", {}),
     ".jsonl": ("json", {}),
+    ".ndjson": ("json", {}),
     ".parquet": ("parquet", {}),
     ".geoparquet": ("parquet", {}),
     ".gpq": ("parquet", {}),

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -61,6 +61,7 @@ _EXTENSION_TO_MODULE: Dict[str, Tuple[str, dict]] = {
     ".tsv": ("csv", {"sep": "\t"}),
     ".json": ("json", {}),
     ".jsonl": ("json", {}),
+    # ndjson is no longer maintained (see: https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417)
     ".ndjson": ("json", {}),
     ".parquet": ("parquet", {}),
     ".geoparquet": ("parquet", {}),

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -25,6 +25,21 @@ def jsonl_file(tmp_path):
 
 
 @pytest.fixture
+def ndjson_file(tmp_path):
+    filename = tmp_path / "file.ndjson"
+    data = textwrap.dedent(
+        """\
+        {"col_1": -1}
+        {"col_1": 1, "col_2": 2}
+        {"col_1": 10, "col_2": 20}
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
 def jsonl_file_utf16_encoded(tmp_path):
     filename = tmp_path / "file_utf16_encoded.jsonl"
     data = textwrap.dedent(
@@ -188,6 +203,7 @@ def test_config_raises_when_invalid_data_files(data_files) -> None:
     "file_fixture, config_kwargs",
     [
         ("jsonl_file", {}),
+        ("ndjson_file", {}),
         ("jsonl_file_utf16_encoded", {"encoding": "utf-16"}),
         ("json_file_with_list_of_dicts", {}),
         ("json_file_with_list_of_dicts_field", {"field": "field3"}),

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -24,6 +24,7 @@ def jsonl_file(tmp_path):
     return str(filename)
 
 
+# ndjson format is no longer maintained (see: https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417)
 @pytest.fixture
 def ndjson_file(tmp_path):
     filename = tmp_path / "file.ndjson"


### PR DESCRIPTION
Support `ndjson` (Newline Delimited JSON) data files.

Fix #7153.