### PR TITLE
fix: raise error when folder-based datasets are loaded without data_dir or data_files

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -523,6 +523,16 @@ class PackagedDatasetModuleFactory(_DatasetModuleFactory):
         increase_load_count(name)
 
     def get_module(self) -> DatasetModule:
+        from datasets.packaged_modules.folder_based_builder.folder_based_builder import FolderBasedBuilderConfig
+
+        # ✅ Early validation for folder-based datasets like "audiofolder"
+        if self.builder_cls.BUILDER_CONFIG_CLASS == FolderBasedBuilderConfig:
+            if not self.data_dir and not self.data_files:
+                raise ValueError(
+                    "Folder-based datasets require either `data_dir` or `data_files` to be specified. "
+                    "Neither was provided."
+                )
+        
         base_path = Path(self.data_dir or "").expanduser().resolve().as_posix()
         patterns = (
             sanitize_patterns(self.data_files)


### PR DESCRIPTION

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #6152

---

### What changes are proposed in this pull request?

This PR adds an early validation step for folder-based datasets (like `audiofolder`) to prevent silent fallback behavior.

**Before this fix**:
- When `data_dir` or `data_files` were not provided, the loader defaulted to the current working directory.
- This caused unexpected behavior like:
  - Long loading times
  - Scanning unintended local files

**Now**:
- If both `data_dir` and `data_files` are missing, a `ValueError` is raised early with a helpful message.

---

### How is this PR tested?

- [x] Manual test via `load_dataset("audiofolder")` with missing `data_dir`
- [ ] Existing unit tests (should not break any)
- [ ] New tests (if needed, maintainers can guide)

---

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

---

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for users.

> Adds early error handling for folder-based datasets when neither `data_dir` nor `data_files` is specified, avoiding unintended resolution to the current directory.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components:
- [x] `area/datasets`
- [x] `area/load`

---

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

---

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
