### PR TITLE
Do not hash `generator` in `BuilderConfig.create_config_id`

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -172,6 +172,9 @@ class BuilderConfig:
                 data_dir = config_kwargs_to_add_to_suffix["data_dir"]
                 data_dir = os.path.normpath(data_dir)
                 config_kwargs_to_add_to_suffix["data_dir"] = data_dir
+        # Hashing a generator can take significant amount of time, removing it
+        if "generator" in config_kwargs_to_add_to_suffix:
+            config_kwargs_to_add_to_suffix.pop("generator", None)
         if config_kwargs_to_add_to_suffix:
             # we don't care about the order of the kwargs
             config_kwargs_to_add_to_suffix = {


### PR DESCRIPTION
`Dataset.from_generator` function passes all of its arguments to `BuilderConfig.create_config_id`, including generator function itself. `BuilderConfig.create_config_id` function tries to hash all the args, and hashing a `generator` can take a large amount of time or even cause MemoryError if the dataset processed in a generator function is large enough.

Maybe we should pop generator from `config_kwargs_to_add_to_suffix` before hashing to avoid it.

There is a more detailed description of the problem this PR solves in #7513 