### PR TITLE
feat: avoid some copies in torch formatter

### DIFF
--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -21,90 +21,194 @@ import numpy as np
 import pyarrow as pa
 
 from .. import config
-from ..utils.py_utils import map_nested
+
+# from ..utils.py_utils import map_nested
 from .formatting import TensorFormatter
 
 
 if TYPE_CHECKING:
     import torch
 
+# Import torch once at module level once
+try:
+    import torch
+
+    _torch_available = True
+except ImportError:
+    _torch_available = False
+    torch = None
+
 
 class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
     def __init__(self, features=None, token_per_repo_id=None, **torch_tensor_kwargs):
         super().__init__(features=features, token_per_repo_id=token_per_repo_id)
         self.torch_tensor_kwargs = torch_tensor_kwargs
-        import torch  # noqa import torch at initialization
+
+        if not _torch_available:
+            raise ImportError("PyTorch is required but not available")
 
     def _consolidate(self, column):
-        import torch
+        """Smarter consolidation that only stacks when safe and beneficial."""
+        if not isinstance(column, list) or not column:
+            return column
 
-        if isinstance(column, list) and column:
-            if all(
-                isinstance(x, torch.Tensor) and x.shape == column[0].shape and x.dtype == column[0].dtype
-                for x in column
-            ):
-                return torch.stack(column)
+        # Check if all items are tensors with matching properties
+        first = column[0]
+        if not isinstance(first, torch.Tensor):
+            return column
+
+        # Fast check: if all tensors have same shape, dtype, and device, we can stack
+        if all(
+            isinstance(x, torch.Tensor)
+            and x.shape == first.shape
+            and x.dtype == first.dtype
+            and x.device == first.device
+            for x in column
+        ):
+            return torch.stack(column)
+
         return column
 
     def _tensorize(self, value):
-        import torch
-
+        """Zero/low-copy tensor conversion with smart dtype handling."""
+        # Fast path for strings, bytes, None
         if isinstance(value, (str, bytes, type(None))):
             return value
-        elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
+
+        # Handle string arrays
+        if isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value.tolist()
 
-        default_dtype = {}
-
-        if isinstance(value, (np.number, np.ndarray)) and np.issubdtype(value.dtype, np.integer):
-            default_dtype = {"dtype": torch.int64}
-
-            # Convert dtype to np.int64 if it's either np.uint16 or np.uint32 to ensure compatibility.
-            # np.uint64 is excluded from this conversion as there is no compatible PyTorch dtype that can handle it without loss.
-            if value.dtype in [np.uint16, np.uint32]:
-                value = value.astype(np.int64)
-
-        elif isinstance(value, (np.number, np.ndarray)) and np.issubdtype(value.dtype, np.floating):
-            default_dtype = {"dtype": torch.float32}
-
+        # PIL Image fast path - avoid extra copies
         if config.PIL_AVAILABLE and "PIL" in sys.modules:
             import PIL.Image
 
             if isinstance(value, PIL.Image.Image):
-                value = np.asarray(value)
-                if value.ndim == 2:
-                    value = value[:, :, np.newaxis]
+                # Single conversion path: PIL -> numpy -> torch
+                arr = np.asarray(value)
+                if arr.ndim == 2:
+                    arr = arr[:, :, np.newaxis]
+                # Use moveaxis instead of transpose
+                arr = np.moveaxis(arr, -1, 0)  # HWC -> CHW
+                # Ensure contiguous for zero-copy conversion
+                if not arr.flags.c_contiguous:
+                    arr = np.ascontiguousarray(arr)
+                return torch.from_numpy(arr)
 
-                value = value.transpose((2, 0, 1))
+        # Video/Audio decoder passthrough
         if config.TORCHVISION_AVAILABLE and "torchvision" in sys.modules:
             from torchvision.io import VideoReader
 
             if isinstance(value, VideoReader):
-                return value  # TODO(QL): set output to torch tensors ?
+                return value
+
         if config.TORCHCODEC_AVAILABLE and "torchcodec" in sys.modules:
             from torchcodec.decoders import AudioDecoder, VideoDecoder
 
             if isinstance(value, (VideoDecoder, AudioDecoder)):
