### PR TITLE
Add albumentations to use dataset

### DIFF
--- a/docs/source/use_dataset.mdx
+++ b/docs/source/use_dataset.mdx
@@ -233,3 +233,5 @@ pip install albumentations
 - Convert PIL images to numpy arrays before applying transforms
 - Albumentations returns a dictionary with the transformed image under the "image" key
 - Convert the result back to PIL format after transformation
+
+**7**. The dataset is now ready for training with your machine learning framework!


### PR DESCRIPTION
1. Fixed broken link to the list of transforms in torchvison.
2. Extended section about video image augmentations with an example from Albumentations.