### PR TITLE
Fix broken link to albumentations

### DIFF
--- a/docs/source/object_detection.mdx
+++ b/docs/source/object_detection.mdx
@@ -2,9 +2,9 @@
 
 Object detection models identify something in an image, and object detection datasets are used for applications such as autonomous driving and detecting natural hazards like wildfire. This guide will show you how to apply transformations to an object detection dataset following the [tutorial](https://albumentations.ai/docs/examples/example_bboxes/) from [Albumentations](https://albumentations.ai/docs/).
 
-To run these examples, make sure you have up-to-date versions of `albumentations` and `cv2` installed:
+To run these examples, make sure you have up-to-date versions of [albumentations](https://albumentations.ai/docs/) and [cv2](https://docs.opencv.org/4.10.0/) installed:
 
-```
+```bash
 pip install -U albumentations opencv-python
 ```
 
@@ -45,7 +45,7 @@ The dataset has the following fields:
 
 You can visualize the `bboxes` on the image using some internal torch utilities. To do that, you will need to reference the [`~datasets.ClassLabel`] feature associated with the category IDs so you can look up the string labels:
 
-    
+
 ```py
 >>> import torch
 >>> from torchvision.ops import box_convert

--- a/docs/source/object_detection.mdx
+++ b/docs/source/object_detection.mdx
@@ -40,7 +40,7 @@ The dataset has the following fields:
 - `objects`: A dictionary containing bounding box metadata for the objects in the image:
   - `id`: The annotation id.
   - `area`: The area of the bounding box.
-  - `bbox`: The object's bounding box (in the [coco](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) format).
+  - `bbox`: The object's bounding box (in the [coco](https://albumentations.ai/docs/3-basic-usage/bounding-boxes-augmentations/#understanding-bounding-box-formats) format).
   - `category`: The object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`.
 
 You can visualize the `bboxes` on the image using some internal torch utilities. To do that, you will need to reference the [`~datasets.ClassLabel`] feature associated with the category IDs so you can look up the string labels:
@@ -68,7 +68,7 @@ You can visualize the `bboxes` on the image using some internal torch utilities.
 ```
 
 <div class="flex justify-center">
-    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/visualize_detection_example.png">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/visualize_detection_example.png"/>
 </div>
 
 
@@ -110,7 +110,7 @@ Now when you visualize the result, the image should be flipped, but the `bboxes`
 ```
 
 <div class="flex justify-center">
-    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/visualize_detection_example_transformed.png">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/visualize_detection_example_transformed.png"/>
 </div>
 
 Create a function to apply the transform to a batch of examples:
@@ -152,7 +152,7 @@ You can verify the transform works by visualizing the 10th example:
 ```
 
 <div class="flex justify-center">
-    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/visualize_detection_example_transformed_2.png">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/visualize_detection_example_transformed_2.png"/>
 </div>
 
 <Tip>


### PR DESCRIPTION
A few months back I rewrote all docs at [https://albumentations.ai/docs](https://albumentations.ai/docs), and some pages changed their links.

In this PR fixed link to the most recent doc in Albumentations about bounding boxes and it's format. 

Fix a few typos in the doc as well.