### PR TITLE
fix: raise error in FolderBasedBuilder when data_dir and data_files are missing

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -66,7 +66,6 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
 
         return datasets.DatasetInfo(features=self.config.features)
 
-
     def _split_generators(self, dl_manager):
         if not self.config.data_files:
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -58,7 +58,14 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
     METADATA_FILENAMES: list[str] = ["metadata.csv", "metadata.jsonl", "metadata.parquet"]
 
     def _info(self):
+        if not self.config.data_dir and not self.config.data_files:
+            raise ValueError(
+                "Folder-based datasets require either `data_dir` or `data_files` to be specified. "
+                "Neither was provided."
+            )
+
         return datasets.DatasetInfo(features=self.config.features)
+
 
     def _split_generators(self, dl_manager):
         if not self.config.data_files:

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -285,7 +285,7 @@ def test_default_folder_builder_not_usable(data_files_with_labels_no_metadata, c
 # test that AutoFolder is extended for streaming when it's child class is instantiated:
 # see line 115 in src/datasets/streaming.py
 def test_streaming_patched():
-    _ = DummyFolderBasedBuilder()
+    _ = DummyFolderBasedBuilder(data_dir=".")
     module = importlib.import_module(FolderBasedBuilder.__module__)
     assert hasattr(module, "_patched_for_streaming")
     assert module._patched_for_streaming


### PR DESCRIPTION
### Related Issues/PRs

Fixes #6152

---

### What changes are proposed in this pull request?

This PR adds a dedicated validation check in the `_info()` method of the `FolderBasedBuilder` class to ensure that users provide either `data_dir` or `data_files` when loading folder-based datasets (such as `audiofolder`, `imagefolder`, etc.).

---

### Why this change?

Previously, when calling:

```python
load_dataset("audiofolder")
````

without specifying `data_dir` or `data_files`, the loader would silently fallback to the **current working directory**, leading to:

* Long loading times
* Unexpected behavior (e.g., scanning unrelated files)

This behavior was discussed in issue #6152. As suggested by maintainers, the fix has now been implemented directly inside the `FolderBasedBuilder._info()` method — keeping the logic localized to the specific builder instead of a generic loader function.

---

### How is this PR tested?

* ✅ Manually tested by calling `load_dataset("audiofolder")` with no `data_dir` or `data_files` → a `ValueError` is now raised early.
* ✅ Existing functionality (with valid input) remains unaffected.

---

### Does this PR require documentation update?

* [x] No

---

### Release Notes

#### Is this a user-facing change?

* [x] Yes

> Folder-based datasets now raise an explicit error if neither `data_dir` nor `data_files` are specified, preventing unintended fallback to the current working directory.

---

#### What component(s) does this PR affect?

* [x] `area/datasets`
* [x] `area/load`

---

<a name="release-note-category"></a>

#### How should the PR be classified?

* [x] `rn/bug-fix` - A user-facing bug fix

---

#### Should this be included in the next patch release?

* [x] Yes