### PR TITLE
Fix typo in error message for cache directory deletion

### DIFF
--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -60,7 +60,7 @@ class _TempCacheDir:
                 shutil.rmtree(self.name)
             except Exception as e:
                 raise OSError(
-                    f"An error occured while trying to delete temporary cache directory {self.name}. Please delete it manually."
+                    f"An error occurred while trying to delete temporary cache directory {self.name}. Please delete it manually."
                 ) from e
 
     def cleanup(self):


### PR DESCRIPTION
This PR fixes a small typo in an error message in `src/datasets/fingerprint.py`:

https://github.com/huggingface/datasets/blob/910fab20606893f69b4fccac5fcc883dddf5a14d/src/datasets/fingerprint.py#L63

```diff
- occured
+ occurred
```