### PR TITLE
Update the beans dataset link in Preprocess

### DIFF
--- a/docs/source/use_dataset.mdx
+++ b/docs/source/use_dataset.mdx
@@ -154,7 +154,7 @@ Use the [`~Dataset.cast_column`] function and set the `sampling_rate` parameter 
 
 The most common preprocessing you'll do with image datasets is _data augmentation_, a process that introduces random variations to an image without changing the meaning of the data. This can mean changing the color properties of an image or randomly cropping an image. You are free to use any data augmentation library you like, and 🤗 Datasets will help you apply your data augmentations to your dataset.
 
-**1**. Start by loading the [Beans](https://huggingface.co/datasets/beans) dataset, the `Image` feature, and the feature extractor corresponding to a pretrained [ViT](https://huggingface.co/google/vit-base-patch16-224-in21k) model:
+**1**. Start by loading the [Beans](https://huggingface.co/datasets/AI-Lab-Makerere/beans) dataset, the `Image` feature, and the feature extractor corresponding to a pretrained [ViT](https://huggingface.co/google/vit-base-patch16-224-in21k) model:
 
 ```py
 >>> from transformers import AutoFeatureExtractor


### PR DESCRIPTION
In the Preprocess tutorial, the to "the beans dataset" is incorrect. Fixed.