### PR TITLE
num_proc=0 behave like None, num_proc=1 uses one worker (not main process) and clarify num_proc documentation

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5615,7 +5615,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             total=num_shards,
             desc=desc,
         )
-        with contextlib.nullcontext() if num_proc is None or num_proc <= 1 else Pool(num_proc) as pool:
+        with contextlib.nullcontext() if num_proc is None or num_proc < 1 else Pool(num_proc) as pool:
             update_stream = (
                 Dataset._push_parquet_shards_to_hub_single(**kwargs_iterable[0])
                 if pool is None

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3007,9 +3007,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             fn_kwargs (`Dict`, *optional*, defaults to `None`):
                 Keyword arguments to be passed to `function`.
             num_proc (`int`, *optional*, defaults to `None`):
-                 The number of processes to use for multiprocessing.  
-                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
-                - If greater than `1`, one or multiple worker processes are used to process data in parallel.  
+                 The number of processes to use for multiprocessing.
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.
                  Note: The function passed to `map()` must be picklable for multiprocessing to work correctly
                  (i.e., prefer functions defined at the top level of a module, not inside another function or class).
              suffix_template (`str`):
@@ -3859,9 +3859,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             fn_kwargs (`dict`, *optional*):
                 Keyword arguments to be passed to `function`.
             num_proc (`int`, *optional*, defaults to `None`):
-                 The number of processes to use for multiprocessing.  
-                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
-                - If greater than `1`, one or multiple worker processes are used to process data in parallel.  
+                 The number of processes to use for multiprocessing.
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.
                  Note: The function passed to `map()` must be picklable for multiprocessing to work correctly
                  (i.e., prefer functions defined at the top level of a module, not inside another function or class).
             suffix_template (`str`):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3007,8 +3007,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             fn_kwargs (`Dict`, *optional*, defaults to `None`):
                 Keyword arguments to be passed to `function`.
             num_proc (`int`, *optional*, defaults to `None`):
-                Max number of processes when generating cache. Already cached shards are loaded sequentially.
-            suffix_template (`str`):
+                    The number of processes to use for multiprocessing.  
+                    - If `None` or `1`, no multiprocessing is used and the operation runs in the main process.  
+                    - If greater than `1`, multiple worker processes are used to process data in parallel.  
+                    - Setting `num_proc=0` is not supported and will raise a `ValueError`.
+                     Note: The function passed to `map()` must be picklable for multiprocessing to work correctly (i.e., defined at the top level of a module, not inside another function or class).
+                           suffix_template (`str`):
                 If `cache_file_name` is specified, then this suffix
                 will be added at the end of the base name of each. Defaults to `"_{rank:05d}_of_{num_proc:05d}"`. For example, if `cache_file_name` is "processed.arrow", then for
                 `rank=1` and `num_proc=4`, the resulting file would be `"processed_00001_of_00004.arrow"` for the default suffix.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3048,8 +3048,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if keep_in_memory and cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `cache_file_name` but not both.")
 
-        if num_proc is not None and num_proc <= 0:
-            raise ValueError("num_proc must be an integer > 0.")
+        if num_proc == 0:
+            num_proc = None
+        elif num_proc is not None and num_proc < 0:
+            raise ValueError("num_proc must be >= 0 or None.")
 
         string_formatter = string.Formatter()
         fields = {field_name for _, field_name, _, _ in string_formatter.parse(suffix_template) if field_name}

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1607,7 +1607,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         )
         shard_lengths = [None] * num_shards
         shard_sizes = [None] * num_shards
-        if num_proc > 1:
+        if num_proc >= 1:
             with Pool(num_proc) as pool:
                 with pbar:
                     for job_id, done, content in iflatmap_unordered(
@@ -3227,7 +3227,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             validate_fingerprint(new_fingerprint)
             return new_fingerprint
 
-        if num_proc is not None and num_proc > 1:
+        if num_proc is not None and num_proc >= 1:
             prev_env = deepcopy(os.environ)
             # check if parallelism if off
             # from https://github.com/huggingface/tokenizers/blob/bb668bc439dc34389b71dbb8ce0c597f15707b53/tokenizers/src/utils/parallelism.rs#L22
@@ -3294,7 +3294,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 unit=" examples",
                 initial=pbar_initial,
                 total=pbar_total,
-                desc=(desc or "Map") + (f" (num_proc={num_proc})" if num_proc is not None and num_proc > 1 else ""),
+                desc=(desc or "Map") + (f" (num_proc={num_proc})" if num_proc is not None and num_proc >= 1 else ""),
             ) as pbar:
                 shards_done = 0
 
@@ -5609,7 +5609,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             for job_id in range(num_jobs)
         ]
         desc = "Uploading the dataset shards"
