### PR TITLE
Update `_dill.py` to use `co_linetable` for Python 3.10+ in place of `co_lnotab`

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -359,7 +359,7 @@ elif config.DILL_VERSION.release[:3] in [
 
         if hasattr(obj, "co_endlinetable"):  # python 3.11a (20 args)
             args = (
-                obj.co_linetable,
+                obj.co_linetable,  # Modification for huggingface/datasets ############################################
                 obj.co_argcount,
                 obj.co_posonlyargcount,
                 obj.co_kwonlyargcount,
@@ -383,7 +383,7 @@ elif config.DILL_VERSION.release[:3] in [
             )
         elif hasattr(obj, "co_exceptiontable"):  # python 3.11 (18 args)
             args = (
-                obj.co_linetable,
+                obj.co_linetable,  # Modification for huggingface/datasets #######################################
                 obj.co_argcount,
                 obj.co_posonlyargcount,
                 obj.co_kwonlyargcount,
@@ -405,7 +405,7 @@ elif config.DILL_VERSION.release[:3] in [
             )
         elif hasattr(obj, "co_linetable"):  # python 3.10 (16 args)
             args = (
-                obj.co_linetable,
+                obj.co_linetable,  # Modification for huggingface/datasets #######################################
                 obj.co_argcount,
                 obj.co_posonlyargcount,
                 obj.co_kwonlyargcount,


### PR DESCRIPTION
Not 100% about this one, but it seems to be recommended.

```
/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/datasets/utils/_dill.py:385: DeprecationWarning: co_lnotab is deprecated, use co_lines instead.
```
Tests pass locally. And the warning is gone with this change.

https://peps.python.org/pep-0626/#backwards-compatibility