### PR TITLE
Fix small bugs with async map

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1211,7 +1211,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                             self._state_dict["previous_state_example_idx"] = previous_state_example_idx
                             previous_state, previous_state_task = None, None
                     # checkpoint
-                    if self._state_dict and previous_state_task is None:
+                    if self._state_dict and previous_state_task is None and tasks:
                         previous_state = self.ex_iterable.state_dict()
                         previous_state_task = tasks[-1]
                         previous_state_example_idx = current_idx

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1081,9 +1081,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
 
         if self.formatting:
             formatter = get_formatter(self.formatting.format_type)
-            format_dict = (
-                formatter.recursive_tensorize if isinstance(formatter, TensorFormatter) else cast_to_python_objects
-            )
+            format_dict = formatter.recursive_tensorize if isinstance(formatter, TensorFormatter) else None
         else:
             format_dict = None
 
@@ -1835,7 +1833,7 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
             format_dict = (
                 formatter.recursive_tensorize
                 if isinstance(formatter, TensorFormatter)
-                else cast_to_python_objects  # cast in case features is None
+                else None  # cast in case features is None
             )
             for key, example in self.ex_iterable:
                 # don't apply feature types if already applied by ex_iterable (e.g. in case of chained with_format)
@@ -1843,7 +1841,9 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
                     example = _apply_feature_types_on_example(
                         example, self.features, token_per_repo_id=self.token_per_repo_id
                     )
-                yield key, format_dict(example)
+                if format_dict:
+                    example = format_dict(example)
+                yield key, example
 
     def _iter_arrow(self) -> Iterator[tuple[Key, pa.Table]]:
         if not self.features:
@@ -2246,9 +2246,7 @@ class IterableDataset(DatasetInfoMixin):
 
         if self._formatting:
             formatter = get_formatter(self._formatting.format_type, features=self.features)
-            format_dict = (
-                formatter.recursive_tensorize if isinstance(formatter, TensorFormatter) else cast_to_python_objects
-            )
+            format_dict = formatter.recursive_tensorize if isinstance(formatter, TensorFormatter) else None
         else:
             format_dict = None
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1818,7 +1818,7 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
 
     def __iter__(self):
         if not self.formatting or self.formatting.is_table:
-            formatter = PythonFormatter()
+            formatter = PythonFormatter(features=self._features if not self.ex_iterable.is_typed else None)
         else:
             formatter = get_formatter(
                 self.formatting.format_type,


### PR DESCRIPTION
helpful for the next PR to enable parallel image/audio/video decoding and make multimodal datasets go brr (e.g. for lerobot)

- fix with_indices
- fix resuming with save_state_dict() / load_state_dict() - omg that wasn't easy
- remove unnecessary decoding in map() to enable parallelism in FormattedExampleIterable later

small bonus: keeping features in batch()