### PR TITLE
Fix double sequence

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1182,7 +1182,11 @@ class Sequence:
 
     def __new__(cls, feature=None, length=-1, **kwargs):
         # useful to still get isinstance(Sequence(Value("int64")), Sequence)
-        if cls is Sequence and isinstance(feature, dict) and any(not isinstance(subfeature, List) for subfeature in feature.values()):
+        if (
+            cls is Sequence
+            and isinstance(feature, dict)
+            and any(not isinstance(subfeature, List) for subfeature in feature.values())
+        ):
             out = {key: List(value, length=length, **kwargs) for key, value in feature.items()}
         else:
             out = super().__new__(List)

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1182,7 +1182,7 @@ class Sequence:
 
     def __new__(cls, feature=None, length=-1, **kwargs):
         # useful to still get isinstance(Sequence(Value("int64")), Sequence)
-        if cls is Sequence and isinstance(feature, dict):
+        if cls is Sequence and isinstance(feature, dict) and any(not isinstance(subfeature, List) for subfeature in feature.values()):
             out = {key: List(value, length=length, **kwargs) for key, value in feature.items()}
         else:
             out = super().__new__(List)


### PR DESCRIPTION
```python
>>> Features({"a": Sequence(Sequence({"c": Value("int64")}))})
{'a': List({'c': List(Value('int64'))})}
```

instead of `{'a': {'c': List(List(Value('int64')))}}`