### PR TITLE
Fix indexing in split commit messages

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5742,7 +5742,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 commit_info = api.create_commit(
                     repo_id,
                     operations=operations,
-                    commit_message=commit_message + f" (part {i:05d}-of-{num_commits:05d})",
+                    commit_message=commit_message + f" (part {i + 1:05d}-of-{num_commits:05d})",
                     commit_description=commit_description,
                     token=token,
                     repo_type="dataset",


### PR DESCRIPTION
When a large commit is split up, it seems the commit index in the message is zero-based while the total number is one-based. I came across this running `convert-to-parquet` and was wondering why there was no `6-of-6` commit. This PR fixes that by adding one to the commit index, so both are one-based.

Current behavior:
<img width="463" alt="Screenshot 2025-04-17 at 1 00 17 PM" src="https://github.com/user-attachments/assets/7f3d389e-cb92-405d-a3c2-f2b1cdf0cb79" />