### PR TITLE
fix: Extended metadata file names for folder_based_builder

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -55,7 +55,7 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
     BUILDER_CONFIG_CLASS: FolderBasedBuilderConfig
     EXTENSIONS: list[str]
 
-    METADATA_FILENAMES: list[str] = ["metadata.csv", "metadata.jsonl", "metadata.parquet"]
+    METADATA_FILENAMES: list[str] = ["metadata.csv", "metadata.jsonl", "metadata.parquet", "dataset_info.json", "state.json"]
 
     def _info(self):
         if not self.config.data_dir and not self.config.data_files:


### PR DESCRIPTION
Fixes #7650.

The metadata files generated by the `DatasetDict.save_to_file` function are not included in the folder_based_builder's metadata list, causing issues when only 1 actual data file is present, as described in issue #7650.

This PR adds these filenames to the builder, allowing correct loading.