### PR TITLE
Fix the environment variable for huggingface cache

### DIFF
--- a/docs/source/cache.mdx
+++ b/docs/source/cache.mdx
@@ -20,7 +20,7 @@ This guide focuses on the 🤗 Datasets cache and will show you how to:
 The default 🤗 Datasets cache directory is `~/.cache/huggingface/datasets`. Change the cache location by setting the shell environment variable, `HF_DATASETS_CACHE` to another directory:
 
 ```
-$ export HF_DATASETS_CACHE="/path/to/another/directory/datasets"
+$ export HF_CACHE="/path/to/another/directory/datasets"
 ```
 
 When you load a dataset, you also have the option to change where the data is cached. Change the `cache_dir` parameter to the path you want:

--- a/docs/source/cache.mdx
+++ b/docs/source/cache.mdx
@@ -17,7 +17,7 @@ This guide focuses on the 🤗 Datasets cache and will show you how to:
 
 ## Cache directory
 
-The default 🤗 Datasets cache directory is `~/.cache/huggingface/datasets`. Change the cache location by setting the shell environment variable, `HF_DATASETS_CACHE` to another directory:
+The default 🤗 Datasets cache directory is `~/.cache/huggingface/datasets`. Change the cache location by setting the shell environment variable, `HF_CACHE` to another directory:
 
 ```
 $ export HF_CACHE="/path/to/another/directory/datasets"

--- a/docs/source/cache.mdx
+++ b/docs/source/cache.mdx
@@ -17,10 +17,10 @@ This guide focuses on the 🤗 Datasets cache and will show you how to:
 
 ## Cache directory
 
-The default 🤗 Datasets cache directory is `~/.cache/huggingface/datasets`. Change the cache location by setting the shell environment variable, `HF_CACHE` to another directory:
+The default 🤗 Datasets cache directory is `~/.cache/huggingface/datasets`. Change the cache location by setting the shell environment variable, `HF_HOME` to another directory:
 
 ```
-$ export HF_CACHE="/path/to/another/directory/datasets"
+$ export HF_HOME="/path/to/another/directory/datasets"
 ```
 
 When you load a dataset, you also have the option to change where the data is cached. Change the `cache_dir` parameter to the path you want:


### PR DESCRIPTION
Resolve  #6256. As far as I tested, `HF_DATASETS_CACHE` was ignored and I could not specify the cache directory at all except for the default one by this environment variable. `HF_HOME` has worked. Perhaps the recent change on file downloading by `huggingface_hub` could affect this bug.

In my testing, I could not specify the cache directory even by `load_dataset("dataset_name" cache_dir="...")`. It might be another issue. I also welcome any advice to solve this issue.