### PR TITLE
Fix lock permission

### DIFF
--- a/src/datasets/utils/_filelock.py
+++ b/src/datasets/utils/_filelock.py
@@ -21,6 +21,7 @@ from filelock import FileLock as FileLock_
 from filelock import UnixFileLock
 from filelock import __version__ as _filelock_version
 from packaging import version
+from pathlib import Path
 
 
 class FileLock(FileLock_):
@@ -32,13 +33,13 @@ class FileLock(FileLock_):
     MAX_FILENAME_LENGTH = 255
 
     def __init__(self, lock_file, *args, **kwargs):
+        lock_file = self.hash_filename_if_too_long(lock_file)
+        # instaed of usimg umask, create a lock file to accomodate ACL
+        Path(lock_file).touch()
         # The "mode" argument is required if we want to use the current umask in filelock >= 3.10
         # In previous previous it was already using the current umask.
         if "mode" not in kwargs and version.parse(_filelock_version) >= version.parse("3.10.0"):
-            umask = os.umask(0o666)
-            os.umask(umask)
-            kwargs["mode"] = 0o666 & ~umask
-        lock_file = self.hash_filename_if_too_long(lock_file)
+            kwargs["mode"] = os.stat(lock_file).st_mode
         super().__init__(lock_file, *args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
All files except lock file have proper permission obeying `ACL` permission.

If the cache directory has `ACL` property, it should be respected instead of just using `umask` for permission.
To fix it, just create a lock file and pass the created `mode`.

By creating a lock file
- if `ACL` is not set, same as before
- if `ACL` is set, `ACL` is respected