### PR TITLE
Faster  folder based builder + parquet support + allow repeated media + use torchvideo

### DIFF
--- a/docs/source/audio_dataset.mdx
+++ b/docs/source/audio_dataset.mdx
@@ -51,8 +51,8 @@ my_dataset/
 
 ## AudioFolder
 
+
 The `AudioFolder` is a dataset builder designed to quickly load an audio dataset with several thousand audio files without requiring you to write any code.
-Any additional information about your dataset - such as transcription, speaker accent, or speaker intent - is automatically loaded by `AudioFolder` as long as you include this information in a metadata file (`metadata.csv`/`metadata.jsonl`).
 
 <Tip>
 
@@ -60,104 +60,39 @@ Any additional information about your dataset - such as transcription, speaker a
 
 </Tip>
 
-Create a dataset repository on the Hugging Face Hub and upload your dataset directory following the `AudioFolder` structure:
+`AudioFolder` automatically infers the class labels of your dataset based on the directory name. Store your dataset in a directory structure like:
 
 ```
-my_dataset/
-├── README.md
-├── metadata.csv
-└── data/
+folder/train/dog/golden_retriever.mp3
+folder/train/dog/german_shepherd.mp3
+folder/train/dog/chihuahua.mp3
+
+folder/train/cat/maine_coon.mp3
+folder/train/cat/bengal.mp3
+folder/train/cat/birman.mp3
 ```
 
