### PR TITLE
fix unbatched arrow map for iterable datasets

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2293,7 +2293,9 @@ class IterableDataset(DatasetInfoMixin):
             else self._ex_iterable
         )
         ex_iterable = (
-            RebatchedArrowExamplesIterable(ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch)
+            RebatchedArrowExamplesIterable(
+                ex_iterable, batch_size=batch_size if batched else 1, drop_last_batch=drop_last_batch
+            )
             if self._formatting and self._formatting.format_type == "arrow"
             else ex_iterable
         )


### PR DESCRIPTION
Fixes the bug when applying map to an arrow-formatted iterable dataset described here:

https://github.com/huggingface/datasets/issues/6833#issuecomment-2399903885

```python

from datasets import load_dataset
ds = load_dataset("rotten_tomatoes", split="train", streaming=True)
ds = ds.with_format("arrow").map(lambda x: x)
for ex in ds:
    pass
```

@lhoestq 