### PR TITLE
Bump dill to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ REQUIRED_PKGS = [
     # Minimum 21.0.0 to support `use_content_defined_chunking` in ParquetWriter
     "pyarrow>=21.0.0",
     # For smart caching dataset processing
-    "dill>=0.3.0,<0.3.10",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
+    "dill>=0.3.0,<0.4.1",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
     # For performance gains with apache arrow
     "pandas",
     # for downloading datasets over HTTPS

--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -105,6 +105,7 @@ def _is_supported_dill_version():
         version.parse("0.3.7").release,
         version.parse("0.3.8").release,
         version.parse("0.3.9").release,
+        version.parse("0.4.0").release,
     ]
 
 


### PR DESCRIPTION
This bumps `dill` to 0.3.9 and closes #7510 

It turns out the only thing required to make the tests pass was to extend the version checks to include 0.3.9.