### PR TITLE
`ClassLabel` docs: Correct value for unknown labels

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -973,7 +973,7 @@ class ClassLabel:
      * `names_file`: File containing the list of labels.
 
     Under the hood the labels are stored as integers.
-    You can use negative integers to represent unknown/missing labels.
+    You can use -1 to represent unknown/missing labels.
 
     Args:
         num_classes (`int`, *optional*):


### PR DESCRIPTION
This small change fixes the documentation to to be compliant with what happens in `encode_example`.
https://github.com/huggingface/datasets/blob/e71b0b19d79c7531f9b9bea7c09916b5f6157f42/src/datasets/features/features.py#L1126-L1129