### PR TITLE
Feature proposal: Stacking, potentially heterogeneous, datasets

### DIFF
--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -17,7 +17,7 @@ __version__ = "3.1.1.dev0"
 from .arrow_dataset import Dataset
 from .arrow_reader import ReadInstruction
 from .builder import ArrowBasedBuilder, BuilderConfig, DatasetBuilder, GeneratorBasedBuilder
-from .combine import concatenate_datasets, interleave_datasets
+from .combine import concatenate_datasets, interleave_datasets, stack_datasets
 from .dataset_dict import DatasetDict, IterableDatasetDict
 from .download import *
 from .features import *

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6325,3 +6325,93 @@ def get_indices_from_mask_function(
         indices_array = indices_mapping.column(0).take(indices_array)
         indices_array = indices_array.to_pylist()
     return {"indices": indices_array}
+
+
+def _stack_map_style_datasets(
+    datasets: Dict[str, "Dataset"],
+    info: Optional[DatasetInfo] = None,
+    split: Optional[NamedSplit] = None,
+    stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
+) -> "Dataset":
+    """
+    Stack several map-style datasets (sources) into a single map-style dataset.
+    The new dataset is constructed by combining examples from each source dataset into a single example.
+
+    Args:
+        datasets (`Dict[str, Dataset]`): Dictionary of datasets to stack.
+        probabilities (`List[float]`, optional, default None): If specified, the new dataset is constructed by sampling
+            examples from one source at a time according to these probabilities.
+        info ([`DatasetInfo`], *optional*, defaults to `None`):
+            Dataset information, like description, citation, etc.
+        split ([`NamedSplit`], *optional*, defaults to `None`):
+            Name of the dataset split.
+        stopping_strategy (`Literal["first_exhausted", "all_exhausted"]`, *optional*, defaults to `first_exhausted`):
+            If undersampling ("first_exhausted"), we stop as soon as one dataset is exhausted.
+            If oversampling ("all_exhausted"), we stop as soon as every dataset is exhausted,
+            i.e as soon as every samples of every dataset has been visited at least once.
+            "all_exhausted" means that the examples of smaller datasets may be visited multiple times.
+
+    Returns:
+        [`Dataset`]: A [`Dataset`] that returns examples where each example is a dictionary
+            with keys corresponding to the keys of the input dictionary of datasets, and values corresponding
+            to the examples of the respective dataset.
+    """
+    if stopping_strategy not in ["first_exhausted", "all_exhausted"]:
+        raise ValueError(
+            f"{stopping_strategy} stopping strategy in `stack_datasets` is not implemented yet with a dict of {type(next(iter(datasets.values())))}"
+        )
+
+    if any(dataset.num_rows > 0 for dataset in datasets.values()):
+        datasets = {name: dataset for name, dataset in datasets.items() if dataset.num_rows > 0}
+    else:
+        # Return first dataset if all datasets are empty
+        return next(iter(datasets.values()))
+
+    # the strategy is: 1. pad or truncate -> 2. join by concatenating along axis=1 -> 3. nest the columns (stacking)
+
+    d2len = {name: len(dataset) for name, dataset in datasets.items()}
+    if stopping_strategy == "first_exhausted":  # truncate all datasets to the length of the shortest one
+        min_len = min(d2len.values())
+        indices = range(min_len)
+        datasets = {name: dataset.select(indices) for name, dataset in datasets.items()}
+    else:  # "all_exhausted" -> "pad" all datasets to the length of the longest one
+        max_len = max(d2len.values())
+        for name in list(datasets.keys()):
+            dataset = datasets[name]
+            rows_remaining = max_len - d2len[name]
+            if rows_remaining == 0:
+                continue
+            n_repreat = max_len // d2len[name]
+            extra_rows = max_len % d2len[name]
+            to_concat = [dataset] * n_repreat
+            if extra_rows != 0:
+                to_concat.append(dataset.select(range(extra_rows)))
+            datasets[name] = _concatenate_map_style_datasets(
+                to_concat, info=dataset.info, split=dataset.split
+            )  # concat it with itself
+
+    # rename columns to avoid conflicts and to later distinguish the source (dataset) of each column
+    for name in list(datasets.keys()):
+        dataset = datasets[name]
+        datasets[name] = dataset.rename_columns({k: f"{name}.{k}" for k in dataset.column_names})
+
+    # create a joint dataset with all columns -> the columns will be named "dataset_name.column_name", so the structure is flattened
+    concatenated_dataset = _concatenate_map_style_datasets(list(datasets.values()), info=info, split=split, axis=1)
+
+    def structure_example(example):  # here we nest the columns again -> this gives us the stacked structure
+        """
+        ```python
+        >>> example = {"dataset1.column1": 1, "dataset2.column2": {'a': 1, 'b': 2}}
+        >>> structure_example(example) == {"dataset1": {"column1": 1}, "dataset2": {"column2": {'a': 1, 'b': 2}}}
+        ```
+        """
+        new_example = {name: {} for name in datasets.keys()}
+        for key, value in example.items():
+            # key.split(".", 1): "dataset_name.column_name" -> ("dataset_name", "column_name"),
+            #   "dataset_name.column_name.etc" -> ("dataset_name", "column_name.etc")
+            key_dataset, key_actual = key.split(".", 1)
+            new_example[key_dataset][key_actual] = value
+        return new_example
+
+    # because we generated new columns, we need to remove the old ones -> "remove_columns=concatenated_dataset.column_names"
+    return concatenated_dataset.map(structure_example, remove_columns=concatenated_dataset.column_names)

--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -251,8 +251,8 @@ def stack_datasets(
 
     Returns:
         [`Dataset`] or [`IterableDataset`]: Return type depends on the input `datasets`
-        parameter. Returns a `Dataset` if the input is a list of `Dataset`,
-        or an `IterableDataset` if the input is a list of `IterableDataset`.
+        parameter. Returns a `Dataset` if the input is a dict of `Dataset`,
+        or an `IterableDataset` if the input is a dict of `IterableDataset`.
 
     Example:
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1772,7 +1772,7 @@ class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
                 is_exhausted[name] = self._state_dict["is_exhausted"][name]
         else:
             is_exhausted = {name: False for name in self.ex_iterables.keys()}
-        
+
         iterators = {name: iter(ex_iterable) for name, ex_iterable in self.ex_iterables.items()}
         # we use this to buffer one example of each iterator to know if an iterator is exhausted
         nexts = {}
@@ -1781,14 +1781,16 @@ class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
             nexts[name] = next(iterators[name], False)
             if nexts[name] is False:
                 empty_iterators.append(name)
-        
+
         if empty_iterators:
-            warnings.warn(f"Iteration stopped because the sub-iterators {empty_iterators} are empty. "
-                          f"Please remove keys {empty_iterators} from the dictionary of Iterators to combine "
-                          f"examples from the remaining iterators, and check that sub-iterators {empty_iterators} "
-                          f"actually returns examples.")
-            return         
-        
+            warnings.warn(
+                f"Iteration stopped because the sub-iterators {empty_iterators} are empty. "
+                f"Please remove keys {empty_iterators} from the dictionary of Iterators to combine "
+                f"examples from the remaining iterators, and check that sub-iterators {empty_iterators} "
+                f"actually returns examples."
+            )
+            return
+
         while True:
             example_dict = {}  # this is the example that will be yielded
             keys = []
@@ -1798,7 +1800,7 @@ class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
 
             for name in list(iterators.keys()):  # everytime we want a new example, we grab one from each iterator
                 result = nexts[name]
-                nexts[name] = next(iterators[name], False) # refill the buffer
+                nexts[name] = next(iterators[name], False)  # refill the buffer
                 if self._state_dict:
                     self._state_dict["previous_states"][name] = deepcopy(self._state_dict["ex_iterables"][name])
 
@@ -1815,14 +1817,13 @@ class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
                     # noew refill the buffer with the first element
                     # will never fail because at this point we know the iterator is not empty
                     nexts[name] = next(iterators[name])
-                
+
                 key, example = result
                 keys.append(key)
                 example_dict[name] = example
-            
-            final_key = "_".join(str(key) for key in keys) # will be of the form "key1_key2_key3..."
-            yield final_key, example_dict
 
+            final_key = "_".join(str(key) for key in keys)  # will be of the form "key1_key2_key3..."
+            yield final_key, example_dict
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "StackedMultiSourcesExamplesIterable":
         """Shuffle each underlying examples iterable."""
@@ -1835,7 +1836,9 @@ class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
     def num_shards(self) -> int:
         return min(ex_iterable.num_shards for ex_iterable in self.ex_iterables.values())
 
-    def shard_data_sources(self, worker_id: int, num_workers: int, contiguous=True) -> "StackedMultiSourcesExamplesIterable":
+    def shard_data_sources(
+        self, worker_id: int, num_workers: int, contiguous=True
+    ) -> "StackedMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         ex_iterables = {
             name: ex_iterable.shard_data_sources(worker_id, num_workers, contiguous)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1837,11 +1837,11 @@ class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
         return min(ex_iterable.num_shards for ex_iterable in self.ex_iterables.values())
 
     def shard_data_sources(
-        self, worker_id: int, num_workers: int, contiguous=True
+        self, num_shards: int, index: int, contiguous=True
     ) -> "StackedMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         ex_iterables = {
-            name: ex_iterable.shard_data_sources(worker_id, num_workers, contiguous)
+            name: ex_iterable.shard_data_sources(num_shards, index, contiguous)
             for name, ex_iterable in self.ex_iterables.items()
         }
         return StackedMultiSourcesExamplesIterable(ex_iterables, self.stopping_strategy)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1,6 +1,7 @@
 import copy
 import itertools
 import sys
+import warnings
 from collections import Counter
 from copy import deepcopy
 from dataclasses import dataclass
@@ -1720,6 +1721,129 @@ class TypedExamplesIterable(_BaseExamplesIterable):
         return self.ex_iterable.num_shards
 
 
+class StackedMultiSourcesExamplesIterable(_BaseExamplesIterable):
+    def __init__(
+        self,
+        ex_iterables: Dict[str, _BaseExamplesIterable],
+        stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
+    ):
+        """
+        A meta-iterable that combines examples from multiple example iterables into a single example.
+
+        Args:
+            ex_iterables (`Dict[str, _BaseExamplesIterable]`): The iterable datasets to combine examples from.
+                Each example returned by the meta-iterable will be a dictionary with keys corresponding to the keys of this dictionary.
+
+            stopping_strategy (`Literal["first_exhausted", "all_exhausted"]`, *optional*, defaults to `first_exhausted`):
+                If undersampling ("first_exhausted"), we stop as soon as one dataset is exhausted.
+                If oversampling ("all_exhausted"), we stop as soon as every dataset is exhausted,
+                i.e as soon as every samples of every dataset has been visited at least once.
+                "all_exhausted" means that iterators with fewer samples will be reinitialized in the process, so
+                some samples of those iterators may be visited multiple times.
+        """
+
+        super().__init__()
+        self.ex_iterables = ex_iterables
+        self.stopping_strategy = stopping_strategy
+
+        # if undersampling ("first_exhausted"), we stop as soon as one dataset is exhausted
+        # if oversampling ("all_exhausted"), we stop as soon as every dataset is exhausted,
+        #   i.e as soon as every samples of every dataset has been visited at least once
+        self.bool_strategy_func = np.all if (stopping_strategy == "all_exhausted") else np.any
+
+    @property
+    def is_typed(self):
+        return all(ex_iterable.is_typed for ex_iterable in self.ex_iterables.values())
+
+    def _init_state_dict(self) -> dict:
+        self._state_dict = {
+            "ex_iterables": {name: ex_iterable._init_state_dict() for name, ex_iterable in self.ex_iterables.items()},
+            "previous_states": {name: None for name in self.ex_iterables.keys()},
+            "is_exhausted": {name: False for name in self.ex_iterables.keys()},
+        }
+        return self._state_dict
+
+    def __iter__(self):
+        if self._state_dict:
+            is_exhausted = {}
+            for name in self.ex_iterables.keys():
+                if self._state_dict["previous_states"][name] is not None:
+                    self.ex_iterables[name].load_state_dict(self._state_dict["previous_states"][name])
+                is_exhausted[name] = self._state_dict["is_exhausted"][name]
+        else:
+            is_exhausted = {name: False for name in self.ex_iterables.keys()}
+        
+        iterators = {name: iter(ex_iterable) for name, ex_iterable in self.ex_iterables.items()}
+        # we use this to buffer one example of each iterator to know if an iterator is exhausted
+        nexts = {}
+        empty_iterators = []
+        for name in self.ex_iterables.keys():
+            nexts[name] = next(iterators[name], False)
+            if nexts[name] is False:
+                empty_iterators.append(name)
+        
+        if empty_iterators:
+            warnings.warn(f"Iteration stopped because the sub-iterators {empty_iterators} are empty. "
+                          f"Please remove keys {empty_iterators} from the dictionary of Iterators to combine "
+                          f"examples from the remaining iterators, and check that sub-iterators {empty_iterators} "
+                          f"actually returns examples.")
+            return         
+        
+        while True:
+            example_dict = {}  # this is the example that will be yielded
+            keys = []
+            # if the stopping criteria is met, break the main for loop
+            if self.bool_strategy_func(list(is_exhausted.values())):
+                break
+
+            for name in list(iterators.keys()):  # everytime we want a new example, we grab one from each iterator
+                result = nexts[name]
+                nexts[name] = next(iterators[name], False) # refill the buffer
+                if self._state_dict:
+                    self._state_dict["previous_states"][name] = deepcopy(self._state_dict["ex_iterables"][name])
+
+                # the iterator is exhausted
+                if nexts[name] is False:
+                    is_exhausted[name] = True
+                    # we reset the iterator preliminarily, the stopping criteria will be
+                    #   checked at the beginning of the next iterator or the next example
+                    if self._state_dict:
+                        self._state_dict["ex_iterables"][name] = self.ex_iterables[name]._init_state_dict()
+                        self._state_dict["previous_states"][name] = None
+                        self._state_dict["is_exhausted"][name] = True
+                    iterators[name] = iter(self.ex_iterables[name])
+                    # noew refill the buffer with the first element
+                    # will never fail because at this point we know the iterator is not empty
+                    nexts[name] = next(iterators[name])
+                
+                key, example = result
+                keys.append(key)
+                example_dict[name] = example
+            
+            final_key = "_".join(str(key) for key in keys) # will be of the form "key1_key2_key3..."
+            yield final_key, example_dict
+
+
+    def shuffle_data_sources(self, generator: np.random.Generator) -> "StackedMultiSourcesExamplesIterable":
+        """Shuffle each underlying examples iterable."""
+        ex_iterables = {
+            name: ex_iterable.shuffle_data_sources(generator) for name, ex_iterable in self.ex_iterables.items()
+        }
+        return StackedMultiSourcesExamplesIterable(ex_iterables, self.stopping_strategy)
+
+    @property
+    def num_shards(self) -> int:
+        return min(ex_iterable.num_shards for ex_iterable in self.ex_iterables.values())
+
+    def shard_data_sources(self, worker_id: int, num_workers: int, contiguous=True) -> "StackedMultiSourcesExamplesIterable":
+        """Either keep only the requested shard, or propagate the request to the underlying iterable."""
+        ex_iterables = {
+            name: ex_iterable.shard_data_sources(worker_id, num_workers, contiguous)
+            for name, ex_iterable in self.ex_iterables.items()
+        }
+        return StackedMultiSourcesExamplesIterable(ex_iterables, self.stopping_strategy)
+
+
 @dataclass
 class FormattingConfig:
     format_type: Optional[str]
@@ -3189,3 +3313,51 @@ def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_s
         distributed=distributed,
         token_per_repo_id=dataset._token_per_repo_id,
     )
