### PR TITLE
feat(load): fallback to `load_from_disk()` when loading a saved dataset directory

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -63,6 +63,7 @@ from .features.features import _fix_for_backward_compatible_features
 from .fingerprint import Hasher
 from .info import DatasetInfo, DatasetInfosDict
 from .iterable_dataset import IterableDataset
+from .load_from_disk import load_from_disk
 from .naming import camelcase_to_snakecase, snakecase_to_camelcase
 from .packaged_modules import (
     _EXTENSION_TO_MODULE,
@@ -1362,6 +1363,18 @@ def load_dataset(
     >>> ds = load_dataset('imagefolder', data_dir='/path/to/images', split='train')
     ```
     """
+    # Fallback: auto-detect save_to_disk-style folders
+    if (
+        os.path.isdir(path)
+        and os.path.exists(os.path.join(path, "dataset_info.json"))  # for Dataset
+        or os.path.exists(os.path.join(path, "dataset_dict.json"))   # for DatasetDict
+    ):
+        logger.warning(
+            "Detected a directory saved via `save_to_disk()`. Redirecting to `load_from_disk('%s')` for compatibility.",
+            path,
+        )
+        return load_from_disk(path)
+        
     if "trust_remote_code" in config_kwargs:
         if config_kwargs.pop("trust_remote_code"):
             logger.error(


### PR DESCRIPTION
### Related Issue

Fixes #7503  
Partially addresses #5044 by allowing `load_dataset()` to auto-detect and gracefully delegate to `load_from_disk()` for locally saved datasets.

---

### What does this PR do?

This PR introduces a minimal fallback mechanism in `load_dataset()` that detects when the provided `path` points to a dataset saved using `save_to_disk()`, and automatically redirects to `load_from_disk()`.

#### 🐛 Before (unexpected metadata-only rows):

```python
ds = load_dataset("/path/to/saved_dataset")
# → returns rows with only internal metadata (_data_files, _fingerprint, etc.)
````

#### ✅ After (graceful fallback):

```python
ds = load_dataset("/path/to/saved_dataset")
# → logs a warning and internally switches to load_from_disk()
```

---

### Why is this useful?

* Prevents confusion when reloading local datasets saved via `save_to_disk()`.
* Enables smoother compatibility with frameworks (e.g., TRL, `lighteval`) that rely on `load_dataset()` calls.
* Fully backward-compatible — hub-based loading, custom builders, and streaming remain untouched.
