### PR TITLE
Solution to issue: #7080 Modified load_dataset function, so that it prompts the user to select a dataset when subdatasets or splits (train, test) are available

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -2088,6 +2088,28 @@ def load_dataset(
         **config_kwargs,
     )
 
+    # Get available splits
+    available_splits = builder_instance.info.splits.keys()
+
+    # If there are subdatasets or splits, print them and ask for user input
+    if available_splits:
+        print("Available splits or subdatasets:")
+        for i, split_name in enumerate(available_splits):
+            print(f"{i + 1}. {split_name}")
+        
+        # Ask for user input to choose the split/subdataset
+        while True:
+            try:
+                user_choice = int(input("Select the split to load (enter the number): ")) - 1
+                if user_choice < 0 or user_choice >= len(available_splits):
+                    raise ValueError("Invalid choice. Please try again.")
+                break
+            except ValueError as e:
+                print(e)
+        
+        # Load the dataset based on user's choice
+        split = list(available_splits)[user_choice]
+    
     # Return iterable dataset in case of streaming
     if streaming:
         return builder_instance.as_streaming_dataset(split=split)
@@ -2101,11 +2123,12 @@ def load_dataset(
         storage_options=storage_options,
     )
 
-    # Build dataset for splits
+    # Build dataset for the chosen split
     keep_in_memory = (
         keep_in_memory if keep_in_memory is not None else is_small_dataset(builder_instance.info.dataset_size)
     )
     ds = builder_instance.as_dataset(split=split, verification_mode=verification_mode, in_memory=keep_in_memory)
+    
     if save_infos:
         builder_instance._save_infos()
 


### PR DESCRIPTION
# Feel free to give suggestions please..

### This PR is raised because of issue: https://github.com/huggingface/datasets/issues/7080

![image](https://github.com/user-attachments/assets/8fbc604f-f0a5-4a59-a63e-aa4c26442c83)

### This PR gives solution to https://github.com/huggingface/datasets/issues/7080

1. Checking whether the dataset has splits or subdatasets.
2. Printing the available splits/subdatasets.
3. Asking the user to choose which one to load.
4. Loading only the selected dataset based on the user's input.

### Key Changes:

1. Available Splits/Subdatasets: The code checks for available splits/subdatasets using builder_instance.info.splits.keys().
2. User Prompt: If splits are found, it prints them out and prompts the user to select one.
3. Loading Based on User Input: The dataset is loaded based on the user's choice.

This way, the dataset loading function will interactively prompt the user to select which subdataset or split they want to load instead of automatically loading all of them.
