### PR TITLE
fix: loading of datasets from Disk(#7373)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5191,8 +5191,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def _generate_tables_from_cache_file(filename: str):
-        for batch_idx, batch in enumerate(_memory_mapped_record_batch_reader_from_file(filename)):
-            yield batch_idx, pa.Table.from_batches([batch])
+        reader, mmap_stream = _memory_mapped_record_batch_reader_from_file(filename)
+        try:
+            for batch_idx, batch in enumerate(reader):
+                yield batch_idx, pa.Table.from_batches([batch])
+        finally:
+            reader.close()
+            mmap_stream.close()
 
     def to_iterable_dataset(self, num_shards: Optional[int] = 1) -> "IterableDataset":
         """Get an [`datasets.IterableDataset`] from a map-style [`datasets.Dataset`].

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -47,7 +47,7 @@ def _in_memory_arrow_table_from_buffer(buffer: pa.Buffer) -> pa.Table:
 
 def _memory_mapped_record_batch_reader_from_file(filename: str) -> pa.RecordBatchStreamReader:
     memory_mapped_stream = pa.memory_map(filename)
-    return pa.ipc.open_stream(memory_mapped_stream)
+    return pa.ipc.open_stream(memory_mapped_stream), memory_mapped_stream
 
 
 def read_schema_from_file(filename: str) -> pa.Schema:
@@ -61,8 +61,9 @@ def read_schema_from_file(filename: str) -> pa.Schema:
 
 
 def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
-    opened_stream = _memory_mapped_record_batch_reader_from_file(filename)
+    opened_stream, memory_mapped_stream = _memory_mapped_record_batch_reader_from_file(filename)
     pa_table = opened_stream.read_all()
+    memory_mapped_stream.close()
     return pa_table
 
 


### PR DESCRIPTION
Fixes dataset loading from disk by ensuring that memory maps and streams are properly closed. 


For more details, see https://github.com/huggingface/datasets/issues/7373.