+
+
+def _stack_iterable_datasets(
+    datasets: Dict[str, IterableDataset],
+    info: Optional[DatasetInfo] = None,
+    split: Optional[NamedSplit] = None,
+    stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "first_exhausted",
+) -> IterableDataset:
+    """
+    Stack multiple datasets into a single dataset. Examples returned are meta-examples containing
+    one example from each dataset. Inspired by torch.utils.data.StackDataset.
+
+    Args:
+        datasets (`Dict[str, IterableDataset]`): Dictionary of datasets to stack.
+        info ([`DatasetInfo`], *optional*, defaults to `None`):
+            Dataset information, like description, citation, etc.
+        split ([`NamedSplit`], *optional*, defaults to `None`):
+            Name of the dataset split.
+        stopping_strategy (`Literal["first_exhausted", "all_exhausted"]`, *optional*, defaults to `first_exhausted`):
+            If undersampling ("first_exhausted"), we stop as soon as one dataset is exhausted.
+            If oversampling ("all_exhausted"), we stop as soon as every dataset is exhausted,
+            i.e as soon as every samples of every dataset has been visited at least once.
+            "all_exhausted" means that iterators with fewer samples will be reinitialized in the process, so
+            some samples of those iterators may be visited multiple times.
+
+    Returns:
+        [`IterableDataset`]: An [`IterableDataset`] that returns examples where each example is a dictionary
+            with keys corresponding to the keys of the input dictionary of datasets, and values corresponding
+            to the examples of the respective dataset.
+    """
+    datasets = {name: dataset._resolve_features() for name, dataset in datasets.items()}
+
+    features = Features({name: dataset.features for name, dataset in datasets.items()})
+
+    ex_iterables = {name: copy.deepcopy(dataset._ex_iterable) for name, dataset in datasets.items()}
+    ex_iterable = StackedMultiSourcesExamplesIterable(ex_iterables, stopping_strategy)
+
+    if info is None:
+        info = DatasetInfo.from_merge([d.info for d in datasets.values()])
+    else:
+        info = info.copy()
+    info.features = features
+    # Get all the auth tokens per repository - in case the datasets come from different private repositories
+    token_per_repo_id = {
+        repo_id: token for dataset in datasets.values() for repo_id, token in dataset._token_per_repo_id.items()
+    }
+
+    return IterableDataset(ex_iterable=ex_iterable, info=info, split=split, token_per_repo_id=token_per_repo_id)


