### PR TITLE
Remove `aiohttp` from direct dependencies

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - fsspec
     - huggingface_hub >=0.23.0,<1.0.0
     - packaging
-    - aiohttp
   run:
     - python
     - pip
@@ -42,7 +41,6 @@ requirements:
     - fsspec
     - huggingface_hub >=0.23.0,<1.0.0
     - packaging
-    - aiohttp
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -130,8 +130,6 @@ REQUIRED_PKGS = [
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
     "fsspec[http]>=2023.1.0,<=2024.9.0",
-    # for data streaming via http
-    "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co
     "huggingface-hub>=0.23.0",
     # Utilities from PyPA to e.g., compare versions

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -27,7 +27,6 @@ from unittest.mock import patch
 from urllib.parse import urlparse
 from xml.etree import ElementTree as ET
 
-import aiohttp.client_exceptions
 import fsspec
 import huggingface_hub
 import huggingface_hub.errors
@@ -44,6 +43,15 @@ from . import _tqdm, logging
 from ._filelock import FileLock
 from .extract import ExtractManager
 from .track import TrackedIterableFromGenerator
+
+try:
+    from aiohttp.client_exceptions import ClientError as _AiohttpClientError
+except ImportError:
+    # aiohttp is not available; synthesize an exception type
+    # that will never be raised by any actual code for use in the `except`
+    # clause only.
+    class _AiohttpClientError(Exception):
+        pass
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -826,7 +834,7 @@ def _add_retries_to_file_obj_read_method(file_obj):
                 out = read(*args, **kwargs)
                 break
             except (
-                aiohttp.client_exceptions.ClientError,
+                _AiohttpClientError,
                 asyncio.TimeoutError,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout,


### PR DESCRIPTION
The dependency is only used for catching an exception from other code. That can be done with an import guard.