-                return value  # TODO(QL): set output to jax arrays ?
+                return value
+
+        # Support for other tensor libraries via __array__
+        if hasattr(value, "__array__") and not isinstance(value, torch.Tensor):
+            value = value.__array__()
+
+        # Fast numpy conversion paths
+        if isinstance(value, np.ndarray):
+            # Handle integer types with smart casting
+            if np.issubdtype(value.dtype, np.integer):
+                target_dtype = torch.int64
+
+                # Safe casting for unsigned types
+                if value.dtype in (np.uint16, np.uint32):
+                    # Cast to int64 in numpy (fast) then convert to torch
+                    value = value.astype(np.int64)
+                    return torch.from_numpy(value)
+                elif value.dtype == np.uint64:
+                    # Check if values fit in int64 range
+                    if np.all(value <= np.iinfo(np.int64).max):
+                        value = value.astype(np.int64)
+                        return torch.from_numpy(value)
+                    else:
+                        # Fallback to safe conversion via Python ints
+                        return torch.tensor(value, dtype=target_dtype, **self.torch_tensor_kwargs)
+                else:
+                    # Use zero-copy conversion for compatible integer types
+                    if value.dtype != np.int64:
+                        # Need dtype conversion, use as_tensor for efficiency
+                        return torch.as_tensor(value, dtype=target_dtype, **self.torch_tensor_kwargs)
+                    else:
+                        # Perfect match, zero-copy conversion
+                        return torch.from_numpy(value)
+
+            # Handle floating point types
+            elif np.issubdtype(value.dtype, np.floating):
+                target_dtype = torch.float32
+                if value.dtype != np.float32:
+                    # Need dtype conversion
+                    return torch.as_tensor(value, dtype=target_dtype, **self.torch_tensor_kwargs)
+                else:
+                    # Zero-copy conversion
+                    return torch.from_numpy(value)
+            else:
+                # Other numpy types, use zero-copy when possible
+                return torch.from_numpy(value)
+
+        # Handle numpy scalars
+        elif isinstance(value, np.number):
+            if np.issubdtype(value.dtype, np.integer):
+                # Use torch.as_tensor for scalar conversion with dtype control
+                return torch.as_tensor(value, dtype=torch.int64, **self.torch_tensor_kwargs)
+            elif np.issubdtype(value.dtype, np.floating):
+                return torch.as_tensor(value, dtype=torch.float32, **self.torch_tensor_kwargs)
+            else:
+                return torch.as_tensor(value, **self.torch_tensor_kwargs)
+
+        # Handle Python lists/tuples of numbers efficiently
+        elif isinstance(value, (list, tuple)):
+            # Try to convert to numpy first for faster tensor creation
+            try:
+                arr = np.array(value)
+                if arr.dtype.kind in "iuf":  # integer, unsigned, float
+                    return self._tensorize(arr)  # Recursive call to handle numpy path
+            except (ValueError, TypeError):
+                pass  # Fall back to torch.tensor
+
+        # Default fallback with dtype defaults
+        default_dtype = {}
+        if isinstance(value, (int, float)):
+            if isinstance(value, int):
+                default_dtype = {"dtype": torch.int64}
+            else:
+                default_dtype = {"dtype": torch.float32}
 
         return torch.tensor(value, **{**default_dtype, **self.torch_tensor_kwargs})
 
     def _recursive_tensorize(self, data_struct):
-        import torch
-
-        # support for torch, tf, jax etc.
+        """Optimized recursive walker with reduced Python overhead."""
+        # Handle tensor-like objects with __array__ interface
         if hasattr(data_struct, "__array__") and not isinstance(data_struct, torch.Tensor):
             data_struct = data_struct.__array__()
-        # support for nested types like struct of list of struct
+
+        # Handle object arrays (nested structures)
         if isinstance(data_struct, np.ndarray):
-            if data_struct.dtype == object:  # torch tensors cannot be instantied from an array of objects
-                return self._consolidate([self.recursive_tensorize(substruct) for substruct in data_struct])
+            if data_struct.dtype == object:
+                # Use list comprehension instead of map_nested
+                result = [self._recursive_tensorize(item) for item in data_struct]
+                return self._consolidate(result)
+        # Handle lists and tuples
         elif isinstance(data_struct, (list, tuple)):
