### PR TITLE
Add torchdata as a regular test dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system "datasets[tests] @ ."
       - name: Install dependencies (latest versions)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: uv pip install --system -r additional-tests-requirements.txt --no-deps
-      - name: Install dependencies (latest versions)
         if: ${{ matrix.deps_versions == 'deps-latest' }}
         run: uv pip install --system --upgrade pyarrow huggingface-hub dill
       - name: Install dependencies (minimum versions)

--- a/additional-tests-requirements.txt
+++ b/additional-tests-requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/pytorch/data.git

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,7 @@ TESTS_REQUIRE = [
     "tensorflow>=2.16.0; python_version>='3.10'",  # Pins numpy < 2
     "tiktoken",
     "torch>=2.0.0",
+    "torchdata",
     "soundfile>=0.12.1",
     "transformers>=4.42.0",  # Pins numpy < 2
     "zstandard",


### PR DESCRIPTION
Add `torchdata` as a regular test dependency.

Fix #7171.