### PR TITLE
Parquet: use data page v2 for efficient page pruning

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -745,12 +745,15 @@ class ArrowWriter:
 
 
 class ParquetWriter(ArrowWriter):
-    def __init__(self, *args, use_content_defined_chunking=True, write_page_index=True, **kwargs):
+    def __init__(
+        self, *args, use_content_defined_chunking=True, write_page_index=True, data_page_version="2.0", **kwargs
+    ):
         super().__init__(*args, **kwargs)
         if use_content_defined_chunking is True:
             use_content_defined_chunking = config.DEFAULT_CDC_OPTIONS
         self.use_content_defined_chunking = use_content_defined_chunking
         self.write_page_index = write_page_index
+        self.data_page_version = data_page_version
 
     def _build_writer(self, inferred_schema: pa.Schema):
         self._schema, self._features = self._build_schema(inferred_schema)
@@ -759,6 +762,7 @@ class ParquetWriter(ArrowWriter):
             self._schema,
             use_content_defined_chunking=self.use_content_defined_chunking,
             write_page_index=self.write_page_index,
+            data_page_version=self.data_page_version,
         )
         if self.use_content_defined_chunking is not False:
             self.pa_writer.add_key_value_metadata(

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -80,6 +80,7 @@ class ParquetDatasetWriter:
         storage_options: Optional[dict] = None,
         use_content_defined_chunking: Union[bool, dict] = True,
         write_page_index: bool = True,
+        data_page_version: str = "2.0",
         **parquet_writer_kwargs,
     ):
         self.dataset = dataset
@@ -95,6 +96,7 @@ class ParquetDatasetWriter:
             use_content_defined_chunking = config.DEFAULT_CDC_OPTIONS
         self.use_content_defined_chunking = use_content_defined_chunking
         self.write_page_index = write_page_index
+        self.data_page_version = data_page_version
 
     def write(self) -> int:
         if isinstance(self.path_or_buf, (str, bytes, os.PathLike)):
@@ -126,7 +128,7 @@ class ParquetDatasetWriter:
             schema=schema,
             use_content_defined_chunking=self.use_content_defined_chunking,
             write_page_index=self.write_page_index,
-            **parquet_writer_kwargs,
+            data_page_version=self.data_page_version**parquet_writer_kwargs,
         )
 
         for offset in hf_tqdm(


### PR DESCRIPTION
This is needed to enable page pruning with DataFusion, which will be useful for the Dataset Viewer.

Indeed page pruning with DataFusion allows to download only certain pages of a row group, reducing the I/O required to read just a few rows.

But while data page v1 generally works, it's not easy with DataFusion to do page pruning on datasets with nested data. This is because rows can span multiple pages in v1, contrary to v2.

cc @severo for viz