-            return self._consolidate([self.recursive_tensorize(substruct) for substruct in data_struct])
+            result = [self._recursive_tensorize(item) for item in data_struct]
+            return self._consolidate(result)
+        # Handle dictionaries
+        elif isinstance(data_struct, dict):
+            return {key: self._recursive_tensorize(value) for key, value in data_struct.items()}
+
+        # Base case: tensorize the leaf value
         return self._tensorize(data_struct)
 
     def recursive_tensorize(self, data_struct: dict):
-        return map_nested(self._recursive_tensorize, data_struct, map_list=False)
+        """Public interface maintaining compatibility."""
+        return self._recursive_tensorize(data_struct)
 
     def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -22,7 +22,6 @@ import pyarrow as pa
 
 from .. import config
 
-# from ..utils.py_utils import map_nested
 from .formatting import TensorFormatter
 
 

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -131,14 +131,14 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
                     else:
                         # Fallback to safe conversion via Python ints
                         kwargs = self.torch_tensor_kwargs.copy()
-                        kwargs.setdefault('dtype', target_dtype)
+                        kwargs.setdefault("dtype", target_dtype)
                         return torch.tensor(value, **kwargs)
                 else:
                     # Use zero-copy conversion for compatible integer types
                     if value.dtype != np.int64:
                         # Need dtype conversion, use as_tensor for efficiency
                         kwargs = self.torch_tensor_kwargs.copy()
-                        kwargs.setdefault('dtype', target_dtype)
+                        kwargs.setdefault("dtype", target_dtype)
                         return torch.as_tensor(value, **kwargs)
                     else:
                         # Perfect match, zero-copy conversion
@@ -149,7 +149,7 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
                 if value.dtype != np.float32:
                     # Need dtype conversion
                     kwargs = self.torch_tensor_kwargs.copy()
-                    kwargs.setdefault('dtype', torch.float32)
+                    kwargs.setdefault("dtype", torch.float32)
                     return torch.as_tensor(value, **kwargs)
                 else:
                     # Zero-copy conversion
@@ -163,11 +163,11 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
             if np.issubdtype(value.dtype, np.integer):
                 # Use torch.as_tensor for scalar conversion with dtype control
                 kwargs = self.torch_tensor_kwargs.copy()
-                kwargs.setdefault('dtype', torch.int64)
+                kwargs.setdefault("dtype", torch.int64)
                 return torch.as_tensor(value, **kwargs)
             elif np.issubdtype(value.dtype, np.floating):
                 kwargs = self.torch_tensor_kwargs.copy()
-                kwargs.setdefault('dtype', torch.float32)
+                kwargs.setdefault("dtype", torch.float32)
                 return torch.as_tensor(value, **kwargs)
             else:
                 return torch.as_tensor(value, **self.torch_tensor_kwargs)

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -130,22 +130,27 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
                         return torch.from_numpy(value)
                     else:
                         # Fallback to safe conversion via Python ints
-                        return torch.tensor(value, dtype=target_dtype, **self.torch_tensor_kwargs)
+                        kwargs = self.torch_tensor_kwargs.copy()
+                        kwargs.setdefault('dtype', target_dtype)
+                        return torch.tensor(value, **kwargs)
                 else:
                     # Use zero-copy conversion for compatible integer types
                     if value.dtype != np.int64:
                         # Need dtype conversion, use as_tensor for efficiency
-                        return torch.as_tensor(value, dtype=target_dtype, **self.torch_tensor_kwargs)
+                        kwargs = self.torch_tensor_kwargs.copy()
+                        kwargs.setdefault('dtype', target_dtype)
+                        return torch.as_tensor(value, **kwargs)
                     else:
                         # Perfect match, zero-copy conversion
                         return torch.from_numpy(value)
 
             # Handle floating point types
             elif np.issubdtype(value.dtype, np.floating):
-                target_dtype = torch.float32
                 if value.dtype != np.float32:
                     # Need dtype conversion
-                    return torch.as_tensor(value, dtype=target_dtype, **self.torch_tensor_kwargs)
+                    kwargs = self.torch_tensor_kwargs.copy()
+                    kwargs.setdefault('dtype', torch.float32)
+                    return torch.as_tensor(value, **kwargs)
                 else:
                     # Zero-copy conversion
                     return torch.from_numpy(value)
@@ -157,9 +162,13 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
         elif isinstance(value, np.number):
             if np.issubdtype(value.dtype, np.integer):
                 # Use torch.as_tensor for scalar conversion with dtype control
