### PR TITLE
add check if repo exists for dataset uploading

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5541,14 +5541,19 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
 
-        repo_url = api.create_repo(
+        if not api.repo_exists(
             repo_id,
             token=token,
-            repo_type="dataset",
-            private=private,
-            exist_ok=True,
-        )
-        repo_id = repo_url.repo_id
+            repo_type=constants.REPO_TYPE_DATASET,
+        ):
+            repo_url = api.create_repo(
+                repo_id,
+                token=token,
+                repo_type=constants.REPO_TYPE_DATASET,
+                private=private,
+                exist_ok=True,
+            )
+            repo_id = repo_url.repo_id
 
         if revision is not None and not revision.startswith("refs/pr/"):
             # We do not call create_branch for a PR reference: 400 Bad Request

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -20,6 +20,7 @@ from huggingface_hub import (
     DatasetCard,
     DatasetCardData,
     HfApi,
+    constants,
 )
 from huggingface_hub.hf_api import RepoFile
 
@@ -1720,14 +1721,19 @@ class DatasetDict(dict):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
 
-        repo_url = api.create_repo(
+        if not api.repo_exists(
             repo_id,
             token=token,
-            repo_type="dataset",
-            private=private,
-            exist_ok=True,
-        )
-        repo_id = repo_url.repo_id
+            repo_type=constants.REPO_TYPE_DATASET,
+        ):
+            repo_url = api.create_repo(
+                repo_id,
+                token=token,
+                repo_type=constants.REPO_TYPE_DATASET,
+                private=private,
+                exist_ok=True,
+            )
+            repo_id = repo_url.repo_id
 
         if revision is not None and not revision.startswith("refs/pr/"):
             # We do not call create_branch for a PR reference: 400 Bad Request


### PR DESCRIPTION
Currently, I'm uploading datasets for `MTEB`. Some of them have a lot of splits (more than 20), and I'm encountering the error:`Too many requests for https://huggingface.co/datasets/repo/create`.

It seems this issue occurs because each time a split is uploaded, the dataset tries to recreate itself. I've added a check to ensure that if the dataset already exists, it won't attempt to recreate it.
