### PR TITLE
Support features in metadata configs

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -9,6 +9,7 @@ import yaml
 from huggingface_hub import DatasetCardData
 
 from ..config import METADATA_CONFIGS_FIELD
+from ..features import Features
 from ..info import DatasetInfo, DatasetInfosDict
 from ..naming import _split_re
 from ..utils.logging import get_logger
@@ -152,8 +153,12 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
                 cls._raise_if_data_files_field_not_valid(metadata_config)
             return cls(
                 {
-                    config["config_name"]: {param: value for param, value in config.items() if param != "config_name"}
-                    for config in metadata_configs
+                    config.pop("config_name"): {
+                        param: value if param != "features" else Features._from_yaml_list(value)
+                        for param, value in config.items()
+                    }
+                    for metadata_config in metadata_configs
+                    if (config := metadata_config.copy())
                 }
             )
         return cls()

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -9,6 +9,7 @@ import yaml
 from huggingface_hub import DatasetCard, DatasetCardData
 
 from datasets.config import METADATA_CONFIGS_FIELD
+from datasets.features import Features, Value
 from datasets.info import DatasetInfo
 from datasets.utils.metadata import MetadataConfigs
 
@@ -93,6 +94,21 @@ README_METADATA_TWO_CONFIGS_WITH_DEFAULT_NAME = f"""\
 """
 
 
+README_METADATA_WITH_FEATURES = f"""\
+---
+{METADATA_CONFIGS_FIELD}:
+  - config_name: default
+    features:
+      - name: id
+        dtype: int64
+      - name:  name
+        dtype: string
+      - name: score
+        dtype: float64
+---
+"""
+
+
 EXPECTED_METADATA_SINGLE_CONFIG = {"custom": {"data_dir": "v1", "drop_labels": True}}
 EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_FLAG = {
     "v1": {"data_dir": "v1", "drop_labels": True},
@@ -101,6 +117,13 @@ EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_FLAG = {
 EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_NAME = {
     "custom": {"data_dir": "custom", "drop_labels": True},
     "default": {"data_dir": "data", "drop_labels": False},
+}
+EXPECTED_METADATA_WITH_FEATURES = {
+    "default": {
+        "features": Features(
+            {"id": Value(dtype="int64"), "name": Value(dtype="string"), "score": Value(dtype="float64")}
+        )
+    }
 }
 
 
@@ -227,6 +250,7 @@ class TestMetadataUtils(unittest.TestCase):
         (README_METADATA_SINGLE_CONFIG, EXPECTED_METADATA_SINGLE_CONFIG, "custom"),
         (README_METADATA_TWO_CONFIGS_WITH_DEFAULT_FLAG, EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_FLAG, "v2"),
         (README_METADATA_TWO_CONFIGS_WITH_DEFAULT_NAME, EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_NAME, "default"),
+        (README_METADATA_WITH_FEATURES, EXPECTED_METADATA_WITH_FEATURES, "default"),
     ],
 )
 def test_metadata_configs_dataset_card_data(


### PR DESCRIPTION
Support features in metadata configs, like:
```
configs:
  - config_name: default
    features:
      - name: id
        dtype: int64
      - name:  name
        dtype: string
      - name: score
        dtype: float64
```

This will allow to avoid inference of data types.

Currently, we allow passing this information in the `dataset_info` (instead of `configs`) field, but this is not intuitive and it is not properly documented.

TODO:
- [ ] Document usage