### PR TITLE
fast array extraction

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -791,10 +791,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
     def to_pylist(self):
         zero_copy_only = _is_zero_copy_only(self.storage.type, unnest=True)
         numpy_arr = self.to_numpy(zero_copy_only=zero_copy_only)
-        if self.type.shape[0] is None and numpy_arr.dtype == object:
-            return [arr.tolist() for arr in numpy_arr.tolist()]
-        else:
-            return numpy_arr.tolist()
+        return list(numpy_arr)
 
 
 class PandasArrayExtensionDtype(PandasExtensionDtype):


### PR DESCRIPTION
Implements #7210 using method suggested in https://github.com/huggingface/datasets/pull/7207#issuecomment-2411789307


```python
import numpy as np
from datasets import Dataset, Features, Array3D
features=Features(**{"array0": Array3D((None, 10, 10), dtype="float32"), "array1": Array3D((None,10,10), dtype="float32")})
dataset = Dataset.from_dict({f"array{i}": [np.zeros((x,10,10), dtype=np.float32) for x in [2000,1000]*25] for i in range(2)}, features=features)
```
~0.02 s vs 0.9s on main

```python
ds = dataset.to_iterable_dataset()
t0 = time.time()
for ex in ds:
    pass
t1 = time.time()
```
< 0.01 s vs 1.3 s on main

@lhoestq I can see this breaks a bunch of array-related tests but can update the test cases if you would support making this change?