### PR TITLE
Update fsspec max version to current release 2025.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ REQUIRED_PKGS = [
     "multiprocess<0.70.17",  # to align with dill<0.3.9 (see above)
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0,<=2025.3.0",
+    "fsspec[http]>=2023.1.0,<=2025.7.0",
     # To get datasets from the Datasets Hub on huggingface.co
     "huggingface-hub>=0.24.0",
     # Utilities from PyPA to e.g., compare versions


### PR DESCRIPTION
Diffusers currently asks for a max fsspec version of `2025.3.0`. This change updates it to the current latest version. This change is mainly required to resolve conflicts with other packages in an environment. In my particular case, `aider-chat` which is a part of my environment installs `2025.5.1` which is incompatible with `datasets`.