### PR TITLE
Write pdf in map

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -42,7 +42,7 @@ from ..utils import experimental, logging
 from ..utils.py_utils import asdict, first_non_null_value, zip_dict
 from .audio import Audio
 from .image import Image, encode_pil_image
-from .pdf import Pdf
+from .pdf import Pdf, encode_pdfplumber_pdf
 from .translation import Translation, TranslationVariableLanguages
 from .video import Video
 
@@ -299,6 +299,9 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
     if config.PIL_AVAILABLE and "PIL" in sys.modules:
         import PIL.Image
 
+    if config.PDFPLUMBER_AVAILABLE and "pdfplumber" in sys.modules:
+        import pdfplumber
+
     if isinstance(obj, np.ndarray):
         if obj.ndim == 0:
             return obj[()], True
@@ -367,6 +370,8 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             )
     elif config.PIL_AVAILABLE and "PIL" in sys.modules and isinstance(obj, PIL.Image.Image):
         return encode_pil_image(obj), True
+    elif config.PDFPLUMBER_AVAILABLE and "pdfplumber" in sys.modules and isinstance(obj, pdfplumber.pdf.PDF):
+        return encode_pdfplumber_pdf(obj), True
     elif isinstance(obj, pd.Series):
         return (
             _cast_to_python_objects(

--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -108,26 +108,6 @@ class Pdf:
                 f"A pdf sample should have one of 'path' or 'bytes' but they are missing or None in {value}."
             )
 
-    def encode_pdfplumber_pdf(pdf: "pdfplumber.pdf.PDF") -> dict:
-        """
-        Encode a pdfplumber.pdf.PDF object into a dictionary.
-
-        If the PDF has an associated file path, returns the path. Otherwise, serializes
-        the PDF content into bytes.
-
-        Args:
-            pdf (pdfplumber.pdf.PDF): A pdfplumber PDF object.
-
-        Returns:
-            dict: A dictionary with "path" or "bytes" field.
-        """
-        if hasattr(pdf, "stream") and hasattr(pdf.stream, "name") and pdf.stream.name:
-            # Return the path if the PDF has an associated file path
-            return {"path": pdf.stream.name, "bytes": None}
-        else:
-            # Convert the PDF to bytes if no path is available
-            return {"path": None, "bytes": pdf_to_bytes(pdf)}
-
     def decode_example(self, value: dict, token_per_repo_id=None) -> "pdfplumber.pdf.PDF":
         """Decode example pdf file into pdf data.
 
@@ -235,3 +215,24 @@ class Pdf:
                 path_array = pa.array([None] * len(storage), type=pa.string())
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
+
+
+def encode_pdfplumber_pdf(pdf: "pdfplumber.pdf.PDF") -> dict:
+    """
+    Encode a pdfplumber.pdf.PDF object into a dictionary.
+
+    If the PDF has an associated file path, returns the path. Otherwise, serializes
+    the PDF content into bytes.
+
+    Args:
+        pdf (pdfplumber.pdf.PDF): A pdfplumber PDF object.
+
+    Returns:
+        dict: A dictionary with "path" or "bytes" field.
+    """
+    if hasattr(pdf, "stream") and hasattr(pdf.stream, "name") and pdf.stream.name:
+        # Return the path if the PDF has an associated file path
+        return {"path": pdf.stream.name, "bytes": None}
+    else:
+        # Convert the PDF to bytes if no path is available
+        return {"path": None, "bytes": pdf_to_bytes(pdf)}

--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -96,7 +96,7 @@ class Pdf:
             return {"path": None, "bytes": value}
         elif pdfplumber is not None and isinstance(value, pdfplumber.pdf.PDF):
             # convert the pdfplumber.pdf.PDF to bytes
-            return self.encode_pdfplumber_pdf(value)
+            return encode_pdfplumber_pdf(value)
         elif value.get("path") is not None and os.path.isfile(value["path"]):
             # we set "bytes": None to not duplicate the data if they're already available locally
             return {"bytes": None, "path": value.get("path")}

--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -321,6 +321,14 @@ def first_non_null_value(iterable):
     return -1, None
 
 
+def first_non_null_non_empty_value(iterable):
+    """Return the index and the value of the first non-null non-empty value in the iterable. If all values are None or empty, return -1 as index."""
+    for i, value in enumerate(iterable):
+        if value is not None and not (isinstance(value, (dict, list)) and len(value) == 0):
+            return i, value
+    return -1, None
+
+
 def zip_dict(*dicts):
     """Iterate over items of dictionaries grouped by their keys."""
     for key in unique_values(itertools.chain(*dicts)):  # set merge all keys


### PR DESCRIPTION
Fix this error when mapping a PDF dataset

```
pyarrow.lib.ArrowInvalid: Could not convert <pdfplumber.pdf.PDF object at 0x13498ee40> with type PDF: did not recognize Python value type when inferring an Arrow data type
```

and also let map() outputs be lists of images or pdfs