### PR TITLE
Remove .h5 from imagefolder extensions

### DIFF
--- a/src/datasets/packaged_modules/imagefolder/imagefolder.py
+++ b/src/datasets/packaged_modules/imagefolder/imagefolder.py
@@ -57,8 +57,8 @@ IMAGE_EXTENSIONS = [
     ".gbr",
     ".gif",
     ".grib",
-    ".h5",
-    ".hdf",
+    # ".h5",   # may contain zero or several images
+    # ".hdf",  # may contain zero or several images
     ".png",
     ".apng",
     ".jp2",


### PR DESCRIPTION
the format is not relevant for imagefolder, and makes the viewer fail to process datasets on HF (so many that the viewer takes more time to process new datasets)