### PR TITLE
check for empty _formatting

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2195,7 +2195,7 @@ class IterableDataset(DatasetInfoMixin):
     ) -> _BaseExamplesIterable:
         ex_iterable = self._ex_iterable
         if (self._formatting or (self.features and ex_iterable.features != self.features)) and (
-            ex_iterable.iter_arrow or self._formatting.is_table
+            ex_iterable.iter_arrow or (self._formatting and self._formatting.is_table)
         ):
             ex_iterable = RebatchedArrowExamplesIterable(
                 ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch


### PR DESCRIPTION
Fixes a regression from #7553 breaking shuffling of iterable datasets 
<img width="884" alt="Screenshot 2025-05-07 at 9 16 52 AM" src="https://github.com/user-attachments/assets/d2f43c5f-4092-4efe-ac31-a32cbd025fe3" />