### PR DESCRIPTION
### Introduction

Hello there,
I noticed that there are two ways to combine multiple datasets: Either through `datasets.concatenate_datasets` or `datasets.interleave_datasets`. However, to my knowledge (please correct me if I am wrong) both approaches require the datasets that are combined to have the same features.

I think it would be a great idea to add support for combining multiple datasets that might not follow the same schema (i.e. have different features), for example an image and text dataset. That is why I propose a third function of the `datasets.combine` module called `stack_datasets`, which can be used to combine a list of datasets with (potentially) different features. This would look as follows:

```python
>>> from datasets import stack_datasets
>>> image_dataset = ...
>>> next(iter(image_dataset))
{'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=555x416 at 0x313E79CD0> }
>>> text_dataset = ...
>>> next(iter(text_dataset))
{'text': "This is a test."}
>>> stacked = stack_datasets(datasets={'i_ds': image_dataset, 't_ds': text_dataset}, stopping_strategy='all_exhausted')
>>> next(iter(stacked))
{
'i_ds': {'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=555x416 at 0x313E79CD0> }
't_ds': {'text': "This is a test."}
}
```
<br />

### Motivation

I motivate this by:

**A**: The fact that Pytorch offers a similar functionality under `torch.utils.data.StackDataset` ([link](https://pytorch.org/docs/stable/data.html#torch.utils.data.StackDataset)).

**B**: In settings where one would like to e.g. train a Vision-Language model using an image-text dataset, an image dataset, and a text dataset, this functionality would offer a clean and intuitive solution to create multimodal datasets. I am aware that the aforementioned is also feasible without my proposed function, but I believe this offers a nice approach that aligns with existing functionality and is directly provided within the `datasets` package.

### API
`stack_datasets` has two arguments: `datasets` and `stopping_strategy `.
<br />

`datasets` is a dictionary of either type `Dict[str, Dataset]` or `Dict[str, IterableDatasets]`, a mixture is not allowed. It contains the names of the datasets (the keys) and the datasets themselves (the values) that should be stacked. Each item returned is a dictionary with one key-value pair for each dataset. The keys are the names of the datasets as provided in the argument `datasets`, and the values are the respective examples from the datasets.
<br />

`stopping_strategy` is the same as for `interleave_datasets`. If it is `first_exhausted` we stop if the smallest dataset runs out of examples, if it is `all_exhausted` we stop if all datasets ran out of examples at least once. For `all_exhausted` that means that we may visit examples from datasets multiple times. 

### Docs
I saw that there are multiple documentations and guides on the HuggingFace website that introduce `concatenate_datasets` and `interleave_datasets`, for example [here](https://huggingface.co/docs/datasets/process#concatenate). If this request is merged I would be willing to add the new functionality at the appropriate points in the documentation (if desired).

### Tests
I also added some tests to ensure correctness. Some tests I wrote in [tests/test_iterable_dataset.py](https://github.com/TimCares/datasets/blob/fadc1159debf2a65d44e40cbf7758f2bd2cc8b08/tests/test_iterable_dataset.py#L2169)
run for both `Dataset` and `IterableDataset` even though tests for `Dataset` technically do not belong in this script, but I found that this was a nice way to cover more cases with mostly the same code.

### Additional information
I tried to write the code in a way so that it is similar to that of `concatenate_datasets` and `interleave_datasets`.
I’m open to feedback and willing to make adjustments based on your suggestions, so feel free to give me your take. :)
