### PR TITLE
Add `--merge-pull-request` option for `convert_to_parquet`

### DIFF
--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -55,7 +55,6 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
             revision=self._revision,
             token=self._token,
             trust_remote_code=self._trust_remote_code,
-            merge_pull_request=self._merge_pull_request,
         )
 
         if self._merge_pull_request:

--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -32,7 +32,7 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
         parser.add_argument(
             "--merge-pull-request",
             action="store_true",
-            help="whether to automatically merge the pull request(s) after conversion",
+            help="whether to automatically merge the pull request after conversion",
         )
         parser.set_defaults(func=_command_factory)
 

--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -42,12 +42,13 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
         token: Optional[str],
         revision: Optional[str],
         trust_remote_code: bool,
+        merge_pull_request: bool = False,
     ):
         self._dataset_id = dataset_id
         self._token = token
         self._revision = revision
         self._trust_remote_code = trust_remote_code
-        self._merge_pull_request = False
+        self._merge_pull_request = merge_pull_request
 
     def run(self) -> None:
         commit_info = convert_to_parquet(

--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -51,10 +51,7 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
 
     def run(self) -> None:
         commit_info = convert_to_parquet(
-            self._dataset_id,
-            revision=self._revision,
-            token=self._token,
-            trust_remote_code=self._trust_remote_code,
+            self._dataset_id, revision=self._revision, token=self._token, trust_remote_code=self._trust_remote_code
         )
 
         if self._merge_pull_request:

--- a/src/datasets/commands/convert_to_parquet.py
+++ b/src/datasets/commands/convert_to_parquet.py
@@ -14,6 +14,7 @@ def _command_factory(args):
         args.token,
         args.revision,
         args.trust_remote_code,
+        args.merge_pull_request,
     )
 
 
@@ -42,7 +43,7 @@ class ConvertToParquetCommand(BaseDatasetsCLICommand):
         token: Optional[str],
         revision: Optional[str],
         trust_remote_code: bool,
-        merge_pull_request: bool = False,
+        merge_pull_request: bool,
     ):
         self._dataset_id = dataset_id
         self._token = token


### PR DESCRIPTION
Closes #7527 

Note that this implementation **will only merge the last PR in the case that they get split up by `push_to_hub`**. See https://github.com/huggingface/datasets/discussions/7555 for more details.