### PR TITLE
Fix local pdf loading

### DIFF
--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -164,8 +164,7 @@ class Pdf:
                 raise ValueError(f"A pdf should have one of 'path' or 'bytes' but both are None in {value}.")
             else:
                 if is_local_path(path):
-                    with pdfplumber.open(path) as p:
-                        pdf = p
+                    pdf = pdfplumber.open(path)
                 else:
                     source_url = path.split("::")[-1]
                     pattern = (


### PR DESCRIPTION
fir this error when accessing a local pdf

```
File ~/.pyenv/versions/3.12.2/envs/hf-datasets/lib/python3.12/site-packages/pdfminer/psparser.py:220, in PSBaseParser.seek(self, pos)
    218 """Seeks the parser to the given position."""
    219 log.debug("seek: %r", pos)
--> 220 self.fp.seek(pos)
    221 # reset the status for nextline()
    222 self.bufpos = pos

ValueError: seek of closed file
```