### PR TITLE
(refactor) remove redundant logic in _check_valid_index_key

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -553,14 +553,9 @@ def _check_valid_index_key(key: Union[int, slice, range, Iterable], size: int) -
         return
     elif isinstance(key, slice):
         pass
-    elif isinstance(key, range):
-        if len(key) > 0:
-            _check_valid_index_key(max(key), size=size)
-            _check_valid_index_key(min(key), size=size)
-    elif isinstance(key, Iterable):
-        if len(key) > 0:
-            _check_valid_index_key(int(max(key)), size=size)
-            _check_valid_index_key(int(min(key)), size=size)
+    elif isinstance(key, (range, Iterable)):
+        _check_valid_index_key(int(max(key)), size=size)
+        _check_valid_index_key(int(min(key)), size=size)
     else:
         _raise_bad_key_type(key)
 


### PR DESCRIPTION
This PR contributes a minor refactor, in a small function in `src/datasets/formatting/formatting.py`. No change in logic. 

In the original code, there are separate if-conditionals for `isinstance(key, range)` and `isinstance(key, Iterable)`, with essentially the same logic. 

This PR combines these two using a single if statement.

**Considerations**

1. Although range in python is guaranteed to have integers, internally calling `int()` on an object that is already an int is negligible. (In python it returns the original object. It doesn't create a new integer object or perform any actual conversion)

2. This PR removes the `if len(key)>0` conditional. I think it is cleaner to have it this way for three reasons.
- There was originally no else statement and the code would have failed silently anyway.  
- The if len(key)>0 should be caught much earlier, rather than in `formatting.py`. 
- There are actually multiple cases where this would fail, if len(key)>0, if key is non numeric or float, or if key is a list of lists. It's clunky to state all this and the error be thrown during max or indexing. 


**Previous PR and Issues Checks**

1. No known PR or Issues (both closed or open) in hf datasets repository 

**Tests**

1. Tested using Dataset (load_dataset("wikitext", "wikitext-103-raw-v1")), Pytorch DataLoader, with a Pytorch BatchSampler (list of indexes returned instead of single index). 
