### PR TITLE
update fsspec 2025.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ REQUIRED_PKGS = [
     "multiprocess<0.70.17",  # to align with dill<0.3.9 (see above)
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0,<=2024.12.0",
+    "fsspec[http]>=2023.1.0,<=2025.3.0",
     # for data streaming via http
     "aiohttp",
     # To get datasets from the Datasets Hub on huggingface.co


### PR DESCRIPTION
It appears there have been two releases of fsspec since this dependency was last updated, it would be great if Datasets could be updated so that it didn't hold back the usage of newer fsspec versions in consuming projects.

PR based on https://github.com/huggingface/datasets/pull/7352