### PR TITLE
Attempt to fix multiprocessing hang by closing and joining the pool before termination

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3175,20 +3175,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                                 shards_done += 1
                                 logger.debug(f"Finished processing shard number {rank} of {num_shards}.")
                                 transformed_shards[rank] = content
-                                # logger.debug(f"Shard set {rank}")
                             else:
                                 pbar.update(content)
-                        # logger.debug("All shards processed")
-                    # logger.debug("End pool")
                     pool.close()
-                    # logger.debug('closed')
                     pool.join()
-                    # logger.debug('joined')
-                # logger.debug("Out of pool")
                 # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:
                     del kwargs["shard"]
-                # logger.debug("deld")
             else:
                 logger.info(f"Loading cached processed dataset at {format_cache_file_name(cache_file_name, '*')}")
             assert None not in transformed_shards, (

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3175,20 +3175,20 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                                 shards_done += 1
                                 logger.debug(f"Finished processing shard number {rank} of {num_shards}.")
                                 transformed_shards[rank] = content
-                                logger.debug(f"Shard set {rank}")
+                                # logger.debug(f"Shard set {rank}")
                             else:
                                 pbar.update(content)
-                        logger.debug("All shards processed")
-                    logger.debug("End pool")
+                        # logger.debug("All shards processed")
+                    # logger.debug("End pool")
                     pool.close()
-                    logger.debug('closed')
+                    # logger.debug('closed')
                     pool.join()
-                    logger.debug('joined')
-                logger.debug("Out of pool")
+                    # logger.debug('joined')
+                # logger.debug("Out of pool")
                 # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:
                     del kwargs["shard"]
-                logger.debug("deld")
+                # logger.debug("deld")
             else:
                 logger.info(f"Loading cached processed dataset at {format_cache_file_name(cache_file_name, '*')}")
             assert None not in transformed_shards, (

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3180,6 +3180,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                                 pbar.update(content)
                         logger.debug("All shards processed")
                     logger.debug("End pool")
+                    pool.close()
+                    pool.join()
                 logger.debug("Out of pool")
                 # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3175,11 +3175,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                                 shards_done += 1
                                 logger.debug(f"Finished processing shard number {rank} of {num_shards}.")
                                 transformed_shards[rank] = content
+                                logger.debug(f"Shard set {rank}")
                             else:
                                 pbar.update(content)
+                        logger.debug("All shards processed")
+                    logger.debug("End pool")
+                logger.debug("Out of pool")
                 # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:
                     del kwargs["shard"]
+                logger.debug("deld")
             else:
                 logger.info(f"Loading cached processed dataset at {format_cache_file_name(cache_file_name, '*')}")
             assert None not in transformed_shards, (

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3181,7 +3181,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                         logger.debug("All shards processed")
                     logger.debug("End pool")
                     pool.close()
+                    logger.debug('closed')
                     pool.join()
+                    logger.debug('joined')
                 logger.debug("Out of pool")
                 # Avoids PermissionError on Windows (the error: https://github.com/huggingface/datasets/actions/runs/4026734820/jobs/6921621805)
                 for kwargs in kwargs_per_job:


### PR DESCRIPTION
https://github.com/huggingface/datasets/issues/6393 has plagued me on and off for a very long time. I have had various workarounds (one time combining two filter calls into one filter call removed the issue, another time making rank 0 go first resolved a cache race condition, one time i think upgrading the version of something resolved it). I don't know hf datasets well enough to fully understand the root cause, but I _think_ this PR fixes it.

Evidence: I have an LLM Foundry training yaml/script (datasets version 3.2.0) that results in a hang ~1/10 times (for a baseline for this testing, it was 2/36 runs that hung). I also reran with the latest datasets version (3.3.1) and got 4/36 hung. Installing datasets from this PR, I was able to successful run the script 144 times without a hang occurring. Assuming the base probability is 1/10, this should be more than enough times to have confidence it works.

After adding some logging, I could see that the code hung during the __exit__ of the mp pool context manager, after all shards had been processed, and the tqdm context manager had exited.

My best explanation: When multiprocessing pool __exit__ is called, it calls pool.terminate, which forcefully exits all the processes (and calls code related to this that I haven't looked at closely). I'm guessing this forceful termination has a bad interaction with some multithreading/multiprocessing that hf datasets does. If we instead call pool.close and pool.join before the pool.terminate happens, perhaps whatever that bad interaction is is able to complete gracefully, and then terminate call proceeds without issue.

If this PR seems good to you, I'd be very appreciative if you were able to do a patch release including it. Thank you!

@lhoestq 