### PR TITLE
fix link for rotten_tomatoes dataset

### DIFF
--- a/docs/source/load_hub.mdx
+++ b/docs/source/load_hub.mdx
@@ -2,7 +2,7 @@
 
 Finding high-quality datasets that are reproducible and accessible can be difficult. One of 🤗 Datasets main goals is to provide a simple way to load a dataset of any format or type. The easiest way to get started is to discover an existing dataset on the [Hugging Face Hub](https://huggingface.co/datasets) - a community-driven collection of datasets for tasks in NLP, computer vision, and audio - and use 🤗 Datasets to download and generate the dataset.
 
-This tutorial uses the [rotten_tomatoes](https://huggingface.co/datasets/rotten_tomatoes) and [MInDS-14](https://huggingface.co/datasets/PolyAI/minds14) datasets, but feel free to load any dataset you want and follow along. Head over to the Hub now and find a dataset for your task!
+This tutorial uses the [rotten_tomatoes](https://huggingface.co/datasets/cornell-movie-review-data/rotten_tomatoes) and [MInDS-14](https://huggingface.co/datasets/PolyAI/minds14) datasets, but feel free to load any dataset you want and follow along. Head over to the Hub now and find a dataset for your task!
 
 ## Load a dataset
 


### PR DESCRIPTION
The current link leads to a 404 page.