-The `data` folder can be any name you want.
-
-<Tip>
-
-It can be helpful to store your metadata as a `jsonl` file if the data columns contain a more complex format (like a list of floats) to avoid parsing errors or reading complex values as strings.
-
-</Tip>
-
-The metadata file should include a `file_name` column to link an audio file to it's metadata:
-
-```csv
-file_name,transcription
-data/first_audio_file.mp3,znowu się duch z ciałem zrośnie w młodocianej wstaniesz wiosnie i możesz skutkiem tych leków umierać wstawać wiek wieków dalej tam były przestrogi jak siekać głowę jak nogi
-data/second_audio_file.mp3,już u źwierzyńca podwojów król zasiada przy nim książęta i panowie rada a gdzie wzniosły krążył ganek rycerze obok kochanek król skinął palcem zaczęto igrzysko
-data/third_audio_file.mp3,pewnie kędyś w obłędzie ubite minęły szlaki zaczekajmy dzień jaki poślemy szukać wszędzie dziś jutro pewnie będzie posłali wszędzie sługi czekali dzień i drugi gdy nic nie doczekali z płaczem chcą jechać dali
-```
-
-Then you can store your dataset in a directory structure like this:
-
-```
-metadata.csv
-data/first_audio_file.mp3
-data/second_audio_file.mp3
-data/third_audio_file.mp3
-
-```
-
-Users can now load your dataset and the associated metadata by specifying `audiofolder` in [`load_dataset`] and the dataset directory in `data_dir`:
+If the dataset follows the `AudioFolder` structure, then you can load it directly with [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
->>> dataset = load_dataset("audiofolder", data_dir="/path/to/data")
->>> dataset["train"][0]
-{'audio':
-    {'path': '/path/to/extracted/audio/first_audio_file.mp3',
-    'array': array([ 0.00088501,  0.0012207 ,  0.00131226, ..., -0.00045776, -0.00054932, -0.00054932], dtype=float32),
-    'sampling_rate': 16000},
- 'transcription': 'znowu się duch z ciałem zrośnie w młodocianej wstaniesz wiosnie i możesz skutkiem tych leków umierać wstawać wiek wieków dalej tam były przestrogi jak siekać głowę jak nogi'
-}
+
+>>> dataset = load_dataset("username/dataset_name")
 ```
 
-You can also use `audiofolder` to load datasets involving multiple splits. To do so, your dataset directory might have the following structure:
-
-```
-data/train/first_train_audio_file.mp3
-data/train/second_train_audio_file.mp3
-
-data/test/first_test_audio_file.mp3
-data/test/second_test_audio_file.mp3
-
-```
-
-<Tip warning={true}>
-
-    Note that if audio files are located not right next to a metadata file, `file_name` column should be a full relative path to an audio file, not just its filename.
-
-</Tip>
-
-For audio datasets that don't have any associated metadata, `AudioFolder` automatically infers the class labels of the dataset based on the directory name. It might be useful for audio classification tasks. Your dataset directory might look like:
-
-```
-data/train/electronic/01.mp3
-data/train/punk/01.mp3
-
-data/test/electronic/09.mp3
-data/test/punk/09.mp3
-```
-
-Load the dataset with `AudioFolder`, and it will create a `label` column from the directory name (language id):
+This is equivalent to passing `audiofolder` manually in [`load_dataset`] and the directory in `data_dir`:
 
 ```py
->>> from datasets import load_dataset
->>> dataset = load_dataset("audiofolder", data_dir="/path/to/data")
->>> dataset["train"][0]
-{'audio':
-    {'path': '/path/to/electronic/01.mp3',
-     'array': array([ 3.9714024e-07,  7.3031038e-07,  7.5640685e-07, ...,
-         -1.1963668e-01, -1.1681189e-01, -1.1244172e-01], dtype=float32),
-     'sampling_rate': 44100},
- 'label': 0  # "electronic"
-}
->>> dataset["train"][-1]
-{'audio':
-    {'path': '/path/to/punk/01.mp3',
-     'array': array([0.15237972, 0.13222949, 0.10627693, ..., 0.41940814, 0.37578005,
-         0.33717662], dtype=float32),
-     'sampling_rate': 44100},
- 'label': 1  # "punk"
-}
+>>> dataset = load_dataset("audiofolder", data_dir="/path/to/folder")
+```
+
+You can also use `audiofolder` to load datasets involving multiple splits. To do so, your dataset directory should have the following structure:
+
+```
+folder/train/dog/golden_retriever.mp3
+folder/train/cat/maine_coon.mp3
+folder/test/dog/german_shepherd.mp3
+folder/test/cat/bengal.mp3
 ```
 
 <Tip warning={true}>
@@ -167,11 +102,57 @@ If all audio files are contained in a single directory or if they are not on the
 </Tip>
 
 
-<Tip>
+If there is additional information you'd like to include about your dataset, like text captions or bounding boxes, add it as a `metadata.csv` file in your folder. This lets you quickly create datasets for different computer vision tasks like text captioning or object detection. You can also use a JSONL file `metadata.jsonl` or a Parquet file `metadata.parquet`.
 
-Some audio datasets, like those found in [Kaggle competitions](https://www.kaggle.com/competitions/kaggle-pog-series-s01e02/overview), have separate metadata files for each split. Provided the metadata features are the same for each split, `audiofolder` can be used to load all splits at once. If the metadata features differ across each split, you should load them with separate `load_dataset()` calls.
+```
+folder/train/metadata.csv
+folder/train/0001.mp3
+folder/train/0002.mp3
+folder/train/0003.mp3
+```
 
-</Tip>
+You can also zip your audio files, and in this case each zip should contain both the audio files and the metadata
+
+```
+folder/train.zip
+folder/test.zip
+folder/validation.zip
+```
+
+Your `metadata.csv` file must have a `file_name` or `*_file_name` field which links audio files with their metadata:
+
+```csv
+file_name,additional_feature
+0001.mp3,This is a first value of a text feature you added to your audio files
+0002.mp3,This is a second value of a text feature you added to your audio files
+0003.mp3,This is a third value of a text feature you added to your audio files
+```
+
+or using `metadata.jsonl`:
+
+```jsonl
+{"file_name": "0001.mp3", "additional_feature": "This is a first value of a text feature you added to your audio files"}
+{"file_name": "0002.mp3", "additional_feature": "This is a second value of a text feature you added to your audio files"}
+{"file_name": "0003.mp3", "additional_feature": "This is a third value of a text feature you added to your audio files"}
+```
+
+Here the `file_name` must be the name of the audio file next to the metadata file. More generally, it must be the relative path from the directory containing the metadata to the audio file.
+
+It's possible to point to more than one audio in each row in your dataset, for example if both your input and output are audio files:
+
+```jsonl
+{"input_file_name": "0001.mp3", "output_file_name": "0001_output.mp3"}
+{"input_file_name": "0002.mp3", "output_file_name": "0002_output.mp3"}
+{"input_file_name": "0003.mp3", "output_file_name": "0003_output.mp3"}
+```
+
+You can also define lists of audio files. In that case you need to name the field `file_names` or `*_file_names`. Here is an example:
+
+```jsonl
+{"recordings_file_names": ["0001_r0.mp3", "0001_r1.mp3"], label: "same_person"}
+{"recordings_file_names": ["0002_r0.mp3", "0002_r1.mp3"], label: "same_person"}
+{"recordings_file_names": ["0003_r0.mp3", "0003_r1.mp3"], label: "different_person"}
+```
 
 ## (Legacy) Loading script
 

--- a/docs/source/audio_dataset.mdx
+++ b/docs/source/audio_dataset.mdx
@@ -154,6 +154,58 @@ You can also define lists of audio files. In that case you need to name the fiel
 {"recordings_file_names": ["0003_r0.mp3", "0003_r1.mp3"], label: "different_person"}
 ```
 
+## WebDataset
+
+The [WebDataset](https://github.com/webdataset/webdataset) format is based on TAR archives and is suitable for big audio datasets.
+Indeed you can group your audio files in TAR archives (e.g. 1GB of audio files per TAR archive) and have thousands of TAR archives:
+
+```
+folder/train/00000.tar
+folder/train/00001.tar
+folder/train/00002.tar
+...
+```
+
+In the archives, each example is made of files sharing the same prefix:
+
+```
+e39871fd9fd74f55.mp3
+e39871fd9fd74f55.json
+f18b91585c4d3f3e.mp3
+f18b91585c4d3f3e.json
+ede6e66b2fb59aab.mp3
+ede6e66b2fb59aab.json
+ed600d57fcee4f94.mp3
+ed600d57fcee4f94.json
+...
+```
+
+You can put your audio files labels/captions/bounding boxes using JSON or text files for example.
+
+Load your WebDataset and it will create on column per file suffix (here "mp3" and "json"):
+
+```python
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("webdataset", data_dir="/path/to/folder", split="train")
+>>> dataset[0]["json"]
+{"transcript": "Hello there !", "speaker": "Obi-Wan Kenobi"}
+```
+
+It's also possible to have several audio files per example like this:
+
+```
+e39871fd9fd74f55.input.mp3
+e39871fd9fd74f55.output.mp3
+e39871fd9fd74f55.json
+f18b91585c4d3f3e.input.mp3
+f18b91585c4d3f3e.output.mp3
+f18b91585c4d3f3e.json
+...
+```
+
+For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
+
 ## (Legacy) Loading script
 
 Write a dataset loading script to manually create a dataset.

--- a/docs/source/audio_load.mdx
+++ b/docs/source/audio_load.mdx
@@ -51,17 +51,15 @@ third_audio_file.mp3,pewnie kędyś w obłędzie ubite minęły szlaki zaczekajm
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("audiofolder", data_dir="/path/to/folder")
->>> # OR by specifying the list of files
->>> dataset = load_dataset("audiofolder", data_files=["path/to/audio_1", "path/to/audio_2", ..., "path/to/audio_n"])
+>>> dataset = load_dataset("username/dataset_name")
+>>> # OR locally:
+>>> dataset = load_dataset("/path/to/folder")
 ```
 
-You can load remote datasets from their URLs with the data_files parameter:
+For local datasets, this is equivalent to passing `audiofolder` manually in [`load_dataset`] and the directory in `data_dir`:
 
 ```py
->>> dataset = load_dataset("audiofolder", data_files=["https://foo.bar/audio_1", "https://foo.bar/audio_2", ..., "https://foo.bar/audio_n"]
->>> # for example, pass SpeechCommands archive:
->>> dataset = load_dataset("audiofolder", data_files="https://s3.amazonaws.com/datasets.huggingface.co/SpeechCommands/v0.01/v0.01_test.tar.gz")
+>>> dataset = load_dataset("audiofolder", data_dir="/path/to/folder")
 ```
 
 Metadata can also be specified as JSON Lines, in which case use `metadata.jsonl` as the name of the metadata file. This format is helpful in scenarios when one of the columns is complex, e.g. a list of floats, to avoid parsing errors or reading the complex values as strings.
@@ -71,7 +69,7 @@ To ignore the information in the metadata file, set `drop_metadata=True` in [`lo
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("audiofolder", data_dir="/path/to/folder", drop_metadata=True)
+>>> dataset = load_dataset("username/dataset_with_metadata", drop_metadata=True)
 ```
 
 If you don't have a metadata file, `AudioFolder` automatically infers the label name from the directory name.
@@ -81,7 +79,14 @@ In this case, your dataset will only contain an audio column:
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("audiofolder", data_dir="/path/to/folder_without_metadata", drop_labels=True)
+>>> dataset = load_dataset("username/dataset_without_metadata", drop_labels=True)
+```
+
+Finally the `filters` argument lets you load only a subset of the dataset, based on a condition on the label or the metadata. This is especially useful if the metadata is in Parquet format, since this format enables fast filtering. It is also recommended to use this argument with `streaming=True`, because by default the dataset is fully downloaded before filtering.
+
+```python
+>>> filters = [("label", "=", 0)]
+>>> dataset = load_dataset("username/dataset_name", streaming=True, filters=filters)
 ```
 
 <Tip>

--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -194,8 +194,6 @@ ed600d57fcee4f94.json
 
 You can put your images labels/captions/bounding boxes using JSON or text files for example.
 
-For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
-
 Load your WebDataset and it will create on column per file suffix (here "jpg" and "json"):
 
 ```python
@@ -205,6 +203,20 @@ Load your WebDataset and it will create on column per file suffix (here "jpg" an
 >>> dataset[0]["json"]
 {"bbox": [[302.0, 109.0, 73.0, 52.0]], "categories": [0]}
 ```
+
+It's also possible to have several images per example like this:
+
+```
+e39871fd9fd74f55.input.jpg
+e39871fd9fd74f55.output.jpg
+e39871fd9fd74f55.json
+f18b91585c4d3f3e.input.jpg
+f18b91585c4d3f3e.output.jpg
+f18b91585c4d3f3e.json
+...
+```
+
+For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
 
 ## (Legacy) Loading script
 

--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -34,11 +34,17 @@ folder/train/cat/bengal.png
 folder/train/cat/birman.png
 ```
 
-Then users can load your dataset by specifying `imagefolder` in [`load_dataset`] and the directory in `data_dir`:
+If the dataset follows the `ImageFolder` structure, then you can load it directly with [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
 
+>>> dataset = load_dataset("path/to/folder")
+```
+
+This is equivalent to passing `imagefolder` manually in [`load_dataset`] and the directory in `data_dir`:
+
+```py
 >>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder")
 ```
 
@@ -58,7 +64,7 @@ If all image files are contained in a single directory or if they are not on the
 </Tip>
 
 
-If there is additional information you'd like to include about your dataset, like text captions or bounding boxes, add it as a `metadata.csv` file in your folder. This lets you quickly create datasets for different computer vision tasks like text captioning or object detection. You can also use a JSONL file `metadata.jsonl`.
+If there is additional information you'd like to include about your dataset, like text captions or bounding boxes, add it as a `metadata.csv` file in your folder. This lets you quickly create datasets for different computer vision tasks like text captioning or object detection. You can also use a JSONL file `metadata.jsonl` or a Parquet file `metadata.parquet`.
 
 ```
 folder/train/metadata.csv
@@ -67,16 +73,15 @@ folder/train/0002.png
 folder/train/0003.png
 ```
 
-You can also zip your images:
+You can also zip your images, and in this case each zip should contain both the images and the metadata
 
 ```
-folder/metadata.csv
 folder/train.zip
 folder/test.zip
-folder/valid.zip
+folder/validation.zip
 ```
 
-Your `metadata.csv` file must have a `file_name` column which links image files with their metadata:
+Your `metadata.csv` file must have a `file_name` or `*_file_name` field which links image files with their metadata:
 
 ```csv
 file_name,additional_feature
@@ -93,11 +98,23 @@ or using `metadata.jsonl`:
 {"file_name": "0003.png", "additional_feature": "This is a third value of a text feature you added to your images"}
 ```
 
-<Tip>
+Here the `file_name` must be the name of the image file next to the metadata file. More generally, it must be the relative path from the directory containing the metadata to the image file.
 
-If metadata files are present, the inferred labels based on the directory name are dropped by default. To include those labels, set `drop_labels=False` in `load_dataset`.
+It's possible to point to more than one image in each row in your dataset, for example if both your input and output are images:
 
-</Tip>
+```jsonl
+{"input_file_name": "0001.png", "output_file_name": "0001_output.png"}
+{"input_file_name": "0002.png", "output_file_name": "0002_output.png"}
+{"input_file_name": "0003.png", "output_file_name": "0003_output.png"}
+```
+
+You can also define lists of images. In that case you need to name the field `file_names` or `*_file_names`. Here is an example:
+
+```jsonl
+{"frames_file_names": ["0001_t0.png", "0001_t1.png"], label: "moving_up"}
+{"frames_file_names": ["0002_t0.png", "0002_t1.png"], label: "moving_down"}
+{"frames_file_names": ["0003_t0.png", "0003_t1.png"], label: "moving_right"}
+```
 
 ### Image captioning
 

--- a/docs/source/image_load.mdx
+++ b/docs/source/image_load.mdx
@@ -13,7 +13,7 @@ When you load an image dataset and call the image column, the images are decoded
 ```py
 >>> from datasets import load_dataset, Image
 
->>> dataset = load_dataset("AI-Lab-Makerere/beans", split="train")
+>>> dataset = load_dataset("beans", split="train")
 >>> dataset[0]["image"]
 ```
 
@@ -39,7 +39,7 @@ You can load a dataset from the image path. Use the [`~Dataset.cast_column`] fun
 If you only want to load the underlying path to the image dataset without decoding the image object, set `decode=False` in the [`Image`] feature:
 
 ```py
->>> dataset = load_dataset("AI-Lab-Makerere/beans", split="train").cast_column("image", Image(decode=False))
+>>> dataset = load_dataset("beans", split="train").cast_column("image", Image(decode=False))
 >>> dataset[0]["image"]
 {'bytes': None,
  'path': '/root/.cache/huggingface/datasets/downloads/extracted/b0a21163f78769a2cf11f58dfc767fb458fc7cea5c05dccc0144a2c0f0bc1292/train/bean_rust/bean_rust_train.29.jpg'}
@@ -59,12 +59,34 @@ folder/train/cat/bengal.png
 folder/train/cat/birman.png
 ```
 
-Load your dataset by specifying `imagefolder` and the directory of your dataset in `data_dir`:
+Alternatively it should have metadata, for example:
+
+```
+folder/train/metadata.csv
+folder/train/0001.png
+folder/train/0002.png
+folder/train/0003.png
+```
+
+If the dataset follows the `ImageFolder` structure, then you can load it directly with [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
 
+>>> dataset = load_dataset("username/dataset_name")
+>>> # OR locally:
+>>> dataset = load_dataset("/path/to/folder")
+```
+
+For local datasets, this is equivalent to passing `imagefolder` manually in [`load_dataset`] and the directory in `data_dir`:
+
+```py
 >>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder")
+```
+
+Then you can access the videos as `PIL.Image` objects:
+
+```
 >>> dataset["train"][0]
 {"image": <PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E6D7160>, "label": 0}
 
@@ -72,20 +94,29 @@ Load your dataset by specifying `imagefolder` and the directory of your dataset 
 {"image": <PIL.PngImagePlugin.PngImageFile image mode=RGBA size=1200x215 at 0x15E8DAD30>, "label": 1}
 ```
 
-Load remote datasets from their URLs with the `data_files` parameter:
-
-```py
->>> dataset = load_dataset("imagefolder", data_files="https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_5340.zip", split="train")
-```
-
-Some datasets have a metadata file (`metadata.csv`/`metadata.jsonl`) associated with it, containing other information about the data like bounding boxes, text captions, and labels. The metadata is automatically loaded when you call [`load_dataset`] and specify `imagefolder`. 
-
-To ignore the information in the metadata file, set `drop_labels=False` in [`load_dataset`], and allow `ImageFolder` to automatically infer the label name from the directory name:
+To ignore the information in the metadata file, set `drop_metadata=True` in [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("imagefolder", data_dir="/path/to/folder", drop_labels=False)
+>>> dataset = load_dataset("username/dataset_with_metadata", drop_metadata=True)
+```
+
+If you don't have a metadata file, `ImageFolder` automatically infers the label name from the directory name.
+If you want to drop automatically created labels, set `drop_labels=True`.
+In this case, your dataset will only contain an image column:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("username/dataset_without_metadata", drop_labels=True)
+```
+
+Finally the `filters` argument lets you load only a subset of the dataset, based on a condition on the label or the metadata. This is especially useful if the metadata is in Parquet format, since this format enables fast filtering. It is also recommended to use this argument with `streaming=True`, because by default the dataset is fully downloaded before filtering.
+
+```python
+>>> filters = [("label", "=", 0)]
+>>> dataset = load_dataset("username/dataset_name", streaming=True, filters=filters)
 ```
 
 <Tip>
@@ -93,6 +124,7 @@ To ignore the information in the metadata file, set `drop_labels=False` in [`loa
 For more information about creating your own `ImageFolder` dataset, take a look at the [Create an image dataset](./image_dataset) guide.
 
 </Tip>
+
 
 ## WebDataset
 

--- a/docs/source/video_dataset.mdx
+++ b/docs/source/video_dataset.mdx
@@ -30,11 +30,17 @@ folder/train/cat/bengal.mp4
 folder/train/cat/birman.mp4
 ```
 
-Then users can load your dataset by specifying `videofolder` in [`load_dataset`] and the directory in `data_dir`:
+If the dataset follows the `VideoFolder` structure, then you can load it directly with [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
 
+>>> dataset = load_dataset("path/to/folder")
+```
+
+This is equivalent to passing `videofolder` manually in [`load_dataset`] and the directory in `data_dir`:
+
+```py
 >>> dataset = load_dataset("videofolder", data_dir="/path/to/folder")
 ```
 
@@ -54,7 +60,7 @@ If all video files are contained in a single directory or if they are not on the
 </Tip>
 
 
-If there is additional information you'd like to include about your dataset, like text captions or bounding boxes, add it as a `metadata.csv` file in your folder. This lets you quickly create datasets for different computer vision tasks like text captioning or object detection. You can also use a JSONL file `metadata.jsonl`.
+If there is additional information you'd like to include about your dataset, like text captions or bounding boxes, add it as a `metadata.csv` file in your folder. This lets you quickly create datasets for different computer vision tasks like text captioning or object detection. You can also use a JSONL file `metadata.jsonl` or a Parquet file `metadata.parquet`.
 
 ```
 folder/train/metadata.csv
@@ -63,16 +69,7 @@ folder/train/0002.mp4
 folder/train/0003.mp4
 ```
 
-You can also zip your videos:
-
-```
-folder/metadata.csv
-folder/train.zip
-folder/test.zip
-folder/valid.zip
-```
-
-Your `metadata.csv` file must have a `file_name` column which links video files with their metadata:
+Your `metadata.csv` file must have a `file_name` or `*_file_name` field which links video files with their metadata:
 
 ```csv
 file_name,additional_feature
@@ -89,11 +86,23 @@ or using `metadata.jsonl`:
 {"file_name": "0003.mp4", "additional_feature": "This is a third value of a text feature you added to your videos"}
 ```
 
-<Tip>
+Here the `file_name` must be the name of the video file next to the metadata file. More generally, it must be the relative path from the directory containing the metadata to the video file.
 
-If metadata files are present, the inferred labels based on the directory name are dropped by default. To include those labels, set `drop_labels=False` in `load_dataset`.
+It's possible to point to more than one video in each row in your dataset, for example if both your input and output are videos:
 
-</Tip>
+```jsonl
+{"input_file_name": "0001.mp4", "output_file_name": "0001_output.mp4"}
+{"input_file_name": "0002.mp4", "output_file_name": "0002_output.mp4"}
+{"input_file_name": "0003.mp4", "output_file_name": "0003_output.mp4"}
+```
+
+You can also define lists of videos. In that case you need to name the field `file_names` or `*_file_names`. Here is an example:
+
+```jsonl
+{"frames_file_names": ["0001_t0.mp4", "0001_t1.mp4"], label: "moving_up"}
+{"frames_file_names": ["0002_t0.mp4", "0002_t1.mp4"], label: "moving_down"}
+{"frames_file_names": ["0003_t0.mp4", "0003_t1.mp4"], label: "moving_right"}
+```
 
 ### Video captioning
 

--- a/docs/source/video_load.mdx
+++ b/docs/source/video_load.mdx
@@ -10,7 +10,7 @@ Video datasets have [`Video`] type columns, which contain `torchvision` objects.
 
 <Tip>
 
-To work with video datasets, you need to have the `torchvision` package installed. Check out the [installation](https://github.com/dmlc/torchvision?tab=readme-ov-file#installation) guide to learn how to install it, or the [related discussions](https://github.com/dmlc/torchvision/issues/213).
+To work with video datasets, you need to have the `torchvision` package installed. Check out the [installation](https://github.com/pytorch/vision#installation) guide to learn how to install it.
 
 </Tip>
 
@@ -34,7 +34,7 @@ For a guide on how to load any type of dataset, take a look at the <a class="und
 
 ## Read frames
 
-Access frames directly from a video using the `VideoReader`:
+Access frames directly from a video using the `VideoReader` using `next()`:
 
 ```python
 >>> video = dataset[0]["video"]

--- a/docs/source/video_load.mdx
+++ b/docs/source/video_load.mdx
@@ -88,10 +88,12 @@ If the dataset follows the `VideoFolder` structure, then you can load it directl
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("path/to/folder")
+>>> dataset = load_dataset("username/dataset_name")
+>>> # OR locally:
+>>> dataset = load_dataset("/path/to/folder")
 ```
 
-This is equivalent to passing `videofolder` manually in [`load_dataset`] and the directory in `data_dir`:
+For local datasets, this is equivalent to passing `videofolder` manually in [`load_dataset`] and the directory in `data_dir`:
 
 ```py
 >>> dataset = load_dataset("videofolder", data_dir="/path/to/folder")

--- a/docs/source/video_load.mdx
+++ b/docs/source/video_load.mdx
@@ -6,27 +6,27 @@ Video support is experimental and is subject to change.
 
 </Tip>
 
-Video datasets have [`Video`] type columns, which contain `decord` objects. 
+Video datasets have [`Video`] type columns, which contain `torchvision` objects. 
 
 <Tip>
 
-To work with video datasets, you need to have the `decord` package installed. Check out the [installation](https://github.com/dmlc/decord?tab=readme-ov-file#installation) guide to learn how to install it, or the [related discussions](https://github.com/dmlc/decord/issues/213).
+To work with video datasets, you need to have the `torchvision` package installed. Check out the [installation](https://github.com/dmlc/torchvision?tab=readme-ov-file#installation) guide to learn how to install it, or the [related discussions](https://github.com/dmlc/torchvision/issues/213).
 
 </Tip>
 
-When you load an video dataset and call the video column, the videos are decoded as `decord` Videos:
+When you load an video dataset and call the video column, the videos are decoded as `torchvision` Videos:
 
 ```py
 >>> from datasets import load_dataset, Video
 
 >>> dataset = load_dataset("path/to/video/folder", split="train")
 >>> dataset[0]["video"]
-<decord.video_reader.VideoReader at 0x1652284c0>
+<torchvision.io.video_reader.VideoReader at 0x1652284c0>
 ```
 
 <Tip warning={true}>
 
-Index into an video dataset using the row index first and then the `video` column - `dataset[0]["video"]` - to avoid reading all the video objects in the dataset. Otherwise, this can be a slow and time-consuming process if you have a large dataset.
+Index into an video dataset using the row index first and then the `video` column - `dataset[0]["video"]` - to avoid creating all the video objects in the dataset. Otherwise, this can be a slow and time-consuming process if you have a large dataset.
 
 </Tip>
 
@@ -37,27 +37,44 @@ For a guide on how to load any type of dataset, take a look at the <a class="und
 Access frames directly from a video using the `VideoReader`:
 
 ```python
->>> dataset[0]["video"][0].shape  # first frame
-(240, 320, 3)
+>>> video = dataset[0]["video"]
+>>> first_frame = next(video)
+>>> first_frame["data"].shape
+(3, 240, 320)
+>>> first_frame["pts"]  # timestamp
+0.0
 ```
 
-To get multiple frames at once, use `get_batch`. This is the efficient way to obtain a long list of frames:
+To get multiple frames at once, you need to iterate on the `VideoReader`. This is the efficient way to obtain a long list of frames:
 
 ```python
->>> frames = dataset[0]["video"].get_batch([1, 3, 5, 7, 9])
+>>> import torch
+>>> import itertools
+>>> frames = torch.stack([frame["data"] for frame in islice(video, 5)])
 >>> frames.shape
-(5, 240, 320, 3)
+(5, 3, 240, 320)
+```
+
+There is also `.seek()` if you need to set the current timestamp of the video:
+
+```python
+>>> video.get_metadata()
+{'video': {'fps': [10.0], 'duration': [16.1]}}
+>>> video = video.seek(8.0, keyframes_only=True)
+>>> frame = next(video)
+>>> first_frame["data"].shape
+(3, 240, 320)
 ```
 
 ## Local files
 
-You can load a dataset from the video path. Use the [`~Dataset.cast_column`] function to accept a column of video file paths, and decode it into a `decord` video with the [`Video`] feature:
+You can load a dataset from the video path. Use the [`~Dataset.cast_column`] function to accept a column of video file paths, and decode it into a `torchvision` video with the [`Video`] feature:
 ```py
 >>> from datasets import Dataset, Video
 
 >>> dataset = Dataset.from_dict({"video": ["path/to/video_1", "path/to/video_2", ..., "path/to/video_n"]}).cast_column("video", Video())
 >>> dataset[0]["video"]
-<decord.video_reader.VideoReader at 0x1657d0280>
+<torchvision.io.video_reader.VideoReader at 0x1657d0280>
 ```
 
 If you only want to load the underlying path to the video dataset without decoding the video object, set `decode=False` in the [`Video`] feature:
@@ -99,14 +116,14 @@ For local datasets, this is equivalent to passing `videofolder` manually in [`lo
 >>> dataset = load_dataset("videofolder", data_dir="/path/to/folder")
 ```
 
-Then you can access the videos as `decord.video_reader.VideoReader` objects:
+Then you can access the videos as `torchvision.io.video_reader.VideoReader` objects:
 
 ```
 >>> dataset["train"][0]
-{"video": <decord.video_reader.VideoReader at 0x161715e50>, "label": 0}
+{"video": <torchvision.io.video_reader.VideoReader at 0x161715e50>, "label": 0}
 
 >>> dataset["train"][-1]
-{"video": <decord.video_reader.VideoReader at 0x16170bd90>, "label": 1}
+{"video": <torchvision.io.video_reader.VideoReader at 0x16170bd90>, "label": 1}
 ```
 
 To ignore the information in the metadata file, set `drop_metadata=True` in [`load_dataset`]:

--- a/docs/source/video_load.mdx
+++ b/docs/source/video_load.mdx
@@ -83,12 +83,23 @@ folder/train/cat/bengal.mp4
 folder/train/cat/birman.mp4
 ```
 
-Load your dataset by specifying `videofolder` and the directory of your dataset in `data_dir`:
+If the dataset follows the `VideoFolder` structure, then you can load it directly with [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
 
+>>> dataset = load_dataset("path/to/folder")
+```
+
+This is equivalent to passing `videofolder` manually in [`load_dataset`] and the directory in `data_dir`:
+
+```py
 >>> dataset = load_dataset("videofolder", data_dir="/path/to/folder")
+```
+
+Then you can access the videos as `decord.video_reader.VideoReader` objects:
+
+```
 >>> dataset["train"][0]
 {"video": <decord.video_reader.VideoReader at 0x161715e50>, "label": 0}
 
@@ -96,20 +107,29 @@ Load your dataset by specifying `videofolder` and the directory of your dataset 
 {"video": <decord.video_reader.VideoReader at 0x16170bd90>, "label": 1}
 ```
 
-Load remote datasets from their URLs with the `data_files` parameter:
-
-```py
->>> dataset = load_dataset("videofolder", data_files="https://foo.bar/videos.zip", split="train")
-```
-
-Some datasets have a metadata file (`metadata.csv`/`metadata.jsonl`) associated with it, containing other information about the data like bounding boxes, text captions, and labels. The metadata is automatically loaded when you call [`load_dataset`] and specify `videofolder`. 
-
-To ignore the information in the metadata file, set `drop_labels=False` in [`load_dataset`], and allow `VideoFolder` to automatically infer the label name from the directory name:
+To ignore the information in the metadata file, set `drop_metadata=True` in [`load_dataset`]:
 
 ```py
 >>> from datasets import load_dataset
 
->>> dataset = load_dataset("videofolder", data_dir="/path/to/folder", drop_labels=False)
+>>> dataset = load_dataset("username/dataset_with_metadata", drop_metadata=True)
+```
+
+If you don't have a metadata file, `ImageFolder` automatically infers the label name from the directory name.
+If you want to drop automatically created labels, set `drop_labels=True`.
+In this case, your dataset will only contain an video column:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("username/dataset_without_metadata", drop_labels=True)
+```
+
+Finally the `filters` argument lets you load only a subset of the dataset, based on a condition on the label or the metadata. This is especially useful if the metadata is in Parquet format, since this format enables fast filtering. It is also recommended to use this argument with `streaming=True`, because by default the dataset is fully downloaded before filtering.
+
+```python
+>>> filters = [("label", "=", 0)]
+>>> dataset = load_dataset("username/dataset_name", streaming=True, filters=filters)
 ```
 
 <Tip>

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,8 @@ TESTS_REQUIRE = [
     "transformers>=4.42.0",  # Pins numpy < 2
     "zstandard",
     "polars[timezone]>=0.20.0",
-    "torchcodec",
+    "torchvision",
+    "pyav",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ TESTS_REQUIRE = [
     "transformers>=4.42.0",  # Pins numpy < 2
     "zstandard",
     "polars[timezone]>=0.20.0",
-    "decord==0.6.0",
+    "torchcodec",
 ]
 
 

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -140,7 +140,7 @@ IS_OPUS_SUPPORTED = importlib.util.find_spec("soundfile") is not None and versio
 IS_MP3_SUPPORTED = importlib.util.find_spec("soundfile") is not None and version.parse(
     importlib.import_module("soundfile").__libsndfile_version__
 ) >= version.parse("1.1.0")
-DECORD_AVAILABLE = importlib.util.find_spec("decord") is not None
+TORCHCODEC_AVAILABLE = importlib.util.find_spec("torchcodec") is not None
 
 # Optional compression tools
 RARFILE_AVAILABLE = importlib.util.find_spec("rarfile") is not None

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -140,7 +140,7 @@ IS_OPUS_SUPPORTED = importlib.util.find_spec("soundfile") is not None and versio
 IS_MP3_SUPPORTED = importlib.util.find_spec("soundfile") is not None and version.parse(
     importlib.import_module("soundfile").__libsndfile_version__
 ) >= version.parse("1.1.0")
-TORCHCODEC_AVAILABLE = importlib.util.find_spec("torchcodec") is not None
+TORCHVISION_AVAILABLE = importlib.util.find_spec("torchvision") is not None
 
 # Optional compression tools
 RARFILE_AVAILABLE = importlib.util.find_spec("rarfile") is not None

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -107,11 +107,14 @@ if config.FSSPEC_VERSION < version.parse("2023.9.0"):
         "**/metadata.csv",
         "metadata.jsonl",
         "**/metadata.jsonl",
+        "metadata.parquet",
+        "**/metadata.parquet",
     ]  # metadata file for ImageFolder and AudioFolder
 else:
     METADATA_PATTERNS = [
         "**/metadata.csv",
         "**/metadata.jsonl",
+        "**/metadata.parquet",
     ]  # metadata file for ImageFolder and AudioFolder
 WILDCARD_CHARACTERS = "*[]"
 FILES_TO_IGNORE = [

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -13,7 +13,7 @@ from ..utils.py_utils import string_to_dict
 
 
 if TYPE_CHECKING:
-    from torchcodec.decoders import VideoDecoder
+    from torchvision.io import VideoReader
 
     from .features import FeatureType
 
@@ -32,7 +32,7 @@ class Video:
 
       This is useful for archived files with sequential access.
 
-    - A `decord.VideoDecoder`: decord video reader object.
+    - A `torchvision.io.VideoReader`: torchvision video reader object.
 
     Args:
         mode (`str`, *optional*):
@@ -49,7 +49,7 @@ class Video:
     >>> ds.features["video"]
     Video(decode=True, id=None)
     >>> ds[0]["video"]
-    <decord.video_reader.VideoDecoder at 0x105525c70>
+    <torchvision.io.video_reader.VideoReader object at 0x325b1aae0>
     >>> ds = ds.cast_column('video', Video(decode=False))
     {'bytes': None,
      'path': 'path/to/Screen Recording.mov'}
@@ -59,32 +59,28 @@ class Video:
     decode: bool = True
     id: Optional[str] = None
     # Automatically constructed
-    dtype: ClassVar[str] = "decord.VideoDecoder"
+    dtype: ClassVar[str] = "torchvision.io.VideoReader"
     pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
     _type: str = field(default="Video", init=False, repr=False)
-
-    def __post_init__(self):
-        if config.TORCHCODEC_AVAILABLE:
-            patch_torchcodec()
 
     def __call__(self):
         return self.pa_type
 
-    def encode_example(self, value: Union[str, bytes, dict, np.ndarray, "VideoDecoder"]) -> dict:
+    def encode_example(self, value: Union[str, bytes, dict, np.ndarray, "VideoReader"]) -> dict:
         """Encode example into a format for Arrow.
 
         Args:
-            value (`str`, `np.ndarray`, `VideoDecoder` or `dict`):
+            value (`str`, `np.ndarray`, `VideoReader` or `dict`):
                 Data passed as input to Video feature.
 
         Returns:
             `dict` with "path" and "bytes" fields
         """
-        if config.TORCHCODEC_AVAILABLE:
-            from torchcodec.decoders import VideoDecoder
+        if config.TORCHVISION_AVAILABLE:
+            from torchvision.io import VideoReader
 
         else:
-            VideoDecoder = None
+            VideoReader = None
 
         if isinstance(value, list):
             value = np.array(value)
@@ -96,9 +92,9 @@ class Video:
         elif isinstance(value, np.ndarray):
             # convert the video array to bytes
             return encode_np_array(value)
-        elif VideoDecoder and isinstance(value, VideoDecoder):
-            # convert the decord video reader to bytes
-            return encode_decord_video(value)
+        elif VideoReader and isinstance(value, VideoReader):
+            # convert the torchvision video reader to bytes
+            return encode_torchvision_video(value)
         elif value.get("path") is not None and os.path.isfile(value["path"]):
             # we set "bytes": None to not duplicate the data if they're already available locally
             return {"bytes": None, "path": value.get("path")}
@@ -110,7 +106,7 @@ class Video:
                 f"A video sample should have one of 'path' or 'bytes' but they are missing or None in {value}."
             )
 
-    def decode_example(self, value: dict, token_per_repo_id=None) -> "VideoDecoder":
+    def decode_example(self, value: dict, token_per_repo_id=None) -> "VideoReader":
         """Decode example video file into video data.
 
         Args:
@@ -126,16 +122,16 @@ class Video:
                 a dictionary repo_id (`str`) -> token (`bool` or `str`).
 
         Returns:
-            `decord.VideoDecoder`
+            `torchvision.io.VideoReader`
         """
         if not self.decode:
             raise RuntimeError("Decoding is disabled for this feature. Please use Video(decode=True) instead.")
 
-        if config.TORCHCODEC_AVAILABLE:
-            from torchcodec.decoders import VideoDecoder
+        if config.TORCHVISION_AVAILABLE:
+            from torchvision.io import VideoReader
 
         else:
-            raise ImportError("To support decoding videos, please install 'decord'.")
+            raise ImportError("To support decoding videos, please install 'torchvision'.")
 
         if token_per_repo_id is None:
             token_per_repo_id = {}
@@ -146,24 +142,12 @@ class Video:
                 raise ValueError(f"A video should have one of 'path' or 'bytes' but both are None in {value}.")
             else:
                 if is_local_path(path):
-                    video = VideoDecoder(path)
+                    video = VideoReader(path)
                 else:
-                    source_url = path.split("::")[-1]
-                    pattern = (
-                        config.HUB_DATASETS_URL
-                        if source_url.startswith(config.HF_ENDPOINT)
-                        else config.HUB_DATASETS_HFFS_URL
-                    )
-                    try:
-                        repo_id = string_to_dict(source_url, pattern)["repo_id"]
-                        token = token_per_repo_id.get(repo_id)
-                    except ValueError:
-                        token = None
-                    download_config = DownloadConfig(token=token)
-                    with xopen(path, "rb", download_config=download_config) as f:
-                        video = VideoDecoder(f.read())
+                    video = hf_video_reader(path, token_per_repo_id=token_per_repo_id)
         else:
-            video = VideoDecoder(bytes_)
+            video = VideoReader(bytes_)
+        video._hf_encoded = {"path": path, "bytes": bytes_}
         return video
 
     def flatten(self) -> Union["FeatureType", Dict[str, "FeatureType"]]:
@@ -226,18 +210,17 @@ class Video:
         return array_cast(storage, self.pa_type)
 
 
-def video_to_bytes(video: "VideoDecoder") -> bytes:
-    """Convert a decord Video object to bytes using native compression if possible"""
+def video_to_bytes(video: "VideoReader") -> bytes:
+    """Convert a torchvision Video object to bytes using native compression if possible"""
     raise NotImplementedError()
 
 
-def encode_decord_video(video: "VideoDecoder") -> dict:
+def encode_torchvision_video(video: "VideoReader") -> dict:
     if hasattr(video, "_hf_encoded"):
         return video._hf_encoded
     else:
         raise NotImplementedError(
-            "Encoding a decord video is not implemented. "
-            "Please call `datasets.features.video.patch_decord()` before loading videos to enable this."
+            "Encoding a VideoReader that doesn't come from datasets.Video.decode() is not implemented"
         )
 
 
@@ -245,24 +228,40 @@ def encode_np_array(array: np.ndarray) -> dict:
     raise NotImplementedError()
 
 
-# Patching decord a little bit to:
+# Patching torchvision a little bit to:
 # 1. store the encoded video data {"path": ..., "bytes": ...} in `video._hf_encoded``
-# 2. set the decord bridge to numpy/torch/tf/jax using `video._hf_bridge_out` (per video instance) instead of decord.bridge.bridge_out (global)
-# This doesn't affect the normal usage of decord.
+# 2. add support for hf:// files
+# This doesn't affect the normal usage of torchvision.
 
 
-def _patched_init(self: "VideoDecoder", source: Union[str, bytes], *args, **kwargs) -> None:
-    if isinstance(source, bytes):
-        self._hf_encoded = {"bytes": source, "path": None}
-    elif isinstance(source, str):
-        self._hf_encoded = {"bytes": None, "path": source}
-    self._original_init(source, *args, **kwargs)
+def hf_video_reader(
+    path: str, token_per_repo_id: Optional[dict[str, str]] = None, stream: str = "video"
+) -> "VideoReader":
+    import av
+    from torchvision import get_video_backend
+    from torchvision.io import VideoReader
 
+    # Load the file from HF
+    if token_per_repo_id is None:
+        token_per_repo_id = {}
+    source_url = path.split("::")[-1]
+    pattern = config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+    try:
+        repo_id = string_to_dict(source_url, pattern)["repo_id"]
+        token = token_per_repo_id.get(repo_id)
+    except ValueError:
+        token = None
+    download_config = DownloadConfig(token=token)
+    f = xopen(path, "rb", download_config=download_config)
 
-def patch_torchcodec():
-    from torchcodec.decoders import VideoDecoder
-
-    if not hasattr(VideoDecoder, "_hf_patched"):
-        VideoDecoder._original_init = VideoDecoder.__init__
-        VideoDecoder.__init__ = _patched_init
-        VideoDecoder._hf_patched = True
+    # Instantiate the VideoReader
+    vr = object.__new__(VideoReader)
+    vr.backend = get_video_backend()
+    if vr.backend != "pyav":
+        raise RuntimeError(f"Unsupported video backend for VideoReader from HF files: {vr.backend}")
+    vr.container = av.open(f, metadata_errors="ignore")
+    stream_type = stream.split(":")[0]
+    stream_id = 0 if len(stream.split(":")) == 1 else int(stream.split(":")[1])
+    vr.pyav_stream = {stream_type: stream_id}
+    vr._c = vr.container.decode(**vr.pyav_stream)
+    return vr

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -106,11 +106,11 @@ class JaxFormatter(TensorFormatter[Mapping, "jax.Array", Mapping]):
 
             if isinstance(value, PIL.Image.Image):
                 value = np.asarray(value)
-        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
-            from torchcodec.decoders import VideoDecoder
+        if config.TORCHVISION_AVAILABLE and "torchvision" in sys.modules:
+            from torchvision.io import VideoReader
 
-            if isinstance(value, VideoDecoder):
-                pass  # TODO(QL): set output to jax arrays ?
+            if isinstance(value, VideoReader):
+                return value  # TODO(QL): set output to jax arrays ?
 
         # using global variable since `jaxlib.xla_extension.Device` is not serializable neither
         # with `pickle` nor with `dill`, so we need to use a global variable instead

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -106,17 +106,11 @@ class JaxFormatter(TensorFormatter[Mapping, "jax.Array", Mapping]):
 
             if isinstance(value, PIL.Image.Image):
                 value = np.asarray(value)
-        if config.DECORD_AVAILABLE and "decord" in sys.modules:
-            # We need to import torch first, otherwise later it can cause issues
-            # e.g. "RuntimeError: random_device could not be read"
-            # when running `torch.tensor(value).share_memory_()`
-            if config.TORCH_AVAILABLE:
-                import torch  # noqa
-            from decord import VideoReader
+        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
+            from torchcodec.decoders import VideoDecoder
 
-            if isinstance(value, VideoReader):
-                value._hf_bridge_out = lambda x: jnp.array(np.asarray(x))
-                return value
+            if isinstance(value, VideoDecoder):
+                pass  # TODO(QL): set output to jax arrays ?
 
         # using global variable since `jaxlib.xla_extension.Device` is not serializable neither
         # with `pickle` nor with `dill`, so we need to use a global variable instead

--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -63,17 +63,11 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
             if isinstance(value, PIL.Image.Image):
                 return np.asarray(value, **self.np_array_kwargs)
-        if config.DECORD_AVAILABLE and "decord" in sys.modules:
-            # We need to import torch first, otherwise later it can cause issues
-            # e.g. "RuntimeError: random_device could not be read"
-            # when running `torch.tensor(value).share_memory_()`
-            if config.TORCH_AVAILABLE:
-                import torch  # noqa
-            from decord import VideoReader
+        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
+            from torchcodec.decoders import VideoDecoder
 
-            if isinstance(value, VideoReader):
-                value._hf_bridge_out = np.asarray
-                return value
+            if isinstance(value, VideoDecoder):
+                pass  # TODO(QL): set output to np arrays ?
 
         return np.asarray(value, **{**default_dtype, **self.np_array_kwargs})
 

--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -63,11 +63,11 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
             if isinstance(value, PIL.Image.Image):
                 return np.asarray(value, **self.np_array_kwargs)
-        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
-            from torchcodec.decoders import VideoDecoder
+        if config.TORCHVISION_AVAILABLE and "torchvision" in sys.modules:
+            from torchvision.io import VideoReader
 
-            if isinstance(value, VideoDecoder):
-                pass  # TODO(QL): set output to np arrays ?
+            if isinstance(value, VideoReader):
+                return value  # TODO(QL): set output to np arrays ?
 
         return np.asarray(value, **{**default_dtype, **self.np_array_kwargs})
 

--- a/src/datasets/formatting/tf_formatter.py
+++ b/src/datasets/formatting/tf_formatter.py
@@ -70,11 +70,11 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
 
             if isinstance(value, PIL.Image.Image):
                 value = np.asarray(value)
-        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
-            from torchcodec.decoders import VideoDecoder
+        if config.TORCHVISION_AVAILABLE and "torchvision" in sys.modules:
+            from torchvision.io import VideoReader
 
-            if isinstance(value, VideoDecoder):
-                pass  # TODO(QL): set output to tf tensors ?
+            if isinstance(value, VideoReader):
+                return value  # TODO(QL): set output to tf tensors ?
 
         return tf.convert_to_tensor(value, **{**default_dtype, **self.tf_tensor_kwargs})
 

--- a/src/datasets/formatting/tf_formatter.py
+++ b/src/datasets/formatting/tf_formatter.py
@@ -70,18 +70,11 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
 
             if isinstance(value, PIL.Image.Image):
                 value = np.asarray(value)
-        if config.DECORD_AVAILABLE and "decord" in sys.modules:
-            # We need to import torch first, otherwise later it can cause issues
-            # e.g. "RuntimeError: random_device could not be read"
-            # when running `torch.tensor(value).share_memory_()`
-            if config.TORCH_AVAILABLE:
-                import torch  # noqa
-            from decord import VideoReader
-            from decord.bridge import to_tensorflow
+        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
+            from torchcodec.decoders import VideoDecoder
 
-            if isinstance(value, VideoReader):
-                value._hf_bridge_out = to_tensorflow
-                return value
+            if isinstance(value, VideoDecoder):
+                pass  # TODO(QL): set output to tf tensors ?
 
         return tf.convert_to_tensor(value, **{**default_dtype, **self.tf_tensor_kwargs})
 

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -76,11 +76,11 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
                     value = value[:, :, np.newaxis]
 
                 value = value.transpose((2, 0, 1))
-        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
-            from torchcodec.decoders import VideoDecoder
+        if config.TORCHVISION_AVAILABLE and "torchvision" in sys.modules:
+            from torchvision.io import VideoReader
 
-            if isinstance(value, VideoDecoder):
-                pass  # TODO(QL): set output to torch tensors ?
+            if isinstance(value, VideoReader):
+                return value  # TODO(QL): set output to torch tensors ?
 
         return torch.tensor(value, **{**default_dtype, **self.torch_tensor_kwargs})
 

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -76,13 +76,11 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
                     value = value[:, :, np.newaxis]
 
                 value = value.transpose((2, 0, 1))
-        if config.DECORD_AVAILABLE and "decord" in sys.modules:
-            from decord import VideoReader
-            from decord.bridge import to_torch
+        if config.TORCHCODEC_AVAILABLE and "decord" in sys.modules:
+            from torchcodec.decoders import VideoDecoder
 
-            if isinstance(value, VideoReader):
-                value._hf_bridge_out = to_torch
-                return value
+            if isinstance(value, VideoDecoder):
+                pass  # TODO(QL): set output to torch tensors ?
 
         return torch.tensor(value, **{**default_dtype, **self.torch_tensor_kwargs})
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -51,14 +51,11 @@ from . import __version__, config
 from .arrow_dataset import Dataset
 from .builder import BuilderConfig, DatasetBuilder
 from .data_files import (
-    DEFAULT_PATTERNS_ALL,
     DataFilesDict,
     DataFilesList,
     DataFilesPatternsDict,
-    DataFilesPatternsList,
     EmptyDatasetError,
     get_data_patterns,
-    get_metadata_patterns,
     sanitize_patterns,
 )
 from .dataset_dict import DatasetDict, IterableDatasetDict
@@ -73,8 +70,8 @@ from .iterable_dataset import IterableDataset
 from .naming import camelcase_to_snakecase, snakecase_to_camelcase
 from .packaged_modules import (
     _EXTENSION_TO_MODULE,
-    _MODULE_SUPPORTS_METADATA,
     _MODULE_TO_EXTENSIONS,
+    _MODULE_TO_METADATA_FILE_NAMES,
     _PACKAGED_DATASETS_MODULES,
     _hash_python_lines,
 )
@@ -607,7 +604,6 @@ def infer_module_for_data_files(
 def create_builder_configs_from_metadata_configs(
     module_path: str,
     metadata_configs: MetadataConfigs,
-    supports_metadata: bool,
     base_path: Optional[str] = None,
     default_builder_kwargs: Dict[str, Any] = None,
     download_config: Optional[DownloadConfig] = None,
@@ -638,19 +634,6 @@ def create_builder_configs_from_metadata_configs(
                 f"Dataset at '{base_path}' doesn't contain data files matching the patterns for config '{config_name}',"
                 f" check `data_files` and `data_fir` parameters in the `configs` YAML field in README.md. "
             ) from e
-        if config_data_files is None and supports_metadata and config_patterns != DEFAULT_PATTERNS_ALL:
-            try:
-                config_metadata_patterns = get_metadata_patterns(base_path, download_config=download_config)
-            except FileNotFoundError:
-                config_metadata_patterns = None
-            if config_metadata_patterns is not None:
-                config_metadata_data_files_list = DataFilesPatternsList.from_patterns(config_metadata_patterns)
-                config_data_files_dict = DataFilesPatternsDict(
-                    {
-                        split: data_files_list + config_metadata_data_files_list
-                        for split, data_files_list in config_data_files_dict.items()
-                    }
-                )
         ignored_params = [
             param for param in config_params if not hasattr(builder_config_cls, param) and param != "default"
         ]
@@ -843,31 +826,15 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             data_files=data_files,
             path=self.path,
         )
-        data_files = data_files.filter_extensions(_MODULE_TO_EXTENSIONS[module_name])
-        # Collect metadata files if the module supports them
-        supports_metadata = module_name in _MODULE_SUPPORTS_METADATA
-        if self.data_files is None and supports_metadata:
-            try:
-                metadata_patterns = get_metadata_patterns(base_path)
-            except FileNotFoundError:
-                metadata_patterns = None
-            if metadata_patterns is not None:
-                metadata_data_files_list = DataFilesList.from_patterns(metadata_patterns, base_path=base_path)
-                if metadata_data_files_list:
-                    data_files = DataFilesDict(
-                        {
-                            split: data_files_list + metadata_data_files_list
-                            for split, data_files_list in data_files.items()
-                        }
-                    )
-
+        data_files = data_files.filter(
+            extensions=_MODULE_TO_EXTENSIONS[module_name], file_names=_MODULE_TO_METADATA_FILE_NAMES[module_name]
+        )
         module_path, _ = _PACKAGED_DATASETS_MODULES[module_name]
         if metadata_configs:
             builder_configs, default_config_name = create_builder_configs_from_metadata_configs(
                 module_path,
                 metadata_configs,
                 base_path=base_path,
-                supports_metadata=supports_metadata,
                 default_builder_kwargs=default_builder_kwargs,
             )
         else:
@@ -946,23 +913,6 @@ class PackagedDatasetModuleFactory(_DatasetModuleFactory):
             download_config=self.download_config,
             base_path=base_path,
         )
-        supports_metadata = self.name in _MODULE_SUPPORTS_METADATA
-        if self.data_files is None and supports_metadata and patterns != DEFAULT_PATTERNS_ALL:
-            try:
-                metadata_patterns = get_metadata_patterns(base_path, download_config=self.download_config)
-            except FileNotFoundError:
-                metadata_patterns = None
-            if metadata_patterns is not None:
-                metadata_data_files_list = DataFilesList.from_patterns(
-                    metadata_patterns, download_config=self.download_config, base_path=base_path
-                )
-                if metadata_data_files_list:
-                    data_files = DataFilesDict(
-                        {
-                            split: data_files_list + metadata_data_files_list
-                            for split, data_files_list in data_files.items()
-                        }
-                    )
 
         module_path, hash = _PACKAGED_DATASETS_MODULES[self.name]
 
@@ -1075,33 +1025,15 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             path=self.name,
             download_config=self.download_config,
         )
-        data_files = data_files.filter_extensions(_MODULE_TO_EXTENSIONS[module_name])
-        # Collect metadata files if the module supports them
-        supports_metadata = module_name in _MODULE_SUPPORTS_METADATA
-        if self.data_files is None and supports_metadata:
-            try:
-                metadata_patterns = get_metadata_patterns(base_path, download_config=self.download_config)
-            except FileNotFoundError:
-                metadata_patterns = None
-            if metadata_patterns is not None:
-                metadata_data_files_list = DataFilesList.from_patterns(
-                    metadata_patterns, download_config=self.download_config, base_path=base_path
-                )
-                if metadata_data_files_list:
-                    data_files = DataFilesDict(
-                        {
-                            split: data_files_list + metadata_data_files_list
-                            for split, data_files_list in data_files.items()
-                        }
-                    )
-
+        data_files = data_files.filter(
+            extensions=_MODULE_TO_EXTENSIONS[module_name], file_names=_MODULE_TO_METADATA_FILE_NAMES[module_name]
+        )
         module_path, _ = _PACKAGED_DATASETS_MODULES[module_name]
         if metadata_configs:
             builder_configs, default_config_name = create_builder_configs_from_metadata_configs(
                 module_path,
                 metadata_configs,
                 base_path=base_path,
-                supports_metadata=supports_metadata,
                 default_builder_kwargs=default_builder_kwargs,
                 download_config=self.download_config,
             )
@@ -1214,7 +1146,6 @@ class HubDatasetModuleFactoryWithParquetExport(_DatasetModuleFactory):
         builder_configs, default_config_name = create_builder_configs_from_metadata_configs(
             module_path,
             metadata_configs,
-            supports_metadata=False,
             download_config=self.download_config,
         )
         builder_kwargs = {

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -81,7 +81,6 @@ _EXTENSION_TO_MODULE.update({ext: ("audiofolder", {}) for ext in audiofolder.Aud
 _EXTENSION_TO_MODULE.update({ext.upper(): ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext: ("videofolder", {}) for ext in videofolder.VideoFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("videofolder", {}) for ext in videofolder.VideoFolder.EXTENSIONS})
-_MODULE_SUPPORTS_METADATA = {"imagefolder", "audiofolder", "videofolder"}
 
 # Used to filter data files based on extensions given a module name
 _MODULE_TO_EXTENSIONS: Dict[str, List[str]] = {}
@@ -90,3 +89,11 @@ for _ext, (_module, _) in _EXTENSION_TO_MODULE.items():
 
 for _module in _MODULE_TO_EXTENSIONS:
     _MODULE_TO_EXTENSIONS[_module].append(".zip")
+
+# Used to filter data files based on file names
+_MODULE_TO_METADATA_FILE_NAMES: Dict[str, List[str]] = {}
+for _module in _MODULE_TO_EXTENSIONS:
+    _MODULE_TO_METADATA_FILE_NAMES[_module] = []
+_MODULE_TO_METADATA_FILE_NAMES["imagefolder"] = imagefolder.ImageFolder.METADATA_FILENAMES
+_MODULE_TO_METADATA_FILE_NAMES["audiofolder"] = imagefolder.ImageFolder.METADATA_FILENAMES
+_MODULE_TO_METADATA_FILE_NAMES["videofolder"] = imagefolder.ImageFolder.METADATA_FILENAMES

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -168,8 +168,10 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
 
             # Check that all metadata files share the same format
             metadata_ext = {
-                os.path.splitext(original_metadata_file)[-1]
-                for original_metadata_file, _ in itertools.chain.from_iterable(metadata_files.values())
+                os.path.splitext(original_metadata_file or downloaded_metadata_file)[-1]
+                for original_metadata_file, downloaded_metadata_file in itertools.chain.from_iterable(
+                    metadata_files.values()
+                )
             }
             if len(metadata_ext) > 1:
                 raise ValueError(f"Found metadata files with different extensions: {list(metadata_ext)}")
@@ -355,7 +357,7 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
             _visit_with_path(self.info.features, find_feature_path)
 
             for original_metadata_file, downloaded_metadata_file in metadata_files:
-                metadata_ext = os.path.splitext(original_metadata_file)[-1]
+                metadata_ext = os.path.splitext(original_metadata_file or downloaded_metadata_file)[-1]
                 downloaded_metadata_dir = os.path.dirname(downloaded_metadata_file)
 
                 def set_feature(item, feature_path: _VisitPath):

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -351,7 +351,7 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
 
             def find_feature_path(feature, feature_path):
                 nonlocal feature_paths
-                if isinstance(feature, self.BASE_FEATURE):
+                if feature_path and isinstance(feature, self.BASE_FEATURE):
                     feature_paths.append(feature_path)
 
             _visit_with_path(self.info.features, find_feature_path)

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -267,6 +267,8 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                 if isinstance(self.config.filters, list)
                 else self.config.filters
             )
+        else:
+            filter_expr = None
         if metadata_ext == ".csv":
             chunksize = 10_000  # 10k lines
             schema = self.config.features.arrow_schema if self.config.features else None
@@ -329,9 +331,9 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
             with open(metadata_file, "rb") as f:
                 parquet_fragment = ds.ParquetFileFormat().make_fragment(f)
                 if parquet_fragment.row_groups:
-                    batch_size = self.config.batch_size or parquet_fragment.row_groups[0].num_rows
+                    batch_size = parquet_fragment.row_groups[0].num_rows
                 else:
-                    batch_size = self.config.batch_size or config.DEFAULT_MAX_BATCH_SIZE
+                    batch_size = config.DEFAULT_MAX_BATCH_SIZE
                 for record_batch in parquet_fragment.to_batches(
                     batch_size=batch_size,
                     filter=filter_expr,

--- a/tests/features/test_video.py
+++ b/tests/features/test_video.py
@@ -43,19 +43,19 @@ def test_dataset_with_video_feature(shared_datadir):
     item = dset[0]
     assert item.keys() == {"video"}
     assert isinstance(item["video"], VideoReader)
-    assert next(iter(item["video"])).shape == (50, 66, 3)
-    assert isinstance(item["video"][0], torch.Tensor)
+    assert next(item["video"])["data"].shape == (3, 50, 66)
+    assert isinstance(next(item["video"])["data"], torch.Tensor)
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"video"}
     assert isinstance(batch["video"], list) and all(isinstance(item, VideoReader) for item in batch["video"])
-    assert batch["video"][0][0].shape == (50, 66, 3)
-    assert isinstance(next(iter(batch["video"][0])), torch.Tensor)
+    assert next(batch["video"][0])["data"].shape == (3, 50, 66)
+    assert isinstance(next(batch["video"][0])["data"], torch.Tensor)
     column = dset["video"]
     assert len(column) == 1
     assert isinstance(column, list) and all(isinstance(item, VideoReader) for item in column)
-    assert next(iter(column[0])).shape == (50, 66, 3)
-    assert isinstance(next(iter(column[0])), torch.Tensor)
+    assert next(column[0])["data"].shape == (3, 50, 66)
+    assert isinstance(next(column[0])["data"], torch.Tensor)
 
     # from bytes
     with open(video_path, "rb") as f:
@@ -64,8 +64,8 @@ def test_dataset_with_video_feature(shared_datadir):
     item = dset[0]
     assert item.keys() == {"video"}
     assert isinstance(item["video"], VideoReader)
-    assert next(iter(item["video"])).shape == (50, 66, 3)
-    assert isinstance(item["video"][0], torch.Tensor)
+    assert next(item["video"])["data"].shape == (3, 50, 66)
+    assert isinstance(next(item["video"])["data"], torch.Tensor)
 
 
 @require_torchvision

--- a/tests/features/test_video.py
+++ b/tests/features/test_video.py
@@ -19,7 +19,7 @@ from ..utils import require_decord
     ],
 )
 def test_video_feature_encode_example(shared_datadir, build_example):
-    from decord import VideoReader
+    from torchcodec.decoders import VideoDecoder
 
     video_path = str(shared_datadir / "test_video_66x50.mov")
     video = Video()
@@ -28,13 +28,13 @@ def test_video_feature_encode_example(shared_datadir, build_example):
     assert encoded_example.keys() == {"bytes", "path"}
     assert encoded_example["bytes"] is not None or encoded_example["path"] is not None
     decoded_example = video.decode_example(encoded_example)
-    assert isinstance(decoded_example, VideoReader)
+    assert isinstance(decoded_example, VideoDecoder)
 
 
 @require_decord
 def test_dataset_with_video_feature(shared_datadir):
-    from decord import VideoReader
     from decord.ndarray import NDArray
+    from torchcodec.decoders import VideoDecoder
 
     video_path = str(shared_datadir / "test_video_66x50.mov")
     data = {"video": [video_path]}
@@ -42,18 +42,18 @@ def test_dataset_with_video_feature(shared_datadir):
     dset = Dataset.from_dict(data, features=features)
     item = dset[0]
     assert item.keys() == {"video"}
-    assert isinstance(item["video"], VideoReader)
+    assert isinstance(item["video"], VideoDecoder)
     assert item["video"][0].shape == (50, 66, 3)
     assert isinstance(item["video"][0], NDArray)
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"video"}
-    assert isinstance(batch["video"], list) and all(isinstance(item, VideoReader) for item in batch["video"])
+    assert isinstance(batch["video"], list) and all(isinstance(item, VideoDecoder) for item in batch["video"])
     assert batch["video"][0][0].shape == (50, 66, 3)
     assert isinstance(batch["video"][0][0], NDArray)
     column = dset["video"]
     assert len(column) == 1
-    assert isinstance(column, list) and all(isinstance(item, VideoReader) for item in column)
+    assert isinstance(column, list) and all(isinstance(item, VideoDecoder) for item in column)
     assert column[0][0].shape == (50, 66, 3)
     assert isinstance(column[0][0], NDArray)
 
@@ -63,7 +63,7 @@ def test_dataset_with_video_feature(shared_datadir):
     dset = Dataset.from_dict(data, features=features)
     item = dset[0]
     assert item.keys() == {"video"}
-    assert isinstance(item["video"], VideoReader)
+    assert isinstance(item["video"], VideoDecoder)
     assert item["video"][0].shape == (50, 66, 3)
     assert isinstance(item["video"][0], NDArray)
 
@@ -71,7 +71,7 @@ def test_dataset_with_video_feature(shared_datadir):
 @require_decord
 def test_dataset_with_video_map_and_formatted(shared_datadir):
     import numpy as np
-    from decord import VideoReader
+    from torchcodec.decoders import VideoDecoder
 
     video_path = str(shared_datadir / "test_video_66x50.mov")
     data = {"video": [video_path]}
@@ -79,7 +79,7 @@ def test_dataset_with_video_map_and_formatted(shared_datadir):
     dset = Dataset.from_dict(data, features=features)
     dset = dset.map(lambda x: x).with_format("numpy")
     example = dset[0]
-    assert isinstance(example["video"], VideoReader)
+    assert isinstance(example["video"], VideoDecoder)
     assert isinstance(example["video"][0], np.ndarray)
 
     # from bytes
@@ -88,5 +88,5 @@ def test_dataset_with_video_map_and_formatted(shared_datadir):
     dset = Dataset.from_dict(data, features=features)
     dset = dset.map(lambda x: x).with_format("numpy")
     example = dset[0]
-    assert isinstance(example["video"], VideoReader)
+    assert isinstance(example["video"], VideoDecoder)
     assert isinstance(example["video"][0], np.ndarray)

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -15,7 +15,6 @@ from datasets.data_files import (
     DataFilesPatternsDict,
     DataFilesPatternsList,
     _get_data_files_patterns,
-    _get_metadata_files_patterns,
     _is_inside_unrequested_special_dir,
     _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir,
     get_data_patterns,
@@ -669,29 +668,6 @@ def test_get_data_files_patterns(base_path, data_file_per_split):
             for file_path in data_file_per_split[split]
         ]
         assert matched == expected
-
-
-@pytest.mark.parametrize(
-    "metadata_files",
-    [
-        # metadata files at the root
-        ["metadata.jsonl"],
-        ["metadata.csv"],
-        # nested metadata files
-        ["metadata.jsonl", "data/metadata.jsonl"],
-        ["metadata.csv", "data/metadata.csv"],
-    ],
-)
-def test_get_metadata_files_patterns(metadata_files):
-    DummyTestFS = mock_fs(metadata_files)
-    fs = DummyTestFS()
-
-    def resolver(pattern):
-        return [file_path for file_path in fs.glob(pattern) if fs.isfile(file_path)]
-
-    patterns = _get_metadata_files_patterns(resolver)
-    matched = [file_path for pattern in patterns for file_path in resolver(pattern)]
-    assert sorted(matched) == sorted(metadata_files)
 
 
 def test_get_data_patterns_from_directory_with_the_word_data_twice(tmp_path):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -151,9 +151,9 @@ def data_dir_with_metadata(tmp_path):
     data_dir.mkdir()
     (data_dir / "train").mkdir()
     (data_dir / "test").mkdir()
-    with open(data_dir / "train"/ "cat.jpg", "wb") as f:
+    with open(data_dir / "train" / "cat.jpg", "wb") as f:
         f.write(b"train_image_bytes")
-    with open(data_dir / "test"/ "dog.jpg", "wb") as f:
+    with open(data_dir / "test" / "dog.jpg", "wb") as f:
         f.write(b"test_image_bytes")
     with open(data_dir / "train" / "metadata.jsonl", "w") as f:
         f.write(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -178,15 +178,15 @@ def require_pil(test_case):
     return test_case
 
 
-def require_decord(test_case):
+def require_torchvision(test_case):
     """
-    Decorator marking a test that requires decord.
+    Decorator marking a test that requires torchvision.
 
-    These tests are skipped when decord isn't installed.
+    These tests are skipped when torchvision isn't installed.
 
     """
-    if not config.TORCHCODEC_AVAILABLE:
-        test_case = unittest.skip("test requires decord")(test_case)
+    if not config.TORCHVISION_AVAILABLE:
+        test_case = unittest.skip("test requires torchvision")(test_case)
     return test_case
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -185,7 +185,7 @@ def require_decord(test_case):
     These tests are skipped when decord isn't installed.
 
     """
-    if not config.DECORD_AVAILABLE:
+    if not config.TORCHCODEC_AVAILABLE:
         test_case = unittest.skip("test requires decord")(test_case)
     return test_case
 


### PR DESCRIPTION
This will be useful for LeRobotDataset (robotics datasets for [lerobot](https://github.com/huggingface/lerobot) based on videos)

Impacted builders:
- ImageFolder
- AudioFolder
- VideoFolder

Improvements:
- faster to stream (got a 5x speed up on an image dataset)
- improved RAM usage
- support for metadata.parquet
- allow to link to an image/audio/video multiple times
- support for pyarrow filters (mostly efficient for parquet)

Changes:
- the builders iterate on the metadata files instead of the media files
- the builders iterate on chunks of metadata instead of loading them in RAM completely
- metadata files are no longer handled separately in `data_files`
- added the `filters` argument to pass to `load_dataset`
  - either as an [Expression](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Expression.html)
  - or as tuples like `filters=[('event_name', '=', 'SomeEvent')]`
- small breaking change: you can't add labels to a dataset with`drop_labels=False` if it has a metadata file
- small breaking change: you can't use one metadata file for multiple splits anymore

Additional change for VideoFolder:
- decord can't be installed in many setups, I switched the backend to torchvision instead
- I also added streaming capability from HF (you can get video frames without downloading the full video from HF)

TODO:
- [x] docs
- [x] fix tests