-                return torch.as_tensor(value, dtype=torch.int64, **self.torch_tensor_kwargs)
+                kwargs = self.torch_tensor_kwargs.copy()
+                kwargs.setdefault('dtype', torch.int64)
+                return torch.as_tensor(value, **kwargs)
             elif np.issubdtype(value.dtype, np.floating):
-                return torch.as_tensor(value, dtype=torch.float32, **self.torch_tensor_kwargs)
+                kwargs = self.torch_tensor_kwargs.copy()
+                kwargs.setdefault('dtype', torch.float32)
+                return torch.as_tensor(value, **kwargs)
             else:
                 return torch.as_tensor(value, **self.torch_tensor_kwargs)
 

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -21,7 +21,6 @@ import numpy as np
 import pyarrow as pa
 
 from .. import config
-
 from .formatting import TensorFormatter
 
 


### PR DESCRIPTION
## perf: reduce copies in TorchFormatter

This PR make changes the torch formatter to avoid unnecessary copies and casts when converting decoded batches to tensors.

Because many arrays are already in a torch-friendly memory layout and dtype, we can do zero‑copy conversions (`torch.from_numpy`) and only fall back to `as_tensor` when a dtype/device change is required. We also consolidate lists of same‑shape tensors with a cheap `stack` only when safe.

Why it helps
- Avoids extra materialization and dtype churn during batched map and indexing.
- Preserves API and outputs; only changes internal conversion logic.


