### PR TITLE
Allow for variation in metadata file names as per issue #7123

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -105,6 +105,8 @@ if config.FSSPEC_VERSION < version.parse("2023.9.0"):
     METADATA_PATTERNS = [
         "metadata.csv",
         "**/metadata.csv",
+        "**/*-metadata.csv",
+        "**/*_metadata.csv",
         "metadata.jsonl",
         "**/metadata.jsonl",
     ]  # metadata file for ImageFolder and AudioFolder


### PR DESCRIPTION
Allow metadata files to have an identifying preface. Specifically, it will recognize files with `-metadata.csv` or `_metadata.csv` as metadata files for the purposes of the dataset viewer functionality.

Resolves #7123.