-        desc += f" (num_proc={num_proc})" if num_proc is not None and num_proc > 1 else ""
+        desc += f" (num_proc={num_proc})" if num_proc is not None and num_proc >= 1 else ""
         pbar = hf_tqdm(
             unit=" shards",
             total=num_shards,

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3008,7 +3008,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Keyword arguments to be passed to `function`.
             num_proc (`int`, *optional*, defaults to `None`):
                     The number of processes to use for multiprocessing.  
-                    - If `None` or `1`, no multiprocessing is used and the operation runs in the main process.  
+                    - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
                     - If greater than `1`, multiple worker processes are used to process data in parallel.  
                     - Setting `num_proc=0` is not supported and will raise a `ValueError`.
                      Note: The function passed to `map()` must be picklable for multiprocessing to work correctly (i.e., defined at the top level of a module, not inside another function or class).

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3007,12 +3007,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             fn_kwargs (`Dict`, *optional*, defaults to `None`):
                 Keyword arguments to be passed to `function`.
             num_proc (`int`, *optional*, defaults to `None`):
-                    The number of processes to use for multiprocessing.  
-                    - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
-                    - If greater than `1`, multiple worker processes are used to process data in parallel.  
-                    - Setting `num_proc=0` is not supported and will raise a `ValueError`.
-                     Note: The function passed to `map()` must be picklable for multiprocessing to work correctly (i.e., defined at the top level of a module, not inside another function or class).
-                           suffix_template (`str`):
+                 The number of processes to use for multiprocessing.  
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.  
+                 Note: The function passed to `map()` must be picklable for multiprocessing to work correctly (i.e., prefer functions defined at the top level of a module, not inside another function or class).
+             suffix_template (`str`):
                 If `cache_file_name` is specified, then this suffix
                 will be added at the end of the base name of each. Defaults to `"_{rank:05d}_of_{num_proc:05d}"`. For example, if `cache_file_name` is "processed.arrow", then for
                 `rank=1` and `num_proc=4`, the resulting file would be `"processed_00001_of_00004.arrow"` for the default suffix.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3010,7 +3010,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                  The number of processes to use for multiprocessing.  
                 - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
                 - If greater than `1`, one or multiple worker processes are used to process data in parallel.  
-                 Note: The function passed to `map()` must be picklable for multiprocessing to work correctly (i.e., prefer functions defined at the top level of a module, not inside another function or class).
+                 Note: The function passed to `map()` must be picklable for multiprocessing to work correctly
+                 (i.e., prefer functions defined at the top level of a module, not inside another function or class).
              suffix_template (`str`):
                 If `cache_file_name` is specified, then this suffix
                 will be added at the end of the base name of each. Defaults to `"_{rank:05d}_of_{num_proc:05d}"`. For example, if `cache_file_name` is "processed.arrow", then for
@@ -3308,7 +3309,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                         assert isinstance(content, int)
                         pbar.update(content)
 
-                if num_proc is not None and num_proc > 1:
+                if num_proc is not None and num_proc >= 1:
                     with Pool(num_proc) as pool:
                         os.environ = prev_env
                         logger.info(f"Spawning {num_proc} processes")
@@ -3857,9 +3858,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Higher value makes the processing do fewer lookups, lower value consume less temporary memory while running `map`.
             fn_kwargs (`dict`, *optional*):
                 Keyword arguments to be passed to `function`.
-            num_proc (`int`, *optional*):
-                Number of processes for multiprocessing. By default it doesn't
-                use multiprocessing.
+            num_proc (`int`, *optional*, defaults to `None`):
+                 The number of processes to use for multiprocessing.  
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.  
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.  
+                 Note: The function passed to `map()` must be picklable for multiprocessing to work correctly
+                 (i.e., prefer functions defined at the top level of a module, not inside another function or class).
             suffix_template (`str`):
                 If `cache_file_name` is specified, then this suffix will be added at the end of the base name of each.
                 For example, if `cache_file_name` is `"processed.arrow"`, then for `rank = 1` and `num_proc = 4`,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -906,8 +906,11 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             fn_kwargs (`Dict`, *optional*, defaults to `None`):
                 Keyword arguments to be passed to `function`
             num_proc (`int`, *optional*, defaults to `None`):
-                Number of processes for multiprocessing. By default it doesn't
-                use multiprocessing.
+                 The number of processes to use for multiprocessing.
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.
+                 Note: The function passed to `map()` must be picklable for multiprocessing to work correctly
+                 (i.e., prefer functions defined at the top level of a module, not inside another function or class).
             desc (`str`, *optional*, defaults to `None`):
                 Meaningful description to be displayed alongside with the progress bar while mapping examples.
             try_original_type (`Optional[bool]`, defaults to `True`):
@@ -1028,8 +1031,11 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             fn_kwargs (`Dict`, *optional*, defaults to `None`):
                 Keyword arguments to be passed to `function`
             num_proc (`int`, *optional*, defaults to `None`):
-                Number of processes for multiprocessing. By default it doesn't
-                use multiprocessing.
+                 The number of processes to use for multiprocessing.
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.
+                 Note: The function passed to `map()` must be picklable for multiprocessing to work correctly
+                 (i.e., prefer functions defined at the top level of a module, not inside another function or class).
             desc (`str`, *optional*, defaults to `None`):
                 Meaningful description to be displayed alongside with the progress bar while filtering examples.
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3876,13 +3876,13 @@ class IterableDataset(DatasetInfoMixin):
             for job_id in range(num_jobs)
         ]
         desc = "Uploading the dataset shards"
-        desc += f" (num_proc={num_proc})" if num_proc is not None and num_proc > 1 else ""
+        desc += f" (num_proc={num_proc})" if num_proc is not None and num_proc >= 1 else ""
         pbar = hf_tqdm(
             unit=" shards",
             total=num_shards,
             desc=desc,
         )
-        with contextlib.nullcontext() if num_proc is None or num_proc <= 1 else Pool(num_proc) as pool:
+        with contextlib.nullcontext() if num_proc is None or num_proc < 1 else Pool(num_proc) as pool:
             update_stream = (
                 IterableDataset._push_parquet_shards_to_hub_single(**kwargs_iterable[0])
                 if pool is None


### PR DESCRIPTION
Fixes issue #7700

This PR makes num_proc=0 behave like None in Dataset.map(), disabling multiprocessing.
It improves UX by aligning with DataLoader(num_workers=0) behavior.
The num_proc docstring is also updated to clearly explain valid values and behavior.

@SunMarc
