### PR TITLE
fix: dill default for version bigger 0.3.8

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -123,6 +123,10 @@ elif config.DILL_VERSION.release[:3] in [
 
     def log(pickler, msg):
         dill._dill.logger.trace(pickler, msg)
+else:
+
+    def log(pickler, msg):
+        dill._dill.log.info(msg)
 
 
 @pklregister(set)


### PR DESCRIPTION
Fixes def log for dill version >= 0.3.9 
https://pypi.org/project/dill/

This project uses dill with the release of version 0.3.9 the datasets lib. 