Small benchmark script (based on https://github.com/huggingface/datasets/issues/6104)

```python
import time
from datasets import load_dataset


def main():
    dataset = load_dataset("NightMachinery/hf_datasets_bug1")
    dataset = dataset["train"] if "train" in dataset else dataset
    t0 = time.time()
    dataset.set_format(type="torch")

    # identity map with small batches
    dataset = dataset.map(lambda x: x, batched=True, batch_size=20)

    # force materialization
    data = dataset[:300]
    print(len(data.keys()))

    t1 = time.time()
    print(f"Duration: {t1 - t0:.2f} s")


if __name__ == "__main__":
    main()

```

Without changes

```bash
uv run bench.py
```

```bash
# 303
# Duration: 7.26 s
```

With changes

```bash
uv run bench.py
```

```bash
# 303
# Duration: 4.43 s
```


# Updated reproduction scripts

Below are some simple test cases using `main` and this `refactor-torch-formatter` branch. I've included the two scripts and output when running on a local machine.

```python
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "torch",
#     "datasets",
#     "pillow",
# ]
#
# [tool.uv.sources]
# datasets = { git = "https://github.com/huggingface/datasets.git" }
# ///
import time
import random
import numpy as np
from PIL import Image
from datasets import Dataset, load_dataset
import torch


def create_mock_images_dataset(num_samples=5000):
    """Create a deterministic mock dataset with PIL images."""
    random.seed(42)
    np.random.seed(42)

    images = []
    labels = []

    for i in range(num_samples):
        # Create deterministic RGB image
        width, height = 64, 64
        rgb_array = np.random.randint(0, 256, (height, width, 3), dtype=np.uint8)
        image = Image.fromarray(rgb_array)
        images.append(image)
        labels.append(i % 10)  # 10 classes

    return Dataset.from_dict({"image": images, "label": labels})


def create_mock_text_dataset(num_samples=5000):
    """Create a deterministic mock dataset with text."""
    random.seed(42)

    words = ["apple", "banana", "cherry", "date", "elderberry", "fig", "grape", "honeydew"]
    texts = []
    labels = []

    for i in range(num_samples):
        # Create deterministic text
        text_length = 5 + (i % 20)  # 5-24 words
        text = " ".join(random.choices(words, k=text_length))
        texts.append(text)
        labels.append(i % 3)  # 3 classes

    return Dataset.from_dict({"text": texts, "label": labels})


def create_mock_ints_dataset(num_samples=5000):
    """Create a deterministic mock dataset with integers."""
    random.seed(42)

    data = []
    labels = []

    for i in range(num_samples):
        # Create deterministic integer arrays
        arr = [random.randint(0, 1000) for _ in range(50)]  # 50 integers each
        data.append(arr)
        labels.append(i % 5)  # 5 classes

    return Dataset.from_dict({"data": data, "label": labels})


def create_mock_floats_dataset(num_samples=5000):
    """Create a deterministic mock dataset with floats."""
    random.seed(42)

    data = []
    labels = []

    for i in range(num_samples):
        # Create deterministic float arrays
        arr = [random.uniform(0.0, 100.0) for _ in range(30)]  # 30 floats each
        data.append(arr)
        labels.append(i % 4)  # 4 classes

    return Dataset.from_dict({"data": data, "label": labels})


def benchmark_dataset(name, dataset, num_samples=1000):
    """Benchmark dataset access speed."""
    print(f"\n=== {name} Dataset Benchmark ===")

    t0 = time.time()
    dataset.set_format(type="torch")

    # identity map with small batches
    dataset = dataset.map(lambda x: x, batched=True, batch_size=20)

    # force materialization
    data = dataset[:num_samples]
    print(f"Keys: {list(data.keys())}")
    print(f"Sample count: {len(data[list(data.keys())[0]])}")

    t1 = time.time()
    print(f"Duration: {t1 - t0:.2f} s")
    print(f"Speed: {num_samples / (t1 - t0):.1f} samples/s")


def main():
    # PIL Images benchmark
    images_dataset = create_mock_images_dataset()
    benchmark_dataset("PIL Images", images_dataset)

    # Text benchmark
    text_dataset = create_mock_text_dataset()
    benchmark_dataset("Text", text_dataset)

    # Integers benchmark
    ints_dataset = create_mock_ints_dataset()
    benchmark_dataset("Integers", ints_dataset)

    # Floats benchmark
    floats_dataset = create_mock_floats_dataset()
    benchmark_dataset("Floats", floats_dataset)


if __name__ == "__main__":
    main()
```

output

```bash
uv run --refresh example1.py
```

```text
=== PIL Images Dataset Benchmark ===
Map:   0%|                                                          | 0/5000 [00:00<?, ? examples/s]/Users/drbh/.cache/uv/environments-v2/example1-2aca1a30e84bdead/lib/python3.10/site-packages/datasets/features/image.py:352: UserWarning: Downcasting array dtype int64 to uint8 to be compatible with 'Pillow'
  warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
Map: 100%|█████████████████████████████████████████████| 5000/5000 [00:01<00:00, 3669.15 examples/s]
Keys: ['image', 'label']
Sample count: 1000
Duration: 2.14 s
Speed: 466.5 samples/s

=== Text Dataset Benchmark ===
Map: 100%|███████████████████████████████████████████| 5000/5000 [00:00<00:00, 141327.04 examples/s]
Keys: ['text', 'label']
Sample count: 1000
Duration: 0.04 s
Speed: 27004.3 samples/s

=== Integers Dataset Benchmark ===
Map: 100%|███████████████████████████████████████████| 5000/5000 [00:00<00:00, 112904.90 examples/s]
Keys: ['data', 'label']
Sample count: 1000
Duration: 0.05 s
Speed: 21680.6 samples/s

=== Floats Dataset Benchmark ===
Map: 100%|███████████████████████████████████████████| 5000/5000 [00:00<00:00, 104084.25 examples/s]
Keys: ['data', 'label']
Sample count: 1000
Duration: 0.05 s
Speed: 20215.1 samples/s
```

and this branch specifically

```python
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "torch",
#     "datasets",
#     "pillow",
# ]
#
# [tool.uv.sources]
# datasets = { git = "https://github.com/huggingface/datasets.git", rev = "refactor-torch-formatter" }
# ///
import time
import random
import numpy as np
from PIL import Image
from datasets import Dataset, load_dataset
import torch


def create_mock_images_dataset(num_samples=5000):
    """Create a deterministic mock dataset with PIL images."""
    random.seed(42)
    np.random.seed(42)

    images = []
    labels = []

    for i in range(num_samples):
        # Create deterministic RGB image
        width, height = 64, 64
        rgb_array = np.random.randint(0, 256, (height, width, 3), dtype=np.uint8)
        image = Image.fromarray(rgb_array)
        images.append(image)
        labels.append(i % 10)  # 10 classes

    return Dataset.from_dict({"image": images, "label": labels})


def create_mock_text_dataset(num_samples=5000):
    """Create a deterministic mock dataset with text."""
    random.seed(42)

    words = [
        "apple",
        "banana",
        "cherry",
        "date",
        "elderberry",
        "fig",
        "grape",
        "honeydew",
    ]
    texts = []
    labels = []

    for i in range(num_samples):
        # Create deterministic text
        text_length = 5 + (i % 20)  # 5-24 words
        text = " ".join(random.choices(words, k=text_length))
        texts.append(text)
        labels.append(i % 3)  # 3 classes

    return Dataset.from_dict({"text": texts, "label": labels})


def create_mock_ints_dataset(num_samples=5000):
    """Create a deterministic mock dataset with integers."""
    random.seed(42)

    data = []
    labels = []

    for i in range(num_samples):
        # Create deterministic integer arrays
        arr = [random.randint(0, 1000) for _ in range(50)]  # 50 integers each
        data.append(arr)
        labels.append(i % 5)  # 5 classes

    return Dataset.from_dict({"data": data, "label": labels})


def create_mock_floats_dataset(num_samples=5000):
    """Create a deterministic mock dataset with floats."""
    random.seed(42)

    data = []
    labels = []

    for i in range(num_samples):
        # Create deterministic float arrays
        arr = [random.uniform(0.0, 100.0) for _ in range(30)]  # 30 floats each
        data.append(arr)
        labels.append(i % 4)  # 4 classes

    return Dataset.from_dict({"data": data, "label": labels})


def benchmark_dataset(name, dataset, num_samples=1000):
    """Benchmark dataset access speed."""
    print(f"\n=== {name} Dataset Benchmark ===")

    t0 = time.time()
    dataset.set_format(type="torch")

    # identity map with small batches
    dataset = dataset.map(lambda x: x, batched=True, batch_size=20)

    # force materialization
    data = dataset[:num_samples]
    print(f"Keys: {list(data.keys())}")
    print(f"Sample count: {len(data[list(data.keys())[0]])}")

    t1 = time.time()
    print(f"Duration: {t1 - t0:.2f} s")
    print(f"Speed: {num_samples / (t1 - t0):.1f} samples/s")


def main():
    # PIL Images benchmark
    images_dataset = create_mock_images_dataset()
    benchmark_dataset("PIL Images", images_dataset)

    # Text benchmark
    text_dataset = create_mock_text_dataset()
    benchmark_dataset("Text", text_dataset)

    # Integers benchmark
    ints_dataset = create_mock_ints_dataset()
    benchmark_dataset("Integers", ints_dataset)

    # Floats benchmark
    floats_dataset = create_mock_floats_dataset()
    benchmark_dataset("Floats", floats_dataset)


if __name__ == "__main__":
    main()

```

```bash
uv run --refresh example2.py
```

```text
    Updated https://github.com/huggingface/datasets.git (2cb64d1b6503afb49d822b20979760efe4519d03)
      Built datasets @ git+https://github.com/huggingface/datasets.git@2cb64d1b6503afb49d822b20979760efe
Uninstalled 1 package in 20ms
Installed 1 package in 5ms

=== PIL Images Dataset Benchmark ===
Map:   0%|                                                          | 0/5000 [00:00<?, ? examples/s]/Users/drbh/.cache/uv/environments-v2/example2-d4af608668b706ec/lib/python3.10/site-packages/datasets/features/image.py:352: UserWarning: Downcasting array dtype int64 to uint8 to be compatible with 'Pillow'
  warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
Map: 100%|█████████████████████████████████████████████| 5000/5000 [00:01<00:00, 3645.14 examples/s]
Keys: ['image', 'label']
Sample count: 1000
Duration: 2.04 s
Speed: 491.2 samples/s

=== Text Dataset Benchmark ===
Map: 100%|████████████████████████████████████████████████████| 5000/5000 [00:00<00:00, 169877.28 examples/s]
Keys: ['text', 'label']
Sample count: 1000
Duration: 0.03 s
Speed: 32236.1 samples/s

=== Integers Dataset Benchmark ===
Map: 100%|████████████████████████████████████████████████████| 5000/5000 [00:00<00:00, 131940.33 examples/s]
Keys: ['data', 'label']
Sample count: 1000
Duration: 0.04 s
Speed: 25493.3 samples/s

=== Floats Dataset Benchmark ===
Map: 100%|████████████████████████████████████████████████████| 5000/5000 [00:00<00:00, 120621.64 examples/s]
Keys: ['data', 'label']
Sample count: 1000
Duration: 0.04 s
Speed: 23370.6 samples/s
```