### PR TITLE
[docs] Fix broken WebDataset link on “Create a video dataset” page

### DIFF
--- a/docs/source/video_dataset.mdx
+++ b/docs/source/video_dataset.mdx
@@ -142,7 +142,7 @@ api.upload_folder(
 
 ## WebDataset
 
-The [WebDataset](https://github.com/webdataset/webdataset) format is based on TAR archives and is suitable for big video datasets.
+The [WebDataset documentation](https://huggingface.co/docs/datasets/main/en/video_load#webdataset) format is based on TAR archives and is suitable for big video datasets.
 Indeed you can group your videos in TAR archives (e.g. 1GB of videos per TAR archive) and have thousands of TAR archives:
 
 ```


### PR DESCRIPTION
### What
Fix the "WebDataset documentation" link on the Create a video dataset page to point
to the correct section on the video load guide.

### Why
The link currently points to an external repo, but the Hugging Face docs
have an internal "WebDataset" section under video_load.

### How
- docs/source/video_dataset.mdx: updated link to
  `https://huggingface.co/docs/datasets/main/en/video_load#webdataset`

### Issue
Fixes #7699
