### PR TITLE
Datasets: Add WMT21 loader (basic TSV loader, sample data, tests)

### DIFF
--- a/benchmarks/benchmark_array_xd.py
+++ b/benchmarks/benchmark_array_xd.py
@@ -14,16 +14,23 @@ SPEED_TEST_SHAPE = (100, 100)
 SPEED_TEST_N_EXAMPLES = 100
 
 DEFAULT_FEATURES = datasets.Features(
-    {"text": Array2D(SHAPE_TEST_1, dtype="float32"), "image": Array2D(SHAPE_TEST_2, dtype="float32")}
+    {
+        "text": Array2D(SHAPE_TEST_1, dtype="float32"),
+        "image": Array2D(SHAPE_TEST_2, dtype="float32"),
+    }
 )
 
 RESULTS_BASEPATH, RESULTS_FILENAME = os.path.split(__file__)
-RESULTS_FILE_PATH = os.path.join(RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json"))
+RESULTS_FILE_PATH = os.path.join(
+    RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json")
+)
 
 
 @get_duration
 def write(my_features, dummy_data, tmp_dir):
-    with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
+    with ArrowWriter(
+        features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+    ) as writer:
         for key, record in dummy_data:
             example = my_features.encode_example(record)
             writer.write(example)
@@ -33,7 +40,8 @@ def write(my_features, dummy_data, tmp_dir):
 @get_duration
 def read_unformated(feats, tmp_dir):
     dataset = datasets.Dataset.from_file(
-        filename=os.path.join(tmp_dir, "beta.arrow"), info=datasets.DatasetInfo(features=feats)
+        filename=os.path.join(tmp_dir, "beta.arrow"),
+        info=datasets.DatasetInfo(features=feats),
     )
     for _ in dataset:
         pass
@@ -42,7 +50,8 @@ def read_unformated(feats, tmp_dir):
 @get_duration
 def read_formatted_as_numpy(feats, tmp_dir):
     dataset = datasets.Dataset.from_file(
-        filename=os.path.join(tmp_dir, "beta.arrow"), info=datasets.DatasetInfo(features=feats)
+        filename=os.path.join(tmp_dir, "beta.arrow"),
+        info=datasets.DatasetInfo(features=feats),
     )
     dataset.set_format("numpy")
     for _ in dataset:
@@ -53,7 +62,8 @@ def read_formatted_as_numpy(feats, tmp_dir):
 def read_batch_unformated(feats, tmp_dir):
     batch_size = 10
     dataset = datasets.Dataset.from_file(
-        filename=os.path.join(tmp_dir, "beta.arrow"), info=datasets.DatasetInfo(features=feats)
+        filename=os.path.join(tmp_dir, "beta.arrow"),
+        info=datasets.DatasetInfo(features=feats),
     )
     for i in range(0, len(dataset), batch_size):
         _ = dataset[i : i + batch_size]
@@ -63,7 +73,8 @@ def read_batch_unformated(feats, tmp_dir):
 def read_batch_formatted_as_numpy(feats, tmp_dir):
     batch_size = 10
     dataset = datasets.Dataset.from_file(
-        filename=os.path.join(tmp_dir, "beta.arrow"), info=datasets.DatasetInfo(features=feats)
+        filename=os.path.join(tmp_dir, "beta.arrow"),
+        info=datasets.DatasetInfo(features=feats),
     )
     dataset.set_format("numpy")
     for i in range(0, len(dataset), batch_size):
@@ -73,7 +84,8 @@ def read_batch_formatted_as_numpy(feats, tmp_dir):
 @get_duration
 def read_col_unformated(feats, tmp_dir):
     dataset = datasets.Dataset.from_file(
-        filename=os.path.join(tmp_dir, "beta.arrow"), info=datasets.DatasetInfo(features=feats)
+        filename=os.path.join(tmp_dir, "beta.arrow"),
+        info=datasets.DatasetInfo(features=feats),
     )
     for col in feats:
         _ = dataset[col]
@@ -82,7 +94,8 @@ def read_col_unformated(feats, tmp_dir):
 @get_duration
 def read_col_formatted_as_numpy(feats, tmp_dir):
     dataset = datasets.Dataset.from_file(
-        filename=os.path.join(tmp_dir, "beta.arrow"), info=datasets.DatasetInfo(features=feats)
+        filename=os.path.join(tmp_dir, "beta.arrow"),
+        info=datasets.DatasetInfo(features=feats),
     )
     dataset.set_format("numpy")
     for col in feats:
@@ -104,27 +117,37 @@ def benchmark_array_xd():
         data = generate_examples(features=feats, num_examples=SPEED_TEST_N_EXAMPLES)
         times["write_array2d"] = write(feats, data, tmp_dir)
         for read_func in read_functions:
-            times[read_func.__name__ + " after write_array2d"] = read_func(feats, tmp_dir)
+            times[read_func.__name__ + " after write_array2d"] = read_func(
+                feats, tmp_dir
+            )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         # don't use fixed length for fair comparison
         # feats = datasets.Features(
         #     {"image": datasets.Sequence(datasets.Sequence(datasets.Value("float32"), SPEED_TEST_SHAPE[1]), SPEED_TEST_SHAPE[0])}
         # )
-        feats = datasets.Features({"image": datasets.Sequence(datasets.Sequence(datasets.Value("float32")))})
+        feats = datasets.Features(
+            {"image": datasets.Sequence(datasets.Sequence(datasets.Value("float32")))}
+        )
         data = generate_examples(
-            features=feats, num_examples=SPEED_TEST_N_EXAMPLES, seq_shapes={"image": SPEED_TEST_SHAPE}
+            features=feats,
+            num_examples=SPEED_TEST_N_EXAMPLES,
+            seq_shapes={"image": SPEED_TEST_SHAPE},
         )
         times["write_nested_sequence"] = write(feats, data, tmp_dir)
         for read_func in read_functions:
-            times[read_func.__name__ + " after write_nested_sequence"] = read_func(feats, tmp_dir)
+            times[read_func.__name__ + " after write_nested_sequence"] = read_func(
+                feats, tmp_dir
+            )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         # don't use fixed length for fair comparison
         # feats = datasets.Features(
         #     {"image": datasets.Sequence(datasets.Value("float32"), SPEED_TEST_SHAPE[0] * SPEED_TEST_SHAPE[1])}
         # )
-        feats = datasets.Features({"image": datasets.Sequence(datasets.Value("float32"))})
+        feats = datasets.Features(
+            {"image": datasets.Sequence(datasets.Value("float32"))}
+        )
         data = generate_examples(
             features=feats,
             num_examples=SPEED_TEST_N_EXAMPLES,
@@ -132,7 +155,9 @@ def benchmark_array_xd():
         )
         times["write_flattened_sequence"] = write(feats, data, tmp_dir)
         for read_func in read_functions:
-            times[read_func.__name__ + " after write_flattened_sequence"] = read_func(feats, tmp_dir)
+            times[read_func.__name__ + " after write_flattened_sequence"] = read_func(
+                feats, tmp_dir
+            )
 
     with open(RESULTS_FILE_PATH, "wb") as f:
         f.write(json.dumps(times).encode("utf-8"))

--- a/benchmarks/benchmark_getitem_100B.py
+++ b/benchmarks/benchmark_getitem_100B.py
@@ -13,7 +13,9 @@ SPEED_TEST_N_EXAMPLES = 100_000_000_000
 SPEED_TEST_CHUNK_SIZE = 10_000
 
 RESULTS_BASEPATH, RESULTS_FILENAME = os.path.split(__file__)
-RESULTS_FILE_PATH = os.path.join(RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json"))
+RESULTS_FILE_PATH = os.path.join(
+    RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json")
+)
 
 
 def generate_100B_dataset(num_examples: int, chunk_size: int) -> datasets.Dataset:
@@ -31,7 +33,9 @@ class RandIter:
 
     def __post_init__(self):
         rng = np.random.default_rng(self.seed)
-        self._sampled_values = rng.integers(low=self.low, high=self.high, size=self.size).tolist()
+        self._sampled_values = rng.integers(
+            low=self.low, high=self.high, size=self.size
+        ).tolist()
 
     def __iter__(self):
         return iter(self._sampled_values)
@@ -62,9 +66,16 @@ def get_batch_of_1024_random_rows(dataset: datasets.Dataset):
 
 def benchmark_table_100B():
     times = {"num examples": SPEED_TEST_N_EXAMPLES}
-    functions = (get_first_row, get_last_row, get_batch_of_1024_rows, get_batch_of_1024_random_rows)
+    functions = (
+        get_first_row,
+        get_last_row,
+        get_batch_of_1024_rows,
+        get_batch_of_1024_random_rows,
+    )
     print("generating dataset")
-    dataset = generate_100B_dataset(num_examples=SPEED_TEST_N_EXAMPLES, chunk_size=SPEED_TEST_CHUNK_SIZE)
+    dataset = generate_100B_dataset(
+        num_examples=SPEED_TEST_N_EXAMPLES, chunk_size=SPEED_TEST_CHUNK_SIZE
+    )
     print("Functions")
     for func in functions:
         print(func.__name__)

--- a/benchmarks/benchmark_indices_mapping.py
+++ b/benchmarks/benchmark_indices_mapping.py
@@ -9,7 +9,9 @@ from utils import generate_example_dataset, get_duration
 SPEED_TEST_N_EXAMPLES = 500_000
 
 RESULTS_BASEPATH, RESULTS_FILENAME = os.path.split(__file__)
-RESULTS_FILE_PATH = os.path.join(RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json"))
+RESULTS_FILE_PATH = os.path.join(
+    RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json")
+)
 
 
 @get_duration
@@ -43,9 +45,13 @@ def benchmark_indices_mapping():
     functions = (select, sort, shuffle, train_test_split, shard)
     with tempfile.TemporaryDirectory() as tmp_dir:
         print("generating dataset")
-        features = datasets.Features({"text": datasets.Value("string"), "numbers": datasets.Value("float32")})
+        features = datasets.Features(
+            {"text": datasets.Value("string"), "numbers": datasets.Value("float32")}
+        )
         dataset = generate_example_dataset(
-            os.path.join(tmp_dir, "dataset.arrow"), features, num_examples=SPEED_TEST_N_EXAMPLES
+            os.path.join(tmp_dir, "dataset.arrow"),
+            features,
+            num_examples=SPEED_TEST_N_EXAMPLES,
         )
         print("Functions")
         for func in functions:

--- a/benchmarks/benchmark_iterating.py
+++ b/benchmarks/benchmark_iterating.py
@@ -10,7 +10,9 @@ SPEED_TEST_N_EXAMPLES = 50_000
 SMALL_TEST = 5_000
 
 RESULTS_BASEPATH, RESULTS_FILENAME = os.path.split(__file__)
-RESULTS_FILE_PATH = os.path.join(RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json"))
+RESULTS_FILE_PATH = os.path.join(
+    RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json")
+)
 
 
 @get_duration
@@ -51,8 +53,14 @@ def benchmark_iterating():
         (read_formatted, {"type": "pandas", "length": SMALL_TEST}),
         (read_formatted, {"type": "torch", "length": SMALL_TEST}),
         (read_formatted, {"type": "tensorflow", "length": SMALL_TEST}),
-        (read_formatted_batch, {"type": "numpy", "length": SMALL_TEST, "batch_size": 10}),
-        (read_formatted_batch, {"type": "numpy", "length": SMALL_TEST, "batch_size": 1_000}),
+        (
+            read_formatted_batch,
+            {"type": "numpy", "length": SMALL_TEST, "batch_size": 10},
+        ),
+        (
+            read_formatted_batch,
+            {"type": "numpy", "length": SMALL_TEST, "batch_size": 1_000},
+        ),
     ]
 
     functions_shuffled = [
@@ -62,13 +70,22 @@ def benchmark_iterating():
         (read_batch, {"length": SPEED_TEST_N_EXAMPLES, "batch_size": 100}),
         (read_batch, {"length": SPEED_TEST_N_EXAMPLES, "batch_size": 1_000}),
         (read_formatted, {"type": "numpy", "length": SMALL_TEST}),
-        (read_formatted_batch, {"type": "numpy", "length": SMALL_TEST, "batch_size": 10}),
-        (read_formatted_batch, {"type": "numpy", "length": SMALL_TEST, "batch_size": 1_000}),
+        (
+            read_formatted_batch,
+            {"type": "numpy", "length": SMALL_TEST, "batch_size": 10},
+        ),
+        (
+            read_formatted_batch,
+            {"type": "numpy", "length": SMALL_TEST, "batch_size": 1_000},
+        ),
     ]
     with tempfile.TemporaryDirectory() as tmp_dir:
         print("generating dataset")
         features = datasets.Features(
-            {"list": datasets.Sequence(datasets.Value("float32")), "numbers": datasets.Value("float32")}
+            {
+                "list": datasets.Sequence(datasets.Value("float32")),
+                "numbers": datasets.Value("float32"),
+            }
         )
         dataset = generate_example_dataset(
             os.path.join(tmp_dir, "dataset.arrow"),
@@ -79,16 +96,21 @@ def benchmark_iterating():
         print("first set of iterations")
         for func, kwargs in functions:
             print(func.__name__, str(kwargs))
-            times[func.__name__ + " " + " ".join(str(v) for v in kwargs.values())] = func(dataset, **kwargs)
+            times[func.__name__ + " " + " ".join(str(v) for v in kwargs.values())] = (
+                func(dataset, **kwargs)
+            )
 
         print("shuffling dataset")
         dataset = dataset.shuffle()
         print("Second set of iterations (after shuffling")
         for func, kwargs in functions_shuffled:
             print("shuffled ", func.__name__, str(kwargs))
-            times["shuffled " + func.__name__ + " " + " ".join(str(v) for v in kwargs.values())] = func(
-                dataset, **kwargs
-            )
+            times[
+                "shuffled "
+                + func.__name__
+                + " "
+                + " ".join(str(v) for v in kwargs.values())
+            ] = func(dataset, **kwargs)
 
     with open(RESULTS_FILE_PATH, "wb") as f:
         f.write(json.dumps(times).encode("utf-8"))

--- a/benchmarks/benchmark_map_filter.py
+++ b/benchmarks/benchmark_map_filter.py
@@ -11,7 +11,9 @@ from utils import generate_example_dataset, get_duration
 SPEED_TEST_N_EXAMPLES = 500_000
 
 RESULTS_BASEPATH, RESULTS_FILENAME = os.path.split(__file__)
-RESULTS_FILE_PATH = os.path.join(RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json"))
+RESULTS_FILE_PATH = os.path.join(
+    RESULTS_BASEPATH, "results", RESULTS_FILENAME.replace(".py", ".json")
+)
 
 
 @get_duration
@@ -27,12 +29,18 @@ def filter(dataset: datasets.Dataset, **kwargs):
 def benchmark_map_filter():
     times = {"num examples": SPEED_TEST_N_EXAMPLES}
     with tempfile.TemporaryDirectory() as tmp_dir:
-        features = datasets.Features({"text": datasets.Value("string"), "numbers": datasets.Value("float32")})
+        features = datasets.Features(
+            {"text": datasets.Value("string"), "numbers": datasets.Value("float32")}
+        )
         dataset = generate_example_dataset(
-            os.path.join(tmp_dir, "dataset.arrow"), features, num_examples=SPEED_TEST_N_EXAMPLES
+            os.path.join(tmp_dir, "dataset.arrow"),
+            features,
+            num_examples=SPEED_TEST_N_EXAMPLES,
         )
 
-        tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-cased", use_fast=True)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            "bert-base-cased", use_fast=True
+        )
 
         def tokenize(examples):
             return tokenizer(examples["text"])
@@ -44,18 +52,28 @@ def benchmark_map_filter():
         times["map no-op batched"] = map(dataset, function=lambda x: None, batched=True)
 
         with dataset.formatted_as(type="numpy"):
-            times["map no-op batched numpy"] = map(dataset, function=lambda x: None, batched=True)
+            times["map no-op batched numpy"] = map(
+                dataset, function=lambda x: None, batched=True
+            )
 
         with dataset.formatted_as(type="pandas"):
-            times["map no-op batched pandas"] = map(dataset, function=lambda x: None, batched=True)
+            times["map no-op batched pandas"] = map(
+                dataset, function=lambda x: None, batched=True
+            )
 
         with dataset.formatted_as(type="torch", columns="numbers"):
-            times["map no-op batched pytorch"] = map(dataset, function=lambda x: None, batched=True)
+            times["map no-op batched pytorch"] = map(
+                dataset, function=lambda x: None, batched=True
+            )
 
         with dataset.formatted_as(type="tensorflow", columns="numbers"):
-            times["map no-op batched tensorflow"] = map(dataset, function=lambda x: None, batched=True)
+            times["map no-op batched tensorflow"] = map(
+                dataset, function=lambda x: None, batched=True
+            )
 
-        times["map fast-tokenizer batched"] = map(dataset, function=tokenize, batched=True)
+        times["map fast-tokenizer batched"] = map(
+            dataset, function=tokenize, batched=True
+        )
 
         times["filter"] = filter(dataset)
 

--- a/benchmarks/format.py
+++ b/benchmarks/format.py
@@ -26,9 +26,13 @@ def format_json_to_md(input_json_file, output_md_file):
             val_str = f" {new_val:f}" if isinstance(new_val, (int, float)) else "None"
 
             if old_val is not None:
-                val_str += f" / {old_val:f}" if isinstance(old_val, (int, float)) else "None"
+                val_str += (
+                    f" / {old_val:f}" if isinstance(old_val, (int, float)) else "None"
+                )
             if dif_val is not None:
-                val_str += f" ({dif_val:f})" if isinstance(dif_val, (int, float)) else "None"
+                val_str += (
+                    f" ({dif_val:f})" if isinstance(dif_val, (int, float)) else "None"
+                )
 
             title += " " + metric_name + " |"
             lines += "---|"

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -29,7 +29,9 @@ def generate_examples(features: dict, num_examples=100, seq_shapes=None):
                 data = np.random.rand(*v.shape).astype(v.dtype)
             elif isinstance(v, datasets.Value):
                 if v.dtype == "string":
-                    data = "The small grey turtle was surprisingly fast when challenged."
+                    data = (
+                        "The small grey turtle was surprisingly fast when challenged."
+                    )
                 else:
                     data = np.random.randint(10, size=1).astype(v.dtype).item()
             elif isinstance(v, datasets.Sequence):
@@ -45,7 +47,9 @@ def generate_examples(features: dict, num_examples=100, seq_shapes=None):
 
 
 def generate_example_dataset(dataset_path, features, num_examples=100, seq_shapes=None):
-    dummy_data = generate_examples(features, num_examples=num_examples, seq_shapes=seq_shapes)
+    dummy_data = generate_examples(
+        features, num_examples=num_examples, seq_shapes=seq_shapes
+    )
 
     with ArrowWriter(features=features, path=dataset_path) as writer:
         for key, record in dummy_data:
@@ -59,6 +63,8 @@ def generate_example_dataset(dataset_path, features, num_examples=100, seq_shape
             f"Error writing the dataset, wrote {num_final_examples} examples but should have written {num_examples}."
         )
 
-    dataset = datasets.Dataset.from_file(filename=dataset_path, info=datasets.DatasetInfo(features=features))
+    dataset = datasets.Dataset.from_file(
+        filename=dataset_path, info=datasets.DatasetInfo(features=features)
+    )
 
     return dataset

--- a/local_datasets/wmt21/README.md
+++ b/local_datasets/wmt21/README.md
@@ -1,0 +1,20 @@
+# WMT21 Local Dataset
+
+This is a local copy of WMT21 for testing / development.
+
+## Structure
+
+- train.tsv
+- validation.tsv
+- test.tsv
+
+Each line is tab-separated: `<source>\t<target>`
+
+## Usage
+
+```python
+from local_datasets.wmt21.wmt21 import WMT21Dataset
+
+wmt21 = WMT21Dataset("local_datasets/wmt21/dummy_data")
+ds = wmt21.load()
+print(ds["train"][0])

--- a/local_datasets/wmt21/__init__.py
+++ b/local_datasets/wmt21/__init__.py
@@ -1,0 +1,1 @@
+from .wmt21_dataset import WMT21Dataset

--- a/local_datasets/wmt21/dummy_data/test.tsv
+++ b/local_datasets/wmt21/dummy_data/test.tsv
@@ -1,0 +1,2 @@
+I love programming	J'adore programmer
+Good night  Bonne nuit

--- a/local_datasets/wmt21/dummy_data/train.tsv
+++ b/local_datasets/wmt21/dummy_data/train.tsv
@@ -1,0 +1,3 @@
+Hello world	Bonjour le monde
+How are you?	Comment ça va ?
+Good morning	Bonjour

--- a/local_datasets/wmt21/dummy_data/validation.tsv
+++ b/local_datasets/wmt21/dummy_data/validation.tsv
@@ -1,0 +1,2 @@
+Thank you	Merci
+See you later	À plus tard

--- a/local_datasets/wmt21/wmt21_dataset.py
+++ b/local_datasets/wmt21/wmt21_dataset.py
@@ -1,0 +1,42 @@
+# local_datasets/wmt21/wmt21_dataset.py
+import os
+from datasets import Dataset, DatasetDict
+
+
+class WMT21Dataset:
+    def __init__(self, data_dir: str):
+        """
+        Args:
+            data_dir (str): Path to the directory containing train.tsv, validation.tsv, test.tsv
+        """
+        self.data_dir = data_dir
+
+    def load(self) -> DatasetDict:
+        """
+        Load the dataset into a Hugging Face DatasetDict with 'train', 'validation', 'test' splits.
+        Handles empty lines and malformed lines gracefully.
+        """
+        splits = ["train", "validation", "test"]
+        data_dict = {}
+
+        for split in splits:
+            file_path = os.path.join(self.data_dir, f"{split}.tsv")
+            if os.path.exists(file_path):
+                with open(file_path, encoding="utf-8") as f:
+                    data = []
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue  # skip empty lines
+                        parts = line.split("\t")
+                        if len(parts) < 2:
+                            continue  # skip malformed lines
+                        # Take only first two columns
+                        source, target = parts[0], parts[1]
+                        data.append({"source": source, "target": target})
+                data_dict[split] = Dataset.from_list(data)
+            else:
+                # If split file does not exist, create empty Dataset
+                data_dict[split] = Dataset.from_list([])
+
+        return DatasetDict(data_dict)

--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,9 @@ NUMPY2_INCOMPATIBLE_LIBRARIES = [
     "tensorflow",
 ]
 TESTS_NUMPY2_REQUIRE = [
-    library for library in TESTS_REQUIRE if library.partition(">")[0] not in NUMPY2_INCOMPATIBLE_LIBRARIES
+    library
+    for library in TESTS_REQUIRE
+    if library.partition(">")[0] not in NUMPY2_INCOMPATIBLE_LIBRARIES
 ]
 
 QUALITY_REQUIRE = ["ruff>=0.3.0"]
@@ -242,7 +244,9 @@ setup(
         "datasets": ["py.typed"],
         "datasets.utils.resources": ["*.json", "*.yaml", "*.tsv"],
     },
-    entry_points={"console_scripts": ["datasets-cli=datasets.commands.datasets_cli:main"]},
+    entry_points={
+        "console_scripts": ["datasets-cli=datasets.commands.datasets_cli:main"]
+    },
     python_requires=">=3.9.0",
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS_REQUIRE,

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -16,7 +16,12 @@ __version__ = "4.1.2.dev0"
 
 from .arrow_dataset import Column, Dataset
 from .arrow_reader import ReadInstruction
-from .builder import ArrowBasedBuilder, BuilderConfig, DatasetBuilder, GeneratorBasedBuilder
+from .builder import (
+    ArrowBasedBuilder,
+    BuilderConfig,
+    DatasetBuilder,
+    GeneratorBasedBuilder,
+)
 from .combine import concatenate_datasets, interleave_datasets
 from .dataset_dict import DatasetDict, IterableDatasetDict
 from .download import *

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -43,7 +43,11 @@ from .info import DatasetInfo
 from .keyhash import DuplicatedKeysError, KeyHasher
 from .table import array_cast, cast_array_to_feature, embed_table_storage, table_cast
 from .utils import logging
-from .utils.py_utils import asdict, convert_file_size_to_int, first_non_null_non_empty_value
+from .utils.py_utils import (
+    asdict,
+    convert_file_size_to_int,
+    first_non_null_non_empty_value,
+)
 
 
 logger = logging.get_logger(__name__)
@@ -51,7 +55,9 @@ logger = logging.get_logger(__name__)
 type_ = type  # keep python's type function
 
 
-def get_arrow_writer_batch_size_from_features(features: Optional[Features]) -> Optional[int]:
+def get_arrow_writer_batch_size_from_features(
+    features: Optional[Features],
+) -> Optional[int]:
     """
     Get the writer_batch_size that defines the maximum record batch size in the arrow files based on configuration values.
     The default value is 100 for image/audio datasets and 10 for videos.
@@ -72,18 +78,35 @@ def get_arrow_writer_batch_size_from_features(features: Optional[Features]) -> O
 
     def set_batch_size(feature: FeatureType) -> None:
         nonlocal batch_size
-        if isinstance(feature, Image) and config.ARROW_RECORD_BATCH_SIZE_FOR_IMAGE_DATASETS is not None:
-            batch_size = min(batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_IMAGE_DATASETS)
-        elif isinstance(feature, Audio) and config.ARROW_RECORD_BATCH_SIZE_FOR_AUDIO_DATASETS is not None:
-            batch_size = min(batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_AUDIO_DATASETS)
-        elif isinstance(feature, Video) and config.ARROW_RECORD_BATCH_SIZE_FOR_VIDEO_DATASETS is not None:
-            batch_size = min(batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_VIDEO_DATASETS)
+        if (
+            isinstance(feature, Image)
+            and config.ARROW_RECORD_BATCH_SIZE_FOR_IMAGE_DATASETS is not None
+        ):
+            batch_size = min(
+                batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_IMAGE_DATASETS
+            )
+        elif (
+            isinstance(feature, Audio)
+            and config.ARROW_RECORD_BATCH_SIZE_FOR_AUDIO_DATASETS is not None
+        ):
+            batch_size = min(
+                batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_AUDIO_DATASETS
+            )
+        elif (
+            isinstance(feature, Video)
+            and config.ARROW_RECORD_BATCH_SIZE_FOR_VIDEO_DATASETS is not None
+        ):
+            batch_size = min(
+                batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_VIDEO_DATASETS
+            )
         elif (
             isinstance(feature, Value)
             and feature.dtype == "binary"
             and config.ARROW_RECORD_BATCH_SIZE_FOR_BINARY_DATASETS is not None
         ):
-            batch_size = min(batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_BINARY_DATASETS)
+            batch_size = min(
+                batch_size, config.ARROW_RECORD_BATCH_SIZE_FOR_BINARY_DATASETS
+            )
 
     _visit(features, set_batch_size)
 
@@ -112,18 +135,35 @@ def get_writer_batch_size_from_features(features: Optional[Features]) -> Optiona
 
     def set_batch_size(feature: FeatureType) -> None:
         nonlocal batch_size
-        if isinstance(feature, Image) and config.PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS is not None:
-            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS)
-        elif isinstance(feature, Audio) and config.PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS is not None:
-            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS)
-        elif isinstance(feature, Video) and config.PARQUET_ROW_GROUP_SIZE_FOR_VIDEO_DATASETS is not None:
-            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_VIDEO_DATASETS)
+        if (
+            isinstance(feature, Image)
+            and config.PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS is not None
+        ):
+            batch_size = min(
+                batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_IMAGE_DATASETS
+            )
+        elif (
+            isinstance(feature, Audio)
+            and config.PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS is not None
+        ):
+            batch_size = min(
+                batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_AUDIO_DATASETS
+            )
+        elif (
+            isinstance(feature, Video)
+            and config.PARQUET_ROW_GROUP_SIZE_FOR_VIDEO_DATASETS is not None
+        ):
+            batch_size = min(
+                batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_VIDEO_DATASETS
+            )
         elif (
             isinstance(feature, Value)
             and feature.dtype == "binary"
             and config.PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS is not None
         ):
-            batch_size = min(batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS)
+            batch_size = min(
+                batch_size, config.PARQUET_ROW_GROUP_SIZE_FOR_BINARY_DATASETS
+            )
 
     _visit(features, set_batch_size)
 
@@ -151,7 +191,14 @@ def get_writer_batch_size_from_data_size(num_rows: int, num_bytes: int) -> int:
         writer_batch_size (`Optional[int]`):
             Writer batch size to pass to a parquet writer.
     """
-    return max(10, num_rows * convert_file_size_to_int(config.MAX_ROW_GROUP_SIZE) // num_bytes) if num_bytes > 0 else 1
+    return (
+        max(
+            10,
+            num_rows * convert_file_size_to_int(config.MAX_ROW_GROUP_SIZE) // num_bytes,
+        )
+        if num_bytes > 0
+        else 1
+    )
 
 
 class SchemaInferenceError(ValueError):
@@ -215,7 +262,9 @@ class TypedSequence:
         self.optimized_int_type = optimized_int_type
         # when trying a type (is ignored if data is not compatible)
         self.trying_type = self.try_type is not None
-        self.trying_int_optimization = optimized_int_type is not None and type is None and try_type is None
+        self.trying_int_optimization = (
+            optimized_int_type is not None and type is None and try_type is None
+        )
         # used to get back the inferred type after __arrow_array__() is called once
         self._inferred_type = None
 
@@ -235,7 +284,9 @@ class TypedSequence:
         return self._inferred_type
 
     @staticmethod
-    def _infer_custom_type_and_encode(data: Iterable) -> tuple[Iterable, Optional[FeatureType]]:
+    def _infer_custom_type_and_encode(
+        data: Iterable,
+    ) -> tuple[Iterable, Optional[FeatureType]]:
         """Implement type inference for custom objects like PIL.Image.Image -> Image type.
 
         This function is only used for custom python objects that can't be directly passed to build
@@ -256,20 +307,40 @@ class TypedSequence:
 
             non_null_idx, non_null_value = first_non_null_non_empty_value(data)
             if isinstance(non_null_value, PIL.Image.Image):
-                return [Image().encode_example(value) if value is not None else None for value in data], Image()
-            if isinstance(non_null_value, list) and isinstance(non_null_value[0], PIL.Image.Image):
                 return [
-                    [Image().encode_example(x) for x in value] if value is not None else None for value in data
+                    Image().encode_example(value) if value is not None else None
+                    for value in data
+                ], Image()
+            if isinstance(non_null_value, list) and isinstance(
+                non_null_value[0], PIL.Image.Image
+            ):
+                return [
+                    (
+                        [Image().encode_example(x) for x in value]
+                        if value is not None
+                        else None
+                    )
+                    for value in data
                 ], List(Image())
         if config.PDFPLUMBER_AVAILABLE and "pdfplumber" in sys.modules:
             import pdfplumber
 
             non_null_idx, non_null_value = first_non_null_non_empty_value(data)
             if isinstance(non_null_value, pdfplumber.pdf.PDF):
-                return [Pdf().encode_example(value) if value is not None else None for value in data], Pdf()
-            if isinstance(non_null_value, list) and isinstance(non_null_value[0], pdfplumber.pdf.PDF):
                 return [
-                    [Pdf().encode_example(x) for x in value] if value is not None else None for value in data
+                    Pdf().encode_example(value) if value is not None else None
+                    for value in data
+                ], Pdf()
+            if isinstance(non_null_value, list) and isinstance(
+                non_null_value[0], pdfplumber.pdf.PDF
+            ):
+                return [
+                    (
+                        [Pdf().encode_example(x) for x in value]
+                        if value is not None
+                        else None
+                    )
+                    for value in data
                 ], List(Pdf())
         return data, None
 
@@ -277,7 +348,9 @@ class TypedSequence:
         """This function is called when calling pa.array(typed_sequence)"""
 
         if type is not None:
-            raise ValueError("TypedSequence is supposed to be used with pa.array(typed_sequence, type=None)")
+            raise ValueError(
+                "TypedSequence is supposed to be used with pa.array(typed_sequence, type=None)"
+            )
         del type  # make sure we don't use it
         data = self.data
         # automatic type inference for custom objects
@@ -289,7 +362,9 @@ class TypedSequence:
             type = self._inferred_type
         pa_type = get_nested_type(type) if type is not None else None
         optimized_int_pa_type = (
-            get_nested_type(self.optimized_int_type) if self.optimized_int_type is not None else None
+            get_nested_type(self.optimized_int_type)
+            if self.optimized_int_type is not None
+            else None
         )
         trying_cast_to_python_objects = False
         try:
@@ -301,7 +376,11 @@ class TypedSequence:
             # efficient np array to pyarrow array
             if isinstance(data, np.ndarray):
                 out = numpy_to_pyarrow_listarray(data)
-            elif isinstance(data, list) and data and isinstance(first_non_null_non_empty_value(data)[1], np.ndarray):
+            elif (
+                isinstance(data, list)
+                and data
+                and isinstance(first_non_null_non_empty_value(data)[1], np.ndarray)
+            ):
                 out = list_of_np_array_to_pyarrow_listarray(data)
             else:
                 trying_cast_to_python_objects = True
@@ -313,7 +392,9 @@ class TypedSequence:
                 elif pa.types.is_list(out.type):
                     if pa.types.is_int64(out.type.value_type):
                         out = array_cast(out, pa.list_(optimized_int_pa_type))
-                    elif pa.types.is_list(out.type.value_type) and pa.types.is_int64(out.type.value_type.value_type):
+                    elif pa.types.is_list(out.type.value_type) and pa.types.is_int64(
+                        out.type.value_type.value_type
+                    ):
                         out = array_cast(out, pa.list_(pa.list_(optimized_int_pa_type)))
             # otherwise we can finally use the user's type
             elif type is not None:
@@ -321,7 +402,10 @@ class TypedSequence:
                 # Also, when trying type "string", we don't want to convert integers or floats to "string".
                 # We only do it if trying_type is False - since this is what the user asks for.
                 out = cast_array_to_feature(
-                    out, type, allow_primitive_to_str=not self.trying_type, allow_decimal_to_str=not self.trying_type
+                    out,
+                    type,
+                    allow_primitive_to_str=not self.trying_type,
+                    allow_decimal_to_str=not self.trying_type,
                 )
             return out
         except (
@@ -337,29 +421,46 @@ class TypedSequence:
                 try:  # second chance
                     if isinstance(data, np.ndarray):
                         return numpy_to_pyarrow_listarray(data)
-                    elif isinstance(data, list) and data and any(isinstance(value, np.ndarray) for value in data):
+                    elif (
+                        isinstance(data, list)
+                        and data
+                        and any(isinstance(value, np.ndarray) for value in data)
+                    ):
                         return list_of_np_array_to_pyarrow_listarray(data)
                     else:
                         trying_cast_to_python_objects = True
-                        return pa.array(cast_to_python_objects(data, only_1d_for_numpy=True))
+                        return pa.array(
+                            cast_to_python_objects(data, only_1d_for_numpy=True)
+                        )
                 except pa.lib.ArrowInvalid as e:
                     if "overflow" in str(e):
                         raise OverflowError(
                             f"There was an overflow with type {type_(data)}. Try to reduce writer_batch_size to have batches smaller than 2GB.\n({e})"
                         ) from None
                     elif self.trying_int_optimization and "not in range" in str(e):
-                        optimized_int_pa_type_str = np.dtype(optimized_int_pa_type.to_pandas_dtype()).name
+                        optimized_int_pa_type_str = np.dtype(
+                            optimized_int_pa_type.to_pandas_dtype()
+                        ).name
                         logger.info(
                             f"Failed to cast a sequence to {optimized_int_pa_type_str}. Falling back to int64."
                         )
                         return out
-                    elif trying_cast_to_python_objects and "Could not convert" in str(e):
+                    elif trying_cast_to_python_objects and "Could not convert" in str(
+                        e
+                    ):
                         out = pa.array(
-                            cast_to_python_objects(data, only_1d_for_numpy=True, optimize_list_casting=False)
+                            cast_to_python_objects(
+                                data,
+                                only_1d_for_numpy=True,
+                                optimize_list_casting=False,
+                            )
                         )
                         if type is not None:
                             out = cast_array_to_feature(
-                                out, type, allow_primitive_to_str=True, allow_decimal_to_str=True
+                                out,
+                                type,
+                                allow_primitive_to_str=True,
+                                allow_decimal_to_str=True,
                             )
                         return out
                     else:
@@ -369,13 +470,26 @@ class TypedSequence:
                     f"There was an overflow with type {type_(data)}. Try to reduce writer_batch_size to have batches smaller than 2GB.\n({e})"
                 ) from None
             elif self.trying_int_optimization and "not in range" in str(e):
-                optimized_int_pa_type_str = np.dtype(optimized_int_pa_type.to_pandas_dtype()).name
-                logger.info(f"Failed to cast a sequence to {optimized_int_pa_type_str}. Falling back to int64.")
+                optimized_int_pa_type_str = np.dtype(
+                    optimized_int_pa_type.to_pandas_dtype()
+                ).name
+                logger.info(
+                    f"Failed to cast a sequence to {optimized_int_pa_type_str}. Falling back to int64."
+                )
                 return out
             elif trying_cast_to_python_objects and "Could not convert" in str(e):
-                out = pa.array(cast_to_python_objects(data, only_1d_for_numpy=True, optimize_list_casting=False))
+                out = pa.array(
+                    cast_to_python_objects(
+                        data, only_1d_for_numpy=True, optimize_list_casting=False
+                    )
+                )
                 if type is not None:
-                    out = cast_array_to_feature(out, type, allow_primitive_to_str=True, allow_decimal_to_str=True)
+                    out = cast_array_to_feature(
+                        out,
+                        type,
+                        allow_primitive_to_str=True,
+                        allow_decimal_to_str=True,
+                    )
                 return out
             else:
                 raise
@@ -393,14 +507,18 @@ class OptimizedTypedSequence(TypedSequence):
         optimized_int_type_by_col = {
             "attention_mask": Value("int8"),  # binary tensor
             "special_tokens_mask": Value("int8"),
-            "input_ids": Value("int32"),  # typical vocab size: 0-50k (max ~500k, never > 1M)
+            "input_ids": Value(
+                "int32"
+            ),  # typical vocab size: 0-50k (max ~500k, never > 1M)
             "token_type_ids": Value(
                 "int8"
             ),  # binary mask; some (XLNetModel) use an additional token represented by a 2
         }
         if type is None and try_type is None:
             optimized_int_type = optimized_int_type_by_col.get(col, None)
-        super().__init__(data, type=type, try_type=try_type, optimized_int_type=optimized_int_type)
+        super().__init__(
+            data, type=type, try_type=try_type, optimized_int_type=optimized_int_type
+        )
 
 
 class ArrowWriter:
@@ -447,7 +565,11 @@ class ArrowWriter:
         if stream is None:
             fs, path = url_to_fs(path, **(storage_options or {}))
             self._fs: fsspec.AbstractFileSystem = fs
-            self._path = path if not is_remote_filesystem(self._fs) else self._fs.unstrip_protocol(path)
+            self._path = (
+                path
+                if not is_remote_filesystem(self._fs)
+                else self._fs.unstrip_protocol(path)
+            )
             self.stream = self._fs.open(path, "wb")
             self._closable_stream = True
         else:
@@ -500,7 +622,9 @@ class ArrowWriter:
         features = self._features
         inferred_features = Features.from_arrow_schema(inferred_schema)
         if self._features is not None:
-            if self.update_features:  # keep original features it they match, or update them
+            if (
+                self.update_features
+            ):  # keep original features it they match, or update them
                 fields = {field.name: field for field in self._features.type}
                 for inferred_field in inferred_features.type:
                     name = inferred_field.name
@@ -514,9 +638,13 @@ class ArrowWriter:
             schema: pa.Schema = inferred_features.arrow_schema
 
         if self.disable_nullable:
-            schema = pa.schema(pa.field(field.name, field.type, nullable=False) for field in schema)
+            schema = pa.schema(
+                pa.field(field.name, field.type, nullable=False) for field in schema
+            )
         if self.with_metadata:
-            schema = schema.with_metadata(self._build_metadata(DatasetInfo(features=features), self.fingerprint))
+            schema = schema.with_metadata(
+                self._build_metadata(DatasetInfo(features=features), self.fingerprint)
+            )
         else:
             schema = schema.with_metadata({})
 
@@ -531,15 +659,23 @@ class ArrowWriter:
         _schema = (
             self._schema
             if self._schema is not None
-            else (pa.schema(self._features.type) if self._features is not None else None)
+            else (
+                pa.schema(self._features.type) if self._features is not None else None
+            )
         )
         if self._disable_nullable and _schema is not None:
-            _schema = pa.schema(pa.field(field.name, field.type, nullable=False) for field in _schema)
+            _schema = pa.schema(
+                pa.field(field.name, field.type, nullable=False) for field in _schema
+            )
         return _schema if _schema is not None else []
 
     @staticmethod
-    def _build_metadata(info: DatasetInfo, fingerprint: Optional[str] = None) -> dict[str, str]:
-        info_keys = ["features"]  # we can add support for more DatasetInfo keys in the future
+    def _build_metadata(
+        info: DatasetInfo, fingerprint: Optional[str] = None
+    ) -> dict[str, str]:
+        info_keys = [
+            "features"
+        ]  # we can add support for more DatasetInfo keys in the future
         info_as_dict = asdict(info)
         metadata = {}
         metadata["info"] = {key: info_as_dict[key] for key in info_keys}
@@ -554,7 +690,9 @@ class ArrowWriter:
         # preserve the order the columns
         if self.schema:
             schema_cols = set(self.schema.names)
-            examples_cols = self.current_examples[0][0].keys()  # .keys() preserves the order (unlike set)
+            examples_cols = self.current_examples[0][
+                0
+            ].keys()  # .keys() preserves the order (unlike set)
             common_cols = [col for col in self.schema.names if col in examples_cols]
             extra_cols = [col for col in examples_cols if col not in schema_cols]
             cols = common_cols + extra_cols
@@ -565,17 +703,26 @@ class ArrowWriter:
             # We use row[0][col] since current_examples contains (example, key) tuples.
             # Moreover, examples could be Arrow arrays of 1 element.
             # This can happen in `.map()` when we want to re-write the same Arrow data
-            if all(isinstance(row[0][col], (pa.Array, pa.ChunkedArray)) for row in self.current_examples):
+            if all(
+                isinstance(row[0][col], (pa.Array, pa.ChunkedArray))
+                for row in self.current_examples
+            ):
                 arrays = [row[0][col] for row in self.current_examples]
                 arrays = [
                     chunk
                     for array in arrays
-                    for chunk in (array.chunks if isinstance(array, pa.ChunkedArray) else [array])
+                    for chunk in (
+                        array.chunks if isinstance(array, pa.ChunkedArray) else [array]
+                    )
                 ]
                 batch_examples[col] = pa.concat_arrays(arrays)
             else:
                 batch_examples[col] = [
-                    row[0][col].to_pylist()[0] if isinstance(row[0][col], (pa.Array, pa.ChunkedArray)) else row[0][col]
+                    (
+                        row[0][col].to_pylist()[0]
+                        if isinstance(row[0][col], (pa.Array, pa.ChunkedArray))
+                        else row[0][col]
+                    )
                     for row in self.current_examples
                 ]
         self.write_batch(batch_examples=batch_examples)
@@ -614,7 +761,10 @@ class ArrowWriter:
 
         if writer_batch_size is None:
             writer_batch_size = self.writer_batch_size
-        if writer_batch_size is not None and len(self.current_examples) >= writer_batch_size:
+        if (
+            writer_batch_size is not None
+            and len(self.current_examples) >= writer_batch_size
+        ):
             if self._check_duplicates:
                 self.check_duplicate_keys()
                 # Re-initializing to empty list for next batch
@@ -644,11 +794,16 @@ class ArrowWriter:
             row: the row to add.
         """
         if len(row) != 1:
-            raise ValueError(f"Only single-row pyarrow tables are allowed but got table with {len(row)} rows.")
+            raise ValueError(
+                f"Only single-row pyarrow tables are allowed but got table with {len(row)} rows."
+            )
         self.current_rows.append(row)
         if writer_batch_size is None:
             writer_batch_size = self.writer_batch_size
-        if writer_batch_size is not None and len(self.current_rows) >= writer_batch_size:
+        if (
+            writer_batch_size is not None
+            and len(self.current_rows) >= writer_batch_size
+        ):
             self.write_rows_on_file()
 
     def write_batch(
@@ -667,14 +822,20 @@ class ArrowWriter:
         """
         if batch_examples and len(next(iter(batch_examples.values()))) == 0:
             return
-        features = None if self.pa_writer is None and self.update_features else self._features
-        try_features = self._features if self.pa_writer is None and self.update_features else None
+        features = (
+            None if self.pa_writer is None and self.update_features else self._features
+        )
+        try_features = (
+            self._features if self.pa_writer is None and self.update_features else None
+        )
         arrays = []
         inferred_features = Features()
         # preserve the order the columns
         if self.schema:
             schema_cols = set(self.schema.names)
-            batch_cols = batch_examples.keys()  # .keys() preserves the order (unlike set)
+            batch_cols = (
+                batch_examples.keys()
+            )  # .keys() preserves the order (unlike set)
             common_cols = [col for col in self.schema.names if col in batch_cols]
             extra_cols = [col for col in batch_cols if col not in schema_cols]
             cols = common_cols + extra_cols
@@ -684,19 +845,29 @@ class ArrowWriter:
             col_values = batch_examples[col]
             col_type = features[col] if features else None
             if isinstance(col_values, (pa.Array, pa.ChunkedArray)):
-                array = cast_array_to_feature(col_values, col_type) if col_type is not None else col_values
+                array = (
+                    cast_array_to_feature(col_values, col_type)
+                    if col_type is not None
+                    else col_values
+                )
                 arrays.append(array)
                 inferred_features[col] = generate_from_arrow_type(col_values.type)
             else:
                 col_try_type = (
                     try_features[col]
-                    if try_features is not None and col in try_features and try_original_type
+                    if try_features is not None
+                    and col in try_features
+                    and try_original_type
                     else None
                 )
-                typed_sequence = OptimizedTypedSequence(col_values, type=col_type, try_type=col_try_type, col=col)
+                typed_sequence = OptimizedTypedSequence(
+                    col_values, type=col_type, try_type=col_try_type, col=col
+                )
                 arrays.append(pa.array(typed_sequence))
                 inferred_features[col] = typed_sequence.get_inferred_type()
-        schema = inferred_features.arrow_schema if self.pa_writer is None else self.schema
+        schema = (
+            inferred_features.arrow_schema if self.pa_writer is None else self.schema
+        )
         pa_table = pa.Table.from_arrays(arrays, schema=schema)
         self.write_table(pa_table, writer_batch_size)
 
@@ -737,7 +908,9 @@ class ArrowWriter:
         else:
             if close_stream:
                 self.stream.close()
-            raise SchemaInferenceError("Please pass `features` or at least one example when writing data")
+            raise SchemaInferenceError(
+                "Please pass `features` or at least one example when writing data"
+            )
         logger.debug(
             f"Done writing {self._num_examples} {self.unit} in {self._num_bytes} bytes {self._path if self._path else ''}."
         )
@@ -745,7 +918,9 @@ class ArrowWriter:
 
 
 class ParquetWriter(ArrowWriter):
-    def __init__(self, *args, use_content_defined_chunking=True, write_page_index=True, **kwargs):
+    def __init__(
+        self, *args, use_content_defined_chunking=True, write_page_index=True, **kwargs
+    ):
         super().__init__(*args, **kwargs)
         if use_content_defined_chunking is True:
             use_content_defined_chunking = config.DEFAULT_CDC_OPTIONS
@@ -762,5 +937,9 @@ class ParquetWriter(ArrowWriter):
         )
         if self.use_content_defined_chunking is not False:
             self.pa_writer.add_key_value_metadata(
-                {"content_defined_chunking": json.dumps(self.use_content_defined_chunking)}
+                {
+                    "content_defined_chunking": json.dumps(
+                        self.use_content_defined_chunking
+                    )
+                }
             )

--- a/src/datasets/combine.py
+++ b/src/datasets/combine.py
@@ -1,9 +1,17 @@
 from typing import Optional, TypeVar
 
-from .arrow_dataset import Dataset, _concatenate_map_style_datasets, _interleave_map_style_datasets
+from .arrow_dataset import (
+    Dataset,
+    _concatenate_map_style_datasets,
+    _interleave_map_style_datasets,
+)
 from .dataset_dict import DatasetDict, IterableDatasetDict
 from .info import DatasetInfo
-from .iterable_dataset import IterableDataset, _concatenate_iterable_datasets, _interleave_iterable_datasets
+from .iterable_dataset import (
+    IterableDataset,
+    _concatenate_iterable_datasets,
+    _interleave_iterable_datasets,
+)
 from .splits import NamedSplit
 from .utils import logging
 from .utils.py_utils import Literal
@@ -137,21 +145,35 @@ def interleave_datasets(
             )
         if i == 0:
             dataset_type, other_type = (
-                (Dataset, IterableDataset) if isinstance(dataset, Dataset) else (IterableDataset, Dataset)
+                (Dataset, IterableDataset)
+                if isinstance(dataset, Dataset)
+                else (IterableDataset, Dataset)
             )
         elif not isinstance(dataset, dataset_type):
             raise ValueError(
                 f"Unable to interleave a {dataset_type.__name__} (at position 0) with a {other_type.__name__} (at position {i}). Expected a list of Dataset objects or a list of IterableDataset objects."
             )
     if stopping_strategy not in ["first_exhausted", "all_exhausted"]:
-        raise ValueError(f"{stopping_strategy} is not supported. Please enter a valid stopping_strategy.")
+        raise ValueError(
+            f"{stopping_strategy} is not supported. Please enter a valid stopping_strategy."
+        )
     if dataset_type is Dataset:
         return _interleave_map_style_datasets(
-            datasets, probabilities, seed, info=info, split=split, stopping_strategy=stopping_strategy
+            datasets,
+            probabilities,
+            seed,
+            info=info,
+            split=split,
+            stopping_strategy=stopping_strategy,
         )
     else:
         return _interleave_iterable_datasets(
-            datasets, probabilities, seed, info=info, split=split, stopping_strategy=stopping_strategy
+            datasets,
+            probabilities,
+            seed,
+            info=info,
+            split=split,
+            stopping_strategy=stopping_strategy,
         )
 
 
@@ -203,7 +225,9 @@ def concatenate_datasets(
             )
         if i == 0:
             dataset_type, other_type = (
-                (Dataset, IterableDataset) if isinstance(dataset, Dataset) else (IterableDataset, Dataset)
+                (Dataset, IterableDataset)
+                if isinstance(dataset, Dataset)
+                else (IterableDataset, Dataset)
             )
         elif not isinstance(dataset, dataset_type):
             raise ValueError(

--- a/src/datasets/commands/datasets_cli.py
+++ b/src/datasets/commands/datasets_cli.py
@@ -8,12 +8,17 @@ from datasets.utils.logging import set_verbosity_info
 
 
 def parse_unknown_args(unknown_args):
-    return {key.lstrip("-"): value for key, value in zip(unknown_args[::2], unknown_args[1::2])}
+    return {
+        key.lstrip("-"): value
+        for key, value in zip(unknown_args[::2], unknown_args[1::2])
+    }
 
 
 def main():
     parser = ArgumentParser(
-        "HuggingFace Datasets CLI tool", usage="datasets-cli <command> [<args>]", allow_abbrev=False
+        "HuggingFace Datasets CLI tool",
+        usage="datasets-cli <command> [<args>]",
+        allow_abbrev=False,
     )
     commands_parser = parser.add_subparsers(help="datasets-cli command helpers")
     set_verbosity_info()

--- a/src/datasets/commands/delete_from_hub.py
+++ b/src/datasets/commands/delete_from_hub.py
@@ -17,9 +17,12 @@ def _command_factory(args):
 class DeleteFromHubCommand(BaseDatasetsCLICommand):
     @staticmethod
     def register_subcommand(parser):
-        parser: ArgumentParser = parser.add_parser("delete_from_hub", help="Delete dataset config from the Hub")
+        parser: ArgumentParser = parser.add_parser(
+            "delete_from_hub", help="Delete dataset config from the Hub"
+        )
         parser.add_argument(
-            "dataset_id", help="source dataset ID, e.g. USERNAME/DATASET_NAME or ORGANIZATION/DATASET_NAME"
+            "dataset_id",
+            help="source dataset ID, e.g. USERNAME/DATASET_NAME or ORGANIZATION/DATASET_NAME",
         )
         parser.add_argument("config_name", help="config name to delete")
         parser.add_argument("--token", help="access token to the Hugging Face Hub")
@@ -39,4 +42,9 @@ class DeleteFromHubCommand(BaseDatasetsCLICommand):
         self._revision = revision
 
     def run(self) -> None:
-        _ = delete_from_hub(self._dataset_id, self._config_name, revision=self._revision, token=self._token)
+        _ = delete_from_hub(
+            self._dataset_id,
+            self._config_name,
+            revision=self._revision,
+            token=self._token,
+        )

--- a/src/datasets/commands/env.py
+++ b/src/datasets/commands/env.py
@@ -17,7 +17,9 @@ def info_command_factory(_):
 class EnvironmentCommand(BaseDatasetsCLICommand):
     @staticmethod
     def register_subcommand(parser: ArgumentParser):
-        download_parser = parser.add_parser("env", help="Print relevant system environment info.")
+        download_parser = parser.add_parser(
+            "env", help="Print relevant system environment info."
+        )
         download_parser.set_defaults(func=info_command_factory)
 
     def run(self):

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -10,11 +10,17 @@ from huggingface_hub import constants
 from packaging import version
 
 
-logger = logging.getLogger(__name__.split(".", 1)[0])  # to avoid circular import from .utils.logging
+logger = logging.getLogger(
+    __name__.split(".", 1)[0]
+)  # to avoid circular import from .utils.logging
 
 # Datasets
-S3_DATASETS_BUCKET_PREFIX = "https://s3.amazonaws.com/datasets.huggingface.co/datasets/datasets"
-CLOUDFRONT_DATASETS_DISTRIB_PREFIX = "https://cdn-datasets.huggingface.co/datasets/datasets"
+S3_DATASETS_BUCKET_PREFIX = (
+    "https://s3.amazonaws.com/datasets.huggingface.co/datasets/datasets"
+)
+CLOUDFRONT_DATASETS_DISTRIB_PREFIX = (
+    "https://cdn-datasets.huggingface.co/datasets/datasets"
+)
 REPO_DATASETS_URL = "https://raw.githubusercontent.com/huggingface/datasets/{revision}/datasets/{path}/{name}"
 
 # Hub
@@ -106,7 +112,9 @@ if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VA
             TF_AVAILABLE = False
     if TF_AVAILABLE:
         if TF_VERSION.major < 2:
-            logger.info(f"TensorFlow found but with version {TF_VERSION}. `datasets` requires version 2 minimum.")
+            logger.info(
+                f"TensorFlow found but with version {TF_VERSION}. `datasets` requires version 2 minimum."
+            )
             TF_AVAILABLE = False
         else:
             logger.info(f"TensorFlow version {TF_VERSION} available.")
@@ -118,7 +126,10 @@ JAX_VERSION = "N/A"
 JAX_AVAILABLE = False
 
 if USE_JAX in ENV_VARS_TRUE_AND_AUTO_VALUES:
-    JAX_AVAILABLE = importlib.util.find_spec("jax") is not None and importlib.util.find_spec("jaxlib") is not None
+    JAX_AVAILABLE = (
+        importlib.util.find_spec("jax") is not None
+        and importlib.util.find_spec("jaxlib") is not None
+    )
     if JAX_AVAILABLE:
         try:
             JAX_VERSION = version.parse(importlib.metadata.version("jax"))
@@ -159,16 +170,25 @@ DEFAULT_HF_MODULES_CACHE = os.path.join(HF_CACHE_HOME, "modules")
 HF_MODULES_CACHE = Path(os.getenv("HF_MODULES_CACHE", DEFAULT_HF_MODULES_CACHE))
 
 DOWNLOADED_DATASETS_DIR = "downloads"
-DEFAULT_DOWNLOADED_DATASETS_PATH = os.path.join(HF_DATASETS_CACHE, DOWNLOADED_DATASETS_DIR)
-DOWNLOADED_DATASETS_PATH = Path(os.getenv("HF_DATASETS_DOWNLOADED_DATASETS_PATH", DEFAULT_DOWNLOADED_DATASETS_PATH))
+DEFAULT_DOWNLOADED_DATASETS_PATH = os.path.join(
+    HF_DATASETS_CACHE, DOWNLOADED_DATASETS_DIR
+)
+DOWNLOADED_DATASETS_PATH = Path(
+    os.getenv("HF_DATASETS_DOWNLOADED_DATASETS_PATH", DEFAULT_DOWNLOADED_DATASETS_PATH)
+)
 
 EXTRACTED_DATASETS_DIR = "extracted"
-DEFAULT_EXTRACTED_DATASETS_PATH = os.path.join(DEFAULT_DOWNLOADED_DATASETS_PATH, EXTRACTED_DATASETS_DIR)
-EXTRACTED_DATASETS_PATH = Path(os.getenv("HF_DATASETS_EXTRACTED_DATASETS_PATH", DEFAULT_EXTRACTED_DATASETS_PATH))
+DEFAULT_EXTRACTED_DATASETS_PATH = os.path.join(
+    DEFAULT_DOWNLOADED_DATASETS_PATH, EXTRACTED_DATASETS_DIR
+)
+EXTRACTED_DATASETS_PATH = Path(
+    os.getenv("HF_DATASETS_EXTRACTED_DATASETS_PATH", DEFAULT_EXTRACTED_DATASETS_PATH)
+)
 
 # Download count for the website
 HF_UPDATE_DOWNLOAD_COUNTS = (
-    os.environ.get("HF_UPDATE_DOWNLOAD_COUNTS", "AUTO").upper() in ENV_VARS_TRUE_AND_AUTO_VALUES
+    os.environ.get("HF_UPDATE_DOWNLOAD_COUNTS", "AUTO").upper()
+    in ENV_VARS_TRUE_AND_AUTO_VALUES
 )
 
 # For downloads and to check remote files metadata
@@ -181,7 +201,11 @@ USE_PARQUET_EXPORT = True
 # https://github.com/apache/arrow/blob/master/docs/source/cpp/arrays.rst#size-limitations-and-recommendations)
 DEFAULT_MAX_BATCH_SIZE = 1000
 
-DEFAULT_CDC_OPTIONS = {"min_chunk_size": 256 * 1024, "max_chunk_size": 1024 * 1024, "norm_level": 0}
+DEFAULT_CDC_OPTIONS = {
+    "min_chunk_size": 256 * 1024,
+    "max_chunk_size": 1024 * 1024,
+    "norm_level": 0,
+}
 
 # Size of the preloaded record batch in `Dataset.__iter__`
 ARROW_READER_BATCH_SIZE_IN_DATASET_ITER = 10
@@ -206,7 +230,11 @@ ARROW_RECORD_BATCH_SIZE_FOR_VIDEO_DATASETS = 10
 
 # Offline mode
 _offline = os.environ.get("HF_DATASETS_OFFLINE")
-HF_HUB_OFFLINE = constants.HF_HUB_OFFLINE if _offline is None else _offline.upper() in ENV_VARS_TRUE_VALUES
+HF_HUB_OFFLINE = (
+    constants.HF_HUB_OFFLINE
+    if _offline is None
+    else _offline.upper() in ENV_VARS_TRUE_VALUES
+)
 HF_DATASETS_OFFLINE = HF_HUB_OFFLINE  # kept for backward-compatibility
 
 # Here, `True` will disable progress bars globally without possibility of enabling it
@@ -214,7 +242,9 @@ HF_DATASETS_OFFLINE = HF_HUB_OFFLINE  # kept for backward-compatibility
 # If environment variable is not set (None), then the user is free to enable/disable
 # them programmatically.
 # TL;DR: env variable has priority over code
-__HF_DATASETS_DISABLE_PROGRESS_BARS = os.environ.get("HF_DATASETS_DISABLE_PROGRESS_BARS")
+__HF_DATASETS_DISABLE_PROGRESS_BARS = os.environ.get(
+    "HF_DATASETS_DISABLE_PROGRESS_BARS"
+)
 HF_DATASETS_DISABLE_PROGRESS_BARS: Optional[bool] = (
     __HF_DATASETS_DISABLE_PROGRESS_BARS.upper() in ENV_VARS_TRUE_VALUES
     if __HF_DATASETS_DISABLE_PROGRESS_BARS is not None
@@ -223,7 +253,9 @@ HF_DATASETS_DISABLE_PROGRESS_BARS: Optional[bool] = (
 
 # In-memory
 DEFAULT_IN_MEMORY_MAX_SIZE = 0  # Disabled
-IN_MEMORY_MAX_SIZE = float(os.environ.get("HF_DATASETS_IN_MEMORY_MAX_SIZE", DEFAULT_IN_MEMORY_MAX_SIZE))
+IN_MEMORY_MAX_SIZE = float(
+    os.environ.get("HF_DATASETS_IN_MEMORY_MAX_SIZE", DEFAULT_IN_MEMORY_MAX_SIZE)
+)
 
 # File names
 DATASET_ARROW_FILENAME = "dataset.arrow"

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -61,7 +61,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
     def _check_values_type(self):
         for dataset in self.values():
             if not isinstance(dataset, Dataset):
-                raise TypeError(f"Values in `DatasetDict` should be of type `Dataset` but got type '{type(dataset)}'")
+                raise TypeError(
+                    f"Values in `DatasetDict` should be of type `Dataset` but got type '{type(dataset)}'"
+                )
 
     def _check_values_features(self):
         items = list(self.items())
@@ -87,9 +89,15 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             return super().__getitem__(k)
         else:
             available_suggested_splits = [
-                split for split in (Split.TRAIN, Split.TEST, Split.VALIDATION) if split in self
+                split
+                for split in (Split.TRAIN, Split.TEST, Split.VALIDATION)
+                if split in self
             ]
-            suggested_split = available_suggested_splits[0] if available_suggested_splits else list(self)[0]
+            suggested_split = (
+                available_suggested_splits[0]
+                if available_suggested_splits
+                else list(self)[0]
+            )
             raise KeyError(
                 f"Invalid key: {k}. Please first select a split. For example: "
                 f"`my_dataset_dictionary['{suggested_split}'][{k}]`. "
@@ -226,7 +234,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         self._check_values_type()
-        return DatasetDict({k: dataset.flatten(max_depth=max_depth) for k, dataset in self.items()})
+        return DatasetDict(
+            {k: dataset.flatten(max_depth=max_depth) for k, dataset in self.items()}
+        )
 
     def unique(self, column: str) -> dict[str, list]:
         """Return a list of the unique elements in a column for each split.
@@ -306,7 +316,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         self._check_values_type()
-        return DatasetDict({k: dataset.cast(features=features) for k, dataset in self.items()})
+        return DatasetDict(
+            {k: dataset.cast(features=features) for k, dataset in self.items()}
+        )
 
     def cast_column(self, column: str, feature) -> "DatasetDict":
         """Cast column to feature for decoding.
@@ -335,7 +347,12 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         self._check_values_type()
-        return DatasetDict({k: dataset.cast_column(column=column, feature=feature) for k, dataset in self.items()})
+        return DatasetDict(
+            {
+                k: dataset.cast_column(column=column, feature=feature)
+                for k, dataset in self.items()
+            }
+        )
 
     def remove_columns(self, column_names: Union[str, list[str]]) -> "DatasetDict":
         """
@@ -377,9 +394,16 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         self._check_values_type()
-        return DatasetDict({k: dataset.remove_columns(column_names=column_names) for k, dataset in self.items()})
+        return DatasetDict(
+            {
+                k: dataset.remove_columns(column_names=column_names)
+                for k, dataset in self.items()
+            }
+        )
 
-    def rename_column(self, original_column_name: str, new_column_name: str) -> "DatasetDict":
+    def rename_column(
+        self, original_column_name: str, new_column_name: str
+    ) -> "DatasetDict":
         """
         Rename a column in the dataset and move the features associated to the original column under the new column name.
         The transformation is applied to all the datasets of the dataset dictionary.
@@ -463,7 +487,12 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         self._check_values_type()
-        return DatasetDict({k: dataset.rename_columns(column_mapping=column_mapping) for k, dataset in self.items()})
+        return DatasetDict(
+            {
+                k: dataset.rename_columns(column_mapping=column_mapping)
+                for k, dataset in self.items()
+            }
+        )
 
     def select_columns(self, column_names: Union[str, list[str]]) -> "DatasetDict":
         """Select one or several column(s) from each split in the dataset and
@@ -499,9 +528,16 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         self._check_values_type()
-        return DatasetDict({k: dataset.select_columns(column_names=column_names) for k, dataset in self.items()})
+        return DatasetDict(
+            {
+                k: dataset.select_columns(column_names=column_names)
+                for k, dataset in self.items()
+            }
+        )
 
-    def class_encode_column(self, column: str, include_nulls: bool = False) -> "DatasetDict":
+    def class_encode_column(
+        self, column: str, include_nulls: bool = False
+    ) -> "DatasetDict":
         """Casts the given column as [`~datasets.features.ClassLabel`] and updates the tables.
 
         Args:
@@ -530,7 +566,12 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         """
         self._check_values_type()
         return DatasetDict(
-            {k: dataset.class_encode_column(column=column, include_nulls=include_nulls) for k, dataset in self.items()}
+            {
+                k: dataset.class_encode_column(
+                    column=column, include_nulls=include_nulls
+                )
+                for k, dataset in self.items()
+            }
         )
 
     @contextlib.contextmanager
@@ -560,7 +601,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         old_format_type = {k: dataset._format_type for k, dataset in self.items()}
         old_format_kwargs = {k: dataset._format_kwargs for k, dataset in self.items()}
         old_format_columns = {k: dataset._format_columns for k, dataset in self.items()}
-        old_output_all_columns = {k: dataset._output_all_columns for k, dataset in self.items()}
+        old_output_all_columns = {
+            k: dataset._output_all_columns for k, dataset in self.items()
+        }
         try:
             self.set_format(type, columns, output_all_columns, **format_kwargs)
             yield
@@ -813,7 +856,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         dataset = copy.deepcopy(self)
-        dataset.set_transform(transform=transform, columns=columns, output_all_columns=output_all_columns)
+        dataset.set_transform(
+            transform=transform, columns=columns, output_all_columns=output_all_columns
+        )
         return dataset
 
     def map(
@@ -1401,9 +1446,15 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         fs: fsspec.AbstractFileSystem
         fs, dataset_dict_path = url_to_fs(dataset_dict_path, **(storage_options or {}))
 
-        dataset_dict_json_path = posixpath.join(dataset_dict_path, config.DATASETDICT_JSON_FILENAME)
-        dataset_state_json_path = posixpath.join(dataset_dict_path, config.DATASET_STATE_JSON_FILENAME)
-        dataset_info_path = posixpath.join(dataset_dict_path, config.DATASET_INFO_FILENAME)
+        dataset_dict_json_path = posixpath.join(
+            dataset_dict_path, config.DATASETDICT_JSON_FILENAME
+        )
+        dataset_state_json_path = posixpath.join(
+            dataset_dict_path, config.DATASET_STATE_JSON_FILENAME
+        )
+        dataset_info_path = posixpath.join(
+            dataset_dict_path, config.DATASET_INFO_FILENAME
+        )
         if not fs.isfile(dataset_dict_json_path):
             if fs.isfile(dataset_info_path) and fs.isfile(dataset_state_json_path):
                 raise FileNotFoundError(
@@ -1418,7 +1469,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
 
         dataset_dict = DatasetDict()
         for k in splits:
-            dataset_dict_split_path = posixpath.join(fs.unstrip_protocol(dataset_dict_path), k)
+            dataset_dict_split_path = posixpath.join(
+                fs.unstrip_protocol(dataset_dict_path), k
+            )
             dataset_dict[k] = Dataset.load_from_disk(
                 dataset_dict_split_path,
                 keep_in_memory=keep_in_memory,
@@ -1605,11 +1658,15 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ).read()
 
     @is_documented_by(Dataset.align_labels_with_mapping)
-    def align_labels_with_mapping(self, label2id: dict, label_column: str) -> "DatasetDict":
+    def align_labels_with_mapping(
+        self, label2id: dict, label_column: str
+    ) -> "DatasetDict":
         self._check_values_type()
         return DatasetDict(
             {
-                k: dataset.align_labels_with_mapping(label2id=label2id, label_column=label_column)
+                k: dataset.align_labels_with_mapping(
+                    label2id=label2id, label_column=label_column
+                )
                 for k, dataset in self.items()
             }
         )
@@ -1736,7 +1793,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
 
         for split in self.keys():
             if not re.match(_split_re, split):
-                raise ValueError(f"Split name should match '{_split_re}' but got '{split}'.")
+                raise ValueError(
+                    f"Split name should match '{_split_re}' but got '{split}'."
+                )
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
 
@@ -1762,13 +1821,17 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             )
 
         if not data_dir:
-            data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
+            data_dir = (
+                config_name if config_name != "default" else "data"
+            )  # for backward compatibility
 
         additions = []
         for split in self.keys():
             logger.info(f"Pushing split {split} to the Hub.")
             # The split=key needs to be removed before merging
-            split_additions, uploaded_size, dataset_nbytes = self[split]._push_parquet_shards_to_hub(
+            split_additions, uploaded_size, dataset_nbytes = self[
+                split
+            ]._push_parquet_shards_to_hub(
                 repo_id,
                 data_dir=data_dir,
                 split=split,
@@ -1783,14 +1846,20 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             additions += split_additions
             total_uploaded_size += uploaded_size
             total_dataset_nbytes += dataset_nbytes
-            info_to_dump.splits[split] = SplitInfo(str(split), num_bytes=dataset_nbytes, num_examples=len(self[split]))
+            info_to_dump.splits[split] = SplitInfo(
+                str(split), num_bytes=dataset_nbytes, num_examples=len(self[split])
+            )
         info_to_dump.download_checksums = None
         info_to_dump.download_size = total_uploaded_size
         info_to_dump.dataset_size = total_dataset_nbytes
         info_to_dump.size_in_bytes = total_uploaded_size + total_dataset_nbytes
 
-        def get_deletions_and_dataset_card() -> tuple[str, list[CommitOperationDelete], str, Optional[str]]:
-            parent_commit = api.repo_info(repo_id, repo_type="dataset", revision=revision).sha
+        def get_deletions_and_dataset_card() -> (
+            tuple[str, list[CommitOperationDelete], str, Optional[str]]
+        ):
+            parent_commit = api.repo_info(
+                repo_id, repo_type="dataset", revision=revision
+            ).sha
 
             # Check if the repo already has a README.md and/or a dataset_infos.json to update them with the new split info (size and pattern)
             # and delete old split shards (if they exist)
@@ -1812,15 +1881,23 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
                 elif repo_file.rfilename == config.DATASETDICT_INFOS_FILENAME:
                     repo_with_dataset_infos = True
                 elif (
-                    repo_file.rfilename.startswith(tuple(f"{data_dir}/{split}-" for split in self.keys()))
+                    repo_file.rfilename.startswith(
+                        tuple(f"{data_dir}/{split}-" for split in self.keys())
+                    )
                     and repo_file.rfilename not in repo_files_to_add
                 ):
-                    deletions.append(CommitOperationDelete(path_in_repo=repo_file.rfilename))
+                    deletions.append(
+                        CommitOperationDelete(path_in_repo=repo_file.rfilename)
+                    )
                 elif fnmatch.fnmatch(
                     repo_file.rfilename,
-                    PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED.replace("{split}", "*"),
+                    PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED.replace(
+                        "{split}", "*"
+                    ),
                 ):
-                    pattern = glob_pattern_to_regex(PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED)
+                    pattern = glob_pattern_to_regex(
+                        PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED
+                    )
                     split_pattern_fields = string_to_dict(repo_file.rfilename, pattern)
                     assert split_pattern_fields is not None
                     repo_split = split_pattern_fields["split"]
@@ -1837,7 +1914,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
                 )
                 dataset_card = DatasetCard.load(Path(dataset_card_path))
                 dataset_card_data = dataset_card.data
-                metadata_configs = MetadataConfigs.from_dataset_card_data(dataset_card_data)
+                metadata_configs = MetadataConfigs.from_dataset_card_data(
+                    dataset_card_data
+                )
             # get the deprecated dataset_infos.json to update them
             elif repo_with_dataset_infos:
                 dataset_card = None
@@ -1850,16 +1929,26 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             # create the metadata configs if it was uploaded with push_to_hub before metadata configs existed
             if not metadata_configs and repo_splits:
                 default_metadata_configs_to_dump = {
-                    "data_files": [{"split": split, "path": f"data/{split}-*"} for split in repo_splits]
+                    "data_files": [
+                        {"split": split, "path": f"data/{split}-*"}
+                        for split in repo_splits
+                    ]
                 }
-                MetadataConfigs({"default": default_metadata_configs_to_dump}).to_dataset_card_data(dataset_card_data)
+                MetadataConfigs(
+                    {"default": default_metadata_configs_to_dump}
+                ).to_dataset_card_data(dataset_card_data)
             metadata_config_to_dump = {
-                "data_files": [{"split": split, "path": f"{data_dir}/{split}-*"} for split in self.keys()],
+                "data_files": [
+                    {"split": split, "path": f"{data_dir}/{split}-*"}
+                    for split in self.keys()
+                ],
             }
             configs_to_dump = {config_name: metadata_config_to_dump}
             if set_default and config_name != "default":
                 if metadata_configs:
-                    current_default_config_name = metadata_configs.get_default_config_name()
+                    current_default_config_name = (
+                        metadata_configs.get_default_config_name()
+                    )
                     if current_default_config_name == "default":
                         raise ValueError(
                             "There exists a configuration named 'default'. To set a different configuration as default, "
@@ -1867,7 +1956,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
                         )
                     if current_default_config_name:
                         _ = metadata_configs[current_default_config_name].pop("default")
-                        configs_to_dump[current_default_config_name] = metadata_configs[current_default_config_name]
+                        configs_to_dump[current_default_config_name] = metadata_configs[
+                            current_default_config_name
+                        ]
                 metadata_config_to_dump["default"] = True
             # push to the deprecated dataset_infos.json
             if repo_with_dataset_infos:
@@ -1884,31 +1975,44 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             else:
                 new_dataset_infos = None
             # push to README
-            DatasetInfosDict({config_name: info_to_dump}).to_dataset_card_data(dataset_card_data)
+            DatasetInfosDict({config_name: info_to_dump}).to_dataset_card_data(
+                dataset_card_data
+            )
             MetadataConfigs(configs_to_dump).to_dataset_card_data(dataset_card_data)
             new_dataset_card = (
-                DatasetCard(f"---\n{dataset_card_data}\n---\n") if dataset_card is None else dataset_card
+                DatasetCard(f"---\n{dataset_card_data}\n---\n")
+                if dataset_card is None
+                else dataset_card
             )
             return parent_commit, deletions, new_dataset_card, new_dataset_infos
 
-        commit_message = commit_message if commit_message is not None else "Upload dataset"
+        commit_message = (
+            commit_message if commit_message is not None else "Upload dataset"
+        )
         if len(additions) > config.UPLOADS_MAX_NUMBER_PER_COMMIT:
             logger.info(
                 f"Number of files to upload is larger than {config.UPLOADS_MAX_NUMBER_PER_COMMIT}. Splitting the push into multiple commits."
             )
-            num_commits = math.ceil(len(additions) / config.UPLOADS_MAX_NUMBER_PER_COMMIT)
+            num_commits = math.ceil(
+                len(additions) / config.UPLOADS_MAX_NUMBER_PER_COMMIT
+            )
             for i in range(0, num_commits):
                 operations = additions[
-                    i * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1) * config.UPLOADS_MAX_NUMBER_PER_COMMIT
+                    i
+                    * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1)
+                    * config.UPLOADS_MAX_NUMBER_PER_COMMIT
                 ]
-                for retry, sleep_time in enumerate(itertools.chain(range(10), itertools.repeat(30)), start=1):
+                for retry, sleep_time in enumerate(
+                    itertools.chain(range(10), itertools.repeat(30)), start=1
+                ):
                     # We need to retry if another commit happens at the same time
                     sleep_time *= 1 + random.random()
                     try:
                         commit_info = api.create_commit(
                             repo_id,
                             operations=operations,
-                            commit_message=commit_message + f" (part {i:05d}-of-{num_commits:05d})",
+                            commit_message=commit_message
+                            + f" (part {i:05d}-of-{num_commits:05d})",
                             commit_description=commit_description,
                             repo_type="dataset",
                             revision=revision,
@@ -1931,17 +2035,25 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
                     break
                 logger.info(
                     f"Commit #{i + 1} completed"
-                    + (f" (still {num_commits - i - 1} to go)" if num_commits - i - 1 else "")
+                    + (
+                        f" (still {num_commits - i - 1} to go)"
+                        if num_commits - i - 1
+                        else ""
+                    )
                     + "."
                 )
             last_commit_additions = []
         else:
             last_commit_additions = additions
 
-        for retry, sleep_time in enumerate(itertools.chain(range(10), itertools.repeat(30)), start=1):
+        for retry, sleep_time in enumerate(
+            itertools.chain(range(10), itertools.repeat(30)), start=1
+        ):
             # We need to retry if there was a commit in between in case it touched the dataset card data
             sleep_time *= 1 + random.random()
-            parent_commit, deletions, dataset_card, dataset_infos = get_deletions_and_dataset_card()
+            parent_commit, deletions, dataset_card, dataset_infos = (
+                get_deletions_and_dataset_card()
+            )
             dataset_card_additions = []
             if dataset_infos:
                 dataset_card_additions.append(
@@ -1951,12 +2063,17 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
                     )
                 )
             dataset_card_additions.append(
-                CommitOperationAdd(path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode())
+                CommitOperationAdd(
+                    path_in_repo=config.REPOCARD_FILENAME,
+                    path_or_fileobj=str(dataset_card).encode(),
+                )
             )
             try:
                 commit_info = api.create_commit(
                     repo_id,
-                    operations=last_commit_additions + dataset_card_additions + deletions,
+                    operations=last_commit_additions
+                    + dataset_card_additions
+                    + deletions,
                     commit_message=commit_message,
                     commit_description=commit_description,
                     repo_type="dataset",
@@ -1988,7 +2105,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
     def _check_values_type(self):
         for dataset in self.values():
             if not isinstance(dataset, IterableDataset):
-                raise TypeError(f"Values in `DatasetDict` should be of type `Dataset` but got type '{type(dataset)}'")
+                raise TypeError(
+                    f"Values in `DatasetDict` should be of type `Dataset` but got type '{type(dataset)}'"
+                )
 
     def _check_values_features(self):
         items = [(key, dataset._resolve_features()) for key, dataset in self.items()]
@@ -2083,7 +2202,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])}
         ```
         """
-        return IterableDatasetDict({k: dataset.with_format(type=type) for k, dataset in self.items()})
+        return IterableDatasetDict(
+            {k: dataset.with_format(type=type) for k, dataset in self.items()}
+        )
 
     def map(
         self,
@@ -2304,12 +2425,16 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         """
         return IterableDatasetDict(
             {
-                k: dataset.shuffle(seed=seed, generator=generator, buffer_size=buffer_size)
+                k: dataset.shuffle(
+                    seed=seed, generator=generator, buffer_size=buffer_size
+                )
                 for k, dataset in self.items()
             }
         )
 
-    def rename_column(self, original_column_name: str, new_column_name: str) -> "IterableDatasetDict":
+    def rename_column(
+        self, original_column_name: str, new_column_name: str
+    ) -> "IterableDatasetDict":
         """
         Rename a column in the dataset, and move the features associated to the original column under the new column
         name.
@@ -2370,10 +2495,15 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         ```
         """
         return IterableDatasetDict(
-            {k: dataset.rename_columns(column_mapping=column_mapping) for k, dataset in self.items()}
+            {
+                k: dataset.rename_columns(column_mapping=column_mapping)
+                for k, dataset in self.items()
+            }
         )
 
-    def remove_columns(self, column_names: Union[str, list[str]]) -> "IterableDatasetDict":
+    def remove_columns(
+        self, column_names: Union[str, list[str]]
+    ) -> "IterableDatasetDict":
         """
         Remove one or several column(s) in the dataset and the features associated to them.
         The removal is done on-the-fly on the examples when iterating over the dataset.
@@ -2397,9 +2527,13 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
-        return IterableDatasetDict({k: dataset.remove_columns(column_names) for k, dataset in self.items()})
+        return IterableDatasetDict(
+            {k: dataset.remove_columns(column_names) for k, dataset in self.items()}
+        )
 
-    def select_columns(self, column_names: Union[str, list[str]]) -> "IterableDatasetDict":
+    def select_columns(
+        self, column_names: Union[str, list[str]]
+    ) -> "IterableDatasetDict":
         """Select one or several column(s) in the dataset and the features
         associated to them. The selection is done on-the-fly on the examples
         when iterating over the dataset. The selection is applied to all the
@@ -2423,7 +2557,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
-        return IterableDatasetDict({k: dataset.select_columns(column_names) for k, dataset in self.items()})
+        return IterableDatasetDict(
+            {k: dataset.select_columns(column_names) for k, dataset in self.items()}
+        )
 
     def cast_column(self, column: str, feature: FeatureType) -> "IterableDatasetDict":
         """Cast column to feature for decoding.
@@ -2453,7 +2589,10 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         ```
         """
         return IterableDatasetDict(
-            {k: dataset.cast_column(column=column, feature=feature) for k, dataset in self.items()}
+            {
+                k: dataset.cast_column(column=column, feature=feature)
+                for k, dataset in self.items()
+            }
         )
 
     def cast(
@@ -2491,7 +2630,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
          'text': Value('large_string')}
         ```
         """
-        return IterableDatasetDict({k: dataset.cast(features=features) for k, dataset in self.items()})
+        return IterableDatasetDict(
+            {k: dataset.cast(features=features) for k, dataset in self.items()}
+        )
 
     def push_to_hub(
         self,
@@ -2605,7 +2746,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
 
         for split in self.keys():
             if not re.match(_split_re, split):
-                raise ValueError(f"Split name should match '{_split_re}' but got '{split}'.")
+                raise ValueError(
+                    f"Split name should match '{_split_re}' but got '{split}'."
+                )
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
 
@@ -2631,13 +2774,17 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
             )
 
         if not data_dir:
-            data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
+            data_dir = (
+                config_name if config_name != "default" else "data"
+            )  # for backward compatibility
 
         additions = []
         for split in self.keys():
             logger.info(f"Pushing split {split} to the Hub.")
             # The split=key needs to be removed before merging
-            split_additions, uploaded_size, dataset_nbytes, num_examples = self[split]._push_parquet_shards_to_hub(
+            split_additions, uploaded_size, dataset_nbytes, num_examples = self[
+                split
+            ]._push_parquet_shards_to_hub(
                 repo_id,
                 data_dir=data_dir,
                 split=split,
@@ -2652,14 +2799,20 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
             additions += split_additions
             total_uploaded_size += uploaded_size
             total_dataset_nbytes += dataset_nbytes
-            info_to_dump.splits[split] = SplitInfo(str(split), num_bytes=dataset_nbytes, num_examples=num_examples)
+            info_to_dump.splits[split] = SplitInfo(
+                str(split), num_bytes=dataset_nbytes, num_examples=num_examples
+            )
         info_to_dump.download_checksums = None
         info_to_dump.download_size = total_uploaded_size
         info_to_dump.dataset_size = total_dataset_nbytes
         info_to_dump.size_in_bytes = total_uploaded_size + total_dataset_nbytes
 
-        def get_deletions_and_dataset_card() -> tuple[str, list[CommitOperationDelete], str, Optional[str]]:
-            parent_commit = api.repo_info(repo_id, repo_type="dataset", revision=revision).sha
+        def get_deletions_and_dataset_card() -> (
+            tuple[str, list[CommitOperationDelete], str, Optional[str]]
+        ):
+            parent_commit = api.repo_info(
+                repo_id, repo_type="dataset", revision=revision
+            ).sha
 
             # Check if the repo already has a README.md and/or a dataset_infos.json to update them with the new split info (size and pattern)
             # and delete old split shards (if they exist)
@@ -2681,15 +2834,23 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                 elif repo_file.rfilename == config.DATASETDICT_INFOS_FILENAME:
                     repo_with_dataset_infos = True
                 elif (
-                    repo_file.rfilename.startswith(tuple(f"{data_dir}/{split}-" for split in self.keys()))
+                    repo_file.rfilename.startswith(
+                        tuple(f"{data_dir}/{split}-" for split in self.keys())
+                    )
                     and repo_file.rfilename not in repo_files_to_add
                 ):
-                    deletions.append(CommitOperationDelete(path_in_repo=repo_file.rfilename))
+                    deletions.append(
+                        CommitOperationDelete(path_in_repo=repo_file.rfilename)
+                    )
                 elif fnmatch.fnmatch(
                     repo_file.rfilename,
-                    PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED.replace("{split}", "*"),
+                    PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED.replace(
+                        "{split}", "*"
+                    ),
                 ):
-                    pattern = glob_pattern_to_regex(PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED)
+                    pattern = glob_pattern_to_regex(
+                        PUSH_TO_HUB_WITHOUT_METADATA_CONFIGS_SPLIT_PATTERN_SHARDED
+                    )
                     split_pattern_fields = string_to_dict(repo_file.rfilename, pattern)
                     assert split_pattern_fields is not None
                     repo_split = split_pattern_fields["split"]
@@ -2706,7 +2867,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                 )
                 dataset_card = DatasetCard.load(Path(dataset_card_path))
                 dataset_card_data = dataset_card.data
-                metadata_configs = MetadataConfigs.from_dataset_card_data(dataset_card_data)
+                metadata_configs = MetadataConfigs.from_dataset_card_data(
+                    dataset_card_data
+                )
             # get the deprecated dataset_infos.json to update them
             elif repo_with_dataset_infos:
                 dataset_card = None
@@ -2719,16 +2882,26 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
             # create the metadata configs if it was uploaded with push_to_hub before metadata configs existed
             if not metadata_configs and repo_splits:
                 default_metadata_configs_to_dump = {
-                    "data_files": [{"split": split, "path": f"data/{split}-*"} for split in repo_splits]
+                    "data_files": [
+                        {"split": split, "path": f"data/{split}-*"}
+                        for split in repo_splits
+                    ]
                 }
-                MetadataConfigs({"default": default_metadata_configs_to_dump}).to_dataset_card_data(dataset_card_data)
+                MetadataConfigs(
+                    {"default": default_metadata_configs_to_dump}
+                ).to_dataset_card_data(dataset_card_data)
             metadata_config_to_dump = {
-                "data_files": [{"split": split, "path": f"{data_dir}/{split}-*"} for split in self.keys()],
+                "data_files": [
+                    {"split": split, "path": f"{data_dir}/{split}-*"}
+                    for split in self.keys()
+                ],
             }
             configs_to_dump = {config_name: metadata_config_to_dump}
             if set_default and config_name != "default":
                 if metadata_configs:
-                    current_default_config_name = metadata_configs.get_default_config_name()
+                    current_default_config_name = (
+                        metadata_configs.get_default_config_name()
+                    )
                     if current_default_config_name == "default":
                         raise ValueError(
                             "There exists a configuration named 'default'. To set a different configuration as default, "
@@ -2736,7 +2909,9 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                         )
                     if current_default_config_name:
                         _ = metadata_configs[current_default_config_name].pop("default")
-                        configs_to_dump[current_default_config_name] = metadata_configs[current_default_config_name]
+                        configs_to_dump[current_default_config_name] = metadata_configs[
+                            current_default_config_name
+                        ]
                 metadata_config_to_dump["default"] = True
             # push to the deprecated dataset_infos.json
             if repo_with_dataset_infos:
@@ -2753,31 +2928,44 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
             else:
                 new_dataset_infos = None
             # push to README
-            DatasetInfosDict({config_name: info_to_dump}).to_dataset_card_data(dataset_card_data)
+            DatasetInfosDict({config_name: info_to_dump}).to_dataset_card_data(
+                dataset_card_data
+            )
             MetadataConfigs(configs_to_dump).to_dataset_card_data(dataset_card_data)
             new_dataset_card = (
-                DatasetCard(f"---\n{dataset_card_data}\n---\n") if dataset_card is None else dataset_card
+                DatasetCard(f"---\n{dataset_card_data}\n---\n")
+                if dataset_card is None
+                else dataset_card
             )
             return parent_commit, deletions, new_dataset_card, new_dataset_infos
 
-        commit_message = commit_message if commit_message is not None else "Upload dataset"
+        commit_message = (
+            commit_message if commit_message is not None else "Upload dataset"
+        )
         if len(additions) > config.UPLOADS_MAX_NUMBER_PER_COMMIT:
             logger.info(
                 f"Number of files to upload is larger than {config.UPLOADS_MAX_NUMBER_PER_COMMIT}. Splitting the push into multiple commits."
             )
-            num_commits = math.ceil(len(additions) / config.UPLOADS_MAX_NUMBER_PER_COMMIT)
+            num_commits = math.ceil(
+                len(additions) / config.UPLOADS_MAX_NUMBER_PER_COMMIT
+            )
             for i in range(0, num_commits):
                 operations = additions[
-                    i * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1) * config.UPLOADS_MAX_NUMBER_PER_COMMIT
+                    i
+                    * config.UPLOADS_MAX_NUMBER_PER_COMMIT : (i + 1)
+                    * config.UPLOADS_MAX_NUMBER_PER_COMMIT
                 ]
-                for retry, sleep_time in enumerate(itertools.chain(range(10), itertools.repeat(30)), start=1):
+                for retry, sleep_time in enumerate(
+                    itertools.chain(range(10), itertools.repeat(30)), start=1
+                ):
                     # We need to retry if another commit happens at the same time
                     sleep_time *= 1 + random.random()
                     try:
                         commit_info = api.create_commit(
                             repo_id,
                             operations=operations,
-                            commit_message=commit_message + f" (part {i:05d}-of-{num_commits:05d})",
+                            commit_message=commit_message
+                            + f" (part {i:05d}-of-{num_commits:05d})",
                             commit_description=commit_description,
                             repo_type="dataset",
                             revision=revision,
@@ -2800,17 +2988,25 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                     break
                 logger.info(
                     f"Commit #{i + 1} completed"
-                    + (f" (still {num_commits - i - 1} to go)" if num_commits - i - 1 else "")
+                    + (
+                        f" (still {num_commits - i - 1} to go)"
+                        if num_commits - i - 1
+                        else ""
+                    )
                     + "."
                 )
             last_commit_additions = []
         else:
             last_commit_additions = additions
 
-        for retry, sleep_time in enumerate(itertools.chain(range(10), itertools.repeat(30)), start=1):
+        for retry, sleep_time in enumerate(
+            itertools.chain(range(10), itertools.repeat(30)), start=1
+        ):
             # We need to retry if there was a commit in between in case it touched the dataset card data
             sleep_time *= 1 + random.random()
-            parent_commit, deletions, dataset_card, dataset_infos = get_deletions_and_dataset_card()
+            parent_commit, deletions, dataset_card, dataset_infos = (
+                get_deletions_and_dataset_card()
+            )
             dataset_card_additions = []
             if dataset_infos:
                 dataset_card_additions.append(
@@ -2820,12 +3016,17 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                     )
                 )
             dataset_card_additions.append(
-                CommitOperationAdd(path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode())
+                CommitOperationAdd(
+                    path_in_repo=config.REPOCARD_FILENAME,
+                    path_or_fileobj=str(dataset_card).encode(),
+                )
             )
             try:
                 commit_info = api.create_commit(
                     repo_id,
-                    operations=last_commit_additions + dataset_card_additions + deletions,
+                    operations=last_commit_additions
+                    + dataset_card_additions
+                    + deletions,
                     commit_message=commit_message,
                     commit_description=commit_description,
                     repo_type="dataset",

--- a/src/datasets/distributed.py
+++ b/src/datasets/distributed.py
@@ -7,7 +7,9 @@ from .iterable_dataset import IterableDataset, _split_by_node_iterable_dataset
 DatasetType = TypeVar("DatasetType", Dataset, IterableDataset)
 
 
-def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> DatasetType:
+def split_dataset_by_node(
+    dataset: DatasetType, rank: int, world_size: int
+) -> DatasetType:
     """
     Split a dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
@@ -34,6 +36,10 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
         [`Dataset`] or [`IterableDataset`]: The dataset to be used on the node at rank `rank`.
     """
     if isinstance(dataset, Dataset):
-        return _split_by_node_map_style_dataset(dataset, rank=rank, world_size=world_size)
+        return _split_by_node_map_style_dataset(
+            dataset, rank=rank, world_size=world_size
+        )
     else:
-        return _split_by_node_iterable_dataset(dataset, rank=rank, world_size=world_size)
+        return _split_by_node_iterable_dataset(
+            dataset, rank=rank, world_size=world_size
+        )

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -75,7 +75,10 @@ class DownloadConfig:
     def __setattr__(self, name, value):
         if name == "token" and getattr(self, "storage_options", None) is not None:
             if "hf" not in self.storage_options:
-                self.storage_options["hf"] = {"token": value, "endpoint": config.HF_ENDPOINT}
+                self.storage_options["hf"] = {
+                    "token": value,
+                    "endpoint": config.HF_ENDPOINT,
+                }
             elif getattr(self.storage_options["hf"], "token", None) is None:
                 self.storage_options["hf"]["token"] = value
         super().__setattr__(name, value)

--- a/src/datasets/download/download_manager.py
+++ b/src/datasets/download/download_manager.py
@@ -100,7 +100,9 @@ class DownloadManager:
         self._data_dir = data_dir
         self._base_path = base_path or os.path.abspath(".")
         # To record what is being used: {url: {num_bytes: int, checksum: str}}
-        self._recorded_sizes_checksums: dict[str, dict[str, Optional[Union[int, str]]]] = {}
+        self._recorded_sizes_checksums: dict[
+            str, dict[str, Optional[Union[int, str]]]
+        ] = {}
         self.record_checksums = record_checksums
         self.download_config = download_config or DownloadConfig()
         self.downloaded_paths = {}
@@ -113,9 +115,16 @@ class DownloadManager:
     @property
     def downloaded_size(self):
         """Returns the total size of downloaded files."""
-        return sum(checksums_dict["num_bytes"] for checksums_dict in self._recorded_sizes_checksums.values())
+        return sum(
+            checksums_dict["num_bytes"]
+            for checksums_dict in self._recorded_sizes_checksums.values()
+        )
 
-    def _record_sizes_checksums(self, url_or_urls: NestedDataStructure, downloaded_path_or_paths: NestedDataStructure):
+    def _record_sizes_checksums(
+        self,
+        url_or_urls: NestedDataStructure,
+        downloaded_path_or_paths: NestedDataStructure,
+    ):
         """Record size/checksum of downloaded files."""
         delay = 5
         for url, path in hf_tqdm(
@@ -169,7 +178,9 @@ class DownloadManager:
         logger.info(f"Downloading took {duration.total_seconds() // 60} min")
         url_or_urls = NestedDataStructure(url_or_urls)
         downloaded_path_or_paths = NestedDataStructure(downloaded_path_or_paths)
-        self.downloaded_paths.update(dict(zip(url_or_urls.flatten(), downloaded_path_or_paths.flatten())))
+        self.downloaded_paths.update(
+            dict(zip(url_or_urls.flatten(), downloaded_path_or_paths.flatten()))
+        )
 
         start_time = datetime.now()
         self._record_sizes_checksums(url_or_urls, downloaded_path_or_paths)
@@ -186,7 +197,9 @@ class DownloadManager:
         if len(url_or_filenames) >= 16:
             download_config = download_config.copy()
             download_config.disable_tqdm = True
-            download_func = partial(self._download_single, download_config=download_config)
+            download_func = partial(
+                self._download_single, download_config=download_config
+            )
 
             fs: fsspec.AbstractFileSystem
             path = str(url_or_filenames[0])
@@ -200,7 +213,9 @@ class DownloadManager:
             except Exception:
                 pass
             max_workers = (
-                config.HF_DATASETS_MULTITHREADING_MAX_WORKERS if size < (20 << 20) else 1
+                config.HF_DATASETS_MULTITHREADING_MAX_WORKERS
+                if size < (20 << 20)
+                else 1
             )  # enable multithreading if files are small
 
             return thread_map(
@@ -208,10 +223,17 @@ class DownloadManager:
                 url_or_filenames,
                 desc=download_config.download_desc or "Downloading",
                 unit="files",
-                position=multiprocessing.current_process()._identity[-1]  # contains the ranks of subprocesses
-                if os.environ.get("HF_DATASETS_STACK_MULTIPROCESSING_DOWNLOAD_PROGRESS_BARS") == "1"
-                and multiprocessing.current_process()._identity
-                else None,
+                position=(
+                    multiprocessing.current_process()._identity[
+                        -1
+                    ]  # contains the ranks of subprocesses
+                    if os.environ.get(
+                        "HF_DATASETS_STACK_MULTIPROCESSING_DOWNLOAD_PROGRESS_BARS"
+                    )
+                    == "1"
+                    and multiprocessing.current_process()._identity
+                    else None
+                ),
                 max_workers=max_workers,
                 tqdm_class=tqdm,
             )
@@ -221,7 +243,9 @@ class DownloadManager:
                 for url_or_filename in url_or_filenames
             ]
 
-    def _download_single(self, url_or_filename: str, download_config: DownloadConfig) -> str:
+    def _download_single(
+        self, url_or_filename: str, download_config: DownloadConfig
+    ) -> str:
         url_or_filename = str(url_or_filename)
         if is_relative_path(url_or_filename):
             # append the relative path to the base_path
@@ -304,7 +328,9 @@ class DownloadManager:
         )
         path_or_paths = NestedDataStructure(path_or_paths)
         extracted_paths = NestedDataStructure(extracted_paths)
-        self.extracted_paths.update(dict(zip(path_or_paths.flatten(), extracted_paths.flatten())))
+        self.extracted_paths.update(
+            dict(zip(path_or_paths.flatten(), extracted_paths.flatten()))
+        )
         return extracted_paths.data
 
     def download_and_extract(self, url_or_urls):
@@ -329,7 +355,9 @@ class DownloadManager:
         return self._recorded_sizes_checksums.copy()
 
     def delete_extracted_files(self):
-        paths_to_delete = set(self.extracted_paths.values()) - set(self.downloaded_paths.values())
+        paths_to_delete = set(self.extracted_paths.values()) - set(
+            self.downloaded_paths.values()
+        )
         for key, path in list(self.extracted_paths.items()):
             if path in paths_to_delete and os.path.isfile(path):
                 os.remove(path)

--- a/src/datasets/download/streaming_download_manager.py
+++ b/src/datasets/download/streaming_download_manager.py
@@ -123,11 +123,15 @@ class StreamingDownloadManager:
 
     def _extract(self, urlpath: str) -> str:
         urlpath = str(urlpath)
-        protocol = _get_extraction_protocol(urlpath, download_config=self.download_config)
+        protocol = _get_extraction_protocol(
+            urlpath, download_config=self.download_config
+        )
         # get inner file: zip://train-00000.json.gz::https://foo.bar/data.zip -> zip://train-00000.json.gz
         path = urlpath.split("::")[0]
         extension = _get_path_extension(path)
-        if extension in ["tgz", "tar"] or path.endswith((".tar.gz", ".tar.bz2", ".tar.xz")):
+        if extension in ["tgz", "tar"] or path.endswith(
+            (".tar.gz", ".tar.bz2", ".tar.xz")
+        ):
             raise NotImplementedError(
                 f"Extraction protocol for TAR archives like '{urlpath}' is not implemented in streaming mode. "
                 f"Please use `dl_manager.iter_archive` instead.\n\n"
@@ -143,7 +147,11 @@ class StreamingDownloadManager:
         elif protocol in SINGLE_FILE_COMPRESSION_PROTOCOLS:
             # there is one single file which is the uncompressed file
             inner_file = os.path.basename(urlpath.split("::")[0])
-            inner_file = inner_file[: inner_file.rindex(".")] if "." in inner_file else inner_file
+            inner_file = (
+                inner_file[: inner_file.rindex(".")]
+                if "." in inner_file
+                else inner_file
+            )
             return f"{protocol}://{inner_file}::{urlpath}"
         else:
             return f"{protocol}://::{urlpath}"
@@ -168,7 +176,9 @@ class StreamingDownloadManager:
         """
         return self.extract(self.download(url_or_urls))
 
-    def iter_archive(self, urlpath_or_buf: Union[str, io.BufferedReader]) -> Iterable[tuple]:
+    def iter_archive(
+        self, urlpath_or_buf: Union[str, io.BufferedReader]
+    ) -> Iterable[tuple]:
         """Iterate over files within an archive.
 
         Args:
@@ -191,7 +201,9 @@ class StreamingDownloadManager:
         if hasattr(urlpath_or_buf, "read"):
             return ArchiveIterable.from_buf(urlpath_or_buf)
         else:
-            return ArchiveIterable.from_urlpath(urlpath_or_buf, download_config=self.download_config)
+            return ArchiveIterable.from_urlpath(
+                urlpath_or_buf, download_config=self.download_config
+            )
 
     def iter_files(self, urlpaths: Union[str, list[str]]) -> Iterable[str]:
         """Iterate over files.
@@ -210,7 +222,9 @@ class StreamingDownloadManager:
         >>> files = dl_manager.iter_files(files)
         ```
         """
-        return FilesIterable.from_urlpaths(urlpaths, download_config=self.download_config)
+        return FilesIterable.from_urlpaths(
+            urlpaths, download_config=self.download_config
+        )
 
     def manage_extracted_files(self):
         pass

--- a/src/datasets/exceptions.py
+++ b/src/datasets/exceptions.py
@@ -59,21 +59,24 @@ class DatasetGenerationCastError(DatasetGenerationError):
         gen_kwargs: dict[str, Any],
         token: Optional[Union[bool, str]],
     ) -> "DatasetGenerationCastError":
-        explanation_message = (
-            f"\n\nAll the data files must have the same columns, but at some point {cast_error.details()}"
-        )
+        explanation_message = f"\n\nAll the data files must have the same columns, but at some point {cast_error.details()}"
         formatted_tracked_gen_kwargs: list[str] = []
         for gen_kwarg in gen_kwargs.values():
-            if not isinstance(gen_kwarg, (tracked_str, tracked_list, TrackedIterableFromGenerator)):
+            if not isinstance(
+                gen_kwarg, (tracked_str, tracked_list, TrackedIterableFromGenerator)
+            ):
                 continue
             while (
-                isinstance(gen_kwarg, (tracked_list, TrackedIterableFromGenerator)) and gen_kwarg.last_item is not None
+                isinstance(gen_kwarg, (tracked_list, TrackedIterableFromGenerator))
+                and gen_kwarg.last_item is not None
             ):
                 gen_kwarg = gen_kwarg.last_item
             if isinstance(gen_kwarg, tracked_str):
                 gen_kwarg = gen_kwarg.get_origin()
             if isinstance(gen_kwarg, str) and gen_kwarg.startswith("hf://"):
-                resolved_path = HfFileSystem(endpoint=config.HF_ENDPOINT, token=token).resolve_path(gen_kwarg)
+                resolved_path = HfFileSystem(
+                    endpoint=config.HF_ENDPOINT, token=token
+                ).resolve_path(gen_kwarg)
                 gen_kwarg = "hf://" + resolved_path.unresolve()
                 if "@" + resolved_path.revision in gen_kwarg:
                     gen_kwarg = (
@@ -84,7 +87,11 @@ class DatasetGenerationCastError(DatasetGenerationError):
         if formatted_tracked_gen_kwargs:
             explanation_message += f"\n\nThis happened while the {builder_name} dataset builder was generating data using\n\n{', '.join(formatted_tracked_gen_kwargs)}"
         help_message = "\n\nPlease either edit the data files to have matching columns, or separate them into different configurations (see docs at https://hf.co/docs/hub/datasets-manual-configuration#multiple-configurations)"
-        return cls("An error occurred while generating the dataset" + explanation_message + help_message)
+        return cls(
+            "An error occurred while generating the dataset"
+            + explanation_message
+            + help_message
+        )
 
 
 class ChecksumVerificationError(DatasetsError):

--- a/src/datasets/features/__init__.py
+++ b/src/datasets/features/__init__.py
@@ -17,7 +17,18 @@ __all__ = [
     "Pdf",
 ]
 from .audio import Audio
-from .features import Array2D, Array3D, Array4D, Array5D, ClassLabel, Features, LargeList, List, Sequence, Value
+from .features import (
+    Array2D,
+    Array3D,
+    Array4D,
+    Array5D,
+    ClassLabel,
+    Features,
+    LargeList,
+    List,
+    Sequence,
+    Value,
+)
 from .image import Image
 from .pdf import Pdf
 from .translation import Translation, TranslationVariableLanguages

--- a/src/datasets/features/_torchcodec.py
+++ b/src/datasets/features/_torchcodec.py
@@ -12,4 +12,6 @@ class AudioDecoder(_AudioDecoder):
         elif hasattr(super(), "__getitem__"):
             return super().__getitem__(key)
         else:
-            raise TypeError("'torchcodec.decoders.AudioDecoder' object is not subscriptable")
+            raise TypeError(
+                "'torchcodec.decoders.AudioDecoder' object is not subscriptable"
+            )

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -115,7 +115,9 @@ def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
     elif pyarrow.types.is_dictionary(arrow_type):
         return _arrow_to_datasets_dtype(arrow_type.value_type)
     else:
-        raise ValueError(f"Arrow type {arrow_type} does not have a datasets dtype equivalent.")
+        raise ValueError(
+            f"Arrow type {arrow_type} does not have a datasets dtype equivalent."
+        )
 
 
 def string_to_arrow(datasets_dtype: str) -> pa.DataType:
@@ -136,10 +138,16 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     def _dtype_error_msg(dtype, pa_dtype, examples=None, urls=None):
         msg = f"{dtype} is not a validly formatted string representation of the pyarrow {pa_dtype} type."
         if examples:
-            examples = ", ".join(examples[:-1]) + " or " + examples[-1] if len(examples) > 1 else examples[0]
+            examples = (
+                ", ".join(examples[:-1]) + " or " + examples[-1]
+                if len(examples) > 1
+                else examples[0]
+            )
             msg += f"\nValid examples include: {examples}."
         if urls:
-            urls = ", ".join(urls[:-1]) + " and " + urls[-1] if len(urls) > 1 else urls[0]
+            urls = (
+                ", ".join(urls[:-1]) + " and " + urls[-1] if len(urls) > 1 else urls[0]
+            )
             msg += f"\nFor more insformation, see: {urls}."
         return msg
 
@@ -152,7 +160,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     timestamp_matches = re.search(r"^timestamp\[(.*)\]$", datasets_dtype)
     if timestamp_matches:
         timestamp_internals = timestamp_matches.group(1)
-        internals_matches = re.search(r"^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+\-:]*)$", timestamp_internals)
+        internals_matches = re.search(
+            r"^(s|ms|us|ns),\s*tz=([a-zA-Z0-9/_+\-:]*)$", timestamp_internals
+        )
         if timestamp_internals in ["s", "ms", "us", "ns"]:
             return pa.timestamp(timestamp_internals)
         elif internals_matches:
@@ -163,7 +173,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                     datasets_dtype,
                     "timestamp",
                     examples=["timestamp[us]", "timestamp[us, tz=America/New_York"],
-                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html"],
+                    urls=[
+                        "https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html"
+                    ],
                 )
             )
 
@@ -178,7 +190,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                     datasets_dtype,
                     "duration",
                     examples=["duration[s]", "duration[us]"],
-                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.duration.html"],
+                    urls=[
+                        "https://arrow.apache.org/docs/python/generated/pyarrow.duration.html"
+                    ],
                 )
             )
 
@@ -218,7 +232,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     if decimal_matches:
         decimal_internals_bits = decimal_matches.group(1)
         if decimal_internals_bits == "128":
-            decimal_internals_precision_and_scale = re.search(r"^(\d+),\s*(-?\d+)$", decimal_matches.group(2))
+            decimal_internals_precision_and_scale = re.search(
+                r"^(\d+),\s*(-?\d+)$", decimal_matches.group(2)
+            )
             if decimal_internals_precision_and_scale:
                 precision = decimal_internals_precision_and_scale.group(1)
                 scale = decimal_internals_precision_and_scale.group(2)
@@ -229,11 +245,15 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                         datasets_dtype,
                         "decimal128",
                         examples=["decimal128(10, 2)", "decimal128(4, -2)"],
-                        urls=["https://arrow.apache.org/docs/python/generated/pyarrow.decimal128.html"],
+                        urls=[
+                            "https://arrow.apache.org/docs/python/generated/pyarrow.decimal128.html"
+                        ],
                     )
                 )
         elif decimal_internals_bits == "256":
-            decimal_internals_precision_and_scale = re.search(r"^(\d+),\s*(-?\d+)$", decimal_matches.group(2))
+            decimal_internals_precision_and_scale = re.search(
+                r"^(\d+),\s*(-?\d+)$", decimal_matches.group(2)
+            )
             if decimal_internals_precision_and_scale:
                 precision = decimal_internals_precision_and_scale.group(1)
                 scale = decimal_internals_precision_and_scale.group(2)
@@ -244,7 +264,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                         datasets_dtype,
                         "decimal256",
                         examples=["decimal256(30, 2)", "decimal256(38, -4)"],
-                        urls=["https://arrow.apache.org/docs/python/generated/pyarrow.decimal256.html"],
+                        urls=[
+                            "https://arrow.apache.org/docs/python/generated/pyarrow.decimal256.html"
+                        ],
                     )
                 )
         else:
@@ -267,7 +289,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     )
 
 
-def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_casting: bool) -> tuple[Any, bool]:
+def _cast_to_python_objects(
+    obj: Any, only_1d_for_numpy: bool, optimize_list_casting: bool
+) -> tuple[Any, bool]:
     """
     Cast pytorch/tensorflow/pandas objects to python numpy array/lists.
     It works recursively.
@@ -316,19 +340,28 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
                     )[0]
                     for x in obj
                 ],
                 True,
             )
-    elif config.TORCH_AVAILABLE and "torch" in sys.modules and isinstance(obj, torch.Tensor):
+    elif (
+        config.TORCH_AVAILABLE
+        and "torch" in sys.modules
+        and isinstance(obj, torch.Tensor)
+    ):
         if obj.dtype == torch.bfloat16:
-            return _cast_to_python_objects(
-                obj.detach().to(torch.float).cpu().numpy(),
-                only_1d_for_numpy=only_1d_for_numpy,
-                optimize_list_casting=optimize_list_casting,
-            )[0], True
+            return (
+                _cast_to_python_objects(
+                    obj.detach().to(torch.float).cpu().numpy(),
+                    only_1d_for_numpy=only_1d_for_numpy,
+                    optimize_list_casting=optimize_list_casting,
+                )[0],
+                True,
+            )
         if obj.ndim == 0:
             return obj.detach().cpu().numpy()[()], True
         elif not only_1d_for_numpy or obj.ndim == 1:
@@ -337,13 +370,19 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
                     )[0]
                     for x in obj.detach().cpu().numpy()
                 ],
                 True,
             )
-    elif config.TF_AVAILABLE and "tensorflow" in sys.modules and isinstance(obj, tf.Tensor):
+    elif (
+        config.TF_AVAILABLE
+        and "tensorflow" in sys.modules
+        and isinstance(obj, tf.Tensor)
+    ):
         if obj.ndim == 0:
             return obj.numpy()[()], True
         elif not only_1d_for_numpy or obj.ndim == 1:
@@ -352,7 +391,9 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
                     )[0]
                     for x in obj.numpy()
                 ],
@@ -367,20 +408,32 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
                     )[0]
                     for x in np.asarray(obj)
                 ],
                 True,
             )
-    elif config.PIL_AVAILABLE and "PIL" in sys.modules and isinstance(obj, PIL.Image.Image):
+    elif (
+        config.PIL_AVAILABLE
+        and "PIL" in sys.modules
+        and isinstance(obj, PIL.Image.Image)
+    ):
         return encode_pil_image(obj), True
-    elif config.PDFPLUMBER_AVAILABLE and "pdfplumber" in sys.modules and isinstance(obj, pdfplumber.pdf.PDF):
+    elif (
+        config.PDFPLUMBER_AVAILABLE
+        and "pdfplumber" in sys.modules
+        and isinstance(obj, pdfplumber.pdf.PDF)
+    ):
         return encode_pdfplumber_pdf(obj), True
     elif isinstance(obj, pd.Series):
         return (
             _cast_to_python_objects(
-                obj.tolist(), only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                obj.tolist(),
+                only_1d_for_numpy=only_1d_for_numpy,
+                optimize_list_casting=optimize_list_casting,
             )[0],
             True,
         )
@@ -388,7 +441,9 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         return (
             {
                 key: _cast_to_python_objects(
-                    value, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                    value,
+                    only_1d_for_numpy=only_1d_for_numpy,
+                    optimize_list_casting=optimize_list_casting,
                 )[0]
                 for key, value in obj.to_dict("series").items()
             },
@@ -403,7 +458,9 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         output = {}
         for k, v in obj.items():
             casted_v, has_changed_v = _cast_to_python_objects(
-                v, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                v,
+                only_1d_for_numpy=only_1d_for_numpy,
+                optimize_list_casting=optimize_list_casting,
             )
             has_changed |= has_changed_v
             output[k] = casted_v
@@ -414,7 +471,9 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         else:
             return (
                 _cast_to_python_objects(
-                    obj.__array__(), only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                    obj.__array__(),
+                    only_1d_for_numpy=only_1d_for_numpy,
+                    optimize_list_casting=optimize_list_casting,
                 )[0],
                 True,
             )
@@ -424,13 +483,17 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
                 if _check_non_null_non_empty_recursive(first_elmt):
                     break
             casted_first_elmt, has_changed_first_elmt = _cast_to_python_objects(
-                first_elmt, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                first_elmt,
+                only_1d_for_numpy=only_1d_for_numpy,
+                optimize_list_casting=optimize_list_casting,
             )
             if has_changed_first_elmt or not optimize_list_casting:
                 return (
                     [
                         _cast_to_python_objects(
-                            elmt, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                            elmt,
+                            only_1d_for_numpy=only_1d_for_numpy,
+                            optimize_list_casting=optimize_list_casting,
                         )[0]
                         for elmt in obj
                     ],
@@ -443,17 +506,27 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
                     return list(obj), True
         else:
             return obj, False
-    elif config.TORCHCODEC_AVAILABLE and "torchcodec" in sys.modules and isinstance(obj, VideoDecoder):
+    elif (
+        config.TORCHCODEC_AVAILABLE
+        and "torchcodec" in sys.modules
+        and isinstance(obj, VideoDecoder)
+    ):
         v = Video()
         return v.encode_example(obj), True
-    elif config.TORCHCODEC_AVAILABLE and "torchcodec" in sys.modules and isinstance(obj, AudioDecoder):
+    elif (
+        config.TORCHCODEC_AVAILABLE
+        and "torchcodec" in sys.modules
+        and isinstance(obj, AudioDecoder)
+    ):
         a = Audio()
         return a.encode_example(obj), True
     else:
         return obj, False
 
 
-def cast_to_python_objects(obj: Any, only_1d_for_numpy=False, optimize_list_casting=True) -> Any:
+def cast_to_python_objects(
+    obj: Any, only_1d_for_numpy=False, optimize_list_casting=True
+) -> Any:
     """
     Cast numpy/pytorch/tensorflow/pandas objects to python lists.
     It works recursively.
@@ -474,7 +547,9 @@ def cast_to_python_objects(obj: Any, only_1d_for_numpy=False, optimize_list_cast
         casted_obj: the casted object
     """
     return _cast_to_python_objects(
-        obj, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+        obj,
+        only_1d_for_numpy=only_1d_for_numpy,
+        optimize_list_casting=optimize_list_casting,
     )[0]
 
 
@@ -567,7 +642,9 @@ class _ArrayXD:
         self.shape = tuple(self.shape)
 
     def __call__(self):
-        pa_type = globals()[self.__class__.__name__ + "ExtensionType"](self.shape, self.dtype)
+        pa_type = globals()[self.__class__.__name__ + "ExtensionType"](
+            self.shape, self.dtype
+        )
         return pa_type
 
     def encode_example(self, value):
@@ -679,16 +756,24 @@ class _ArrayXDExtensionType(pa.ExtensionType):
 
     def __init__(self, shape: tuple, dtype: str):
         if self.ndims is None or self.ndims <= 1:
-            raise ValueError("You must instantiate an array type with a value for dim that is > 1")
+            raise ValueError(
+                "You must instantiate an array type with a value for dim that is > 1"
+            )
         if len(shape) != self.ndims:
             raise ValueError(f"shape={shape} and ndims={self.ndims} don't match")
         for dim in range(1, self.ndims):
             if shape[dim] is None:
-                raise ValueError(f"Support only dynamic size on first dimension. Got: {shape}")
+                raise ValueError(
+                    f"Support only dynamic size on first dimension. Got: {shape}"
+                )
         self.shape = tuple(shape)
         self.value_type = dtype
         self.storage_dtype = self._generate_dtype(self.value_type)
-        pa.ExtensionType.__init__(self, self.storage_dtype, f"{self.__class__.__module__}.{self.__class__.__name__}")
+        pa.ExtensionType.__init__(
+            self,
+            self.storage_dtype,
+            f"{self.__class__.__module__}.{self.__class__.__name__}",
+        )
 
     def __arrow_ext_serialize__(self):
         return json.dumps((self.shape, self.value_type)).encode()
@@ -700,7 +785,10 @@ class _ArrayXDExtensionType(pa.ExtensionType):
 
     # This was added to pa.ExtensionType in pyarrow >= 13.0.0
     def __reduce__(self):
-        return self.__arrow_ext_deserialize__, (self.storage_type, self.__arrow_ext_serialize__())
+        return self.__arrow_ext_deserialize__, (
+            self.storage_type,
+            self.__arrow_ext_serialize__(),
+        )
 
     def __hash__(self):
         return hash((self.__class__, self.shape, self.value_type))
@@ -762,7 +850,9 @@ def _is_zero_copy_only(pa_type: pa.DataType, unnest: bool = False) -> bool:
 
     if unnest:
         pa_type = _unnest_pa_type(pa_type)
-    return pa.types.is_primitive(pa_type) and not (pa.types.is_boolean(pa_type) or pa.types.is_temporal(pa_type))
+    return pa.types.is_primitive(pa_type) and not (
+        pa.types.is_boolean(pa_type) or pa.types.is_temporal(pa_type)
+    )
 
 
 class ArrayExtensionArray(pa.ExtensionArray):
@@ -779,16 +869,22 @@ class ArrayExtensionArray(pa.ExtensionArray):
 
         if self.type.shape[0] is not None:
             size = 1
-            null_indices = np.arange(len(storage))[null_mask] - np.arange(np.sum(null_mask))
+            null_indices = np.arange(len(storage))[null_mask] - np.arange(
+                np.sum(null_mask)
+            )
 
             for i in range(self.type.ndims):
                 size *= self.type.shape[i]
                 storage = storage.flatten()
             numpy_arr = storage.to_numpy(zero_copy_only=zero_copy_only)
-            numpy_arr = numpy_arr.reshape(len(self) - len(null_indices), *self.type.shape)
+            numpy_arr = numpy_arr.reshape(
+                len(self) - len(null_indices), *self.type.shape
+            )
 
             if len(null_indices):
-                numpy_arr = np.insert(numpy_arr.astype(np.float64), null_indices, np.nan, axis=0)
+                numpy_arr = np.insert(
+                    numpy_arr.astype(np.float64), null_indices, np.nan, axis=0
+                )
 
         else:
             shape = self.type.shape
@@ -834,7 +930,9 @@ class PandasArrayExtensionDtype(PandasExtensionDtype):
 
     def __from_arrow__(self, array: Union[pa.Array, pa.ChunkedArray]):
         if isinstance(array, pa.ChunkedArray):
-            array = array.type.wrap_array(pa.concat_arrays([chunk.storage for chunk in array.chunks]))
+            array = array.type.wrap_array(
+                pa.concat_arrays([chunk.storage for chunk in array.chunks])
+            )
         zero_copy_only = _is_zero_copy_only(array.storage.type, unnest=True)
         numpy_arr = array.to_numpy(zero_copy_only=zero_copy_only)
         return PandasArrayExtensionArray(numpy_arr)
@@ -890,21 +988,32 @@ class PandasArrayExtensionArray(PandasExtensionArray):
 
     @classmethod
     def _from_sequence(
-        cls, scalars, dtype: Optional[PandasArrayExtensionDtype] = None, copy: bool = False
+        cls,
+        scalars,
+        dtype: Optional[PandasArrayExtensionDtype] = None,
+        copy: bool = False,
     ) -> "PandasArrayExtensionArray":
         if len(scalars) > 1 and all(
-            isinstance(x, np.ndarray) and x.shape == scalars[0].shape and x.dtype == scalars[0].dtype for x in scalars
+            isinstance(x, np.ndarray)
+            and x.shape == scalars[0].shape
+            and x.dtype == scalars[0].dtype
+            for x in scalars
         ):
-            data = np.array(scalars, dtype=dtype if dtype is None else dtype.value_type, copy=copy)
+            data = np.array(
+                scalars, dtype=dtype if dtype is None else dtype.value_type, copy=copy
+            )
         else:
             data = np.empty(len(scalars), dtype=object)
             data[:] = scalars
         return cls(data, copy=copy)
 
     @classmethod
-    def _concat_same_type(cls, to_concat: Sequence_["PandasArrayExtensionArray"]) -> "PandasArrayExtensionArray":
+    def _concat_same_type(
+        cls, to_concat: Sequence_["PandasArrayExtensionArray"]
+    ) -> "PandasArrayExtensionArray":
         if len(to_concat) > 1 and all(
-            va._data.shape == to_concat[0]._data.shape and va._data.dtype == to_concat[0]._data.dtype
+            va._data.shape == to_concat[0]._data.shape
+            and va._data.dtype == to_concat[0]._data.dtype
             for va in to_concat
         ):
             data = np.vstack([va._data for va in to_concat])
@@ -927,7 +1036,9 @@ class PandasArrayExtensionArray(PandasExtensionArray):
     def __setitem__(self, key: Union[int, slice, np.ndarray], value: Any) -> None:
         raise NotImplementedError()
 
-    def __getitem__(self, item: Union[int, slice, np.ndarray]) -> Union[np.ndarray, "PandasArrayExtensionArray"]:
+    def __getitem__(
+        self, item: Union[int, slice, np.ndarray]
+    ) -> Union[np.ndarray, "PandasArrayExtensionArray"]:
         if isinstance(item, int):
             return self._data[item]
         return PandasArrayExtensionArray(self._data[item], copy=False)
@@ -938,17 +1049,25 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         indices: np.ndarray = np.asarray(indices, dtype=int)
         if allow_fill:
             fill_value = (
-                self.dtype.na_value if fill_value is None else np.asarray(fill_value, dtype=self.dtype.value_type)
+                self.dtype.na_value
+                if fill_value is None
+                else np.asarray(fill_value, dtype=self.dtype.value_type)
             )
             mask = indices == -1
             if (indices < -1).any():
-                raise ValueError("Invalid value in `indices`, must be all >= -1 for `allow_fill` is True")
+                raise ValueError(
+                    "Invalid value in `indices`, must be all >= -1 for `allow_fill` is True"
+                )
             elif len(self) > 0:
                 pass
             elif not np.all(mask):
-                raise IndexError("Invalid take for empty PandasArrayExtensionArray, must be all -1.")
+                raise IndexError(
+                    "Invalid take for empty PandasArrayExtensionArray, must be all -1."
+                )
             else:
-                data = np.array([fill_value] * len(indices), dtype=self.dtype.value_type)
+                data = np.array(
+                    [fill_value] * len(indices), dtype=self.dtype.value_type
+                )
                 return PandasArrayExtensionArray(data, copy=False)
         took = self._data.take(indices, axis=0)
         if allow_fill and mask.any():
@@ -1001,9 +1120,13 @@ class ClassLabel:
     ```
     """
 
-    num_classes: InitVar[Optional[int]] = None  # Pseudo-field: ignored by asdict/fields when converting to/from dict
+    num_classes: InitVar[Optional[int]] = (
+        None  # Pseudo-field: ignored by asdict/fields when converting to/from dict
+    )
     names: list[str] = None
-    names_file: InitVar[Optional[str]] = None  # Pseudo-field: ignored by asdict/fields when converting to/from dict
+    names_file: InitVar[Optional[str]] = (
+        None  # Pseudo-field: ignored by asdict/fields when converting to/from dict
+    )
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     dtype: ClassVar[str] = "int64"
@@ -1024,7 +1147,9 @@ class ClassLabel:
             elif self.num_classes is not None:
                 self.names = [str(i) for i in range(self.num_classes)]
             else:
-                raise ValueError("Please provide either num_classes, names or names_file.")
+                raise ValueError(
+                    "Please provide either num_classes, names or names_file."
+                )
         elif not isinstance(self.names, SequenceABC):
             raise TypeError(f"Please provide names as a list, is {type(self.names)}")
         # Set self.num_classes
@@ -1039,7 +1164,9 @@ class ClassLabel:
         self._int2str = [str(name) for name in self.names]
         self._str2int = {name: i for i, name in enumerate(self._int2str)}
         if len(self._int2str) != len(self._str2int):
-            raise ValueError("Some label names are duplicated. Each label name should be unique.")
+            raise ValueError(
+                "Some label names are duplicated. Each label name should be unique."
+            )
 
     def __call__(self):
         return self.pa_type
@@ -1132,10 +1259,14 @@ class ClassLabel:
 
         # Allowing -1 to mean no label.
         if not -1 <= example_data < self.num_classes:
-            raise ValueError(f"Class label {example_data:d} greater than configured num_classes {self.num_classes}")
+            raise ValueError(
+                f"Class label {example_data:d} greater than configured num_classes {self.num_classes}"
+            )
         return example_data
 
-    def cast_storage(self, storage: Union[pa.StringArray, pa.IntegerArray]) -> pa.Int64Array:
+    def cast_storage(
+        self, storage: Union[pa.StringArray, pa.IntegerArray]
+    ) -> pa.Int64Array:
         """Cast an Arrow array to the `ClassLabel` arrow storage type.
         The Arrow types that can be converted to the `ClassLabel` pyarrow storage type are:
 
@@ -1157,14 +1288,19 @@ class ClassLabel:
                 )
         elif isinstance(storage, pa.StringArray):
             storage = pa.array(
-                [self._strval2int(label) if label is not None else None for label in storage.to_pylist()]
+                [
+                    self._strval2int(label) if label is not None else None
+                    for label in storage.to_pylist()
+                ]
             )
         return array_cast(storage, self.pa_type)
 
     @staticmethod
     def _load_names_from_file(names_filepath):
         with open(names_filepath, encoding="utf-8") as f:
-            return [name.strip() for name in f.read().split("\n") if name.strip()]  # Filter empty names
+            return [
+                name.strip() for name in f.read().split("\n") if name.strip()
+            ]  # Filter empty names
 
 
 class Sequence:
@@ -1194,7 +1330,10 @@ class Sequence:
             and isinstance(feature, dict)
             and any(not isinstance(subfeature, List) for subfeature in feature.values())
         ):
-            out = {key: List(value, length=length, **kwargs) for key, value in feature.items()}
+            out = {
+                key: List(value, length=length, **kwargs)
+                for key, value in feature.items()
+            }
         else:
             out = super().__new__(List)
         return out
@@ -1270,14 +1409,18 @@ FeatureType = Union[
 ]
 
 
-def _check_non_null_non_empty_recursive(obj, schema: Optional[FeatureType] = None) -> bool:
+def _check_non_null_non_empty_recursive(
+    obj, schema: Optional[FeatureType] = None
+) -> bool:
     """
     Check if the object is not None.
     If the object is a list or a tuple, recursively check the first element of the sequence and stop if at any point the first element is not a sequence or is an empty sequence.
     """
     if obj is None:
         return False
-    elif isinstance(obj, (list, tuple)) and (schema is None or isinstance(schema, (list, tuple, LargeList, List))):
+    elif isinstance(obj, (list, tuple)) and (
+        schema is None or isinstance(schema, (list, tuple, LargeList, List))
+    ):
         if len(obj) > 0:
             if schema is None:
                 pass
@@ -1311,7 +1454,9 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
         )  # however don't sort on struct types since the order matters
     elif isinstance(schema, (list, tuple)):
         if len(schema) != 1:
-            raise ValueError("When defining list feature, you should just provide one example of the inner type")
+            raise ValueError(
+                "When defining list feature, you should just provide one example of the inner type"
+            )
         value_type = get_nested_type(schema[0])
         return pa.list_(value_type)
     elif isinstance(schema, LargeList):
@@ -1337,7 +1482,10 @@ def encode_nested_example(schema, obj, level=0):
         if level == 0 and obj is None:
             raise ValueError("Got None but expected a dictionary instead")
         return (
-            {k: encode_nested_example(schema[k], obj.get(k), level=level + 1) for k in schema}
+            {
+                k: encode_nested_example(schema[k], obj.get(k), level=level + 1)
+                for k in schema
+            }
             if obj is not None
             else None
         )
@@ -1351,11 +1499,17 @@ def encode_nested_example(schema, obj, level=0):
                     if _check_non_null_non_empty_recursive(first_elmt, sub_schema):
                         break
                 try:
-                    changed = bool(encode_nested_example(sub_schema, first_elmt, level=level + 1) != first_elmt)
+                    changed = bool(
+                        encode_nested_example(sub_schema, first_elmt, level=level + 1)
+                        != first_elmt
+                    )
                 except ValueError:  # can happen when comparing arrays
                     changed = False
                 if changed:
-                    return [encode_nested_example(sub_schema, o, level=level + 1) for o in obj]
+                    return [
+                        encode_nested_example(sub_schema, o, level=level + 1)
+                        for o in obj
+                    ]
             return list(obj)
     # Object with special encoding:
     # ClassLabel will convert from string to int, TranslationVariableLanguages does some checks
@@ -1365,7 +1519,9 @@ def encode_nested_example(schema, obj, level=0):
     return obj
 
 
-def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None):
+def decode_nested_example(
+    schema, obj, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None
+):
     """Decode a nested example.
     This is used since some features (in particular Audio and Image) have some logic during decoding.
 
@@ -1375,7 +1531,10 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Uni
     # Nested structures: we allow dict, list/tuples, sequences
     if isinstance(schema, dict):
         return (
-            {k: decode_nested_example(sub_schema, sub_obj) for k, (sub_schema, sub_obj) in zip_dict(schema, obj)}
+            {
+                k: decode_nested_example(sub_schema, sub_obj)
+                for k, (sub_schema, sub_obj) in zip_dict(schema, obj)
+            }
             if obj is not None
             else None
         )
@@ -1406,7 +1565,11 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Uni
     # Object with special decoding:
     elif hasattr(schema, "decode_example") and getattr(schema, "decode", True):
         # we pass the token to read and decode files from private repositories in streaming mode
-        return schema.decode_example(obj, token_per_repo_id=token_per_repo_id) if obj is not None else None
+        return (
+            schema.decode_example(obj, token_per_repo_id=token_per_repo_id)
+            if obj is not None
+            else None
+        )
     return obj
 
 
@@ -1466,7 +1629,9 @@ def generate_from_dict(obj: Any):
     class_type = _FEATURE_TYPES.get(_type, None) or globals().get(_type, None)
 
     if class_type is None:
-        raise ValueError(f"Feature type '{_type}' not found. Available feature types: {list(_FEATURE_TYPES.keys())}")
+        raise ValueError(
+            f"Feature type '{_type}' not found. Available feature types: {list(_FEATURE_TYPES.keys())}"
+        )
 
     if class_type == LargeList:
         feature = obj.pop("feature")
@@ -1474,7 +1639,9 @@ def generate_from_dict(obj: Any):
     if class_type == List:
         feature = obj.pop("feature")
         return List(generate_from_dict(feature), **obj)
-    if class_type == Sequence:  # backward compatibility, this translates to a List or a dict
+    if (
+        class_type == Sequence
+    ):  # backward compatibility, this translates to a List or a dict
         feature = obj.pop("feature")
         return Sequence(feature=generate_from_dict(feature), **obj)
 
@@ -1495,7 +1662,9 @@ def generate_from_arrow_type(pa_type: pa.DataType) -> FeatureType:
     if isinstance(pa_type, pa.StructType):
         return {field.name: generate_from_arrow_type(field.type) for field in pa_type}
     elif isinstance(pa_type, pa.FixedSizeListType):
-        return List(generate_from_arrow_type(pa_type.value_type), length=pa_type.list_size)
+        return List(
+            generate_from_arrow_type(pa_type.value_type), length=pa_type.list_size
+        )
     elif isinstance(pa_type, pa.ListType):
         return List(generate_from_arrow_type(pa_type.value_type))
     elif isinstance(pa_type, pa.LargeListType):
@@ -1509,7 +1678,9 @@ def generate_from_arrow_type(pa_type: pa.DataType) -> FeatureType:
         raise ValueError(f"Cannot convert {pa_type} to a Feature type.")
 
 
-def numpy_to_pyarrow_listarray(arr: np.ndarray, type: pa.DataType = None) -> pa.ListArray:
+def numpy_to_pyarrow_listarray(
+    arr: np.ndarray, type: pa.DataType = None
+) -> pa.ListArray:
     """Build a PyArrow ListArray from a multidimensional NumPy array"""
     arr = np.array(arr)
     values = pa.array(arr.flatten(), type=type)
@@ -1521,7 +1692,9 @@ def numpy_to_pyarrow_listarray(arr: np.ndarray, type: pa.DataType = None) -> pa.
     return values
 
 
-def list_of_pa_arrays_to_pyarrow_listarray(l_arr: list[Optional[pa.Array]]) -> pa.ListArray:
+def list_of_pa_arrays_to_pyarrow_listarray(
+    l_arr: list[Optional[pa.Array]],
+) -> pa.ListArray:
     null_mask = np.array([arr is None for arr in l_arr])
     null_indices = np.arange(len(null_mask))[null_mask] - np.arange(np.sum(null_mask))
     l_arr = [arr for arr in l_arr if arr is not None]
@@ -1534,11 +1707,16 @@ def list_of_pa_arrays_to_pyarrow_listarray(l_arr: list[Optional[pa.Array]]) -> p
     return pa.ListArray.from_arrays(offsets, values)
 
 
-def list_of_np_array_to_pyarrow_listarray(l_arr: list[np.ndarray], type: pa.DataType = None) -> pa.ListArray:
+def list_of_np_array_to_pyarrow_listarray(
+    l_arr: list[np.ndarray], type: pa.DataType = None
+) -> pa.ListArray:
     """Build a PyArrow ListArray from a possibly nested list of NumPy arrays"""
     if len(l_arr) > 0:
         return list_of_pa_arrays_to_pyarrow_listarray(
-            [numpy_to_pyarrow_listarray(arr, type=type) if arr is not None else None for arr in l_arr]
+            [
+                numpy_to_pyarrow_listarray(arr, type=type) if arr is not None else None
+                for arr in l_arr
+            ]
         )
     else:
         return pa.array([], type=type)
@@ -1561,7 +1739,9 @@ def contains_any_np_array(data: Any):
         return False
 
 
-def any_np_array_to_pyarrow_listarray(data: Union[np.ndarray, list], type: pa.DataType = None) -> pa.ListArray:
+def any_np_array_to_pyarrow_listarray(
+    data: Union[np.ndarray, list], type: pa.DataType = None
+) -> pa.ListArray:
     """Convert to PyArrow ListArray either a NumPy ndarray or (recursively) a list that may contain any NumPy ndarray.
 
     Args:
@@ -1574,7 +1754,9 @@ def any_np_array_to_pyarrow_listarray(data: Union[np.ndarray, list], type: pa.Da
     if isinstance(data, np.ndarray):
         return numpy_to_pyarrow_listarray(data, type=type)
     elif isinstance(data, list):
-        return list_of_pa_arrays_to_pyarrow_listarray([any_np_array_to_pyarrow_listarray(i, type=type) for i in data])
+        return list_of_pa_arrays_to_pyarrow_listarray(
+            [any_np_array_to_pyarrow_listarray(i, type=type) for i in data]
+        )
 
 
 def to_pyarrow_listarray(data: Any, pa_type: _ArrayXDExtensionType) -> pa.Array:
@@ -1593,7 +1775,9 @@ def to_pyarrow_listarray(data: Any, pa_type: _ArrayXDExtensionType) -> pa.Array:
         return pa.array(data, pa_type.storage_dtype)
 
 
-def _visit(feature: FeatureType, func: Callable[[FeatureType], Optional[FeatureType]]) -> FeatureType:
+def _visit(
+    feature: FeatureType, func: Callable[[FeatureType], Optional[FeatureType]]
+) -> FeatureType:
     """Visit a (possibly nested) feature.
 
     Args:
@@ -1618,7 +1802,9 @@ _VisitPath = list[Union[str, Literal[0]]]
 
 
 def _visit_with_path(
-    feature: FeatureType, func: Callable[[FeatureType, _VisitPath], Optional[FeatureType]], visit_path: _VisitPath = []
+    feature: FeatureType,
+    func: Callable[[FeatureType, _VisitPath], Optional[FeatureType]],
+    visit_path: _VisitPath = [],
 ) -> FeatureType:
     """Visit a (possibly nested) feature with its path in the Feature object.
 
@@ -1637,19 +1823,44 @@ def _visit_with_path(
         `FeatureType`: the visited feature.
     """
     if isinstance(feature, Features):
-        out = func(Features({k: _visit_with_path(f, func, visit_path + [k]) for k, f in feature.items()}), visit_path)
+        out = func(
+            Features(
+                {
+                    k: _visit_with_path(f, func, visit_path + [k])
+                    for k, f in feature.items()
+                }
+            ),
+            visit_path,
+        )
     elif isinstance(feature, dict):
-        out = func({k: _visit_with_path(f, func, visit_path + [k]) for k, f in feature.items()}, visit_path)
+        out = func(
+            {
+                k: _visit_with_path(f, func, visit_path + [k])
+                for k, f in feature.items()
+            },
+            visit_path,
+        )
     elif isinstance(feature, List):
-        out = func(List(_visit_with_path(feature.feature, func, visit_path + [0]), length=feature.length), visit_path)
+        out = func(
+            List(
+                _visit_with_path(feature.feature, func, visit_path + [0]),
+                length=feature.length,
+            ),
+            visit_path,
+        )
     elif isinstance(feature, LargeList):
-        out = func(LargeList(_visit_with_path(feature.feature, func, visit_path + [0])), visit_path)
+        out = func(
+            LargeList(_visit_with_path(feature.feature, func, visit_path + [0])),
+            visit_path,
+        )
     else:
         out = func(feature, visit_path)
     return feature if out is None else out
 
 
-def require_decoding(feature: FeatureType, ignore_decode_attribute: bool = False) -> bool:
+def require_decoding(
+    feature: FeatureType, ignore_decode_attribute: bool = False
+) -> bool:
     """Check if a (possibly nested) feature requires decoding.
 
     Args:
@@ -1724,7 +1935,9 @@ def keep_features_dicts_synced(func):
             self: "Features" = kwargs.pop("self")
         out = func(self, *args, **kwargs)
         assert hasattr(self, "_column_requires_decoding")
-        self._column_requires_decoding = {col: require_decoding(feature) for col, feature in self.items()}
+        self._column_requires_decoding = {
+            col: require_decoding(feature) for col, feature in self.items()
+        }
         return out
 
     wrapper._decorator_name_ = "_keep_dicts_synced"
@@ -1764,7 +1977,9 @@ class Features(dict):
     def __init__(*args, **kwargs):
         # self not in the signature to allow passing self as a kwarg
         if not args:
-            raise TypeError("descriptor '__init__' of 'Features' object needs an argument")
+            raise TypeError(
+                "descriptor '__init__' of 'Features' object needs an argument"
+            )
         self, *args = args
         super(Features, self).__init__(*args, **kwargs)
         # keep track of columns which require decoding
@@ -1811,7 +2026,9 @@ class Features(dict):
             :obj:`pyarrow.Schema`
         """
         hf_metadata = {"info": {"features": self.to_dict()}}
-        return pa.schema(self.type).with_metadata({"huggingface": json.dumps(hf_metadata)})
+        return pa.schema(self.type).with_metadata(
+            {"huggingface": json.dumps(hf_metadata)}
+        )
 
     @classmethod
     def from_arrow_schema(cls, pa_schema: pa.Schema) -> "Features":
@@ -1834,13 +2051,18 @@ class Features(dict):
         metadata_features = Features()
         if pa_schema.metadata is not None and b"huggingface" in pa_schema.metadata:
             metadata = json.loads(pa_schema.metadata[b"huggingface"].decode())
-            if "info" in metadata and "features" in metadata["info"] and metadata["info"]["features"] is not None:
+            if (
+                "info" in metadata
+                and "features" in metadata["info"]
+                and metadata["info"]["features"] is not None
+            ):
                 metadata_features = Features.from_dict(metadata["info"]["features"])
         metadata_features_schema = metadata_features.arrow_schema
         obj = {
             field.name: (
                 metadata_features[field.name]
-                if field.name in metadata_features and metadata_features_schema.field(field.name) == field
+                if field.name in metadata_features
+                and metadata_features_schema.field(field.name) == field
                 else generate_from_arrow_type(field.type)
             )
             for field in pa_schema
@@ -1892,7 +2114,9 @@ class Features(dict):
                 # list_type:                ->              list_type: int32
                 #   dtype: int32            ->
                 #
-                if isinstance(feature.get(list_type), dict) and list(feature[list_type]) == ["dtype"]:
+                if isinstance(feature.get(list_type), dict) and list(
+                    feature[list_type]
+                ) == ["dtype"]:
                     feature[list_type] = feature[list_type]["dtype"]
 
                 #
@@ -1901,7 +2125,9 @@ class Features(dict):
                 #   - name: foo             ->                dtype: int32
                 #     dtype: int32          ->
                 #
-                if isinstance(feature.get(list_type), dict) and list(feature[list_type]) == ["struct"]:
+                if isinstance(feature.get(list_type), dict) and list(
+                    feature[list_type]
+                ) == ["struct"]:
                     feature[list_type] = feature[list_type]["struct"]
 
             #
@@ -1910,10 +2136,15 @@ class Features(dict):
             #   - negative              ->                  '0': negative
             #   - positive              ->                  '1': positive
             #
-            if isinstance(feature.get("class_label"), dict) and isinstance(feature["class_label"].get("names"), list):
+            if isinstance(feature.get("class_label"), dict) and isinstance(
+                feature["class_label"].get("names"), list
+            ):
                 # server-side requirement: keys must be strings
                 feature["class_label"]["names"] = {
-                    str(label_id): label_name for label_id, label_name in enumerate(feature["class_label"]["names"])
+                    str(label_id): label_name
+                    for label_id, label_name in enumerate(
+                        feature["class_label"]["names"]
+                    )
                 }
             return feature
 
@@ -1933,7 +2164,12 @@ class Features(dict):
                 elif _type:
                     return {"dtype": simplify({camelcase_to_snakecase(_type): obj})}
                 else:
-                    return {"struct": [{"name": name, **to_yaml_inner(_feature)} for name, _feature in obj.items()]}
+                    return {
+                        "struct": [
+                            {"name": name, **to_yaml_inner(_feature)}
+                            for name, _feature in obj.items()
+                        ]
+                    }
             elif isinstance(obj, list):
                 return simplify({"list": simplify(to_yaml_inner(obj[0]))})
             elif isinstance(obj, tuple):
@@ -1977,13 +2213,19 @@ class Features(dict):
             #     '0': negative              ->               - negative
             #     '1': positive              ->               - positive
             #
-            if isinstance(feature.get("class_label"), dict) and isinstance(feature["class_label"].get("names"), dict):
+            if isinstance(feature.get("class_label"), dict) and isinstance(
+                feature["class_label"].get("names"), dict
+            ):
                 label_ids = sorted(feature["class_label"]["names"], key=int)
-                if label_ids and [int(label_id) for label_id in label_ids] != list(range(int(label_ids[-1]) + 1)):
+                if label_ids and [int(label_id) for label_id in label_ids] != list(
+                    range(int(label_ids[-1]) + 1)
+                ):
                     raise ValueError(
                         f"ClassLabel expected a value for all label ids [0:{int(label_ids[-1]) + 1}] but some ids are missing."
                     )
-                feature["class_label"]["names"] = [feature["class_label"]["names"][label_id] for label_id in label_ids]
+                feature["class_label"]["names"] = [
+                    feature["class_label"]["names"][label_id] for label_id in label_ids
+                ]
             return feature
 
         def from_yaml_inner(obj: Union[dict, list]) -> Union[dict, list]:
@@ -2021,10 +2263,16 @@ class Features(dict):
                     else:
                         return from_yaml_inner(obj["dtype"])
                 else:
-                    return {"_type": snakecase_to_camelcase(_type), **unsimplify(obj)[_type]}
+                    return {
+                        "_type": snakecase_to_camelcase(_type),
+                        **unsimplify(obj)[_type],
+                    }
             elif isinstance(obj, list):
                 names = [_feature.pop("name") for _feature in obj]
-                return {name: from_yaml_inner(_feature) for name, _feature in zip(names, obj)}
+                return {
+                    name: from_yaml_inner(_feature)
+                    for name, _feature in zip(names, obj)
+                }
             else:
                 raise TypeError(f"Expected a dict or a list but got {type(obj)}: {obj}")
 
@@ -2058,7 +2306,9 @@ class Features(dict):
             `list[Any]`
         """
         column = cast_to_python_objects(column)
-        return [encode_nested_example(self[column_name], obj, level=1) for obj in column]
+        return [
+            encode_nested_example(self[column_name], obj, level=1) for obj in column
+        ]
 
     def encode_batch(self, batch):
         """
@@ -2073,13 +2323,21 @@ class Features(dict):
         """
         encoded_batch = {}
         if set(batch) != set(self):
-            raise ValueError(f"Column mismatch between batch {set(batch)} and features {set(self)}")
+            raise ValueError(
+                f"Column mismatch between batch {set(batch)} and features {set(self)}"
+            )
         for key, column in batch.items():
             column = cast_to_python_objects(column)
-            encoded_batch[key] = [encode_nested_example(self[key], obj, level=1) for obj in column]
+            encoded_batch[key] = [
+                encode_nested_example(self[key], obj, level=1) for obj in column
+            ]
         return encoded_batch
 
-    def decode_example(self, example: dict, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None):
+    def decode_example(
+        self,
+        example: dict,
+        token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None,
+    ):
         """Decode example with custom feature decoding.
 
         Args:
@@ -2094,16 +2352,23 @@ class Features(dict):
         """
 
         return {
-            column_name: decode_nested_example(feature, value, token_per_repo_id=token_per_repo_id)
-            if self._column_requires_decoding[column_name]
-            else value
+            column_name: (
+                decode_nested_example(
+                    feature, value, token_per_repo_id=token_per_repo_id
+                )
+                if self._column_requires_decoding[column_name]
+                else value
+            )
             for column_name, (feature, value) in zip_dict(
                 {key: value for key, value in self.items() if key in example}, example
             )
         }
 
     def decode_column(
-        self, column: list, column_name: str, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None
+        self,
+        column: list,
+        column_name: str,
+        token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None,
     ):
         """Decode column with custom feature decoding.
 
@@ -2118,16 +2383,24 @@ class Features(dict):
         """
         return (
             [
-                decode_nested_example(self[column_name], value, token_per_repo_id=token_per_repo_id)
-                if value is not None
-                else None
+                (
+                    decode_nested_example(
+                        self[column_name], value, token_per_repo_id=token_per_repo_id
+                    )
+                    if value is not None
+                    else None
+                )
                 for value in column
             ]
             if self._column_requires_decoding[column_name]
             else column
         )
 
-    def decode_batch(self, batch: dict, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None):
+    def decode_batch(
+        self,
+        batch: dict,
+        token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None,
+    ):
         """Decode batch with custom feature decoding.
 
         Args:
@@ -2144,9 +2417,15 @@ class Features(dict):
         for column_name, column in batch.items():
             decoded_batch[column_name] = (
                 [
-                    decode_nested_example(self[column_name], value, token_per_repo_id=token_per_repo_id)
-                    if value is not None
-                    else None
+                    (
+                        decode_nested_example(
+                            self[column_name],
+                            value,
+                            token_per_repo_id=token_per_repo_id,
+                        )
+                        if value is not None
+                        else None
+                    )
                     for value in column
                 ]
                 if self._column_requires_decoding[column_name]
@@ -2205,23 +2484,40 @@ class Features(dict):
             stack_position = " at " + stack[1:] if stack else ""
             if isinstance(source, dict):
                 if not isinstance(target, dict):
-                    raise ValueError(f"Type mismatch: between {source} and {target}" + stack_position)
+                    raise ValueError(
+                        f"Type mismatch: between {source} and {target}" + stack_position
+                    )
                 if sorted(source) != sorted(target):
                     message = (
                         f"Keys mismatch: between {source} (source) and {target} (target).\n"
                         f"{source.keys() - target.keys()} are missing from target "
-                        f"and {target.keys() - source.keys()} are missing from source" + stack_position
+                        f"and {target.keys() - source.keys()} are missing from source"
+                        + stack_position
                     )
                     raise ValueError(message)
-                return {key: recursive_reorder(source[key], target[key], stack + f".{key}") for key in target}
+                return {
+                    key: recursive_reorder(source[key], target[key], stack + f".{key}")
+                    for key in target
+                }
             elif isinstance(source, List):
                 if not isinstance(target, List):
-                    raise ValueError(f"Type mismatch: between {source} and {target}" + stack_position)
-                return List(recursive_reorder(source.feature, target.feature, stack + ".<list>"), length=source.length)
+                    raise ValueError(
+                        f"Type mismatch: between {source} and {target}" + stack_position
+                    )
+                return List(
+                    recursive_reorder(
+                        source.feature, target.feature, stack + ".<list>"
+                    ),
+                    length=source.length,
+                )
             elif isinstance(source, LargeList):
                 if not isinstance(target, LargeList):
-                    raise ValueError(f"Type mismatch: between {source} and {target}" + stack_position)
-                return LargeList(recursive_reorder(source.feature, target.feature, stack + ".<list>"))
+                    raise ValueError(
+                        f"Type mismatch: between {source} and {target}" + stack_position
+                    )
+                return LargeList(
+                    recursive_reorder(source.feature, target.feature, stack + ".<list>")
+                )
             else:
                 return source
 
@@ -2259,11 +2555,21 @@ class Features(dict):
             for column_name, subfeature in self.items():
                 if isinstance(subfeature, dict):
                     no_change = False
-                    flattened.update({f"{column_name}.{k}": v for k, v in subfeature.items()})
+                    flattened.update(
+                        {f"{column_name}.{k}": v for k, v in subfeature.items()}
+                    )
                     del flattened[column_name]
-                elif hasattr(subfeature, "flatten") and subfeature.flatten() != subfeature:
+                elif (
+                    hasattr(subfeature, "flatten")
+                    and subfeature.flatten() != subfeature
+                ):
                     no_change = False
-                    flattened.update({f"{column_name}.{k}": v for k, v in subfeature.flatten().items()})
+                    flattened.update(
+                        {
+                            f"{column_name}.{k}": v
+                            for k, v in subfeature.flatten().items()
+                        }
+                    )
                     del flattened[column_name]
             self = flattened
             if no_change:
@@ -2279,10 +2585,15 @@ def _align_features(features_list: list[Features]) -> list[Features]:
             if k in name2feature and isinstance(v, dict):
                 # Recursively align features.
                 name2feature[k] = _align_features([name2feature[k], v])[0]
-            elif k not in name2feature or (isinstance(name2feature[k], Value) and name2feature[k].dtype == "null"):
+            elif k not in name2feature or (
+                isinstance(name2feature[k], Value) and name2feature[k].dtype == "null"
+            ):
                 name2feature[k] = v
 
-    return [Features({k: name2feature[k] for k in features.keys()}) for features in features_list]
+    return [
+        Features({k: name2feature[k] for k in features.keys()})
+        for features in features_list
+    ]
 
 
 def _check_if_features_can_be_aligned(features_list: list[Features]):
@@ -2293,7 +2604,9 @@ def _check_if_features_can_be_aligned(features_list: list[Features]):
     name2feature = {}
     for features in features_list:
         for k, v in features.items():
-            if k not in name2feature or (isinstance(name2feature[k], Value) and name2feature[k].dtype == "null"):
+            if k not in name2feature or (
+                isinstance(name2feature[k], Value) and name2feature[k].dtype == "null"
+            ):
                 name2feature[k] = v
 
     for features in features_list:
@@ -2301,7 +2614,10 @@ def _check_if_features_can_be_aligned(features_list: list[Features]):
             if isinstance(v, dict) and isinstance(name2feature[k], dict):
                 # Deep checks for structure.
                 _check_if_features_can_be_aligned([name2feature[k], v])
-            elif not (isinstance(v, Value) and v.dtype == "null") and name2feature[k] != v:
+            elif (
+                not (isinstance(v, Value) and v.dtype == "null")
+                and name2feature[k] != v
+            ):
                 raise ValueError(
                     f'The features can\'t be aligned because the key {k} of features {features} has unexpected type - {v} (expected either {name2feature[k]} or Value("null").'
                 )

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -13,7 +13,11 @@ from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
 from ..utils.file_utils import is_local_path, xopen
-from ..utils.py_utils import first_non_null_value, no_op_if_value_is_null, string_to_dict
+from ..utils.py_utils import (
+    first_non_null_value,
+    no_op_if_value_is_null,
+    string_to_dict,
+)
 
 
 if TYPE_CHECKING:
@@ -95,7 +99,9 @@ class Image:
     def __call__(self):
         return self.pa_type
 
-    def encode_example(self, value: Union[str, bytes, bytearray, dict, np.ndarray, "PIL.Image.Image"]) -> dict:
+    def encode_example(
+        self, value: Union[str, bytes, bytearray, dict, np.ndarray, "PIL.Image.Image"]
+    ) -> dict:
         """Encode example into a format for Arrow.
 
         Args:
@@ -155,7 +161,9 @@ class Image:
             `PIL.Image.Image`
         """
         if not self.decode:
-            raise RuntimeError("Decoding is disabled for this feature. Please use Image(decode=True) instead.")
+            raise RuntimeError(
+                "Decoding is disabled for this feature. Please use Image(decode=True) instead."
+            )
 
         if config.PIL_AVAILABLE:
             import PIL.Image
@@ -169,7 +177,9 @@ class Image:
         path, bytes_ = value["path"], value["bytes"]
         if bytes_ is None:
             if path is None:
-                raise ValueError(f"An image should have one of 'path' or 'bytes' but both are None in {value}.")
+                raise ValueError(
+                    f"An image should have one of 'path' or 'bytes' but both are None in {value}."
+                )
             else:
                 if is_local_path(path):
                     image = PIL.Image.open(path)
@@ -182,7 +192,9 @@ class Image:
                     )
                     source_url_fields = string_to_dict(source_url, pattern)
                     token = (
-                        token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+                        token_per_repo_id.get(source_url_fields["repo_id"])
+                        if source_url_fields is not None
+                        else None
                     )
                     download_config = DownloadConfig(token=token)
                     with xopen(path, "rb", download_config=download_config) as f:
@@ -210,7 +222,9 @@ class Image:
             }
         )
 
-    def cast_storage(self, storage: Union[pa.StringArray, pa.StructArray, pa.ListArray]) -> pa.StructArray:
+    def cast_storage(
+        self, storage: Union[pa.StringArray, pa.StructArray, pa.ListArray]
+    ) -> pa.StructArray:
         """Cast an Arrow array to the Image arrow storage type.
         The Arrow types that can be converted to the Image pyarrow storage type are:
 
@@ -231,10 +245,14 @@ class Image:
         """
         if pa.types.is_string(storage.type):
             bytes_array = pa.array([None] * len(storage), type=pa.binary())
-            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
+            storage = pa.StructArray.from_arrays(
+                [bytes_array, storage], ["bytes", "path"], mask=storage.is_null()
+            )
         elif pa.types.is_binary(storage.type):
             path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([storage, path_array], ["bytes", "path"], mask=storage.is_null())
+            storage = pa.StructArray.from_arrays(
+                [storage, path_array], ["bytes", "path"], mask=storage.is_null()
+            )
         elif pa.types.is_struct(storage.type):
             if storage.type.get_field_index("bytes") >= 0:
                 bytes_array = storage.field("bytes")
@@ -244,10 +262,15 @@ class Image:
                 path_array = storage.field("path")
             else:
                 path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
+            storage = pa.StructArray.from_arrays(
+                [bytes_array, path_array], ["bytes", "path"], mask=storage.is_null()
+            )
         elif pa.types.is_list(storage.type):
             bytes_array = pa.array(
-                [encode_np_array(np.array(arr))["bytes"] if arr is not None else None for arr in storage.to_pylist()],
+                [
+                    encode_np_array(np.array(arr))["bytes"] if arr is not None else None
+                    for arr in storage.to_pylist()
+                ],
                 type=pa.binary(),
             )
             path_array = pa.array([None] * len(storage), type=pa.string())
@@ -256,7 +279,9 @@ class Image:
             )
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None
+    ) -> pa.StructArray:
         """Embed image files into the Arrow array.
 
         Args:
@@ -274,26 +299,41 @@ class Image:
         def path_to_bytes(path):
             source_url = path.split("::")[-1]
             pattern = (
-                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+                config.HUB_DATASETS_URL
+                if source_url.startswith(config.HF_ENDPOINT)
+                else config.HUB_DATASETS_HFFS_URL
             )
             source_url_fields = string_to_dict(source_url, pattern)
-            token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+            token = (
+                token_per_repo_id.get(source_url_fields["repo_id"])
+                if source_url_fields is not None
+                else None
+            )
             download_config = DownloadConfig(token=token)
             with xopen(path, "rb", download_config=download_config) as f:
                 return f.read()
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"])
+                    if x is not None
+                    else None
+                )
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                os.path.basename(path) if path is not None else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
-        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
+        storage = pa.StructArray.from_arrays(
+            [bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null()
+        )
         return array_cast(storage, self.pa_type)
 
 
@@ -306,7 +346,9 @@ def list_image_compression_formats() -> list[str]:
     global _IMAGE_COMPRESSION_FORMATS
     if _IMAGE_COMPRESSION_FORMATS is None:
         PIL.Image.init()
-        _IMAGE_COMPRESSION_FORMATS = list(set(PIL.Image.OPEN.keys()) & set(PIL.Image.SAVE.keys()))
+        _IMAGE_COMPRESSION_FORMATS = list(
+            set(PIL.Image.OPEN.keys()) & set(PIL.Image.SAVE.keys())
+        )
     return _IMAGE_COMPRESSION_FORMATS
 
 
@@ -349,7 +391,9 @@ def encode_np_array(array: np.ndarray) -> dict:
             )
         dest_dtype = np.dtype("|u1")
         if dtype != dest_dtype:
-            warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
+            warnings.warn(
+                f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'"
+            )
     # Exact match
     elif dtype in _VALID_IMAGE_ARRAY_DTPYES:
         dest_dtype = dtype
@@ -358,7 +402,9 @@ def encode_np_array(array: np.ndarray) -> dict:
             dtype_str = dtype_byteorder + dtype_kind + str(dtype_itemsize)
             if np.dtype(dtype_str) in _VALID_IMAGE_ARRAY_DTPYES:
                 dest_dtype = np.dtype(dtype_str)
-                warnings.warn(f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'")
+                warnings.warn(
+                    f"Downcasting array dtype {dtype} to {dest_dtype} to be compatible with 'Pillow'"
+                )
                 break
             else:
                 dtype_itemsize //= 2
@@ -383,7 +429,10 @@ def objects_to_list_of_image_dicts(
     if objs:
         _, obj = first_non_null_value(objs)
         if isinstance(obj, str):
-            return [{"path": obj, "bytes": None} if obj is not None else None for obj in objs]
+            return [
+                {"path": obj, "bytes": None} if obj is not None else None
+                for obj in objs
+            ]
         if isinstance(obj, np.ndarray):
             obj_to_image_dict_func = no_op_if_value_is_null(encode_np_array)
             return [obj_to_image_dict_func(obj) for obj in objs]

--- a/src/datasets/features/translation.py
+++ b/src/datasets/features/translation.py
@@ -94,7 +94,9 @@ class TranslationVariableLanguages:
         self.num_languages = len(self.languages) if self.languages else None
 
     def __call__(self):
-        return pa.struct({"language": pa.list_(pa.string()), "translation": pa.list_(pa.string())})
+        return pa.struct(
+            {"language": pa.list_(pa.string()), "translation": pa.list_(pa.string())}
+        )
 
     def encode_example(self, translation_dict):
         lang_set = set(self.languages)

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -104,7 +104,9 @@ class Video:
     def __call__(self):
         return self.pa_type
 
-    def encode_example(self, value: Union[str, bytes, bytearray, Example, np.ndarray, "VideoDecoder"]) -> Example:
+    def encode_example(
+        self, value: Union[str, bytes, bytearray, Example, np.ndarray, "VideoDecoder"]
+    ) -> Example:
         """Encode example into a format for Arrow.
 
         Args:
@@ -175,13 +177,17 @@ class Video:
             `torchcodec.decoders.VideoDecoder`
         """
         if not self.decode:
-            raise RuntimeError("Decoding is disabled for this feature. Please use Video(decode=True) instead.")
+            raise RuntimeError(
+                "Decoding is disabled for this feature. Please use Video(decode=True) instead."
+            )
 
         if config.TORCHCODEC_AVAILABLE:
             from torchcodec.decoders import VideoDecoder
 
         else:
-            raise ImportError("To support decoding videos, please install 'torchcodec'.")
+            raise ImportError(
+                "To support decoding videos, please install 'torchcodec'."
+            )
 
         if token_per_repo_id is None:
             token_per_repo_id = {}
@@ -193,7 +199,9 @@ class Video:
 
         if bytes_ is None:
             if path is None:
-                raise ValueError(f"A video should have one of 'path' or 'bytes' but both are None in {value}.")
+                raise ValueError(
+                    f"A video should have one of 'path' or 'bytes' but both are None in {value}."
+                )
             elif is_local_path(path):
                 video = VideoDecoder(
                     path,
@@ -238,7 +246,9 @@ class Video:
             }
         )
 
-    def cast_storage(self, storage: Union[pa.StringArray, pa.StructArray, pa.ListArray]) -> pa.StructArray:
+    def cast_storage(
+        self, storage: Union[pa.StringArray, pa.StructArray, pa.ListArray]
+    ) -> pa.StructArray:
         """Cast an Arrow array to the Video arrow storage type.
         The Arrow types that can be converted to the Video pyarrow storage type are:
 
@@ -259,10 +269,14 @@ class Video:
         """
         if pa.types.is_string(storage.type):
             bytes_array = pa.array([None] * len(storage), type=pa.binary())
-            storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
+            storage = pa.StructArray.from_arrays(
+                [bytes_array, storage], ["bytes", "path"], mask=storage.is_null()
+            )
         elif pa.types.is_binary(storage.type):
             path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([storage, path_array], ["bytes", "path"], mask=storage.is_null())
+            storage = pa.StructArray.from_arrays(
+                [storage, path_array], ["bytes", "path"], mask=storage.is_null()
+            )
         elif pa.types.is_struct(storage.type):
             if storage.type.get_field_index("bytes") >= 0:
                 bytes_array = storage.field("bytes")
@@ -272,10 +286,15 @@ class Video:
                 path_array = storage.field("path")
             else:
                 path_array = pa.array([None] * len(storage), type=pa.string())
-            storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
+            storage = pa.StructArray.from_arrays(
+                [bytes_array, path_array], ["bytes", "path"], mask=storage.is_null()
+            )
         elif pa.types.is_list(storage.type):
             bytes_array = pa.array(
-                [encode_np_array(np.array(arr))["bytes"] if arr is not None else None for arr in storage.to_pylist()],
+                [
+                    encode_np_array(np.array(arr))["bytes"] if arr is not None else None
+                    for arr in storage.to_pylist()
+                ],
                 type=pa.binary(),
             )
             path_array = pa.array([None] * len(storage), type=pa.string())
@@ -323,9 +342,17 @@ def hf_video_reader(
     if token_per_repo_id is None:
         token_per_repo_id = {}
     source_url = path.split("::")[-1]
-    pattern = config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+    pattern = (
+        config.HUB_DATASETS_URL
+        if source_url.startswith(config.HF_ENDPOINT)
+        else config.HUB_DATASETS_HFFS_URL
+    )
     source_url_fields = string_to_dict(source_url, pattern)
-    token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+    token = (
+        token_per_repo_id.get(source_url_fields["repo_id"])
+        if source_url_fields is not None
+        else None
+    )
     download_config = DownloadConfig(token=token)
     f = xopen(path, "rb", download_config=download_config)
 

--- a/src/datasets/filesystems/__init__.py
+++ b/src/datasets/filesystems/__init__.py
@@ -20,8 +20,13 @@ COMPRESSION_FILESYSTEMS: list[compression.BaseCompressedFileFileSystem] = [
 
 # Register custom filesystems
 for fs_class in COMPRESSION_FILESYSTEMS:
-    if fs_class.protocol in fsspec.registry and fsspec.registry[fs_class.protocol] is not fs_class:
-        warnings.warn(f"A filesystem protocol was already set for {fs_class.protocol} and will be overwritten.")
+    if (
+        fs_class.protocol in fsspec.registry
+        and fsspec.registry[fs_class.protocol] is not fs_class
+    ):
+        warnings.warn(
+            f"A filesystem protocol was already set for {fs_class.protocol} and will be overwritten."
+        )
     fsspec.register_implementation(fs_class.protocol, fs_class, clobber=True)
 
 

--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -14,10 +14,16 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
         None  # protocol passed in prefix to the url. ex: "gzip", for gzip://file.txt::http://foo.bar/file.txt.gz
     )
     compression: str = None  # compression type in fsspec. ex: "gzip"
-    extensions: list[str] = None  # extensions of the filename to strip. ex: ".gz" to get file.txt from file.txt.gz
+    extensions: list[str] = (
+        None  # extensions of the filename to strip. ex: ".gz" to get file.txt from file.txt.gz
+    )
 
     def __init__(
-        self, fo: str = "", target_protocol: Optional[str] = None, target_options: Optional[dict] = None, **kwargs
+        self,
+        fo: str = "",
+        target_protocol: Optional[str] = None,
+        target_options: Optional[dict] = None,
+        **kwargs,
     ):
         """
         The compressed file system can be instantiated from any compressed file.
@@ -44,7 +50,9 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
             client_kwargs={
                 "requote_redirect_url": False,  # see https://github.com/huggingface/datasets/pull/5459
                 "trust_env": True,  # Enable reading proxy env variables.
-                **(target_options or {}).pop("client_kwargs", {}),  # To avoid issues if it was already passed.
+                **(target_options or {}).pop(
+                    "client_kwargs", {}
+                ),  # To avoid issues if it was already passed.
             },
             **(target_options or {}),
         )
@@ -63,7 +71,10 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
 
     def _get_dirs(self):
         if self.dir_cache is None:
-            f = {**self._open_with_fsspec().fs.info(self.fo), "name": self.uncompressed_name}
+            f = {
+                **self._open_with_fsspec().fs.info(self.fo),
+                "name": self.uncompressed_name,
+            }
             self.dir_cache = {f["name"]: f}
 
     def cat(self, path: str):
@@ -81,7 +92,9 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
     ):
         path = self._strip_protocol(path)
         if mode != "rb":
-            raise ValueError(f"Tried to read with mode {mode} on file {self.fo} opened with mode 'rb'")
+            raise ValueError(
+                f"Tried to read with mode {mode} on file {self.fo} opened with mode 'rb'"
+            )
         return self._open_with_fsspec().open()
 
 

--- a/src/datasets/formatting/__init__.py
+++ b/src/datasets/formatting/__init__.py
@@ -61,7 +61,9 @@ def _register_formatter(
 
 
 def _register_unavailable_formatter(
-    unavailable_error: Exception, format_type: Optional[str], aliases: Optional[list[str]] = None
+    unavailable_error: Exception,
+    format_type: Optional[str],
+    aliases: Optional[list[str]] = None,
 ):
     """
     Register an unavailable Formatter object using a name and optional aliases.
@@ -84,7 +86,9 @@ if config.POLARS_AVAILABLE:
 
     _register_formatter(PolarsFormatter, "polars", aliases=["pl"])
 else:
-    _polars_error = ValueError("Polars needs to be installed to be able to return Polars dataframes.")
+    _polars_error = ValueError(
+        "Polars needs to be installed to be able to return Polars dataframes."
+    )
     _register_unavailable_formatter(_polars_error, "polars", aliases=["pl"])
 
 if config.TORCH_AVAILABLE:
@@ -92,7 +96,9 @@ if config.TORCH_AVAILABLE:
 
     _register_formatter(TorchFormatter, "torch", aliases=["pt", "pytorch"])
 else:
-    _torch_error = ValueError("PyTorch needs to be installed to be able to return PyTorch tensors.")
+    _torch_error = ValueError(
+        "PyTorch needs to be installed to be able to return PyTorch tensors."
+    )
     _register_unavailable_formatter(_torch_error, "torch", aliases=["pt", "pytorch"])
 
 if config.TF_AVAILABLE:
@@ -100,7 +106,9 @@ if config.TF_AVAILABLE:
 
     _register_formatter(TFFormatter, "tensorflow", aliases=["tf"])
 else:
-    _tf_error = ValueError("Tensorflow needs to be installed to be able to return Tensorflow tensors.")
+    _tf_error = ValueError(
+        "Tensorflow needs to be installed to be able to return Tensorflow tensors."
+    )
     _register_unavailable_formatter(_tf_error, "tensorflow", aliases=["tf"])
 
 if config.JAX_AVAILABLE:
@@ -108,7 +116,9 @@ if config.JAX_AVAILABLE:
 
     _register_formatter(JaxFormatter, "jax", aliases=[])
 else:
-    _jax_error = ValueError("JAX needs to be installed to be able to return JAX arrays.")
+    _jax_error = ValueError(
+        "JAX needs to be installed to be able to return JAX arrays."
+    )
     _register_unavailable_formatter(_jax_error, "jax", aliases=[])
 
 
@@ -133,4 +143,6 @@ def get_formatter(format_type: Optional[str], **format_kwargs) -> Formatter:
     if format_type in _FORMAT_TYPES_ALIASES_UNAVAILABLE:
         raise _FORMAT_TYPES_ALIASES_UNAVAILABLE[format_type]
     else:
-        raise ValueError(f"Format type should be one of {list(_FORMAT_TYPES.keys())}, but got '{format_type}'")
+        raise ValueError(
+            f"Format type should be one of {list(_FORMAT_TYPES.keys())}, but got '{format_type}'"
+        )

--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -31,7 +31,10 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
     def _consolidate(self, column):
         if isinstance(column, list):
             if column and all(
-                isinstance(x, np.ndarray) and x.shape == column[0].shape and x.dtype == column[0].dtype for x in column
+                isinstance(x, np.ndarray)
+                and x.shape == column[0].shape
+                and x.dtype == column[0].dtype
+                for x in column
             ):
                 return np.stack(column)
             else:
@@ -46,7 +49,9 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
     def _tensorize(self, value):
         if isinstance(value, (str, bytes, type(None))):
             return value
-        elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
+        elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(
+            value.dtype, np.character
+        ):
             return value
         elif isinstance(value, np.number):
             return value
@@ -83,14 +88,20 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
             if isinstance(data_struct, torch.Tensor):
                 return self._tensorize(data_struct.detach().cpu().numpy()[()])
-        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.character, np.number)):
+        if hasattr(data_struct, "__array__") and not isinstance(
+            data_struct, (np.ndarray, np.character, np.number)
+        ):
             data_struct = data_struct.__array__()
         # support for nested types like struct of list of struct
         if isinstance(data_struct, np.ndarray):
             if data_struct.dtype == object:
-                return self._consolidate([self.recursive_tensorize(substruct) for substruct in data_struct])
+                return self._consolidate(
+                    [self.recursive_tensorize(substruct) for substruct in data_struct]
+                )
         if isinstance(data_struct, (list, tuple)):
-            return self._consolidate([self.recursive_tensorize(substruct) for substruct in data_struct])
+            return self._consolidate(
+                [self.recursive_tensorize(substruct) for substruct in data_struct]
+            )
         return self._tensorize(data_struct)
 
     def recursive_tensorize(self, data_struct: dict):
@@ -103,7 +114,9 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
     def format_column(self, pa_table: pa.Table) -> np.ndarray:
         column = self.numpy_arrow_extractor().extract_column(pa_table)
-        column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
+        column = self.python_features_decoder.decode_column(
+            column, pa_table.column_names[0]
+        )
         column = self.recursive_tensorize(column)
         column = self._consolidate(column)
         return column

--- a/src/datasets/formatting/polars_formatter.py
+++ b/src/datasets/formatting/polars_formatter.py
@@ -29,7 +29,9 @@ if TYPE_CHECKING:
     import polars as pl
 
 
-class PolarsArrowExtractor(BaseArrowExtractor["pl.DataFrame", "pl.Series", "pl.DataFrame"]):
+class PolarsArrowExtractor(
+    BaseArrowExtractor["pl.DataFrame", "pl.Series", "pl.DataFrame"]
+):
     def extract_row(self, pa_table: pa.Table) -> "pl.DataFrame":
         if config.POLARS_AVAILABLE:
             if "polars" not in sys.modules:
@@ -39,7 +41,9 @@ class PolarsArrowExtractor(BaseArrowExtractor["pl.DataFrame", "pl.Series", "pl.D
 
             return polars.from_arrow(pa_table.slice(length=1))
         else:
-            raise ValueError("Polars needs to be installed to be able to return Polars dataframes.")
+            raise ValueError(
+                "Polars needs to be installed to be able to return Polars dataframes."
+            )
 
     def extract_column(self, pa_table: pa.Table) -> "pl.Series":
         if config.POLARS_AVAILABLE:
@@ -50,7 +54,9 @@ class PolarsArrowExtractor(BaseArrowExtractor["pl.DataFrame", "pl.Series", "pl.D
 
             return polars.from_arrow(pa_table.select([0]))[pa_table.column_names[0]]
         else:
-            raise ValueError("Polars needs to be installed to be able to return Polars dataframes.")
+            raise ValueError(
+                "Polars needs to be installed to be able to return Polars dataframes."
+            )
 
     def extract_batch(self, pa_table: pa.Table) -> "pl.DataFrame":
         if config.POLARS_AVAILABLE:
@@ -61,7 +67,9 @@ class PolarsArrowExtractor(BaseArrowExtractor["pl.DataFrame", "pl.Series", "pl.D
 
             return polars.from_arrow(pa_table)
         else:
-            raise ValueError("Polars needs to be installed to be able to return Polars dataframes.")
+            raise ValueError(
+                "Polars needs to be installed to be able to return Polars dataframes."
+            )
 
 
 class PolarsFeaturesDecoder:
@@ -72,7 +80,9 @@ class PolarsFeaturesDecoder:
     def decode_row(self, row: "pl.DataFrame") -> "pl.DataFrame":
         decode = (
             {
-                column_name: no_op_if_value_is_null(partial(decode_nested_example, feature))
+                column_name: no_op_if_value_is_null(
+                    partial(decode_nested_example, feature)
+                )
                 for column_name, feature in self.features.items()
                 if self.features._column_requires_decoding[column_name]
             }
@@ -85,8 +95,12 @@ class PolarsFeaturesDecoder:
 
     def decode_column(self, column: "pl.Series", column_name: str) -> "pl.Series":
         decode = (
-            no_op_if_value_is_null(partial(decode_nested_example, self.features[column_name]))
-            if self.features and column_name in self.features and self.features._column_requires_decoding[column_name]
+            no_op_if_value_is_null(
+                partial(decode_nested_example, self.features[column_name])
+            )
+            if self.features
+            and column_name in self.features
+            and self.features._column_requires_decoding[column_name]
             else None
         )
         if decode:
@@ -115,7 +129,9 @@ class PolarsFormatter(TableFormatter["pl.DataFrame", "pl.Series", "pl.DataFrame"
 
     def format_column(self, pa_table: pa.Table) -> "pl.Series":
         column = self.polars_arrow_extractor().extract_column(pa_table)
-        column = self.polars_features_decoder.decode_column(column, pa_table.column_names[0])
+        column = self.polars_features_decoder.decode_column(
+            column, pa_table.column_names[0]
+        )
         return column
 
     def format_batch(self, pa_table: pa.Table) -> "pl.DataFrame":

--- a/src/datasets/formatting/tf_formatter.py
+++ b/src/datasets/formatting/tf_formatter.py
@@ -40,11 +40,16 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
 
         if isinstance(column, list) and column:
             if all(
-                isinstance(x, tf.Tensor) and x.shape == column[0].shape and x.dtype == column[0].dtype for x in column
+                isinstance(x, tf.Tensor)
+                and x.shape == column[0].shape
+                and x.dtype == column[0].dtype
+                for x in column
             ):
                 return tf.stack(column)
             elif all(
-                isinstance(x, (tf.Tensor, tf.RaggedTensor)) and x.ndim == 1 and x.dtype == column[0].dtype
+                isinstance(x, (tf.Tensor, tf.RaggedTensor))
+                and x.ndim == 1
+                and x.dtype == column[0].dtype
                 for x in column
             ):
                 # only rag 1-D tensors, otherwise some dimensions become ragged even though they were consolidated
@@ -60,9 +65,13 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
 
         default_dtype = {}
 
-        if isinstance(value, (np.number, np.ndarray)) and np.issubdtype(value.dtype, np.integer):
+        if isinstance(value, (np.number, np.ndarray)) and np.issubdtype(
+            value.dtype, np.integer
+        ):
             default_dtype = {"dtype": tf.int64}
-        elif isinstance(value, (np.number, np.ndarray)) and np.issubdtype(value.dtype, np.floating):
+        elif isinstance(value, (np.number, np.ndarray)) and np.issubdtype(
+            value.dtype, np.floating
+        ):
             default_dtype = {"dtype": tf.float32}
 
         if config.PIL_AVAILABLE and "PIL" in sys.modules:
@@ -96,10 +105,16 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
             data_struct = data_struct.__array__()
         # support for nested types like struct of list of struct
         if isinstance(data_struct, np.ndarray):
-            if data_struct.dtype == object:  # tf tensors cannot be instantied from an array of objects
-                return self._consolidate([self.recursive_tensorize(substruct) for substruct in data_struct])
+            if (
+                data_struct.dtype == object
+            ):  # tf tensors cannot be instantied from an array of objects
+                return self._consolidate(
+                    [self.recursive_tensorize(substruct) for substruct in data_struct]
+                )
         elif isinstance(data_struct, (list, tuple)):
-            return self._consolidate([self.recursive_tensorize(substruct) for substruct in data_struct])
+            return self._consolidate(
+                [self.recursive_tensorize(substruct) for substruct in data_struct]
+            )
         return self._tensorize(data_struct)
 
     def recursive_tensorize(self, data_struct: dict):
@@ -112,7 +127,9 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
 
     def format_column(self, pa_table: pa.Table) -> "tf.Tensor":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
-        column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
+        column = self.python_features_decoder.decode_column(
+            column, pa_table.column_names[0]
+        )
         column = self.recursive_tensorize(column)
         column = self._consolidate(column)
         return column

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -74,7 +74,9 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
             return value
 
         # Handle string arrays
-        if isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
+        if isinstance(value, (np.character, np.ndarray)) and np.issubdtype(
+            value.dtype, np.character
+        ):
             return value.tolist()
 
         # PIL Image fast path - avoid extra copies
@@ -224,7 +226,9 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
     def _recursive_tensorize(self, data_struct):
         """Optimized recursive walker with reduced Python overhead."""
         # Handle tensor-like objects with __array__ interface
-        if hasattr(data_struct, "__array__") and not isinstance(data_struct, torch.Tensor):
+        if hasattr(data_struct, "__array__") and not isinstance(
+            data_struct, torch.Tensor
+        ):
             data_struct = data_struct.__array__()
 
         # Handle object arrays (nested structures)
@@ -239,7 +243,10 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
             return self._consolidate(result)
         # Handle dictionaries
         elif isinstance(data_struct, dict):
-            return {key: self._recursive_tensorize(value) for key, value in data_struct.items()}
+            return {
+                key: self._recursive_tensorize(value)
+                for key, value in data_struct.items()
+            }
 
         # Base case: tensorize the leaf value
         return self._tensorize(data_struct)
@@ -255,7 +262,9 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
 
     def format_column(self, pa_table: pa.Table) -> "torch.Tensor":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
-        column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
+        column = self.python_features_decoder.decode_column(
+            column, pa_table.column_names[0]
+        )
         column = self.recursive_tensorize(column)
         column = self._consolidate(column)
         return column

--- a/src/datasets/hub.py
+++ b/src/datasets/hub.py
@@ -42,11 +42,16 @@ def delete_from_hub(
     for data_file in chain(*builder.config.data_files.values()):
         data_file_resolved_path = fs.resolve_path(data_file)
         if data_file_resolved_path.repo_id == repo_id:
-            operations.append(CommitOperationDelete(path_in_repo=data_file_resolved_path.path_in_repo))
+            operations.append(
+                CommitOperationDelete(path_in_repo=data_file_resolved_path.path_in_repo)
+            )
     # README.md
     dataset_card = DatasetCard.load(repo_id)
     # config_names
-    if dataset_card.data.get("config_names", None) and config_name in dataset_card.data["config_names"]:
+    if (
+        dataset_card.data.get("config_names", None)
+        and config_name in dataset_card.data["config_names"]
+    ):
         dataset_card.data["config_names"].remove(config_name)
     # metadata_configs
     metadata_configs = MetadataConfigs.from_dataset_card_data(dataset_card.data)
@@ -55,13 +60,15 @@ def delete_from_hub(
         dataset_card_data = DatasetCardData()
         metadata_configs.to_dataset_card_data(dataset_card_data)
         if datasets.config.METADATA_CONFIGS_FIELD in dataset_card_data:
-            dataset_card.data[datasets.config.METADATA_CONFIGS_FIELD] = dataset_card_data[
-                datasets.config.METADATA_CONFIGS_FIELD
-            ]
+            dataset_card.data[datasets.config.METADATA_CONFIGS_FIELD] = (
+                dataset_card_data[datasets.config.METADATA_CONFIGS_FIELD]
+            )
         else:
             _ = dataset_card.data.pop(datasets.config.METADATA_CONFIGS_FIELD, None)
     # dataset_info
-    dataset_infos: DatasetInfosDict = DatasetInfosDict.from_dataset_card_data(dataset_card.data)
+    dataset_infos: DatasetInfosDict = DatasetInfosDict.from_dataset_card_data(
+        dataset_card.data
+    )
     if dataset_infos:
         _ = dataset_infos.pop(config_name, None)
         dataset_card_data = DatasetCardData()
@@ -72,7 +79,10 @@ def delete_from_hub(
             _ = dataset_card.data.pop("dataset_info", None)
     # Commit
     operations.append(
-        CommitOperationAdd(path_in_repo=datasets.config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode())
+        CommitOperationAdd(
+            path_in_repo=datasets.config.REPOCARD_FILENAME,
+            path_or_fileobj=str(dataset_card).encode(),
+        )
     )
     api = HfApi(endpoint=datasets.config.HF_ENDPOINT, token=token)
     commit_info = api.create_commit(

--- a/src/datasets/inspect.py
+++ b/src/datasets/inspect.py
@@ -166,9 +166,13 @@ def get_dataset_config_names(
         data_files=data_files,
         **download_kwargs,
     )
-    builder_cls = get_dataset_builder_class(dataset_module, dataset_name=os.path.basename(path))
+    builder_cls = get_dataset_builder_class(
+        dataset_module, dataset_name=os.path.basename(path)
+    )
     return list(builder_cls.builder_configs.keys()) or [
-        dataset_module.builder_kwargs.get("config_name", builder_cls.DEFAULT_CONFIG_NAME or "default")
+        dataset_module.builder_kwargs.get(
+            "config_name", builder_cls.DEFAULT_CONFIG_NAME or "default"
+        )
     ]
 
 
@@ -225,7 +229,9 @@ def get_dataset_default_config_name(
         data_files=data_files,
         **download_kwargs,
     )
-    builder_cls = get_dataset_builder_class(dataset_module, dataset_name=os.path.basename(path))
+    builder_cls = get_dataset_builder_class(
+        dataset_module, dataset_name=os.path.basename(path)
+    )
     builder_configs = list(builder_cls.builder_configs.keys())
     if builder_configs:
         default_config_name = builder_configs[0] if len(builder_configs) == 1 else None
@@ -237,7 +243,9 @@ def get_dataset_default_config_name(
 def get_dataset_config_info(
     path: str,
     config_name: Optional[str] = None,
-    data_files: Optional[Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]] = None,
+    data_files: Optional[
+        Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]
+    ] = None,
     download_config: Optional[DownloadConfig] = None,
     download_mode: Optional[Union[DownloadMode, str]] = None,
     revision: Optional[Union[str, Version]] = None,
@@ -277,28 +285,41 @@ def get_dataset_config_info(
     )
     info = builder.info
     if info.splits is None:
-        download_config = download_config.copy() if download_config else DownloadConfig()
+        download_config = (
+            download_config.copy() if download_config else DownloadConfig()
+        )
         if token is not None:
             download_config.token = token
         builder._check_manual_download(
-            StreamingDownloadManager(base_path=builder.base_path, download_config=download_config)
+            StreamingDownloadManager(
+                base_path=builder.base_path, download_config=download_config
+            )
         )
         try:
             info.splits = {
-                split_generator.name: {"name": split_generator.name, "dataset_name": path}
+                split_generator.name: {
+                    "name": split_generator.name,
+                    "dataset_name": path,
+                }
                 for split_generator in builder._split_generators(
-                    StreamingDownloadManager(base_path=builder.base_path, download_config=download_config)
+                    StreamingDownloadManager(
+                        base_path=builder.base_path, download_config=download_config
+                    )
                 )
             }
         except Exception as err:
-            raise SplitsNotFoundError("The split names could not be parsed from the dataset config.") from err
+            raise SplitsNotFoundError(
+                "The split names could not be parsed from the dataset config."
+            ) from err
     return info
 
 
 def get_dataset_split_names(
     path: str,
     config_name: Optional[str] = None,
-    data_files: Optional[Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]] = None,
+    data_files: Optional[
+        Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]
+    ] = None,
     download_config: Optional[DownloadConfig] = None,
     download_mode: Optional[Union[DownloadMode, str]] = None,
     revision: Optional[Union[str, Version]] = None,

--- a/src/datasets/io/abc.py
+++ b/src/datasets/io/abc.py
@@ -1,7 +1,14 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 
-from .. import Dataset, DatasetDict, Features, IterableDataset, IterableDatasetDict, NamedSplit
+from .. import (
+    Dataset,
+    DatasetDict,
+    Features,
+    IterableDataset,
+    IterableDatasetDict,
+    NamedSplit,
+)
 from ..utils.typing import NestedDataStructureLike, PathLike
 
 

--- a/src/datasets/io/csv.py
+++ b/src/datasets/io/csv.py
@@ -34,7 +34,11 @@ class CsvDatasetReader(AbstractDatasetReader):
             num_proc=num_proc,
             **kwargs,
         )
-        path_or_paths = path_or_paths if isinstance(path_or_paths, dict) else {self.split: path_or_paths}
+        path_or_paths = (
+            path_or_paths
+            if isinstance(path_or_paths, dict)
+            else {self.split: path_or_paths}
+        )
         self.builder = Csv(
             cache_dir=cache_dir,
             data_files=path_or_paths,
@@ -61,7 +65,9 @@ class CsvDatasetReader(AbstractDatasetReader):
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(
-                split=self.split, verification_mode=verification_mode, in_memory=self.keep_in_memory
+                split=self.split,
+                verification_mode=verification_mode,
+                in_memory=self.keep_in_memory,
             )
         return dataset
 
@@ -93,10 +99,19 @@ class CsvDatasetWriter:
         index = self.to_csv_kwargs.pop("index", False)
 
         if isinstance(self.path_or_buf, (str, bytes, os.PathLike)):
-            with fsspec.open(self.path_or_buf, "wb", **(self.storage_options or {})) as buffer:
-                written = self._write(file_obj=buffer, header=header, index=index, **self.to_csv_kwargs)
+            with fsspec.open(
+                self.path_or_buf, "wb", **(self.storage_options or {})
+            ) as buffer:
+                written = self._write(
+                    file_obj=buffer, header=header, index=index, **self.to_csv_kwargs
+                )
         else:
-            written = self._write(file_obj=self.path_or_buf, header=header, index=index, **self.to_csv_kwargs)
+            written = self._write(
+                file_obj=self.path_or_buf,
+                header=header,
+                index=index,
+                **self.to_csv_kwargs,
+            )
         return written
 
     def _batch_csv(self, args):
@@ -108,7 +123,10 @@ class CsvDatasetWriter:
             indices=self.dataset._indices,
         )
         csv_str = batch.to_pandas().to_csv(
-            path_or_buf=None, header=header if (offset == 0) else False, index=index, **to_csv_kwargs
+            path_or_buf=None,
+            header=header if (offset == 0) else False,
+            index=index,
+            **to_csv_kwargs,
         )
         return csv_str.encode(self.encoding)
 
@@ -134,9 +152,16 @@ class CsvDatasetWriter:
                 for csv_str in hf_tqdm(
                     pool.imap(
                         self._batch_csv,
-                        [(offset, header, index, to_csv_kwargs) for offset in range(0, num_rows, batch_size)],
+                        [
+                            (offset, header, index, to_csv_kwargs)
+                            for offset in range(0, num_rows, batch_size)
+                        ],
                     ),
-                    total=(num_rows // batch_size) + 1 if num_rows % batch_size else num_rows // batch_size,
+                    total=(
+                        (num_rows // batch_size) + 1
+                        if num_rows % batch_size
+                        else num_rows // batch_size
+                    ),
                     unit="ba",
                     desc="Creating CSV from Arrow format",
                 ):

--- a/src/datasets/io/generator.py
+++ b/src/datasets/io/generator.py
@@ -54,6 +54,8 @@ class GeneratorDatasetInputStream(AbstractDatasetInputStream):
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(
-                split=self.builder.config.split, verification_mode=verification_mode, in_memory=self.keep_in_memory
+                split=self.builder.config.split,
+                verification_mode=verification_mode,
+                in_memory=self.keep_in_memory,
             )
         return dataset

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -6,7 +6,10 @@ import fsspec
 import pyarrow.parquet as pq
 
 from .. import Dataset, Features, NamedSplit, config
-from ..arrow_writer import get_writer_batch_size_from_data_size, get_writer_batch_size_from_features
+from ..arrow_writer import (
+    get_writer_batch_size_from_data_size,
+    get_writer_batch_size_from_features,
+)
 from ..formatting import query_table
 from ..packaged_modules import _PACKAGED_DATASETS_MODULES
 from ..packaged_modules.parquet.parquet import Parquet
@@ -37,7 +40,11 @@ class ParquetDatasetReader(AbstractDatasetReader):
             num_proc=num_proc,
             **kwargs,
         )
-        path_or_paths = path_or_paths if isinstance(path_or_paths, dict) else {self.split: path_or_paths}
+        path_or_paths = (
+            path_or_paths
+            if isinstance(path_or_paths, dict)
+            else {self.split: path_or_paths}
+        )
         hash = _PACKAGED_DATASETS_MODULES["parquet"][1]
         self.builder = Parquet(
             cache_dir=cache_dir,
@@ -66,7 +73,9 @@ class ParquetDatasetReader(AbstractDatasetReader):
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(
-                split=self.split, verification_mode=verification_mode, in_memory=self.keep_in_memory
+                split=self.split,
+                verification_mode=verification_mode,
+                in_memory=self.keep_in_memory,
             )
         return dataset
 
@@ -87,7 +96,9 @@ class ParquetDatasetWriter:
         self.batch_size = (
             batch_size
             or get_writer_batch_size_from_features(dataset.features)
-            or get_writer_batch_size_from_data_size(len(dataset), dataset._estimate_nbytes())
+            or get_writer_batch_size_from_data_size(
+                len(dataset), dataset._estimate_nbytes()
+            )
         )
         self.storage_options = storage_options or {}
         self.parquet_writer_kwargs = parquet_writer_kwargs
@@ -98,7 +109,9 @@ class ParquetDatasetWriter:
 
     def write(self) -> int:
         if isinstance(self.path_or_buf, (str, bytes, os.PathLike)):
-            with fsspec.open(self.path_or_buf, "wb", **(self.storage_options or {})) as buffer:
+            with fsspec.open(
+                self.path_or_buf, "wb", **(self.storage_options or {})
+            ) as buffer:
                 written = self._write(
                     file_obj=buffer,
                     batch_size=self.batch_size,
@@ -112,7 +125,9 @@ class ParquetDatasetWriter:
             )
         return written
 
-    def _write(self, file_obj: BinaryIO, batch_size: int, **parquet_writer_kwargs) -> int:
+    def _write(
+        self, file_obj: BinaryIO, batch_size: int, **parquet_writer_kwargs
+    ) -> int:
         """Writes the pyarrow table as Parquet to a binary file handle.
 
         Caller is responsible for opening and closing the handle.
@@ -144,7 +159,13 @@ class ParquetDatasetWriter:
 
         # TODO(kszucs): we may want to persist multiple parameters
         if self.use_content_defined_chunking is not False:
-            writer.add_key_value_metadata({"content_defined_chunking": json.dumps(self.use_content_defined_chunking)})
+            writer.add_key_value_metadata(
+                {
+                    "content_defined_chunking": json.dumps(
+                        self.use_content_defined_chunking
+                    )
+                }
+            )
 
         writer.close()
         return written

--- a/src/datasets/io/spark.py
+++ b/src/datasets/io/spark.py
@@ -49,7 +49,9 @@ class SparkDatasetReader(AbstractDatasetReader):
     def read(self):
         if self.streaming:
             return self.builder.as_streaming_dataset(split=self.split)
-        download_mode = None if self._load_from_cache_file else DownloadMode.FORCE_REDOWNLOAD
+        download_mode = (
+            None if self._load_from_cache_file else DownloadMode.FORCE_REDOWNLOAD
+        )
         self.builder.download_and_prepare(
             download_mode=download_mode,
             file_format=self._file_format,

--- a/src/datasets/io/sql.py
+++ b/src/datasets/io/sql.py
@@ -18,13 +18,23 @@ class SqlDatasetReader(AbstractDatasetInputStream):
     def __init__(
         self,
         sql: Union[str, "sqlalchemy.sql.Selectable"],
-        con: Union[str, "sqlalchemy.engine.Connection", "sqlalchemy.engine.Engine", "sqlite3.Connection"],
+        con: Union[
+            str,
+            "sqlalchemy.engine.Connection",
+            "sqlalchemy.engine.Engine",
+            "sqlite3.Connection",
+        ],
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,
         **kwargs,
     ):
-        super().__init__(features=features, cache_dir=cache_dir, keep_in_memory=keep_in_memory, **kwargs)
+        super().__init__(
+            features=features,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
+            **kwargs,
+        )
         self.builder = Sql(
             cache_dir=cache_dir,
             features=features,
@@ -48,7 +58,9 @@ class SqlDatasetReader(AbstractDatasetInputStream):
 
         # Build dataset for splits
         dataset = self.builder.as_dataset(
-            split="train", verification_mode=verification_mode, in_memory=self.keep_in_memory
+            split="train",
+            verification_mode=verification_mode,
+            in_memory=self.keep_in_memory,
         )
         return dataset
 
@@ -58,7 +70,12 @@ class SqlDatasetWriter:
         self,
         dataset: Dataset,
         name: str,
-        con: Union[str, "sqlalchemy.engine.Connection", "sqlalchemy.engine.Engine", "sqlite3.Connection"],
+        con: Union[
+            str,
+            "sqlalchemy.engine.Connection",
+            "sqlalchemy.engine.Engine",
+            "sqlite3.Connection",
+        ],
         batch_size: Optional[int] = None,
         num_proc: Optional[int] = None,
         **to_sql_kwargs,
@@ -83,7 +100,9 @@ class SqlDatasetWriter:
 
     def _batch_sql(self, args):
         offset, index, to_sql_kwargs = args
-        to_sql_kwargs = {**to_sql_kwargs, "if_exists": "append"} if offset > 0 else to_sql_kwargs
+        to_sql_kwargs = (
+            {**to_sql_kwargs, "if_exists": "append"} if offset > 0 else to_sql_kwargs
+        )
         batch = query_table(
             table=self.dataset.data,
             key=slice(offset, offset + self.batch_size),
@@ -113,9 +132,16 @@ class SqlDatasetWriter:
                 for num_rows in hf_tqdm(
                     pool.imap(
                         self._batch_sql,
-                        [(offset, index, to_sql_kwargs) for offset in range(0, num_rows, batch_size)],
+                        [
+                            (offset, index, to_sql_kwargs)
+                            for offset in range(0, num_rows, batch_size)
+                        ],
                     ),
-                    total=(num_rows // batch_size) + 1 if num_rows % batch_size else num_rows // batch_size,
+                    total=(
+                        (num_rows // batch_size) + 1
+                        if num_rows % batch_size
+                        else num_rows // batch_size
+                    ),
                     unit="ba",
                     desc="Creating SQL from Arrow format",
                 ):

--- a/src/datasets/io/text.py
+++ b/src/datasets/io/text.py
@@ -28,7 +28,11 @@ class TextDatasetReader(AbstractDatasetReader):
             num_proc=num_proc,
             **kwargs,
         )
-        path_or_paths = path_or_paths if isinstance(path_or_paths, dict) else {self.split: path_or_paths}
+        path_or_paths = (
+            path_or_paths
+            if isinstance(path_or_paths, dict)
+            else {self.split: path_or_paths}
+        )
         self.builder = Text(
             cache_dir=cache_dir,
             data_files=path_or_paths,
@@ -55,6 +59,8 @@ class TextDatasetReader(AbstractDatasetReader):
                 num_proc=self.num_proc,
             )
             dataset = self.builder.as_dataset(
-                split=self.split, verification_mode=verification_mode, in_memory=self.keep_in_memory
+                split=self.split,
+                verification_mode=verification_mode,
+                in_memory=self.keep_in_memory,
             )
         return dataset

--- a/src/datasets/naming.py
+++ b/src/datasets/naming.py
@@ -42,7 +42,9 @@ def snakecase_to_camelcase(name):
     """Convert snake-case string to camel-case string."""
     name = _single_underscore_re.split(name)
     name = [_multiple_underscores_re.split(n) for n in name]
-    return "".join(n.capitalize() for n in itertools.chain.from_iterable(name) if n != "")
+    return "".join(
+        n.capitalize() for n in itertools.chain.from_iterable(name) if n != ""
+    )
 
 
 def filename_prefix_for_name(name):
@@ -67,13 +69,18 @@ def filepattern_for_dataset_split(dataset_name, split, data_dir, filetype_suffix
     return f"{filepath}*"
 
 
-def filenames_for_dataset_split(path, dataset_name, split, filetype_suffix=None, shard_lengths=None):
+def filenames_for_dataset_split(
+    path, dataset_name, split, filetype_suffix=None, shard_lengths=None
+):
     prefix = filename_prefix_for_split(dataset_name, split)
     prefix = os.path.join(path, prefix)
 
     if shard_lengths:
         num_shards = len(shard_lengths)
-        filenames = [f"{prefix}-{shard_id:05d}-of-{num_shards:05d}" for shard_id in range(num_shards)]
+        filenames = [
+            f"{prefix}-{shard_id:05d}-of-{num_shards:05d}"
+            for shard_id in range(num_shards)
+        ]
         if filetype_suffix:
             filenames = [filename + f".{filetype_suffix}" for filename in filenames]
         return filenames

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -38,15 +38,39 @@ def _hash_python_lines(lines: list[str]) -> str:
 _PACKAGED_DATASETS_MODULES = {
     "csv": (csv.__name__, _hash_python_lines(inspect.getsource(csv).splitlines())),
     "json": (json.__name__, _hash_python_lines(inspect.getsource(json).splitlines())),
-    "pandas": (pandas.__name__, _hash_python_lines(inspect.getsource(pandas).splitlines())),
-    "parquet": (parquet.__name__, _hash_python_lines(inspect.getsource(parquet).splitlines())),
-    "arrow": (arrow.__name__, _hash_python_lines(inspect.getsource(arrow).splitlines())),
+    "pandas": (
+        pandas.__name__,
+        _hash_python_lines(inspect.getsource(pandas).splitlines()),
+    ),
+    "parquet": (
+        parquet.__name__,
+        _hash_python_lines(inspect.getsource(parquet).splitlines()),
+    ),
+    "arrow": (
+        arrow.__name__,
+        _hash_python_lines(inspect.getsource(arrow).splitlines()),
+    ),
     "text": (text.__name__, _hash_python_lines(inspect.getsource(text).splitlines())),
-    "imagefolder": (imagefolder.__name__, _hash_python_lines(inspect.getsource(imagefolder).splitlines())),
-    "audiofolder": (audiofolder.__name__, _hash_python_lines(inspect.getsource(audiofolder).splitlines())),
-    "videofolder": (videofolder.__name__, _hash_python_lines(inspect.getsource(videofolder).splitlines())),
-    "pdffolder": (pdffolder.__name__, _hash_python_lines(inspect.getsource(pdffolder).splitlines())),
-    "webdataset": (webdataset.__name__, _hash_python_lines(inspect.getsource(webdataset).splitlines())),
+    "imagefolder": (
+        imagefolder.__name__,
+        _hash_python_lines(inspect.getsource(imagefolder).splitlines()),
+    ),
+    "audiofolder": (
+        audiofolder.__name__,
+        _hash_python_lines(inspect.getsource(audiofolder).splitlines()),
+    ),
+    "videofolder": (
+        videofolder.__name__,
+        _hash_python_lines(inspect.getsource(videofolder).splitlines()),
+    ),
+    "pdffolder": (
+        pdffolder.__name__,
+        _hash_python_lines(inspect.getsource(pdffolder).splitlines()),
+    ),
+    "webdataset": (
+        webdataset.__name__,
+        _hash_python_lines(inspect.getsource(webdataset).splitlines()),
+    ),
     "xml": (xml.__name__, _hash_python_lines(inspect.getsource(xml).splitlines())),
     "hdf5": (hdf5.__name__, _hash_python_lines(inspect.getsource(hdf5).splitlines())),
 }
@@ -81,14 +105,30 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".hdf5": ("hdf5", {}),
     ".h5": ("hdf5", {}),
 }
-_EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext: ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext.upper(): ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext: ("videofolder", {}) for ext in videofolder.VideoFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext.upper(): ("videofolder", {}) for ext in videofolder.VideoFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext: ("pdffolder", {}) for ext in pdffolder.PdfFolder.EXTENSIONS})
-_EXTENSION_TO_MODULE.update({ext.upper(): ("pdffolder", {}) for ext in pdffolder.PdfFolder.EXTENSIONS})
+_EXTENSION_TO_MODULE.update(
+    {ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext: ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext.upper(): ("audiofolder", {}) for ext in audiofolder.AudioFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext: ("videofolder", {}) for ext in videofolder.VideoFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext.upper(): ("videofolder", {}) for ext in videofolder.VideoFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext: ("pdffolder", {}) for ext in pdffolder.PdfFolder.EXTENSIONS}
+)
+_EXTENSION_TO_MODULE.update(
+    {ext.upper(): ("pdffolder", {}) for ext in pdffolder.PdfFolder.EXTENSIONS}
+)
 
 # Used to filter data files based on extensions given a module name
 _MODULE_TO_EXTENSIONS: dict[str, list[str]] = {}
@@ -102,7 +142,13 @@ for _module in _MODULE_TO_EXTENSIONS:
 _MODULE_TO_METADATA_FILE_NAMES: Dict[str, List[str]] = {}
 for _module in _MODULE_TO_EXTENSIONS:
     _MODULE_TO_METADATA_FILE_NAMES[_module] = []
-_MODULE_TO_METADATA_FILE_NAMES["imagefolder"] = imagefolder.ImageFolder.METADATA_FILENAMES
-_MODULE_TO_METADATA_FILE_NAMES["audiofolder"] = imagefolder.ImageFolder.METADATA_FILENAMES
-_MODULE_TO_METADATA_FILE_NAMES["videofolder"] = imagefolder.ImageFolder.METADATA_FILENAMES
+_MODULE_TO_METADATA_FILE_NAMES["imagefolder"] = (
+    imagefolder.ImageFolder.METADATA_FILENAMES
+)
+_MODULE_TO_METADATA_FILE_NAMES["audiofolder"] = (
+    imagefolder.ImageFolder.METADATA_FILENAMES
+)
+_MODULE_TO_METADATA_FILE_NAMES["videofolder"] = (
+    imagefolder.ImageFolder.METADATA_FILENAMES
+)
 _MODULE_TO_METADATA_FILE_NAMES["pdffolder"] = imagefolder.ImageFolder.METADATA_FILENAMES

--- a/src/datasets/packaged_modules/arrow/arrow.py
+++ b/src/datasets/packaged_modules/arrow/arrow.py
@@ -30,7 +30,9 @@ class Arrow(datasets.ArrowBasedBuilder):
     def _split_generators(self, dl_manager):
         """We handle string, list and dicts in datafiles"""
         if not self.config.data_files:
-            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
         dl_manager.download_config.extract_on_the_fly = True
         data_files = dl_manager.download_and_extract(self.config.data_files)
         splits = []
@@ -47,9 +49,13 @@ class Arrow(datasets.ArrowBasedBuilder):
                             reader = pa.ipc.open_stream(f)
                         except (OSError, pa.lib.ArrowInvalid):
                             reader = pa.ipc.open_file(f)
-                    self.info.features = datasets.Features.from_arrow_schema(reader.schema)
+                    self.info.features = datasets.Features.from_arrow_schema(
+                        reader.schema
+                    )
                     break
-            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
@@ -67,7 +73,10 @@ class Arrow(datasets.ArrowBasedBuilder):
                         batches = pa.ipc.open_stream(f)
                     except (OSError, pa.lib.ArrowInvalid):
                         reader = pa.ipc.open_file(f)
-                        batches = (reader.get_batch(i) for i in range(reader.num_record_batches))
+                        batches = (
+                            reader.get_batch(i)
+                            for i in range(reader.num_record_batches)
+                        )
                     for batch_idx, record_batch in enumerate(batches):
                         pa_table = pa.Table.from_batches([record_batch])
                         # Uncomment for debugging (will print the Arrow table size and elements)
@@ -75,5 +84,7 @@ class Arrow(datasets.ArrowBasedBuilder):
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
                         yield f"{file_idx}_{batch_idx}", self._cast_table(pa_table)
                 except ValueError as e:
-                    logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")
+                    logger.error(
+                        f"Failed to read file '{file}' with error {type(e)}: {e}"
+                    )
                     raise

--- a/src/datasets/packaged_modules/generator/generator.py
+++ b/src/datasets/packaged_modules/generator/generator.py
@@ -27,7 +27,11 @@ class Generator(datasets.GeneratorBasedBuilder):
         return datasets.DatasetInfo(features=self.config.features)
 
     def _split_generators(self, dl_manager):
-        return [datasets.SplitGenerator(name=self.config.split, gen_kwargs=self.config.gen_kwargs)]
+        return [
+            datasets.SplitGenerator(
+                name=self.config.split, gen_kwargs=self.config.gen_kwargs
+            )
+        ]
 
     def _generate_examples(self, **gen_kwargs):
         yield from enumerate(self.config.generator(**gen_kwargs))

--- a/src/datasets/packaged_modules/hdf5/hdf5.py
+++ b/src/datasets/packaged_modules/hdf5/hdf5.py
@@ -49,7 +49,9 @@ class HDF5(datasets.ArrowBasedBuilder):
         import h5py
 
         if not self.config.data_files:
-            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
         dl_manager.download_config.extract_on_the_fly = True
         data_files = dl_manager.download_and_extract(self.config.data_files)
         splits = []
@@ -64,7 +66,9 @@ class HDF5(datasets.ArrowBasedBuilder):
                     with h5py.File(first_file, "r") as h5:
                         self.info.features = _recursive_infer_features(h5)
                     break
-            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
         return splits
 
     def _generate_tables(self, files):
@@ -81,14 +85,20 @@ class HDF5(datasets.ArrowBasedBuilder):
                     if num_rows is None:
                         logger.warning(f"File {file} contains no data, skipping...")
                         continue
-                    effective_batch = batch_size_cfg or self._writer_batch_size or num_rows
+                    effective_batch = (
+                        batch_size_cfg or self._writer_batch_size or num_rows
+                    )
                     for start in range(0, num_rows, effective_batch):
                         end = min(start + effective_batch, num_rows)
-                        pa_table = _recursive_load_arrays(h5, self.info.features, start, end)
+                        pa_table = _recursive_load_arrays(
+                            h5, self.info.features, start, end
+                        )
                         if pa_table is None:
                             logger.warning(f"File {file} contains no data, skipping...")
                             continue
-                        yield f"{file_idx}_{start}", cast_table_to_features(pa_table, self.info.features)
+                        yield f"{file_idx}_{start}", cast_table_to_features(
+                            pa_table, self.info.features
+                        )
             except ValueError as e:
                 logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")
                 raise
@@ -121,7 +131,9 @@ def _create_complex_features(dset) -> Features:
         # two float64s
         value_type = Value("float64")
     else:
-        logger.warning(f"Found complex dtype {dtype} that is not supported. Converting to float64...")
+        logger.warning(
+            f"Found complex dtype {dtype} that is not supported. Converting to float64..."
+        )
         value_type = Value("float64")
 
     return Features(
@@ -137,7 +149,9 @@ def _convert_complex_to_nested(arr: np.ndarray) -> pa.StructArray:
         "real": datasets.features.features.numpy_to_pyarrow_listarray(arr.real),
         "imag": datasets.features.features.numpy_to_pyarrow_listarray(arr.imag),
     }
-    return pa.StructArray.from_arrays([data["real"], data["imag"]], names=["real", "imag"])
+    return pa.StructArray.from_arrays(
+        [data["real"], data["imag"]], names=["real", "imag"]
+    )
 
 
 # ┌────────────┐
@@ -168,7 +182,9 @@ class _CompoundField:
     shape: tuple[int, ...] = field(init=False)
 
     def __post_init__(self):
-        self.shape = (len(self.data) if self.data is not None else 0,) + self.dtype.shape
+        self.shape = (
+            len(self.data) if self.data is not None else 0,
+        ) + self.dtype.shape
 
     def __getitem__(self, key):
         return self.data[key][self.name]
@@ -356,7 +372,9 @@ def _check_dataset_lengths(h5_obj, features: Features) -> int:
             continue
         if _is_dataset(dset):
             if dset.shape[0] != num_rows:
-                raise ValueError(f"Dataset '{path}' has length {dset.shape[0]} but expected {num_rows}")
+                raise ValueError(
+                    f"Dataset '{path}' has length {dset.shape[0]} but expected {num_rows}"
+                )
     return num_rows
 
 

--- a/src/datasets/packaged_modules/pandas/pandas.py
+++ b/src/datasets/packaged_modules/pandas/pandas.py
@@ -33,7 +33,9 @@ class Pandas(datasets.ArrowBasedBuilder):
     def _split_generators(self, dl_manager):
         """We handle string, list and dicts in datafiles"""
         if not self.config.data_files:
-            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
         data_files = dl_manager.download_and_extract(self.config.data_files)
         if isinstance(data_files, (str, list, tuple)):
             files = data_files
@@ -41,14 +43,20 @@ class Pandas(datasets.ArrowBasedBuilder):
                 files = [files]
             # Use `dl_manager.iter_files` to skip hidden files in an extracted archive
             files = [dl_manager.iter_files(file) for file in files]
-            return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"files": files})]
+            return [
+                datasets.SplitGenerator(
+                    name=datasets.Split.TRAIN, gen_kwargs={"files": files}
+                )
+            ]
         splits = []
         for split_name, files in data_files.items():
             if isinstance(files, str):
                 files = [files]
             # Use `dl_manager.iter_files` to skip hidden files in an extracted archive
             files = [dl_manager.iter_files(file) for file in files]
-            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:

--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -38,7 +38,9 @@ class Text(datasets.ArrowBasedBuilder):
         If dict, then keys should be from the `datasets.Split` enum.
         """
         if not self.config.data_files:
-            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
         dl_manager.download_config.extract_on_the_fly = True
         data_files = dl_manager.download_and_extract(self.config.data_files)
         splits = []
@@ -46,13 +48,18 @@ class Text(datasets.ArrowBasedBuilder):
             if isinstance(files, str):
                 files = [files]
             files = [dl_manager.iter_files(file) for file in files]
-            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         if self.config.features is not None:
             schema = self.config.features.arrow_schema
-            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
+            if all(
+                not require_storage_cast(feature)
+                for feature in self.config.features.values()
+            ):
                 # cheaper cast
                 pa_table = pa_table.cast(schema)
             else:
@@ -63,10 +70,14 @@ class Text(datasets.ArrowBasedBuilder):
             return pa_table.cast(pa.schema({"text": pa.string()}))
 
     def _generate_tables(self, files):
-        pa_table_names = list(self.config.features) if self.config.features is not None else ["text"]
+        pa_table_names = (
+            list(self.config.features) if self.config.features is not None else ["text"]
+        )
         for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
             # open in text mode, by default translates universal newlines ("\n", "\r\n" and "\r") into "\n"
-            with open(file, encoding=self.config.encoding, errors=self.config.encoding_errors) as f:
+            with open(
+                file, encoding=self.config.encoding, errors=self.config.encoding_errors
+            ) as f:
                 if self.config.sample_by == "line":
                     batch_idx = 0
                     while True:
@@ -78,7 +89,9 @@ class Text(datasets.ArrowBasedBuilder):
                         batch = StringIO(batch).readlines()
                         if not self.config.keep_linebreaks:
                             batch = [line.rstrip("\n") for line in batch]
-                        pa_table = pa.Table.from_arrays([pa.array(batch)], names=pa_table_names)
+                        pa_table = pa.Table.from_arrays(
+                            [pa.array(batch)], names=pa_table_names
+                        )
                         # Uncomment for debugging (will print the Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
@@ -95,7 +108,8 @@ class Text(datasets.ArrowBasedBuilder):
                         batch += f.readline()  # finish current line
                         batch = batch.split("\n\n")
                         pa_table = pa.Table.from_arrays(
-                            [pa.array([example for example in batch[:-1] if example])], names=pa_table_names
+                            [pa.array([example for example in batch[:-1] if example])],
+                            names=pa_table_names,
                         )
                         # Uncomment for debugging (will print the Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
@@ -104,9 +118,13 @@ class Text(datasets.ArrowBasedBuilder):
                         batch_idx += 1
                         batch = batch[-1]
                     if batch:
-                        pa_table = pa.Table.from_arrays([pa.array([batch])], names=pa_table_names)
+                        pa_table = pa.Table.from_arrays(
+                            [pa.array([batch])], names=pa_table_names
+                        )
                         yield (file_idx, batch_idx), self._cast_table(pa_table)
                 elif self.config.sample_by == "document":
                     text = f.read()
-                    pa_table = pa.Table.from_arrays([pa.array([text])], names=pa_table_names)
+                    pa_table = pa.Table.from_arrays(
+                        [pa.array([text])], names=pa_table_names
+                    )
                     yield file_idx, self._cast_table(pa_table)

--- a/src/datasets/packaged_modules/webdataset/_tenbin.py
+++ b/src/datasets/packaged_modules/webdataset/_tenbin.py
@@ -124,7 +124,9 @@ def encode_header(a, info=""):
         raise ValueError("mismatch between size and shape")
     if a.dtype.name not in long_to_short:
         raise ValueError("unsupported array type")
-    header = [str64(long_to_short[a.dtype.name]), str64(info), len(a.shape)] + list(a.shape)
+    header = [str64(long_to_short[a.dtype.name]), str64(info), len(a.shape)] + list(
+        a.shape
+    )
     return bytedata(np.array(header, dtype="i8"))
 
 

--- a/src/datasets/packaged_modules/xml/xml.py
+++ b/src/datasets/packaged_modules/xml/xml.py
@@ -34,7 +34,9 @@ class Xml(datasets.ArrowBasedBuilder):
         If dict, then keys should be from the `datasets.Split` enum.
         """
         if not self.config.data_files:
-            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
         dl_manager.download_config.extract_on_the_fly = True
         data_files = dl_manager.download_and_extract(self.config.data_files)
         splits = []
@@ -42,13 +44,18 @@ class Xml(datasets.ArrowBasedBuilder):
             if isinstance(files, str):
                 files = [files]
             files = [dl_manager.iter_files(file) for file in files]
-            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         if self.config.features is not None:
             schema = self.config.features.arrow_schema
-            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
+            if all(
+                not require_storage_cast(feature)
+                for feature in self.config.features.values()
+            ):
                 # cheaper cast
                 pa_table = pa_table.cast(schema)
             else:
@@ -59,10 +66,14 @@ class Xml(datasets.ArrowBasedBuilder):
             return pa_table.cast(pa.schema({"xml": pa.string()}))
 
     def _generate_tables(self, files):
-        pa_table_names = list(self.config.features) if self.config.features is not None else ["xml"]
+        pa_table_names = (
+            list(self.config.features) if self.config.features is not None else ["xml"]
+        )
         for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
             # open in text mode, by default translates universal newlines ("\n", "\r\n" and "\r") into "\n"
-            with open(file, encoding=self.config.encoding, errors=self.config.encoding_errors) as f:
+            with open(
+                file, encoding=self.config.encoding, errors=self.config.encoding_errors
+            ) as f:
                 xml = f.read()
                 pa_table = pa.Table.from_arrays([pa.array([xml])], names=pa_table_names)
                 yield file_idx, self._cast_table(pa_table)

--- a/src/datasets/parallel/parallel.py
+++ b/src/datasets/parallel/parallel.py
@@ -14,7 +14,17 @@ class ParallelBackendConfig:
 
 
 @experimental
-def parallel_map(function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, single_map_nested_func):
+def parallel_map(
+    function,
+    iterable,
+    num_proc,
+    batched,
+    batch_size,
+    types,
+    disable_tqdm,
+    desc,
+    single_map_nested_func,
+):
     """
     **Experimental.** Apply a function to iterable elements in parallel, where the implementation uses either
     multiprocessing.Pool or joblib for parallelization.
@@ -32,16 +42,40 @@ def parallel_map(function, iterable, num_proc, batched, batch_size, types, disab
     """
     if ParallelBackendConfig.backend_name is None:
         return _map_with_multiprocessing_pool(
-            function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, single_map_nested_func
+            function,
+            iterable,
+            num_proc,
+            batched,
+            batch_size,
+            types,
+            disable_tqdm,
+            desc,
+            single_map_nested_func,
         )
 
     return _map_with_joblib(
-        function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, single_map_nested_func
+        function,
+        iterable,
+        num_proc,
+        batched,
+        batch_size,
+        types,
+        disable_tqdm,
+        desc,
+        single_map_nested_func,
     )
 
 
 def _map_with_multiprocessing_pool(
-    function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, single_map_nested_func
+    function,
+    iterable,
+    num_proc,
+    batched,
+    batch_size,
+    types,
+    disable_tqdm,
+    desc,
+    single_map_nested_func,
 ):
     num_proc = num_proc if num_proc <= len(iterable) else len(iterable)
     split_kwds = []  # We organize the splits ourselve (contiguous splits)
@@ -50,7 +84,18 @@ def _map_with_multiprocessing_pool(
         mod = len(iterable) % num_proc
         start = div * index + min(index, mod)
         end = start + div + (1 if index < mod else 0)
-        split_kwds.append((function, iterable[start:end], batched, batch_size, types, index, disable_tqdm, desc))
+        split_kwds.append(
+            (
+                function,
+                iterable[start:end],
+                batched,
+                batch_size,
+                types,
+                index,
+                disable_tqdm,
+                desc,
+            )
+        )
 
     if len(iterable) != sum(len(i[1]) for i in split_kwds):
         raise ValueError(
@@ -75,7 +120,15 @@ def _map_with_multiprocessing_pool(
 
 
 def _map_with_joblib(
-    function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, single_map_nested_func
+    function,
+    iterable,
+    num_proc,
+    batched,
+    batch_size,
+    types,
+    disable_tqdm,
+    desc,
+    single_map_nested_func,
 ):
     # progress bar is not yet supported for _map_with_joblib, because tqdm couldn't accurately be applied to joblib,
     # and it requires monkey-patching joblib internal classes which is subject to change
@@ -83,7 +136,9 @@ def _map_with_joblib(
 
     with joblib.parallel_backend(ParallelBackendConfig.backend_name, n_jobs=num_proc):
         return joblib.Parallel()(
-            joblib.delayed(single_map_nested_func)((function, obj, batched, batch_size, types, None, True, None))
+            joblib.delayed(single_map_nested_func)(
+                (function, obj, batched, batch_size, types, None, True, None)
+            )
             for obj in iterable
         )
 

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -30,9 +30,15 @@ from .utils.py_utils import NonMutableDict, asdict
 
 @dataclass
 class SplitInfo:
-    name: str = dataclasses.field(default="", metadata={"include_in_asdict_even_if_is_default": True})
-    num_bytes: int = dataclasses.field(default=0, metadata={"include_in_asdict_even_if_is_default": True})
-    num_examples: int = dataclasses.field(default=0, metadata={"include_in_asdict_even_if_is_default": True})
+    name: str = dataclasses.field(
+        default="", metadata={"include_in_asdict_even_if_is_default": True}
+    )
+    num_bytes: int = dataclasses.field(
+        default=0, metadata={"include_in_asdict_even_if_is_default": True}
+    )
+    num_examples: int = dataclasses.field(
+        default=0, metadata={"include_in_asdict_even_if_is_default": True}
+    )
     shard_lengths: Optional[list[int]] = None
 
     # Deprecated
@@ -129,7 +135,9 @@ class SplitBase(metaclass=abc.ABCMeta):
         """Equality: datasets.Split.TRAIN == 'train'."""
         if isinstance(other, (NamedSplit, str)):
             return False
-        raise NotImplementedError("Equality is not implemented between merged/sub splits.")
+        raise NotImplementedError(
+            "Equality is not implemented between merged/sub splits."
+        )
 
     def __ne__(self, other):
         """InEquality: datasets.Split.TRAIN != 'test'."""
@@ -139,7 +147,9 @@ class SplitBase(metaclass=abc.ABCMeta):
         """Merging: datasets.Split.TRAIN + datasets.Split.TEST."""
         return _SplitMerged(self, other)
 
-    def subsplit(self, arg=None, k=None, percent=None, weighted=None):  # pylint: disable=redefined-outer-name
+    def subsplit(
+        self, arg=None, k=None, percent=None, weighted=None
+    ):  # pylint: disable=redefined-outer-name
         """Divides this split into subsplits.
 
         There are 3 ways to define subsplits, which correspond to the 3
@@ -208,7 +218,9 @@ class SplitBase(metaclass=abc.ABCMeta):
 
         def assert_slices_coverage(slices):
             # Ensure that the expended slices cover all percents.
-            assert sum((list(range(*s.indices(100))) for s in slices), []) == list(range(100))
+            assert sum((list(range(*s.indices(100))) for s in slices), []) == list(
+                range(100)
+            )
 
         if k:
             if not 0 < k <= 100:
@@ -253,7 +265,9 @@ class SplitBase(metaclass=abc.ABCMeta):
 class PercentSliceMeta(type):
     def __getitem__(cls, slice_value):
         if not isinstance(slice_value, slice):
-            raise ValueError(f"datasets.percent should only be called with slice, not {slice_value}")
+            raise ValueError(
+                f"datasets.percent should only be called with slice, not {slice_value}"
+            )
         return slice_value
 
 
@@ -356,10 +370,14 @@ class NamedSplit(SplitBase):
 
     def __init__(self, name):
         self._name = name
-        split_names_from_instruction = [split_instruction.split("[")[0] for split_instruction in name.split("+")]
+        split_names_from_instruction = [
+            split_instruction.split("[")[0] for split_instruction in name.split("+")
+        ]
         for split_name in split_names_from_instruction:
             if not re.match(_split_re, split_name):
-                raise ValueError(f"Split name should match '{_split_re}' but got '{split_name}'.")
+                raise ValueError(
+                    f"Split name should match '{_split_re}' but got '{split_name}'."
+                )
 
     def __str__(self):
         return self._name
@@ -478,7 +496,9 @@ class SplitReadInstruction:
     """
 
     def __init__(self, split_info=None):
-        self._splits = NonMutableDict(error_msg="Overlap between splits. Split {key} has been added with itself.")
+        self._splits = NonMutableDict(
+            error_msg="Overlap between splits. Split {key} has been added with itself."
+        )
 
         if split_info:
             self.add(SlicedSplitInfo(split_info=split_info, slice_value=None))
@@ -496,8 +516,12 @@ class SplitReadInstruction:
         # TODO(epot): If a split is already added but there is no overlap between
         # the slices, should merge the slices (ex: [:10] + [80:])
         split_instruction = SplitReadInstruction()
-        split_instruction._splits.update(self._splits)  # pylint: disable=protected-access
-        split_instruction._splits.update(other._splits)  # pylint: disable=protected-access
+        split_instruction._splits.update(
+            self._splits
+        )  # pylint: disable=protected-access
+        split_instruction._splits.update(
+            other._splits
+        )  # pylint: disable=protected-access
         return split_instruction
 
     def __getitem__(self, slice_value):
@@ -506,7 +530,9 @@ class SplitReadInstruction:
         split_instruction = SplitReadInstruction()
         for v in self._splits.values():
             if v.slice_value is not None:
-                raise ValueError(f"Trying to slice Split {v.split_info.name} which has already been sliced")
+                raise ValueError(
+                    f"Trying to slice Split {v.split_info.name} which has already been sliced"
+                )
             v = v._asdict()
             v["slice_value"] = slice_value
             split_instruction.add(SlicedSplitInfo(**v))
@@ -538,7 +564,9 @@ class SplitDict(dict):
 
     def __setitem__(self, key: Union[SplitBase, str], value: SplitInfo):
         if key != value.name:
-            raise ValueError(f"Cannot add elem. (key mismatch: '{key}' != '{value.name}')")
+            raise ValueError(
+                f"Cannot add elem. (key mismatch: '{key}' != '{value.name}')"
+            )
         super().__setitem__(key, value)
 
     def add(self, split_info: SplitInfo):
@@ -554,7 +582,9 @@ class SplitDict(dict):
         return sum(s.num_examples for s in self.values())
 
     @classmethod
-    def from_split_dict(cls, split_infos: Union[list, dict], dataset_name: Optional[str] = None):
+    def from_split_dict(
+        cls, split_infos: Union[list, dict], dataset_name: Optional[str] = None
+    ):
         """Returns a new SplitDict initialized from a Dict or List of `split_infos`."""
         if isinstance(split_infos, dict):
             split_infos = list(split_infos.values())

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -21,7 +21,9 @@ logger = get_logger(__name__)
 
 def inject_arrow_table_documentation(arrow_table_method):
     def wrapper(fn):
-        fn.__doc__ = arrow_table_method.__doc__ + (fn.__doc__ if fn.__doc__ is not None else "")
+        fn.__doc__ = arrow_table_method.__doc__ + (
+            fn.__doc__ if fn.__doc__ is not None else ""
+        )
         fn.__doc__ = fn.__doc__.replace("pyarrow.Table", "Table")
         if hasattr(arrow_table_method, "__annotations__"):
             fn.__annotations__ = arrow_table_method.__annotations__
@@ -44,7 +46,9 @@ def _in_memory_arrow_table_from_buffer(buffer: pa.Buffer) -> pa.Table:
     return table
 
 
-def _memory_mapped_record_batch_reader_from_file(filename: str) -> pa.RecordBatchStreamReader:
+def _memory_mapped_record_batch_reader_from_file(
+    filename: str,
+) -> pa.RecordBatchStreamReader:
     memory_mapped_stream = pa.memory_map(filename)
     return pa.ipc.open_stream(memory_mapped_stream)
 
@@ -107,7 +111,9 @@ class IndexedTableMixin:
         self._batches: list[pa.RecordBatch] = [
             recordbatch for recordbatch in table.to_batches() if len(recordbatch) > 0
         ]
-        self._offsets: np.ndarray = np.cumsum([0] + [len(b) for b in self._batches], dtype=np.int64)
+        self._offsets: np.ndarray = np.cumsum(
+            [0] + [len(b) for b in self._batches], dtype=np.int64
+        )
 
     def fast_gather(self, indices: Union[list[int], np.ndarray]) -> pa.Table:
         """
@@ -1007,7 +1013,9 @@ class MemoryMappedTable(TableBlock):
     stay low.
     """
 
-    def __init__(self, table: pa.Table, path: str, replays: Optional[list[Replay]] = None):
+    def __init__(
+        self, table: pa.Table, path: str, replays: Optional[list[Replay]] = None
+    ):
         super().__init__(table)
         self.path = os.path.abspath(path)
         self.replays: list[Replay] = replays if replays is not None else []
@@ -1029,7 +1037,9 @@ class MemoryMappedTable(TableBlock):
         MemoryMappedTable.__init__(self, table, path=path, replays=replays)
 
     @staticmethod
-    def _apply_replays(table: pa.Table, replays: Optional[list[Replay]] = None) -> pa.Table:
+    def _apply_replays(
+        table: pa.Table, replays: Optional[list[Replay]] = None
+    ) -> pa.Table:
         if replays is not None:
             for name, args, kwargs in replays:
                 if name == "cast":
@@ -1062,7 +1072,9 @@ class MemoryMappedTable(TableBlock):
         replay = ("slice", (offset, length), {})
         replays = self._append_replay(replay)
         # Use fast slicing here
-        return MemoryMappedTable(self.fast_slice(offset=offset, length=length), self.path, replays)
+        return MemoryMappedTable(
+            self.fast_slice(offset=offset, length=length), self.path, replays
+        )
 
     def filter(self, *args, **kwargs):
         """
@@ -1086,7 +1098,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("flatten", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(table_flatten(self.table, *args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            table_flatten(self.table, *args, **kwargs), self.path, replays
+        )
 
     def combine_chunks(self, *args, **kwargs):
         """
@@ -1104,7 +1118,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("combine_chunks", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.combine_chunks(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.combine_chunks(*args, **kwargs), self.path, replays
+        )
 
     def cast(self, *args, **kwargs):
         """
@@ -1121,7 +1137,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("cast", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(table_cast(self.table, *args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            table_cast(self.table, *args, **kwargs), self.path, replays
+        )
 
     def replace_schema_metadata(self, *args, **kwargs):
         """
@@ -1137,7 +1155,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("replace_schema_metadata", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.replace_schema_metadata(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.replace_schema_metadata(*args, **kwargs), self.path, replays
+        )
 
     def add_column(self, *args, **kwargs):
         """
@@ -1160,7 +1180,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("add_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.add_column(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.add_column(*args, **kwargs), self.path, replays
+        )
 
     def append_column(self, *args, **kwargs):
         """
@@ -1179,7 +1201,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("append_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.append_column(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.append_column(*args, **kwargs), self.path, replays
+        )
 
     def remove_column(self, *args, **kwargs):
         """
@@ -1195,7 +1219,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("remove_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.remove_column(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.remove_column(*args, **kwargs), self.path, replays
+        )
 
     def set_column(self, *args, **kwargs):
         """
@@ -1216,7 +1242,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("set_column", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.set_column(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.set_column(*args, **kwargs), self.path, replays
+        )
 
     def rename_columns(self, *args, **kwargs):
         """
@@ -1224,7 +1252,9 @@ class MemoryMappedTable(TableBlock):
         """
         replay = ("rename_columns", copy.deepcopy(args), copy.deepcopy(kwargs))
         replays = self._append_replay(replay)
-        return MemoryMappedTable(self.table.rename_columns(*args, **kwargs), self.path, replays)
+        return MemoryMappedTable(
+            self.table.rename_columns(*args, **kwargs), self.path, replays
+        )
 
     def drop(self, *args, **kwargs):
         """
@@ -1267,7 +1297,9 @@ class MemoryMappedTable(TableBlock):
 # The ``blocks`` attributes stores a list of list of blocks.
 # The first axis concatenates the tables along the axis 0 (it appends rows),
 # while the second axis concatenates tables along the axis 1 (it appends columns).
-TableBlockContainer = TypeVar("TableBlockContainer", TableBlock, list[TableBlock], list[list[TableBlock]])
+TableBlockContainer = TypeVar(
+    "TableBlockContainer", TableBlock, list[TableBlock], list[list[TableBlock]]
+)
 
 
 class ConcatenationTable(Table):
@@ -1324,8 +1356,12 @@ class ConcatenationTable(Table):
         ConcatenationTable.__init__(self, table, blocks=blocks)
 
     @staticmethod
-    def _concat_blocks(blocks: list[Union[TableBlock, pa.Table]], axis: int = 0) -> pa.Table:
-        pa_tables = [table.table if hasattr(table, "table") else table for table in blocks]
+    def _concat_blocks(
+        blocks: list[Union[TableBlock, pa.Table]], axis: int = 0
+    ) -> pa.Table:
+        pa_tables = [
+            table.table if hasattr(table, "table") else table for table in blocks
+        ]
         if axis == 0:
             # We set promote_options="default" to fill missing columns with null values
             return pa.concat_tables(pa_tables, promote_options="default")
@@ -1341,7 +1377,9 @@ class ConcatenationTable(Table):
             raise ValueError("'axis' must be either 0 or 1")
 
     @classmethod
-    def _concat_blocks_horizontally_and_vertically(cls, blocks: list[list[TableBlock]]) -> pa.Table:
+    def _concat_blocks_horizontally_and_vertically(
+        cls, blocks: list[list[TableBlock]]
+    ) -> pa.Table:
         pa_tables_to_concat_vertically = []
         for i, tables in enumerate(blocks):
             if not tables:
@@ -1351,18 +1389,27 @@ class ConcatenationTable(Table):
         return cls._concat_blocks(pa_tables_to_concat_vertically, axis=0)
 
     @classmethod
-    def _merge_blocks(cls, blocks: TableBlockContainer, axis: Optional[int] = None) -> TableBlockContainer:
+    def _merge_blocks(
+        cls, blocks: TableBlockContainer, axis: Optional[int] = None
+    ) -> TableBlockContainer:
         if axis is not None:
             merged_blocks = []
-            for is_in_memory, block_group in groupby(blocks, key=lambda x: isinstance(x, InMemoryTable)):
+            for is_in_memory, block_group in groupby(
+                blocks, key=lambda x: isinstance(x, InMemoryTable)
+            ):
                 if is_in_memory:
-                    block_group = [InMemoryTable(cls._concat_blocks(list(block_group), axis=axis))]
+                    block_group = [
+                        InMemoryTable(cls._concat_blocks(list(block_group), axis=axis))
+                    ]
                 merged_blocks += list(block_group)
         else:  # both
-            merged_blocks = [cls._merge_blocks(row_block, axis=1) for row_block in blocks]
+            merged_blocks = [
+                cls._merge_blocks(row_block, axis=1) for row_block in blocks
+            ]
             if all(len(row_block) == 1 for row_block in merged_blocks):
                 merged_blocks = cls._merge_blocks(
-                    [block for row_block in merged_blocks for block in row_block], axis=0
+                    [block for row_block in merged_blocks for block in row_block],
+                    axis=0,
                 )
         return merged_blocks
 
@@ -1390,7 +1437,9 @@ class ConcatenationTable(Table):
             return cls(table, blocks)
 
     @classmethod
-    def from_tables(cls, tables: list[Union[pa.Table, Table]], axis: int = 0) -> "ConcatenationTable":
+    def from_tables(
+        cls, tables: list[Union[pa.Table, Table]], axis: int = 0
+    ) -> "ConcatenationTable":
         """Create `ConcatenationTable` from list of tables.
 
         Args:
@@ -1411,9 +1460,13 @@ class ConcatenationTable(Table):
             else:
                 return [[table]]
 
-        def _slice_row_block(row_block: list[TableBlock], length: int) -> tuple[list[TableBlock], list[TableBlock]]:
+        def _slice_row_block(
+            row_block: list[TableBlock], length: int
+        ) -> tuple[list[TableBlock], list[TableBlock]]:
             sliced = [table.slice(0, length) for table in row_block]
-            remainder = [table.slice(length, len(row_block[0]) - length) for table in row_block]
+            remainder = [
+                table.slice(length, len(row_block[0]) - length) for table in row_block
+            ]
             return sliced, remainder
 
         def _split_both_like(
@@ -1440,21 +1493,29 @@ class ConcatenationTable(Table):
                 # and we replace the long row block by its remainder if necessary
                 if len(result[0][0]) > len(blocks[0][0]):
                     new_blocks.append(blocks[0])
-                    sliced, result[0] = _slice_row_block(result[0], len(blocks.pop(0)[0]))
+                    sliced, result[0] = _slice_row_block(
+                        result[0], len(blocks.pop(0)[0])
+                    )
                     new_result.append(sliced)
                 elif len(result[0][0]) < len(blocks[0][0]):
                     new_result.append(result[0])
-                    sliced, blocks[0] = _slice_row_block(blocks[0], len(result.pop(0)[0]))
+                    sliced, blocks[0] = _slice_row_block(
+                        blocks[0], len(result.pop(0)[0])
+                    )
                     new_blocks.append(sliced)
                 else:
                     new_result.append(result.pop(0))
                     new_blocks.append(blocks.pop(0))
             if result or blocks:
-                raise ValueError("Failed to concatenate on axis=1 because tables don't have the same number of rows")
+                raise ValueError(
+                    "Failed to concatenate on axis=1 because tables don't have the same number of rows"
+                )
             return new_result, new_blocks
 
         def _extend_blocks(
-            result: list[list[TableBlock]], blocks: list[list[TableBlock]], axis: int = 0
+            result: list[list[TableBlock]],
+            blocks: list[list[TableBlock]],
+            axis: int = 0,
         ) -> list[list[TableBlock]]:
             if axis == 0:
                 result.extend(blocks)
@@ -1583,8 +1644,21 @@ class ConcatenationTable(Table):
             for subtable in subtables:
                 subfields = []
                 for name in subtable.column_names:
-                    subfields.append(fields.pop(next(i for i, field in enumerate(fields) if field.name == name)))
-                subfeatures = Features({subfield.name: target_features[subfield.name] for subfield in subfields})
+                    subfields.append(
+                        fields.pop(
+                            next(
+                                i
+                                for i, field in enumerate(fields)
+                                if field.name == name
+                            )
+                        )
+                    )
+                subfeatures = Features(
+                    {
+                        subfield.name: target_features[subfield.name]
+                        for subfield in subfields
+                    }
+                )
                 subschema = subfeatures.arrow_schema
                 new_tables.append(subtable.cast(subschema, *args, **kwargs))
             blocks.append(new_tables)
@@ -1664,7 +1738,11 @@ class ConcatenationTable(Table):
         for tables in self.blocks:
             blocks.append(
                 [
-                    t.remove_column(t.column_names.index(name), *args, **kwargs) if name in t.column_names else t
+                    (
+                        t.remove_column(t.column_names.index(name), *args, **kwargs)
+                        if name in t.column_names
+                        else t
+                    )
                     for t in tables
                 ]
             )
@@ -1698,7 +1776,12 @@ class ConcatenationTable(Table):
         blocks = []
         for tables in self.blocks:
             blocks.append(
-                [t.rename_columns([names[name] for name in t.column_names], *args, **kwargs) for t in tables]
+                [
+                    t.rename_columns(
+                        [names[name] for name in t.column_names], *args, **kwargs
+                    )
+                    for t in tables
+                ]
             )
         return ConcatenationTable(table, blocks)
 
@@ -1720,7 +1803,12 @@ class ConcatenationTable(Table):
         table = self.table.drop(columns, *args, **kwargs)
         blocks = []
         for tables in self.blocks:
-            blocks.append([t.drop([c for c in columns if c in t.column_names], *args, **kwargs) for t in tables])
+            blocks.append(
+                [
+                    t.drop([c for c in columns if c in t.column_names], *args, **kwargs)
+                    for t in tables
+                ]
+            )
         return ConcatenationTable(table, blocks)
 
     def select(self, columns, *args, **kwargs):
@@ -1739,7 +1827,14 @@ class ConcatenationTable(Table):
         table = self.table.select(columns, *args, **kwargs)
         blocks = []
         for tables in self.blocks:
-            blocks.append([t.select([c for c in columns if c in t.column_names], *args, **kwargs) for t in tables])
+            blocks.append(
+                [
+                    t.select(
+                        [c for c in columns if c in t.column_names], *args, **kwargs
+                    )
+                    for t in tables
+                ]
+            )
         return ConcatenationTable(table, blocks)
 
 
@@ -1792,7 +1887,9 @@ def _wrap_for_chunked_arrays(func):
 
     def wrapper(array, *args, **kwargs):
         if isinstance(array, pa.ChunkedArray):
-            return pa.chunked_array([func(chunk, *args, **kwargs) for chunk in array.chunks])
+            return pa.chunked_array(
+                [func(chunk, *args, **kwargs) for chunk in array.chunks]
+            )
         else:
             return func(array, *args, **kwargs)
 
@@ -1801,7 +1898,9 @@ def _wrap_for_chunked_arrays(func):
 
 def _are_list_values_of_length(array: pa.ListArray, length: int) -> bool:
     """Check if all the sub-lists of a `pa.ListArray` have the specified length."""
-    return pc.all(pc.equal(array.value_lengths(), length)).as_py() or array.null_count == len(array)
+    return pc.all(
+        pc.equal(array.value_lengths(), length)
+    ).as_py() or array.null_count == len(array)
 
 
 def _combine_list_array_offsets_with_mask(array: pa.ListArray) -> pa.Array:
@@ -1810,7 +1909,9 @@ def _combine_list_array_offsets_with_mask(array: pa.ListArray) -> pa.Array:
     if array.null_count > 0:
         offsets = pa.concat_arrays(
             [
-                pc.replace_with_mask(offsets[:-1], array.is_null(), pa.nulls(len(array), pa.int32())),
+                pc.replace_with_mask(
+                    offsets[:-1], array.is_null(), pa.nulls(len(array), pa.int32())
+                ),
                 offsets[-1:],
             ]
         )
@@ -1822,7 +1923,9 @@ def _storage_type(type: pa.DataType) -> pa.DataType:
     if isinstance(type, pa.ExtensionType):
         return _storage_type(type.storage_type)
     elif isinstance(type, pa.StructType):
-        return pa.struct([pa.field(field.name, _storage_type(field.type)) for field in type])
+        return pa.struct(
+            [pa.field(field.name, _storage_type(field.type)) for field in type]
+        )
     elif isinstance(type, pa.ListType):
         return pa.list_(_storage_type(type.value_type))
     elif isinstance(type, pa.FixedSizeListType):
@@ -1839,8 +1942,13 @@ def _short_str(value: Any) -> str:
 
 @_wrap_for_chunked_arrays
 def array_cast(
-    array: pa.Array, pa_type: pa.DataType, allow_primitive_to_str: bool = True, allow_decimal_to_str: bool = True
-) -> Union[pa.Array, pa.FixedSizeListArray, pa.ListArray, pa.StructArray, pa.ExtensionArray]:
+    array: pa.Array,
+    pa_type: pa.DataType,
+    allow_primitive_to_str: bool = True,
+    allow_decimal_to_str: bool = True,
+) -> Union[
+    pa.Array, pa.FixedSizeListArray, pa.ListArray, pa.StructArray, pa.ExtensionArray
+]:
     """Improved version of `pa.Array.cast`
 
     It supports casting `pa.StructArray` objects to re-order the fields.
@@ -1871,7 +1979,11 @@ def array_cast(
     Returns:
         `List[pyarrow.Array]`: the casted array
     """
-    _c = partial(array_cast, allow_primitive_to_str=allow_primitive_to_str, allow_decimal_to_str=allow_decimal_to_str)
+    _c = partial(
+        array_cast,
+        allow_primitive_to_str=allow_primitive_to_str,
+        allow_decimal_to_str=allow_decimal_to_str,
+    )
     if isinstance(array, pa.ExtensionArray):
         array = array.storage
     if isinstance(pa_type, pa.ExtensionType):
@@ -1879,11 +1991,15 @@ def array_cast(
     elif array.type == pa_type:
         return array
     elif pa.types.is_struct(array.type):
-        if pa.types.is_struct(pa_type) and ({field.name for field in pa_type} == {field.name for field in array.type}):
+        if pa.types.is_struct(pa_type) and (
+            {field.name for field in pa_type} == {field.name for field in array.type}
+        ):
             if array.type.num_fields == 0:
                 return array
             arrays = [_c(array.field(field.name), field.type) for field in pa_type]
-            return pa.StructArray.from_arrays(arrays, fields=list(pa_type), mask=array.is_null())
+            return pa.StructArray.from_arrays(
+                arrays, fields=list(pa_type), mask=array.is_null()
+            )
     elif pa.types.is_list(array.type) or pa.types.is_large_list(array.type):
         if pa.types.is_fixed_size_list(pa_type):
             if _are_list_values_of_length(array, pa_type.list_size):
@@ -1894,43 +2010,71 @@ def array_cast(
                     if array_type != storage_type:
                         # Temporarily convert to the storage type to support extension types in the slice operation
                         array = _c(array, storage_type)
-                        array = pc.list_slice(array, 0, pa_type.list_size, return_fixed_size_list=True)
+                        array = pc.list_slice(
+                            array, 0, pa_type.list_size, return_fixed_size_list=True
+                        )
                         array = _c(array, array_type)
                     else:
-                        array = pc.list_slice(array, 0, pa_type.list_size, return_fixed_size_list=True)
+                        array = pc.list_slice(
+                            array, 0, pa_type.list_size, return_fixed_size_list=True
+                        )
                     array_values = array.values
                     return pa.FixedSizeListArray.from_arrays(
-                        _c(array_values, pa_type.value_type), pa_type.list_size, mask=array.is_null()
+                        _c(array_values, pa_type.value_type),
+                        pa_type.list_size,
+                        mask=array.is_null(),
                     )
                 else:
                     array_values = array.values[
-                        array.offset * pa_type.list_size : (array.offset + len(array)) * pa_type.list_size
+                        array.offset
+                        * pa_type.list_size : (array.offset + len(array))
+                        * pa_type.list_size
                     ]
-                    return pa.FixedSizeListArray.from_arrays(_c(array_values, pa_type.value_type), pa_type.list_size)
+                    return pa.FixedSizeListArray.from_arrays(
+                        _c(array_values, pa_type.value_type), pa_type.list_size
+                    )
         elif pa.types.is_list(pa_type):
             # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
             array_offsets = _combine_list_array_offsets_with_mask(array)
-            return pa.ListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type))
+            return pa.ListArray.from_arrays(
+                array_offsets, _c(array.values, pa_type.value_type)
+            )
         elif pa.types.is_large_list(pa_type):
             # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
             array_offsets = _combine_list_array_offsets_with_mask(array)
-            return pa.LargeListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type))
+            return pa.LargeListArray.from_arrays(
+                array_offsets, _c(array.values, pa_type.value_type)
+            )
     elif pa.types.is_fixed_size_list(array.type):
         if pa.types.is_fixed_size_list(pa_type):
             if pa_type.list_size == array.type.list_size:
                 array_values = array.values[
-                    array.offset * array.type.list_size : (array.offset + len(array)) * array.type.list_size
+                    array.offset
+                    * array.type.list_size : (array.offset + len(array))
+                    * array.type.list_size
                 ]
                 return pa.FixedSizeListArray.from_arrays(
-                    _c(array_values, pa_type.value_type), pa_type.list_size, mask=array.is_null()
+                    _c(array_values, pa_type.value_type),
+                    pa_type.list_size,
+                    mask=array.is_null(),
                 )
         elif pa.types.is_list(pa_type):
-            array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
-            return pa.ListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type), mask=array.is_null())
+            array_offsets = (
+                np.arange(len(array) + 1) + array.offset
+            ) * array.type.list_size
+            return pa.ListArray.from_arrays(
+                array_offsets,
+                _c(array.values, pa_type.value_type),
+                mask=array.is_null(),
+            )
         elif pa.types.is_large_list(pa_type):
-            array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
+            array_offsets = (
+                np.arange(len(array) + 1) + array.offset
+            ) * array.type.list_size
             return pa.LargeListArray.from_arrays(
-                array_offsets, _c(array.values, pa_type.value_type), mask=array.is_null()
+                array_offsets,
+                _c(array.values, pa_type.value_type),
+                mask=array.is_null(),
             )
     else:
         if pa.types.is_string(pa_type):
@@ -1945,14 +2089,21 @@ def array_cast(
                     f"and allow_decimal_to_str is set to {allow_decimal_to_str}"
                 )
         if pa.types.is_null(pa_type) and not pa.types.is_null(array.type):
-            raise TypeError(f"Couldn't cast array of type {_short_str(array.type)} to {_short_str(pa_type)}")
+            raise TypeError(
+                f"Couldn't cast array of type {_short_str(array.type)} to {_short_str(pa_type)}"
+            )
         return array.cast(pa_type)
-    raise TypeError(f"Couldn't cast array of type {_short_str(array.type)} to {_short_str(pa_type)}")
+    raise TypeError(
+        f"Couldn't cast array of type {_short_str(array.type)} to {_short_str(pa_type)}"
+    )
 
 
 @_wrap_for_chunked_arrays
 def cast_array_to_feature(
-    array: pa.Array, feature: "FeatureType", allow_primitive_to_str: bool = True, allow_decimal_to_str: bool = True
+    array: pa.Array,
+    feature: "FeatureType",
+    allow_primitive_to_str: bool = True,
+    allow_decimal_to_str: bool = True,
 ) -> pa.Array:
     """Cast an array to the arrow type that corresponds to the requested feature type.
     For custom features like [`Audio`] or [`Image`], it takes into account the "cast_storage" methods
@@ -1996,18 +2147,28 @@ def cast_array_to_feature(
 
     if pa.types.is_struct(array.type):
         # feature must be a dict
-        if isinstance(feature, dict) and (array_fields := {field.name for field in array.type}) <= set(feature):
+        if isinstance(feature, dict) and (
+            array_fields := {field.name for field in array.type}
+        ) <= set(feature):
             null_array = pa.array([None] * len(array))
             arrays = [
-                _c(array.field(name) if name in array_fields else null_array, subfeature)
+                _c(
+                    array.field(name) if name in array_fields else null_array,
+                    subfeature,
+                )
                 for name, subfeature in feature.items()
             ]
-            return pa.StructArray.from_arrays(arrays, names=list(feature), mask=array.is_null())
+            return pa.StructArray.from_arrays(
+                arrays, names=list(feature), mask=array.is_null()
+            )
     elif pa.types.is_list(array.type) or pa.types.is_large_list(array.type):
         # feature must be either List(subfeature) or LargeList(subfeature)
         if isinstance(feature, LargeList):
             casted_array_values = _c(array.values, feature.feature)
-            if pa.types.is_large_list(array.type) and casted_array_values.type == array.values.type:
+            if (
+                pa.types.is_large_list(array.type)
+                and casted_array_values.type == array.values.type
+            ):
                 # Both array and feature have equal large_list type and values (within the list) type
                 return array
             else:
@@ -2029,7 +2190,9 @@ def cast_array_to_feature(
                                 allow_primitive_to_str=allow_primitive_to_str,
                                 allow_decimal_to_str=allow_decimal_to_str,
                             )
-                            array = pc.list_slice(array, 0, feature.length, return_fixed_size_list=True)
+                            array = pc.list_slice(
+                                array, 0, feature.length, return_fixed_size_list=True
+                            )
                             array = array_cast(
                                 array,
                                 array_type,
@@ -2037,7 +2200,9 @@ def cast_array_to_feature(
                                 allow_decimal_to_str=allow_decimal_to_str,
                             )
                         else:
-                            array = pc.list_slice(array, 0, feature.length, return_fixed_size_list=True)
+                            array = pc.list_slice(
+                                array, 0, feature.length, return_fixed_size_list=True
+                            )
                         array_values = array.values
                         casted_array_values = _c(array_values, feature.feature)
                         return pa.FixedSizeListArray.from_arrays(
@@ -2045,12 +2210,19 @@ def cast_array_to_feature(
                         )
                     else:
                         array_values = array.values[
-                            array.offset * feature.length : (array.offset + len(array)) * feature.length
+                            array.offset
+                            * feature.length : (array.offset + len(array))
+                            * feature.length
                         ]
-                        return pa.FixedSizeListArray.from_arrays(_c(array_values, feature.feature), feature.length)
+                        return pa.FixedSizeListArray.from_arrays(
+                            _c(array_values, feature.feature), feature.length
+                        )
             else:
                 casted_array_values = _c(array.values, feature.feature)
-                if pa.types.is_list(array.type) and casted_array_values.type == array.values.type:
+                if (
+                    pa.types.is_list(array.type)
+                    and casted_array_values.type == array.values.type
+                ):
                     # Both array and feature have equal list type and values (within the list) type
                     return array
                 else:
@@ -2060,7 +2232,9 @@ def cast_array_to_feature(
     elif pa.types.is_fixed_size_list(array.type):
         # feature must be List(subfeature)
         if isinstance(feature, LargeList):
-            array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
+            array_offsets = (
+                np.arange(len(array) + 1) + array.offset
+            ) * array.type.list_size
             return pa.LargeListArray.from_arrays(
                 array_offsets, _c(array.values, feature.feature), mask=array.is_null()
             )
@@ -2068,13 +2242,23 @@ def cast_array_to_feature(
             if feature.length > -1:
                 if feature.length == array.type.list_size:
                     array_values = array.values[
-                        array.offset * array.type.list_size : (array.offset + len(array)) * array.type.list_size
+                        array.offset
+                        * array.type.list_size : (array.offset + len(array))
+                        * array.type.list_size
                     ]
                     casted_array_values = _c(array_values, feature.feature)
-                    return pa.FixedSizeListArray.from_arrays(casted_array_values, feature.length, mask=array.is_null())
+                    return pa.FixedSizeListArray.from_arrays(
+                        casted_array_values, feature.length, mask=array.is_null()
+                    )
             else:
-                array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
-                return pa.ListArray.from_arrays(array_offsets, _c(array.values, feature.feature), mask=array.is_null())
+                array_offsets = (
+                    np.arange(len(array) + 1) + array.offset
+                ) * array.type.list_size
+                return pa.ListArray.from_arrays(
+                    array_offsets,
+                    _c(array.values, feature.feature),
+                    mask=array.is_null(),
+                )
     if pa.types.is_null(array.type):
         return array_cast(
             array,
@@ -2089,11 +2273,15 @@ def cast_array_to_feature(
             allow_primitive_to_str=allow_primitive_to_str,
             allow_decimal_to_str=allow_decimal_to_str,
         )
-    raise TypeError(f"Couldn't cast array of type\n{_short_str(array.type)}\nto\n{_short_str(feature)}")
+    raise TypeError(
+        f"Couldn't cast array of type\n{_short_str(array.type)}\nto\n{_short_str(feature)}"
+    )
 
 
 @_wrap_for_chunked_arrays
-def embed_array_storage(array: pa.Array, feature: "FeatureType", token_per_repo_id=None):
+def embed_array_storage(
+    array: pa.Array, feature: "FeatureType", token_per_repo_id=None
+):
     """Embed data into an arrays's storage.
     For custom features like Audio or Image, it takes into account the "embed_storage" methods
     they define to embed external data (e.g. an image file) into an array.
@@ -2125,53 +2313,79 @@ def embed_array_storage(array: pa.Array, feature: "FeatureType", token_per_repo_
     elif pa.types.is_struct(array.type):
         # feature must be a dict
         if isinstance(feature, dict):
-            arrays = [_e(array.field(name), subfeature) for name, subfeature in feature.items()]
-            return pa.StructArray.from_arrays(arrays, names=list(feature), mask=array.is_null())
+            arrays = [
+                _e(array.field(name), subfeature)
+                for name, subfeature in feature.items()
+            ]
+            return pa.StructArray.from_arrays(
+                arrays, names=list(feature), mask=array.is_null()
+            )
     elif pa.types.is_list(array.type):
         # feature must be either List(subfeature)
         # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
         array_offsets = _combine_list_array_offsets_with_mask(array)
         if isinstance(feature, List) and feature.length == -1:
-            return pa.ListArray.from_arrays(array_offsets, _e(array.values, feature.feature))
+            return pa.ListArray.from_arrays(
+                array_offsets, _e(array.values, feature.feature)
+            )
     elif pa.types.is_large_list(array.type):
         # feature must be LargeList(subfeature)
         # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
         array_offsets = _combine_list_array_offsets_with_mask(array)
-        return pa.LargeListArray.from_arrays(array_offsets, _e(array.values, feature.feature))
+        return pa.LargeListArray.from_arrays(
+            array_offsets, _e(array.values, feature.feature)
+        )
     elif pa.types.is_fixed_size_list(array.type):
         # feature must be List(subfeature)
         if isinstance(feature, List) and feature.length > -1:
             array_values = array.values[
-                array.offset * array.type.list_size : (array.offset + len(array)) * array.type.list_size
+                array.offset
+                * array.type.list_size : (array.offset + len(array))
+                * array.type.list_size
             ]
             embedded_array_values = _e(array_values, feature.feature)
-            return pa.FixedSizeListArray.from_arrays(embedded_array_values, feature.length, mask=array.is_null())
+            return pa.FixedSizeListArray.from_arrays(
+                embedded_array_values, feature.length, mask=array.is_null()
+            )
     if not isinstance(feature, (List, LargeList, dict)):
         return array
-    raise TypeError(f"Couldn't embed array of type\n{_short_str(array.type)}\nwith\n{_short_str(feature)}")
+    raise TypeError(
+        f"Couldn't embed array of type\n{_short_str(array.type)}\nwith\n{_short_str(feature)}"
+    )
 
 
 class CastError(ValueError):
     """When it's not possible to cast an Arrow table to a specific schema or set of features"""
 
-    def __init__(self, *args, table_column_names: list[str], requested_column_names: list[str]) -> None:
+    def __init__(
+        self, *args, table_column_names: list[str], requested_column_names: list[str]
+    ) -> None:
         super().__init__(*args)
         self.table_column_names = table_column_names
         self.requested_column_names = requested_column_names
 
     def __reduce__(self):
         # Fix unpickling: TypeError: __init__() missing 2 required keyword-only arguments: 'table_column_names' and 'requested_column_names'
-        return partial(
-            CastError, table_column_names=self.table_column_names, requested_column_names=self.requested_column_names
-        ), ()
+        return (
+            partial(
+                CastError,
+                table_column_names=self.table_column_names,
+                requested_column_names=self.requested_column_names,
+            ),
+            (),
+        )
 
     def details(self):
         new_columns = set(self.table_column_names) - set(self.requested_column_names)
-        missing_columns = set(self.requested_column_names) - set(self.table_column_names)
+        missing_columns = set(self.requested_column_names) - set(
+            self.table_column_names
+        )
         if new_columns and missing_columns:
             return f"there are {len(new_columns)} new columns ({_short_str(new_columns)}) and {len(missing_columns)} missing columns ({_short_str(missing_columns)})."
         elif new_columns:
-            return f"there are {len(new_columns)} new columns ({_short_str(new_columns)})"
+            return (
+                f"there are {len(new_columns)} new columns ({_short_str(new_columns)})"
+            )
         else:
             return f"there are {len(missing_columns)} missing columns ({_short_str(missing_columns)})"
 
@@ -2194,7 +2408,10 @@ def cast_table_to_features(table: pa.Table, features: "Features"):
             table_column_names=table.column_names,
             requested_column_names=list(features),
         )
-    arrays = [cast_array_to_feature(table[name], feature) for name, feature in features.items()]
+    arrays = [
+        cast_array_to_feature(table[name], feature)
+        for name, feature in features.items()
+    ]
     return pa.Table.from_arrays(arrays, schema=features.arrow_schema)
 
 
@@ -2222,7 +2439,11 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
         )
     arrays = [
         cast_array_to_feature(
-            table[name] if name in table_column_names else pa.array([None] * len(table), type=schema.field(name).type),
+            (
+                table[name]
+                if name in table_column_names
+                else pa.array([None] * len(table), type=schema.field(name).type)
+            ),
             feature,
         )
         for name, feature in features.items()
@@ -2246,9 +2467,13 @@ def embed_table_storage(table: pa.Table, token_per_repo_id=None):
 
     features = Features.from_arrow_schema(table.schema)
     arrays = [
-        embed_array_storage(table[name], feature, token_per_repo_id=token_per_repo_id)
-        if require_storage_embed(feature)
-        else table[name]
+        (
+            embed_array_storage(
+                table[name], feature, token_per_repo_id=token_per_repo_id
+            )
+            if require_storage_embed(feature)
+            else table[name]
+        )
         for name, feature in features.items()
     ]
     return pa.Table.from_arrays(arrays, schema=features.arrow_schema)
@@ -2292,7 +2517,10 @@ def table_flatten(table: pa.Table):
     from .features import Features
 
     features = Features.from_arrow_schema(table.schema)
-    if any(hasattr(subfeature, "flatten") and subfeature.flatten() == subfeature for subfeature in features.values()):
+    if any(
+        hasattr(subfeature, "flatten") and subfeature.flatten() == subfeature
+        for subfeature in features.values()
+    ):
         flat_arrays = []
         flat_column_names = []
         for field in table.schema:
@@ -2302,7 +2530,9 @@ def table_flatten(table: pa.Table):
                 not hasattr(subfeature, "flatten") or subfeature.flatten() != subfeature
             ):
                 flat_arrays.extend(array.flatten())
-                flat_column_names.extend([f"{field.name}.{subfield.name}" for subfield in field.type])
+                flat_column_names.extend(
+                    [f"{field.name}.{subfield.name}" for subfield in field.type]
+                )
             else:
                 flat_arrays.append(array)
                 flat_column_names.append(field.name)
@@ -2314,7 +2544,12 @@ def table_flatten(table: pa.Table):
         flat_table = table.flatten()
     # Preserve complex types in the metadata
     flat_features = features.flatten(max_depth=2)
-    flat_features = Features({column_name: flat_features[column_name] for column_name in flat_table.column_names})
+    flat_features = Features(
+        {
+            column_name: flat_features[column_name]
+            for column_name in flat_table.column_names
+        }
+    )
     return flat_table.replace_schema_metadata(flat_features.arrow_schema.metadata)
 
 
@@ -2350,7 +2585,9 @@ def table_visitor(table: pa.Table, function: Callable[[pa.Array], None]):
         _visit(table[name], feature)
 
 
-def table_iter(table: Table, batch_size: int, drop_last_batch=False) -> Iterator[pa.Table]:
+def table_iter(
+    table: Table, batch_size: int, drop_last_batch=False
+) -> Iterator[pa.Table]:
     """Iterate over sub-tables of size `batch_size`.
 
     Args:
@@ -2379,7 +2616,9 @@ def table_iter(table: Table, batch_size: int, drop_last_batch=False) -> Iterator
             cropped_chunk_length = batch_size - chunks_buffer_size
             chunks_buffer.append(chunk.slice(0, cropped_chunk_length))
             yield pa.Table.from_batches(chunks_buffer)
-            chunks_buffer = [chunk.slice(cropped_chunk_length, len(chunk) - cropped_chunk_length)]
+            chunks_buffer = [
+                chunk.slice(cropped_chunk_length, len(chunk) - cropped_chunk_length)
+            ]
             chunks_buffer_size = len(chunk) - cropped_chunk_length
     if not drop_last_batch and chunks_buffer:
         yield pa.Table.from_batches(chunks_buffer)

--- a/src/datasets/utils/_dataset_viewer.py
+++ b/src/datasets/utils/_dataset_viewer.py
@@ -30,16 +30,23 @@ def get_exported_parquet_files(
     Get the dataset exported parquet files
     Docs: https://huggingface.co/docs/datasets-server/parquet
     """
-    dataset_viewer_parquet_url = config.HF_ENDPOINT.replace("://", "://datasets-server.") + "/parquet?dataset="
+    dataset_viewer_parquet_url = (
+        config.HF_ENDPOINT.replace("://", "://datasets-server.") + "/parquet?dataset="
+    )
     try:
         parquet_data_files_response = get_session().get(
             url=dataset_viewer_parquet_url + dataset,
-            headers=get_authentication_headers_for_url(config.HF_ENDPOINT + f"datasets/{dataset}", token=token),
+            headers=get_authentication_headers_for_url(
+                config.HF_ENDPOINT + f"datasets/{dataset}", token=token
+            ),
             timeout=100.0,
         )
         parquet_data_files_response.raise_for_status()
         if "X-Revision" in parquet_data_files_response.headers:
-            if parquet_data_files_response.headers["X-Revision"] == commit_hash or commit_hash is None:
+            if (
+                parquet_data_files_response.headers["X-Revision"] == commit_hash
+                or commit_hash is None
+            ):
                 parquet_data_files_response_json = parquet_data_files_response.json()
                 if (
                     parquet_data_files_response_json.get("partial") is False
@@ -49,13 +56,19 @@ def get_exported_parquet_files(
                 ):
                     return parquet_data_files_response_json["parquet_files"]
                 else:
-                    logger.debug(f"Parquet export for {dataset} is not completely ready yet.")
+                    logger.debug(
+                        f"Parquet export for {dataset} is not completely ready yet."
+                    )
             else:
                 logger.debug(
                     f"Parquet export for {dataset} is available but outdated (commit_hash='{parquet_data_files_response.headers['X-Revision']}')"
                 )
-    except Exception as e:  # noqa catch any exception of the dataset viewer API and consider the parquet export doesn't exist
-        logger.debug(f"No parquet export for {dataset} available ({type(e).__name__}: {e})")
+    except (
+        Exception
+    ) as e:  # noqa catch any exception of the dataset viewer API and consider the parquet export doesn't exist
+        logger.debug(
+            f"No parquet export for {dataset} available ({type(e).__name__}: {e})"
+        )
     raise DatasetViewerError("No exported Parquet files available.")
 
 
@@ -66,16 +79,23 @@ def get_exported_dataset_infos(
     Get the dataset information, can be useful to get e.g. the dataset features.
     Docs: https://huggingface.co/docs/datasets-server/info
     """
-    dataset_viewer_info_url = config.HF_ENDPOINT.replace("://", "://datasets-server.") + "/info?dataset="
+    dataset_viewer_info_url = (
+        config.HF_ENDPOINT.replace("://", "://datasets-server.") + "/info?dataset="
+    )
     try:
         info_response = get_session().get(
             url=dataset_viewer_info_url + dataset,
-            headers=get_authentication_headers_for_url(config.HF_ENDPOINT + f"datasets/{dataset}", token=token),
+            headers=get_authentication_headers_for_url(
+                config.HF_ENDPOINT + f"datasets/{dataset}", token=token
+            ),
             timeout=100.0,
         )
         info_response.raise_for_status()
         if "X-Revision" in info_response.headers:
-            if info_response.headers["X-Revision"] == commit_hash or commit_hash is None:
+            if (
+                info_response.headers["X-Revision"] == commit_hash
+                or commit_hash is None
+            ):
                 info_response = info_response.json()
                 if (
                     info_response.get("partial") is False
@@ -85,11 +105,17 @@ def get_exported_dataset_infos(
                 ):
                     return info_response["dataset_info"]
                 else:
-                    logger.debug(f"Dataset info for {dataset} is not completely ready yet.")
+                    logger.debug(
+                        f"Dataset info for {dataset} is not completely ready yet."
+                    )
             else:
                 logger.debug(
                     f"Dataset info for {dataset} is available but outdated (commit_hash='{info_response.headers['X-Revision']}')"
                 )
-    except Exception as e:  # noqa catch any exception of the dataset viewer API and consider the dataset info doesn't exist
-        logger.debug(f"No dataset info for {dataset} available ({type(e).__name__}: {e})")
+    except (
+        Exception
+    ) as e:  # noqa catch any exception of the dataset viewer API and consider the dataset info doesn't exist
+        logger.debug(
+            f"No dataset info for {dataset} available ({type(e).__name__}: {e})"
+        )
     raise DatasetViewerError("No exported dataset infos available.")

--- a/src/datasets/utils/_filelock.py
+++ b/src/datasets/utils/_filelock.py
@@ -33,7 +33,9 @@ class FileLock(FileLock_):
     def __init__(self, lock_file, *args, **kwargs):
         # The "mode" argument is required if we want to use the current umask in filelock >= 3.10
         # In previous previous it was already using the current umask.
-        if "mode" not in kwargs and version.parse(_filelock_version) >= version.parse("3.10.0"):
+        if "mode" not in kwargs and version.parse(_filelock_version) >= version.parse(
+            "3.10.0"
+        ):
             umask = os.umask(0o666)
             os.umask(umask)
             kwargs["mode"] = 0o666 & ~umask
@@ -46,12 +48,17 @@ class FileLock(FileLock_):
         filename = os.path.basename(path)
         max_filename_length = cls.MAX_FILENAME_LENGTH
         if issubclass(cls, UnixFileLock):
-            max_filename_length = min(max_filename_length, os.statvfs(os.path.dirname(path)).f_namemax)
+            max_filename_length = min(
+                max_filename_length, os.statvfs(os.path.dirname(path)).f_namemax
+            )
         if len(filename) > max_filename_length:
             dirname = os.path.dirname(path)
             hashed_filename = str(hash(filename))
             new_filename = (
-                filename[: max_filename_length - len(hashed_filename) - 8] + "..." + hashed_filename + ".lock"
+                filename[: max_filename_length - len(hashed_filename) - 8]
+                + "..."
+                + hashed_filename
+                + ".lock"
             )
             return os.path.join(dirname, new_filename)
         else:

--- a/src/datasets/utils/deprecation_utils.py
+++ b/src/datasets/utils/deprecation_utils.py
@@ -29,10 +29,15 @@ def deprecated(help_message: Optional[str] = None):
             deprecated_function = deprecated_class_or_function
             name = deprecated_function.__name__
             # Support deprecating __init__ class method: class name instead
-            name = name if name != "__init__" else deprecated_function.__qualname__.split(".")[-2]
+            name = (
+                name
+                if name != "__init__"
+                else deprecated_function.__qualname__.split(".")[-2]
+            )
 
         warning_msg = (
-            f"{name} is deprecated and will be removed in the next major version of datasets." + f" {help_message}"
+            f"{name} is deprecated and will be removed in the next major version of datasets."
+            + f" {help_message}"
             if help_message
             else ""
         )
@@ -73,8 +78,12 @@ class OnAccess(enum.EnumMeta):
             member._on_access()
         return member
 
-    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1):
-        obj = super().__call__(value, names, module=module, qualname=qualname, type=type, start=start)
+    def __call__(
+        cls, value, names=None, *, module=None, qualname=None, type=None, start=1
+    ):
+        obj = super().__call__(
+            value, names, module=module, qualname=qualname, type=type, start=start
+        )
         if isinstance(obj, enum.Enum) and obj._on_access:
             obj._on_access()
         return obj

--- a/src/datasets/utils/experimental.py
+++ b/src/datasets/utils/experimental.py
@@ -35,7 +35,9 @@ def experimental(fn: Callable) -> Callable:
     @wraps(fn)
     def _inner_fn(*args, **kwargs):
         warnings.warn(
-            (f"'{fn.__name__}' is experimental and might be subject to breaking changes in the future."),
+            (
+                f"'{fn.__name__}' is experimental and might be subject to breaking changes in the future."
+            ),
             UserWarning,
         )
         return fn(*args, **kwargs)

--- a/src/datasets/utils/filelock.py
+++ b/src/datasets/utils/filelock.py
@@ -8,4 +8,6 @@ from filelock import (  # noqa: F401 # imported for backward compatibility TODO:
     WindowsFileLock,
 )
 
-from ._filelock import FileLock  # noqa: F401 # imported for backward compatibility. TODO: remove in 3.0.0
+from ._filelock import (
+    FileLock,
+)  # noqa: F401 # imported for backward compatibility. TODO: remove in 3.0.0

--- a/src/datasets/utils/info_utils.py
+++ b/src/datasets/utils/info_utils.py
@@ -41,16 +41,28 @@ class VerificationMode(enum.Enum):
     NO_CHECKS = "no_checks"
 
 
-def verify_checksums(expected_checksums: Optional[dict], recorded_checksums: dict, verification_name=None):
+def verify_checksums(
+    expected_checksums: Optional[dict], recorded_checksums: dict, verification_name=None
+):
     if expected_checksums is None:
         logger.info("Unable to verify checksums.")
         return
     if len(set(expected_checksums) - set(recorded_checksums)) > 0:
-        raise ExpectedMoreDownloadedFilesError(str(set(expected_checksums) - set(recorded_checksums)))
+        raise ExpectedMoreDownloadedFilesError(
+            str(set(expected_checksums) - set(recorded_checksums))
+        )
     if len(set(recorded_checksums) - set(expected_checksums)) > 0:
-        raise UnexpectedDownloadedFileError(str(set(recorded_checksums) - set(expected_checksums)))
-    bad_urls = [url for url in expected_checksums if expected_checksums[url] != recorded_checksums[url]]
-    for_verification_name = " for " + verification_name if verification_name is not None else ""
+        raise UnexpectedDownloadedFileError(
+            str(set(recorded_checksums) - set(expected_checksums))
+        )
+    bad_urls = [
+        url
+        for url in expected_checksums
+        if expected_checksums[url] != recorded_checksums[url]
+    ]
+    for_verification_name = (
+        " for " + verification_name if verification_name is not None else ""
+    )
     if len(bad_urls) > 0:
         raise NonMatchingChecksumError(
             f"Checksums didn't match{for_verification_name}:\n"

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -94,7 +94,9 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
                             len(yaml_data_files_item) == 2
                             and "split" in yaml_data_files_item
                             and re.match(_split_re, yaml_data_files_item["split"])
-                            and isinstance(yaml_data_files_item.get("path"), (str, list))
+                            and isinstance(
+                                yaml_data_files_item.get("path"), (str, list)
+                            )
                         )
                     ):
                         raise ValueError(yaml_error_message)
@@ -112,15 +114,23 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
                     {
                         "split": split_name,
                         "path": [
-                            parquet_file["url"].replace("refs%2Fconvert%2Fparquet", parquet_commit_hash)
+                            parquet_file["url"].replace(
+                                "refs%2Fconvert%2Fparquet", parquet_commit_hash
+                            )
                             for parquet_file in parquet_files_for_split
                         ],
                     }
-                    for split_name, parquet_files_for_split in groupby(parquet_files_for_config, itemgetter("split"))
+                    for split_name, parquet_files_for_split in groupby(
+                        parquet_files_for_config, itemgetter("split")
+                    )
                 ],
-                "version": str(dataset_infos.get(config_name, DatasetInfo()).version or "0.0.0"),
+                "version": str(
+                    dataset_infos.get(config_name, DatasetInfo()).version or "0.0.0"
+                ),
             }
-            for config_name, parquet_files_for_config in groupby(exported_parquet_files, itemgetter("config"))
+            for config_name, parquet_files_for_config in groupby(
+                exported_parquet_files, itemgetter("config")
+            )
         }
         if dataset_infos:
             # Preserve order of configs and splits
@@ -139,11 +149,15 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
         return cls(metadata_configs)
 
     @classmethod
-    def from_dataset_card_data(cls, dataset_card_data: DatasetCardData) -> "MetadataConfigs":
+    def from_dataset_card_data(
+        cls, dataset_card_data: DatasetCardData
+    ) -> "MetadataConfigs":
         if dataset_card_data.get(cls.FIELD_NAME):
             metadata_configs = dataset_card_data[cls.FIELD_NAME]
             if not isinstance(metadata_configs, list):
-                raise ValueError(f"Expected {cls.FIELD_NAME} to be a list, but got '{metadata_configs}'")
+                raise ValueError(
+                    f"Expected {cls.FIELD_NAME} to be a list, but got '{metadata_configs}'"
+                )
             for metadata_config in metadata_configs:
                 if "config_name" not in metadata_config:
                     raise ValueError(
@@ -154,7 +168,11 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
             return cls(
                 {
                     config.pop("config_name"): {
-                        param: value if param != "features" else Features._from_yaml_list(value)
+                        param: (
+                            value
+                            if param != "features"
+                            else Features._from_yaml_list(value)
+                        )
                         for param, value in config.items()
                     }
                     for metadata_config in metadata_configs
@@ -168,7 +186,9 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
             for metadata_config in self.values():
                 self._raise_if_data_files_field_not_valid(metadata_config)
             current_metadata_configs = self.from_dataset_card_data(dataset_card_data)
-            total_metadata_configs = dict(sorted({**current_metadata_configs, **self}.items()))
+            total_metadata_configs = dict(
+                sorted({**current_metadata_configs, **self}.items())
+            )
             for config_name, config_metadata in total_metadata_configs.items():
                 config_metadata.pop("config_name", None)
             dataset_card_data[self.FIELD_NAME] = [
@@ -179,7 +199,11 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
     def get_default_config_name(self) -> Optional[str]:
         default_config_name = None
         for config_name, metadata_config in self.items():
-            if len(self) == 1 or config_name == "default" or metadata_config.get("default"):
+            if (
+                len(self) == 1
+                or config_name == "default"
+                or metadata_config.get("default")
+            ):
                 if default_config_name is None:
                     default_config_name = config_name
                 else:

--- a/src/datasets/utils/patching.py
+++ b/src/datasets/utils/patching.py
@@ -15,7 +15,9 @@ class _PatchedModuleObj:
             for key in module.__dict__:
                 if key in attrs or not key.startswith("__"):
                     setattr(self, key, getattr(module, key))
-        self._original_module = module._original_module if isinstance(module, _PatchedModuleObj) else module
+        self._original_module = (
+            module._original_module if isinstance(module, _PatchedModuleObj) else module
+        )
 
 
 class patch_submodule:
@@ -63,15 +65,24 @@ class patch_submodule:
                 # We don't check for the name of the global, but rather if its value *is* "os" or "os.path".
                 # This allows to patch renamed modules like "from os import path as ospath".
                 if obj_attr is submodule or (
-                    isinstance(obj_attr, _PatchedModuleObj) and obj_attr._original_module is submodule
+                    isinstance(obj_attr, _PatchedModuleObj)
+                    and obj_attr._original_module is submodule
                 ):
                     self.original[attr] = obj_attr
                     # patch at top level
-                    setattr(self.obj, attr, _PatchedModuleObj(obj_attr, attrs=self.attrs))
+                    setattr(
+                        self.obj, attr, _PatchedModuleObj(obj_attr, attrs=self.attrs)
+                    )
                     patched = getattr(self.obj, attr)
                     # construct lower levels patches
                     for key in submodules[i + 1 :]:
-                        setattr(patched, key, _PatchedModuleObj(getattr(patched, key, None), attrs=self.attrs))
+                        setattr(
+                            patched,
+                            key,
+                            _PatchedModuleObj(
+                                getattr(patched, key, None), attrs=self.attrs
+                            ),
+                        )
                         patched = getattr(patched, key)
                     # finally set the target attribute
                     setattr(patched, target_attr, self.new)
@@ -97,7 +108,9 @@ class patch_submodule:
             self.original[target_attr] = globals()["__builtins__"][target_attr]
             setattr(self.obj, target_attr, self.new)
         else:
-            raise RuntimeError(f"Tried to patch attribute {target_attr} instead of a submodule.")
+            raise RuntimeError(
+                f"Tried to patch attribute {target_attr} instead of a submodule."
+            )
 
     def __exit__(self, *exc_info):
         for attr in list(self.original):

--- a/src/datasets/utils/sharding.py
+++ b/src/datasets/utils/sharding.py
@@ -5,12 +5,17 @@ def _number_of_shards_in_gen_kwargs(gen_kwargs: dict) -> int:
     """Return the number of possible shards according to the input gen_kwargs"""
     # Having lists of different sizes makes sharding ambigious, raise an error in this case
     # until we decide how to define sharding without ambiguity for users
-    lists_lengths = {key: len(value) for key, value in gen_kwargs.items() if isinstance(value, list)}
+    lists_lengths = {
+        key: len(value) for key, value in gen_kwargs.items() if isinstance(value, list)
+    }
     if len(set(lists_lengths.values())) > 1:
         raise RuntimeError(
             "Sharding is ambiguous for this dataset: "
             + "we found several data sources lists of different lengths, and we don't know over which list we should parallelize:\n"
-            + "\n".join(f"\t- key {key} has length {length}" for key, length in lists_lengths.items())
+            + "\n".join(
+                f"\t- key {key} has length {length}"
+                for key, length in lists_lengths.items()
+            )
             + "\nTo fix this, check the 'gen_kwargs' and make sure to use lists only for data sources, "
             + "and use tuples otherwise. In the end there should only be one single list, or several lists with the same length."
         )
@@ -36,7 +41,9 @@ def _distribute_shards(num_shards: int, max_num_jobs: int) -> list[range]:
     """
     shards_indices_per_group = []
     for group_idx in range(max_num_jobs):
-        num_shards_to_add = num_shards // max_num_jobs + (group_idx < (num_shards % max_num_jobs))
+        num_shards_to_add = num_shards // max_num_jobs + (
+            group_idx < (num_shards % max_num_jobs)
+        )
         if num_shards_to_add == 0:
             break
         start = shards_indices_per_group[-1].stop if shards_indices_per_group else 0
@@ -52,12 +59,19 @@ def _split_gen_kwargs(gen_kwargs: dict, max_num_jobs: int) -> list[dict]:
     if num_shards == 1:
         return [dict(gen_kwargs)]
     else:
-        shard_indices_per_group = _distribute_shards(num_shards=num_shards, max_num_jobs=max_num_jobs)
+        shard_indices_per_group = _distribute_shards(
+            num_shards=num_shards, max_num_jobs=max_num_jobs
+        )
         return [
             {
-                key: [value[shard_idx] for shard_idx in shard_indices_per_group[group_idx]]
-                if isinstance(value, list)
-                else value
+                key: (
+                    [
+                        value[shard_idx]
+                        for shard_idx in shard_indices_per_group[group_idx]
+                    ]
+                    if isinstance(value, list)
+                    else value
+                )
                 for key, value in gen_kwargs.items()
             }
             for group_idx in range(len(shard_indices_per_group))
@@ -66,9 +80,11 @@ def _split_gen_kwargs(gen_kwargs: dict, max_num_jobs: int) -> list[dict]:
 
 def _merge_gen_kwargs(gen_kwargs_list: list[dict]) -> dict:
     return {
-        key: [value for gen_kwargs in gen_kwargs_list for value in gen_kwargs[key]]
-        if isinstance(gen_kwargs_list[0][key], list)
-        else gen_kwargs_list[0][key]
+        key: (
+            [value for gen_kwargs in gen_kwargs_list for value in gen_kwargs[key]]
+            if isinstance(gen_kwargs_list[0][key], list)
+            else gen_kwargs_list[0][key]
+        )
         for key in gen_kwargs_list[0]
     }
 
@@ -79,7 +95,9 @@ def _shuffle_gen_kwargs(rng: np.random.Generator, gen_kwargs: dict) -> dict:
     # This way entangled lists of (shard, shard_metadata) are still in the right order.
 
     # First, let's generate the shuffled indices per list size
-    list_sizes = {len(value) for value in gen_kwargs.values() if isinstance(value, list)}
+    list_sizes = {
+        len(value) for value in gen_kwargs.values() if isinstance(value, list)
+    }
     indices_per_size = {}
     for size in list_sizes:
         indices_per_size[size] = list(range(size))

--- a/src/datasets/utils/stratify.py
+++ b/src/datasets/utils/stratify.py
@@ -81,13 +81,17 @@ def stratified_shuffle_split_generate_indices(y, n_train, n_test, rng, n_splits=
         raise ValueError("Minimum class count error")
     if n_train < n_classes:
         raise ValueError(
-            "The train_size = %d should be greater or equal to the number of classes = %d" % (n_train, n_classes)
+            "The train_size = %d should be greater or equal to the number of classes = %d"
+            % (n_train, n_classes)
         )
     if n_test < n_classes:
         raise ValueError(
-            "The test_size = %d should be greater or equal to the number of classes = %d" % (n_test, n_classes)
+            "The test_size = %d should be greater or equal to the number of classes = %d"
+            % (n_test, n_classes)
         )
-    class_indices = np.split(np.argsort(y_indices, kind="mergesort"), np.cumsum(class_counts)[:-1])
+    class_indices = np.split(
+        np.argsort(y_indices, kind="mergesort"), np.cumsum(class_counts)[:-1]
+    )
     for _ in range(n_splits):
         n_i = approximate_mode(class_counts, n_train, rng)
         class_counts_remaining = class_counts - n_i

--- a/src/datasets/utils/track.py
+++ b/src/datasets/utils/track.py
@@ -12,7 +12,10 @@ class tracked_str(str):
         return self.origins.get(super().__repr__(), str(self))
 
     def __repr__(self) -> str:
-        if super().__repr__() not in self.origins or self.origins[super().__repr__()] == self:
+        if (
+            super().__repr__() not in self.origins
+            or self.origins[super().__repr__()] == self
+        ):
             return super().__repr__()
         else:
             return f"{str(self)} (origin={self.origins[super().__repr__()]})"

--- a/src/datasets/utils/version.py
+++ b/src/datasets/utils/version.py
@@ -97,8 +97,12 @@ def _str_to_version_tuple(version_str):
     """Return the tuple (major, minor, patch) version extracted from the str."""
     res = _VERSION_REG.match(version_str)
     if not res:
-        raise ValueError(f"Invalid version '{version_str}'. Format should be x.y.z with {{x,y,z}} being digits.")
-    return tuple(int(v) for v in [res.group("major"), res.group("minor"), res.group("patch")])
+        raise ValueError(
+            f"Invalid version '{version_str}'. Format should be x.y.z with {{x,y,z}} being digits."
+        )
+    return tuple(
+        int(v) for v in [res.group("major"), res.group("minor"), res.group("patch")]
+    )
 
 
 def _version_tuple_to_str(version_tuple):

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -5,5 +5,7 @@ from huggingface_hub import snapshot_download
 @pytest.fixture
 def dataset_dir(tmp_path):
     dataset_dir = tmp_path / "test_command_dataset_dir"
-    snapshot_download("hf-internal-testing/ner-jsonl", repo_type="dataset", local_dir=dataset_dir)
+    snapshot_download(
+        "hf-internal-testing/ner-jsonl", repo_type="dataset", local_dir=dataset_dir
+    )
     return str(dataset_dir)

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -45,7 +45,17 @@ def test_test_command(dataset_dir):
                     {
                         "tokens": List(Value("string")),
                         "ner_tags": List(
-                            ClassLabel(names=["O", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC"])
+                            ClassLabel(
+                                names=[
+                                    "O",
+                                    "B-PER",
+                                    "I-PER",
+                                    "B-ORG",
+                                    "I-ORG",
+                                    "B-LOC",
+                                    "I-LOC",
+                                ]
+                            )
                         ),
                         "langs": List(Value("string")),
                         "spans": List(Value("string")),
@@ -70,7 +80,9 @@ def test_test_command(dataset_dir):
     )
     assert dataset_infos.keys() == expected_dataset_infos.keys()
     for key in DatasetInfo._INCLUDED_INFO_IN_YAML:
-        result, expected = getattr(dataset_infos["default"], key), getattr(expected_dataset_infos["default"], key)
+        result, expected = getattr(dataset_infos["default"], key), getattr(
+            expected_dataset_infos["default"], key
+        )
         if key == "num_bytes":
             assert is_1percent_close(result, expected)
         elif key == "splits":
@@ -78,6 +90,8 @@ def test_test_command(dataset_dir):
             for split in result:
                 assert result[split].name == expected[split].name
                 assert result[split].num_examples == expected[split].num_examples
-                assert is_1percent_close(result[split].num_bytes, expected[split].num_bytes)
+                assert is_1percent_close(
+                    result[split].num_bytes, expected[split].num_bytes
+                )
         else:
             result == expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,11 +21,17 @@ def set_test_cache_config(tmp_path_factory, monkeypatch):
     # test_hf_cache_home = tmp_path_factory.mktemp("cache")  # TODO: why a cache dir per test function does not work?
     test_hf_cache_home = tmp_path_factory.getbasetemp() / "cache"
     test_hf_datasets_cache = test_hf_cache_home / "datasets"
-    monkeypatch.setattr("datasets.config.HF_DATASETS_CACHE", str(test_hf_datasets_cache))
+    monkeypatch.setattr(
+        "datasets.config.HF_DATASETS_CACHE", str(test_hf_datasets_cache)
+    )
     test_downloaded_datasets_path = test_hf_datasets_cache / "downloads"
-    monkeypatch.setattr("datasets.config.DOWNLOADED_DATASETS_PATH", str(test_downloaded_datasets_path))
+    monkeypatch.setattr(
+        "datasets.config.DOWNLOADED_DATASETS_PATH", str(test_downloaded_datasets_path)
+    )
     test_extracted_datasets_path = test_hf_datasets_cache / "downloads" / "extracted"
-    monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_PATH", str(test_extracted_datasets_path))
+    monkeypatch.setattr(
+        "datasets.config.EXTRACTED_DATASETS_PATH", str(test_extracted_datasets_path)
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/distributed_scripts/run_torch_distributed.py
+++ b/tests/distributed_scripts/run_torch_distributed.py
@@ -48,7 +48,9 @@ def main():
 
     local_size = sum(1 for _ in dataloader)
     if local_size != expected_local_size:
-        raise FailedTestError(f"local_size {local_size} != expected_local_size {expected_local_size}")
+        raise FailedTestError(
+            f"local_size {local_size} != expected_local_size {expected_local_size}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -12,7 +12,11 @@ from absl.testing import parameterized
 import datasets
 from datasets.arrow_writer import ArrowWriter
 from datasets.features import Array2D, Array3D, Array4D, Array5D, Value
-from datasets.features.features import Array3DExtensionType, PandasArrayExtensionDtype, _ArrayXD
+from datasets.features.features import (
+    Array3DExtensionType,
+    PandasArrayExtensionDtype,
+    _ArrayXD,
+)
 from datasets.formatting.formatting import NumpyArrowExtractor, SimpleArrowExtractor
 
 
@@ -60,7 +64,9 @@ class ExtensionTypeCompatibilityTest(unittest.TestCase):
     def test_array2d_nonspecific_shape(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             my_features = DEFAULT_FEATURES.copy()
-            with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
+            with ArrowWriter(
+                features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+            ) as writer:
                 for key, record in generate_examples(
                     features=my_features,
                     num_examples=1,
@@ -73,16 +79,29 @@ class ExtensionTypeCompatibilityTest(unittest.TestCase):
             row = dataset[0]
             first_shape = row["image"].shape
             second_shape = row["text"].shape
-            self.assertTrue(first_shape is not None and second_shape is not None, "need atleast 2 different shapes")
-            self.assertEqual(len(first_shape), len(second_shape), "both shapes are supposed to be equal length")
-            self.assertNotEqual(first_shape, second_shape, "shapes must not be the same")
+            self.assertTrue(
+                first_shape is not None and second_shape is not None,
+                "need atleast 2 different shapes",
+            )
+            self.assertEqual(
+                len(first_shape),
+                len(second_shape),
+                "both shapes are supposed to be equal length",
+            )
+            self.assertNotEqual(
+                first_shape, second_shape, "shapes must not be the same"
+            )
             del dataset
 
     def test_multiple_extensions_same_row(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             my_features = DEFAULT_FEATURES.copy()
-            with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
-                for key, record in generate_examples(features=my_features, num_examples=1):
+            with ArrowWriter(
+                features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+            ) as writer:
+                for key, record in generate_examples(
+                    features=my_features, num_examples=1
+                ):
                     example = my_features.encode_example(record)
                     writer.write(example)
                 num_examples, num_bytes = writer.finalize()
@@ -101,28 +120,40 @@ class ExtensionTypeCompatibilityTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             my_features = DEFAULT_FEATURES.copy()
             my_features["image_id"] = datasets.Value("string")
-            with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
-                for key, record in generate_examples(features=my_features, num_examples=1):
+            with ArrowWriter(
+                features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+            ) as writer:
+                for key, record in generate_examples(
+                    features=my_features, num_examples=1
+                ):
                     example = my_features.encode_example(record)
                     writer.write(example)
                 num_examples, num_bytes = writer.finalize()
             dataset = datasets.Dataset.from_file(os.path.join(tmp_dir, "beta.arrow"))
-            self.assertIsInstance(dataset[0]["image_id"], str, "image id must be of type string")
+            self.assertIsInstance(
+                dataset[0]["image_id"], str, "image id must be of type string"
+            )
             del dataset
 
     def test_extension_indexing(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             my_features = DEFAULT_FEATURES.copy()
             my_features["explicit_ext"] = Array2D((3, 3), dtype="float32")
-            with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
-                for key, record in generate_examples(features=my_features, num_examples=1):
+            with ArrowWriter(
+                features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+            ) as writer:
+                for key, record in generate_examples(
+                    features=my_features, num_examples=1
+                ):
                     example = my_features.encode_example(record)
                     writer.write(example)
                 num_examples, num_bytes = writer.finalize()
             dataset = datasets.Dataset.from_file(os.path.join(tmp_dir, "beta.arrow"))
             dataset.set_format("numpy")
             data = dataset[0]["explicit_ext"]
-            self.assertIsInstance(data, np.ndarray, "indexed extension must return numpy.ndarray")
+            self.assertIsInstance(
+                data, np.ndarray, "indexed extension must return numpy.ndarray"
+            )
             del dataset
 
 
@@ -183,13 +214,17 @@ class ArrayXDTest(unittest.TestCase):
         self.assertIsInstance(matrix_field_of_first_example, list)
         self.assertIsInstance(matrix_field_of_first_example, list)
         self.assertEqual(np.array(matrix_field_of_first_example).shape, shape_2)
-        np.testing.assert_array_equal(np.array(matrix_field_of_first_example), np.array(first_matrix))
+        np.testing.assert_array_equal(
+            np.array(matrix_field_of_first_example), np.array(first_matrix)
+        )
 
         matrix_field_of_first_two_examples = dataset[:2]["matrix"]
         self.assertIsInstance(matrix_field_of_first_two_examples, list)
         self.assertIsInstance(matrix_field_of_first_two_examples[0], list)
         self.assertIsInstance(matrix_field_of_first_two_examples[0][0], list)
-        self.assertTupleEqual(np.array(matrix_field_of_first_two_examples).shape, (2, *shape_2))
+        self.assertTupleEqual(
+            np.array(matrix_field_of_first_two_examples).shape, (2, *shape_2)
+        )
 
         with dataset.formatted_as("numpy"):
             self.assertTupleEqual(dataset["matrix"][:].shape, (2, *shape_2))
@@ -211,13 +246,17 @@ class ArrayXDTest(unittest.TestCase):
                 (0, self.get_dict_example_0(shape_1, shape_2)),
                 (1, self.get_dict_example_1(shape_1, shape_2)),
             ]
-            with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
+            with ArrowWriter(
+                features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+            ) as writer:
                 for key, record in my_examples:
                     example = my_features.encode_example(record)
                     writer.write(example)
                 num_examples, num_bytes = writer.finalize()
             dataset = datasets.Dataset.from_file(os.path.join(tmp_dir, "beta.arrow"))
-            self._check_getitem_output_type(dataset, shape_1, shape_2, my_examples[0][1]["matrix"])
+            self._check_getitem_output_type(
+                dataset, shape_1, shape_2, my_examples[0][1]["matrix"]
+            )
             del dataset
 
     def test_write_batch(self, array_feature, shape_1, shape_2):
@@ -225,11 +264,15 @@ class ArrayXDTest(unittest.TestCase):
             my_features = self.get_features(array_feature, shape_1, shape_2)
             dict_examples = self.get_dict_examples(shape_1, shape_2)
             dict_examples = my_features.encode_batch(dict_examples)
-            with ArrowWriter(features=my_features, path=os.path.join(tmp_dir, "beta.arrow")) as writer:
+            with ArrowWriter(
+                features=my_features, path=os.path.join(tmp_dir, "beta.arrow")
+            ) as writer:
                 writer.write_batch(dict_examples)
                 num_examples, num_bytes = writer.finalize()
             dataset = datasets.Dataset.from_file(os.path.join(tmp_dir, "beta.arrow"))
-            self._check_getitem_output_type(dataset, shape_1, shape_2, dict_examples["matrix"][0])
+            self._check_getitem_output_type(
+                dataset, shape_1, shape_2, dict_examples["matrix"][0]
+            )
             del dataset
 
     def test_from_dict(self, array_feature, shape_1, shape_2):
@@ -237,23 +280,38 @@ class ArrayXDTest(unittest.TestCase):
         dataset = datasets.Dataset.from_dict(
             dict_examples, features=self.get_features(array_feature, shape_1, shape_2)
         )
-        self._check_getitem_output_type(dataset, shape_1, shape_2, dict_examples["matrix"][0])
+        self._check_getitem_output_type(
+            dataset, shape_1, shape_2, dict_examples["matrix"][0]
+        )
         del dataset
 
 
 class ArrayXDDynamicTest(unittest.TestCase):
     def get_one_col_dataset(self, first_dim_list, fixed_shape):
-        features = datasets.Features({"image": Array3D(shape=(None, *fixed_shape), dtype="float32")})
-        dict_values = {"image": [np.random.rand(fdim, *fixed_shape).astype("float32") for fdim in first_dim_list]}
+        features = datasets.Features(
+            {"image": Array3D(shape=(None, *fixed_shape), dtype="float32")}
+        )
+        dict_values = {
+            "image": [
+                np.random.rand(fdim, *fixed_shape).astype("float32")
+                for fdim in first_dim_list
+            ]
+        }
         dataset = datasets.Dataset.from_dict(dict_values, features=features)
         return dataset
 
     def get_two_col_datasset(self, first_dim_list, fixed_shape):
         features = datasets.Features(
-            {"image": Array3D(shape=(None, *fixed_shape), dtype="float32"), "text": Value("string")}
+            {
+                "image": Array3D(shape=(None, *fixed_shape), dtype="float32"),
+                "text": Value("string"),
+            }
         )
         dict_values = {
-            "image": [np.random.rand(fdim, *fixed_shape).astype("float32") for fdim in first_dim_list],
+            "image": [
+                np.random.rand(fdim, *fixed_shape).astype("float32")
+                for fdim in first_dim_list
+            ],
             "text": ["text" for _ in first_dim_list],
         }
         dataset = datasets.Dataset.from_dict(dict_values, features=features)
@@ -280,7 +338,9 @@ class ArrayXDDynamicTest(unittest.TestCase):
         arr_xd = SimpleArrowExtractor().extract_column(dataset._data)
         self.assertIsInstance(arr_xd.type, Array3DExtensionType)
         # replace with arr_xd = arr_xd.combine_chunks() when 12.0.0 will be the minimal required PyArrow version
-        arr_xd = arr_xd.type.wrap_array(pa.concat_arrays([chunk.storage for chunk in arr_xd.chunks]))
+        arr_xd = arr_xd.type.wrap_array(
+            pa.concat_arrays([chunk.storage for chunk in arr_xd.chunks])
+        )
         numpy_arr = arr_xd.to_numpy()
 
         self.assertIsInstance(numpy_arr, np.ndarray)
@@ -295,7 +355,9 @@ class ArrayXDDynamicTest(unittest.TestCase):
         arr_xd = SimpleArrowExtractor().extract_column(dataset._data)
         self.assertIsInstance(arr_xd.type, Array3DExtensionType)
         # replace with arr_xd = arr_xd.combine_chunks() when 12.0.0 will be the minimal required PyArrow version
-        arr_xd = arr_xd.type.wrap_array(pa.concat_arrays([chunk.storage for chunk in arr_xd.chunks]))
+        arr_xd = arr_xd.type.wrap_array(
+            pa.concat_arrays([chunk.storage for chunk in arr_xd.chunks])
+        )
         numpy_arr = arr_xd.to_numpy()
 
         self.assertIsInstance(numpy_arr, np.ndarray)
@@ -348,56 +410,88 @@ class ArrayXDDynamicTest(unittest.TestCase):
         first_dim_list = [1, 3, 10]
         dataset = self.get_one_col_dataset(first_dim_list, fixed_shape)
 
-        dataset = dataset.map(lambda a: {"image": np.concatenate([a] * 2)}, input_columns="image")
+        dataset = dataset.map(
+            lambda a: {"image": np.concatenate([a] * 2)}, input_columns="image"
+        )
 
         # check also if above function resulted with 2x bigger first dim
         for first_dim, ds_row in zip(first_dim_list, dataset):
             single_arr = ds_row["image"]
             self.assertIsInstance(single_arr, list)
-            self.assertTupleEqual(np.array(single_arr).shape, (first_dim * 2, *fixed_shape))
+            self.assertTupleEqual(
+                np.array(single_arr).shape, (first_dim * 2, *fixed_shape)
+            )
 
 
-@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+@pytest.mark.parametrize(
+    "dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)]
+)
 def test_table_to_pandas(dtype, dummy_value):
     features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
-    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    dataset = datasets.Dataset.from_dict(
+        {"foo": [[[dummy_value] * 2] * 2]}, features=features
+    )
     df = dataset._data.to_pandas()
     assert isinstance(df.foo.dtype, PandasArrayExtensionDtype)
     arr = df.foo.to_numpy()
-    np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
+    np.testing.assert_equal(
+        arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype))
+    )
 
 
-@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+@pytest.mark.parametrize(
+    "dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)]
+)
 def test_array_xd_numpy_arrow_extractor(dtype, dummy_value):
     features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
-    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    dataset = datasets.Dataset.from_dict(
+        {"foo": [[[dummy_value] * 2] * 2]}, features=features
+    )
     arr = NumpyArrowExtractor().extract_column(dataset._data)
     assert isinstance(arr, np.ndarray)
-    np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
+    np.testing.assert_equal(
+        arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype))
+    )
 
 
 def test_array_xd_with_none():
     # Fixed shape
     features = datasets.Features({"foo": datasets.Array2D(dtype="int32", shape=(2, 2))})
     dummy_array = np.array([[1, 2], [3, 4]], dtype="int32")
-    dataset = datasets.Dataset.from_dict({"foo": [dummy_array, None, dummy_array, None]}, features=features)
+    dataset = datasets.Dataset.from_dict(
+        {"foo": [dummy_array, None, dummy_array, None]}, features=features
+    )
     arr = NumpyArrowExtractor().extract_column(dataset._data)
-    assert isinstance(arr, np.ndarray) and arr.dtype == np.float64 and arr.shape == (4, 2, 2)
+    assert (
+        isinstance(arr, np.ndarray)
+        and arr.dtype == np.float64
+        and arr.shape == (4, 2, 2)
+    )
     assert np.allclose(arr[0], dummy_array) and np.allclose(arr[2], dummy_array)
-    assert np.all(np.isnan(arr[1])) and np.all(np.isnan(arr[3]))  # broadcasted np.nan - use np.all
+    assert np.all(np.isnan(arr[1])) and np.all(
+        np.isnan(arr[3])
+    )  # broadcasted np.nan - use np.all
 
     # Dynamic shape
-    features = datasets.Features({"foo": datasets.Array2D(dtype="int32", shape=(None, 2))})
+    features = datasets.Features(
+        {"foo": datasets.Array2D(dtype="int32", shape=(None, 2))}
+    )
     dummy_array = np.array([[1, 2], [3, 4]], dtype="int32")
-    dataset = datasets.Dataset.from_dict({"foo": [dummy_array, None, dummy_array, None]}, features=features)
+    dataset = datasets.Dataset.from_dict(
+        {"foo": [dummy_array, None, dummy_array, None]}, features=features
+    )
     arr = NumpyArrowExtractor().extract_column(dataset._data)
     assert isinstance(arr, np.ndarray) and arr.dtype == object and arr.shape == (4,)
     np.testing.assert_equal(arr[0], dummy_array)
     np.testing.assert_equal(arr[2], dummy_array)
-    assert np.isnan(arr[1]) and np.isnan(arr[3])  # a single np.nan value - np.all not needed
+    assert np.isnan(arr[1]) and np.isnan(
+        arr[3]
+    )  # a single np.nan value - np.all not needed
 
 
-@pytest.mark.parametrize("seq_type", ["no_sequence", "sequence", "sequence_of_sequence"])
+@pytest.mark.parametrize(
+    "seq_type", ["no_sequence", "sequence", "sequence_of_sequence"]
+)
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -415,7 +509,9 @@ def test_array_xd_with_none():
         "float64",
     ],
 )
-@pytest.mark.parametrize("shape, feature_class", [((2, 3), datasets.Array2D), ((2, 3, 4), datasets.Array3D)])
+@pytest.mark.parametrize(
+    "shape, feature_class", [((2, 3), datasets.Array2D), ((2, 3, 4), datasets.Array3D)]
+)
 def test_array_xd_with_np(seq_type, dtype, shape, feature_class):
     feature = feature_class(dtype=dtype, shape=shape)
     data = np.zeros(shape, dtype=dtype)
@@ -428,7 +524,9 @@ def test_array_xd_with_np(seq_type, dtype, shape, feature_class):
         feature = datasets.List(datasets.List(feature))
         data = [[data]]
         expected = [[expected]]
-    ds = datasets.Dataset.from_dict({"col": [data]}, features=datasets.Features({"col": feature}))
+    ds = datasets.Dataset.from_dict(
+        {"col": [data]}, features=datasets.Features({"col": feature})
+    )
     assert ds[0]["col"] == expected
 
 
@@ -454,7 +552,9 @@ def test_dataset_map(with_none):
         return batch
 
     features = datasets.Features({"image": Array3D(dtype="int32", shape=(3, 3, 3))})
-    processed_ds = ds.map(process_data, batched=True, remove_columns=ds.column_names, features=features)
+    processed_ds = ds.map(
+        process_data, batched=True, remove_columns=ds.column_names, features=features
+    )
     assert processed_ds.shape == (2, 1)
     with processed_ds.with_format("numpy") as pds:
         for i, example in enumerate(pds):

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -54,9 +54,13 @@ def test_audio_feature_type_to_arrow():
     features = Features({"audio": Audio()})
     assert features.arrow_schema == pa.schema({"audio": Audio().pa_type})
     features = Features({"struct_containing_an_audio": {"audio": Audio()}})
-    assert features.arrow_schema == pa.schema({"struct_containing_an_audio": pa.struct({"audio": Audio().pa_type})})
+    assert features.arrow_schema == pa.schema(
+        {"struct_containing_an_audio": pa.struct({"audio": Audio().pa_type})}
+    )
     features = Features({"sequence_of_audios": List(Audio())})
-    assert features.arrow_schema == pa.schema({"sequence_of_audios": pa.list_(Audio().pa_type)})
+    assert features.arrow_schema == pa.schema(
+        {"sequence_of_audios": pa.list_(Audio().pa_type)}
+    )
 
 
 @require_torchcodec
@@ -71,7 +75,10 @@ def test_audio_feature_type_to_arrow():
         lambda audio_path: {"path": audio_path, "bytes": open(audio_path, "rb").read()},
         lambda audio_path: {"path": None, "bytes": open(audio_path, "rb").read()},
         lambda audio_path: {"bytes": open(audio_path, "rb").read()},
-        lambda audio_path: {"array": np.array([0.1, 0.2, 0.3]), "sampling_rate": 16_000},
+        lambda audio_path: {
+            "array": np.array([0.1, 0.2, 0.3]),
+            "sampling_rate": 16_000,
+        },
     ],
 )
 def test_audio_feature_encode_example(shared_datadir, build_example):
@@ -93,8 +100,15 @@ def test_audio_feature_encode_example(shared_datadir, build_example):
     [
         lambda audio_path: {"path": audio_path, "sampling_rate": 16_000},
         lambda audio_path: {"path": audio_path, "bytes": None, "sampling_rate": 16_000},
-        lambda audio_path: {"path": audio_path, "bytes": open(audio_path, "rb").read(), "sampling_rate": 16_000},
-        lambda audio_path: {"array": np.array([0.1, 0.2, 0.3]), "sampling_rate": 16_000},
+        lambda audio_path: {
+            "path": audio_path,
+            "bytes": open(audio_path, "rb").read(),
+            "sampling_rate": 16_000,
+        },
+        lambda audio_path: {
+            "array": np.array([0.1, 0.2, 0.3]),
+            "sampling_rate": 16_000,
+        },
     ],
 )
 def test_audio_feature_encode_example_pcm(shared_datadir, build_example):
@@ -118,7 +132,9 @@ sample_rates = [16_000, 48_000]
     "in_sample_rate,out_sample_rate",
     list(product(sample_rates, sample_rates)),
 )
-def test_audio_feature_encode_example_audiodecoder(shared_datadir, in_sample_rate, out_sample_rate):
+def test_audio_feature_encode_example_audiodecoder(
+    shared_datadir, in_sample_rate, out_sample_rate
+):
     from torchcodec.decoders import AudioDecoder
 
     audio_path = str(shared_datadir / "test_audio_44100.wav")
@@ -237,14 +253,18 @@ def test_backwards_compatibility(shared_datadir):
     samples = decoded_example.get_all_samples()
     assert decoded_example["sampling_rate"] == samples.sample_rate
     assert decoded_example["array"].ndim == 1  # mono
-    assert abs(decoded_example["array"].shape[0] - samples.data.shape[1]) < 2  # can have off by one error
+    assert (
+        abs(decoded_example["array"].shape[0] - samples.data.shape[1]) < 2
+    )  # can have off by one error
 
     decoded_example = audio.decode_example(audio.encode_example(audio_path2))
     assert isinstance(decoded_example, AudioDecoder)
     samples = decoded_example.get_all_samples()
     assert decoded_example["sampling_rate"] == samples.sample_rate
     assert decoded_example["array"].ndim == 1  # mono
-    assert abs(decoded_example["array"].shape[0] - samples.data.shape[1]) < 2  # can have off by one error
+    assert (
+        abs(decoded_example["array"].shape[0] - samples.data.shape[1]) < 2
+    )  # can have off by one error
 
 
 @require_torchcodec
@@ -355,7 +375,9 @@ def test_dataset_with_audio_feature_with_none():
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"audio"}
-    assert isinstance(batch["audio"], list) and all(item is None for item in batch["audio"])
+    assert isinstance(batch["audio"], list) and all(
+        item is None for item in batch["audio"]
+    )
     column = dset["audio"]
     assert len(column) == 1
     assert isinstance(column, Column) and all(item is None for item in column)
@@ -510,8 +532,12 @@ def test_resampling_after_loading_dataset_with_audio_feature_mp3(shared_datadir)
         lambda audio_path: {"audio": [open(audio_path, "rb").read()]},
         lambda audio_path: {"audio": [{"path": audio_path}]},
         lambda audio_path: {"audio": [{"path": audio_path, "bytes": None}]},
-        lambda audio_path: {"audio": [{"path": audio_path, "bytes": open(audio_path, "rb").read()}]},
-        lambda audio_path: {"audio": [{"path": None, "bytes": open(audio_path, "rb").read()}]},
+        lambda audio_path: {
+            "audio": [{"path": audio_path, "bytes": open(audio_path, "rb").read()}]
+        },
+        lambda audio_path: {
+            "audio": [{"path": None, "bytes": open(audio_path, "rb").read()}]
+        },
         lambda audio_path: {"audio": [{"bytes": open(audio_path, "rb").read()}]},
     ],
 )
@@ -540,10 +566,12 @@ def test_dataset_concatenate_audio_features(shared_datadir):
     concatenated_dataset = concatenate_datasets([dset1, dset2])
     assert len(concatenated_dataset) == len(dset1) + len(dset2)
     assert (
-        concatenated_dataset[0]["audio"].get_all_samples().data.shape == dset1[0]["audio"].get_all_samples().data.shape
+        concatenated_dataset[0]["audio"].get_all_samples().data.shape
+        == dset1[0]["audio"].get_all_samples().data.shape
     )
     assert (
-        concatenated_dataset[1]["audio"].get_all_samples().data.shape == dset2[0]["audio"].get_all_samples().data.shape
+        concatenated_dataset[1]["audio"].get_all_samples().data.shape
+        == dset2[0]["audio"].get_all_samples().data.shape
     )
 
 
@@ -554,17 +582,29 @@ def test_dataset_concatenate_nested_audio_features(shared_datadir):
     features = Features({"list_of_structs_of_audios": [{"audio": Audio()}]})
     data1 = {"list_of_structs_of_audios": [[{"audio": audio_path}]]}
     dset1 = Dataset.from_dict(data1, features=features)
-    data2 = {"list_of_structs_of_audios": [[{"audio": {"bytes": open(audio_path, "rb").read()}}]]}
+    data2 = {
+        "list_of_structs_of_audios": [
+            [{"audio": {"bytes": open(audio_path, "rb").read()}}]
+        ]
+    }
     dset2 = Dataset.from_dict(data2, features=features)
     concatenated_dataset = concatenate_datasets([dset1, dset2])
     assert len(concatenated_dataset) == len(dset1) + len(dset2)
     assert (
-        concatenated_dataset[0]["list_of_structs_of_audios"][0]["audio"].get_all_samples().data.shape
-        == dset1[0]["list_of_structs_of_audios"][0]["audio"].get_all_samples().data.shape
+        concatenated_dataset[0]["list_of_structs_of_audios"][0]["audio"]
+        .get_all_samples()
+        .data.shape
+        == dset1[0]["list_of_structs_of_audios"][0]["audio"]
+        .get_all_samples()
+        .data.shape
     )
     assert (
-        concatenated_dataset[1]["list_of_structs_of_audios"][0]["audio"].get_all_samples().data.shape
-        == dset2[0]["list_of_structs_of_audios"][0]["audio"].get_all_samples().data.shape
+        concatenated_dataset[1]["list_of_structs_of_audios"][0]["audio"]
+        .get_all_samples()
+        .data.shape
+        == dset2[0]["list_of_structs_of_audios"][0]["audio"]
+        .get_all_samples()
+        .data.shape
     )
 
 
@@ -687,13 +727,21 @@ def jsonl_audio_dataset_path(shared_datadir, tmp_path_factory):
 
 @require_torchcodec
 @pytest.mark.parametrize("streaming", [False, True])
-def test_load_dataset_with_audio_feature(streaming, jsonl_audio_dataset_path, shared_datadir):
+def test_load_dataset_with_audio_feature(
+    streaming, jsonl_audio_dataset_path, shared_datadir
+):
     from torchcodec.decoders import AudioDecoder
 
     audio_path = str(shared_datadir / "test_audio_44100.wav")
     data_files = jsonl_audio_dataset_path
     features = Features({"audio": Audio(), "text": Value("string")})
-    dset = load_dataset("json", split="train", data_files=data_files, features=features, streaming=streaming)
+    dset = load_dataset(
+        "json",
+        split="train",
+        data_files=data_files,
+        features=features,
+        streaming=streaming,
+    )
     item = dset[0] if not streaming else next(iter(dset))
     assert item.keys() == {"audio", "text"}
     assert isinstance(item["audio"], AudioDecoder)
@@ -709,7 +757,9 @@ def test_dataset_with_audio_feature_loaded_from_cache():
     # load first time
     ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean")
     # load from cache
-    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+    ds = load_dataset(
+        "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+    )
     assert isinstance(ds, Dataset)
 
 
@@ -782,7 +832,12 @@ def test_dataset_with_audio_feature_map_undecoded(shared_datadir):
 def test_audio_embed_storage(shared_datadir):
     audio_path = str(shared_datadir / "test_audio_44100.wav")
     example = {"bytes": None, "path": audio_path}
-    storage = pa.array([example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()}))
+    storage = pa.array(
+        [example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()})
+    )
     embedded_storage = Audio().embed_storage(storage)
     embedded_example = embedded_storage.to_pylist()[0]
-    assert embedded_example == {"bytes": open(audio_path, "rb").read(), "path": "test_audio_44100.wav"}
+    assert embedded_example == {
+        "bytes": open(audio_path, "rb").read(),
+        "path": "test_audio_44100.wav",
+    }

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -9,7 +9,16 @@ import pytest
 
 from datasets import Array2D
 from datasets.arrow_dataset import Column, Dataset
-from datasets.features import Audio, ClassLabel, Features, Image, LargeList, List, Sequence, Value
+from datasets.features import (
+    Audio,
+    ClassLabel,
+    Features,
+    Image,
+    LargeList,
+    List,
+    Sequence,
+    Value,
+)
 from datasets.features.features import (
     _align_features,
     _arrow_to_datasets_dtype,
@@ -42,7 +51,9 @@ def list_with(item):
 class FeaturesTest(TestCase):
     def test_from_arrow_schema_simple(self):
         data = {"a": [{"b": {"c": "text"}}] * 10, "foo": [1] * 10}
-        original_features = Features({"a": {"b": {"c": Value("string")}}, "foo": Value("int64")})
+        original_features = Features(
+            {"a": {"b": {"c": Value("string")}}, "foo": Value("int64")}
+        )
         dset = Dataset.from_dict(data, features=original_features)
         new_features = dset.features
         new_dset = Dataset.from_dict(data, features=new_features)
@@ -52,7 +63,9 @@ class FeaturesTest(TestCase):
 
     def test_from_arrow_schema_with_sequence(self):
         data = {"a": [{"b": {"c": ["text"]}}] * 10, "foo": [1] * 10}
-        original_features = Features({"a": {"b": {"c": List(Value("string"))}}, "foo": Value("int64")})
+        original_features = Features(
+            {"a": {"b": {"c": List(Value("string"))}}, "foo": Value("int64")}
+        )
         dset = Dataset.from_dict(data, features=original_features)
         new_features = dset.features
         new_dset = Dataset.from_dict(data, features=new_features)
@@ -144,7 +157,10 @@ class FeaturesTest(TestCase):
                     "title": Value("string"),
                     "url": Value("string"),
                     "html": Value("string"),
-                    "tokens": {"token": List(Value("string")), "is_html": List(Value("bool"))},
+                    "tokens": {
+                        "token": List(Value("string")),
+                        "is_html": List(Value("bool")),
+                    },
                 },
                 "question": {
                     "text": Value("string"),
@@ -178,7 +194,10 @@ class FeaturesTest(TestCase):
             {
                 "id": Value("string"),
                 "document": {
-                    "tokens": {"token": List(Value("string")), "is_html": List(Value("bool"))},
+                    "tokens": {
+                        "token": List(Value("string")),
+                        "is_html": List(Value("bool")),
+                    },
                     "title": Value("string"),
                     "url": Value("string"),
                     "html": Value("string"),
@@ -215,7 +234,10 @@ class FeaturesTest(TestCase):
             {
                 "id": Value("string"),
                 "document": {
-                    "tokens": {"token": List(Value("string")), "is_html": List(Value("bool"))},
+                    "tokens": {
+                        "token": List(Value("string")),
+                        "is_html": List(Value("bool")),
+                    },
                     "title": Value("string"),
                     "url": Value("string"),
                     "html": Value("string"),
@@ -255,18 +277,27 @@ class FeaturesTest(TestCase):
         self.assertNotEqual(reordered_features.type, features.type)
 
     def test_flatten(self):
-        features = Features({"foo": {"bar1": Value("int32"), "bar2": {"foobar": Value("string")}}})
+        features = Features(
+            {"foo": {"bar1": Value("int32"), "bar2": {"foobar": Value("string")}}}
+        )
         _features = features.copy()
         flattened_features = features.flatten()
-        assert flattened_features == {"foo.bar1": Value("int32"), "foo.bar2.foobar": Value("string")}
-        assert features == _features, "calling flatten shouldn't alter the current features"
+        assert flattened_features == {
+            "foo.bar1": Value("int32"),
+            "foo.bar2.foobar": Value("string"),
+        }
+        assert (
+            features == _features
+        ), "calling flatten shouldn't alter the current features"
 
     def test_flatten_with_sequence(self):
         features = Features({"foo": {"bar": List({"my_value": Value("int32")})}})
         _features = features.copy()
         flattened_features = features.flatten()
         assert flattened_features == {"foo.bar": List({"my_value": Value("int32")})}
-        assert features == _features, "calling flatten shouldn't alter the current features"
+        assert (
+            features == _features
+        ), "calling flatten shouldn't alter the current features"
 
     def test_features_dicts_are_synced(self):
         def assert_features_dicts_are_synced(features: Features):
@@ -305,7 +336,9 @@ def test_classlabel_init(tmp_path_factory):
     classlabel = ClassLabel(num_classes=len(names), names=names)
     assert classlabel.names == names and classlabel.num_classes == len(names)
     classlabel = ClassLabel(num_classes=len(names))
-    assert classlabel.names == [str(i) for i in range(len(names))] and classlabel.num_classes == len(names)
+    assert classlabel.names == [
+        str(i) for i in range(len(names))
+    ] and classlabel.num_classes == len(names)
     with pytest.raises(ValueError):
         classlabel = ClassLabel(num_classes=len(names) + 1, names=names)
     with pytest.raises(ValueError):
@@ -429,9 +462,21 @@ def test_encode_nested_example_sequence_with_none(inner_type):
     "features_dict, example, expected_encoded_example",
     [
         ({"col_1": ClassLabel(names=["a", "b"])}, {"col_1": "b"}, {"col_1": 1}),
-        ({"col_1": List(ClassLabel(names=["a", "b"]))}, {"col_1": ["b"]}, {"col_1": [1]}),
-        ({"col_1": LargeList(ClassLabel(names=["a", "b"]))}, {"col_1": ["b"]}, {"col_1": [1]}),
-        ({"col_1": List(ClassLabel(names=["a", "b"]))}, {"col_1": ["b"]}, {"col_1": [1]}),
+        (
+            {"col_1": List(ClassLabel(names=["a", "b"]))},
+            {"col_1": ["b"]},
+            {"col_1": [1]},
+        ),
+        (
+            {"col_1": LargeList(ClassLabel(names=["a", "b"]))},
+            {"col_1": ["b"]},
+            {"col_1": [1]},
+        ),
+        (
+            {"col_1": List(ClassLabel(names=["a", "b"]))},
+            {"col_1": ["b"]},
+            {"col_1": [1]},
+        ),
     ],
 )
 def test_encode_example(features_dict, example, expected_encoded_example):
@@ -519,10 +564,14 @@ def iternumpy(key1, value1, value2):
 def dict_diff(d1: dict, d2: dict):  # check if 2 dictionaries are equal
     np.testing.assert_equal(d1, d2)  # sanity check if dict values are equal or not
 
-    for (k1, v1), (k2, v2) in zip(d1.items(), d2.items()):  # check if their values have same dtype or not
+    for (k1, v1), (k2, v2) in zip(
+        d1.items(), d2.items()
+    ):  # check if their values have same dtype or not
         if isinstance(v1, dict):  # nested dictionary case
             dict_diff(v1, v2)
-        elif isinstance(v1, np.ndarray):  # checks if dtype and value of np.ndarray is equal
+        elif isinstance(
+            v1, np.ndarray
+        ):  # checks if dtype and value of np.ndarray is equal
             iternumpy(k1, v1, v2)
         elif isinstance(v1, list):
             for element1, element2 in zip(v1, v2):  # iterates over all elements of list
@@ -534,19 +583,34 @@ def dict_diff(d1: dict, d2: dict):  # check if 2 dictionaries are equal
 
 class CastToPythonObjectsTest(TestCase):
     def test_cast_to_python_objects_list(self):
-        obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}
-        expected_obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}
+        obj = {
+            "col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3,
+            "col_2": [[1, 2], [3, 4], [5, 6]],
+        }
+        expected_obj = {
+            "col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3,
+            "col_2": [[1, 2], [3, 4], [5, 6]],
+        }
         casted_obj = cast_to_python_objects(obj)
         self.assertDictEqual(casted_obj, expected_obj)
 
     def test_cast_to_python_objects_tuple(self):
-        obj = {"col_1": [{"vec": (1, 2, 3), "txt": "foo"}] * 3, "col_2": [(1, 2), (3, 4), (5, 6)]}
-        expected_obj = {"col_1": [{"vec": (1, 2, 3), "txt": "foo"}] * 3, "col_2": [(1, 2), (3, 4), (5, 6)]}
+        obj = {
+            "col_1": [{"vec": (1, 2, 3), "txt": "foo"}] * 3,
+            "col_2": [(1, 2), (3, 4), (5, 6)],
+        }
+        expected_obj = {
+            "col_1": [{"vec": (1, 2, 3), "txt": "foo"}] * 3,
+            "col_2": [(1, 2), (3, 4), (5, 6)],
+        }
         casted_obj = cast_to_python_objects(obj)
         self.assertDictEqual(casted_obj, expected_obj)
 
     def test_cast_to_python_or_numpy(self):
-        obj = {"col_1": [{"vec": np.arange(1, 4), "txt": "foo"}] * 3, "col_2": np.arange(1, 7).reshape(3, 2)}
+        obj = {
+            "col_1": [{"vec": np.arange(1, 4), "txt": "foo"}] * 3,
+            "col_2": np.arange(1, 7).reshape(3, 2),
+        }
         expected_obj = {
             "col_1": [{"vec": np.array([1, 2, 3]), "txt": "foo"}] * 3,
             "col_2": np.array([[1, 2], [3, 4], [5, 6]]),
@@ -559,13 +623,24 @@ class CastToPythonObjectsTest(TestCase):
             "col_1": pd.Series([{"vec": [1, 2, 3], "txt": "foo"}] * 3),
             "col_2": pd.Series([[1, 2], [3, 4], [5, 6]]),
         }
-        expected_obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}
+        expected_obj = {
+            "col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3,
+            "col_2": [[1, 2], [3, 4], [5, 6]],
+        }
         casted_obj = cast_to_python_objects(obj)
         self.assertDictEqual(casted_obj, expected_obj)
 
     def test_cast_to_python_objects_dataframe(self):
-        obj = pd.DataFrame({"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]})
-        expected_obj = {"col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3, "col_2": [[1, 2], [3, 4], [5, 6]]}
+        obj = pd.DataFrame(
+            {
+                "col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3,
+                "col_2": [[1, 2], [3, 4], [5, 6]],
+            }
+        )
+        expected_obj = {
+            "col_1": [{"vec": [1, 2, 3], "txt": "foo"}] * 3,
+            "col_2": [[1, 2], [3, 4], [5, 6]],
+        }
         casted_obj = cast_to_python_objects(obj)
         self.assertDictEqual(casted_obj, expected_obj)
 
@@ -636,7 +711,10 @@ class CastToPythonObjectsTest(TestCase):
         casted_obj = cast_to_python_objects(obj)
         dict_diff(casted_obj, expected_obj)
 
-    @patch("datasets.features.features._cast_to_python_objects", side_effect=_cast_to_python_objects)
+    @patch(
+        "datasets.features.features._cast_to_python_objects",
+        side_effect=_cast_to_python_objects,
+    )
     def test_dont_iterate_over_each_element_in_a_list(self, mocked_cast):
         obj = {"col_1": [[1, 2], [3, 4], [5, 6]]}
         cast_to_python_objects(obj)
@@ -681,7 +759,10 @@ NESTED_CUSTOM_FEATURES = [
 ]
 
 
-@pytest.mark.parametrize("features", SIMPLE_FEATURES + CUSTOM_FEATURES + NESTED_FEATURES + NESTED_CUSTOM_FEATURES)
+@pytest.mark.parametrize(
+    "features",
+    SIMPLE_FEATURES + CUSTOM_FEATURES + NESTED_FEATURES + NESTED_CUSTOM_FEATURES,
+)
 def test_features_to_dict_and_from_dict_round_trip(features: Features):
     features_dict = features.to_dict()
     assert isinstance(features_dict, dict)
@@ -689,7 +770,10 @@ def test_features_to_dict_and_from_dict_round_trip(features: Features):
     assert features == reloaded
 
 
-@pytest.mark.parametrize("features", SIMPLE_FEATURES + CUSTOM_FEATURES + NESTED_FEATURES + NESTED_CUSTOM_FEATURES)
+@pytest.mark.parametrize(
+    "features",
+    SIMPLE_FEATURES + CUSTOM_FEATURES + NESTED_FEATURES + NESTED_CUSTOM_FEATURES,
+)
 def test_features_to_yaml_list(features: Features):
     features_yaml_list = features._to_yaml_list()
     assert isinstance(features_yaml_list, list)
@@ -700,9 +784,18 @@ def test_features_to_yaml_list(features: Features):
 @pytest.mark.parametrize(
     "features_dict, expected_features_dict",
     [
-        ({"col": [{"sub_col": Value("int32")}]}, {"col": [{"sub_col": Value("int32")}]}),
-        ({"col": LargeList({"sub_col": Value("int32")})}, {"col": LargeList({"sub_col": Value("int32")})}),
-        ({"col": {"sub_col": List(Value("int32"))}}, {"col.sub_col": List(Value("int32"))}),
+        (
+            {"col": [{"sub_col": Value("int32")}]},
+            {"col": [{"sub_col": Value("int32")}]},
+        ),
+        (
+            {"col": LargeList({"sub_col": Value("int32")})},
+            {"col": LargeList({"sub_col": Value("int32")})},
+        ),
+        (
+            {"col": {"sub_col": List(Value("int32"))}},
+            {"col.sub_col": List(Value("int32"))},
+        ),
     ],
 )
 def test_features_flatten_with_list_types(features_dict, expected_features_dict):
@@ -719,24 +812,46 @@ def test_features_flatten_with_list_types(features_dict, expected_features_dict)
             {"col": List(Value("int32"))},
         ),
         (
-            {"col": {"feature": {"dtype": "int32", "_type": "Value"}, "_type": "LargeList"}},
+            {
+                "col": {
+                    "feature": {"dtype": "int32", "_type": "Value"},
+                    "_type": "LargeList",
+                }
+            },
             {"col": LargeList(Value("int32"))},
         ),
         (
-            {"col": {"feature": {"sub_col": {"dtype": "int32", "_type": "Value"}}, "_type": "List"}},
+            {
+                "col": {
+                    "feature": {"sub_col": {"dtype": "int32", "_type": "Value"}},
+                    "_type": "List",
+                }
+            },
             {"col": List({"sub_col": Value("int32")})},
         ),
         (
-            {"col": {"feature": {"sub_col": {"dtype": "int32", "_type": "Value"}}, "_type": "LargeList"}},
+            {
+                "col": {
+                    "feature": {"sub_col": {"dtype": "int32", "_type": "Value"}},
+                    "_type": "LargeList",
+                }
+            },
             {"col": LargeList({"sub_col": Value("int32")})},
         ),
         (
-            {"col": {"feature": {"sub_col": {"dtype": "int32", "_type": "Value"}}, "_type": "Sequence"}},
+            {
+                "col": {
+                    "feature": {"sub_col": {"dtype": "int32", "_type": "Value"}},
+                    "_type": "Sequence",
+                }
+            },
             {"col": {"sub_col": List(Value("int32"))}},
         ),
     ],
 )
-def test_features_from_dict_with_list_types(deserialized_features_dict, expected_features_dict):
+def test_features_from_dict_with_list_types(
+    deserialized_features_dict, expected_features_dict
+):
     features = Features.from_dict(deserialized_features_dict)
     assert features == Features(expected_features_dict)
 
@@ -753,20 +868,33 @@ def test_features_from_dict_with_list_types(deserialized_features_dict, expected
             List(Value("int32")),
         ),
         (
-            {"feature": {"sub_col": {"dtype": "int32", "_type": "Value"}}, "_type": "List"},
+            {
+                "feature": {"sub_col": {"dtype": "int32", "_type": "Value"}},
+                "_type": "List",
+            },
             List({"sub_col": Value("int32")}),
         ),
         (
-            {"feature": {"sub_col": {"dtype": "int32", "_type": "Value"}}, "_type": "LargeList"},
+            {
+                "feature": {"sub_col": {"dtype": "int32", "_type": "Value"}},
+                "_type": "LargeList",
+            },
             LargeList({"sub_col": Value("int32")}),
         ),
         (
-            {"sub_col": {"feature": {"dtype": "int32", "_type": "Value"}, "_type": "List"}},
+            {
+                "sub_col": {
+                    "feature": {"dtype": "int32", "_type": "Value"},
+                    "_type": "List",
+                }
+            },
             {"sub_col": List(Value("int32"))},
         ),
     ],
 )
-def test_generate_from_dict_with_list_types(deserialized_feature_dict, expected_feature):
+def test_generate_from_dict_with_list_types(
+    deserialized_feature_dict, expected_feature
+):
     feature = generate_from_dict(deserialized_feature_dict)
     assert feature == expected_feature
 
@@ -781,7 +909,9 @@ def test_generate_from_dict_with_list_types(deserialized_feature_dict, expected_
         ),
     ],
 )
-def test_features_to_yaml_list_with_large_list(features_dict, expected_features_yaml_list):
+def test_features_to_yaml_list_with_large_list(
+    features_dict, expected_features_yaml_list
+):
     features = Features(features_dict)
     features_yaml_list = features._to_yaml_list()
     assert features_yaml_list == expected_features_yaml_list
@@ -797,12 +927,17 @@ def test_features_to_yaml_list_with_large_list(features_dict, expected_features_
         ),
     ],
 )
-def test_features_from_yaml_list_with_large_list(features_yaml_list, expected_features_dict):
+def test_features_from_yaml_list_with_large_list(
+    features_yaml_list, expected_features_dict
+):
     features = Features._from_yaml_list(features_yaml_list)
     assert features == Features(expected_features_dict)
 
 
-@pytest.mark.parametrize("features", SIMPLE_FEATURES + CUSTOM_FEATURES + NESTED_FEATURES + NESTED_CUSTOM_FEATURES)
+@pytest.mark.parametrize(
+    "features",
+    SIMPLE_FEATURES + CUSTOM_FEATURES + NESTED_FEATURES + NESTED_CUSTOM_FEATURES,
+)
 def test_features_to_arrow_schema(features: Features):
     arrow_schema = features.arrow_schema
     assert isinstance(arrow_schema, pa.Schema)
@@ -812,12 +947,24 @@ def test_features_to_arrow_schema(features: Features):
 
 NESTED_COMPARISON = [
     [
-        [Features({"email": Value(dtype="string", id=None)}), Features({"email": Value(dtype="string", id=None)})],
-        [Features({"email": Value(dtype="string", id=None)}), Features({"email": Value(dtype="string", id=None)})],
+        [
+            Features({"email": Value(dtype="string", id=None)}),
+            Features({"email": Value(dtype="string", id=None)}),
+        ],
+        [
+            Features({"email": Value(dtype="string", id=None)}),
+            Features({"email": Value(dtype="string", id=None)}),
+        ],
     ],
     [
-        [Features({"email": Value(dtype="string", id=None)}), Features({"email": Value(dtype="null", id=None)})],
-        [Features({"email": Value(dtype="string", id=None)}), Features({"email": Value(dtype="string", id=None)})],
+        [
+            Features({"email": Value(dtype="string", id=None)}),
+            Features({"email": Value(dtype="null", id=None)}),
+        ],
+        [
+            Features({"email": Value(dtype="string", id=None)}),
+            Features({"email": Value(dtype="string", id=None)}),
+        ],
     ],
     [
         [
@@ -845,7 +992,9 @@ NESTED_COMPARISON = [
 @pytest.mark.parametrize("features", NESTED_COMPARISON)
 def test_features_alignment(features: tuple[list[Features], list[Features]]):
     inputs, expected = features
-    _check_if_features_can_be_aligned(inputs)  # Check that we can align, will raise otherwise.
+    _check_if_features_can_be_aligned(
+        inputs
+    )  # Check that we can align, will raise otherwise.
     assert _align_features(inputs) == expected
 
 
@@ -890,7 +1039,8 @@ def test_features_reorder_fields_as_with_list_types(feature, other_feature):
 
 
 @pytest.mark.parametrize(
-    "feature, expected_arrow_data_type", [(Value("int64"), pa.int64), (Value("string"), pa.string)]
+    "feature, expected_arrow_data_type",
+    [(Value("int64"), pa.int64), (Value("string"), pa.string)],
 )
 def test_get_nested_type_with_scalar_feature(feature, expected_arrow_data_type):
     arrow_data_type = get_nested_type(feature)
@@ -898,37 +1048,51 @@ def test_get_nested_type_with_scalar_feature(feature, expected_arrow_data_type):
 
 
 @pytest.mark.parametrize(
-    "scalar_feature, expected_arrow_primitive_data_type", [(Value("int64"), pa.int64), (Value("string"), pa.string)]
+    "scalar_feature, expected_arrow_primitive_data_type",
+    [(Value("int64"), pa.int64), (Value("string"), pa.string)],
 )
 @pytest.mark.parametrize(
     "list_feature, expected_arrow_nested_data_type",
     [(list_with, pa.list_), (LargeList, pa.large_list), (Sequence, pa.list_)],
 )
 def test_get_nested_type_with_list_feature(
-    list_feature, expected_arrow_nested_data_type, scalar_feature, expected_arrow_primitive_data_type
+    list_feature,
+    expected_arrow_nested_data_type,
+    scalar_feature,
+    expected_arrow_primitive_data_type,
 ):
     feature = list_feature(scalar_feature)
     arrow_data_type = get_nested_type(feature)
-    assert arrow_data_type == expected_arrow_nested_data_type(expected_arrow_primitive_data_type())
+    assert arrow_data_type == expected_arrow_nested_data_type(
+        expected_arrow_primitive_data_type()
+    )
 
 
 @pytest.mark.parametrize(
-    "arrow_primitive_data_type, expected_feature", [(pa.int32, Value("int32")), (pa.string, Value("string"))]
+    "arrow_primitive_data_type, expected_feature",
+    [(pa.int32, Value("int32")), (pa.string, Value("string"))],
 )
-def test_generate_from_arrow_type_with_arrow_primitive_data_type(arrow_primitive_data_type, expected_feature):
+def test_generate_from_arrow_type_with_arrow_primitive_data_type(
+    arrow_primitive_data_type, expected_feature
+):
     arrow_data_type = arrow_primitive_data_type()
     feature = generate_from_arrow_type(arrow_data_type)
     assert feature == expected_feature
 
 
 @pytest.mark.parametrize(
-    "arrow_primitive_data_type, expected_scalar_feature", [(pa.int32, Value("int32")), (pa.string, Value("string"))]
+    "arrow_primitive_data_type, expected_scalar_feature",
+    [(pa.int32, Value("int32")), (pa.string, Value("string"))],
 )
 @pytest.mark.parametrize(
-    "arrow_nested_data_type, expected_list_feature", [(pa.list_, Sequence), (pa.large_list, LargeList)]
+    "arrow_nested_data_type, expected_list_feature",
+    [(pa.list_, Sequence), (pa.large_list, LargeList)],
 )
 def test_generate_from_arrow_type_with_arrow_nested_data_type(
-    arrow_nested_data_type, expected_list_feature, arrow_primitive_data_type, expected_scalar_feature
+    arrow_nested_data_type,
+    expected_list_feature,
+    arrow_primitive_data_type,
+    expected_scalar_feature,
 ):
     arrow_data_type = arrow_nested_data_type(arrow_primitive_data_type())
     feature = generate_from_arrow_type(arrow_data_type)
@@ -938,7 +1102,11 @@ def test_generate_from_arrow_type_with_arrow_nested_data_type(
 
 @pytest.mark.parametrize(
     "schema",
-    [[ClassLabel(names=["a", "b"])], LargeList(ClassLabel(names=["a", "b"])), List(ClassLabel(names=["a", "b"]))],
+    [
+        [ClassLabel(names=["a", "b"])],
+        LargeList(ClassLabel(names=["a", "b"])),
+        List(ClassLabel(names=["a", "b"])),
+    ],
 )
 def test_check_non_null_non_empty_recursive_with_list_types(schema):
     assert _check_non_null_non_empty_recursive([], schema) is False
@@ -973,7 +1141,11 @@ def test_require_storage_embed_with_list_types(feature):
 
 @pytest.mark.parametrize(
     "feature, expected",
-    [(List(Value("int32")), List(1)), (LargeList(Value("int32")), LargeList(1)), (List(Value("int32")), List(1))],
+    [
+        (List(Value("int32")), List(1)),
+        (LargeList(Value("int32")), LargeList(1)),
+        (List(Value("int32")), List(1)),
+    ],
 )
 def test_visit_with_list_types(feature, expected):
     def func(x):

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -10,7 +10,16 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from datasets import Column, Dataset, Features, Image, List, Value, concatenate_datasets, load_dataset
+from datasets import (
+    Column,
+    Dataset,
+    Features,
+    Image,
+    List,
+    Value,
+    concatenate_datasets,
+    load_dataset,
+)
 from datasets.features.image import encode_np_array, image_to_bytes
 
 from ..utils import require_pil
@@ -45,9 +54,13 @@ def test_image_feature_type_to_arrow():
     features = Features({"image": Image()})
     assert features.arrow_schema == pa.schema({"image": Image().pa_type})
     features = Features({"struct_containing_an_image": {"image": Image()}})
-    assert features.arrow_schema == pa.schema({"struct_containing_an_image": pa.struct({"image": Image().pa_type})})
+    assert features.arrow_schema == pa.schema(
+        {"struct_containing_an_image": pa.struct({"image": Image().pa_type})}
+    )
     features = Features({"sequence_of_images": List(Image())})
-    assert features.arrow_schema == pa.schema({"sequence_of_images": pa.list_(Image().pa_type)})
+    assert features.arrow_schema == pa.schema(
+        {"sequence_of_images": pa.list_(Image().pa_type)}
+    )
 
 
 @require_pil
@@ -121,7 +134,9 @@ def test_image_change_mode(shared_datadir):
     decoded_example = image.decode_example({"path": image_path, "bytes": None})
 
     assert isinstance(decoded_example, PIL.Image.Image)
-    assert not hasattr(decoded_example, "filename")  # changing the mode drops the filename
+    assert not hasattr(
+        decoded_example, "filename"
+    )  # changing the mode drops the filename
     assert decoded_example.size == (640, 480)
     assert decoded_example.mode == "YCbCr"
 
@@ -144,14 +159,18 @@ def test_dataset_with_image_feature(shared_datadir):
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"image"}
-    assert isinstance(batch["image"], list) and all(isinstance(item, PIL.Image.Image) for item in batch["image"])
+    assert isinstance(batch["image"], list) and all(
+        isinstance(item, PIL.Image.Image) for item in batch["image"]
+    )
     assert os.path.samefile(batch["image"][0].filename, image_path)
     assert batch["image"][0].format == "JPEG"
     assert batch["image"][0].size == (640, 480)
     assert batch["image"][0].mode == "RGB"
     column = dset["image"]
     assert len(column) == 1
-    assert isinstance(column, Column) and all(isinstance(item, PIL.Image.Image) for item in column)
+    assert isinstance(column, Column) and all(
+        isinstance(item, PIL.Image.Image) for item in column
+    )
     assert os.path.samefile(column[0].filename, image_path)
     assert column[0].format == "JPEG"
     assert column[0].size == (640, 480)
@@ -177,14 +196,18 @@ def test_dataset_with_image_feature_from_pil_image(infer_feature, shared_datadir
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"image"}
-    assert isinstance(batch["image"], list) and all(isinstance(item, PIL.Image.Image) for item in batch["image"])
+    assert isinstance(batch["image"], list) and all(
+        isinstance(item, PIL.Image.Image) for item in batch["image"]
+    )
     assert os.path.samefile(batch["image"][0].filename, image_path)
     assert batch["image"][0].format == "JPEG"
     assert batch["image"][0].size == (640, 480)
     assert batch["image"][0].mode == "RGB"
     column = dset["image"]
     assert len(column) == 1
-    assert isinstance(column, Column) and all(isinstance(item, PIL.Image.Image) for item in column)
+    assert isinstance(column, Column) and all(
+        isinstance(item, PIL.Image.Image) for item in column
+    )
     assert os.path.samefile(column[0].filename, image_path)
     assert column[0].format == "JPEG"
     assert column[0].size == (640, 480)
@@ -210,14 +233,18 @@ def test_dataset_with_image_feature_from_np_array():
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"image"}
-    assert isinstance(batch["image"], list) and all(isinstance(item, PIL.Image.Image) for item in batch["image"])
+    assert isinstance(batch["image"], list) and all(
+        isinstance(item, PIL.Image.Image) for item in batch["image"]
+    )
     np.testing.assert_array_equal(np.array(batch["image"][0]), image_array)
     assert batch["image"][0].filename == ""
     assert batch["image"][0].format in ["PNG", "TIFF"]
     assert batch["image"][0].size == (640, 480)
     column = dset["image"]
     assert len(column) == 1
-    assert isinstance(column, Column) and all(isinstance(item, PIL.Image.Image) for item in column)
+    assert isinstance(column, Column) and all(
+        isinstance(item, PIL.Image.Image) for item in column
+    )
     np.testing.assert_array_equal(np.array(column[0]), image_array)
     assert column[0].filename == ""
     assert column[0].format in ["PNG", "TIFF"]
@@ -245,14 +272,18 @@ def test_dataset_with_image_feature_tar_jpg(tar_jpg_path):
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"image"}
-    assert isinstance(batch["image"], list) and all(isinstance(item, PIL.Image.Image) for item in batch["image"])
+    assert isinstance(batch["image"], list) and all(
+        isinstance(item, PIL.Image.Image) for item in batch["image"]
+    )
     assert batch["image"][0].filename == ""
     assert batch["image"][0].format == "JPEG"
     assert batch["image"][0].size == (640, 480)
     assert batch["image"][0].mode == "RGB"
     column = dset["image"]
     assert len(column) == 1
-    assert isinstance(column, Column) and all(isinstance(item, PIL.Image.Image) for item in column)
+    assert isinstance(column, Column) and all(
+        isinstance(item, PIL.Image.Image) for item in column
+    )
     assert column[0].filename == ""
     assert column[0].format == "JPEG"
     assert column[0].size == (640, 480)
@@ -270,7 +301,9 @@ def test_dataset_with_image_feature_with_none():
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"image"}
-    assert isinstance(batch["image"], list) and all(item is None for item in batch["image"])
+    assert isinstance(batch["image"], list) and all(
+        item is None for item in batch["image"]
+    )
     column = dset["image"]
     assert len(column) == 1
     assert isinstance(column, Column) and all(item is None for item in column)
@@ -301,8 +334,12 @@ def test_dataset_with_image_feature_with_none():
         lambda image_path: {"image": [open(image_path, "rb").read()]},
         lambda image_path: {"image": [{"path": image_path}]},
         lambda image_path: {"image": [{"path": image_path, "bytes": None}]},
-        lambda image_path: {"image": [{"path": image_path, "bytes": open(image_path, "rb").read()}]},
-        lambda image_path: {"image": [{"path": None, "bytes": open(image_path, "rb").read()}]},
+        lambda image_path: {
+            "image": [{"path": image_path, "bytes": open(image_path, "rb").read()}]
+        },
+        lambda image_path: {
+            "image": [{"path": None, "bytes": open(image_path, "rb").read()}]
+        },
         lambda image_path: {"image": [{"bytes": open(image_path, "rb").read()}]},
     ],
 )
@@ -341,7 +378,11 @@ def test_dataset_concatenate_nested_image_features(shared_datadir):
     features = Features({"list_of_structs_of_images": List({"image": Image()})})
     data1 = {"list_of_structs_of_images": [[{"image": image_path}]]}
     dset1 = Dataset.from_dict(data1, features=features)
-    data2 = {"list_of_structs_of_images": [[{"image": {"bytes": open(image_path, "rb").read()}}]]}
+    data2 = {
+        "list_of_structs_of_images": [
+            [{"image": {"bytes": open(image_path, "rb").read()}}]
+        ]
+    }
     dset2 = Dataset.from_dict(data2, features=features)
     concatenated_dataset = concatenate_datasets([dset1, dset2])
     assert len(concatenated_dataset) == len(dset1) + len(dset2)
@@ -364,7 +405,10 @@ def test_dataset_with_image_feature_map(shared_datadir):
 
     for item in dset.cast_column("image", Image(decode=False)):
         assert item.keys() == {"image", "caption"}
-        assert item == {"image": {"path": image_path, "bytes": None}, "caption": "cats sleeping"}
+        assert item == {
+            "image": {"path": image_path, "bytes": None},
+            "caption": "cats sleeping",
+        }
 
     # no decoding
 
@@ -375,7 +419,10 @@ def test_dataset_with_image_feature_map(shared_datadir):
     processed_dset = dset.map(process_caption)
     for item in processed_dset.cast_column("image", Image(decode=False)):
         assert item.keys() == {"image", "caption"}
-        assert item == {"image": {"path": image_path, "bytes": None}, "caption": "Two cats sleeping"}
+        assert item == {
+            "image": {"path": image_path, "bytes": None},
+            "caption": "Two cats sleeping",
+        }
 
     # decoding example
 
@@ -414,7 +461,10 @@ def test_formatted_dataset_with_image_feature_map(shared_datadir):
     dset = Dataset.from_dict(data, features=features)
     for item in dset.cast_column("image", Image(decode=False)):
         assert item.keys() == {"image", "caption"}
-        assert item == {"image": {"path": image_path, "bytes": None}, "caption": "cats sleeping"}
+        assert item == {
+            "image": {"path": image_path, "bytes": None},
+            "caption": "cats sleeping",
+        }
 
     def process_image_by_example(example):
         example["num_channels"] = example["image"].shape[-1]
@@ -467,7 +517,12 @@ def test_dataset_with_image_feature_map_change_image(shared_datadir):
     decoded_dset = dset.map(process_image_resize_by_example)
     for item in decoded_dset.cast_column("image", Image(decode=False)):
         assert item.keys() == {"image"}
-        assert item == {"image": {"bytes": image_to_bytes(pil_image.resize((100, 100))), "path": None}}
+        assert item == {
+            "image": {
+                "bytes": image_to_bytes(pil_image.resize((100, 100))),
+                "path": None,
+            }
+        }
 
     def process_image_resize_by_batch(batch):
         batch["image"] = [image.resize((100, 100)) for image in batch["image"]]
@@ -476,7 +531,12 @@ def test_dataset_with_image_feature_map_change_image(shared_datadir):
     decoded_dset = dset.map(process_image_resize_by_batch, batched=True)
     for item in decoded_dset.cast_column("image", Image(decode=False)):
         assert item.keys() == {"image"}
-        assert item == {"image": {"bytes": image_to_bytes(pil_image.resize((100, 100))), "path": None}}
+        assert item == {
+            "image": {
+                "bytes": image_to_bytes(pil_image.resize((100, 100))),
+                "path": None,
+            }
+        }
 
     # return np.ndarray (e.g. when using albumentations)
 
@@ -489,13 +549,17 @@ def test_dataset_with_image_feature_map_change_image(shared_datadir):
         assert item.keys() == {"image"}
         assert item == {
             "image": {
-                "bytes": image_to_bytes(PIL.Image.fromarray(np.array(pil_image.resize((100, 100))))),
+                "bytes": image_to_bytes(
+                    PIL.Image.fromarray(np.array(pil_image.resize((100, 100))))
+                ),
                 "path": None,
             }
         }
 
     def process_image_resize_by_batch_return_np_array(batch):
-        batch["image"] = [np.array(image.resize((100, 100))) for image in batch["image"]]
+        batch["image"] = [
+            np.array(image.resize((100, 100))) for image in batch["image"]
+        ]
         return batch
 
     decoded_dset = dset.map(process_image_resize_by_batch_return_np_array, batched=True)
@@ -503,7 +567,9 @@ def test_dataset_with_image_feature_map_change_image(shared_datadir):
         assert item.keys() == {"image"}
         assert item == {
             "image": {
-                "bytes": image_to_bytes(PIL.Image.fromarray(np.array(pil_image.resize((100, 100))))),
+                "bytes": image_to_bytes(
+                    PIL.Image.fromarray(np.array(pil_image.resize((100, 100))))
+                ),
                 "path": None,
             }
         }
@@ -553,7 +619,9 @@ def test_formatted_dataset_with_image_feature(shared_datadir):
         assert batch["image"][0].mode == "RGB"
         column = dset["image"]
         assert len(column) == 2
-        assert isinstance(column, pd.Series) and all(isinstance(item, PIL.Image.Image) for item in column)
+        assert isinstance(column, pd.Series) and all(
+            isinstance(item, PIL.Image.Image) for item in column
+        )
         assert os.path.samefile(column[0].filename, image_path)
         assert column[0].format == "JPEG"
         assert column[0].size == (640, 480)
@@ -564,7 +632,9 @@ def test_formatted_dataset_with_image_feature(shared_datadir):
 def img_dataset_dir(shared_datadir, tmp_path):
     data_dir = tmp_path / "dummy_img_dataset_data"
     data_dir.mkdir()
-    shutil.copy(str(shared_datadir / "test_image_rgb.jpg"), str(data_dir / "image_rgb.jpg"))
+    shutil.copy(
+        str(shared_datadir / "test_image_rgb.jpg"), str(data_dir / "image_rgb.jpg")
+    )
     with open(data_dir / "metadata.jsonl", "w") as f:
         f.write('{"file_name": "image_rgb.jpg", "caption": "Two cats sleeping"}\n')
     return str(data_dir)
@@ -659,10 +729,15 @@ def test_dataset_with_image_feature_map_undecoded(shared_datadir):
 def test_image_embed_storage(shared_datadir):
     image_path = str(shared_datadir / "test_image_rgb.jpg")
     example = {"bytes": None, "path": image_path}
-    storage = pa.array([example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()}))
+    storage = pa.array(
+        [example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()})
+    )
     embedded_storage = Image().embed_storage(storage)
     embedded_example = embedded_storage.to_pylist()[0]
-    assert embedded_example == {"bytes": open(image_path, "rb").read(), "path": "test_image_rgb.jpg"}
+    assert embedded_example == {
+        "bytes": open(image_path, "rb").read(),
+        "path": "test_image_rgb.jpg",
+    }
 
 
 @require_pil
@@ -682,7 +757,9 @@ def test_encode_np_array(array, dtype_cast, expected_image_format):
     if dtype_cast.startswith("downcast"):
         _, dest_dtype = dtype_cast.split("->")
         dest_dtype = np.dtype(dest_dtype)
-        with pytest.warns(UserWarning, match=f"Downcasting array dtype.+{dest_dtype}.+"):
+        with pytest.warns(
+            UserWarning, match=f"Downcasting array dtype.+{dest_dtype}.+"
+        ):
             encoded_image = Image().encode_example(array)
     elif dtype_cast == "error":
         with pytest.raises(TypeError):
@@ -696,7 +773,9 @@ def test_encode_np_array(array, dtype_cast, expected_image_format):
     assert isinstance(encoded_image, dict)
     assert encoded_image.keys() == {"path", "bytes"}
     assert encoded_image["path"] is None
-    assert encoded_image["bytes"] is not None and isinstance(encoded_image["bytes"], bytes)
+    assert encoded_image["bytes"] is not None and isinstance(
+        encoded_image["bytes"], bytes
+    )
     decoded_image = Image().decode_example(encoded_image)
     assert decoded_image.format == expected_image_format
     np.testing.assert_array_equal(np.array(decoded_image), array)

--- a/tests/features/test_pdf.py
+++ b/tests/features/test_pdf.py
@@ -48,10 +48,14 @@ def test_dataset_with_pdf_feature(shared_datadir):
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"pdf"}
-    assert isinstance(batch["pdf"], list) and all(isinstance(item, pdfplumber.pdf.PDF) for item in batch["pdf"])
+    assert isinstance(batch["pdf"], list) and all(
+        isinstance(item, pdfplumber.pdf.PDF) for item in batch["pdf"]
+    )
     column = dset["pdf"]
     assert len(column) == 1
-    assert isinstance(column, list) and all(isinstance(item, pdfplumber.pdf.PDF) for item in column)
+    assert isinstance(column, list) and all(
+        isinstance(item, pdfplumber.pdf.PDF) for item in column
+    )
 
     # from bytes
     with open(pdf_path, "rb") as f:

--- a/tests/features/test_video.py
+++ b/tests/features/test_video.py
@@ -51,13 +51,17 @@ def test_dataset_with_video_feature(shared_datadir):
     batch = dset[:1]
     assert len(batch) == 1
     assert batch.keys() == {"video"}
-    assert isinstance(batch["video"], list) and all(isinstance(item, VideoDecoder) for item in batch["video"])
+    assert isinstance(batch["video"], list) and all(
+        isinstance(item, VideoDecoder) for item in batch["video"]
+    )
     assert batch["video"][0].get_frame_at(0).data.shape == (3, 50, 66)
     assert isinstance(batch["video"][0].get_frame_at(0).data, torch.Tensor)
     column = dset["video"]
     assert len(column) == 1
 
-    assert isinstance(column, Column) and all(isinstance(item, VideoDecoder) for item in column)
+    assert isinstance(column, Column) and all(
+        isinstance(item, VideoDecoder) for item in column
+    )
     assert next(iter(column)).get_frame_at(0).data.shape == (3, 50, 66)
     assert isinstance(next(iter(column)).get_frame_at(0).data, torch.Tensor)
 
@@ -141,13 +145,21 @@ def jsonl_video_dataset_path(shared_datadir, tmp_path_factory):
 
 @require_torchcodec
 @pytest.mark.parametrize("streaming", [False, True])
-def test_load_dataset_with_video_feature(streaming, jsonl_video_dataset_path, shared_datadir):
+def test_load_dataset_with_video_feature(
+    streaming, jsonl_video_dataset_path, shared_datadir
+):
     from torchcodec.decoders import VideoDecoder
 
     video_path = str(shared_datadir / "test_video_66x50.mov")
     data_files = jsonl_video_dataset_path
     features = Features({"video": Video(), "text": Value("string")})
-    dset = load_dataset("json", split="train", data_files=data_files, features=features, streaming=streaming)
+    dset = load_dataset(
+        "json",
+        split="train",
+        data_files=data_files,
+        features=features,
+        streaming=streaming,
+    )
     item = dset[0] if not streaming else next(iter(dset))
     assert item.keys() == {"video", "text"}
     assert isinstance(item["video"], VideoDecoder)

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -25,7 +25,9 @@ def dataset():
     features = datasets.Features(
         {
             "tokens": datasets.List(datasets.Value("string")),
-            "labels": datasets.List(datasets.ClassLabel(names=["negative", "positive"])),
+            "labels": datasets.List(
+                datasets.ClassLabel(names=["negative", "positive"])
+            ),
             "answers": {
                 "text": datasets.List(datasets.Value("string")),
                 "answer_start": datasets.List(datasets.Value("int32")),
@@ -251,7 +253,10 @@ def sqlite_path(tmp_path_factory):
         cur = con.cursor()
         cur.execute("CREATE TABLE dataset(col_1 text, col_2 int, col_3 real)")
         for item in DATA:
-            cur.execute("INSERT INTO dataset(col_1, col_2, col_3) VALUES (?, ?, ?)", tuple(item.values()))
+            cur.execute(
+                "INSERT INTO dataset(col_1, col_2, col_3) VALUES (?, ?, ?)",
+                tuple(item.values()),
+            )
         con.commit()
     return path
 
@@ -314,7 +319,9 @@ def zip_csv_with_dir_path(csv_path, csv2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.csv.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(csv_path, arcname=os.path.join("main_dir", os.path.basename(csv_path)))
-        f.write(csv2_path, arcname=os.path.join("main_dir", os.path.basename(csv2_path)))
+        f.write(
+            csv2_path, arcname=os.path.join("main_dir", os.path.basename(csv2_path))
+        )
     return path
 
 
@@ -330,7 +337,9 @@ def parquet_path(tmp_path_factory):
     )
     with open(path, "wb") as f:
         writer = pq.ParquetWriter(f, schema=schema)
-        pa_table = pa.Table.from_pydict({k: [DATA[i][k] for i in range(len(DATA))] for k in DATA[0]}, schema=schema)
+        pa_table = pa.Table.from_pydict(
+            {k: [DATA[i][k] for i in range(len(DATA))] for k in DATA[0]}, schema=schema
+        )
         writer.write_table(pa_table)
         writer.close()
     return path
@@ -338,7 +347,9 @@ def parquet_path(tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def geoparquet_path(tmp_path_factory):
-    df = pd.read_parquet(path="https://github.com/opengeospatial/geoparquet/raw/v1.0.0/examples/example.parquet")
+    df = pd.read_parquet(
+        path="https://github.com/opengeospatial/geoparquet/raw/v1.0.0/examples/example.parquet"
+    )
     path = str(tmp_path_factory.mktemp("data") / "dataset.geoparquet")
     df.to_parquet(path=path)
     return path
@@ -433,7 +444,10 @@ def zip_jsonl_path(jsonl_path, jsonl2_path, tmp_path_factory):
 def zip_nested_jsonl_path(zip_jsonl_path, jsonl_path, jsonl2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset_nested.jsonl.zip"
     with zipfile.ZipFile(path, "w") as f:
-        f.write(zip_jsonl_path, arcname=os.path.join("nested", os.path.basename(zip_jsonl_path)))
+        f.write(
+            zip_jsonl_path,
+            arcname=os.path.join("nested", os.path.basename(zip_jsonl_path)),
+        )
     return path
 
 
@@ -441,8 +455,12 @@ def zip_nested_jsonl_path(zip_jsonl_path, jsonl_path, jsonl2_path, tmp_path_fact
 def zip_jsonl_with_dir_path(jsonl_path, jsonl2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.jsonl.zip"
     with zipfile.ZipFile(path, "w") as f:
-        f.write(jsonl_path, arcname=os.path.join("main_dir", os.path.basename(jsonl_path)))
-        f.write(jsonl2_path, arcname=os.path.join("main_dir", os.path.basename(jsonl2_path)))
+        f.write(
+            jsonl_path, arcname=os.path.join("main_dir", os.path.basename(jsonl_path))
+        )
+        f.write(
+            jsonl2_path, arcname=os.path.join("main_dir", os.path.basename(jsonl2_path))
+        )
     return path
 
 
@@ -459,7 +477,10 @@ def tar_jsonl_path(jsonl_path, jsonl2_path, tmp_path_factory):
 def tar_nested_jsonl_path(tar_jsonl_path, jsonl_path, jsonl2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset_nested.jsonl.tar"
     with tarfile.TarFile(path, "w") as f:
-        f.add(tar_jsonl_path, arcname=os.path.join("nested", os.path.basename(tar_jsonl_path)))
+        f.add(
+            tar_jsonl_path,
+            arcname=os.path.join("nested", os.path.basename(tar_jsonl_path)),
+        )
     return path
 
 
@@ -516,8 +537,12 @@ def zip_text_path(text_path, text2_path, tmp_path_factory):
 def zip_text_with_dir_path(text_path, text2_path, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset_with_dir.text.zip"
     with zipfile.ZipFile(path, "w") as f:
-        f.write(text_path, arcname=os.path.join("main_dir", os.path.basename(text_path)))
-        f.write(text2_path, arcname=os.path.join("main_dir", os.path.basename(text2_path)))
+        f.write(
+            text_path, arcname=os.path.join("main_dir", os.path.basename(text_path))
+        )
+        f.write(
+            text2_path, arcname=os.path.join("main_dir", os.path.basename(text2_path))
+        )
     return path
 
 
@@ -574,7 +599,9 @@ def zip_image_path(image_file, tmp_path_factory):
     path = tmp_path_factory.mktemp("data") / "dataset.img.zip"
     with zipfile.ZipFile(path, "w") as f:
         f.write(image_file, arcname=os.path.basename(image_file))
-        f.write(image_file, arcname=os.path.basename(image_file).replace(".jpg", "2.jpg"))
+        f.write(
+            image_file, arcname=os.path.basename(image_file).replace(".jpg", "2.jpg")
+        )
     return path
 
 

--- a/tests/fixtures/fsspec.py
+++ b/tests/fixtures/fsspec.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from fsspec.implementations.local import AbstractFileSystem, LocalFileSystem, stringify_path
+from fsspec.implementations.local import (
+    AbstractFileSystem,
+    LocalFileSystem,
+    stringify_path,
+)
 from fsspec.registry import _registry as _fsspec_registry
 
 
@@ -31,7 +35,10 @@ class MockFileSystem(AbstractFileSystem):
         path = posixpath.join(self.local_root_dir, self._strip_protocol(path))
         out = self._fs.ls(path, detail=detail, *args, **kwargs)
         if detail:
-            return [{**info, "name": info["name"][len(self.local_root_dir) :]} for info in out]
+            return [
+                {**info, "name": info["name"][len(self.local_root_dir) :]}
+                for info in out
+            ]
         else:
             return [name[len(self.local_root_dir) :] for name in out]
 

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -17,7 +17,9 @@ CI_HUB_USER_TOKEN = "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"
 
 CI_HUB_ENDPOINT = "https://hub-ci.huggingface.co"
 CI_HUB_DATASETS_URL = CI_HUB_ENDPOINT + "/datasets/{repo_id}/resolve/{revision}/{path}"
-CI_HFH_HUGGINGFACE_CO_URL_TEMPLATE = CI_HUB_ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
+CI_HFH_HUGGINGFACE_CO_URL_TEMPLATE = (
+    CI_HUB_ENDPOINT + "/{repo_id}/resolve/{revision}/{filename}"
+)
 
 
 @pytest.fixture
@@ -25,7 +27,8 @@ def ci_hub_config(monkeypatch):
     monkeypatch.setattr("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT)
     monkeypatch.setattr("datasets.config.HUB_DATASETS_URL", CI_HUB_DATASETS_URL)
     monkeypatch.setattr(
-        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE", CI_HFH_HUGGINGFACE_CO_URL_TEMPLATE
+        "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE",
+        CI_HFH_HUGGINGFACE_CO_URL_TEMPLATE,
     )
     old_environ = dict(os.environ)
     os.environ["HF_ENDPOINT"] = CI_HUB_ENDPOINT
@@ -37,7 +40,9 @@ def ci_hub_config(monkeypatch):
 @pytest.fixture
 def set_ci_hub_access_token(ci_hub_config, monkeypatch):
     # Enable implicit token
-    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", False)
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_DISABLE_IMPLICIT_TOKEN", False
+    )
     old_environ = dict(os.environ)
     os.environ["HF_TOKEN"] = CI_HUB_USER_TOKEN
     os.environ["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "0"
@@ -55,7 +60,9 @@ def _http_ci_user_agent(*args, **kwargs):
 def set_hf_ci_headers(monkeypatch):
     old_environ = dict(os.environ)
     os.environ["TRANSFORMERS_IS_CI"] = "1"
-    monkeypatch.setattr("huggingface_hub.utils._headers._http_user_agent", _http_ci_user_agent)
+    monkeypatch.setattr(
+        "huggingface_hub.utils._headers._http_user_agent", _http_ci_user_agent
+    )
     yield
     os.environ.clear()
     os.environ.update(old_environ)
@@ -83,7 +90,10 @@ def cleanup_repo(hf_api):
 def temporary_repo(cleanup_repo):
     @contextmanager
     def _temporary_repo(repo_id: Optional[str] = None):
-        repo_id = repo_id or f"{CI_HUB_USER}/test-dataset-{uuid.uuid4().hex[:6]}-{int(time.time() * 10e3)}"
+        repo_id = (
+            repo_id
+            or f"{CI_HUB_USER}/test-dataset-{uuid.uuid4().hex[:6]}-{int(time.time() * 10e3)}"
+        )
         try:
             yield repo_id
         finally:
@@ -118,7 +128,10 @@ def _hf_gated_dataset_repo_txt_data(hf_api: HfApi, hf_token, text_file_content):
     yield repo_id
     try:
         hf_api.delete_repo(repo_id, token=hf_token, repo_type="dataset")
-    except (requests.exceptions.HTTPError, ValueError):  # catch http error and token invalid error
+    except (
+        requests.exceptions.HTTPError,
+        ValueError,
+    ):  # catch http error and token invalid error
         pass
 
 
@@ -142,7 +155,10 @@ def hf_private_dataset_repo_txt_data_(hf_api: HfApi, hf_token, text_file_content
     yield repo_id
     try:
         hf_api.delete_repo(repo_id, token=hf_token, repo_type="dataset")
-    except (requests.exceptions.HTTPError, ValueError):  # catch http error and token invalid error
+    except (
+        requests.exceptions.HTTPError,
+        ValueError,
+    ):  # catch http error and token invalid error
         pass
 
 
@@ -152,7 +168,9 @@ def hf_private_dataset_repo_txt_data(hf_private_dataset_repo_txt_data_, ci_hub_c
 
 
 @pytest.fixture(scope="session")
-def hf_private_dataset_repo_zipped_txt_data_(hf_api: HfApi, hf_token, zip_csv_with_dir_path):
+def hf_private_dataset_repo_zipped_txt_data_(
+    hf_api: HfApi, hf_token, zip_csv_with_dir_path
+):
     repo_name = f"repo_zipped_txt_data-{int(time.time() * 10e6)}"
     repo_id = f"{CI_HUB_USER}/{repo_name}"
     hf_api.create_repo(repo_id, token=hf_token, repo_type="dataset", private=True)
@@ -166,12 +184,17 @@ def hf_private_dataset_repo_zipped_txt_data_(hf_api: HfApi, hf_token, zip_csv_wi
     yield repo_id
     try:
         hf_api.delete_repo(repo_id, token=hf_token, repo_type="dataset")
-    except (requests.exceptions.HTTPError, ValueError):  # catch http error and token invalid error
+    except (
+        requests.exceptions.HTTPError,
+        ValueError,
+    ):  # catch http error and token invalid error
         pass
 
 
 @pytest.fixture()
-def hf_private_dataset_repo_zipped_txt_data(hf_private_dataset_repo_zipped_txt_data_, ci_hub_config):
+def hf_private_dataset_repo_zipped_txt_data(
+    hf_private_dataset_repo_zipped_txt_data_, ci_hub_config
+):
     return hf_private_dataset_repo_zipped_txt_data_
 
 
@@ -190,10 +213,15 @@ def hf_private_dataset_repo_zipped_img_data_(hf_api: HfApi, hf_token, zip_image_
     yield repo_id
     try:
         hf_api.delete_repo(repo_id, token=hf_token, repo_type="dataset")
-    except (requests.exceptions.HTTPError, ValueError):  # catch http error and token invalid error
+    except (
+        requests.exceptions.HTTPError,
+        ValueError,
+    ):  # catch http error and token invalid error
         pass
 
 
 @pytest.fixture()
-def hf_private_dataset_repo_zipped_img_data(hf_private_dataset_repo_zipped_img_data_, ci_hub_config):
+def hf_private_dataset_repo_zipped_img_data(
+    hf_private_dataset_repo_zipped_img_data_, ci_hub_config
+):
     return hf_private_dataset_repo_zipped_img_data_

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -23,8 +23,14 @@ def _check_csv_dataset(dataset, expected_features):
 def test_dataset_from_csv_keep_in_memory(keep_in_memory, csv_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = CsvDatasetReader(csv_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = CsvDatasetReader(
+            csv_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_csv_dataset(dataset, expected_features)
 
 
@@ -44,7 +50,9 @@ def test_dataset_from_csv_features(features, csv_path, tmp_path):
     default_expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
     dataset = CsvDatasetReader(csv_path, features=features, cache_dir=cache_dir).read()
     _check_csv_dataset(dataset, expected_features)
@@ -86,8 +94,14 @@ def _check_csv_datasetdict(dataset_dict, expected_features, splits=("train",)):
 def test_csv_datasetdict_reader_keep_in_memory(keep_in_memory, csv_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = CsvDatasetReader({"train": csv_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = CsvDatasetReader(
+            {"train": csv_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_csv_datasetdict(dataset, expected_features)
 
 
@@ -107,9 +121,13 @@ def test_csv_datasetdict_reader_features(features, csv_path, tmp_path):
     default_expected_features = {"col_1": "int64", "col_2": "int64", "col_3": "float64"}
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = CsvDatasetReader({"train": csv_path}, features=features, cache_dir=cache_dir).read()
+    dataset = CsvDatasetReader(
+        {"train": csv_path}, features=features, cache_dir=cache_dir
+    ).read()
     _check_csv_datasetdict(dataset, expected_features)
 
 
@@ -167,7 +185,9 @@ def test_dataset_to_csv_invalidproc(csv_path, tmp_path):
 
 def test_dataset_to_csv_fsspec(dataset, mockfs):
     dataset_path = "mock://my_dataset.csv"
-    writer = CsvDatasetWriter(dataset, dataset_path, storage_options=mockfs.storage_options)
+    writer = CsvDatasetWriter(
+        dataset, dataset_path, storage_options=mockfs.storage_options
+    )
     assert writer.write() > 0
     assert mockfs.isfile(dataset_path)
 

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -23,8 +23,14 @@ def _check_json_dataset(dataset, expected_features):
 def test_dataset_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = JsonDatasetReader(jsonl_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = JsonDatasetReader(
+            jsonl_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_json_dataset(dataset, expected_features)
 
 
@@ -40,12 +46,20 @@ def test_dataset_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_path):
 )
 def test_dataset_from_json_features(features, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"
-    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    default_expected_features = {
+        "col_1": "string",
+        "col_2": "int64",
+        "col_3": "float64",
+    }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = JsonDatasetReader(jsonl_path, features=features, cache_dir=cache_dir).read()
+    dataset = JsonDatasetReader(
+        jsonl_path, features=features, cache_dir=cache_dir
+    ).read()
     _check_json_dataset(dataset, expected_features)
 
 
@@ -56,14 +70,24 @@ def test_dataset_from_json_features(features, jsonl_path, tmp_path):
         {"col_3": "float64", "col_1": "string", "col_2": "int64"},
     ],
 )
-def test_dataset_from_json_with_unsorted_column_names(features, jsonl_312_path, tmp_path):
+def test_dataset_from_json_with_unsorted_column_names(
+    features, jsonl_312_path, tmp_path
+):
     cache_dir = tmp_path / "cache"
-    default_expected_features = {"col_3": "float64", "col_1": "string", "col_2": "int64"}
+    default_expected_features = {
+        "col_3": "float64",
+        "col_1": "string",
+        "col_2": "int64",
+    }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = JsonDatasetReader(jsonl_312_path, features=features, cache_dir=cache_dir).read()
+    dataset = JsonDatasetReader(
+        jsonl_312_path, features=features, cache_dir=cache_dir
+    ).read()
     assert isinstance(dataset, Dataset)
     assert dataset.num_rows == 2
     assert dataset.num_columns == 3
@@ -77,10 +101,14 @@ def test_dataset_from_json_with_mismatched_features(jsonl_312_path, tmp_path):
     features = {"col_2": "int64", "col_3": "float64", "col_1": "string"}
     expected_features = features.copy()
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
     cache_dir = tmp_path / "cache"
-    dataset = JsonDatasetReader(jsonl_312_path, features=features, cache_dir=cache_dir).read()
+    dataset = JsonDatasetReader(
+        jsonl_312_path, features=features, cache_dir=cache_dir
+    ).read()
     assert isinstance(dataset, Dataset)
     assert dataset.num_rows == 2
     assert dataset.num_columns == 3
@@ -125,8 +153,14 @@ def _check_json_datasetdict(dataset_dict, expected_features, splits=("train",)):
 def test_datasetdict_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = JsonDatasetReader({"train": jsonl_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = JsonDatasetReader(
+            {"train": jsonl_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_json_datasetdict(dataset, expected_features)
 
 
@@ -142,12 +176,20 @@ def test_datasetdict_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_pa
 )
 def test_datasetdict_from_json_features(features, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"
-    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    default_expected_features = {
+        "col_1": "string",
+        "col_2": "int64",
+        "col_3": "float64",
+    }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = JsonDatasetReader({"train": jsonl_path}, features=features, cache_dir=cache_dir).read()
+    dataset = JsonDatasetReader(
+        {"train": jsonl_path}, features=features, cache_dir=cache_dir
+    ).read()
     _check_json_datasetdict(dataset, expected_features)
 
 
@@ -174,7 +216,9 @@ def load_json_lines(buffer):
 
 
 class TestJsonDatasetWriter:
-    @pytest.mark.parametrize("lines, load_json_function", [(True, load_json_lines), (False, load_json)])
+    @pytest.mark.parametrize(
+        "lines, load_json_function", [(True, load_json_lines), (False, load_json)]
+    )
     def test_dataset_to_json_lines(self, lines, load_json_function, dataset):
         with io.BytesIO() as buffer:
             JsonDatasetWriter(dataset, buffer, lines=lines).write()
@@ -207,13 +251,17 @@ class TestJsonDatasetWriter:
             else:
                 assert exported_content[0].keys() == keys
         else:
-            assert not hasattr(exported_content, "keys") and not hasattr(exported_content[0], "keys")
+            assert not hasattr(exported_content, "keys") and not hasattr(
+                exported_content[0], "keys"
+            )
         if len_at:
             assert len(exported_content[len_at]) == 10
         else:
             assert len(exported_content) == 10
 
-    @pytest.mark.parametrize("lines, load_json_function", [(True, load_json_lines), (False, load_json)])
+    @pytest.mark.parametrize(
+        "lines, load_json_function", [(True, load_json_lines), (False, load_json)]
+    )
     def test_dataset_to_json_lines_multiproc(self, lines, load_json_function, dataset):
         with io.BytesIO() as buffer:
             JsonDatasetWriter(dataset, buffer, lines=lines, num_proc=2).write()
@@ -234,9 +282,13 @@ class TestJsonDatasetWriter:
             ("table", dict, {"schema", "data"}, "data"),
         ],
     )
-    def test_dataset_to_json_orient_multiproc(self, orient, container, keys, len_at, dataset):
+    def test_dataset_to_json_orient_multiproc(
+        self, orient, container, keys, len_at, dataset
+    ):
         with io.BytesIO() as buffer:
-            JsonDatasetWriter(dataset, buffer, lines=False, orient=orient, num_proc=2).write()
+            JsonDatasetWriter(
+                dataset, buffer, lines=False, orient=orient, num_proc=2
+            ).write()
             buffer.seek(0)
             exported_content = load_json(buffer)
         assert isinstance(exported_content, container)
@@ -246,7 +298,9 @@ class TestJsonDatasetWriter:
             else:
                 assert exported_content[0].keys() == keys
         else:
-            assert not hasattr(exported_content, "keys") and not hasattr(exported_content[0], "keys")
+            assert not hasattr(exported_content, "keys") and not hasattr(
+                exported_content[0], "keys"
+            )
         if len_at:
             assert len(exported_content[len_at]) == 10
         else:
@@ -257,8 +311,12 @@ class TestJsonDatasetWriter:
             with io.BytesIO() as buffer:
                 JsonDatasetWriter(dataset, buffer, num_proc=0)
 
-    @pytest.mark.parametrize("compression, extension", [("gzip", "gz"), ("bz2", "bz2"), ("xz", "xz")])
-    def test_dataset_to_json_compression(self, shared_datadir, tmp_path_factory, extension, compression, dataset):
+    @pytest.mark.parametrize(
+        "compression, extension", [("gzip", "gz"), ("bz2", "bz2"), ("xz", "xz")]
+    )
+    def test_dataset_to_json_compression(
+        self, shared_datadir, tmp_path_factory, extension, compression, dataset
+    ):
         path = tmp_path_factory.mktemp("data") / f"test.json.{extension}"
         original_path = str(shared_datadir / f"test_file.json.{extension}")
         JsonDatasetWriter(dataset, path, compression=compression).write()
@@ -271,7 +329,9 @@ class TestJsonDatasetWriter:
 
     def test_dataset_to_json_fsspec(self, dataset, mockfs):
         dataset_path = "mock://my_dataset.json"
-        writer = JsonDatasetWriter(dataset, dataset_path, storage_options=mockfs.storage_options)
+        writer = JsonDatasetWriter(
+            dataset, dataset_path, storage_options=mockfs.storage_options
+        )
         assert writer.write() > 0
         assert mockfs.isfile(dataset_path)
 

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -5,7 +5,17 @@ import fsspec
 import pyarrow.parquet as pq
 import pytest
 
-from datasets import Audio, Dataset, DatasetDict, Features, IterableDatasetDict, List, NamedSplit, Value, config
+from datasets import (
+    Audio,
+    Dataset,
+    DatasetDict,
+    Features,
+    IterableDatasetDict,
+    List,
+    NamedSplit,
+    Value,
+    config,
+)
 from datasets.arrow_writer import get_arrow_writer_batch_size_from_features
 from datasets.features.image import Image
 from datasets.info import DatasetInfo
@@ -27,8 +37,14 @@ def _check_parquet_dataset(dataset, expected_features):
 def test_dataset_from_parquet_keep_in_memory(keep_in_memory, parquet_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = ParquetDatasetReader(parquet_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = ParquetDatasetReader(
+            parquet_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_parquet_dataset(dataset, expected_features)
 
 
@@ -44,12 +60,20 @@ def test_dataset_from_parquet_keep_in_memory(keep_in_memory, parquet_path, tmp_p
 )
 def test_dataset_from_parquet_features(features, parquet_path, tmp_path):
     cache_dir = tmp_path / "cache"
-    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    default_expected_features = {
+        "col_1": "string",
+        "col_2": "int64",
+        "col_3": "float64",
+    }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = ParquetDatasetReader(parquet_path, features=features, cache_dir=cache_dir).read()
+    dataset = ParquetDatasetReader(
+        parquet_path, features=features, cache_dir=cache_dir
+    ).read()
     _check_parquet_dataset(dataset, expected_features)
 
 
@@ -57,7 +81,9 @@ def test_dataset_from_parquet_features(features, parquet_path, tmp_path):
 def test_dataset_from_parquet_split(split, parquet_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
-    dataset = ParquetDatasetReader(parquet_path, cache_dir=cache_dir, split=split).read()
+    dataset = ParquetDatasetReader(
+        parquet_path, cache_dir=cache_dir, split=split
+    ).read()
     _check_parquet_dataset(dataset, expected_features)
     assert dataset.split == split if split else "train"
 
@@ -76,7 +102,9 @@ def test_dataset_from_parquet_path_type(path_type, parquet_path, tmp_path):
 
 def test_parquet_read_geoparquet(geoparquet_path, tmp_path):
     cache_dir = tmp_path / "cache"
-    dataset = ParquetDatasetReader(path_or_paths=geoparquet_path, cache_dir=cache_dir).read()
+    dataset = ParquetDatasetReader(
+        path_or_paths=geoparquet_path, cache_dir=cache_dir
+    ).read()
 
     expected_features = {
         "pop_est": "float64",
@@ -88,7 +116,14 @@ def test_parquet_read_geoparquet(geoparquet_path, tmp_path):
     assert isinstance(dataset, Dataset)
     assert dataset.num_rows == 5
     assert dataset.num_columns == 6
-    assert dataset.column_names == ["pop_est", "continent", "name", "iso_a3", "gdp_md_est", "geometry"]
+    assert dataset.column_names == [
+        "pop_est",
+        "continent",
+        "name",
+        "iso_a3",
+        "gdp_md_est",
+        "geometry",
+    ]
     for feature, expected_dtype in expected_features.items():
         assert dataset.features[feature].dtype == expected_dtype
 
@@ -96,7 +131,9 @@ def test_parquet_read_geoparquet(geoparquet_path, tmp_path):
 def test_parquet_read_filters(parquet_path, tmp_path):
     cache_dir = tmp_path / "cache"
     filters = [("col_2", "==", 1)]
-    dataset = ParquetDatasetReader(path_or_paths=parquet_path, cache_dir=cache_dir, filters=filters).read()
+    dataset = ParquetDatasetReader(
+        path_or_paths=parquet_path, cache_dir=cache_dir, filters=filters
+    ).read()
 
     assert isinstance(dataset, Dataset)
     assert all(example["col_2"] == 1 for example in dataset)
@@ -115,10 +152,16 @@ def _check_parquet_datasetdict(dataset_dict, expected_features, splits=("train",
 
 
 @pytest.mark.parametrize("keep_in_memory", [False, True])
-def test_parquet_datasetdict_reader_keep_in_memory(keep_in_memory, parquet_path, tmp_path):
+def test_parquet_datasetdict_reader_keep_in_memory(
+    keep_in_memory, parquet_path, tmp_path
+):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
         dataset = ParquetDatasetReader(
             {"train": parquet_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory
         ).read()
@@ -136,15 +179,26 @@ def test_parquet_datasetdict_reader_keep_in_memory(keep_in_memory, parquet_path,
         {"col_1": "float32", "col_2": "float32", "col_3": "float32"},
     ],
 )
-def test_parquet_datasetdict_reader_features(streaming, features, parquet_path, tmp_path):
+def test_parquet_datasetdict_reader_features(
+    streaming, features, parquet_path, tmp_path
+):
     cache_dir = tmp_path / "cache"
-    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    default_expected_features = {
+        "col_1": "string",
+        "col_2": "int64",
+        "col_3": "float64",
+    }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
     dataset = ParquetDatasetReader(
-        {"train": parquet_path}, features=features, cache_dir=cache_dir, streaming=streaming
+        {"train": parquet_path},
+        features=features,
+        cache_dir=cache_dir,
+        streaming=streaming,
     ).read()
     _check_parquet_datasetdict(dataset, expected_features)
 
@@ -153,21 +207,40 @@ def test_parquet_datasetdict_reader_features(streaming, features, parquet_path, 
 @pytest.mark.parametrize("columns", [None, ["col_1"]])
 @pytest.mark.parametrize("pass_features", [False, True])
 @pytest.mark.parametrize("pass_info", [False, True])
-def test_parquet_datasetdict_reader_columns(streaming, columns, pass_features, pass_info, parquet_path, tmp_path):
+def test_parquet_datasetdict_reader_columns(
+    streaming, columns, pass_features, pass_info, parquet_path, tmp_path
+):
     cache_dir = tmp_path / "cache"
 
-    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    default_expected_features = {
+        "col_1": "string",
+        "col_2": "int64",
+        "col_3": "float64",
+    }
     info = (
-        DatasetInfo(features=Features({feature: Value(dtype) for feature, dtype in default_expected_features.items()}))
+        DatasetInfo(
+            features=Features(
+                {
+                    feature: Value(dtype)
+                    for feature, dtype in default_expected_features.items()
+                }
+            )
+        )
         if pass_info
         else None
     )
 
     expected_features = (
-        {col: default_expected_features[col] for col in columns} if columns else default_expected_features
+        {col: default_expected_features[col] for col in columns}
+        if columns
+        else default_expected_features
     )
     features = (
-        Features({feature: Value(dtype) for feature, dtype in expected_features.items()}) if pass_features else None
+        Features(
+            {feature: Value(dtype) for feature, dtype in expected_features.items()}
+        )
+        if pass_features
+        else None
     )
 
     dataset = ParquetDatasetReader(
@@ -233,9 +306,14 @@ def test_parquet_writer_persist_cdc_options_as_metadata(dataset, tmp_path):
         return key_value_metadata
 
     # by default no arguments are passed, same as passing True using the default options
-    for key_value_metadata in [write_and_get_metadata(), write_and_get_metadata(use_content_defined_chunking=True)]:
+    for key_value_metadata in [
+        write_and_get_metadata(),
+        write_and_get_metadata(use_content_defined_chunking=True),
+    ]:
         assert b"content_defined_chunking" in key_value_metadata
-        json_encoded_options = key_value_metadata[b"content_defined_chunking"].decode("utf-8")
+        json_encoded_options = key_value_metadata[b"content_defined_chunking"].decode(
+            "utf-8"
+        )
         assert json.loads(json_encoded_options) == config.DEFAULT_CDC_OPTIONS
 
     # passing False disables the content defined chunking and doesn't persist the options in metadata
@@ -248,9 +326,13 @@ def test_parquet_writer_persist_cdc_options_as_metadata(dataset, tmp_path):
         "max_chunk_size": 512 * 1024,  # 512 KiB
         "norm_level": 1,
     }
-    key_value_metadata = write_and_get_metadata(use_content_defined_chunking=custom_cdc_options)
+    key_value_metadata = write_and_get_metadata(
+        use_content_defined_chunking=custom_cdc_options
+    )
     assert b"content_defined_chunking" in key_value_metadata
-    json_encoded_options = key_value_metadata[b"content_defined_chunking"].decode("utf-8")
+    json_encoded_options = key_value_metadata[b"content_defined_chunking"].decode(
+        "utf-8"
+    )
     assert json.loads(json_encoded_options) == custom_cdc_options
 
 
@@ -265,7 +347,9 @@ def test_dataset_to_parquet_keeps_features(shared_datadir, tmp_path):
     reloaded_dataset = Dataset.from_parquet(str(tmp_path / "foo.parquet"))
     assert dataset.features == reloaded_dataset.features
 
-    reloaded_iterable_dataset = ParquetDatasetReader(str(tmp_path / "foo.parquet"), streaming=True).read()
+    reloaded_iterable_dataset = ParquetDatasetReader(
+        str(tmp_path / "foo.parquet"), streaming=True
+    ).read()
     assert dataset.features == reloaded_iterable_dataset.features
 
 
@@ -273,8 +357,14 @@ def test_dataset_to_parquet_keeps_features(shared_datadir, tmp_path):
     "feature, expected",
     [
         (Features({"foo": Value("int32")}), None),
-        (Features({"image": Image(), "foo": Value("int32")}), config.ARROW_RECORD_BATCH_SIZE_FOR_IMAGE_DATASETS),
-        (Features({"nested": List(Audio())}), config.ARROW_RECORD_BATCH_SIZE_FOR_AUDIO_DATASETS),
+        (
+            Features({"image": Image(), "foo": Value("int32")}),
+            config.ARROW_RECORD_BATCH_SIZE_FOR_IMAGE_DATASETS,
+        ),
+        (
+            Features({"nested": List(Audio())}),
+            config.ARROW_RECORD_BATCH_SIZE_FOR_AUDIO_DATASETS,
+        ),
     ],
 )
 def test_get_arrow_writer_batch_size_from_features(feature, expected):
@@ -283,7 +373,9 @@ def test_get_arrow_writer_batch_size_from_features(feature, expected):
 
 def test_dataset_to_parquet_fsspec(dataset, mockfs):
     dataset_path = "mock://my_dataset.csv"
-    writer = ParquetDatasetWriter(dataset, dataset_path, storage_options=mockfs.storage_options)
+    writer = ParquetDatasetWriter(
+        dataset, dataset_path, storage_options=mockfs.storage_options
+    )
     assert writer.write() > 0
     assert mockfs.isfile(dataset_path)
 

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -7,7 +7,11 @@ import pytest
 from datasets import Dataset, Features, Value
 from datasets.io.sql import SqlDatasetReader, SqlDatasetWriter
 
-from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases, require_sqlalchemy
+from ..utils import (
+    assert_arrow_memory_doesnt_increase,
+    assert_arrow_memory_increases,
+    require_sqlalchemy,
+)
 
 
 def _check_sql_dataset(dataset, expected_features):
@@ -21,12 +25,21 @@ def _check_sql_dataset(dataset, expected_features):
 
 @require_sqlalchemy
 @pytest.mark.parametrize("keep_in_memory", [False, True])
-def test_dataset_from_sql_keep_in_memory(keep_in_memory, sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning):
+def test_dataset_from_sql_keep_in_memory(
+    keep_in_memory, sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning
+):
     cache_dir = tmp_path / "cache"
     expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
         dataset = SqlDatasetReader(
-            "dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+            "dataset",
+            "sqlite:///" + sqlite_path,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
         ).read()
     _check_sql_dataset(dataset, expected_features)
 
@@ -42,14 +55,24 @@ def test_dataset_from_sql_keep_in_memory(keep_in_memory, sqlite_path, tmp_path, 
         {"col_1": "float32", "col_2": "float32", "col_3": "float32"},
     ],
 )
-def test_dataset_from_sql_features(features, sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning):
+def test_dataset_from_sql_features(
+    features, sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning
+):
     cache_dir = tmp_path / "cache"
-    default_expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    default_expected_features = {
+        "col_1": "string",
+        "col_2": "int64",
+        "col_3": "float64",
+    }
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, features=features, cache_dir=cache_dir).read()
+    dataset = SqlDatasetReader(
+        "dataset", "sqlite:///" + sqlite_path, features=features, cache_dir=cache_dir
+    ).read()
     _check_sql_dataset(dataset, expected_features)
 
 
@@ -65,8 +88,12 @@ def iter_sql_file(sqlite_path):
 def test_dataset_to_sql(sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning):
     cache_dir = tmp_path / "cache"
     output_sqlite_path = os.path.join(cache_dir, "tmp.sql")
-    dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
-    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=1).write()
+    dataset = SqlDatasetReader(
+        "dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir
+    ).read()
+    SqlDatasetWriter(
+        dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=1
+    ).write()
 
     original_sql = iter_sql_file(sqlite_path)
     expected_sql = iter_sql_file(output_sqlite_path)
@@ -76,11 +103,17 @@ def test_dataset_to_sql(sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warni
 
 
 @require_sqlalchemy
-def test_dataset_to_sql_multiproc(sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning):
+def test_dataset_to_sql_multiproc(
+    sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning
+):
     cache_dir = tmp_path / "cache"
     output_sqlite_path = os.path.join(cache_dir, "tmp.sql")
-    dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
-    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=2).write()
+    dataset = SqlDatasetReader(
+        "dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir
+    ).read()
+    SqlDatasetWriter(
+        dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=2
+    ).write()
 
     original_sql = iter_sql_file(sqlite_path)
     expected_sql = iter_sql_file(output_sqlite_path)
@@ -90,9 +123,15 @@ def test_dataset_to_sql_multiproc(sqlite_path, tmp_path, set_sqlalchemy_silence_
 
 
 @require_sqlalchemy
-def test_dataset_to_sql_invalidproc(sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning):
+def test_dataset_to_sql_invalidproc(
+    sqlite_path, tmp_path, set_sqlalchemy_silence_uber_warning
+):
     cache_dir = tmp_path / "cache"
     output_sqlite_path = os.path.join(cache_dir, "tmp.sql")
-    dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
+    dataset = SqlDatasetReader(
+        "dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir
+    ).read()
     with pytest.raises(ValueError):
-        SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=0).write()
+        SqlDatasetWriter(
+            dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=0
+        ).write()

--- a/tests/io/test_text.py
+++ b/tests/io/test_text.py
@@ -19,8 +19,14 @@ def _check_text_dataset(dataset, expected_features):
 def test_dataset_from_text_keep_in_memory(keep_in_memory, text_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"text": "string"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = TextDatasetReader(text_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = TextDatasetReader(
+            text_path, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_text_dataset(dataset, expected_features)
 
 
@@ -38,9 +44,13 @@ def test_dataset_from_text_features(features, text_path, tmp_path):
     default_expected_features = {"text": "string"}
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = TextDatasetReader(text_path, features=features, cache_dir=cache_dir).read()
+    dataset = TextDatasetReader(
+        text_path, features=features, cache_dir=cache_dir
+    ).read()
     _check_text_dataset(dataset, expected_features)
 
 
@@ -80,8 +90,14 @@ def _check_text_datasetdict(dataset_dict, expected_features, splits=("train",)):
 def test_datasetdict_from_text_keep_in_memory(keep_in_memory, text_path, tmp_path):
     cache_dir = tmp_path / "cache"
     expected_features = {"text": "string"}
-    with assert_arrow_memory_increases() if keep_in_memory else assert_arrow_memory_doesnt_increase():
-        dataset = TextDatasetReader({"train": text_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory).read()
+    with (
+        assert_arrow_memory_increases()
+        if keep_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
+        dataset = TextDatasetReader(
+            {"train": text_path}, cache_dir=cache_dir, keep_in_memory=keep_in_memory
+        ).read()
     _check_text_datasetdict(dataset, expected_features)
 
 
@@ -100,9 +116,13 @@ def test_datasetdict_from_text_features(features, text_path, tmp_path):
     default_expected_features = {"text": "string"}
     expected_features = features.copy() if features else default_expected_features
     features = (
-        Features({feature: Value(dtype) for feature, dtype in features.items()}) if features is not None else None
+        Features({feature: Value(dtype) for feature, dtype in features.items()})
+        if features is not None
+        else None
     )
-    dataset = TextDatasetReader({"train": text_path}, features=features, cache_dir=cache_dir).read()
+    dataset = TextDatasetReader(
+        {"train": text_path}, features=features, cache_dir=cache_dir
+    ).read()
     _check_text_datasetdict(dataset, expected_features)
 
 

--- a/tests/packaged_modules/test_arrow.py
+++ b/tests/packaged_modules/test_arrow.py
@@ -55,7 +55,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = ArrowConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = ArrowConfig(name="name", data_files=data_files)

--- a/tests/packaged_modules/test_audiofolder.py
+++ b/tests/packaged_modules/test_audiofolder.py
@@ -8,7 +8,10 @@ from datasets import Audio, ClassLabel, Features
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesDict, DataFilesList, get_data_patterns
 from datasets.download.streaming_download_manager import StreamingDownloadManager
-from datasets.packaged_modules.audiofolder.audiofolder import AudioFolder, AudioFolderConfig
+from datasets.packaged_modules.audiofolder.audiofolder import (
+    AudioFolder,
+    AudioFolderConfig,
+)
 
 from ..utils import require_torchcodec
 
@@ -175,7 +178,9 @@ def data_files_with_zip_archives(tmp_path, audio_file_44100, audio_file_16000):
     shutil.make_archive(str(archive_dir), "zip", archive_dir)
     shutil.rmtree(str(archive_dir))
 
-    data_files_with_zip_archives = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+    data_files_with_zip_archives = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
 
     assert len(data_files_with_zip_archives) == 1
     assert len(data_files_with_zip_archives["train"]) == 1
@@ -187,7 +192,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = AudioFolderConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = AudioFolderConfig(name="name", data_files=data_files)
@@ -197,9 +204,15 @@ def test_config_raises_when_invalid_data_files(data_files) -> None:
 # check that labels are inferred correctly from dir names
 def test_generate_examples_with_labels(data_files_with_labels_no_metadata, cache_dir):
     # there are no metadata.jsonl files in this test case
-    audiofolder = AudioFolder(data_files=data_files_with_labels_no_metadata, cache_dir=cache_dir, drop_labels=False)
+    audiofolder = AudioFolder(
+        data_files=data_files_with_labels_no_metadata,
+        cache_dir=cache_dir,
+        drop_labels=False,
+    )
     audiofolder.download_and_prepare()
-    assert audiofolder.info.features == Features({"audio": Audio(), "label": ClassLabel(names=["fr", "uk"])})
+    assert audiofolder.info.features == Features(
+        {"audio": Audio(), "label": ClassLabel(names=["fr", "uk"])}
+    )
     dataset = list(audiofolder.as_dataset()["train"])
     label_feature = audiofolder.info.features["label"]
 
@@ -210,23 +223,31 @@ def test_generate_examples_with_labels(data_files_with_labels_no_metadata, cache
 @require_torchcodec
 @pytest.mark.parametrize("drop_metadata", [None, True, False])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
-def test_generate_examples_drop_labels(data_files_with_labels_no_metadata, drop_metadata, drop_labels):
+def test_generate_examples_drop_labels(
+    data_files_with_labels_no_metadata, drop_metadata, drop_labels
+):
     audiofolder = AudioFolder(
-        drop_metadata=drop_metadata, drop_labels=drop_labels, data_files=data_files_with_labels_no_metadata
+        drop_metadata=drop_metadata,
+        drop_labels=drop_labels,
+        data_files=data_files_with_labels_no_metadata,
     )
     gen_kwargs = audiofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
     # removing the labels explicitly requires drop_labels=True
     assert gen_kwargs["add_labels"] is not bool(drop_labels)
-    assert gen_kwargs["add_metadata"] is False  # metadata files is not present in this case
+    assert (
+        gen_kwargs["add_metadata"] is False
+    )  # metadata files is not present in this case
     generator = audiofolder._generate_examples(**gen_kwargs)
     if not drop_labels:
         assert all(
-            example.keys() == {"audio", "label"} and all(val is not None for val in example.values())
+            example.keys() == {"audio", "label"}
+            and all(val is not None for val in example.values())
             for _, example in generator
         )
     else:
         assert all(
-            example.keys() == {"audio"} and all(val is not None for val in example.values())
+            example.keys() == {"audio"}
+            and all(val is not None for val in example.values())
             for _, example in generator
         )
 
@@ -234,10 +255,14 @@ def test_generate_examples_drop_labels(data_files_with_labels_no_metadata, drop_
 @require_torchcodec
 @pytest.mark.parametrize("drop_metadata", [None, True, False])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
-def test_generate_examples_drop_metadata(audio_file_with_metadata, drop_metadata, drop_labels):
+def test_generate_examples_drop_metadata(
+    audio_file_with_metadata, drop_metadata, drop_labels
+):
     audio_file, audio_metadata_file = audio_file_with_metadata
     audiofolder = AudioFolder(
-        drop_metadata=drop_metadata, drop_labels=drop_labels, data_files={"train": [audio_file, audio_metadata_file]}
+        drop_metadata=drop_metadata,
+        drop_labels=drop_labels,
+        data_files={"train": [audio_file, audio_metadata_file]},
     )
     gen_kwargs = audiofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
     # since the dataset has metadata, removing the metadata explicitly requires drop_metadata=True
@@ -260,46 +285,66 @@ def test_generate_examples_drop_metadata(audio_file_with_metadata, drop_metadata
 
 @require_torchcodec
 @pytest.mark.parametrize("streaming", [False, True])
-def test_data_files_with_metadata_and_single_split(streaming, cache_dir, data_files_with_one_split_and_metadata):
+def test_data_files_with_metadata_and_single_split(
+    streaming, cache_dir, data_files_with_one_split_and_metadata
+):
     data_files = data_files_with_one_split_and_metadata
     audiofolder = AudioFolder(data_files=data_files, cache_dir=cache_dir)
     audiofolder.download_and_prepare()
-    datasets = audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
+    datasets = (
+        audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
+    )
     for split, data_files in data_files.items():
         expected_num_of_audios = len(data_files) - 1  # don't count the metadata file
         assert split in datasets
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_audios
         # make sure each sample has its own audio and metadata
-        assert len({example["audio"].metadata.path for example in dataset}) == expected_num_of_audios
+        assert (
+            len({example["audio"].metadata.path for example in dataset})
+            == expected_num_of_audios
+        )
         assert len({example["text"] for example in dataset}) == expected_num_of_audios
         assert all(example["text"] is not None for example in dataset)
 
 
 @require_torchcodec
 @pytest.mark.parametrize("streaming", [False, True])
-def test_data_files_with_metadata_and_multiple_splits(streaming, cache_dir, data_files_with_two_splits_and_metadata):
+def test_data_files_with_metadata_and_multiple_splits(
+    streaming, cache_dir, data_files_with_two_splits_and_metadata
+):
     data_files = data_files_with_two_splits_and_metadata
     audiofolder = AudioFolder(data_files=data_files, cache_dir=cache_dir)
     audiofolder.download_and_prepare()
-    datasets = audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
+    datasets = (
+        audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
+    )
     for split, data_files in data_files.items():
         expected_num_of_audios = len(data_files) - 1  # don't count the metadata file
         assert split in datasets
         dataset = list(datasets[split])
         assert len(dataset) == expected_num_of_audios
         # make sure each sample has its own audio and metadata
-        assert len({example["audio"].metadata.path for example in dataset}) == expected_num_of_audios
+        assert (
+            len({example["audio"].metadata.path for example in dataset})
+            == expected_num_of_audios
+        )
         assert len({example["text"] for example in dataset}) == expected_num_of_audios
         assert all(example["text"] is not None for example in dataset)
 
 
 @require_torchcodec
 @pytest.mark.parametrize("streaming", [False, True])
-def test_data_files_with_metadata_and_archives(streaming, cache_dir, data_files_with_zip_archives):
-    audiofolder = AudioFolder(data_files=data_files_with_zip_archives, cache_dir=cache_dir)
+def test_data_files_with_metadata_and_archives(
+    streaming, cache_dir, data_files_with_zip_archives
+):
+    audiofolder = AudioFolder(
+        data_files=data_files_with_zip_archives, cache_dir=cache_dir
+    )
     audiofolder.download_and_prepare()
-    datasets = audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
+    datasets = (
+        audiofolder.as_streaming_dataset() if streaming else audiofolder.as_dataset()
+    )
     for split, data_files in data_files_with_zip_archives.items():
         num_of_archives = len(data_files)  # the metadata file is inside the archive
         expected_num_of_audios = 2 * num_of_archives
@@ -310,7 +355,8 @@ def test_data_files_with_metadata_and_archives(streaming, cache_dir, data_files_
         assert (
             sum(
                 np.array_equal(
-                    dataset[0]["audio"].get_all_samples().data.numpy(), example["audio"].get_all_samples().data.numpy()
+                    dataset[0]["audio"].get_all_samples().data.numpy(),
+                    example["audio"].get_all_samples().data.numpy(),
                 )
                 for example in dataset[1:]
             )
@@ -334,8 +380,12 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, audio_fil
     with open(audio_metadata_filename, "w", encoding="utf-8") as f:
         f.write(audio_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
-    audiofolder = AudioFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
+    audiofolder = AudioFolder(
+        data_files=data_files_with_bad_metadata, cache_dir=cache_dir
+    )
     audiofolder.download_and_prepare()
     dataset = audiofolder.as_dataset(split="train")
     # check that there are no metadata, since the metadata file name doesn't have the right name
@@ -343,7 +393,9 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, audio_fil
 
 
 @require_torchcodec
-def test_data_files_with_custom_audio_file_name_column_in_metadata_file(cache_dir, tmp_path, audio_file):
+def test_data_files_with_custom_audio_file_name_column_in_metadata_file(
+    cache_dir, tmp_path, audio_file
+):
     data_dir = tmp_path / "data_dir_with_custom_file_name_metadata"
     data_dir.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(audio_file, data_dir / "audio_file.wav")
@@ -356,8 +408,12 @@ def test_data_files_with_custom_audio_file_name_column_in_metadata_file(cache_di
     with open(audio_metadata_filename, "w", encoding="utf-8") as f:
         f.write(audio_metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
-    audiofolder = AudioFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
+    audiofolder = AudioFolder(
+        data_files=data_files_with_bad_metadata, cache_dir=cache_dir
+    )
     audiofolder.download_and_prepare()
     dataset = audiofolder.as_dataset(split="train")
     assert "speech" in dataset.features
@@ -365,7 +421,9 @@ def test_data_files_with_custom_audio_file_name_column_in_metadata_file(cache_di
 
 
 @require_torchcodec
-def test_data_files_with_with_metadata_in_different_formats(cache_dir, tmp_path, audio_file):
+def test_data_files_with_with_metadata_in_different_formats(
+    cache_dir, tmp_path, audio_file
+):
     data_dir = tmp_path / "data_dir_with_metadata_in_different_format"
     data_dir.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(audio_file, data_dir / "audio_file.wav")
@@ -387,8 +445,12 @@ def test_data_files_with_with_metadata_in_different_formats(cache_dir, tmp_path,
     with open(audio_metadata_filename_csv, "w", encoding="utf-8") as f:
         f.write(audio_metadata_csv)
 
-    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
-    audiofolder = AudioFolder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
+    audiofolder = AudioFolder(
+        data_files=data_files_with_bad_metadata, cache_dir=cache_dir
+    )
     with pytest.raises(ValueError) as exc_info:
         audiofolder.download_and_prepare()
     assert "metadata files with different extensions" in str(exc_info.value)

--- a/tests/packaged_modules/test_cache.py
+++ b/tests/packaged_modules/test_cache.py
@@ -6,8 +6,12 @@ from datasets import load_dataset
 from datasets.packaged_modules.cache.cache import Cache
 
 
-SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA = "hf-internal-testing/audiofolder_single_config_in_metadata"
-SAMPLE_DATASET_TWO_CONFIG_IN_METADATA = "hf-internal-testing/audiofolder_two_configs_in_metadata"
+SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA = (
+    "hf-internal-testing/audiofolder_single_config_in_metadata"
+)
+SAMPLE_DATASET_TWO_CONFIG_IN_METADATA = (
+    "hf-internal-testing/audiofolder_two_configs_in_metadata"
+)
 SAMPLE_DATASET_CAPITAL_LETTERS_IN_NAME = "hf-internal-testing/DatasetWithCapitalLetters"
 
 
@@ -34,7 +38,12 @@ def test_cache_streaming(text_dir: Path, tmp_path: Path):
 def test_cache_auto_hash(text_dir: Path, tmp_path: Path):
     cache_dir = tmp_path / "test_cache_auto_hash"
     ds = load_dataset(str(text_dir), cache_dir=str(cache_dir))
-    cache = Cache(cache_dir=str(cache_dir), dataset_name=text_dir.name, version="auto", hash="auto")
+    cache = Cache(
+        cache_dir=str(cache_dir),
+        dataset_name=text_dir.name,
+        version="auto",
+        hash="auto",
+    )
     reloaded = cache.as_dataset()
     assert list(ds) == list(reloaded)
     assert list(ds["train"]) == list(reloaded["train"])
@@ -45,9 +54,18 @@ def test_cache_auto_hash_with_custom_config(text_dir: Path, tmp_path: Path):
     ds = load_dataset(str(text_dir), sample_by="paragraph", cache_dir=str(cache_dir))
     another_ds = load_dataset(str(text_dir), cache_dir=str(cache_dir))
     cache = Cache(
-        cache_dir=str(cache_dir), dataset_name=text_dir.name, version="auto", hash="auto", sample_by="paragraph"
+        cache_dir=str(cache_dir),
+        dataset_name=text_dir.name,
+        version="auto",
+        hash="auto",
+        sample_by="paragraph",
     )
-    another_cache = Cache(cache_dir=str(cache_dir), dataset_name=text_dir.name, version="auto", hash="auto")
+    another_cache = Cache(
+        cache_dir=str(cache_dir),
+        dataset_name=text_dir.name,
+        version="auto",
+        hash="auto",
+    )
     assert cache.config_id.endswith("paragraph")
     assert not another_cache.config_id.endswith("paragraph")
     reloaded = cache.as_dataset()
@@ -61,14 +79,30 @@ def test_cache_auto_hash_with_custom_config(text_dir: Path, tmp_path: Path):
 def test_cache_missing(text_dir: Path, tmp_path: Path):
     cache_dir = tmp_path / "test_cache_missing"
     load_dataset(str(text_dir), cache_dir=str(cache_dir))
-    Cache(cache_dir=str(cache_dir), dataset_name=text_dir.name, version="auto", hash="auto").download_and_prepare()
-    with pytest.raises(ValueError):
-        Cache(cache_dir=str(cache_dir), dataset_name="missing", version="auto", hash="auto").download_and_prepare()
-    with pytest.raises(ValueError):
-        Cache(cache_dir=str(cache_dir), dataset_name=text_dir.name, hash="missing").download_and_prepare()
+    Cache(
+        cache_dir=str(cache_dir),
+        dataset_name=text_dir.name,
+        version="auto",
+        hash="auto",
+    ).download_and_prepare()
     with pytest.raises(ValueError):
         Cache(
-            cache_dir=str(cache_dir), dataset_name=text_dir.name, config_name="missing", version="auto", hash="auto"
+            cache_dir=str(cache_dir),
+            dataset_name="missing",
+            version="auto",
+            hash="auto",
+        ).download_and_prepare()
+    with pytest.raises(ValueError):
+        Cache(
+            cache_dir=str(cache_dir), dataset_name=text_dir.name, hash="missing"
+        ).download_and_prepare()
+    with pytest.raises(ValueError):
+        Cache(
+            cache_dir=str(cache_dir),
+            dataset_name=text_dir.name,
+            config_name="missing",
+            version="auto",
+            hash="auto",
         ).download_and_prepare()
 
 
@@ -109,7 +143,13 @@ def test_cache_single_config(tmp_path: Path):
     dataset_name = repo_id.split("/")[-1]
     config_name = "custom"
     ds = load_dataset(repo_id, cache_dir=str(cache_dir))
-    cache = Cache(cache_dir=str(cache_dir), dataset_name=dataset_name, repo_id=repo_id, version="auto", hash="auto")
+    cache = Cache(
+        cache_dir=str(cache_dir),
+        dataset_name=dataset_name,
+        repo_id=repo_id,
+        version="auto",
+        hash="auto",
+    )
     reloaded = cache.as_dataset()
     assert list(ds) == list(reloaded)
     assert len(ds["train"]) == len(reloaded["train"])
@@ -142,7 +182,13 @@ def test_cache_capital_letters(tmp_path: Path):
     repo_id = SAMPLE_DATASET_CAPITAL_LETTERS_IN_NAME
     dataset_name = repo_id.split("/")[-1]
     ds = load_dataset(repo_id, cache_dir=str(cache_dir))
-    cache = Cache(cache_dir=str(cache_dir), dataset_name=dataset_name, repo_id=repo_id, version="auto", hash="auto")
+    cache = Cache(
+        cache_dir=str(cache_dir),
+        dataset_name=dataset_name,
+        repo_id=repo_id,
+        version="auto",
+        hash="auto",
+    )
     reloaded = cache.as_dataset()
     assert list(ds) == list(reloaded)
     assert len(ds["train"]) == len(reloaded["train"])

--- a/tests/packaged_modules/test_csv.py
+++ b/tests/packaged_modules/test_csv.py
@@ -93,13 +93,17 @@ def test_config_raises_when_invalid_name() -> None:
         _ = CsvConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = CsvConfig(name="name", data_files=data_files)
 
 
-def test_csv_generate_tables_raises_error_with_malformed_csv(csv_file, malformed_csv_file, caplog):
+def test_csv_generate_tables_raises_error_with_malformed_csv(
+    csv_file, malformed_csv_file, caplog
+):
     csv = Csv()
     generator = csv._generate_tables([[csv_file, malformed_csv_file]])
     with pytest.raises(ValueError, match="Error tokenizing data"):
@@ -128,16 +132,25 @@ def test_csv_cast_image(csv_file_with_image):
 def test_csv_cast_label(csv_file_with_label):
     with open(csv_file_with_label, encoding="utf-8") as f:
         labels = f.read().splitlines()[1:]
-    csv = Csv(encoding="utf-8", features=Features({"label": ClassLabel(names=["good", "bad"])}))
+    csv = Csv(
+        encoding="utf-8",
+        features=Features({"label": ClassLabel(names=["good", "bad"])}),
+    )
     generator = csv._generate_tables([[csv_file_with_label]])
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa_table.schema.field("label").type == ClassLabel(names=["good", "bad"])()
     generated_content = pa_table.to_pydict()["label"]
-    assert generated_content == [ClassLabel(names=["good", "bad"]).str2int(label) for label in labels]
+    assert generated_content == [
+        ClassLabel(names=["good", "bad"]).str2int(label) for label in labels
+    ]
 
 
 def test_csv_convert_int_list(csv_file_with_int_list):
-    csv = Csv(encoding="utf-8", sep=",", converters={"int_list": lambda x: [int(i) for i in x.split()]})
+    csv = Csv(
+        encoding="utf-8",
+        sep=",",
+        converters={"int_list": lambda x: [int(i) for i in x.split()]},
+    )
     generator = csv._generate_tables([[csv_file_with_int_list]])
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa.types.is_list(pa_table.schema.field("int_list").type)

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -96,7 +96,9 @@ def data_files_with_one_label_no_metadata(tmp_path, auto_text_file):
     filename2 = data_dir / "file1.txt"
     shutil.copyfile(auto_text_file, filename2)
 
-    data_files_with_one_label = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+    data_files_with_one_label = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
 
     return data_files_with_one_label
 
@@ -244,7 +246,9 @@ def data_files_with_zip_archives(tmp_path, auto_text_file):
     shutil.make_archive(archive_dir, "zip", archive_dir)
     shutil.rmtree(str(archive_dir))
 
-    data_files_with_zip_archives = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+    data_files_with_zip_archives = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
 
     assert len(data_files_with_zip_archives) == 1
     assert len(data_files_with_zip_archives["train"]) == 1
@@ -256,7 +260,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = FolderBasedBuilderConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = FolderBasedBuilderConfig(name="name", data_files=data_files)
@@ -264,7 +270,9 @@ def test_config_raises_when_invalid_data_files(data_files) -> None:
 
 def test_inferring_labels_from_data_dirs(data_files_with_labels_no_metadata, cache_dir):
     autofolder = DummyFolderBasedBuilder(
-        data_files=data_files_with_labels_no_metadata, cache_dir=cache_dir, drop_labels=False
+        data_files=data_files_with_labels_no_metadata,
+        cache_dir=cache_dir,
+        drop_labels=False,
     )
     gen_kwargs = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
     assert autofolder.info.features["label"] == ClassLabel(names=["class0", "class1"])
@@ -272,7 +280,9 @@ def test_inferring_labels_from_data_dirs(data_files_with_labels_no_metadata, cac
     assert all(example["label"] in {"class0", "class1"} for _, example in generator)
 
 
-def test_default_folder_builder_not_usable(data_files_with_labels_no_metadata, cache_dir):
+def test_default_folder_builder_not_usable(
+    data_files_with_labels_no_metadata, cache_dir
+):
     # builder would try to access non-existing attributes of a default `BuilderConfig` class
     # as a custom one is not provided
     with pytest.raises(AttributeError):
@@ -294,7 +304,11 @@ def test_streaming_patched():
 @pytest.mark.parametrize("drop_metadata", [None, True, False])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
 def test_generate_examples_drop_labels(
-    data_files_with_labels_no_metadata, auto_text_file, drop_metadata, drop_labels, cache_dir
+    data_files_with_labels_no_metadata,
+    auto_text_file,
+    drop_metadata,
+    drop_labels,
+    cache_dir,
 ):
     autofolder = DummyFolderBasedBuilder(
         data_files=data_files_with_labels_no_metadata,
@@ -309,18 +323,23 @@ def test_generate_examples_drop_labels(
     generator = autofolder._generate_examples(**gen_kwargs)
     if not drop_labels:
         assert all(
-            example.keys() == {"base", "label"} and all(val is not None for val in example.values())
+            example.keys() == {"base", "label"}
+            and all(val is not None for val in example.values())
             for _, example in generator
         )
     else:
         assert all(
-            example.keys() == {"base"} and all(val is not None for val in example.values()) for _, example in generator
+            example.keys() == {"base"}
+            and all(val is not None for val in example.values())
+            for _, example in generator
         )
 
 
 @pytest.mark.parametrize("drop_metadata", [None, True, False])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
-def test_generate_examples_drop_metadata(file_with_metadata, drop_metadata, drop_labels, cache_dir):
+def test_generate_examples_drop_metadata(
+    file_with_metadata, drop_metadata, drop_labels, cache_dir
+):
     file, metadata_file = file_with_metadata
     autofolder = DummyFolderBasedBuilder(
         data_files=[file, metadata_file],
@@ -352,7 +371,9 @@ def test_generate_examples_drop_metadata(file_with_metadata, drop_metadata, drop
 def test_data_files_with_different_levels_no_metadata(
     data_files_with_different_levels_no_metadata, drop_labels, remote, cache_dir
 ):
-    data_files = remote_files if remote else data_files_with_different_levels_no_metadata
+    data_files = (
+        remote_files if remote else data_files_with_different_levels_no_metadata
+    )
     autofolder = DummyFolderBasedBuilder(
         data_files=data_files,
         cache_dir=cache_dir,
@@ -372,7 +393,9 @@ def test_data_files_with_different_levels_no_metadata(
 
 @pytest.mark.parametrize("remote", [False, True])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
-def test_data_files_with_one_label_no_metadata(data_files_with_one_label_no_metadata, drop_labels, remote, cache_dir):
+def test_data_files_with_one_label_no_metadata(
+    data_files_with_one_label_no_metadata, drop_labels, remote, cache_dir
+):
     data_files = remote_files[:2] if remote else data_files_with_one_label_no_metadata
     autofolder = DummyFolderBasedBuilder(
         data_files=data_files,
@@ -394,9 +417,17 @@ def test_data_files_with_one_label_no_metadata(data_files_with_one_label_no_meta
 @pytest.mark.parametrize("streaming", [False, True])
 @pytest.mark.parametrize("n_splits", [1, 2])
 def test_data_files_with_metadata_and_splits(
-    streaming, cache_dir, n_splits, data_files_with_one_split_and_metadata, data_files_with_two_splits_and_metadata
+    streaming,
+    cache_dir,
+    n_splits,
+    data_files_with_one_split_and_metadata,
+    data_files_with_two_splits_and_metadata,
 ):
-    data_files = data_files_with_one_split_and_metadata if n_splits == 1 else data_files_with_two_splits_and_metadata
+    data_files = (
+        data_files_with_one_split_and_metadata
+        if n_splits == 1
+        else data_files_with_two_splits_and_metadata
+    )
     autofolder = DummyFolderBasedBuilder(
         data_files=data_files,
         cache_dir=cache_dir,
@@ -406,27 +437,55 @@ def test_data_files_with_metadata_and_splits(
     for (split, files), generated_split in zip(data_files.items(), generated_splits):
         assert split == generated_split.name
         expected_num_of_examples = len(files) - 1
-        generated_examples = list(autofolder._generate_examples(**generated_split.gen_kwargs))
+        generated_examples = list(
+            autofolder._generate_examples(**generated_split.gen_kwargs)
+        )
         assert len(generated_examples) == expected_num_of_examples
-        assert len({example["base"] for _, example in generated_examples}) == expected_num_of_examples
-        assert len({example["additional_feature"] for _, example in generated_examples}) == expected_num_of_examples
-        assert all(example["additional_feature"] is not None for _, example in generated_examples)
+        assert (
+            len({example["base"] for _, example in generated_examples})
+            == expected_num_of_examples
+        )
+        assert (
+            len({example["additional_feature"] for _, example in generated_examples})
+            == expected_num_of_examples
+        )
+        assert all(
+            example["additional_feature"] is not None
+            for _, example in generated_examples
+        )
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_data_files_with_metadata_and_archives(streaming, cache_dir, data_files_with_zip_archives):
-    autofolder = DummyFolderBasedBuilder(data_files=data_files_with_zip_archives, cache_dir=cache_dir)
+def test_data_files_with_metadata_and_archives(
+    streaming, cache_dir, data_files_with_zip_archives
+):
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_zip_archives, cache_dir=cache_dir
+    )
     download_manager = StreamingDownloadManager() if streaming else DownloadManager()
     generated_splits = autofolder._split_generators(download_manager)
-    for (split, files), generated_split in zip(data_files_with_zip_archives.items(), generated_splits):
+    for (split, files), generated_split in zip(
+        data_files_with_zip_archives.items(), generated_splits
+    ):
         assert split == generated_split.name
         num_of_archives = len(files)
         expected_num_of_examples = 2 * num_of_archives
-        generated_examples = list(autofolder._generate_examples(**generated_split.gen_kwargs))
+        generated_examples = list(
+            autofolder._generate_examples(**generated_split.gen_kwargs)
+        )
         assert len(generated_examples) == expected_num_of_examples
-        assert len({example["base"] for _, example in generated_examples}) == expected_num_of_examples
-        assert len({example["additional_feature"] for _, example in generated_examples}) == expected_num_of_examples
-        assert all(example["additional_feature"] is not None for _, example in generated_examples)
+        assert (
+            len({example["base"] for _, example in generated_examples})
+            == expected_num_of_examples
+        )
+        assert (
+            len({example["additional_feature"] for _, example in generated_examples})
+            == expected_num_of_examples
+        )
+        assert all(
+            example["additional_feature"] is not None
+            for _, example in generated_examples
+        )
 
 
 def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, auto_text_file):
@@ -442,14 +501,20 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, auto_text
     with open(metadata_filename, "w", encoding="utf-8") as f:
         f.write(metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
-    autofolder = DummyFolderBasedBuilder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_bad_metadata, cache_dir=cache_dir
+    )
     gen_kwargs = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
     generator = autofolder._generate_examples(**gen_kwargs)
     assert all("additional_feature" not in example for _, example in generator)
 
 
-def test_data_files_with_custom_file_name_column_in_metadata_file(cache_dir, tmp_path, auto_text_file):
+def test_data_files_with_custom_file_name_column_in_metadata_file(
+    cache_dir, tmp_path, auto_text_file
+):
     data_dir = tmp_path / "data_dir_with_custom_file_name_metadata"
     data_dir.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(auto_text_file, data_dir / "file.txt")
@@ -462,8 +527,15 @@ def test_data_files_with_custom_file_name_column_in_metadata_file(cache_dir, tmp
     with open(metadata_filename, "w", encoding="utf-8") as f:
         f.write(metadata)
 
-    data_files_with_bad_metadata = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
-    autofolder = DummyFolderBasedBuilder(data_files=data_files_with_bad_metadata, cache_dir=cache_dir)
+    data_files_with_bad_metadata = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_bad_metadata, cache_dir=cache_dir
+    )
     gen_kwargs = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
     generator = autofolder._generate_examples(**gen_kwargs)
-    assert all("text" in example and "text_file_name" not in example for _, example in generator)
+    assert all(
+        "text" in example and "text_file_name" not in example
+        for _, example in generator
+    )

--- a/tests/packaged_modules/test_hdf5.py
+++ b/tests/packaged_modules/test_hdf5.py
@@ -47,15 +47,25 @@ def hdf5_file_with_arrays(tmp_path):
 
     with h5py.File(filename, "w") as f:
         # 2D array (should become Array2D)
-        f.create_dataset("matrix_2d", data=np.random.randn(n_rows, 3, 4).astype(np.float32))
+        f.create_dataset(
+            "matrix_2d", data=np.random.randn(n_rows, 3, 4).astype(np.float32)
+        )
         # 3D array (should become Array3D)
-        f.create_dataset("tensor_3d", data=np.random.randn(n_rows, 2, 3, 4).astype(np.float64))
+        f.create_dataset(
+            "tensor_3d", data=np.random.randn(n_rows, 2, 3, 4).astype(np.float64)
+        )
         # 4D array (should become Array4D)
-        f.create_dataset("tensor_4d", data=np.random.randn(n_rows, 2, 3, 4, 5).astype(np.float32))
+        f.create_dataset(
+            "tensor_4d", data=np.random.randn(n_rows, 2, 3, 4, 5).astype(np.float32)
+        )
         # 5D array (should become Array5D)
-        f.create_dataset("tensor_5d", data=np.random.randn(n_rows, 2, 3, 4, 5, 6).astype(np.float64))
+        f.create_dataset(
+            "tensor_5d", data=np.random.randn(n_rows, 2, 3, 4, 5, 6).astype(np.float64)
+        )
         # 1D array (should become Value)
-        f.create_dataset("vector_1d", data=np.random.randn(n_rows, 10).astype(np.float32))
+        f.create_dataset(
+            "vector_1d", data=np.random.randn(n_rows, 10).astype(np.float32)
+        )
 
     return str(filename)
 
@@ -76,7 +86,9 @@ def hdf5_file_with_different_dtypes(tmp_path):
         f.create_dataset("uint64", data=np.arange(n_rows, dtype=np.uint64))
         f.create_dataset("float16", data=np.arange(n_rows, dtype=np.float16) / 10.0)
         f.create_dataset("float64", data=np.arange(n_rows, dtype=np.float64) / 10.0)
-        f.create_dataset("bytes", data=np.array([b"row_%d" % i for i in range(n_rows)], dtype="S10"))
+        f.create_dataset(
+            "bytes", data=np.array([b"row_%d" % i for i in range(n_rows)], dtype="S10")
+        )
 
     return str(filename)
 
@@ -119,7 +131,12 @@ def hdf5_file_with_variable_length_strings(tmp_path):
 
     with h5py.File(filename, "w") as f:
         # Variable-length string dataset
-        var_strings = ["short", "medium length string", "very long string with many characters", "tiny"]
+        var_strings = [
+            "short",
+            "medium length string",
+            "very long string with many characters",
+            "tiny",
+        ]
         # Create variable-length string dataset using vlen_dtype
         dt = h5py.vlen_dtype(str)
         dset = f.create_dataset("var_strings", (n_rows,), dtype=dt)
@@ -127,7 +144,12 @@ def hdf5_file_with_variable_length_strings(tmp_path):
             dset[i] = s
 
         # Variable-length bytes dataset
-        var_bytes = [b"short", b"medium length bytes", b"very long bytes with many characters", b"tiny"]
+        var_bytes = [
+            b"short",
+            b"medium length bytes",
+            b"very long bytes with many characters",
+            b"tiny",
+        ]
         dt_bytes = h5py.vlen_dtype(bytes)
         dset_bytes = f.create_dataset("var_bytes", (n_rows,), dtype=dt_bytes)
         for i, b in enumerate(var_bytes):
@@ -147,12 +169,20 @@ def hdf5_file_with_complex_data(tmp_path):
         f.create_dataset("complex_64", data=complex_data)
 
         # Complex double precision
-        complex_double = np.array([1.5 + 2.5j, 3.5 + 4.5j, 5.5 + 6.5j, 7.5 + 8.5j], dtype=np.complex128)
+        complex_double = np.array(
+            [1.5 + 2.5j, 3.5 + 4.5j, 5.5 + 6.5j, 7.5 + 8.5j], dtype=np.complex128
+        )
         f.create_dataset("complex_128", data=complex_double)
 
         # Complex array
         complex_array = np.array(
-            [[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j], [9 + 10j, 11 + 12j], [13 + 14j, 15 + 16j]], dtype=np.complex64
+            [
+                [1 + 2j, 3 + 4j],
+                [5 + 6j, 7 + 8j],
+                [9 + 10j, 11 + 12j],
+                [13 + 14j, 15 + 16j],
+            ],
+            dtype=np.complex64,
         )
         f.create_dataset("complex_array", data=complex_array)
 
@@ -172,12 +202,22 @@ def hdf5_file_with_compound_data(tmp_path):
 
         # Compound type with complex numbers
         dt_complex = np.dtype([("real", "f4"), ("imag", "f4")])
-        compound_complex = np.array([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dtype=dt_complex)
+        compound_complex = np.array(
+            [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dtype=dt_complex
+        )
         f.create_dataset("complex_compound", data=compound_complex)
 
         # Nested compound type
-        dt_nested = np.dtype([("position", [("x", "i4"), ("y", "i4")]), ("velocity", [("vx", "f4"), ("vy", "f4")])])
-        compound_nested = np.array([((1, 2), (1.5, 2.5)), ((3, 4), (3.5, 4.5)), ((5, 6), (5.5, 6.5))], dtype=dt_nested)
+        dt_nested = np.dtype(
+            [
+                ("position", [("x", "i4"), ("y", "i4")]),
+                ("velocity", [("vx", "f4"), ("vy", "f4")]),
+            ]
+        )
+        compound_nested = np.array(
+            [((1, 2), (1.5, 2.5)), ((3, 4), (3.5, 4.5)), ((5, 6), (5.5, 6.5))],
+            dtype=dt_nested,
+        )
         f.create_dataset("nested_compound", data=compound_nested)
 
     return str(filename)
@@ -205,19 +245,28 @@ def hdf5_file_with_compound_complex_arrays(tmp_path):
                 (
                     (1, 2),
                     1.0 + 2.0j,
-                    [[1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j], [7.0 + 8.0j, 9.0 + 10.0j, 11.0 + 12.0j]],
+                    [
+                        [1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j],
+                        [7.0 + 8.0j, 9.0 + 10.0j, 11.0 + 12.0j],
+                    ],
                     (1.5, 2.5),
                 ),
                 (
                     (3, 4),
                     3.0 + 4.0j,
-                    [[13.0 + 14.0j, 15.0 + 16.0j, 17.0 + 18.0j], [19.0 + 20.0j, 21.0 + 22.0j, 23.0 + 24.0j]],
+                    [
+                        [13.0 + 14.0j, 15.0 + 16.0j, 17.0 + 18.0j],
+                        [19.0 + 20.0j, 21.0 + 22.0j, 23.0 + 24.0j],
+                    ],
                     (3.5, 4.5),
                 ),
                 (
                     (5, 6),
                     5.0 + 6.0j,
-                    [[25.0 + 26.0j, 27.0 + 28.0j, 29.0 + 30.0j], [31.0 + 32.0j, 33.0 + 34.0j, 35.0 + 36.0j]],
+                    [
+                        [25.0 + 26.0j, 27.0 + 28.0j, 29.0 + 30.0j],
+                        [31.0 + 32.0j, 33.0 + 34.0j, 35.0 + 36.0j],
+                    ],
                     (5.5, 6.5),
                 ),
             ],
@@ -241,7 +290,13 @@ def hdf5_file_with_mismatched_lengths(tmp_path):
         f.create_dataset("data3", data=np.random.randn(5, 3, 4).astype(np.float32))
         f.create_dataset("data4", data=np.arange(5, dtype=np.float64) / 10.0)
         f.create_dataset("data5", data=np.array([True, False, True, False, True]))
-        var_strings = ["short", "medium length", "very long string", "tiny", "another string"]
+        var_strings = [
+            "short",
+            "medium length",
+            "very long string",
+            "tiny",
+            "another string",
+        ]
         dt = h5py.vlen_dtype(str)
         dset = f.create_dataset("data6", (5,), dtype=dt)
         for i, s in enumerate(var_strings):
@@ -309,7 +364,9 @@ def test_config_raises_when_invalid_name():
         _ = HDF5Config(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files):
     """Test that invalid data_files parameter raises an error."""
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
@@ -368,7 +425,9 @@ def test_hdf5_multi_dimensional_arrays(hdf5_file_with_arrays):
 
 def test_hdf5_vlen_arrays(hdf5_file_with_vlen_arrays):
     """Test HDF5 loading with variable-length arrays (int32)."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_vlen_arrays], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_vlen_arrays], split="train"
+    )
 
     expected_columns = {"vlen_ints", "mixed_data"}
     assert set(dataset.column_names) == expected_columns
@@ -392,7 +451,9 @@ def test_hdf5_vlen_arrays(hdf5_file_with_vlen_arrays):
 
 def test_hdf5_variable_length_strings(hdf5_file_with_variable_length_strings):
     """Test HDF5 loading with variable-length string datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_variable_length_strings], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_variable_length_strings], split="train"
+    )
     expected_columns = {"var_strings", "var_bytes"}
     assert set(dataset.column_names) == expected_columns
 
@@ -415,8 +476,21 @@ def test_hdf5_variable_length_strings(hdf5_file_with_variable_length_strings):
 
 def test_hdf5_different_dtypes(hdf5_file_with_different_dtypes):
     """Test HDF5 loading with various numeric dtypes."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_different_dtypes], split="train")
-    expected_columns = {"int8", "int16", "int64", "uint8", "uint16", "uint32", "uint64", "float16", "float64", "bytes"}
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_different_dtypes], split="train"
+    )
+    expected_columns = {
+        "int8",
+        "int16",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float16",
+        "float64",
+        "bytes",
+    }
     assert set(dataset.column_names) == expected_columns
 
     # Check specific dtypes
@@ -449,8 +523,15 @@ def test_hdf5_batch_processing(hdf5_file):
 
 def test_hdf5_column_filtering(hdf5_file_with_groups):
     """Test HDF5 loading with column filtering."""
-    features = Features({"root_data": Value("int32"), "group1": Features({"group_data": Value("float32")})})
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_groups], split="train", features=features)
+    features = Features(
+        {
+            "root_data": Value("int32"),
+            "group1": Features({"group_data": Value("float32")}),
+        }
+    )
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_groups], split="train", features=features
+    )
 
     expected_columns = {"root_data", "group1"}
     assert set(dataset.column_names) == expected_columns
@@ -466,8 +547,12 @@ def test_hdf5_column_filtering(hdf5_file_with_groups):
 
 def test_hdf5_feature_specification(hdf5_file):
     """Test HDF5 loading with explicit feature specification."""
-    features = Features({"int32": Value("int32"), "float32": Value("float64"), "bool": Value("bool")})
-    dataset = load_dataset("hdf5", data_files=[hdf5_file], split="train", features=features)
+    features = Features(
+        {"int32": Value("int32"), "float32": Value("float64"), "bool": Value("bool")}
+    )
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file], split="train", features=features
+    )
 
     # Check that features are properly cast
     assert np.asarray(dataset.data["float32"]).dtype == np.float64
@@ -478,7 +563,9 @@ def test_hdf5_feature_specification(hdf5_file):
 def test_hdf5_mismatched_lengths_error(hdf5_file_with_mismatched_lengths):
     """Test that mismatched dataset lengths raise an error."""
     with pytest.raises(DatasetGenerationError) as exc_info:
-        load_dataset("hdf5", data_files=[hdf5_file_with_mismatched_lengths], split="train")
+        load_dataset(
+            "hdf5", data_files=[hdf5_file_with_mismatched_lengths], split="train"
+        )
 
     assert isinstance(exc_info.value.__cause__, ValueError)
     assert "3 but expected 5" in str(exc_info.value.__cause__)
@@ -486,7 +573,9 @@ def test_hdf5_mismatched_lengths_error(hdf5_file_with_mismatched_lengths):
 
 def test_hdf5_zero_dimensions_handling(hdf5_file_with_zero_dimensions, caplog):
     """Test that zero dimensions are handled gracefully."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_zero_dimensions], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_zero_dimensions], split="train"
+    )
 
     expected_columns = {"zero_dim", "zero_middle", "zero_last"}
     assert set(dataset.column_names) == expected_columns
@@ -497,7 +586,9 @@ def test_hdf5_zero_dimensions_handling(hdf5_file_with_zero_dimensions, caplog):
     assert all(len(row) == 0 for row in zero_dim_data)  # Each row is empty
 
     # Check that shape info is lost
-    assert all(isinstance(col, List) and col.length == -1 for col in dataset.features.values())
+    assert all(
+        isinstance(col, List) and col.length == -1 for col in dataset.features.values()
+    )
 
     # Check for the warnings
     assert (
@@ -505,7 +596,8 @@ def test_hdf5_zero_dimensions_handling(hdf5_file_with_zero_dimensions, caplog):
             [
                 record.message
                 for record in caplog.records
-                if record.levelname == "WARNING" and "dimension with size 0" in record.message
+                if record.levelname == "WARNING"
+                and "dimension with size 0" in record.message
             ]
         )
         == 3
@@ -514,11 +606,14 @@ def test_hdf5_zero_dimensions_handling(hdf5_file_with_zero_dimensions, caplog):
 
 def test_hdf5_empty_file_warning(empty_hdf5_file, hdf5_file_with_arrays, caplog):
     """Test that empty files (no datasets) are skipped with a warning."""
-    load_dataset("hdf5", data_files=[hdf5_file_with_arrays, empty_hdf5_file], split="train")
+    load_dataset(
+        "hdf5", data_files=[hdf5_file_with_arrays, empty_hdf5_file], split="train"
+    )
 
     # Check that warning was logged
     assert any(
-        record.levelname == "WARNING" and "contains no data, skipping" in record.message for record in caplog.records
+        record.levelname == "WARNING" and "contains no data, skipping" in record.message
+        for record in caplog.records
     )
 
 
@@ -547,7 +642,9 @@ def test_hdf5_feature_inference(hdf5_file_with_arrays):
 
 def test_hdf5_vlen_feature_inference(hdf5_file_with_vlen_arrays):
     """Test automatic feature inference from variable-length HDF5 datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_vlen_arrays], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_vlen_arrays], split="train"
+    )
 
     # Check that features were inferred
     assert dataset.features is not None
@@ -567,7 +664,9 @@ def test_hdf5_vlen_feature_inference(hdf5_file_with_vlen_arrays):
 
 def test_hdf5_variable_string_feature_inference(hdf5_file_with_variable_length_strings):
     """Test automatic feature inference from variable-length string datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_variable_length_strings], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_variable_length_strings], split="train"
+    )
 
     # Check that features were inferred
     assert dataset.features is not None
@@ -587,12 +686,21 @@ def test_hdf5_invalid_features(hdf5_file_with_arrays):
     """Test that invalid features raise an error."""
     features = Features({"fakefeature": Value("int32")})
     with pytest.raises(ValueError):
-        load_dataset("hdf5", data_files=[hdf5_file_with_arrays], split="train", features=features)
+        load_dataset(
+            "hdf5", data_files=[hdf5_file_with_arrays], split="train", features=features
+        )
 
     # try with one valid and one invalid feature
-    features = Features({"matrix_2d": Array2D(shape=(3, 4), dtype="float32"), "fakefeature": Value("int32")})
+    features = Features(
+        {
+            "matrix_2d": Array2D(shape=(3, 4), dtype="float32"),
+            "fakefeature": Value("int32"),
+        }
+    )
     with pytest.raises(DatasetGenerationError):
-        load_dataset("hdf5", data_files=[hdf5_file_with_arrays], split="train", features=features)
+        load_dataset(
+            "hdf5", data_files=[hdf5_file_with_arrays], split="train", features=features
+        )
 
 
 def test_hdf5_no_data_files_error():
@@ -607,7 +715,9 @@ def test_hdf5_no_data_files_error():
 
 def test_hdf5_complex_numbers(hdf5_file_with_complex_data):
     """Test HDF5 loading with complex number datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_complex_data], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_complex_data], split="train"
+    )
 
     # Check that complex numbers are represented as nested Features
     expected_columns = {
@@ -627,22 +737,32 @@ def test_hdf5_complex_numbers(hdf5_file_with_complex_data):
 
     assert np.asarray(dataset.data["complex_64"].flatten()[0]).dtype == np.float32
     assert np.asarray(dataset.data["complex_64"].flatten()[1]).dtype == np.float32
-    assert (np.asarray(dataset.data["complex_64"].flatten()[0]) == np.array([1, 3, 5, 7], dtype=np.float32)).all()
-    assert (np.asarray(dataset.data["complex_64"].flatten()[1]) == np.array([2, 4, 6, 8], dtype=np.float32)).all()
+    assert (
+        np.asarray(dataset.data["complex_64"].flatten()[0])
+        == np.array([1, 3, 5, 7], dtype=np.float32)
+    ).all()
+    assert (
+        np.asarray(dataset.data["complex_64"].flatten()[1])
+        == np.array([2, 4, 6, 8], dtype=np.float32)
+    ).all()
 
     assert np.asarray(dataset.data["complex_128"].flatten()[0]).dtype == np.float64
     assert np.asarray(dataset.data["complex_128"].flatten()[1]).dtype == np.float64
     assert (
-        np.asarray(dataset.data["complex_128"].flatten()[0]) == np.array([1.5, 3.5, 5.5, 7.5], dtype=np.float64)
+        np.asarray(dataset.data["complex_128"].flatten()[0])
+        == np.array([1.5, 3.5, 5.5, 7.5], dtype=np.float64)
     ).all()
     assert (
-        np.asarray(dataset.data["complex_128"].flatten()[1]) == np.array([2.5, 4.5, 6.5, 8.5], dtype=np.float64)
+        np.asarray(dataset.data["complex_128"].flatten()[1])
+        == np.array([2.5, 4.5, 6.5, 8.5], dtype=np.float64)
     ).all()
 
 
 def test_hdf5_compound_types(hdf5_file_with_compound_data):
     """Test HDF5 loading with compound/structured datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_compound_data], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_compound_data], split="train"
+    )
 
     # Check that compound types are represented as nested structures
     expected_columns = {
@@ -662,7 +782,9 @@ def test_hdf5_compound_types(hdf5_file_with_compound_data):
 
 def test_hdf5_feature_inference_complex(hdf5_file_with_complex_data):
     """Test automatic feature inference for complex datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_complex_data], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_complex_data], split="train"
+    )
 
     # Check that features were inferred correctly
     assert dataset.features is not None
@@ -678,7 +800,9 @@ def test_hdf5_feature_inference_complex(hdf5_file_with_complex_data):
 
 def test_hdf5_feature_inference_compound(hdf5_file_with_compound_data):
     """Test automatic feature inference for compound datasets."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_compound_data], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_compound_data], split="train"
+    )
 
     # Check that features were inferred correctly
     assert dataset.features is not None
@@ -694,7 +818,9 @@ def test_hdf5_feature_inference_compound(hdf5_file_with_compound_data):
 
 def test_hdf5_mixed_data_types(hdf5_file_with_mixed_data_types):
     """Test HDF5 loading with mixed data types in the same file."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_mixed_data_types], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_mixed_data_types], split="train"
+    )
 
     # Check all expected columns are present
     expected_columns = {
@@ -711,11 +837,18 @@ def test_hdf5_mixed_data_types(hdf5_file_with_mixed_data_types):
     assert len(dataset["compound_data"]) == 3
 
 
-def test_hdf5_mismatched_lengths_with_column_filtering(hdf5_file_with_mismatched_lengths):
+def test_hdf5_mismatched_lengths_with_column_filtering(
+    hdf5_file_with_mismatched_lengths,
+):
     """Test that mismatched dataset lengths are ignored when the mismatched dataset is excluded via columns config."""
     # Test 1: Include only the first dataset
     features = Features({"data1": Value("int32")})
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_mismatched_lengths], split="train", features=features)
+    dataset = load_dataset(
+        "hdf5",
+        data_files=[hdf5_file_with_mismatched_lengths],
+        split="train",
+        features=features,
+    )
 
     # Should work without error since we're only including the first dataset
     expected_columns = {"data1"}
@@ -736,7 +869,12 @@ def test_hdf5_mismatched_lengths_with_column_filtering(hdf5_file_with_mismatched
             "data6": Value("string"),
         }
     )
-    dataset2 = load_dataset("hdf5", data_files=[hdf5_file_with_mismatched_lengths], split="train", features=features)
+    dataset2 = load_dataset(
+        "hdf5",
+        data_files=[hdf5_file_with_mismatched_lengths],
+        split="train",
+        features=features,
+    )
 
     # Should work without error since we're excluding the mismatched dataset
     expected_columns2 = {"data1", "data3", "data4", "data5", "data6"}
@@ -748,7 +886,9 @@ def test_hdf5_mismatched_lengths_with_column_filtering(hdf5_file_with_mismatched
     assert len(dataset2["data3"]) == 5  # Array2D
     assert len(dataset2["data3"][0]) == 3  # 3 rows in each 2D array
     assert len(dataset2["data3"][0][0]) == 4  # 4 columns in each 2D array
-    np.testing.assert_allclose(dataset2["data4"], [0.0, 0.1, 0.2, 0.3, 0.4], rtol=1e-6)  # float64
+    np.testing.assert_allclose(
+        dataset2["data4"], [0.0, 0.1, 0.2, 0.3, 0.4], rtol=1e-6
+    )  # float64
     assert dataset2["data5"] == [True, False, True, False, True]  # boolean
     assert dataset2["data6"] == [
         "short",
@@ -761,7 +901,9 @@ def test_hdf5_mismatched_lengths_with_column_filtering(hdf5_file_with_mismatched
 
 def test_hdf5_compound_with_complex_arrays(hdf5_file_with_compound_complex_arrays):
     """Test HDF5 loading with compound datasets containing complex arrays."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_compound_complex_arrays], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_compound_complex_arrays], split="train"
+    )
 
     # Check that compound types with complex arrays are represented as nested structures
     expected_columns = {"compound_with_complex"}
@@ -794,9 +936,13 @@ def test_hdf5_compound_with_complex_arrays(hdf5_file_with_compound_complex_array
     assert first_row["nested_complex"]["imag"] == 2.5
 
 
-def test_hdf5_feature_inference_compound_complex_arrays(hdf5_file_with_compound_complex_arrays):
+def test_hdf5_feature_inference_compound_complex_arrays(
+    hdf5_file_with_compound_complex_arrays,
+):
     """Test automatic feature inference for compound datasets with complex arrays."""
-    dataset = load_dataset("hdf5", data_files=[hdf5_file_with_compound_complex_arrays], split="train")
+    dataset = load_dataset(
+        "hdf5", data_files=[hdf5_file_with_compound_complex_arrays], split="train"
+    )
 
     # Check that features were inferred correctly
     assert dataset.features is not None
@@ -821,8 +967,12 @@ def test_hdf5_feature_inference_compound_complex_arrays(hdf5_file_with_compound_
     assert compound_features["complex_field"]["imag"] == Value("float32")
 
     # Check complex array (should be nested real/imag structures)
-    assert compound_features["complex_array"]["real"] == Array2D(shape=(2, 3), dtype="float32")
-    assert compound_features["complex_array"]["imag"] == Array2D(shape=(2, 3), dtype="float32")
+    assert compound_features["complex_array"]["real"] == Array2D(
+        shape=(2, 3), dtype="float32"
+    )
+    assert compound_features["complex_array"]["imag"] == Array2D(
+        shape=(2, 3), dtype="float32"
+    )
 
     # Check nested complex field
     assert compound_features["nested_complex"]["real"] == Value("float32")

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -194,7 +194,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = JsonConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = JsonConfig(name="name", data_files=data_files)
@@ -229,28 +231,54 @@ def test_json_generate_tables(file_fixture, config_kwargs, request):
     [
         (
             "jsonl_file",
-            {"features": Features({"col_1": Value("int64"), "col_2": Value("int64"), "missing_col": Value("string")})},
+            {
+                "features": Features(
+                    {
+                        "col_1": Value("int64"),
+                        "col_2": Value("int64"),
+                        "missing_col": Value("string"),
+                    }
+                )
+            },
         ),
         (
             "json_file_with_list_of_dicts",
-            {"features": Features({"col_1": Value("int64"), "col_2": Value("int64"), "missing_col": Value("string")})},
+            {
+                "features": Features(
+                    {
+                        "col_1": Value("int64"),
+                        "col_2": Value("int64"),
+                        "missing_col": Value("string"),
+                    }
+                )
+            },
         ),
         (
             "json_file_with_list_of_dicts_field",
             {
                 "field": "field3",
                 "features": Features(
-                    {"col_1": Value("int64"), "col_2": Value("int64"), "missing_col": Value("string")}
+                    {
+                        "col_1": Value("int64"),
+                        "col_2": Value("int64"),
+                        "missing_col": Value("string"),
+                    }
                 ),
             },
         ),
     ],
 )
-def test_json_generate_tables_with_missing_features(file_fixture, config_kwargs, request):
+def test_json_generate_tables_with_missing_features(
+    file_fixture, config_kwargs, request
+):
     json = Json(**config_kwargs)
     generator = json._generate_tables([[request.getfixturevalue(file_fixture)]])
     pa_table = pa.concat_tables([table for _, table in generator])
-    assert pa_table.to_pydict() == {"col_1": [-1, 1, 10], "col_2": [None, 2, 20], "missing_col": [None, None, None]}
+    assert pa_table.to_pydict() == {
+        "col_1": [-1, 1, 10],
+        "col_2": [None, 2, 20],
+        "missing_col": [None, None, None],
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/packaged_modules/test_pandas.py
+++ b/tests/packaged_modules/test_pandas.py
@@ -10,7 +10,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = PandasConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = PandasConfig(name="name", data_files=data_files)

--- a/tests/packaged_modules/test_parquet.py
+++ b/tests/packaged_modules/test_parquet.py
@@ -10,7 +10,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = ParquetConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = ParquetConfig(name="name", data_files=data_files)

--- a/tests/packaged_modules/test_spark.py
+++ b/tests/packaged_modules/test_spark.py
@@ -25,7 +25,9 @@ def _get_expected_row_ids_and_row_dicts_for_partition_order(df, partition_order)
     for part_id in partition_order:
         partition = df.where(f"SPARK_PARTITION_ID() = {part_id}").collect()
         for row_idx, row in enumerate(partition):
-            expected_row_ids_and_row_dicts.append((f"{part_id}_{row_idx}", row.asDict()))
+            expected_row_ids_and_row_dicts.append(
+                (f"{part_id}_{row_idx}", row.asDict())
+            )
     return expected_row_ids_and_row_dicts
 
 
@@ -34,7 +36,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = SparkConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = SparkConfig(name="name", data_files=data_files)
@@ -43,7 +47,11 @@ def test_config_raises_when_invalid_data_files(data_files) -> None:
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_repartition_df_if_needed():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     df = spark.range(100).repartition(1)
     spark_builder = Spark(df)
     # The id ints will be converted to Pyarrow int64s, so each row will be 8 bytes. Setting a max_shard_size of 16 means
@@ -56,11 +64,19 @@ def test_repartition_df_if_needed():
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_generate_iterable_examples():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     df = spark.range(10).repartition(2)
     partition_order = [1, 0]
-    iterator = _generate_iterable_examples(df, partition_order)  # Reverse the partitions.
-    expected_row_ids_and_row_dicts = _get_expected_row_ids_and_row_dicts_for_partition_order(df, partition_order)
+    iterator = _generate_iterable_examples(
+        df, partition_order
+    )  # Reverse the partitions.
+    expected_row_ids_and_row_dicts = (
+        _get_expected_row_ids_and_row_dicts_for_partition_order(df, partition_order)
+    )
 
     for i, (row_id, row_dict) in enumerate(iterator):
         expected_row_id, expected_row_dict = expected_row_ids_and_row_dicts[i]
@@ -71,7 +87,11 @@ def test_generate_iterable_examples():
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_spark_examples_iterable():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     df = spark.range(10).repartition(1)
     it = SparkExamplesIterable(df)
     assert it.num_shards == 1
@@ -83,12 +103,18 @@ def test_spark_examples_iterable():
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_spark_examples_iterable_shuffle():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     df = spark.range(30).repartition(3)
     # Mock the generator so that shuffle reverses the partition indices.
     with patch("numpy.random.Generator") as generator_mock:
         generator_mock.shuffle.side_effect = lambda x: x.reverse()
-        expected_row_ids_and_row_dicts = _get_expected_row_ids_and_row_dicts_for_partition_order(df, [2, 1, 0])
+        expected_row_ids_and_row_dicts = (
+            _get_expected_row_ids_and_row_dicts_for_partition_order(df, [2, 1, 0])
+        )
 
         shuffled_it = SparkExamplesIterable(df).shuffle_data_sources(generator_mock)
         assert shuffled_it.num_shards == 3
@@ -101,22 +127,34 @@ def test_spark_examples_iterable_shuffle():
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_spark_examples_iterable_shard():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     df = spark.range(20).repartition(4)
 
     # Partitions 0 and 2
-    shard_it_1 = SparkExamplesIterable(df).shard_data_sources(index=0, num_shards=2, contiguous=False)
+    shard_it_1 = SparkExamplesIterable(df).shard_data_sources(
+        index=0, num_shards=2, contiguous=False
+    )
     assert shard_it_1.num_shards == 2
-    expected_row_ids_and_row_dicts_1 = _get_expected_row_ids_and_row_dicts_for_partition_order(df, [0, 2])
+    expected_row_ids_and_row_dicts_1 = (
+        _get_expected_row_ids_and_row_dicts_for_partition_order(df, [0, 2])
+    )
     for i, (row_id, row_dict) in enumerate(shard_it_1):
         expected_row_id, expected_row_dict = expected_row_ids_and_row_dicts_1[i]
         assert row_id == expected_row_id
         assert row_dict == expected_row_dict
 
     # Partitions 1 and 3
-    shard_it_2 = SparkExamplesIterable(df).shard_data_sources(index=1, num_shards=2, contiguous=False)
+    shard_it_2 = SparkExamplesIterable(df).shard_data_sources(
+        index=1, num_shards=2, contiguous=False
+    )
     assert shard_it_2.num_shards == 2
-    expected_row_ids_and_row_dicts_2 = _get_expected_row_ids_and_row_dicts_for_partition_order(df, [1, 3])
+    expected_row_ids_and_row_dicts_2 = (
+        _get_expected_row_ids_and_row_dicts_for_partition_order(df, [1, 3])
+    )
     for i, (row_id, row_dict) in enumerate(shard_it_2):
         expected_row_id, expected_row_dict = expected_row_ids_and_row_dicts_2[i]
         assert row_id == expected_row_id
@@ -126,7 +164,11 @@ def test_spark_examples_iterable_shard():
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_repartition_df_if_needed_max_num_df_rows():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     df = spark.range(100).repartition(1)
     spark_builder = Spark(df)
     # Choose a small max_shard_size for maximum partitioning.
@@ -138,7 +180,11 @@ def test_repartition_df_if_needed_max_num_df_rows():
 @require_not_windows
 @require_dill_gt_0_3_2
 def test_iterable_image_features():
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     img_bytes = np.zeros((10, 10, 3), dtype=np.uint8).tobytes()
     data = [(img_bytes,)]
     df = spark.createDataFrame(data, "image: binary")
@@ -156,7 +202,11 @@ def test_iterable_image_features_decode():
 
     import PIL.Image
 
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     img = PIL.Image.fromarray(np.zeros((10, 10, 3), dtype=np.uint8), "RGB")
     buffer = BytesIO()
     img.save(buffer, format="PNG")

--- a/tests/packaged_modules/test_sql.py
+++ b/tests/packaged_modules/test_sql.py
@@ -10,7 +10,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = SqlConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = SqlConfig(name="name", data_files=data_files)

--- a/tests/packaged_modules/test_text.py
+++ b/tests/packaged_modules/test_text.py
@@ -46,7 +46,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = TextConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = TextConfig(name="name", data_files=data_files)
@@ -58,7 +60,9 @@ def test_text_linebreaks(text_file, keep_linebreaks):
         expected_content = f.read().splitlines(keepends=keep_linebreaks)
     text = Text(keep_linebreaks=keep_linebreaks, encoding="utf-8")
     generator = text._generate_tables([[text_file]])
-    generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()["text"]
+    generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()[
+        "text"
+    ]
     assert generated_content == expected_content
 
 
@@ -86,5 +90,7 @@ def test_text_sample_by(sample_by, text_file):
         expected_content = [expected_content]
     text = Text(sample_by=sample_by, encoding="utf-8", chunksize=100)
     generator = text._generate_tables([[text_file]])
-    generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()["text"]
+    generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()[
+        "text"
+    ]
     assert generated_content == expected_content

--- a/tests/packaged_modules/test_webdataset.py
+++ b/tests/packaged_modules/test_webdataset.py
@@ -46,7 +46,10 @@ def upper_lower_case_file(tmp_path):
         ("INFO1", "json"),
         ("info2", "json"),
         ("info3", "JSON"),
-        ("info3", "json"),  # should probably remove if testing on a case insensitive filesystem
+        (
+            "info3",
+            "json",
+        ),  # should probably remove if testing on a case insensitive filesystem
     ]
     with tarfile.open(tar_path, "w") as tar:
         for example_idx in range(num_examples):
@@ -119,7 +122,9 @@ def test_gzipped_text_webdataset(gzipped_text_wds_file, text_path):
     assert len(examples) == 3
     assert isinstance(examples[0]["txt.gz"], str)
     with open(text_path, "r") as f:
-        assert examples[0]["txt.gz"].replace("\r\n", "\n") == f.read().replace("\r\n", "\n")
+        assert examples[0]["txt.gz"].replace("\r\n", "\n") == f.read().replace(
+            "\r\n", "\n"
+        )
 
 
 @require_pil
@@ -145,7 +150,9 @@ def test_image_webdataset(image_wds_file):
     assert len(examples) == 3
     assert isinstance(examples[0]["json"], dict)
     assert isinstance(examples[0]["json"]["caption"], str)
-    assert isinstance(examples[0]["jpg"], dict)  # keep encoded to avoid unecessary copies
+    assert isinstance(
+        examples[0]["jpg"], dict
+    )  # keep encoded to avoid unecessary copies
     encoded = webdataset.info.features.encode_example(examples[0])
     decoded = webdataset.info.features.decode_example(encoded)
     assert isinstance(decoded["json"], dict)
@@ -251,7 +258,9 @@ def test_audio_webdataset(audio_wds_file):
     assert isinstance(examples[0]["json"], dict)
     assert isinstance(examples[0]["json"]["transcript"], str)
     assert isinstance(examples[0]["wav"], dict)
-    assert isinstance(examples[0]["wav"]["bytes"], bytes)  # keep encoded to avoid unecessary copies
+    assert isinstance(
+        examples[0]["wav"]["bytes"], bytes
+    )  # keep encoded to avoid unecessary copies
     encoded = webdataset.info.features.encode_example(examples[0])
     decoded = webdataset.info.features.decode_example(encoded)
     assert isinstance(decoded["json"], dict)
@@ -318,7 +327,9 @@ def test_tensor_webdataset(tensor_wds_file):
     assert len(examples) == 3
     assert isinstance(examples[0]["json"], dict)
     assert isinstance(examples[0]["json"]["text"], str)
-    assert isinstance(examples[0]["pth"], torch.Tensor)  # keep encoded to avoid unecessary copies
+    assert isinstance(
+        examples[0]["pth"], torch.Tensor
+    )  # keep encoded to avoid unecessary copies
     encoded = webdataset.info.features.encode_example(examples[0])
     decoded = webdataset.info.features.decode_example(encoded)
     assert isinstance(decoded["json"], dict)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -53,7 +53,9 @@ class DummyBuilder(DatasetBuilder):
 
     def _prepare_split(self, split_generator, **kwargs):
         fname = f"{self.dataset_name}-{split_generator.name}.arrow"
-        with ArrowWriter(features=self.info.features, path=os.path.join(self._output_dir, fname)) as writer:
+        with ArrowWriter(
+            features=self.info.features, path=os.path.join(self._output_dir, fname)
+        ) as writer:
             writer.write_batch({"text": ["foo"] * 100})
             num_examples, num_bytes = writer.finalize()
         split_generator.split_info.num_examples = num_examples
@@ -136,9 +138,13 @@ class DummyBuilderWithDownload(DummyBuilder):
 
     def _split_generators(self, dl_manager):
         if self._rel_path is not None:
-            assert os.path.exists(dl_manager.download(self._rel_path)), "dl_manager must support relative paths"
+            assert os.path.exists(
+                dl_manager.download(self._rel_path)
+            ), "dl_manager must support relative paths"
         if self._abs_path is not None:
-            assert os.path.exists(dl_manager.download(self._abs_path)), "dl_manager must support absolute paths"
+            assert os.path.exists(
+                dl_manager.download(self._abs_path)
+            ), "dl_manager must support absolute paths"
         return [SplitGenerator(name=Split.TRAIN)]
 
 
@@ -155,25 +161,41 @@ class DummyBuilderWithManualDownload(DummyBuilderWithMultipleConfigs):
 
 class DummyArrowBasedBuilderWithShards(ArrowBasedBuilder):
     def _info(self):
-        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+        return DatasetInfo(
+            features=Features({"id": Value("int8"), "filepath": Value("string")})
+        )
 
     def _split_generators(self, dl_manager):
-        return [SplitGenerator(name=Split.TRAIN, gen_kwargs={"filepaths": [f"data{i}.txt" for i in range(4)]})]
+        return [
+            SplitGenerator(
+                name=Split.TRAIN,
+                gen_kwargs={"filepaths": [f"data{i}.txt" for i in range(4)]},
+            )
+        ]
 
     def _generate_tables(self, filepaths):
         idx = 0
         for filepath in filepaths:
             for i in range(10):
-                yield idx, pa.table({"id": range(10 * i, 10 * (i + 1)), "filepath": [filepath] * 10})
+                yield idx, pa.table(
+                    {"id": range(10 * i, 10 * (i + 1)), "filepath": [filepath] * 10}
+                )
                 idx += 1
 
 
 class DummyGeneratorBasedBuilderWithShards(GeneratorBasedBuilder):
     def _info(self):
-        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+        return DatasetInfo(
+            features=Features({"id": Value("int8"), "filepath": Value("string")})
+        )
 
     def _split_generators(self, dl_manager):
-        return [SplitGenerator(name=Split.TRAIN, gen_kwargs={"filepaths": [f"data{i}.txt" for i in range(4)]})]
+        return [
+            SplitGenerator(
+                name=Split.TRAIN,
+                gen_kwargs={"filepaths": [f"data{i}.txt" for i in range(4)]},
+            )
+        ]
 
     def _generate_examples(self, filepaths):
         idx = 0
@@ -185,7 +207,9 @@ class DummyGeneratorBasedBuilderWithShards(GeneratorBasedBuilder):
 
 class DummyArrowBasedBuilderWithAmbiguousShards(ArrowBasedBuilder):
     def _info(self):
-        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+        return DatasetInfo(
+            features=Features({"id": Value("int8"), "filepath": Value("string")})
+        )
 
     def _split_generators(self, dl_manager):
         return [
@@ -193,7 +217,9 @@ class DummyArrowBasedBuilderWithAmbiguousShards(ArrowBasedBuilder):
                 name=Split.TRAIN,
                 gen_kwargs={
                     "filepaths": [f"data{i}.txt" for i in range(4)],
-                    "dummy_kwarg_with_different_length": [f"dummy_data{i}.txt" for i in range(3)],
+                    "dummy_kwarg_with_different_length": [
+                        f"dummy_data{i}.txt" for i in range(3)
+                    ],
                 },
             )
         ]
@@ -202,13 +228,17 @@ class DummyArrowBasedBuilderWithAmbiguousShards(ArrowBasedBuilder):
         idx = 0
         for filepath in filepaths:
             for i in range(10):
-                yield idx, pa.table({"id": range(10 * i, 10 * (i + 1)), "filepath": [filepath] * 10})
+                yield idx, pa.table(
+                    {"id": range(10 * i, 10 * (i + 1)), "filepath": [filepath] * 10}
+                )
                 idx += 1
 
 
 class DummyGeneratorBasedBuilderWithAmbiguousShards(GeneratorBasedBuilder):
     def _info(self):
-        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+        return DatasetInfo(
+            features=Features({"id": Value("int8"), "filepath": Value("string")})
+        )
 
     def _split_generators(self, dl_manager):
         return [
@@ -216,7 +246,9 @@ class DummyGeneratorBasedBuilderWithAmbiguousShards(GeneratorBasedBuilder):
                 name=Split.TRAIN,
                 gen_kwargs={
                     "filepaths": [f"data{i}.txt" for i in range(4)],
-                    "dummy_kwarg_with_different_length": [f"dummy_data{i}.txt" for i in range(3)],
+                    "dummy_kwarg_with_different_length": [
+                        f"dummy_data{i}.txt" for i in range(3)
+                    ],
                 },
             )
         ]
@@ -249,22 +281,41 @@ class BuilderTest(TestCase):
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
-                        tmp_dir, builder.dataset_name, "default", "0.0.0", f"{builder.dataset_name}-train.arrow"
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        f"{builder.dataset_name}-train.arrow",
                     )
                 )
             )
-            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                builder.info.features, Features({"text": Value("string")})
+            )
             self.assertEqual(builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, builder.dataset_name, "default", "0.0.0", "dataset_info.json"))
+                os.path.exists(
+                    os.path.join(
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        "dataset_info.json",
+                    )
+                )
             )
 
     def test_download_and_prepare_checksum_computation(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder_no_verification = DummyBuilder(cache_dir=tmp_dir)
-            builder_no_verification.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
+            builder_no_verification.download_and_prepare(
+                download_mode=DownloadMode.FORCE_REDOWNLOAD
+            )
             self.assertTrue(
-                all(v["checksum"] is not None for _, v in builder_no_verification.info.download_checksums.items())
+                all(
+                    v["checksum"] is not None
+                    for _, v in builder_no_verification.info.download_checksums.items()
+                )
             )
             builder_with_verification = DummyBuilder(cache_dir=tmp_dir)
             builder_with_verification.download_and_prepare(
@@ -272,7 +323,10 @@ class BuilderTest(TestCase):
                 verification_mode=VerificationMode.ALL_CHECKS,
             )
             self.assertTrue(
-                all(v["checksum"] is None for _, v in builder_with_verification.info.download_checksums.items())
+                all(
+                    v["checksum"] is None
+                    for _, v in builder_with_verification.info.download_checksums.items()
+                )
             )
 
     def test_concurrent_download_and_prepare(self):
@@ -280,7 +334,9 @@ class BuilderTest(TestCase):
             processes = 2
             with Pool(processes=processes) as pool:
                 jobs = [
-                    pool.apply_async(_run_concurrent_download_and_prepare, kwds={"tmp_dir": tmp_dir})
+                    pool.apply_async(
+                        _run_concurrent_download_and_prepare, kwds={"tmp_dir": tmp_dir}
+                    )
                     for _ in range(processes)
                 ]
                 builders = [job.get() for job in jobs]
@@ -296,11 +352,19 @@ class BuilderTest(TestCase):
                             )
                         )
                     )
-                    self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+                    self.assertDictEqual(
+                        builder.info.features, Features({"text": Value("string")})
+                    )
                     self.assertEqual(builder.info.splits["train"].num_examples, 100)
                     self.assertTrue(
                         os.path.exists(
-                            os.path.join(tmp_dir, builder.dataset_name, "default", "0.0.0", "dataset_info.json")
+                            os.path.join(
+                                tmp_dir,
+                                builder.dataset_name,
+                                "default",
+                                "0.0.0",
+                                "dataset_info.json",
+                            )
                         )
                     )
 
@@ -311,16 +375,24 @@ class BuilderTest(TestCase):
             # test relative path is missing
             builder = DummyBuilderWithDownload(cache_dir=tmp_dir, rel_path=rel_path)
             with self.assertRaises(FileNotFoundError):
-                builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir)
+                builder.download_and_prepare(
+                    download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir
+                )
             # test absolute path is missing
             builder = DummyBuilderWithDownload(cache_dir=tmp_dir, abs_path=abs_path)
             with self.assertRaises(FileNotFoundError):
-                builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir)
+                builder.download_and_prepare(
+                    download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir
+                )
             # test that they are both properly loaded when they exist
             open(os.path.join(tmp_dir, rel_path), "w")
             open(abs_path, "w")
-            builder = DummyBuilderWithDownload(cache_dir=tmp_dir, rel_path=rel_path, abs_path=abs_path)
-            builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir)
+            builder = DummyBuilderWithDownload(
+                cache_dir=tmp_dir, rel_path=rel_path, abs_path=abs_path
+            )
+            builder.download_and_prepare(
+                download_mode=DownloadMode.FORCE_REDOWNLOAD, base_path=tmp_dir
+            )
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
@@ -338,7 +410,9 @@ class BuilderTest(TestCase):
             def char_tokenize(example):
                 return {"tokens": list(example["text"])}
 
-            return dataset.map(char_tokenize, cache_file_name=resources_paths["tokenized_dataset"])
+            return dataset.map(
+                char_tokenize, cache_file_name=resources_paths["tokenized_dataset"]
+            )
 
         def _post_processing_resources(self, split):
             return {"tokenized_dataset": f"tokenized_dataset-{split}.arrow"}
@@ -346,10 +420,14 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder = DummyBuilder(cache_dir=tmp_dir)
             builder.info.post_processed = PostProcessedInfo(
-                features=Features({"text": Value("string"), "tokens": List(Value("string"))})
+                features=Features(
+                    {"text": Value("string"), "tokens": List(Value("string"))}
+                )
             )
             builder._post_process = types.MethodType(_post_process, builder)
-            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            builder._post_processing_resources = types.MethodType(
+                _post_processing_resources, builder
+            )
             os.makedirs(builder.cache_dir)
 
             builder.info.splits = SplitDict()
@@ -358,17 +436,25 @@ class BuilderTest(TestCase):
 
             for split in builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(builder.cache_dir, f"{builder.dataset_name}-{split}.arrow"),
+                    path=os.path.join(
+                        builder.cache_dir, f"{builder.dataset_name}-{split}.arrow"
+                    ),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
                     writer.finalize()
 
                 with ArrowWriter(
-                    path=os.path.join(builder.cache_dir, f"tokenized_dataset-{split}.arrow"),
-                    features=Features({"text": Value("string"), "tokens": List(Value("string"))}),
+                    path=os.path.join(
+                        builder.cache_dir, f"tokenized_dataset-{split}.arrow"
+                    ),
+                    features=Features(
+                        {"text": Value("string"), "tokens": List(Value("string"))}
+                    ),
                 ) as writer:
-                    writer.write_batch({"text": ["foo"] * 10, "tokens": [list("foo")] * 10})
+                    writer.write_batch(
+                        {"text": ["foo"] * 10, "tokens": [list("foo")] * 10}
+                    )
                     writer.finalize()
 
             dsets = builder.as_dataset()
@@ -377,10 +463,12 @@ class BuilderTest(TestCase):
             self.assertEqual(len(dsets["train"]), 10)
             self.assertEqual(len(dsets["test"]), 10)
             self.assertDictEqual(
-                dsets["train"].features, Features({"text": Value("string"), "tokens": List(Value("string"))})
+                dsets["train"].features,
+                Features({"text": Value("string"), "tokens": List(Value("string"))}),
             )
             self.assertDictEqual(
-                dsets["test"].features, Features({"text": Value("string"), "tokens": List(Value("string"))})
+                dsets["test"].features,
+                Features({"text": Value("string"), "tokens": List(Value("string"))}),
             )
             self.assertListEqual(dsets["train"].column_names, ["text", "tokens"])
             self.assertListEqual(dsets["test"].column_names, ["text", "tokens"])
@@ -390,11 +478,17 @@ class BuilderTest(TestCase):
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train")
             self.assertEqual(len(dset), 10)
-            self.assertDictEqual(dset.features, Features({"text": Value("string"), "tokens": List(Value("string"))}))
+            self.assertDictEqual(
+                dset.features,
+                Features({"text": Value("string"), "tokens": List(Value("string"))}),
+            )
             self.assertListEqual(dset.column_names, ["text", "tokens"])
             self.assertGreater(builder.info.post_processing_size, 0)
             self.assertGreater(
-                builder.info.post_processed.resources_checksums["train"]["tokenized_dataset"]["num_bytes"], 0
+                builder.info.post_processed.resources_checksums["train"][
+                    "tokenized_dataset"
+                ]["num_bytes"],
+                0,
             )
             del dset
 
@@ -402,7 +496,10 @@ class BuilderTest(TestCase):
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train+test[:30%]")
             self.assertEqual(len(dset), 13)
-            self.assertDictEqual(dset.features, Features({"text": Value("string"), "tokens": List(Value("string"))}))
+            self.assertDictEqual(
+                dset.features,
+                Features({"text": Value("string"), "tokens": List(Value("string"))}),
+            )
             self.assertListEqual(dset.column_names, ["text", "tokens"])
             del dset
 
@@ -410,7 +507,10 @@ class BuilderTest(TestCase):
             self.assertIsInstance(dset, Dataset)
             self.assertEqual(dset.split, "train+test")
             self.assertEqual(len(dset), 20)
-            self.assertDictEqual(dset.features, Features({"text": Value("string"), "tokens": List(Value("string"))}))
+            self.assertDictEqual(
+                dset.features,
+                Features({"text": Value("string"), "tokens": List(Value("string"))}),
+            )
             self.assertListEqual(dset.column_names, ["text", "tokens"])
             del dset
 
@@ -428,14 +528,18 @@ class BuilderTest(TestCase):
 
             for split in builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(builder.cache_dir, f"{builder.dataset_name}-{split}.arrow"),
+                    path=os.path.join(
+                        builder.cache_dir, f"{builder.dataset_name}-{split}.arrow"
+                    ),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
                     writer.finalize()
 
                 with ArrowWriter(
-                    path=os.path.join(builder.cache_dir, f"small_dataset-{split}.arrow"),
+                    path=os.path.join(
+                        builder.cache_dir, f"small_dataset-{split}.arrow"
+                    ),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 2})
@@ -446,8 +550,12 @@ class BuilderTest(TestCase):
             self.assertListEqual(list(dsets.keys()), ["train", "test"])
             self.assertEqual(len(dsets["train"]), 2)
             self.assertEqual(len(dsets["test"]), 2)
-            self.assertDictEqual(dsets["train"].features, Features({"text": Value("string")}))
-            self.assertDictEqual(dsets["test"].features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                dsets["train"].features, Features({"text": Value("string")})
+            )
+            self.assertDictEqual(
+                dsets["test"].features, Features({"text": Value("string")})
+            )
             self.assertListEqual(dsets["train"].column_names, ["text"])
             self.assertListEqual(dsets["test"].column_names, ["text"])
             del dsets
@@ -476,7 +584,9 @@ class BuilderTest(TestCase):
                 return dataset
             else:
                 dataset.add_faiss_index_from_external_arrays(
-                    external_arrays=np.ones((len(dataset), 8)), string_factory="Flat", index_name="my_index"
+                    external_arrays=np.ones((len(dataset), 8)),
+                    string_factory="Flat",
+                    index_name="my_index",
                 )
                 dataset.save_faiss_index("my_index", resources_paths["index"])
                 return dataset
@@ -487,7 +597,9 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder = DummyBuilder(cache_dir=tmp_dir)
             builder._post_process = types.MethodType(_post_process, builder)
-            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            builder._post_processing_resources = types.MethodType(
+                _post_processing_resources, builder
+            )
             os.makedirs(builder.cache_dir)
 
             builder.info.splits = SplitDict()
@@ -496,14 +608,18 @@ class BuilderTest(TestCase):
 
             for split in builder.info.splits:
                 with ArrowWriter(
-                    path=os.path.join(builder.cache_dir, f"{builder.dataset_name}-{split}.arrow"),
+                    path=os.path.join(
+                        builder.cache_dir, f"{builder.dataset_name}-{split}.arrow"
+                    ),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 10})
                     writer.finalize()
 
                 with ArrowWriter(
-                    path=os.path.join(builder.cache_dir, f"small_dataset-{split}.arrow"),
+                    path=os.path.join(
+                        builder.cache_dir, f"small_dataset-{split}.arrow"
+                    ),
                     features=Features({"text": Value("string")}),
                 ) as writer:
                     writer.write_batch({"text": ["foo"] * 2})
@@ -514,14 +630,23 @@ class BuilderTest(TestCase):
             self.assertListEqual(list(dsets.keys()), ["train", "test"])
             self.assertEqual(len(dsets["train"]), 10)
             self.assertEqual(len(dsets["test"]), 10)
-            self.assertDictEqual(dsets["train"].features, Features({"text": Value("string")}))
-            self.assertDictEqual(dsets["test"].features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                dsets["train"].features, Features({"text": Value("string")})
+            )
+            self.assertDictEqual(
+                dsets["test"].features, Features({"text": Value("string")})
+            )
             self.assertListEqual(dsets["train"].column_names, ["text"])
             self.assertListEqual(dsets["test"].column_names, ["text"])
             self.assertListEqual(dsets["train"].list_indexes(), ["my_index"])
             self.assertListEqual(dsets["test"].list_indexes(), ["my_index"])
             self.assertGreater(builder.info.post_processing_size, 0)
-            self.assertGreater(builder.info.post_processed.resources_checksums["train"]["index"]["num_bytes"], 0)
+            self.assertGreater(
+                builder.info.post_processed.resources_checksums["train"]["index"][
+                    "num_bytes"
+                ],
+                0,
+            )
             del dsets
 
             dset = builder.as_dataset("train")
@@ -547,7 +672,9 @@ class BuilderTest(TestCase):
             def char_tokenize(example):
                 return {"tokens": list(example["text"])}
 
-            return dataset.map(char_tokenize, cache_file_name=resources_paths["tokenized_dataset"])
+            return dataset.map(
+                char_tokenize, cache_file_name=resources_paths["tokenized_dataset"]
+            )
 
         def _post_processing_resources(self, split):
             return {"tokenized_dataset": f"tokenized_dataset-{split}.arrow"}
@@ -555,26 +682,44 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder = DummyBuilder(cache_dir=tmp_dir)
             builder.info.post_processed = PostProcessedInfo(
-                features=Features({"text": Value("string"), "tokens": List(Value("string"))})
+                features=Features(
+                    {"text": Value("string"), "tokens": List(Value("string"))}
+                )
             )
             builder._post_process = types.MethodType(_post_process, builder)
-            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            builder._post_processing_resources = types.MethodType(
+                _post_processing_resources, builder
+            )
             builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
-                        tmp_dir, builder.dataset_name, "default", "0.0.0", f"{builder.dataset_name}-train.arrow"
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        f"{builder.dataset_name}-train.arrow",
                     )
                 )
             )
-            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                builder.info.features, Features({"text": Value("string")})
+            )
             self.assertDictEqual(
                 builder.info.post_processed.features,
                 Features({"text": Value("string"), "tokens": List(Value("string"))}),
             )
             self.assertEqual(builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, builder.dataset_name, "default", "0.0.0", "dataset_info.json"))
+                os.path.exists(
+                    os.path.join(
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        "dataset_info.json",
+                    )
+                )
             )
 
         def _post_process(self, dataset, resources_paths):
@@ -587,15 +732,29 @@ class BuilderTest(TestCase):
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
-                        tmp_dir, builder.dataset_name, "default", "0.0.0", f"{builder.dataset_name}-train.arrow"
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        f"{builder.dataset_name}-train.arrow",
                     )
                 )
             )
-            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                builder.info.features, Features({"text": Value("string")})
+            )
             self.assertIsNone(builder.info.post_processed)
             self.assertEqual(builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, builder.dataset_name, "default", "0.0.0", "dataset_info.json"))
+                os.path.exists(
+                    os.path.join(
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        "dataset_info.json",
+                    )
+                )
             )
 
         def _post_process(self, dataset, resources_paths):
@@ -604,7 +763,9 @@ class BuilderTest(TestCase):
                 return dataset
             else:
                 dataset = dataset.add_faiss_index_from_external_arrays(
-                    external_arrays=np.ones((len(dataset), 8)), string_factory="Flat", index_name="my_index"
+                    external_arrays=np.ones((len(dataset), 8)),
+                    string_factory="Flat",
+                    index_name="my_index",
                 )
                 dataset.save_faiss_index("my_index", resources_paths["index"])
                 return dataset
@@ -615,20 +776,36 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder = DummyBuilder(cache_dir=tmp_dir)
             builder._post_process = types.MethodType(_post_process, builder)
-            builder._post_processing_resources = types.MethodType(_post_processing_resources, builder)
+            builder._post_processing_resources = types.MethodType(
+                _post_processing_resources, builder
+            )
             builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
             self.assertTrue(
                 os.path.exists(
                     os.path.join(
-                        tmp_dir, builder.dataset_name, "default", "0.0.0", f"{builder.dataset_name}-train.arrow"
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        f"{builder.dataset_name}-train.arrow",
                     )
                 )
             )
-            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                builder.info.features, Features({"text": Value("string")})
+            )
             self.assertIsNone(builder.info.post_processed)
             self.assertEqual(builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, builder.dataset_name, "default", "0.0.0", "dataset_info.json"))
+                os.path.exists(
+                    os.path.join(
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        "dataset_info.json",
+                    )
+                )
             )
 
     def test_error_download_and_prepare(self):
@@ -660,18 +837,31 @@ class BuilderTest(TestCase):
                     )
                 )
             )
-            self.assertDictEqual(builder.info.features, Features({"text": Value("string")}))
+            self.assertDictEqual(
+                builder.info.features, Features({"text": Value("string")})
+            )
             self.assertEqual(builder.info.splits["train"].num_examples, 100)
             self.assertTrue(
-                os.path.exists(os.path.join(tmp_dir, builder.dataset_name, "default", "0.0.0", "dataset_info.json"))
+                os.path.exists(
+                    os.path.join(
+                        tmp_dir,
+                        builder.dataset_name,
+                        "default",
+                        "0.0.0",
+                        "dataset_info.json",
+                    )
+                )
             )
 
         # Test that duplicated keys are ignored if verification_mode is "no_checks"
         with tempfile.TemporaryDirectory() as tmp_dir:
             builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir)
-            with patch("datasets.builder.ArrowWriter", side_effect=ArrowWriter) as mock_arrow_writer:
+            with patch(
+                "datasets.builder.ArrowWriter", side_effect=ArrowWriter
+            ) as mock_arrow_writer:
                 builder.download_and_prepare(
-                    download_mode=DownloadMode.FORCE_REDOWNLOAD, verification_mode=VerificationMode.NO_CHECKS
+                    download_mode=DownloadMode.FORCE_REDOWNLOAD,
+                    verification_mode=VerificationMode.NO_CHECKS,
                 )
                 mock_arrow_writer.assert_called_once()
                 args, kwargs = mock_arrow_writer.call_args_list[0]
@@ -680,7 +870,8 @@ class BuilderTest(TestCase):
                 mock_arrow_writer.reset_mock()
 
                 builder.download_and_prepare(
-                    download_mode=DownloadMode.FORCE_REDOWNLOAD, verification_mode=VerificationMode.BASIC_CHECKS
+                    download_mode=DownloadMode.FORCE_REDOWNLOAD,
+                    verification_mode=VerificationMode.BASIC_CHECKS,
                 )
                 mock_arrow_writer.assert_called_once()
                 args, kwargs = mock_arrow_writer.call_args_list[0]
@@ -688,9 +879,13 @@ class BuilderTest(TestCase):
 
     def test_cache_dir_no_args(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_dir=None, data_files=None)
+            builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_dir=None, data_files=None
+            )
             relative_cache_dir_parts = Path(builder._relative_data_dir()).parts
-            self.assertTupleEqual(relative_cache_dir_parts, (builder.dataset_name, "default", "0.0.0"))
+            self.assertTupleEqual(
+                relative_cache_dir_parts, (builder.dataset_name, "default", "0.0.0")
+            )
 
     def test_cache_dir_for_data_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -701,45 +896,75 @@ class BuilderTest(TestCase):
             with open(dummy_data2, "w", encoding="utf-8") as f:
                 f.writelines("foo bar\n")
 
-            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=dummy_data1)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=dummy_data1)
+            builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files=dummy_data1
+            )
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files=dummy_data1
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=[dummy_data1])
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files=[dummy_data1]
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files={"train": dummy_data1})
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files={"train": dummy_data1}
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files={Split.TRAIN: dummy_data1})
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files={Split.TRAIN: dummy_data1}
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files={"train": [dummy_data1]})
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files={"train": [dummy_data1]}
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files={"test": dummy_data1})
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files={"test": dummy_data1}
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=dummy_data2)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files=dummy_data2
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=[dummy_data2])
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files=[dummy_data2]
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=[dummy_data1, dummy_data2])
-            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
-
-            builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=[dummy_data1, dummy_data2])
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=[dummy_data1, dummy_data2])
-            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, data_files=[dummy_data2, dummy_data1])
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, data_files=[dummy_data1, dummy_data2]
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
             builder = DummyGeneratorBasedBuilder(
-                cache_dir=tmp_dir, data_files={"train": dummy_data1, "test": dummy_data2}
+                cache_dir=tmp_dir, data_files=[dummy_data1, dummy_data2]
             )
             other_builder = DummyGeneratorBasedBuilder(
-                cache_dir=tmp_dir, data_files={"train": dummy_data1, "test": dummy_data2}
-            )
-            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilder(
-                cache_dir=tmp_dir, data_files={"train": [dummy_data1], "test": dummy_data2}
+                cache_dir=tmp_dir, data_files=[dummy_data1, dummy_data2]
             )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
-                cache_dir=tmp_dir, data_files={"train": dummy_data1, "validation": dummy_data2}
+                cache_dir=tmp_dir, data_files=[dummy_data2, dummy_data1]
+            )
+            self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
+
+            builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir,
+                data_files={"train": dummy_data1, "test": dummy_data2},
+            )
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir,
+                data_files={"train": dummy_data1, "test": dummy_data2},
+            )
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir,
+                data_files={"train": [dummy_data1], "test": dummy_data2},
+            )
+            self.assertEqual(builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir,
+                data_files={"train": dummy_data1, "validation": dummy_data2},
             )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
             other_builder = DummyGeneratorBasedBuilder(
@@ -752,47 +977,78 @@ class BuilderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             f1 = Features({"id": Value("int8")})
             f2 = Features({"id": Value("int32")})
-            builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, features=f1)
-            other_builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, features=f1)
+            builder = DummyGeneratorBasedBuilderWithIntegers(
+                cache_dir=tmp_dir, features=f1
+            )
+            other_builder = DummyGeneratorBasedBuilderWithIntegers(
+                cache_dir=tmp_dir, features=f1
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilderWithIntegers(cache_dir=tmp_dir, features=f2)
+            other_builder = DummyGeneratorBasedBuilderWithIntegers(
+                cache_dir=tmp_dir, features=f2
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
     def test_cache_dir_for_config_kwargs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # create config on the fly
-            builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, content="foo", times=2)
-            other_builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, times=2, content="foo")
+            builder = DummyGeneratorBasedBuilderWithConfig(
+                cache_dir=tmp_dir, content="foo", times=2
+            )
+            other_builder = DummyGeneratorBasedBuilderWithConfig(
+                cache_dir=tmp_dir, times=2, content="foo"
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             self.assertIn("content=foo", builder.cache_dir)
             self.assertIn("times=2", builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, content="bar", times=2)
+            other_builder = DummyGeneratorBasedBuilderWithConfig(
+                cache_dir=tmp_dir, content="bar", times=2
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyGeneratorBasedBuilderWithConfig(cache_dir=tmp_dir, content="foo")
+            other_builder = DummyGeneratorBasedBuilderWithConfig(
+                cache_dir=tmp_dir, content="foo"
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             # overwrite an existing config
-            builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, config_name="a", content="foo", times=2)
-            other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, config_name="a", times=2, content="foo")
+            builder = DummyBuilderWithMultipleConfigs(
+                cache_dir=tmp_dir, config_name="a", content="foo", times=2
+            )
+            other_builder = DummyBuilderWithMultipleConfigs(
+                cache_dir=tmp_dir, config_name="a", times=2, content="foo"
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
             self.assertIn("content=foo", builder.cache_dir)
             self.assertIn("times=2", builder.cache_dir)
-            other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, config_name="a", content="bar", times=2)
+            other_builder = DummyBuilderWithMultipleConfigs(
+                cache_dir=tmp_dir, config_name="a", content="bar", times=2
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, config_name="a", content="foo")
+            other_builder = DummyBuilderWithMultipleConfigs(
+                cache_dir=tmp_dir, config_name="a", content="foo"
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
     def test_config_names(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self.assertRaises(ValueError) as error_context:
-                DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, data_files=None, data_dir=None)
-            self.assertIn("Please pick one among the available configs", str(error_context.exception))
+                DummyBuilderWithMultipleConfigs(
+                    cache_dir=tmp_dir, data_files=None, data_dir=None
+                )
+            self.assertIn(
+                "Please pick one among the available configs",
+                str(error_context.exception),
+            )
 
-            builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, config_name="a")
+            builder = DummyBuilderWithMultipleConfigs(
+                cache_dir=tmp_dir, config_name="a"
+            )
             self.assertEqual(builder.config.name, "a")
 
-            builder = DummyBuilderWithMultipleConfigs(cache_dir=tmp_dir, config_name="b")
+            builder = DummyBuilderWithMultipleConfigs(
+                cache_dir=tmp_dir, config_name="b"
+            )
             self.assertEqual(builder.config.name, "b")
 
             with self.assertRaises(ValueError):
@@ -803,10 +1059,16 @@ class BuilderTest(TestCase):
 
     def test_cache_dir_for_data_dir(self):
         with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as data_dir:
-            builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, config_name="a", data_dir=data_dir)
-            other_builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, config_name="a", data_dir=data_dir)
+            builder = DummyBuilderWithManualDownload(
+                cache_dir=tmp_dir, config_name="a", data_dir=data_dir
+            )
+            other_builder = DummyBuilderWithManualDownload(
+                cache_dir=tmp_dir, config_name="a", data_dir=data_dir
+            )
             self.assertEqual(builder.cache_dir, other_builder.cache_dir)
-            other_builder = DummyBuilderWithManualDownload(cache_dir=tmp_dir, config_name="a", data_dir=tmp_dir)
+            other_builder = DummyBuilderWithManualDownload(
+                cache_dir=tmp_dir, config_name="a", data_dir=tmp_dir
+            )
             self.assertNotEqual(builder.cache_dir, other_builder.cache_dir)
 
     def test_cache_dir_for_configured_builder(self):
@@ -829,7 +1091,9 @@ def test_config_raises_when_invalid_name() -> None:
         _ = BuilderConfig(name="name-with-*-invalid-character")
 
 
-@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+@pytest.mark.parametrize(
+    "data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])]
+)
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = BuilderConfig(name="name", data_files=data_files)
@@ -849,7 +1113,11 @@ def test_arrow_based_download_and_prepare(tmp_path):
     )
     assert builder.info.features, Features({"text": Value("string")})
     assert builder.info.splits["train"].num_examples == 100
-    assert os.path.exists(os.path.join(tmp_path, builder.dataset_name, "default", "0.0.0", "dataset_info.json"))
+    assert os.path.exists(
+        os.path.join(
+            tmp_path, builder.dataset_name, "default", "0.0.0", "dataset_info.json"
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -861,7 +1129,9 @@ def test_arrow_based_download_and_prepare(tmp_path):
     ],
 )
 @pytest.mark.parametrize("in_memory", [False, True])
-def test_builder_as_dataset(split, expected_dataset_class, expected_dataset_length, in_memory, tmp_path):
+def test_builder_as_dataset(
+    split, expected_dataset_class, expected_dataset_length, in_memory, tmp_path
+):
     cache_dir = str(tmp_path)
     builder = DummyBuilder(cache_dir=cache_dir)
     os.makedirs(builder.cache_dir)
@@ -872,13 +1142,19 @@ def test_builder_as_dataset(split, expected_dataset_class, expected_dataset_leng
 
     for info_split in builder.info.splits:
         with ArrowWriter(
-            path=os.path.join(builder.cache_dir, f"{builder.dataset_name}-{info_split}.arrow"),
+            path=os.path.join(
+                builder.cache_dir, f"{builder.dataset_name}-{info_split}.arrow"
+            ),
             features=Features({"text": Value("string")}),
         ) as writer:
             writer.write_batch({"text": ["foo"] * 10})
             writer.finalize()
 
-    with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
+    with (
+        assert_arrow_memory_increases()
+        if in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
         dataset = builder.as_dataset(split=split, in_memory=in_memory)
     assert isinstance(dataset, expected_dataset_class)
     if isinstance(dataset, DatasetDict):
@@ -902,20 +1178,31 @@ def test_generator_based_builder_as_dataset(in_memory, tmp_path):
     cache_dir = str(cache_dir)
     builder = DummyGeneratorBasedBuilder(cache_dir=cache_dir)
     builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
-    with assert_arrow_memory_increases() if in_memory else assert_arrow_memory_doesnt_increase():
+    with (
+        assert_arrow_memory_increases()
+        if in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
         dataset = builder.as_dataset("train", in_memory=in_memory)
     assert dataset.data.to_pydict() == {"text": ["foo"] * 100}
 
 
 @pytest.mark.parametrize(
-    "writer_batch_size, default_writer_batch_size, expected_chunks", [(None, None, 1), (None, 5, 20), (10, None, 10)]
+    "writer_batch_size, default_writer_batch_size, expected_chunks",
+    [(None, None, 1), (None, 5, 20), (10, None, 10)],
 )
-def test_custom_writer_batch_size(tmp_path, writer_batch_size, default_writer_batch_size, expected_chunks):
+def test_custom_writer_batch_size(
+    tmp_path, writer_batch_size, default_writer_batch_size, expected_chunks
+):
     cache_dir = str(tmp_path)
     if default_writer_batch_size:
         DummyGeneratorBasedBuilder.DEFAULT_WRITER_BATCH_SIZE = default_writer_batch_size
-    builder = DummyGeneratorBasedBuilder(cache_dir=cache_dir, writer_batch_size=writer_batch_size)
-    assert builder._writer_batch_size == (writer_batch_size or default_writer_batch_size)
+    builder = DummyGeneratorBasedBuilder(
+        cache_dir=cache_dir, writer_batch_size=writer_batch_size
+    )
+    assert builder._writer_batch_size == (
+        writer_batch_size or default_writer_batch_size
+    )
     builder.download_and_prepare(download_mode=DownloadMode.FORCE_REDOWNLOAD)
     dataset = builder.as_dataset("train")
     assert len(dataset.data[0].chunks) == expected_chunks
@@ -942,7 +1229,9 @@ def _run_test_builder_streaming_works_in_subprocesses(builder):
 
 def test_builder_streaming_works_in_subprocess(tmp_path):
     dummy_builder = DummyGeneratorBasedBuilder(cache_dir=str(tmp_path))
-    p = Process(target=_run_test_builder_streaming_works_in_subprocesses, args=(dummy_builder,))
+    p = Process(
+        target=_run_test_builder_streaming_works_in_subprocesses, args=(dummy_builder,)
+    )
     p.start()
     p.join()
 
@@ -1016,7 +1305,9 @@ def test_builder_download_and_prepare_with_absolute_output_dir(tmp_path):
     builder.download_and_prepare(output_dir)
     assert builder._output_dir.startswith(tmp_path.resolve().as_posix())
     assert os.path.exists(os.path.join(output_dir, "dataset_info.json"))
-    assert os.path.exists(os.path.join(output_dir, f"{builder.dataset_name}-train.arrow"))
+    assert os.path.exists(
+        os.path.join(output_dir, f"{builder.dataset_name}-train.arrow")
+    )
     assert not os.path.exists(os.path.join(output_dir + ".incomplete"))
 
 
@@ -1025,15 +1316,24 @@ def test_builder_download_and_prepare_with_relative_output_dir():
         builder = DummyGeneratorBasedBuilder()
         output_dir = "test-out"
         builder.download_and_prepare(output_dir)
-        assert Path(builder._output_dir).resolve().as_posix().startswith(Path(output_dir).resolve().as_posix())
+        assert (
+            Path(builder._output_dir)
+            .resolve()
+            .as_posix()
+            .startswith(Path(output_dir).resolve().as_posix())
+        )
         assert os.path.exists(os.path.join(output_dir, "dataset_info.json"))
-        assert os.path.exists(os.path.join(output_dir, f"{builder.dataset_name}-train.arrow"))
+        assert os.path.exists(
+            os.path.join(output_dir, f"{builder.dataset_name}-train.arrow")
+        )
         assert not os.path.exists(os.path.join(output_dir + ".incomplete"))
 
 
 def test_builder_with_filesystem_download_and_prepare(tmp_path, mockfs):
     builder = DummyGeneratorBasedBuilder(cache_dir=tmp_path)
-    builder.download_and_prepare("mock://my_dataset", storage_options=mockfs.storage_options)
+    builder.download_and_prepare(
+        "mock://my_dataset", storage_options=mockfs.storage_options
+    )
     assert builder._output_dir.startswith("mock://my_dataset")
     assert is_local_path(builder._cache_downloaded_dir)
     assert isinstance(builder._fs, type(mockfs))
@@ -1046,11 +1346,15 @@ def test_builder_with_filesystem_download_and_prepare(tmp_path, mockfs):
 def test_builder_with_filesystem_download_and_prepare_reload(tmp_path, mockfs, caplog):
     builder = DummyGeneratorBasedBuilder(cache_dir=tmp_path)
     mockfs.makedirs("my_dataset")
-    DatasetInfo().write_to_directory("mock://my_dataset", storage_options=mockfs.storage_options)
+    DatasetInfo().write_to_directory(
+        "mock://my_dataset", storage_options=mockfs.storage_options
+    )
     mockfs.touch(f"my_dataset/{builder.dataset_name}-train.arrow")
     caplog.clear()
     with caplog.at_level(INFO, logger=get_logger().name):
-        builder.download_and_prepare("mock://my_dataset", storage_options=mockfs.storage_options)
+        builder.download_and_prepare(
+            "mock://my_dataset", storage_options=mockfs.storage_options
+        )
     assert "Found cached dataset" in caplog.text
 
 
@@ -1059,7 +1363,11 @@ def test_generator_based_builder_download_and_prepare_as_parquet(tmp_path):
     builder.download_and_prepare(file_format="parquet")
     assert builder.info.splits["train"].num_examples == 100
     parquet_path = os.path.join(
-        tmp_path, builder.dataset_name, "default", "0.0.0", f"{builder.dataset_name}-train.parquet"
+        tmp_path,
+        builder.dataset_name,
+        "default",
+        "0.0.0",
+        f"{builder.dataset_name}-train.parquet",
     )
     assert os.path.exists(parquet_path)
     assert pq.ParquetFile(parquet_path) is not None
@@ -1067,7 +1375,9 @@ def test_generator_based_builder_download_and_prepare_as_parquet(tmp_path):
 
 def test_generator_based_builder_download_and_prepare_sharded(tmp_path):
     writer_batch_size = 25
-    builder = DummyGeneratorBasedBuilder(cache_dir=tmp_path, writer_batch_size=writer_batch_size)
+    builder = DummyGeneratorBasedBuilder(
+        cache_dir=tmp_path, writer_batch_size=writer_batch_size
+    )
     with patch("datasets.config.MAX_SHARD_SIZE", 1):  # one batch per shard
         builder.download_and_prepare(file_format="parquet")
     expected_num_shards = 100 // writer_batch_size
@@ -1092,8 +1402,12 @@ def test_generator_based_builder_download_and_prepare_sharded(tmp_path):
 
 def test_generator_based_builder_download_and_prepare_with_max_shard_size(tmp_path):
     writer_batch_size = 25
-    builder = DummyGeneratorBasedBuilder(cache_dir=tmp_path, writer_batch_size=writer_batch_size)
-    builder.download_and_prepare(file_format="parquet", max_shard_size=1)  # one batch per shard
+    builder = DummyGeneratorBasedBuilder(
+        cache_dir=tmp_path, writer_batch_size=writer_batch_size
+    )
+    builder.download_and_prepare(
+        file_format="parquet", max_shard_size=1
+    )  # one batch per shard
     expected_num_shards = 100 // writer_batch_size
     assert builder.info.splits["train"].num_examples == 100
     parquet_path = os.path.join(
@@ -1137,9 +1451,12 @@ def test_generator_based_builder_download_and_prepare_with_num_proc(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "num_proc, expectation", [(None, does_not_raise()), (1, does_not_raise()), (2, pytest.raises(RuntimeError))]
+    "num_proc, expectation",
+    [(None, does_not_raise()), (1, does_not_raise()), (2, pytest.raises(RuntimeError))],
 )
-def test_generator_based_builder_download_and_prepare_with_ambiguous_shards(num_proc, expectation, tmp_path):
+def test_generator_based_builder_download_and_prepare_with_ambiguous_shards(
+    num_proc, expectation, tmp_path
+):
     builder = DummyGeneratorBasedBuilderWithAmbiguousShards(cache_dir=tmp_path)
     with expectation:
         builder.download_and_prepare(num_proc=num_proc)
@@ -1150,7 +1467,11 @@ def test_arrow_based_builder_download_and_prepare_as_parquet(tmp_path):
     builder.download_and_prepare(file_format="parquet")
     assert builder.info.splits["train"].num_examples == 100
     parquet_path = os.path.join(
-        tmp_path, builder.dataset_name, "default", "0.0.0", f"{builder.dataset_name}-train.parquet"
+        tmp_path,
+        builder.dataset_name,
+        "default",
+        "0.0.0",
+        f"{builder.dataset_name}-train.parquet",
     )
     assert os.path.exists(parquet_path)
     assert pq.ParquetFile(parquet_path) is not None
@@ -1182,7 +1503,9 @@ def test_arrow_based_builder_download_and_prepare_sharded(tmp_path):
 
 def test_arrow_based_builder_download_and_prepare_with_max_shard_size(tmp_path):
     builder = DummyArrowBasedBuilder(cache_dir=tmp_path)
-    builder.download_and_prepare(file_format="parquet", max_shard_size=1)  # one table per shard
+    builder.download_and_prepare(
+        file_format="parquet", max_shard_size=1
+    )  # one table per shard
     expected_num_shards = 10
     assert builder.info.splits["train"].num_examples == 100
     parquet_path = os.path.join(
@@ -1226,9 +1549,12 @@ def test_arrow_based_builder_download_and_prepare_with_num_proc(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "num_proc, expectation", [(None, does_not_raise()), (1, does_not_raise()), (2, pytest.raises(RuntimeError))]
+    "num_proc, expectation",
+    [(None, does_not_raise()), (1, does_not_raise()), (2, pytest.raises(RuntimeError))],
 )
-def test_arrow_based_builder_download_and_prepare_with_ambiguous_shards(num_proc, expectation, tmp_path):
+def test_arrow_based_builder_download_and_prepare_with_ambiguous_shards(
+    num_proc, expectation, tmp_path
+):
     builder = DummyArrowBasedBuilderWithAmbiguousShards(cache_dir=tmp_path)
     with expectation:
         builder.download_and_prepare(num_proc=num_proc)

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -101,10 +101,13 @@ def pattern_results(complex_data_dir):
     return {
         pattern: sorted(
             Path(os.path.abspath(path)).as_posix()
-            for path in fsspec.filesystem("file").glob(os.path.join(complex_data_dir, pattern))
+            for path in fsspec.filesystem("file").glob(
+                os.path.join(complex_data_dir, pattern)
+            )
             if Path(path).name not in _FILES_TO_IGNORE
             and not any(
-                is_relative_to(Path(path), os.path.join(complex_data_dir, dir_path)) for dir_path in _DIRS_TO_IGNORE
+                is_relative_to(Path(path), os.path.join(complex_data_dir, dir_path))
+                for dir_path in _DIRS_TO_IGNORE
             )
             and Path(path).is_file()
         )
@@ -122,7 +125,9 @@ def hub_dataset_repo_path(tmpfs, complex_data_dir):
 
 
 @pytest.fixture
-def hub_dataset_repo_patterns_results(hub_dataset_repo_path, complex_data_dir, pattern_results):
+def hub_dataset_repo_patterns_results(
+    hub_dataset_repo_path, complex_data_dir, pattern_results
+):
     return {
         pattern: [
             hub_dataset_repo_path + Path(path).relative_to(complex_data_dir).as_posix()
@@ -137,7 +142,9 @@ def test_is_inside_unrequested_special_dir(complex_data_dir, pattern_results):
     for pattern, result in pattern_results.items():
         if result:
             matched_rel_path = str(Path(result[0]).relative_to(complex_data_dir))
-            assert _is_inside_unrequested_special_dir(matched_rel_path, pattern) is False
+            assert (
+                _is_inside_unrequested_special_dir(matched_rel_path, pattern) is False
+            )
     # check behavior for special dir
     f = _is_inside_unrequested_special_dir
     assert f("__pycache__/b.txt", "**") is True
@@ -148,12 +155,16 @@ def test_is_inside_unrequested_special_dir(complex_data_dir, pattern_results):
     assert f("__b.txt", "*") is False
 
 
-def test_is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir(complex_data_dir, pattern_results):
+def test_is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir(
+    complex_data_dir, pattern_results
+):
     # usual patterns outside hidden dir work fine
     for pattern, result in pattern_results.items():
         if result:
             matched_rel_path = str(Path(result[0]).relative_to(complex_data_dir))
-            assert _is_inside_unrequested_special_dir(matched_rel_path, pattern) is False
+            assert (
+                _is_inside_unrequested_special_dir(matched_rel_path, pattern) is False
+            )
     # check behavior for hidden dir and file
     f = _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir
     assert f(".hidden_file.txt", "**") is True
@@ -185,7 +196,9 @@ def test_resolve_pattern_locally(complex_data_dir, pattern, pattern_results):
 
 def test_resolve_pattern_locally_with_dot_in_base_path(complex_data_dir):
     base_path_with_dot = os.path.join(complex_data_dir, "data", ".dummy_subdir")
-    resolved_data_files = resolve_pattern(os.path.join(base_path_with_dot, "train.txt"), base_path_with_dot)
+    resolved_data_files = resolve_pattern(
+        os.path.join(base_path_with_dot, "train.txt"), base_path_with_dot
+    )
     assert len(resolved_data_files) == 1
 
 
@@ -196,12 +209,18 @@ def test_resolve_pattern_locally_with_absolute_path(tmp_path, complex_data_dir):
 
 
 def test_resolve_pattern_locally_with_double_dots(tmp_path, complex_data_dir):
-    path_with_double_dots = os.path.join(complex_data_dir, "data", "subdir", "..", "train.txt")
-    resolved_data_files = resolve_pattern(path_with_double_dots, str(tmp_path / "blabla"))
+    path_with_double_dots = os.path.join(
+        complex_data_dir, "data", "subdir", "..", "train.txt"
+    )
+    resolved_data_files = resolve_pattern(
+        path_with_double_dots, str(tmp_path / "blabla")
+    )
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_pattern_locally_returns_hidden_file_only_if_requested(complex_data_dir):
+def test_resolve_pattern_locally_returns_hidden_file_only_if_requested(
+    complex_data_dir,
+):
     with pytest.raises(FileNotFoundError):
         resolve_pattern("*dummy", complex_data_dir)
     resolved_data_files = resolve_pattern(".dummy", complex_data_dir)
@@ -219,16 +238,22 @@ def test_resolve_pattern_locally_hidden_base_path(tmp_path):
 def test_resolve_pattern_locallyreturns_hidden_dir_only_if_requested(complex_data_dir):
     with pytest.raises(FileNotFoundError):
         resolve_pattern("data/*dummy_subdir/train.txt", complex_data_dir)
-    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", complex_data_dir)
+    resolved_data_files = resolve_pattern(
+        "data/.dummy_subdir/train.txt", complex_data_dir
+    )
     assert len(resolved_data_files) == 1
     resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", complex_data_dir)
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_pattern_locally_returns_special_dir_only_if_requested(complex_data_dir):
+def test_resolve_pattern_locally_returns_special_dir_only_if_requested(
+    complex_data_dir,
+):
     with pytest.raises(FileNotFoundError):
         resolve_pattern("data/*dummy_subdir/train.txt", complex_data_dir)
-    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", complex_data_dir)
+    resolved_data_files = resolve_pattern(
+        "data/.dummy_subdir/train.txt", complex_data_dir
+    )
     assert len(resolved_data_files) == 1
     resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", complex_data_dir)
     assert len(resolved_data_files) == 1
@@ -242,10 +267,17 @@ def test_resolve_pattern_locally_special_base_path(tmp_path):
     assert len(resolved_data_files) == 1
 
 
-@pytest.mark.parametrize("pattern,size,extensions", [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])])
-def test_resolve_pattern_locally_with_extensions(complex_data_dir, pattern, size, extensions):
+@pytest.mark.parametrize(
+    "pattern,size,extensions",
+    [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])],
+)
+def test_resolve_pattern_locally_with_extensions(
+    complex_data_dir, pattern, size, extensions
+):
     if size > 0:
-        resolved_data_files = resolve_pattern(pattern, complex_data_dir, allowed_extensions=extensions)
+        resolved_data_files = resolve_pattern(
+            pattern, complex_data_dir, allowed_extensions=extensions
+        )
         assert len(resolved_data_files) == size
     else:
         with pytest.raises(FileNotFoundError):
@@ -257,9 +289,15 @@ def test_fail_resolve_pattern_locally(complex_data_dir):
         resolve_pattern(complex_data_dir, ["blablabla"])
 
 
-@pytest.mark.skipif(os.name == "nt", reason="Windows does not support symlinks in the default mode")
-def test_resolve_pattern_locally_does_not_resolve_symbolic_links(tmp_path, complex_data_dir):
-    (tmp_path / "train_data_symlink.txt").symlink_to(os.path.join(complex_data_dir, "data", "train.txt"))
+@pytest.mark.skipif(
+    os.name == "nt", reason="Windows does not support symlinks in the default mode"
+)
+def test_resolve_pattern_locally_does_not_resolve_symbolic_links(
+    tmp_path, complex_data_dir
+):
+    (tmp_path / "train_data_symlink.txt").symlink_to(
+        os.path.join(complex_data_dir, "data", "train.txt")
+    )
     resolved_data_files = resolve_pattern("train_data_symlink.txt", str(tmp_path))
     assert len(resolved_data_files) == 1
     assert Path(resolved_data_files[0]) == tmp_path / "train_data_symlink.txt"
@@ -277,18 +315,31 @@ def test_resolve_pattern_locally_sorted_files(tmp_path_factory):
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_resolve_pattern_in_dataset_repository(hub_dataset_repo_path, pattern, hub_dataset_repo_patterns_results):
+def test_resolve_pattern_in_dataset_repository(
+    hub_dataset_repo_path, pattern, hub_dataset_repo_patterns_results
+):
     try:
         resolved_data_files = resolve_pattern(pattern, hub_dataset_repo_path)
-        assert sorted(str(f) for f in resolved_data_files) == hub_dataset_repo_patterns_results[pattern]
+        assert (
+            sorted(str(f) for f in resolved_data_files)
+            == hub_dataset_repo_patterns_results[pattern]
+        )
     except FileNotFoundError:
         assert len(hub_dataset_repo_patterns_results[pattern]) == 0
 
 
 @pytest.mark.parametrize(
-    "pattern,size,base_path", [("**", 4, None), ("**", 4, "data"), ("**", 2, "data/subdir"), ("**", 0, "data/subdir2")]
+    "pattern,size,base_path",
+    [
+        ("**", 4, None),
+        ("**", 4, "data"),
+        ("**", 2, "data/subdir"),
+        ("**", 0, "data/subdir2"),
+    ],
 )
-def test_resolve_pattern_in_dataset_repository_with_base_path(hub_dataset_repo_path, pattern, size, base_path):
+def test_resolve_pattern_in_dataset_repository_with_base_path(
+    hub_dataset_repo_path, pattern, size, base_path
+):
     base_path = hub_dataset_repo_path + (base_path or "")
     if size > 0:
         resolved_data_files = resolve_pattern(pattern, base_path)
@@ -298,14 +349,23 @@ def test_resolve_pattern_in_dataset_repository_with_base_path(hub_dataset_repo_p
             resolve_pattern(pattern, base_path)
 
 
-@pytest.mark.parametrize("pattern,size,extensions", [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])])
-def test_resolve_pattern_in_dataset_repository_with_extensions(hub_dataset_repo_path, pattern, size, extensions):
+@pytest.mark.parametrize(
+    "pattern,size,extensions",
+    [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])],
+)
+def test_resolve_pattern_in_dataset_repository_with_extensions(
+    hub_dataset_repo_path, pattern, size, extensions
+):
     if size > 0:
-        resolved_data_files = resolve_pattern(pattern, hub_dataset_repo_path, allowed_extensions=extensions)
+        resolved_data_files = resolve_pattern(
+            pattern, hub_dataset_repo_path, allowed_extensions=extensions
+        )
         assert len(resolved_data_files) == size
     else:
         with pytest.raises(FileNotFoundError):
-            resolved_data_files = resolve_pattern(pattern, hub_dataset_repo_path, allowed_extensions=extensions)
+            resolved_data_files = resolve_pattern(
+                pattern, hub_dataset_repo_path, allowed_extensions=extensions
+            )
 
 
 def test_fail_resolve_pattern_in_dataset_repository(hub_dataset_repo_path):
@@ -313,7 +373,9 @@ def test_fail_resolve_pattern_in_dataset_repository(hub_dataset_repo_path):
         resolve_pattern("blablabla", hub_dataset_repo_path)
 
 
-def test_resolve_pattern_in_dataset_repository_returns_hidden_file_only_if_requested(hub_dataset_repo_path):
+def test_resolve_pattern_in_dataset_repository_returns_hidden_file_only_if_requested(
+    hub_dataset_repo_path,
+):
     with pytest.raises(FileNotFoundError):
         resolve_pattern("*dummy", hub_dataset_repo_path)
     resolved_data_files = resolve_pattern(".dummy", hub_dataset_repo_path)
@@ -326,21 +388,33 @@ def test_resolve_pattern_in_dataset_repository_hidden_base_path(tmpfs):
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_pattern_in_dataset_repository_returns_hidden_dir_only_if_requested(hub_dataset_repo_path):
+def test_resolve_pattern_in_dataset_repository_returns_hidden_dir_only_if_requested(
+    hub_dataset_repo_path,
+):
     with pytest.raises(FileNotFoundError):
         resolve_pattern("data/*dummy_subdir/train.txt", hub_dataset_repo_path)
-    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern(
+        "data/.dummy_subdir/train.txt", hub_dataset_repo_path
+    )
     assert len(resolved_data_files) == 1
-    resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern(
+        "*/.dummy_subdir/train.txt", hub_dataset_repo_path
+    )
     assert len(resolved_data_files) == 1
 
 
-def test_resolve_pattern_in_dataset_repository_returns_special_dir_only_if_requested(hub_dataset_repo_path):
+def test_resolve_pattern_in_dataset_repository_returns_special_dir_only_if_requested(
+    hub_dataset_repo_path,
+):
     with pytest.raises(FileNotFoundError):
         resolve_pattern("data/*dummy_subdir/train.txt", hub_dataset_repo_path)
-    resolved_data_files = resolve_pattern("data/.dummy_subdir/train.txt", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern(
+        "data/.dummy_subdir/train.txt", hub_dataset_repo_path
+    )
     assert len(resolved_data_files) == 1
-    resolved_data_files = resolve_pattern("*/.dummy_subdir/train.txt", hub_dataset_repo_path)
+    resolved_data_files = resolve_pattern(
+        "*/.dummy_subdir/train.txt", hub_dataset_repo_path
+    )
     assert len(resolved_data_files) == 1
 
 
@@ -377,8 +451,12 @@ def test_DataFilesList_from_patterns_in_dataset_repository_(
         assert len(hub_dataset_repo_patterns_results[pattern]) == 0
 
 
-def test_DataFilesList_from_patterns_locally_with_extra_files(complex_data_dir, text_file):
-    data_files_list = DataFilesList.from_patterns([_TEST_URL, text_file.as_posix()], complex_data_dir)
+def test_DataFilesList_from_patterns_locally_with_extra_files(
+    complex_data_dir, text_file
+):
+    data_files_list = DataFilesList.from_patterns(
+        [_TEST_URL, text_file.as_posix()], complex_data_dir
+    )
     assert list(data_files_list) == [_TEST_URL, text_file.as_posix()]
     assert len(data_files_list.origin_metadata) == 2
 
@@ -392,7 +470,9 @@ class TestDataFilesDict:
     def test_key_order_after_copy(self):
         data_files = DataFilesDict({"train": "train.csv", "test": "test.csv"})
         copied_data_files = copy.deepcopy(data_files)
-        assert list(copied_data_files.keys()) == list(data_files.keys())  # test split order with list()
+        assert list(copied_data_files.keys()) == list(
+            data_files.keys()
+        )  # test split order with list()
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
@@ -401,9 +481,16 @@ def test_DataFilesDict_from_patterns_in_dataset_repository(
 ):
     split_name = "train"
     try:
-        data_files = DataFilesDict.from_patterns({split_name: [pattern]}, hub_dataset_repo_path)
-        assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
-        assert sorted(data_files[split_name]) == hub_dataset_repo_patterns_results[pattern]
+        data_files = DataFilesDict.from_patterns(
+            {split_name: [pattern]}, hub_dataset_repo_path
+        )
+        assert all(
+            isinstance(data_files_list, DataFilesList)
+            for data_files_list in data_files.values()
+        )
+        assert (
+            sorted(data_files[split_name]) == hub_dataset_repo_patterns_results[pattern]
+        )
     except FileNotFoundError:
         assert len(hub_dataset_repo_patterns_results[pattern]) == 0
 
@@ -422,7 +509,9 @@ def test_DataFilesDict_from_patterns_in_dataset_repository_with_base_path(
 ):
     base_path = hub_dataset_repo_path + (base_path or "")
     if size > 0:
-        data_files = DataFilesDict.from_patterns({split_name: [pattern]}, base_path=base_path)
+        data_files = DataFilesDict.from_patterns(
+            {split_name: [pattern]}, base_path=base_path
+        )
         assert len(data_files[split_name]) == size
     else:
         with pytest.raises(FileNotFoundError):
@@ -430,17 +519,26 @@ def test_DataFilesDict_from_patterns_in_dataset_repository_with_base_path(
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)
-def test_DataFilesDict_from_patterns_locally(complex_data_dir, pattern_results, pattern):
+def test_DataFilesDict_from_patterns_locally(
+    complex_data_dir, pattern_results, pattern
+):
     split_name = "train"
     try:
-        data_files = DataFilesDict.from_patterns({split_name: [pattern]}, complex_data_dir)
-        assert all(isinstance(data_files_list, DataFilesList) for data_files_list in data_files.values())
+        data_files = DataFilesDict.from_patterns(
+            {split_name: [pattern]}, complex_data_dir
+        )
+        assert all(
+            isinstance(data_files_list, DataFilesList)
+            for data_files_list in data_files.values()
+        )
         assert sorted(data_files[split_name]) == pattern_results[pattern]
     except FileNotFoundError:
         assert len(pattern_results[pattern]) == 0
 
 
-def test_DataFilesDict_from_patterns_in_dataset_repository_hashing(hub_dataset_repo_path):
+def test_DataFilesDict_from_patterns_in_dataset_repository_hashing(
+    hub_dataset_repo_path,
+):
     patterns = {"train": ["**/train.txt"], "test": ["**/test.txt"]}
     data_files1 = DataFilesDict.from_patterns(patterns, hub_dataset_repo_path)
     data_files2 = DataFilesDict.from_patterns(patterns, hub_dataset_repo_path)
@@ -479,22 +577,32 @@ def test_DataFilesDict_from_patterns_locally_or_remote_hashing(text_file):
 
 
 def test_DataFilesPatternsList(text_file):
-    data_files_patterns = DataFilesPatternsList([str(text_file)], allowed_extensions=[None])
+    data_files_patterns = DataFilesPatternsList(
+        [str(text_file)], allowed_extensions=[None]
+    )
     data_files = data_files_patterns.resolve(base_path="")
     assert data_files == [text_file.as_posix()]
     assert isinstance(data_files, DataFilesList)
-    data_files_patterns = DataFilesPatternsList([str(text_file)], allowed_extensions=[[".txt"]])
+    data_files_patterns = DataFilesPatternsList(
+        [str(text_file)], allowed_extensions=[[".txt"]]
+    )
     data_files = data_files_patterns.resolve(base_path="")
     assert data_files == [text_file.as_posix()]
     assert isinstance(data_files, DataFilesList)
-    data_files_patterns = DataFilesPatternsList([str(text_file).replace(".txt", ".tx*")], allowed_extensions=[None])
+    data_files_patterns = DataFilesPatternsList(
+        [str(text_file).replace(".txt", ".tx*")], allowed_extensions=[None]
+    )
     data_files = data_files_patterns.resolve(base_path="")
     assert data_files == [text_file.as_posix()]
     assert isinstance(data_files, DataFilesList)
-    data_files_patterns = DataFilesPatternsList([Path(text_file).name], allowed_extensions=[None])
+    data_files_patterns = DataFilesPatternsList(
+        [Path(text_file).name], allowed_extensions=[None]
+    )
     data_files = data_files_patterns.resolve(base_path=str(Path(text_file).parent))
     assert data_files == [text_file.as_posix()]
-    data_files_patterns = DataFilesPatternsList([str(text_file)], allowed_extensions=[[".zip"]])
+    data_files_patterns = DataFilesPatternsList(
+        [str(text_file)], allowed_extensions=[[".zip"]]
+    )
     with pytest.raises(FileNotFoundError):
         data_files_patterns.resolve(base_path="")
 
@@ -526,11 +634,13 @@ def mock_fs(file_paths: List[str]):
     """
     file_paths = [file_path.split("://")[-1] for file_path in file_paths]
     dir_paths = {
-        "/".join(file_path.split("/")[: i + 1]) for file_path in file_paths for i in range(file_path.count("/"))
+        "/".join(file_path.split("/")[: i + 1])
+        for file_path in file_paths
+        for i in range(file_path.count("/"))
     }
-    fs_contents = [{"name": dir_path, "type": "directory"} for dir_path in dir_paths] + [
-        {"name": file_path, "type": "file", "size": 10} for file_path in file_paths
-    ]
+    fs_contents = [
+        {"name": dir_path, "type": "directory"} for dir_path in dir_paths
+    ] + [{"name": file_path, "type": "file", "size": 10} for file_path in file_paths]
 
     class DummyTestFS(AbstractFileSystem):
         protocol = ("mock", "dummy")
@@ -542,7 +652,11 @@ def mock_fs(file_paths: List[str]):
 
             files = not refresh and self._ls_from_cache(path)
             if not files:
-                files = [file for file in self._fs_contents if path == self._parent(file["name"])]
+                files = [
+                    file
+                    for file in self._fs_contents
+                    if path == self._parent(file["name"])
+                ]
                 files.sort(key=lambda file: file["name"])
                 self.dircache[path.rstrip("/")] = files
 
@@ -622,7 +736,11 @@ def mock_fs(file_paths: List[str]):
         {"validation": "val.txt"},
         {"validation": "data/val.txt"},
         # With other extensions
-        {"train": "train.parquet", "validation": "valid.parquet", "test": "test.parquet"},
+        {
+            "train": "train.parquet",
+            "validation": "valid.parquet",
+            "test": "test.parquet",
+        },
         # With "dev" or "eval" without separators
         {"train": "developers_list.txt"},
         {"train": "data/seqeval_results.txt"},
@@ -639,7 +757,9 @@ def mock_fs(file_paths: List[str]):
     ],
 )
 def test_get_data_files_patterns(base_path, data_file_per_split):
-    data_file_per_split = {k: v if isinstance(v, list) else [v] for k, v in data_file_per_split.items()}
+    data_file_per_split = {
+        k: v if isinstance(v, list) else [v] for k, v in data_file_per_split.items()
+    }
     data_file_per_split = {
         split: [
             base_path + ("/" if base_path and base_path[-1] != "/" else "") + file_path
@@ -652,7 +772,9 @@ def test_get_data_files_patterns(base_path, data_file_per_split):
     fs = DummyTestFS()
 
     def resolver(pattern):
-        pattern = base_path + ("/" if base_path and base_path[-1] != "/" else "") + pattern
+        pattern = (
+            base_path + ("/" if base_path and base_path[-1] != "/" else "") + pattern
+        )
         return [
             file_path[len(fs._strip_protocol(base_path)) :].lstrip("/")
             for file_path in fs.glob(pattern)
@@ -660,21 +782,31 @@ def test_get_data_files_patterns(base_path, data_file_per_split):
         ]
 
     patterns_per_split = _get_data_files_patterns(resolver)
-    assert list(patterns_per_split.keys()) == list(data_file_per_split.keys())  # Test split order with list()
+    assert list(patterns_per_split.keys()) == list(
+        data_file_per_split.keys()
+    )  # Test split order with list()
     for split, patterns in patterns_per_split.items():
         matched = [file_path for pattern in patterns for file_path in resolver(pattern)]
         expected = [
-            fs._strip_protocol(file_path)[len(fs._strip_protocol(base_path)) :].lstrip("/")
+            fs._strip_protocol(file_path)[len(fs._strip_protocol(base_path)) :].lstrip(
+                "/"
+            )
             for file_path in data_file_per_split[split]
         ]
         assert matched == expected
 
 
 def test_get_data_patterns_from_directory_with_the_word_data_twice(tmp_path):
-    repo_dir = tmp_path / "directory-name-ending-with-the-word-data"  # parent directory contains the word "data/"
+    repo_dir = (
+        tmp_path / "directory-name-ending-with-the-word-data"
+    )  # parent directory contains the word "data/"
     data_dir = repo_dir / "data"
     data_dir.mkdir(parents=True)
     data_file = data_dir / "train-00001-of-00009.parquet"
     data_file.touch()
     data_file_patterns = get_data_patterns(repo_dir.as_posix())
-    assert data_file_patterns == {"train": ["data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"]}
+    assert data_file_patterns == {
+        "train": [
+            "data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"
+        ]
+    }

--- a/tests/test_dataset_list.py
+++ b/tests/test_dataset_list.py
@@ -27,16 +27,22 @@ class DatasetListTest(TestCase):
     def test_list_dict_equivalent(self):
         example_records = self._create_example_records()
         dset = Dataset.from_list(example_records)
-        dset_from_dict = Dataset.from_dict({k: [r[k] for r in example_records] for k in example_records[0]})
+        dset_from_dict = Dataset.from_dict(
+            {k: [r[k] for r in example_records] for k in example_records[0]}
+        )
         self.assertEqual(dset.info, dset_from_dict.info)
 
     def test_uneven_records(self):  # checks what happens with missing columns
         uneven_records = [{"col_1": 1}, {"col_2": "x"}]
         dset = Dataset.from_list(uneven_records)
         self.assertDictEqual(dset[0], {"col_1": 1})
-        self.assertDictEqual(dset[1], {"col_1": None})  # NB: first record is used for columns
+        self.assertDictEqual(
+            dset[1], {"col_1": None}
+        )  # NB: first record is used for columns
 
-    def test_variable_list_records(self):  # checks if the type can be inferred from the second record
+    def test_variable_list_records(
+        self,
+    ):  # checks if the type can be inferred from the second record
         list_records = [{"col_1": []}, {"col_1": [1, 2]}]
         dset = Dataset.from_list(list_records)
         self.assertEqual(dset.info.features["col_1"], List(Value("int64")))

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -15,7 +15,8 @@ def test_split_dataset_by_node_map_style():
     full_size = len(full_ds)
     world_size = 3
     datasets_per_rank = [
-        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size)
+        for rank in range(world_size)
     ]
     assert sum(len(ds) for ds in datasets_per_rank) == full_size
     assert len({tuple(x.values()) for ds in datasets_per_rank for x in ds}) == full_size
@@ -29,7 +30,8 @@ def test_split_dataset_by_node_iterable():
     full_ds = IterableDataset.from_generator(gen)
     full_size = len(list(full_ds))
     datasets_per_rank = [
-        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size)
+        for rank in range(world_size)
     ]
     assert sum(len(list(ds)) for ds in datasets_per_rank) == full_size
     assert len({tuple(x.values()) for ds in datasets_per_rank for x in ds}) == full_size
@@ -43,12 +45,15 @@ def test_split_dataset_by_node_iterable_sharded(shards_per_node):
 
     world_size = 3
     num_shards = shards_per_node * world_size
-    gen_kwargs = {"shards": [f"shard_{shard_idx}.txt" for shard_idx in range(num_shards)]}
+    gen_kwargs = {
+        "shards": [f"shard_{shard_idx}.txt" for shard_idx in range(num_shards)]
+    }
     full_ds = IterableDataset.from_generator(gen, gen_kwargs=gen_kwargs)
     full_size = len(list(full_ds))
     assert full_ds.num_shards == world_size * shards_per_node
     datasets_per_rank = [
-        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size)
+        for rank in range(world_size)
     ]
     assert [ds.num_shards for ds in datasets_per_rank] == [shards_per_node] * world_size
     assert sum(len(list(ds)) for ds in datasets_per_rank) == full_size
@@ -64,7 +69,8 @@ def test_split_dataset_by_node_iterable_distributed():
     full_ds = IterableDataset.from_generator(gen)
     full_size = len(list(full_ds))
     datasets_per_rank = [
-        split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size)
+        for rank in range(world_size)
     ]
     datasets_per_rank_per_worker = [
         split_dataset_by_node(ds, rank=worker, world_size=num_workers)
@@ -72,7 +78,10 @@ def test_split_dataset_by_node_iterable_distributed():
         for worker in range(num_workers)
     ]
     assert sum(len(list(ds)) for ds in datasets_per_rank_per_worker) == full_size
-    assert len({tuple(x.values()) for ds in datasets_per_rank_per_worker for x in ds}) == full_size
+    assert (
+        len({tuple(x.values()) for ds in datasets_per_rank_per_worker for x in ds})
+        == full_size
+    )
 
 
 def test_distributed_shuffle_iterable():
@@ -83,12 +92,16 @@ def test_distributed_shuffle_iterable():
     full_ds = IterableDataset.from_generator(gen)
     full_size = len(list(full_ds))
 
-    ds_rank0 = split_dataset_by_node(full_ds, rank=0, world_size=world_size).shuffle(seed=42)
+    ds_rank0 = split_dataset_by_node(full_ds, rank=0, world_size=world_size).shuffle(
+        seed=42
+    )
     assert len(list(ds_rank0)) == 1 + full_size // world_size
     with pytest.raises(RuntimeError):
         split_dataset_by_node(full_ds, rank=0, world_size=world_size).shuffle()
 
-    ds_rank0 = split_dataset_by_node(full_ds.shuffle(seed=42), rank=0, world_size=world_size)
+    ds_rank0 = split_dataset_by_node(
+        full_ds.shuffle(seed=42), rank=0, world_size=world_size
+    )
     assert len(list(ds_rank0)) == 1 + full_size // world_size
     with pytest.raises(RuntimeError):
         split_dataset_by_node(full_ds.shuffle(), rank=0, world_size=world_size)
@@ -96,12 +109,18 @@ def test_distributed_shuffle_iterable():
 
 @pytest.mark.parametrize("streaming", [False, True])
 @require_torch
-@pytest.mark.skipif(os.name == "nt", reason="execute_subprocess_async doesn't support windows")
+@pytest.mark.skipif(
+    os.name == "nt", reason="execute_subprocess_async doesn't support windows"
+)
 @pytest.mark.integration
 def test_torch_distributed_run(streaming):
     nproc_per_node = 2
     master_port = get_torch_dist_unique_port()
-    test_script = Path(__file__).resolve().parent / "distributed_scripts" / "run_torch_distributed.py"
+    test_script = (
+        Path(__file__).resolve().parent
+        / "distributed_scripts"
+        / "run_torch_distributed.py"
+    )
     distributed_args = f"""
         -m torch.distributed.run
         --nproc_per_node={nproc_per_node}
@@ -119,16 +138,25 @@ def test_torch_distributed_run(streaming):
     "nproc_per_node, num_workers",
     [
         (2, 2),  # each node has 2 shards and each worker has 1 shards
-        (3, 2),  # each node uses all the shards but skips examples, and each worker has 2 shards
+        (
+            3,
+            2,
+        ),  # each node uses all the shards but skips examples, and each worker has 2 shards
     ],
 )
 @require_torch
-@pytest.mark.skipif(os.name == "nt", reason="execute_subprocess_async doesn't support windows")
+@pytest.mark.skipif(
+    os.name == "nt", reason="execute_subprocess_async doesn't support windows"
+)
 @pytest.mark.integration
 def test_torch_distributed_run_streaming_with_num_workers(nproc_per_node, num_workers):
     streaming = True
     master_port = get_torch_dist_unique_port()
-    test_script = Path(__file__).resolve().parent / "distributed_scripts" / "run_torch_distributed.py"
+    test_script = (
+        Path(__file__).resolve().parent
+        / "distributed_scripts"
+        / "run_torch_distributed.py"
+    )
     distributed_args = f"""
         -m torch.distributed.run
         --nproc_per_node={nproc_per_node}

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -34,7 +34,12 @@ def test_download_manager_download(urls_type, tmp_path, tmpfs):
     url = URL
     with tmpfs.open(url, "w") as f:
         f.write(CONTENT)
-    urls_types = {"str": url, "list": [url], "dict": {"train": url}, "dict_of_dict": {"train": {"en": url}}}
+    urls_types = {
+        "str": url,
+        "list": [url],
+        "dict": {"train": url},
+        "dict_of_dict": {"train": {"en": url}},
+    }
     urls = urls_types[urls_type]
     dataset_name = "dummy"
     cache_subdir = "downloads"
@@ -43,7 +48,9 @@ def test_download_manager_download(urls_type, tmp_path, tmpfs):
         cache_dir=os.path.join(cache_dir_root, cache_subdir),
         use_etag=False,
     )
-    dl_manager = DownloadManager(dataset_name=dataset_name, download_config=download_config)
+    dl_manager = DownloadManager(
+        dataset_name=dataset_name, download_config=download_config
+    )
     downloaded_paths = dl_manager.download(urls)
     assert isinstance(downloaded_paths, type(urls))
     if "urls_type".startswith("list"):
@@ -55,7 +62,8 @@ def test_download_manager_download(urls_type, tmp_path, tmpfs):
             assert isinstance(downloaded_paths[key], dict)
             assert downloaded_paths[key].keys() == urls[key].keys()
     for downloaded_path, url in zip(
-        NestedDataStructure(downloaded_paths).flatten(), NestedDataStructure(urls).flatten()
+        NestedDataStructure(downloaded_paths).flatten(),
+        NestedDataStructure(urls).flatten(),
     ):
         downloaded_path = Path(downloaded_path)
         parts = downloaded_path.parts
@@ -88,7 +96,9 @@ def test_download_manager_extract(paths_type, xz_file, text_file, extract_on_the
         use_etag=False,
         extract_on_the_fly=extract_on_the_fly,
     )
-    dl_manager = DownloadManager(dataset_name=dataset_name, download_config=download_config)
+    dl_manager = DownloadManager(
+        dataset_name=dataset_name, download_config=download_config
+    )
     extracted_paths = dl_manager.extract(paths)
     input_paths = paths
     for extracted_paths in [extracted_paths]:
@@ -126,7 +136,9 @@ def test_download_manager_delete_extracted_files(xz_file):
         cache_dir=cache_dir,
         use_etag=False,
     )
-    dl_manager = DownloadManager(dataset_name=dataset_name, download_config=download_config)
+    dl_manager = DownloadManager(
+        dataset_name=dataset_name, download_config=download_config
+    )
     extracted_path = dl_manager.extract(xz_file)
     assert extracted_path == dl_manager.extracted_paths[xz_file]
     extracted_path = Path(extracted_path)
@@ -151,17 +163,25 @@ def _test_jsonl(path, file):
 def test_iter_archive_path(archive_jsonl, request):
     archive_jsonl_path = request.getfixturevalue(archive_jsonl)
     dl_manager = DownloadManager()
-    for num_jsonl, (path, file) in enumerate(dl_manager.iter_archive(archive_jsonl_path), start=1):
+    for num_jsonl, (path, file) in enumerate(
+        dl_manager.iter_archive(archive_jsonl_path), start=1
+    ):
         _test_jsonl(path, file)
     assert num_jsonl == 2
 
 
-@pytest.mark.parametrize("archive_nested_jsonl", ["tar_nested_jsonl_path", "zip_nested_jsonl_path"])
+@pytest.mark.parametrize(
+    "archive_nested_jsonl", ["tar_nested_jsonl_path", "zip_nested_jsonl_path"]
+)
 def test_iter_archive_file(archive_nested_jsonl, request):
     archive_nested_jsonl_path = request.getfixturevalue(archive_nested_jsonl)
     dl_manager = DownloadManager()
-    for num_tar, (path, file) in enumerate(dl_manager.iter_archive(archive_nested_jsonl_path), start=1):
-        for num_jsonl, (subpath, subfile) in enumerate(dl_manager.iter_archive(file), start=1):
+    for num_tar, (path, file) in enumerate(
+        dl_manager.iter_archive(archive_nested_jsonl_path), start=1
+    ):
+        for num_jsonl, (subpath, subfile) in enumerate(
+            dl_manager.iter_archive(file), start=1
+        ):
             _test_jsonl(subpath, subfile)
     assert num_tar == 1
     assert num_jsonl == 2
@@ -169,6 +189,8 @@ def test_iter_archive_file(archive_nested_jsonl, request):
 
 def test_iter_files(data_dir_with_hidden_files):
     dl_manager = DownloadManager()
-    for num_file, file in enumerate(dl_manager.iter_files(data_dir_with_hidden_files), start=1):
+    for num_file, file in enumerate(
+        dl_manager.iter_files(data_dir_with_hidden_files), start=1
+    ):
         assert os.path.basename(file) == ("test.txt" if num_file == 1 else "train.txt")
     assert num_file == 2

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -29,7 +29,9 @@ from datasets.exceptions import (
     ],
 )
 def test_error_not_deprecated(error, monkeypatch):
-    monkeypatch.setattr(datasets.utils.deprecation_utils, "_emitted_deprecation_warnings", set())
+    monkeypatch.setattr(
+        datasets.utils.deprecation_utils, "_emitted_deprecation_warnings", set()
+    )
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         error()

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -162,7 +162,9 @@ def tar_file_with_sym_link(tmp_path):
     path = directory / "tar_file_with_sym_link.tar"
     os.symlink("..", directory / "subdir", target_is_directory=True)
     with tarfile.TarFile(path, "w") as f:
-        f.add(str(directory / "subdir"), arcname="subdir")  # str required by os.readlink on Windows and Python < 3.8
+        f.add(
+            str(directory / "subdir"), arcname="subdir"
+        )  # str required by os.readlink on Windows and Python < 3.8
     return path
 
 
@@ -171,7 +173,12 @@ def tar_file_with_sym_link(tmp_path):
     [("tar_file_with_dot_dot", "illegal path"), ("tar_file_with_sym_link", "Symlink")],
 )
 def test_tar_extract_insecure_files(
-    insecure_tar_file, error_log, tar_file_with_dot_dot, tar_file_with_sym_link, tmp_path, caplog
+    insecure_tar_file,
+    error_log,
+    tar_file_with_dot_dot,
+    tar_file_with_sym_link,
+    tmp_path,
+    caplog,
 ):
     insecure_tar_files = {
         "tar_file_with_dot_dot": tar_file_with_dot_dot,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -48,9 +48,15 @@ TEST_URL = "https://huggingface.co/datasets/hf-internal-testing/dataset_with_dat
 TEST_URL_CONTENT = "foo\n" * 10
 
 TEST_GG_DRIVE_FILENAME = "train.tsv"
-TEST_GG_DRIVE_URL = "https://drive.google.com/uc?export=download&id=17bOgBDc3hRCoPZ89EYtKDzK-yXAWat94"
-TEST_GG_DRIVE_GZIPPED_URL = "https://drive.google.com/uc?export=download&id=1Bt4Garpf0QLiwkJhHJzXaVa0I0H5Qhwz"
-TEST_GG_DRIVE_ZIPPED_URL = "https://drive.google.com/uc?export=download&id=1k92sUfpHxKq8PXWRr7Y5aNHXwOCNUmqh"
+TEST_GG_DRIVE_URL = (
+    "https://drive.google.com/uc?export=download&id=17bOgBDc3hRCoPZ89EYtKDzK-yXAWat94"
+)
+TEST_GG_DRIVE_GZIPPED_URL = (
+    "https://drive.google.com/uc?export=download&id=1Bt4Garpf0QLiwkJhHJzXaVa0I0H5Qhwz"
+)
+TEST_GG_DRIVE_ZIPPED_URL = (
+    "https://drive.google.com/uc?export=download&id=1k92sUfpHxKq8PXWRr7Y5aNHXwOCNUmqh"
+)
 TEST_GG_DRIVE_CONTENT = """\
 pokemon_name, type
 Charmander, fire
@@ -75,7 +81,9 @@ def tmpfs_file(tmpfs):
 
 
 @pytest.mark.parametrize("compression_format", ["gzip", "xz", "zstd"])
-def test_cached_path_extract(compression_format, gz_file, xz_file, zstd_path, tmp_path, text_file):
+def test_cached_path_extract(
+    compression_format, gz_file, xz_file, zstd_path, tmp_path, text_file
+):
     input_paths = {"gzip": gz_file, "xz": xz_file, "zstd": zstd_path}
     input_path = input_paths[compression_format]
     cache_dir = tmp_path / "cache"
@@ -90,22 +98,34 @@ def test_cached_path_extract(compression_format, gz_file, xz_file, zstd_path, tm
 
 @pytest.mark.parametrize("default_extracted", [True, False])
 @pytest.mark.parametrize("default_cache_dir", [True, False])
-def test_extracted_datasets_path(default_extracted, default_cache_dir, xz_file, tmp_path, monkeypatch):
+def test_extracted_datasets_path(
+    default_extracted, default_cache_dir, xz_file, tmp_path, monkeypatch
+):
     custom_cache_dir = "custom_cache"
     custom_extracted_dir = "custom_extracted_dir"
     custom_extracted_path = tmp_path / "custom_extracted_path"
     if default_extracted:
         expected = ("downloads" if default_cache_dir else custom_cache_dir, "extracted")
     else:
-        monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_DIR", custom_extracted_dir)
-        monkeypatch.setattr("datasets.config.EXTRACTED_DATASETS_PATH", str(custom_extracted_path))
-        expected = custom_extracted_path.parts[-2:] if default_cache_dir else (custom_cache_dir, custom_extracted_dir)
+        monkeypatch.setattr(
+            "datasets.config.EXTRACTED_DATASETS_DIR", custom_extracted_dir
+        )
+        monkeypatch.setattr(
+            "datasets.config.EXTRACTED_DATASETS_PATH", str(custom_extracted_path)
+        )
+        expected = (
+            custom_extracted_path.parts[-2:]
+            if default_cache_dir
+            else (custom_cache_dir, custom_extracted_dir)
+        )
 
     filename = xz_file
     download_config = (
         DownloadConfig(extract_compressed_file=True)
         if default_cache_dir
-        else DownloadConfig(cache_dir=tmp_path / custom_cache_dir, extract_compressed_file=True)
+        else DownloadConfig(
+            cache_dir=tmp_path / custom_cache_dir, extract_compressed_file=True
+        )
     )
     extracted_file_path = cached_path(filename, download_config=download_config)
     assert Path(extracted_file_path).parent.parts[-2:] == expected
@@ -172,9 +192,17 @@ def test_fsspec_offline(tmp_path_factory):
         ),
         (
             "https://huggingface.co/datasets/hf-internal-testing/dataset_with_data_files/resolve/main/data/train.txt",
-            DownloadConfig(token="MY-TOKEN", storage_options={"hf": {"on_error": "omit"}}),
+            DownloadConfig(
+                token="MY-TOKEN", storage_options={"hf": {"on_error": "omit"}}
+            ),
             "hf://datasets/hf-internal-testing/dataset_with_data_files@main/data/train.txt",
-            {"hf": {"endpoint": "https://huggingface.co", "token": "MY-TOKEN", "on_error": "omit"}},
+            {
+                "hf": {
+                    "endpoint": "https://huggingface.co",
+                    "token": "MY-TOKEN",
+                    "on_error": "omit",
+                }
+            },
         ),
         (
             "https://domain.org/data.txt",
@@ -190,13 +218,17 @@ def test_fsspec_offline(tmp_path_factory):
         ),
         (
             "https://domain.org/data.txt",
-            DownloadConfig(storage_options={"https": {"client_kwargs": {"raise_for_status": True}}}),
+            DownloadConfig(
+                storage_options={"https": {"client_kwargs": {"raise_for_status": True}}}
+            ),
             "https://domain.org/data.txt",
             {"https": {"client_kwargs": {"trust_env": True, "raise_for_status": True}}},
         ),
         (
             "https://domain.org/data.txt",
-            DownloadConfig(storage_options={"https": {"client_kwargs": {"trust_env": False}}}),
+            DownloadConfig(
+                storage_options={"https": {"client_kwargs": {"trust_env": False}}}
+            ),
             "https://domain.org/data.txt",
             {"https": {"client_kwargs": {"trust_env": False}}},
         ),
@@ -217,11 +249,15 @@ def test_prepare_single_hop_path_and_storage_options(
     urlpath, download_config, expected_urlpath, expected_storage_options
 ):
     original_download_config_storage_options = str(download_config.storage_options)
-    prepared_urlpath, storage_options = _prepare_single_hop_path_and_storage_options(urlpath, download_config)
+    prepared_urlpath, storage_options = _prepare_single_hop_path_and_storage_options(
+        urlpath, download_config
+    )
     assert prepared_urlpath == expected_urlpath
     assert storage_options == expected_storage_options
     # Check that DownloadConfig.storage_options are not modified:
-    assert str(download_config.storage_options) == original_download_config_storage_options
+    assert (
+        str(download_config.storage_options) == original_download_config_storage_options
+    )
 
 
 class DummyTestFS(AbstractFileSystem):
@@ -278,7 +314,9 @@ class DummyTestFS(AbstractFileSystem):
 
         files = not refresh and self._ls_from_cache(path)
         if not files:
-            files = [file for file in self._fs_contents if path == self._parent(file["name"])]
+            files = [
+                file for file in self._fs_contents if path == self._parent(file["name"])
+            ]
             files.sort(key=lambda file: file["name"])
             self.dircache[path.rstrip("/")] = files
 
@@ -390,7 +428,9 @@ def test_xjoin(input_path, paths_to_join, expected_path):
 def test_xdirname(input_path, expected_path):
     output_path = xdirname(input_path)
     output_path = _readd_double_slash_removed_by_path(Path(output_path).as_posix())
-    assert output_path == _readd_double_slash_removed_by_path(Path(expected_path).as_posix())
+    assert output_path == _readd_double_slash_removed_by_path(
+        Path(expected_path).as_posix()
+    )
 
 
 @pytest.mark.parametrize(
@@ -399,7 +439,10 @@ def test_xdirname(input_path, expected_path):
         ("tmp_path/file.txt", True),
         ("tmp_path/file_that_doesnt_exist.txt", False),
         ("mock://top_level/second_level/date=2019-10-01/a.parquet", True),
-        ("mock://top_level/second_level/date=2019-10-01/file_that_doesnt_exist.parquet", False),
+        (
+            "mock://top_level/second_level/date=2019-10-01/file_that_doesnt_exist.parquet",
+            False,
+        ),
     ],
 )
 def test_xexists(input_path, exists, tmp_path, mock_fsspec2):
@@ -414,7 +457,9 @@ def test_xexists_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_txt_data, "")
     download_config = DownloadConfig(token=hf_token)
     assert xexists(root_url + "data/text_data.txt", download_config=download_config)
-    assert not xexists(root_url + "file_that_doesnt_exist.txt", download_config=download_config)
+    assert not xexists(
+        root_url + "file_that_doesnt_exist.txt", download_config=download_config
+    )
 
 
 @pytest.mark.parametrize(
@@ -425,9 +470,18 @@ def test_xexists_private(hf_private_dataset_repo_txt_data, hf_token):
             (str(Path(__file__).resolve().parent), str(Path(__file__).resolve().name)),
         ),
         ("https://host.com/archive.zip", ("https://host.com", "archive.zip")),
-        ("zip://file.txt::https://host.com/archive.zip", ("zip://::https://host.com/archive.zip", "file.txt")),
-        ("zip://folder::https://host.com/archive.zip", ("zip://::https://host.com/archive.zip", "folder")),
-        ("zip://::https://host.com/archive.zip", ("zip://::https://host.com/archive.zip", "")),
+        (
+            "zip://file.txt::https://host.com/archive.zip",
+            ("zip://::https://host.com/archive.zip", "file.txt"),
+        ),
+        (
+            "zip://folder::https://host.com/archive.zip",
+            ("zip://::https://host.com/archive.zip", "folder"),
+        ),
+        (
+            "zip://::https://host.com/archive.zip",
+            ("zip://::https://host.com/archive.zip", ""),
+        ),
     ],
 )
 def test_xsplit(input_path, expected_head_and_tail):
@@ -444,12 +498,24 @@ def test_xsplit(input_path, expected_head_and_tail):
     [
         (
             str(Path(__file__).resolve()),
-            (str(Path(__file__).resolve().with_suffix("")), str(Path(__file__).resolve().suffix)),
+            (
+                str(Path(__file__).resolve().with_suffix("")),
+                str(Path(__file__).resolve().suffix),
+            ),
         ),
         ("https://host.com/archive.zip", ("https://host.com/archive", ".zip")),
-        ("zip://file.txt::https://host.com/archive.zip", ("zip://file::https://host.com/archive.zip", ".txt")),
-        ("zip://folder::https://host.com/archive.zip", ("zip://folder::https://host.com/archive.zip", "")),
-        ("zip://::https://host.com/archive.zip", ("zip://::https://host.com/archive.zip", "")),
+        (
+            "zip://file.txt::https://host.com/archive.zip",
+            ("zip://file::https://host.com/archive.zip", ".txt"),
+        ),
+        (
+            "zip://folder::https://host.com/archive.zip",
+            ("zip://folder::https://host.com/archive.zip", ""),
+        ),
+        (
+            "zip://::https://host.com/archive.zip",
+            ("zip://::https://host.com/archive.zip", ""),
+        ),
     ],
 )
 def test_xsplitext(input_path, expected_path_and_ext):
@@ -462,9 +528,13 @@ def test_xsplitext(input_path, expected_path_and_ext):
 
 
 def test_xopen_local(text_path):
-    with xopen(text_path, "r", encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
+    with xopen(text_path, "r", encoding="utf-8") as f, open(
+        text_path, encoding="utf-8"
+    ) as expected_file:
         assert list(f) == list(expected_file)
-    with xPath(text_path).open("r", encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
+    with xPath(text_path).open("r", encoding="utf-8") as f, open(
+        text_path, encoding="utf-8"
+    ) as expected_file:
         assert list(f) == list(expected_file)
 
 
@@ -499,7 +569,10 @@ def test_xlistdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     download_config = DownloadConfig(token=hf_token)
     assert len(xlistdir("zip://::" + root_url, download_config=download_config)) == 1
-    assert len(xlistdir("zip://main_dir::" + root_url, download_config=download_config)) == 2
+    assert (
+        len(xlistdir("zip://main_dir::" + root_url, download_config=download_config))
+        == 2
+    )
     with pytest.raises(FileNotFoundError):
         xlistdir("zip://qwertyuiop::" + root_url, download_config=download_config)
     with pytest.raises(FileNotFoundError):
@@ -528,8 +601,13 @@ def test_xisdir_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     download_config = DownloadConfig(token=hf_token)
     assert xisdir("zip://::" + root_url, download_config=download_config) is True
-    assert xisdir("zip://main_dir::" + root_url, download_config=download_config) is True
-    assert xisdir("zip://qwertyuiop::" + root_url, download_config=download_config) is False
+    assert (
+        xisdir("zip://main_dir::" + root_url, download_config=download_config) is True
+    )
+    assert (
+        xisdir("zip://qwertyuiop::" + root_url, download_config=download_config)
+        is False
+    )
     assert xisdir(root_url, download_config=download_config) is False
 
 
@@ -553,7 +631,10 @@ def test_xisfile(input_path, isfile, tmp_path, mock_fsspec2):
 def test_xisfile_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_txt_data, "")
     download_config = DownloadConfig(token=hf_token)
-    assert xisfile(root_url + "data/text_data.txt", download_config=download_config) is True
+    assert (
+        xisfile(root_url + "data/text_data.txt", download_config=download_config)
+        is True
+    )
     assert xisfile(root_url + "qwertyuiop", download_config=download_config) is False
 
 
@@ -577,7 +658,9 @@ def test_xgetsize(input_path, size, tmp_path, mock_fsspec2):
 def test_xgetsize_private(hf_private_dataset_repo_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_txt_data, "")
     download_config = DownloadConfig(token=hf_token)
-    assert xgetsize(root_url + "data/text_data.txt", download_config=download_config) == 39
+    assert (
+        xgetsize(root_url + "data/text_data.txt", download_config=download_config) == 39
+    )
     with pytest.raises(FileNotFoundError):
         xgetsize(root_url + "qwertyuiop", download_config=download_config)
 
@@ -622,7 +705,10 @@ def test_xglob_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     download_config = DownloadConfig(token=hf_token)
     assert len(xglob("zip://**::" + root_url, download_config=download_config)) == 3
-    assert len(xglob("zip://qwertyuiop/*::" + root_url, download_config=download_config)) == 0
+    assert (
+        len(xglob("zip://qwertyuiop/*::" + root_url, download_config=download_config))
+        == 0
+    )
 
 
 @pytest.mark.parametrize(
@@ -632,8 +718,16 @@ def test_xglob_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
         (
             "mock://top_level/second_level",
             [
-                ("mock://top_level/second_level", ["date=2019-10-01", "date=2019-10-02", "date=2019-10-04"], []),
-                ("mock://top_level/second_level/date=2019-10-01", [], ["a.parquet", "b.parquet"]),
+                (
+                    "mock://top_level/second_level",
+                    ["date=2019-10-01", "date=2019-10-02", "date=2019-10-04"],
+                    [],
+                ),
+                (
+                    "mock://top_level/second_level/date=2019-10-01",
+                    [],
+                    ["a.parquet", "b.parquet"],
+                ),
                 ("mock://top_level/second_level/date=2019-10-02", [], ["a.parquet"]),
                 ("mock://top_level/second_level/date=2019-10-04", [], ["a.parquet"]),
             ],
@@ -645,14 +739,21 @@ def test_xwalk(input_path, expected_outputs, tmp_path, mock_fsspec2):
         input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
         expected_outputs = sorted(
             [
-                (str(tmp_path / dirpath).rstrip("/"), sorted(dirnames), sorted(filenames))
+                (
+                    str(tmp_path / dirpath).rstrip("/"),
+                    sorted(dirnames),
+                    sorted(filenames),
+                )
                 for dirpath, dirnames, filenames in expected_outputs
             ]
         )
         for file in ["file1.txt", "file2.txt", "README.md"]:
             (tmp_path / file).touch()
     outputs = sorted(xwalk(input_path))
-    outputs = [(dirpath, sorted(dirnames), sorted(filenames)) for dirpath, dirnames, filenames in outputs]
+    outputs = [
+        (dirpath, sorted(dirnames), sorted(filenames))
+        for dirpath, dirnames, filenames in outputs
+    ]
     assert outputs == expected_outputs
 
 
@@ -661,16 +762,38 @@ def test_xwalk_private(hf_private_dataset_repo_zipped_txt_data, hf_token):
     root_url = hf_dataset_url(hf_private_dataset_repo_zipped_txt_data, "data.zip")
     download_config = DownloadConfig(token=hf_token)
     assert len(list(xwalk("zip://::" + root_url, download_config=download_config))) == 2
-    assert len(list(xwalk("zip://main_dir::" + root_url, download_config=download_config))) == 1
-    assert len(list(xwalk("zip://qwertyuiop::" + root_url, download_config=download_config))) == 0
+    assert (
+        len(list(xwalk("zip://main_dir::" + root_url, download_config=download_config)))
+        == 1
+    )
+    assert (
+        len(
+            list(
+                xwalk("zip://qwertyuiop::" + root_url, download_config=download_config)
+            )
+        )
+        == 0
+    )
 
 
 @pytest.mark.parametrize(
     "input_path, start_path, expected_path",
     [
-        ("dir1/dir2/file.txt".replace("/", os.path.sep), "dir1", "dir2/file.txt".replace("/", os.path.sep)),
-        ("dir1/dir2/file.txt".replace("/", os.path.sep), "dir1/dir2".replace("/", os.path.sep), "file.txt"),
-        ("zip://file.txt::https://host.com/archive.zip", "zip://::https://host.com/archive.zip", "file.txt"),
+        (
+            "dir1/dir2/file.txt".replace("/", os.path.sep),
+            "dir1",
+            "dir2/file.txt".replace("/", os.path.sep),
+        ),
+        (
+            "dir1/dir2/file.txt".replace("/", os.path.sep),
+            "dir1/dir2".replace("/", os.path.sep),
+            "file.txt",
+        ),
+        (
+            "zip://file.txt::https://host.com/archive.zip",
+            "zip://::https://host.com/archive.zip",
+            "file.txt",
+        ),
         (
             "zip://folder/file.txt::https://host.com/archive.zip",
             "zip://::https://host.com/archive.zip",
@@ -706,10 +829,19 @@ class TestxPath:
         "input_path, expected_path",
         [
             ("https://host.com/archive.zip", "https://host.com/archive.zip"),
-            ("zip://file.txt::https://host.com/archive.zip", "zip://file.txt::https://host.com/archive.zip"),
-            ("zip://dir/file.txt::https://host.com/archive.zip", "zip://dir/file.txt::https://host.com/archive.zip"),
+            (
+                "zip://file.txt::https://host.com/archive.zip",
+                "zip://file.txt::https://host.com/archive.zip",
+            ),
+            (
+                "zip://dir/file.txt::https://host.com/archive.zip",
+                "zip://dir/file.txt::https://host.com/archive.zip",
+            ),
             ("file.txt", "file.txt"),
-            (str(Path().resolve() / "file.txt"), (Path().resolve() / "file.txt").as_posix()),
+            (
+                str(Path().resolve() / "file.txt"),
+                (Path().resolve() / "file.txt").as_posix(),
+            ),
         ],
     )
     def test_xpath_as_posix(self, input_path, expected_path):
@@ -721,12 +853,17 @@ class TestxPath:
             ("tmp_path/file.txt", True),
             ("tmp_path/file_that_doesnt_exist.txt", False),
             ("mock://top_level/second_level/date=2019-10-01/a.parquet", True),
-            ("mock://top_level/second_level/date=2019-10-01/file_that_doesnt_exist.parquet", False),
+            (
+                "mock://top_level/second_level/date=2019-10-01/file_that_doesnt_exist.parquet",
+                False,
+            ),
         ],
     )
     def test_xpath_exists(self, input_path, exists, tmp_path, mock_fsspec2):
         if input_path.startswith("tmp_path"):
-            input_path = input_path.replace("/", os.sep).replace("tmp_path", str(tmp_path))
+            input_path = input_path.replace("/", os.sep).replace(
+                "tmp_path", str(tmp_path)
+            )
             (tmp_path / "file.txt").touch()
         assert xexists(input_path) is exists
 
@@ -757,7 +894,9 @@ class TestxPath:
             ),
         ],
     )
-    def test_xpath_glob(self, input_path, pattern, expected_paths, tmp_path, mock_fsspec2):
+    def test_xpath_glob(
+        self, input_path, pattern, expected_paths, tmp_path, mock_fsspec2
+    ):
         if input_path == "tmp_path":
             input_path = tmp_path
             expected_paths = [tmp_path / file for file in expected_paths]
@@ -812,7 +951,9 @@ class TestxPath:
             ),
         ],
     )
-    def test_xpath_rglob(self, input_path, pattern, expected_paths, tmp_path, mock_fsspec2):
+    def test_xpath_rglob(
+        self, input_path, pattern, expected_paths, tmp_path, mock_fsspec2
+    ):
         if input_path == "tmp_path":
             input_path = tmp_path
             dir_path = tmp_path / "dir"
@@ -829,8 +970,14 @@ class TestxPath:
         "input_path, expected_path",
         [
             ("https://host.com/archive.zip", "https://host.com"),
-            ("zip://file.txt::https://host.com/archive.zip", "zip://::https://host.com/archive.zip"),
-            ("zip://dir/file.txt::https://host.com/archive.zip", "zip://dir::https://host.com/archive.zip"),
+            (
+                "zip://file.txt::https://host.com/archive.zip",
+                "zip://::https://host.com/archive.zip",
+            ),
+            (
+                "zip://dir/file.txt::https://host.com/archive.zip",
+                "zip://dir::https://host.com/archive.zip",
+            ),
             ("file.txt", ""),
             (str(Path().resolve() / "file.txt"), str(Path().resolve())),
         ],
@@ -881,14 +1028,22 @@ class TestxPath:
         "input_path, suffix, expected",
         [
             ("https://host.com/archive.zip", ".ann", "https://host.com/archive.ann"),
-            ("zip://file.txt::https://host.com/archive.zip", ".ann", "zip://file.ann::https://host.com/archive.zip"),
+            (
+                "zip://file.txt::https://host.com/archive.zip",
+                ".ann",
+                "zip://file.ann::https://host.com/archive.zip",
+            ),
             (
                 "zip://dir/file.txt::https://host.com/archive.zip",
                 ".ann",
                 "zip://dir/file.ann::https://host.com/archive.zip",
             ),
             ("file.txt", ".ann", "file.ann"),
-            (str(Path().resolve() / "file.txt"), ".ann", str(Path().resolve() / "file.ann")),
+            (
+                str(Path().resolve() / "file.txt"),
+                ".ann",
+                str(Path().resolve() / "file.ann"),
+            ),
         ],
     )
     def test_xpath_with_suffix(self, input_path, suffix, expected):
@@ -901,9 +1056,18 @@ class TestxPath:
         ("zip://train-00000.json.gz::https://foo.bar/data.zip", "gzip"),
         ("https://foo.bar/train.json.gz?dl=1", "gzip"),
         ("http://opus.nlpl.eu/download.php?f=Bianet/v1/moses/en-ku.txt.zip", "zip"),
-        ("https://github.com/user/what-time-is-it/blob/master/gutenberg_time_phrases.zip?raw=true", "zip"),
-        ("https://github.com/user/repo/blob/master/data/morph_train.tsv?raw=true", None),
-        ("https://repo.org/bitstream/handle/20.500.12185/346/annotated_corpus.zip?sequence=3&isAllowed=y", "zip"),
+        (
+            "https://github.com/user/what-time-is-it/blob/master/gutenberg_time_phrases.zip?raw=true",
+            "zip",
+        ),
+        (
+            "https://github.com/user/repo/blob/master/data/morph_train.tsv?raw=true",
+            None,
+        ),
+        (
+            "https://repo.org/bitstream/handle/20.500.12185/346/annotated_corpus.zip?sequence=3&isAllowed=y",
+            "zip",
+        ),
         ("https://zenodo.org/record/2787612/files/SICK.zip?download=1", "zip"),
     ],
 )

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -33,8 +33,16 @@ def test_is_remote_filesystem(mockfs):
 
 
 @pytest.mark.parametrize("compression_fs_class", COMPRESSION_FILESYSTEMS)
-def test_compression_filesystems(compression_fs_class, gz_file, bz2_file, lz4_file, zstd_file, xz_file, text_file):
-    input_paths = {"gzip": gz_file, "xz": xz_file, "zstd": zstd_file, "bz2": bz2_file, "lz4": lz4_file}
+def test_compression_filesystems(
+    compression_fs_class, gz_file, bz2_file, lz4_file, zstd_file, xz_file, text_file
+):
+    input_paths = {
+        "gzip": gz_file,
+        "xz": xz_file,
+        "zstd": zstd_file,
+        "bz2": bz2_file,
+        "lz4": lz4_file,
+    }
     input_path = input_paths[compression_fs_class.protocol]
     if input_path is None:
         reason = f"for '{compression_fs_class.protocol}' compression protocol, "
@@ -48,7 +56,9 @@ def test_compression_filesystems(compression_fs_class, gz_file, bz2_file, lz4_fi
     expected_filename = os.path.basename(input_path)
     expected_filename = expected_filename[: expected_filename.rindex(".")]
     assert fs.glob("*") == [expected_filename]
-    with fs.open(expected_filename, "r", encoding="utf-8") as f, open(text_file, encoding="utf-8") as expected_file:
+    with fs.open(expected_filename, "r", encoding="utf-8") as f, open(
+        text_file, encoding="utf-8"
+    ) as expected_file:
         assert f.read() == expected_file.read()
 
 

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -74,6 +74,7 @@ if config.TORCH_AVAILABLE:
         def forward(self, x):
             x = F.relu(self.conv1(x))
             return F.relu(self.conv2(x))
+
 else:
     TorchModule = None
 
@@ -180,7 +181,13 @@ class RecurseHashTest(TestCase):
             code = func.__code__
             # Use _create_code from dill in order to make it work for different python versions
             code = code.replace(co_filename=co_filename)
-            return FunctionType(code, func.__globals__, func.__name__, func.__defaults__, func.__closure__)
+            return FunctionType(
+                code,
+                func.__globals__,
+                func.__name__,
+                func.__defaults__,
+                func.__closure__,
+            )
 
         co_filename, returned_obj = "<ipython-input-2-e0383a102aae>", [0]
         hash1 = Hasher.hash(create_ipython_func(co_filename, returned_obj))
@@ -191,11 +198,17 @@ class RecurseHashTest(TestCase):
         self.assertEqual(hash1, hash3)
         self.assertNotEqual(hash1, hash2)
 
-        co_filename, returned_obj = os.path.join(gettempdir(), "ipykernel_12345", "321456789.py"), [0]
+        co_filename, returned_obj = os.path.join(
+            gettempdir(), "ipykernel_12345", "321456789.py"
+        ), [0]
         hash4 = Hasher.hash(create_ipython_func(co_filename, returned_obj))
-        co_filename, returned_obj = os.path.join(gettempdir(), "ipykernel_12345", "321456789.py"), [1]
+        co_filename, returned_obj = os.path.join(
+            gettempdir(), "ipykernel_12345", "321456789.py"
+        ), [1]
         hash5 = Hasher.hash(create_ipython_func(co_filename, returned_obj))
-        co_filename, returned_obj = os.path.join(gettempdir(), "ipykernel_12345", "654123987.py"), [0]
+        co_filename, returned_obj = os.path.join(
+            gettempdir(), "ipykernel_12345", "654123987.py"
+        ), [0]
         hash6 = Hasher.hash(create_ipython_func(co_filename, returned_obj))
         self.assertEqual(hash4, hash6)
         self.assertNotEqual(hash4, hash5)
@@ -214,10 +227,14 @@ class RecurseHashTest(TestCase):
         def globalvars_mock2_side_effect(func, *args, **kwargs):
             return {"bar": bar, "foo": foo}
 
-        with patch("dill.detect.globalvars", side_effect=globalvars_mock1_side_effect) as globalvars_mock1:
+        with patch(
+            "dill.detect.globalvars", side_effect=globalvars_mock1_side_effect
+        ) as globalvars_mock1:
             hash1 = Hasher.hash(func)
             self.assertGreater(globalvars_mock1.call_count, 0)
-        with patch("dill.detect.globalvars", side_effect=globalvars_mock2_side_effect) as globalvars_mock2:
+        with patch(
+            "dill.detect.globalvars", side_effect=globalvars_mock2_side_effect
+        ) as globalvars_mock2:
             hash2 = Hasher.hash(func)
             self.assertGreater(globalvars_mock2.call_count, 0)
         self.assertEqual(hash1, hash2)
@@ -279,7 +296,9 @@ class HashingTest(TestCase):
         rng = np.random.default_rng(42)
         set_ = {rng.random() for _ in range(10_000)}
         expected_hash = Hasher.hash(set_)
-        assert expected_hash == Pool(1).apply_async(partial(Hasher.hash, set(set_))).get()
+        assert (
+            expected_hash == Pool(1).apply_async(partial(Hasher.hash, set(set_))).get()
+        )
 
     def test_set_doesnt_depend_on_order(self):
         set_ = set("abc")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -8,7 +8,12 @@ import pyarrow as pa
 import pytest
 
 from datasets import Audio, Features, Image, IterableDataset
-from datasets.formatting import NumpyFormatter, PandasFormatter, PythonFormatter, query_table
+from datasets.formatting import (
+    NumpyFormatter,
+    PandasFormatter,
+    PythonFormatter,
+    query_table,
+)
 from datasets.formatting.formatting import (
     LazyBatch,
     LazyRow,
@@ -61,13 +66,17 @@ AUDIO_PATH_1 = Path(__file__).parent / "features" / "data" / "test_audio_44100.w
 
 class ArrowExtractorTest(TestCase):
     def _create_dummy_table(self):
-        return pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C, "d": _COL_D})
+        return pa.Table.from_pydict(
+            {"a": _COL_A, "b": _COL_B, "c": _COL_C, "d": _COL_D}
+        )
 
     def test_python_extractor(self):
         pa_table = self._create_dummy_table()
         extractor = PythonArrowExtractor()
         row = extractor.extract_row(pa_table)
-        self.assertEqual(row, {"a": _COL_A[0], "b": _COL_B[0], "c": _COL_C[0], "d": _COL_D[0]})
+        self.assertEqual(
+            row, {"a": _COL_A[0], "b": _COL_B[0], "c": _COL_C[0], "d": _COL_D[0]}
+        )
         col = extractor.extract_column(pa_table)
         self.assertEqual(col, _COL_A)
         batch = extractor.extract_batch(pa_table)
@@ -256,11 +265,15 @@ class FormatterTest(TestCase):
         pa_table = self._create_dummy_table()
         formatter = NumpyFormatter()
         row = formatter.format_row(pa_table)
-        np.testing.assert_equal(row, {"a": _COL_A[0], "b": _COL_B[0], "c": np.array(_COL_C[0])})
+        np.testing.assert_equal(
+            row, {"a": _COL_A[0], "b": _COL_B[0], "c": np.array(_COL_C[0])}
+        )
         col = formatter.format_column(pa_table)
         np.testing.assert_equal(col, np.array(_COL_A))
         batch = formatter.format_batch(pa_table)
-        np.testing.assert_equal(batch, {"a": np.array(_COL_A), "b": np.array(_COL_B), "c": np.array(_COL_C)})
+        np.testing.assert_equal(
+            batch, {"a": np.array(_COL_A), "b": np.array(_COL_B), "c": np.array(_COL_C)}
+        )
         assert batch["c"].shape == np.array(_COL_C).shape
 
     def test_numpy_formatter_np_array_kwargs(self):
@@ -291,7 +304,12 @@ class FormatterTest(TestCase):
 
         # different dimensions
         pa_table = pa.table(
-            {"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}, {"bytes": None, "path": str(IMAGE_PATH_2)}]}
+            {
+                "image": [
+                    {"bytes": None, "path": str(IMAGE_PATH_1)},
+                    {"bytes": None, "path": str(IMAGE_PATH_2)},
+                ]
+            }
         )
         formatter = NumpyFormatter(features=Features({"image": Image()}))
         row = formatter.format_row(pa_table)
@@ -313,11 +331,17 @@ class FormatterTest(TestCase):
         pa_table = pa.table({"audio": [{"bytes": None, "path": str(AUDIO_PATH_1)}]})
         formatter = NumpyFormatter(features=Features({"audio": Audio()}))
         row = formatter.format_row(pa_table)
-        self.assertEqual(row["audio"].get_all_samples().data.cpu().numpy().dtype, np.dtype(np.float32))
+        self.assertEqual(
+            row["audio"].get_all_samples().data.cpu().numpy().dtype,
+            np.dtype(np.float32),
+        )
         col = formatter.format_column(pa_table)
         self.assertEqual(col[0].get_all_samples().data.cpu().numpy().dtype, np.float32)
         batch = formatter.format_batch(pa_table)
-        self.assertEqual(batch["audio"][0].get_all_samples().data.cpu().numpy().dtype, np.dtype(np.float32))
+        self.assertEqual(
+            batch["audio"][0].get_all_samples().data.cpu().numpy().dtype,
+            np.dtype(np.float32),
+        )
 
     def test_pandas_formatter(self):
         pa_table = self._create_dummy_table()
@@ -364,13 +388,17 @@ class FormatterTest(TestCase):
         row = formatter.format_row(pa_table)
         torch.testing.assert_close(row["a"], torch.tensor(_COL_A, dtype=torch.int64)[0])
         assert row["b"] == _COL_B[0]
-        torch.testing.assert_close(row["c"], torch.tensor(_COL_C, dtype=torch.float32)[0])
+        torch.testing.assert_close(
+            row["c"], torch.tensor(_COL_C, dtype=torch.float32)[0]
+        )
         col = formatter.format_column(pa_table)
         torch.testing.assert_close(col, torch.tensor(_COL_A, dtype=torch.int64))
         batch = formatter.format_batch(pa_table)
         torch.testing.assert_close(batch["a"], torch.tensor(_COL_A, dtype=torch.int64))
         assert batch["b"] == _COL_B
-        torch.testing.assert_close(batch["c"], torch.tensor(_COL_C, dtype=torch.float32))
+        torch.testing.assert_close(
+            batch["c"], torch.tensor(_COL_C, dtype=torch.float32)
+        )
         assert batch["c"].shape == np.array(_COL_C).shape
 
     @require_numpy1_on_windows
@@ -414,7 +442,12 @@ class FormatterTest(TestCase):
 
         # different dimensions
         pa_table = pa.table(
-            {"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}, {"bytes": None, "path": str(IMAGE_PATH_2)}]}
+            {
+                "image": [
+                    {"bytes": None, "path": str(IMAGE_PATH_1)},
+                    {"bytes": None, "path": str(IMAGE_PATH_2)},
+                ]
+            }
         )
         formatter = TorchFormatter(features=Features({"image": Image()}))
         row = formatter.format_row(pa_table)
@@ -454,20 +487,34 @@ class FormatterTest(TestCase):
         pa_table = self._create_dummy_table()
         formatter = TFFormatter()
         row = formatter.format_row(pa_table)
-        tf.debugging.assert_equal(row["a"], tf.convert_to_tensor(_COL_A, dtype=tf.int64)[0])
-        tf.debugging.assert_equal(row["b"], tf.convert_to_tensor(_COL_B, dtype=tf.string)[0])
-        tf.debugging.assert_equal(row["c"], tf.convert_to_tensor(_COL_C, dtype=tf.float32)[0])
+        tf.debugging.assert_equal(
+            row["a"], tf.convert_to_tensor(_COL_A, dtype=tf.int64)[0]
+        )
+        tf.debugging.assert_equal(
+            row["b"], tf.convert_to_tensor(_COL_B, dtype=tf.string)[0]
+        )
+        tf.debugging.assert_equal(
+            row["c"], tf.convert_to_tensor(_COL_C, dtype=tf.float32)[0]
+        )
         col = formatter.format_column(pa_table)
         tf.debugging.assert_equal(col, tf.ragged.constant(_COL_A, dtype=tf.int64))
         batch = formatter.format_batch(pa_table)
-        tf.debugging.assert_equal(batch["a"], tf.convert_to_tensor(_COL_A, dtype=tf.int64))
-        tf.debugging.assert_equal(batch["b"], tf.convert_to_tensor(_COL_B, dtype=tf.string))
+        tf.debugging.assert_equal(
+            batch["a"], tf.convert_to_tensor(_COL_A, dtype=tf.int64)
+        )
+        tf.debugging.assert_equal(
+            batch["b"], tf.convert_to_tensor(_COL_B, dtype=tf.string)
+        )
         self.assertIsInstance(batch["c"], tf.Tensor)
         self.assertEqual(batch["c"].dtype, tf.float32)
         tf.debugging.assert_equal(
-            batch["c"].shape.as_list(), tf.convert_to_tensor(_COL_C, dtype=tf.float32).shape.as_list()
+            batch["c"].shape.as_list(),
+            tf.convert_to_tensor(_COL_C, dtype=tf.float32).shape.as_list(),
         )
-        tf.debugging.assert_equal(tf.convert_to_tensor(batch["c"]), tf.convert_to_tensor(_COL_C, dtype=tf.float32))
+        tf.debugging.assert_equal(
+            tf.convert_to_tensor(batch["c"]),
+            tf.convert_to_tensor(_COL_C, dtype=tf.float32),
+        )
 
     @require_tf
     def test_tf_formatter_tf_tensor_kwargs(self):
@@ -507,7 +554,12 @@ class FormatterTest(TestCase):
 
         # different dimensions
         pa_table = pa.table(
-            {"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}, {"bytes": None, "path": str(IMAGE_PATH_2)}]}
+            {
+                "image": [
+                    {"bytes": None, "path": str(IMAGE_PATH_1)},
+                    {"bytes": None, "path": str(IMAGE_PATH_2)},
+                ]
+            }
         )
         formatter = TFFormatter(features=Features({"image": Image()}))
         row = formatter.format_row(pa_table)
@@ -537,7 +589,9 @@ class FormatterTest(TestCase):
         tf_col_0 = tf.convert_to_tensor(col[0].get_all_samples().data.cpu().numpy())
         self.assertEqual(tf_col_0.dtype, tf.float32)
         batch = formatter.format_batch(pa_table)
-        tf_batch_0 = tf.convert_to_tensor(batch["audio"][0].get_all_samples().data.cpu().numpy())
+        tf_batch_0 = tf.convert_to_tensor(
+            batch["audio"][0].get_all_samples().data.cpu().numpy()
+        )
         self.assertEqual(tf_batch_0.dtype, tf.float32)
 
     @require_jax
@@ -550,13 +604,28 @@ class FormatterTest(TestCase):
         pa_table = self._create_dummy_table()
         formatter = JaxFormatter()
         row = formatter.format_row(pa_table)
-        jnp.allclose(row["a"], jnp.array(_COL_A, dtype=jnp.int64 if jax.config.jax_enable_x64 else jnp.int32)[0])
+        jnp.allclose(
+            row["a"],
+            jnp.array(
+                _COL_A, dtype=jnp.int64 if jax.config.jax_enable_x64 else jnp.int32
+            )[0],
+        )
         assert row["b"] == _COL_B[0]
         jnp.allclose(row["c"], jnp.array(_COL_C, dtype=jnp.float32)[0])
         col = formatter.format_column(pa_table)
-        jnp.allclose(col, jnp.array(_COL_A, dtype=jnp.int64 if jax.config.jax_enable_x64 else jnp.int32))
+        jnp.allclose(
+            col,
+            jnp.array(
+                _COL_A, dtype=jnp.int64 if jax.config.jax_enable_x64 else jnp.int32
+            ),
+        )
         batch = formatter.format_batch(pa_table)
-        jnp.allclose(batch["a"], jnp.array(_COL_A, dtype=jnp.int64 if jax.config.jax_enable_x64 else jnp.int32))
+        jnp.allclose(
+            batch["a"],
+            jnp.array(
+                _COL_A, dtype=jnp.int64 if jax.config.jax_enable_x64 else jnp.int32
+            ),
+        )
         assert batch["b"] == _COL_B
         jnp.allclose(batch["c"], jnp.array(_COL_C, dtype=jnp.float32))
         assert batch["c"].shape == np.array(_COL_C).shape
@@ -599,7 +668,12 @@ class FormatterTest(TestCase):
 
         # different dimensions
         pa_table = pa.table(
-            {"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}, {"bytes": None, "path": str(IMAGE_PATH_2)}]}
+            {
+                "image": [
+                    {"bytes": None, "path": str(IMAGE_PATH_1)},
+                    {"bytes": None, "path": str(IMAGE_PATH_2)},
+                ]
+            }
         )
         formatter = JaxFormatter(features=Features({"image": Image()}))
         row = formatter.format_row(pa_table)
@@ -654,7 +728,9 @@ class QueryTest(TestCase):
         return pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C})
 
     def _create_dummy_arrow_indices(self):
-        return pa.Table.from_arrays([pa.array(_INDICES, type=pa.uint64())], names=["indices"])
+        return pa.Table.from_arrays(
+            [pa.array(_INDICES, type=pa.uint64())], names=["indices"]
+        )
 
     def assertTableEqual(self, first: pa.Table, second: pa.Table):
         self.assertEqual(first.schema, second.schema)
@@ -668,11 +744,24 @@ class QueryTest(TestCase):
         n = pa_table.num_rows
         # classical usage
         subtable = query_table(table, 0)
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[:1], "b": _COL_B[:1], "c": _COL_C[:1]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict({"a": _COL_A[:1], "b": _COL_B[:1], "c": _COL_C[:1]}),
+        )
         subtable = query_table(table, 1)
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[1:2], "b": _COL_B[1:2], "c": _COL_C[1:2]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[1:2], "b": _COL_B[1:2], "c": _COL_C[1:2]}
+            ),
+        )
         subtable = query_table(table, -1)
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[-1:], "b": _COL_B[-1:], "c": _COL_C[-1:]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[-1:], "b": _COL_B[-1:], "c": _COL_C[-1:]}
+            ),
+        )
         # raise an IndexError
         with self.assertRaises(IndexError):
             query_table(table, n)
@@ -683,7 +772,13 @@ class QueryTest(TestCase):
         subtable = query_table(table, 0, indices=indices)
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": [_COL_A[_INDICES[0]]], "b": [_COL_B[_INDICES[0]]], "c": [_COL_C[_INDICES[0]]]}),
+            pa.Table.from_pydict(
+                {
+                    "a": [_COL_A[_INDICES[0]]],
+                    "b": [_COL_B[_INDICES[0]]],
+                    "c": [_COL_C[_INDICES[0]]],
+                }
+            ),
         )
         with self.assertRaises(IndexError):
             assert len(indices) < n
@@ -695,31 +790,68 @@ class QueryTest(TestCase):
         n = pa_table.num_rows
         # classical usage
         subtable = query_table(table, slice(0, 1))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[:1], "b": _COL_B[:1], "c": _COL_C[:1]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict({"a": _COL_A[:1], "b": _COL_B[:1], "c": _COL_C[:1]}),
+        )
         subtable = query_table(table, slice(1, 2))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[1:2], "b": _COL_B[1:2], "c": _COL_C[1:2]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[1:2], "b": _COL_B[1:2], "c": _COL_C[1:2]}
+            ),
+        )
         subtable = query_table(table, slice(-2, -1))
         self.assertTableEqual(
-            subtable, pa.Table.from_pydict({"a": _COL_A[-2:-1], "b": _COL_B[-2:-1], "c": _COL_C[-2:-1]})
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[-2:-1], "b": _COL_B[-2:-1], "c": _COL_C[-2:-1]}
+            ),
         )
         # usage with None
         subtable = query_table(table, slice(-1, None))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[-1:], "b": _COL_B[-1:], "c": _COL_C[-1:]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[-1:], "b": _COL_B[-1:], "c": _COL_C[-1:]}
+            ),
+        )
         subtable = query_table(table, slice(None, n + 1))
         self.assertTableEqual(
-            subtable, pa.Table.from_pydict({"a": _COL_A[: n + 1], "b": _COL_B[: n + 1], "c": _COL_C[: n + 1]})
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[: n + 1], "b": _COL_B[: n + 1], "c": _COL_C[: n + 1]}
+            ),
         )
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C}))
+        self.assertTableEqual(
+            subtable, pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C})
+        )
         subtable = query_table(table, slice(-(n + 1), None))
         self.assertTableEqual(
-            subtable, pa.Table.from_pydict({"a": _COL_A[-(n + 1) :], "b": _COL_B[-(n + 1) :], "c": _COL_C[-(n + 1) :]})
+            subtable,
+            pa.Table.from_pydict(
+                {
+                    "a": _COL_A[-(n + 1) :],
+                    "b": _COL_B[-(n + 1) :],
+                    "c": _COL_C[-(n + 1) :],
+                }
+            ),
         )
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C}))
+        self.assertTableEqual(
+            subtable, pa.Table.from_pydict({"a": _COL_A, "b": _COL_B, "c": _COL_C})
+        )
         # usage with step
         subtable = query_table(table, slice(None, None, 2))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[::2], "b": _COL_B[::2], "c": _COL_C[::2]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[::2], "b": _COL_B[::2], "c": _COL_C[::2]}
+            ),
+        )
         # empty ouput but no errors
-        subtable = query_table(table, slice(-1, 0))  # usage with both negative and positive idx
+        subtable = query_table(
+            table, slice(-1, 0)
+        )  # usage with both negative and positive idx
         assert len(_COL_A[-1:0]) == 0
         self.assertTableEqual(subtable, pa_table.slice(0, 0))
         subtable = query_table(table, slice(2, 1))
@@ -738,7 +870,13 @@ class QueryTest(TestCase):
         subtable = query_table(table, slice(0, 1), indices=indices)
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": [_COL_A[_INDICES[0]]], "b": [_COL_B[_INDICES[0]]], "c": [_COL_C[_INDICES[0]]]}),
+            pa.Table.from_pydict(
+                {
+                    "a": [_COL_A[_INDICES[0]]],
+                    "b": [_COL_B[_INDICES[0]]],
+                    "c": [_COL_C[_INDICES[0]]],
+                }
+            ),
         )
         subtable = query_table(table, slice(n - 1, n), indices=indices)
         assert len(indices.column(0).to_pylist()[n - 1 : n]) == 0
@@ -748,42 +886,78 @@ class QueryTest(TestCase):
         pa_table = self._create_dummy_table()
         table = InMemoryTable(pa_table)
         n = pa_table.num_rows
-        np_A, np_B, np_C = np.array(_COL_A, dtype=np.int64), np.array(_COL_B), np.array(_COL_C)
+        np_A, np_B, np_C = (
+            np.array(_COL_A, dtype=np.int64),
+            np.array(_COL_B),
+            np.array(_COL_C),
+        )
         # classical usage
         subtable = query_table(table, range(0, 1))
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": np_A[range(0, 1)], "b": np_B[range(0, 1)], "c": np_C[range(0, 1)].tolist()}),
+            pa.Table.from_pydict(
+                {
+                    "a": np_A[range(0, 1)],
+                    "b": np_B[range(0, 1)],
+                    "c": np_C[range(0, 1)].tolist(),
+                }
+            ),
         )
         subtable = query_table(table, range(1, 2))
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": np_A[range(1, 2)], "b": np_B[range(1, 2)], "c": np_C[range(1, 2)].tolist()}),
+            pa.Table.from_pydict(
+                {
+                    "a": np_A[range(1, 2)],
+                    "b": np_B[range(1, 2)],
+                    "c": np_C[range(1, 2)].tolist(),
+                }
+            ),
         )
         subtable = query_table(table, range(-2, -1))
         self.assertTableEqual(
             subtable,
             pa.Table.from_pydict(
-                {"a": np_A[range(-2, -1)], "b": np_B[range(-2, -1)], "c": np_C[range(-2, -1)].tolist()}
+                {
+                    "a": np_A[range(-2, -1)],
+                    "b": np_B[range(-2, -1)],
+                    "c": np_C[range(-2, -1)].tolist(),
+                }
             ),
         )
         # usage with both negative and positive idx
         subtable = query_table(table, range(-1, 0))
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": np_A[range(-1, 0)], "b": np_B[range(-1, 0)], "c": np_C[range(-1, 0)].tolist()}),
+            pa.Table.from_pydict(
+                {
+                    "a": np_A[range(-1, 0)],
+                    "b": np_B[range(-1, 0)],
+                    "c": np_C[range(-1, 0)].tolist(),
+                }
+            ),
         )
         subtable = query_table(table, range(-1, n))
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": np_A[range(-1, n)], "b": np_B[range(-1, n)], "c": np_C[range(-1, n)].tolist()}),
+            pa.Table.from_pydict(
+                {
+                    "a": np_A[range(-1, n)],
+                    "b": np_B[range(-1, n)],
+                    "c": np_C[range(-1, n)].tolist(),
+                }
+            ),
         )
         # usage with step
         subtable = query_table(table, range(0, n, 2))
         self.assertTableEqual(
             subtable,
             pa.Table.from_pydict(
-                {"a": np_A[range(0, n, 2)], "b": np_B[range(0, n, 2)], "c": np_C[range(0, n, 2)].tolist()}
+                {
+                    "a": np_A[range(0, n, 2)],
+                    "b": np_B[range(0, n, 2)],
+                    "c": np_C[range(0, n, 2)].tolist(),
+                }
             ),
         )
         subtable = query_table(table, range(0, n + 1, 2 * n))
@@ -800,10 +974,14 @@ class QueryTest(TestCase):
         # empty ouput but no errors
         subtable = query_table(table, range(2, 1))
         assert len(np_A[range(2, 1)]) == 0
-        self.assertTableEqual(subtable, pa.Table.from_batches([], schema=pa_table.schema))
+        self.assertTableEqual(
+            subtable, pa.Table.from_batches([], schema=pa_table.schema)
+        )
         subtable = query_table(table, range(n, n))
         assert len(np_A[range(n, n)]) == 0
-        self.assertTableEqual(subtable, pa.Table.from_batches([], schema=pa_table.schema))
+        self.assertTableEqual(
+            subtable, pa.Table.from_batches([], schema=pa_table.schema)
+        )
         # raise an IndexError
         with self.assertRaises(IndexError):
             with self.assertRaises(IndexError):
@@ -822,7 +1000,13 @@ class QueryTest(TestCase):
         subtable = query_table(table, range(0, 1), indices=indices)
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": [_COL_A[_INDICES[0]]], "b": [_COL_B[_INDICES[0]]], "c": [_COL_C[_INDICES[0]]]}),
+            pa.Table.from_pydict(
+                {
+                    "a": [_COL_A[_INDICES[0]]],
+                    "b": [_COL_B[_INDICES[0]]],
+                    "c": [_COL_C[_INDICES[0]]],
+                }
+            ),
         )
         with self.assertRaises(IndexError):
             assert len(indices) < n
@@ -837,41 +1021,70 @@ class QueryTest(TestCase):
             query_table(table, "z")
         indices = InMemoryTable(self._create_dummy_arrow_indices())
         subtable = query_table(table, "a", indices=indices)
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": [_COL_A[i] for i in _INDICES]}))
+        self.assertTableEqual(
+            subtable, pa.Table.from_pydict({"a": [_COL_A[i] for i in _INDICES]})
+        )
 
     def test_query_table_iterable(self):
         pa_table = self._create_dummy_table()
         table = InMemoryTable(pa_table)
         n = pa_table.num_rows
-        np_A, np_B, np_C = np.array(_COL_A, dtype=np.int64), np.array(_COL_B), np.array(_COL_C)
+        np_A, np_B, np_C = (
+            np.array(_COL_A, dtype=np.int64),
+            np.array(_COL_B),
+            np.array(_COL_C),
+        )
         # classical usage
         subtable = query_table(table, [0])
         self.assertTableEqual(
-            subtable, pa.Table.from_pydict({"a": np_A[[0]], "b": np_B[[0]], "c": np_C[[0]].tolist()})
+            subtable,
+            pa.Table.from_pydict(
+                {"a": np_A[[0]], "b": np_B[[0]], "c": np_C[[0]].tolist()}
+            ),
         )
         subtable = query_table(table, [1])
         self.assertTableEqual(
-            subtable, pa.Table.from_pydict({"a": np_A[[1]], "b": np_B[[1]], "c": np_C[[1]].tolist()})
+            subtable,
+            pa.Table.from_pydict(
+                {"a": np_A[[1]], "b": np_B[[1]], "c": np_C[[1]].tolist()}
+            ),
         )
         subtable = query_table(table, [-1])
         self.assertTableEqual(
-            subtable, pa.Table.from_pydict({"a": np_A[[-1]], "b": np_B[[-1]], "c": np_C[[-1]].tolist()})
+            subtable,
+            pa.Table.from_pydict(
+                {"a": np_A[[-1]], "b": np_B[[-1]], "c": np_C[[-1]].tolist()}
+            ),
         )
         subtable = query_table(table, [0, -1, 1])
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": np_A[[0, -1, 1]], "b": np_B[[0, -1, 1]], "c": np_C[[0, -1, 1]].tolist()}),
+            pa.Table.from_pydict(
+                {
+                    "a": np_A[[0, -1, 1]],
+                    "b": np_B[[0, -1, 1]],
+                    "c": np_C[[0, -1, 1]].tolist(),
+                }
+            ),
         )
         # numpy iterable
         subtable = query_table(table, np.array([0, -1, 1]))
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": np_A[[0, -1, 1]], "b": np_B[[0, -1, 1]], "c": np_C[[0, -1, 1]].tolist()}),
+            pa.Table.from_pydict(
+                {
+                    "a": np_A[[0, -1, 1]],
+                    "b": np_B[[0, -1, 1]],
+                    "c": np_C[[0, -1, 1]].tolist(),
+                }
+            ),
         )
         # empty ouput but no errors
         subtable = query_table(table, [])
         assert len(np_A[[]]) == 0
-        self.assertTableEqual(subtable, pa.Table.from_batches([], schema=pa_table.schema))
+        self.assertTableEqual(
+            subtable, pa.Table.from_batches([], schema=pa_table.schema)
+        )
         # raise an IndexError
         with self.assertRaises(IndexError):
             with self.assertRaises(IndexError):
@@ -886,7 +1099,13 @@ class QueryTest(TestCase):
         subtable = query_table(table, [0], indices=indices)
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": [_COL_A[_INDICES[0]]], "b": [_COL_B[_INDICES[0]]], "c": [_COL_C[_INDICES[0]]]}),
+            pa.Table.from_pydict(
+                {
+                    "a": [_COL_A[_INDICES[0]]],
+                    "b": [_COL_B[_INDICES[0]]],
+                    "c": [_COL_C[_INDICES[0]]],
+                }
+            ),
         )
         with self.assertRaises(IndexError):
             assert len(indices) < n
@@ -898,11 +1117,24 @@ class QueryTest(TestCase):
         n = pa_table.num_rows
         # classical usage
         subtable = query_table(table, np.int64(0))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[:1], "b": _COL_B[:1], "c": _COL_C[:1]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict({"a": _COL_A[:1], "b": _COL_B[:1], "c": _COL_C[:1]}),
+        )
         subtable = query_table(table, np.int64(1))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[1:2], "b": _COL_B[1:2], "c": _COL_C[1:2]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[1:2], "b": _COL_B[1:2], "c": _COL_C[1:2]}
+            ),
+        )
         subtable = query_table(table, np.int64(-1))
-        self.assertTableEqual(subtable, pa.Table.from_pydict({"a": _COL_A[-1:], "b": _COL_B[-1:], "c": _COL_C[-1:]}))
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": _COL_A[-1:], "b": _COL_B[-1:], "c": _COL_C[-1:]}
+            ),
+        )
         # raise an IndexError
         with self.assertRaises(IndexError):
             query_table(table, np.int64(n))
@@ -913,7 +1145,13 @@ class QueryTest(TestCase):
         subtable = query_table(table, np.int64(0), indices=indices)
         self.assertTableEqual(
             subtable,
-            pa.Table.from_pydict({"a": [_COL_A[_INDICES[0]]], "b": [_COL_B[_INDICES[0]]], "c": [_COL_C[_INDICES[0]]]}),
+            pa.Table.from_pydict(
+                {
+                    "a": [_COL_A[_INDICES[0]]],
+                    "b": [_COL_B[_INDICES[0]]],
+                    "c": [_COL_C[_INDICES[0]]],
+                }
+            ),
         )
         with self.assertRaises(IndexError):
             assert len(indices) < n
@@ -966,15 +1204,23 @@ def test_tf_formatter_sets_default_dtypes(cast_schema, arrow_table):
     formatter = TFFormatter()
 
     row = formatter.format_row(arrow_table)
-    tf.debugging.assert_equal(row["col_int"], tf.ragged.constant(list_int, dtype=tf.int64)[0])
-    tf.debugging.assert_equal(row["col_float"], tf.ragged.constant(list_float, dtype=tf.float32)[0])
+    tf.debugging.assert_equal(
+        row["col_int"], tf.ragged.constant(list_int, dtype=tf.int64)[0]
+    )
+    tf.debugging.assert_equal(
+        row["col_float"], tf.ragged.constant(list_float, dtype=tf.float32)[0]
+    )
 
     col = formatter.format_column(arrow_table)
     tf.debugging.assert_equal(col, tf.ragged.constant(list_int, dtype=tf.int64))
 
     batch = formatter.format_batch(arrow_table)
-    tf.debugging.assert_equal(batch["col_int"], tf.ragged.constant(list_int, dtype=tf.int64))
-    tf.debugging.assert_equal(batch["col_float"], tf.ragged.constant(list_float, dtype=tf.float32))
+    tf.debugging.assert_equal(
+        batch["col_int"], tf.ragged.constant(list_int, dtype=tf.int64)
+    )
+    tf.debugging.assert_equal(
+        batch["col_float"], tf.ragged.constant(list_float, dtype=tf.float32)
+    )
 
 
 @require_numpy1_on_windows
@@ -1001,29 +1247,43 @@ def test_torch_formatter_sets_default_dtypes(cast_schema, arrow_table):
     formatter = TorchFormatter()
 
     row = formatter.format_row(arrow_table)
-    torch.testing.assert_close(row["col_int"], torch.tensor(list_int, dtype=torch.int64)[0])
-    torch.testing.assert_close(row["col_float"], torch.tensor(list_float, dtype=torch.float32)[0])
+    torch.testing.assert_close(
+        row["col_int"], torch.tensor(list_int, dtype=torch.int64)[0]
+    )
+    torch.testing.assert_close(
+        row["col_float"], torch.tensor(list_float, dtype=torch.float32)[0]
+    )
 
     col = formatter.format_column(arrow_table)
     torch.testing.assert_close(col, torch.tensor(list_int, dtype=torch.int64))
 
     batch = formatter.format_batch(arrow_table)
-    torch.testing.assert_close(batch["col_int"], torch.tensor(list_int, dtype=torch.int64))
-    torch.testing.assert_close(batch["col_float"], torch.tensor(list_float, dtype=torch.float32))
+    torch.testing.assert_close(
+        batch["col_int"], torch.tensor(list_int, dtype=torch.int64)
+    )
+    torch.testing.assert_close(
+        batch["col_float"], torch.tensor(list_float, dtype=torch.float32)
+    )
 
 
-def test_iterable_dataset_of_arrays_format_to_arrow(any_arrays_dataset: IterableDataset):
+def test_iterable_dataset_of_arrays_format_to_arrow(
+    any_arrays_dataset: IterableDataset,
+):
     formatted = any_arrays_dataset.with_format("arrow")
     assert all(isinstance(example, pa.Table) for example in formatted)
 
 
-def test_iterable_dataset_of_arrays_format_to_numpy(any_arrays_dataset: IterableDataset):
+def test_iterable_dataset_of_arrays_format_to_numpy(
+    any_arrays_dataset: IterableDataset,
+):
     formatted = any_arrays_dataset.with_format("np")
     assert all(isinstance(example["array"], np.ndarray) for example in formatted)
 
 
 @require_torch
-def test_iterable_dataset_of_arrays_format_to_torch(any_arrays_dataset: IterableDataset):
+def test_iterable_dataset_of_arrays_format_to_torch(
+    any_arrays_dataset: IterableDataset,
+):
     import torch
 
     formatted = any_arrays_dataset.with_format("torch")

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -17,10 +17,15 @@ from datasets.utils.hub import hf_dataset_url
 @pytest.mark.parametrize("revision", [None, "v2"])
 def test_dataset_url(repo_id, filename, revision):
     url = hf_dataset_url(repo_id=repo_id, filename=filename, revision=revision)
-    assert url == f"https://huggingface.co/datasets/{repo_id}/resolve/{revision or 'main'}/{quote(filename)}"
+    assert (
+        url
+        == f"https://huggingface.co/datasets/{repo_id}/resolve/{revision or 'main'}/{quote(filename)}"
+    )
 
 
-def test_delete_from_hub(temporary_repo, hf_api, hf_token, csv_path, ci_hub_config) -> None:
+def test_delete_from_hub(
+    temporary_repo, hf_api, hf_token, csv_path, ci_hub_config
+) -> None:
     with temporary_repo() as repo_id:
         hf_api.create_repo(repo_id, token=hf_token, repo_type="dataset")
         hf_api.upload_file(
@@ -61,7 +66,9 @@ def test_delete_from_hub(temporary_repo, hf_api, hf_token, csv_path, ci_hub_conf
         commit_info = SimpleNamespace(
             pr_url="https:///hub-ci.huggingface.co/datasets/__DUMMY_USER__/__DUMMY_DATASET__/refs%2Fpr%2F1"
         )
-        with patch.object(datasets.hub.HfApi, "create_commit", return_value=commit_info) as mock_method:
+        with patch.object(
+            datasets.hub.HfApi, "create_commit", return_value=commit_info
+        ) as mock_method:
             _ = delete_from_hub(repo_id, "dogs")
     assert mock_method.called
     assert mock_method.call_args.kwargs.get("commit_message") == "Delete 'dogs' config"

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -119,7 +119,9 @@ def test_dataset_info_to_yaml_dict_empty():
         ),
     ],
 )
-def test_dataset_infos_dict_dump_and_reload(tmp_path, dataset_infos_dict: DatasetInfosDict):
+def test_dataset_infos_dict_dump_and_reload(
+    tmp_path, dataset_infos_dict: DatasetInfosDict
+):
     tmp_path = str(tmp_path)
     dataset_infos_dict.write_to_directory(tmp_path)
     reloaded = DatasetInfosDict.from_directory(tmp_path)
@@ -129,7 +131,9 @@ def test_dataset_infos_dict_dump_and_reload(tmp_path, dataset_infos_dict: Datase
         dataset_info.config_name = config_name
         # the yaml representation doesn't include fields like description or citation
         # so we just test that we can recover what we can from the yaml
-        dataset_infos_dict[config_name] = DatasetInfo._from_yaml_dict(dataset_info._to_yaml_dict())
+        dataset_infos_dict[config_name] = DatasetInfo._from_yaml_dict(
+            dataset_info._to_yaml_dict()
+        )
     assert dataset_infos_dict == reloaded
 
     if dataset_infos_dict:
@@ -170,7 +174,12 @@ def test_dataset_info_from_dict_with_large_list():
     dataset_info_dict = {
         "citation": "",
         "description": "",
-        "features": {"col_1": {"feature": {"dtype": "int64", "_type": "Value"}, "_type": "LargeList"}},
+        "features": {
+            "col_1": {
+                "feature": {"dtype": "int64", "_type": "Value"},
+                "_type": "LargeList",
+            }
+        },
         "homepage": "",
         "license": "",
     }

--- a/tests/test_info_utils.py
+++ b/tests/test_info_utils.py
@@ -5,10 +5,14 @@ from datasets.utils.info_utils import is_small_dataset
 
 
 @pytest.mark.parametrize("dataset_size", [None, 400 * 2**20, 600 * 2**20])
-@pytest.mark.parametrize("input_in_memory_max_size", ["default", 0, 100 * 2**20, 900 * 2**20])
+@pytest.mark.parametrize(
+    "input_in_memory_max_size", ["default", 0, 100 * 2**20, 900 * 2**20]
+)
 def test_is_small_dataset(dataset_size, input_in_memory_max_size, monkeypatch):
     if input_in_memory_max_size != "default":
-        monkeypatch.setattr(datasets.config, "IN_MEMORY_MAX_SIZE", input_in_memory_max_size)
+        monkeypatch.setattr(
+            datasets.config, "IN_MEMORY_MAX_SIZE", input_in_memory_max_size
+        )
     in_memory_max_size = datasets.config.IN_MEMORY_MAX_SIZE
     if input_in_memory_max_size == "default":
         assert in_memory_max_size == 0

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -28,7 +28,9 @@ def test_get_dataset_config_info(path, config_name, expected_splits):
 
 
 def test_get_dataset_config_info_private(hf_token, hf_private_dataset_repo_txt_data):
-    info = get_dataset_config_info(hf_private_dataset_repo_txt_data, config_name="default", token=hf_token)
+    info = get_dataset_config_info(
+        hf_private_dataset_repo_txt_data, config_name="default", token=hf_token
+    )
     assert list(info.splits.keys()) == ["train"]
 
 
@@ -38,10 +40,26 @@ def test_get_dataset_config_info_private(hf_token, hf_private_dataset_repo_txt_d
         ("paws", None, ValueError),
         # non-existing, gated, private:
         ("hf-internal-testing/non-existing-dataset", "default", DatasetNotFoundError),
-        ("hf-internal-testing/gated_dataset_with_data_files", "default", DatasetNotFoundError),
-        ("hf-internal-testing/private_dataset_with_data_files", "default", DatasetNotFoundError),
-        ("hf-internal-testing/gated_dataset_with_data_files", "default", DatasetNotFoundError),
-        ("hf-internal-testing/private_dataset_with_data_files", "default", DatasetNotFoundError),
+        (
+            "hf-internal-testing/gated_dataset_with_data_files",
+            "default",
+            DatasetNotFoundError,
+        ),
+        (
+            "hf-internal-testing/private_dataset_with_data_files",
+            "default",
+            DatasetNotFoundError,
+        ),
+        (
+            "hf-internal-testing/gated_dataset_with_data_files",
+            "default",
+            DatasetNotFoundError,
+        ),
+        (
+            "hf-internal-testing/private_dataset_with_data_files",
+            "default",
+            DatasetNotFoundError,
+        ),
     ],
 )
 def test_get_dataset_config_info_raises(path, config_name, expected_exception):
@@ -91,7 +109,11 @@ def test_get_dataset_default_config_name(path, expected):
     [
         ("rajpurkar/squad", ["plain_text"], ["train", "validation"]),
         ("dalle-mini/wit", ["default"], ["train"]),
-        ("paws", ["labeled_final", "labeled_swap", "unlabeled_final"], ["train", "test", "validation"]),
+        (
+            "paws",
+            ["labeled_final", "labeled_swap", "unlabeled_final"],
+            ["train", "test", "validation"],
+        ),
     ],
 )
 def test_get_dataset_info(path, expected_configs, expected_splits_in_first_config):

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -108,16 +108,23 @@ def generate_tables_fn(**kwargs):
 @pytest.fixture
 def dataset():
     ex_iterable = ExamplesIterable(generate_examples_fn, {})
-    return IterableDataset(ex_iterable, info=DatasetInfo(description="dummy"), split="train")
+    return IterableDataset(
+        ex_iterable, info=DatasetInfo(description="dummy"), split="train"
+    )
 
 
 @pytest.fixture
 def dataset_with_several_columns():
     ex_iterable = ExamplesIterable(
         generate_examples_fn,
-        {"filepath": ["data0.txt", "data1.txt", "data2.txt"], "metadata": {"sources": ["https://foo.bar"]}},
+        {
+            "filepath": ["data0.txt", "data1.txt", "data2.txt"],
+            "metadata": {"sources": ["https://foo.bar"]},
+        },
     )
-    return IterableDataset(ex_iterable, info=DatasetInfo(description="dummy"), split="train")
+    return IterableDataset(
+        ex_iterable, info=DatasetInfo(description="dummy"), split="train"
+    )
 
 
 @pytest.fixture
@@ -137,7 +144,9 @@ def assert_load_state_dict_resumes_iteration(ex_iterable: _BaseExamplesIterable)
     for i, state_dict in enumerate(state_dicts):
         ex_iterable.load_state_dict(state_dict)
         examples_after_resuming = [example for _, example in ex_iterable]
-        assert examples_after_resuming == examples[i:], f"resuming from idx {i} with {state_dict=}"
+        assert (
+            examples_after_resuming == examples[i:]
+        ), f"resuming from idx {i} with {state_dict=}"
 
 
 def assert_load_state_dict_resumes_arrow_iteration(ex_iterable: _BaseExamplesIterable):
@@ -153,9 +162,13 @@ def assert_load_state_dict_resumes_arrow_iteration(ex_iterable: _BaseExamplesIte
     for i, state_dict in zip(indices, state_dicts):
         ex_iterable.load_state_dict(state_dict)
         examples_after_resuming = [
-            example for _, pa_table in ex_iterable.iter_arrow() for example in pa_table.to_pylist()
+            example
+            for _, pa_table in ex_iterable.iter_arrow()
+            for example in pa_table.to_pylist()
         ]
-        assert examples_after_resuming == examples[i:], f"resuming from idx {i} with {state_dict=}"
+        assert (
+            examples_after_resuming == examples[i:]
+        ), f"resuming from idx {i} with {state_dict=}"
 
 
 ################################
@@ -170,8 +183,16 @@ def assert_load_state_dict_resumes_arrow_iteration(ex_iterable: _BaseExamplesIte
 def test_convert_to_arrow(batch_size, drop_last_batch):
     examples = [{"foo": i} for i in range(10)]
     full_table = pa.Table.from_pylist(examples)
-    num_rows = len(full_table) if not drop_last_batch else len(full_table) // batch_size * batch_size
-    num_batches = (num_rows // batch_size) + 1 if num_rows % batch_size else num_rows // batch_size
+    num_rows = (
+        len(full_table)
+        if not drop_last_batch
+        else len(full_table) // batch_size * batch_size
+    )
+    num_batches = (
+        (num_rows // batch_size) + 1
+        if num_rows % batch_size
+        else num_rows // batch_size
+    )
     subtables = list(
         _convert_to_arrow(
             list(enumerate(examples)),
@@ -207,7 +228,9 @@ def test_examples_iterable():
 
 
 def test_examples_iterable_with_kwargs():
-    ex_iterable = ExamplesIterable(generate_examples_fn, {"filepaths": ["0.txt", "1.txt"], "split": "train"})
+    ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"filepaths": ["0.txt", "1.txt"], "split": "train"}
+    )
     expected = list(generate_examples_fn(filepaths=["0.txt", "1.txt"], split="train"))
     assert list(ex_iterable) == expected
     assert all("split" in ex for _, ex in ex_iterable)
@@ -216,9 +239,13 @@ def test_examples_iterable_with_kwargs():
 
 
 def test_examples_iterable_shuffle_data_sources():
-    ex_iterable = ExamplesIterable(generate_examples_fn, {"filepaths": ["0.txt", "1.txt"]})
+    ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"filepaths": ["0.txt", "1.txt"]}
+    )
     ex_iterable = ex_iterable.shuffle_data_sources(np.random.default_rng(40))
-    expected = list(generate_examples_fn(filepaths=["1.txt", "0.txt"]))  # shuffle the filepaths
+    expected = list(
+        generate_examples_fn(filepaths=["1.txt", "0.txt"])
+    )  # shuffle the filepaths
     assert list(ex_iterable) == expected
     assert_load_state_dict_resumes_iteration(ex_iterable)
 
@@ -239,7 +266,9 @@ def test_examples_iterable_shuffle_shards_and_metadata():
     out = list(ex_iterable)
     filepaths_ids = [x["filepath"].split(".")[0] for _, x in out]
     metadata_ids = [x["metadata"]["id"] for _, x in out]
-    assert filepaths_ids == metadata_ids, "entangled lists of shards/metadata should be shuffled the same way"
+    assert (
+        filepaths_ids == metadata_ids
+    ), "entangled lists of shards/metadata should be shuffled the same way"
     assert_load_state_dict_resumes_iteration(ex_iterable)
 
 
@@ -254,9 +283,17 @@ def test_arrow_examples_iterable():
 
 
 def test_arrow_examples_iterable_with_kwargs():
-    ex_iterable = ArrowExamplesIterable(generate_tables_fn, {"filepaths": ["0.txt", "1.txt"], "split": "train"})
+    ex_iterable = ArrowExamplesIterable(
+        generate_tables_fn, {"filepaths": ["0.txt", "1.txt"], "split": "train"}
+    )
     expected = sum(
-        [pa_table.to_pylist() for _, pa_table in generate_tables_fn(filepaths=["0.txt", "1.txt"], split="train")], []
+        [
+            pa_table.to_pylist()
+            for _, pa_table in generate_tables_fn(
+                filepaths=["0.txt", "1.txt"], split="train"
+            )
+        ],
+        [],
     )
     assert [example for _, example in ex_iterable] == expected
     assert all("split" in ex for _, ex in ex_iterable)
@@ -267,10 +304,16 @@ def test_arrow_examples_iterable_with_kwargs():
 
 
 def test_arrow_examples_iterable_shuffle_data_sources():
-    ex_iterable = ArrowExamplesIterable(generate_tables_fn, {"filepaths": ["0.txt", "1.txt"]})
+    ex_iterable = ArrowExamplesIterable(
+        generate_tables_fn, {"filepaths": ["0.txt", "1.txt"]}
+    )
     ex_iterable = ex_iterable.shuffle_data_sources(np.random.default_rng(40))
     expected = sum(
-        [pa_table.to_pylist() for _, pa_table in generate_tables_fn(filepaths=["1.txt", "0.txt"])], []
+        [
+            pa_table.to_pylist()
+            for _, pa_table in generate_tables_fn(filepaths=["1.txt", "0.txt"])
+        ],
+        [],
     )  # shuffle the filepaths
     assert [example for _, example in ex_iterable] == expected
     expected = list(generate_tables_fn(filepaths=["1.txt", "0.txt"]))
@@ -291,15 +334,25 @@ def test_arrow_examples_iterable_shuffle_data_sources():
 @pytest.mark.parametrize("drop_last_batch", [False, True])
 def test_rebatched_arrow_examples_iterable(tables, batch_size, drop_last_batch):
     full_table = pa.concat_tables(tables)
-    num_rows = len(full_table) if not drop_last_batch else len(full_table) // batch_size * batch_size
-    num_batches = (num_rows // batch_size) + 1 if num_rows % batch_size else num_rows // batch_size
+    num_rows = (
+        len(full_table)
+        if not drop_last_batch
+        else len(full_table) // batch_size * batch_size
+    )
+    num_batches = (
+        (num_rows // batch_size) + 1
+        if num_rows % batch_size
+        else num_rows // batch_size
+    )
 
     def gen(tables):
         for i, table in enumerate(tables):
             yield str(i), table
 
     ex_iterable = ArrowExamplesIterable(gen, {"tables": tables})
-    ex_iterable = RebatchedArrowExamplesIterable(ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch)
+    ex_iterable = RebatchedArrowExamplesIterable(
+        ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch
+    )
     subtables = list(ex_iterable.iter_arrow())
     assert len(subtables) == num_batches
     if drop_last_batch:
@@ -319,14 +372,24 @@ def test_buffer_shuffled_examples_iterable(seed):
     n, buffer_size = 100, 30
     generator = np.random.default_rng(seed)
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = BufferShuffledExamplesIterable(base_ex_iterable, buffer_size=buffer_size, generator=generator)
+    ex_iterable = BufferShuffledExamplesIterable(
+        base_ex_iterable, buffer_size=buffer_size, generator=generator
+    )
 
     rng = deepcopy(generator)
     expected_indices_used_for_shuffling = list(
-        islice(BufferShuffledExamplesIterable._iter_random_indices(rng, buffer_size=buffer_size), n - buffer_size)
+        islice(
+            BufferShuffledExamplesIterable._iter_random_indices(
+                rng, buffer_size=buffer_size
+            ),
+            n - buffer_size,
+        )
     )
     # indices to pick in the shuffle buffer should all be in the right range
-    assert all(0 <= index_to_pick < buffer_size for index_to_pick in expected_indices_used_for_shuffling)
+    assert all(
+        0 <= index_to_pick < buffer_size
+        for index_to_pick in expected_indices_used_for_shuffling
+    )
     # it should be random indices
     assert expected_indices_used_for_shuffling != list(range(buffer_size))
 
@@ -352,14 +415,19 @@ def test_cycling_multi_sources_examples_iterable():
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"text": "foo"})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"text": "bar"})
     ex_iterable = CyclingMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
-    expected = list(chain(*zip(generate_examples_fn(text="foo"), generate_examples_fn(text="bar"))))
+    expected = list(
+        chain(*zip(generate_examples_fn(text="foo"), generate_examples_fn(text="bar")))
+    )
 
     # The cycling stops as soon as one iterable is out of examples (here ex_iterable1), so the last sample from ex_iterable2 is unecessary
     expected = expected[:-1]
 
     assert next(iter(ex_iterable)) == expected[0]
     assert list(ex_iterable) == expected
-    assert all((x["id"], x["text"]) == (i // 2, "bar" if i % 2 else "foo") for i, (_, x) in enumerate(ex_iterable))
+    assert all(
+        (x["id"], x["text"]) == (i // 2, "bar" if i % 2 else "foo")
+        for i, (_, x) in enumerate(ex_iterable)
+    )
     assert_load_state_dict_resumes_iteration(ex_iterable)
 
 
@@ -397,7 +465,9 @@ def test_randomly_cycling_multi_sources_examples_iterable(probabilities):
 @pytest.mark.parametrize("probabilities", [None, (0.5, 0.5), (0.9, 0.1)])
 @pytest.mark.parametrize("stopping_strategy", ["first_exhausted", "all_exhausted"])
 @pytest.mark.parametrize("step", [-1, 0, 5, 20, 30, 300])
-def test_randomly_cycling_multi_sources_examples_iterable_state(probabilities, stopping_strategy, step):
+def test_randomly_cycling_multi_sources_examples_iterable_state(
+    probabilities, stopping_strategy, step
+):
     seed = 42
     generator = np.random.default_rng(seed)
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"text": "foo"})
@@ -427,14 +497,26 @@ def test_randomly_cycling_multi_sources_examples_iterable_state(probabilities, s
         (3, lambda x: {"id+1": [x["id"][0] + 1]}, True, 1),  # same with bs=1
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
         (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
-        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None),  # same with bs=None
+        (
+            5,
+            lambda x: {"id+1": [i + 1 for i in x["id"]]},
+            True,
+            None,
+        ),  # same with bs=None
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1),  # same with bs<=0
-        (3, lambda x: {k: v * 2 for k, v in x.items()}, True, 1),  # make a duplicate of each example
+        (
+            3,
+            lambda x: {k: v * 2 for k, v in x.items()},
+            True,
+            1,
+        ),  # make a duplicate of each example
     ],
 )
 def test_mapped_examples_iterable(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = MappedExamplesIterable(base_ex_iterable, func, batched=batched, batch_size=batch_size)
+    ex_iterable = MappedExamplesIterable(
+        base_ex_iterable, func, batched=batched, batch_size=batch_size
+    )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
         expected = [{**x, **func(x)} for x in all_examples]
@@ -464,15 +546,29 @@ def test_mapped_examples_iterable(n, func, batched, batch_size):
         (3, lambda x: {"id+1": [x["id"][0] + 1]}, True, 1),  # same with bs=1
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
         (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10),  # same with bs=10
-        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None),  # same with bs=None
+        (
+            5,
+            lambda x: {"id+1": [i + 1 for i in x["id"]]},
+            True,
+            None,
+        ),  # same with bs=None
         (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1),  # same with bs<=0
-        (3, lambda x: {k: v * 2 for k, v in x.items()}, True, 1),  # make a duplicate of each example
+        (
+            3,
+            lambda x: {k: v * 2 for k, v in x.items()},
+            True,
+            1,
+        ),  # make a duplicate of each example
     ],
 )
 def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batched, batch_size=batch_size, drop_last_batch=True
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        drop_last_batch=True,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     is_empty = False
@@ -492,7 +588,11 @@ def test_mapped_examples_iterable_drop_last_batch(n, func, batched, batch_size):
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
-        all_examples = all_examples if n % batch_size == 0 else all_examples[: n // batch_size * batch_size]
+        all_examples = (
+            all_examples
+            if n % batch_size == 0
+            else all_examples[: n // batch_size * batch_size]
+        )
         if all_examples:
             expected = _examples_to_batch(all_examples)
             expected.update(_examples_to_batch(all_transformed_examples))
@@ -518,22 +618,41 @@ def _wrap_async(func, *args, **kwargs):
 @pytest.mark.parametrize(
     "n, func, batched, batch_size",
     [
-        (3, lambda x, index: {"id+idx": x["id"] + index}, False, None),  # add the index to the id
+        (
+            3,
+            lambda x, index: {"id+idx": x["id"] + index},
+            False,
+            None,
+        ),  # add the index to the id
         (
             25,
             lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
             True,
             10,
         ),  # add the index to the id
-        (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, None),  # same with bs=None
-        (5, lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]}, True, -1),  # same with bs<=0
+        (
+            5,
+            lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
+            True,
+            None,
+        ),  # same with bs=None
+        (
+            5,
+            lambda x, indices: {"id+idx": [i + j for i, j in zip(x["id"], indices)]},
+            True,
+            -1,
+        ),  # same with bs<=0
     ],
 )
 @pytest.mark.parametrize("wrapper", [lambda x: x, _wrap_async])
 def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size, wrapper):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, wrapper(func), batched=batched, batch_size=batch_size, with_indices=True
+        base_ex_iterable,
+        wrapper(func),
+        batched=batched,
+        batch_size=batch_size,
+        with_indices=True,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
@@ -561,28 +680,67 @@ def test_mapped_examples_iterable_with_indices(n, func, batched, batch_size, wra
 @pytest.mark.parametrize(
     "n, func, batched, batch_size, remove_columns",
     [
-        (3, lambda x: {"id+1": x["id"] + 1}, False, None, ["extra_column"]),  # just add 1 to the id
-        (25, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, 10, ["extra_column"]),  # same with bs=10
+        (
+            3,
+            lambda x: {"id+1": x["id"] + 1},
+            False,
+            None,
+            ["extra_column"],
+        ),  # just add 1 to the id
+        (
+            25,
+            lambda x: {"id+1": [i + 1 for i in x["id"]]},
+            True,
+            10,
+            ["extra_column"],
+        ),  # same with bs=10
         (
             50,
-            lambda x: {"foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)},
+            lambda x: {
+                "foo": ["bar"] * np.random.default_rng(x["id"][0]).integers(0, 10)
+            },
             True,
             8,
             ["extra_column", "id"],
         ),  # make a duplicate of each example
-        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, None, ["extra_column"]),  # same with bs=None
-        (5, lambda x: {"id+1": [i + 1 for i in x["id"]]}, True, -1, ["extra_column"]),  # same with bs<=0
+        (
+            5,
+            lambda x: {"id+1": [i + 1 for i in x["id"]]},
+            True,
+            None,
+            ["extra_column"],
+        ),  # same with bs=None
+        (
+            5,
+            lambda x: {"id+1": [i + 1 for i in x["id"]]},
+            True,
+            -1,
+            ["extra_column"],
+        ),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_remove_columns(n, func, batched, batch_size, remove_columns):
-    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n, "extra_column": "foo"})
+def test_mapped_examples_iterable_remove_columns(
+    n, func, batched, batch_size, remove_columns
+):
+    base_ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"n": n, "extra_column": "foo"}
+    )
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batched, batch_size=batch_size, remove_columns=remove_columns
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        remove_columns=remove_columns,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    columns_to_remove = remove_columns if isinstance(remove_columns, list) else [remove_columns]
+    columns_to_remove = (
+        remove_columns if isinstance(remove_columns, list) else [remove_columns]
+    )
     if batched is False:
-        expected = [{**{k: v for k, v in x.items() if k not in columns_to_remove}, **func(x)} for x in all_examples]
+        expected = [
+            {**{k: v for k, v in x.items() if k not in columns_to_remove}, **func(x)}
+            for x in all_examples
+        ]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
@@ -594,7 +752,11 @@ def test_mapped_examples_iterable_remove_columns(n, func, batched, batch_size, r
             batch = _examples_to_batch(examples)
             transformed_batch = func(batch)
             all_transformed_examples.extend(_batch_to_examples(transformed_batch))
-        expected = {k: v for k, v in _examples_to_batch(all_examples).items() if k not in columns_to_remove}
+        expected = {
+            k: v
+            for k, v in _examples_to_batch(all_examples).items()
+            if k not in columns_to_remove
+        }
         expected.update(_examples_to_batch(all_transformed_examples))
         expected = list(_batch_to_examples(expected))
     assert next(iter(ex_iterable))[1] == expected[0]
@@ -608,7 +770,9 @@ def test_mapped_examples_iterable_remove_columns(n, func, batched, batch_size, r
 @pytest.mark.parametrize("input_columns", [None, ["i"]])
 @pytest.mark.parametrize("remove_columns", [None, ["i"]])
 @pytest.mark.parametrize("new_output", [False, True])
-def test_iterable_dataset_vs_dataset_map(batched, batch_size, input_columns, remove_columns, new_output):
+def test_iterable_dataset_vs_dataset_map(
+    batched, batch_size, input_columns, remove_columns, new_output
+):
     if input_columns is not None and not new_output:
         return
 
@@ -618,6 +782,7 @@ def test_iterable_dataset_vs_dataset_map(batched, batch_size, input_columns, rem
 
         def f1(i):
             return {"i": [j + 1 for j in i]}
+
     else:
 
         def f1(i):
@@ -627,6 +792,7 @@ def test_iterable_dataset_vs_dataset_map(batched, batch_size, input_columns, rem
 
         def f2(x):
             return f1(x["i"])
+
     else:
         f2 = f1
 
@@ -661,14 +827,30 @@ def test_iterable_dataset_vs_dataset_map(batched, batch_size, input_columns, rem
         (3, lambda x, y=0: {"id+y": x["id"] + y}, False, None, None),
         (3, lambda x, y=0: {"id+y": x["id"] + y}, False, None, {"y": 3}),
         (25, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, True, 10, {"y": 3}),
-        (5, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, True, None, {"y": 3}),  # same with bs=None
-        (5, lambda x, y=0: {"id+y": [i + y for i in x["id"]]}, True, -1, {"y": 3}),  # same with bs<=0
+        (
+            5,
+            lambda x, y=0: {"id+y": [i + y for i in x["id"]]},
+            True,
+            None,
+            {"y": 3},
+        ),  # same with bs=None
+        (
+            5,
+            lambda x, y=0: {"id+y": [i + y for i in x["id"]]},
+            True,
+            -1,
+            {"y": 3},
+        ),  # same with bs<=0
     ],
 )
 def test_mapped_examples_iterable_fn_kwargs(n, func, batched, batch_size, fn_kwargs):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batched, batch_size=batch_size, fn_kwargs=fn_kwargs
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        fn_kwargs=fn_kwargs,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if fn_kwargs is None:
@@ -698,20 +880,48 @@ def test_mapped_examples_iterable_fn_kwargs(n, func, batched, batch_size, fn_kwa
     "n, func, batched, batch_size, input_columns",
     [
         (3, lambda id_: {"id+1": id_ + 1}, False, None, ["id"]),  # just add 1 to the id
-        (25, lambda ids_: {"id+1": [i + 1 for i in ids_]}, True, 10, ["id"]),  # same with bs=10
-        (5, lambda ids_: {"id+1": [i + 1 for i in ids_]}, True, None, ["id"]),  # same with bs=None
-        (5, lambda ids_: {"id+1": [i + 1 for i in ids_]}, True, -1, ["id"]),  # same with bs<=0
+        (
+            25,
+            lambda ids_: {"id+1": [i + 1 for i in ids_]},
+            True,
+            10,
+            ["id"],
+        ),  # same with bs=10
+        (
+            5,
+            lambda ids_: {"id+1": [i + 1 for i in ids_]},
+            True,
+            None,
+            ["id"],
+        ),  # same with bs=None
+        (
+            5,
+            lambda ids_: {"id+1": [i + 1 for i in ids_]},
+            True,
+            -1,
+            ["id"],
+        ),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_input_columns(n, func, batched, batch_size, input_columns):
+def test_mapped_examples_iterable_input_columns(
+    n, func, batched, batch_size, input_columns
+):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = MappedExamplesIterable(
-        base_ex_iterable, func, batched=batched, batch_size=batch_size, input_columns=input_columns
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        input_columns=input_columns,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    columns_to_input = input_columns if isinstance(input_columns, list) else [input_columns]
+    columns_to_input = (
+        input_columns if isinstance(input_columns, list) else [input_columns]
+    )
     if batched is False:
-        expected = [{**x, **func(*[x[col] for col in columns_to_input])} for x in all_examples]
+        expected = [
+            {**x, **func(*[x[col] for col in columns_to_input])} for x in all_examples
+        ]
     else:
         # For batched map we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         all_transformed_examples = []
@@ -734,18 +944,55 @@ def test_mapped_examples_iterable_input_columns(n, func, batched, batch_size, in
 @pytest.mark.parametrize(
     "n, func, batched, batch_size",
     [
-        (3, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), False, None),  # just add 1 to the id
-        (3, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 1),  # same with bs=1
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10),  # same with bs=10
-        (25, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10),  # same with bs=10
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, None),  # same with bs=None
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, -1),  # same with bs<=0
-        (3, lambda t: pa.concat_tables([t] * 2), True, 1),  # make a duplicate of each example
+        (
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            False,
+            None,
+        ),  # just add 1 to the id
+        (
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            1,
+        ),  # same with bs=1
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            25,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            None,
+        ),  # same with bs=None
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            -1,
+        ),  # same with bs<=0
+        (
+            3,
+            lambda t: pa.concat_tables([t] * 2),
+            True,
+            1,
+        ),  # make a duplicate of each example
     ],
 )
 def test_mapped_examples_iterable_arrow_format(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -755,7 +1002,9 @@ def test_mapped_examples_iterable_arrow_format(n, func, batched, batch_size):
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
-        expected = [func(pa.Table.from_pylist([x])).to_pylist()[0] for x in all_examples]
+        expected = [
+            func(pa.Table.from_pylist([x])).to_pylist()[0] for x in all_examples
+        ]
     else:
         expected = []
         # If batch_size is None or <=0, we use the whole dataset as a single batch
@@ -774,18 +1023,57 @@ def test_mapped_examples_iterable_arrow_format(n, func, batched, batch_size):
 @pytest.mark.parametrize(
     "n, func, batched, batch_size",
     [
-        (3, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), False, None),  # just add 1 to the id
-        (3, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 1),  # same with bs=1
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10),  # same with bs=10
-        (25, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10),  # same with bs=10
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, None),  # same with bs=None
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, -1),  # same with bs<=0
-        (3, lambda t: pa.concat_tables([t] * 2), True, 1),  # make a duplicate of each example
+        (
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            False,
+            None,
+        ),  # just add 1 to the id
+        (
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            1,
+        ),  # same with bs=1
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            25,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            None,
+        ),  # same with bs=None
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            -1,
+        ),  # same with bs<=0
+        (
+            3,
+            lambda t: pa.concat_tables([t] * 2),
+            True,
+            1,
+        ),  # make a duplicate of each example
     ],
 )
-def test_mapped_examples_iterable_arrow_format_from_arrow_examples_iterable(n, func, batched, batch_size):
+def test_mapped_examples_iterable_arrow_format_from_arrow_examples_iterable(
+    n, func, batched, batch_size
+):
     base_ex_iterable = ArrowExamplesIterable(generate_tables_fn, {"n": n})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -795,7 +1083,9 @@ def test_mapped_examples_iterable_arrow_format_from_arrow_examples_iterable(n, f
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
-        expected = [func(pa.Table.from_pylist([x])).to_pylist()[0] for x in all_examples]
+        expected = [
+            func(pa.Table.from_pylist([x])).to_pylist()[0] for x in all_examples
+        ]
     else:
         expected = []
         # If batch_size is None or <=0, we use the whole dataset as a single batch
@@ -814,18 +1104,57 @@ def test_mapped_examples_iterable_arrow_format_from_arrow_examples_iterable(n, f
 @pytest.mark.parametrize(
     "n, func, batched, batch_size",
     [
-        (3, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), False, None),  # just add 1 to the id
-        (3, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 1),  # same with bs=1
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10),  # same with bs=10
-        (25, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10),  # same with bs=10
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, None),  # same with bs=None
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, -1),  # same with bs<=0
-        (3, lambda t: pa.concat_tables([t] * 2), True, 1),  # make a duplicate of each example
+        (
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            False,
+            None,
+        ),  # just add 1 to the id
+        (
+            3,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            1,
+        ),  # same with bs=1
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            25,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            None,
+        ),  # same with bs=None
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            -1,
+        ),  # same with bs<=0
+        (
+            3,
+            lambda t: pa.concat_tables([t] * 2),
+            True,
+            1,
+        ),  # make a duplicate of each example
     ],
 )
-def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batched, batch_size):
+def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(
+    n, func, batched, batch_size
+):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -838,7 +1167,9 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
     is_empty = False
     if batched is False:
         # `drop_last_batch` has no effect here
-        expected = [func(pa.Table.from_pylist([x])).to_pylist()[0] for x in all_examples]
+        expected = [
+            func(pa.Table.from_pylist([x])).to_pylist()[0] for x in all_examples
+        ]
     else:
         all_transformed_examples = []
         # If batch_size is None or <=0, we use the whole dataset as a single batch
@@ -853,7 +1184,11 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
             all_transformed_examples.extend(
                 out.to_pylist()
             )  # we don't merge with input since they're arrow tables and not dictionaries
-        all_examples = all_examples if n % batch_size == 0 else all_examples[: n // batch_size * batch_size]
+        all_examples = (
+            all_examples
+            if n % batch_size == 0
+            else all_examples[: n // batch_size * batch_size]
+        )
         if all_examples:
             expected = all_transformed_examples
         else:
@@ -882,13 +1217,27 @@ def test_mapped_examples_iterable_drop_last_batch_and_arrow_format(n, func, batc
             True,
             10,
         ),  # add the index to the id
-        (5, lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)), True, None),  # same with bs=None
-        (5, lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)), True, -1),  # same with bs<=0
+        (
+            5,
+            lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)),
+            True,
+            None,
+        ),  # same with bs=None
+        (
+            5,
+            lambda t, indices: t.append_column("id+idx", pc.add(t["id"], indices)),
+            True,
+            -1,
+        ),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched, batch_size):
+def test_mapped_examples_iterable_with_indices_and_arrow_format(
+    n, func, batched, batch_size
+):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -899,7 +1248,10 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
-        expected = [func(pa.Table.from_pylist([x]), i).to_pylist()[0] for i, x in enumerate(all_examples)]
+        expected = [
+            func(pa.Table.from_pylist([x]), i).to_pylist()[0]
+            for i, x in enumerate(all_examples)
+        ]
     else:
         expected = []
         # If batch_size is None or <=0, we use the whole dataset as a single batch
@@ -908,7 +1260,11 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
         for batch_offset in range(0, len(all_examples), batch_size):
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
-            expected.extend(func(batch, list(range(batch_offset, batch_offset + len(batch)))).to_pylist())
+            expected.extend(
+                func(
+                    batch, list(range(batch_offset, batch_offset + len(batch)))
+                ).to_pylist()
+            )
     assert next(iter(ex_iterable))[1] == expected[0]
     assert [x for _, x in ex_iterable] == expected
     assert_load_state_dict_resumes_iteration(ex_iterable)
@@ -925,21 +1281,50 @@ def test_mapped_examples_iterable_with_indices_and_arrow_format(n, func, batched
             None,
             ["extra_column"],
         ),  # just add 1 to the id
-        (25, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, 10, ["extra_column"]),  # same with bs=10
+        (
+            25,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            10,
+            ["extra_column"],
+        ),  # same with bs=10
         (
             50,
-            lambda t: pa.table({"foo": ["bar"] * np.random.default_rng(t["id"][0].as_py()).integers(0, 10)}),
+            lambda t: pa.table(
+                {
+                    "foo": ["bar"]
+                    * np.random.default_rng(t["id"][0].as_py()).integers(0, 10)
+                }
+            ),
             True,
             8,
             ["extra_column", "id"],
         ),  # make a duplicate of each example
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, None, ["extra_column"]),  # same with bs=None
-        (5, lambda t: t.append_column("id+1", pc.add(t["id"], 1)), True, -1, ["extra_column"]),  # same with bs<=0
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            None,
+            ["extra_column"],
+        ),  # same with bs=None
+        (
+            5,
+            lambda t: t.append_column("id+1", pc.add(t["id"], 1)),
+            True,
+            -1,
+            ["extra_column"],
+        ),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_remove_columns_arrow_format(n, func, batched, batch_size, remove_columns):
-    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n, "extra_column": "foo"})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+def test_mapped_examples_iterable_remove_columns_arrow_format(
+    n, func, batched, batch_size, remove_columns
+):
+    base_ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"n": n, "extra_column": "foo"}
+    )
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -949,10 +1334,18 @@ def test_mapped_examples_iterable_remove_columns_arrow_format(n, func, batched, 
         formatting=FormattingConfig(format_type="arrow"),
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    columns_to_remove = remove_columns if isinstance(remove_columns, list) else [remove_columns]
+    columns_to_remove = (
+        remove_columns if isinstance(remove_columns, list) else [remove_columns]
+    )
     if batched is False:
         expected = [
-            {**{k: v for k, v in func(pa.Table.from_pylist([x])).to_pylist()[0].items() if k not in columns_to_remove}}
+            {
+                **{
+                    k: v
+                    for k, v in func(pa.Table.from_pylist([x])).to_pylist()[0].items()
+                    if k not in columns_to_remove
+                }
+            }
             for x in all_examples
         ]
     else:
@@ -964,7 +1357,10 @@ def test_mapped_examples_iterable_remove_columns_arrow_format(n, func, batched, 
             examples = all_examples[batch_offset : batch_offset + batch_size]
             batch = pa.Table.from_pylist(examples)
             expected.extend(
-                [{k: v for k, v in x.items() if k not in columns_to_remove} for x in func(batch).to_pylist()]
+                [
+                    {k: v for k, v in x.items() if k not in columns_to_remove}
+                    for x in func(batch).to_pylist()
+                ]
             )
     assert next(iter(ex_iterable))[1] == expected[0]
     assert [x for _, x in ex_iterable] == expected
@@ -975,16 +1371,50 @@ def test_mapped_examples_iterable_remove_columns_arrow_format(n, func, batched, 
 @pytest.mark.parametrize(
     "n, func, batched, batch_size, fn_kwargs",
     [
-        (3, lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)), False, None, None),
-        (3, lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)), False, None, {"y": 3}),
-        (25, lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)), True, 10, {"y": 3}),
-        (5, lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)), True, None, {"y": 3}),  # same with bs=None
-        (5, lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)), True, -1, {"y": 3}),  # same with bs<=0
+        (
+            3,
+            lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)),
+            False,
+            None,
+            None,
+        ),
+        (
+            3,
+            lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)),
+            False,
+            None,
+            {"y": 3},
+        ),
+        (
+            25,
+            lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)),
+            True,
+            10,
+            {"y": 3},
+        ),
+        (
+            5,
+            lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)),
+            True,
+            None,
+            {"y": 3},
+        ),  # same with bs=None
+        (
+            5,
+            lambda t, y=0: t.append_column("id+idx", pc.add(t["id"], y)),
+            True,
+            -1,
+            {"y": 3},
+        ),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_fn_kwargs_and_arrow_format(n, func, batched, batch_size, fn_kwargs):
+def test_mapped_examples_iterable_fn_kwargs_and_arrow_format(
+    n, func, batched, batch_size, fn_kwargs
+):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -997,7 +1427,10 @@ def test_mapped_examples_iterable_fn_kwargs_and_arrow_format(n, func, batched, b
     if fn_kwargs is None:
         fn_kwargs = {}
     if batched is False:
-        expected = [func(pa.Table.from_pylist([x]), **fn_kwargs).to_pylist()[0] for x in all_examples]
+        expected = [
+            func(pa.Table.from_pylist([x]), **fn_kwargs).to_pylist()[0]
+            for x in all_examples
+        ]
     else:
         expected = []
         # If batch_size is None or <=0, we use the whole dataset as a single batch
@@ -1016,15 +1449,43 @@ def test_mapped_examples_iterable_fn_kwargs_and_arrow_format(n, func, batched, b
 @pytest.mark.parametrize(
     "n, func, batched, batch_size, input_columns",
     [
-        (3, lambda id_: pa.table({"id+1": pc.add(id_, 1)}), False, None, ["id"]),  # just add 1 to the id
-        (25, lambda ids_: pa.table({"id+1": pc.add(ids_, 1)}), True, 10, ["id"]),  # same with bs=10
-        (5, lambda ids_: pa.table({"id+1": pc.add(ids_, 1)}), True, None, ["id"]),  # same with bs=None
-        (5, lambda ids_: pa.table({"id+1": pc.add(ids_, 1)}), True, -1, ["id"]),  # same with bs<=0
+        (
+            3,
+            lambda id_: pa.table({"id+1": pc.add(id_, 1)}),
+            False,
+            None,
+            ["id"],
+        ),  # just add 1 to the id
+        (
+            25,
+            lambda ids_: pa.table({"id+1": pc.add(ids_, 1)}),
+            True,
+            10,
+            ["id"],
+        ),  # same with bs=10
+        (
+            5,
+            lambda ids_: pa.table({"id+1": pc.add(ids_, 1)}),
+            True,
+            None,
+            ["id"],
+        ),  # same with bs=None
+        (
+            5,
+            lambda ids_: pa.table({"id+1": pc.add(ids_, 1)}),
+            True,
+            -1,
+            ["id"],
+        ),  # same with bs<=0
     ],
 )
-def test_mapped_examples_iterable_input_columns_and_arrow_format(n, func, batched, batch_size, input_columns):
+def test_mapped_examples_iterable_input_columns_and_arrow_format(
+    n, func, batched, batch_size, input_columns
+):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    base_ex_iterable = RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=batch_size if batched else 1)
+    base_ex_iterable = RebatchedArrowExamplesIterable(
+        base_ex_iterable, batch_size=batch_size if batched else 1
+    )
     ex_iterable = MappedExamplesIterable(
         base_ex_iterable,
         func,
@@ -1034,10 +1495,15 @@ def test_mapped_examples_iterable_input_columns_and_arrow_format(n, func, batche
         formatting=FormattingConfig(format_type="arrow"),
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    columns_to_input = input_columns if isinstance(input_columns, list) else [input_columns]
+    columns_to_input = (
+        input_columns if isinstance(input_columns, list) else [input_columns]
+    )
     if batched is False:
         expected = [
-            func(*[pa.Table.from_pylist([x])[col] for col in columns_to_input]).to_pylist()[0] for x in all_examples
+            func(
+                *[pa.Table.from_pylist([x])[col] for col in columns_to_input]
+            ).to_pylist()[0]
+            for x in all_examples
         ]
     else:
         expected = []
@@ -1068,7 +1534,9 @@ def test_mapped_examples_iterable_input_columns_and_arrow_format(n, func, batche
 )
 def test_filtered_examples_iterable(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
-    ex_iterable = FilteredExamplesIterable(base_ex_iterable, func, batched=batched, batch_size=batch_size)
+    ex_iterable = FilteredExamplesIterable(
+        base_ex_iterable, func, batched=batched, batch_size=batch_size
+    )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
         expected = [x for x in all_examples if func(x)]
@@ -1093,15 +1561,34 @@ def test_filtered_examples_iterable(n, func, batched, batch_size):
     "n, func, batched, batch_size",
     [
         (3, lambda x, index: index % 2 == 0, False, None),  # keep even number
-        (25, lambda x, indices: [idx % 2 == 0 for idx in indices], True, 10),  # same with bs=10
-        (5, lambda x, indices: [idx % 2 == 0 for idx in indices], True, None),  # same with bs=None
-        (5, lambda x, indices: [idx % 2 == 0 for idx in indices], True, -1),  # same with bs<=0
+        (
+            25,
+            lambda x, indices: [idx % 2 == 0 for idx in indices],
+            True,
+            10,
+        ),  # same with bs=10
+        (
+            5,
+            lambda x, indices: [idx % 2 == 0 for idx in indices],
+            True,
+            None,
+        ),  # same with bs=None
+        (
+            5,
+            lambda x, indices: [idx % 2 == 0 for idx in indices],
+            True,
+            -1,
+        ),  # same with bs<=0
     ],
 )
 def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = FilteredExamplesIterable(
-        base_ex_iterable, func, batched=batched, batch_size=batch_size, with_indices=True
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        with_indices=True,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
     if batched is False:
@@ -1127,20 +1614,48 @@ def test_filtered_examples_iterable_with_indices(n, func, batched, batch_size):
     "n, func, batched, batch_size, input_columns",
     [
         (3, lambda id_: id_ % 2 == 0, False, None, ["id"]),  # keep even number
-        (25, lambda ids_: [i % 2 == 0 for i in ids_], True, 10, ["id"]),  # same with bs=10
-        (3, lambda ids_: [i % 2 == 0 for i in ids_], True, None, ["id"]),  # same with bs=None
-        (3, lambda ids_: [i % 2 == 0 for i in ids_], True, None, ["id"]),  # same with bs=None
+        (
+            25,
+            lambda ids_: [i % 2 == 0 for i in ids_],
+            True,
+            10,
+            ["id"],
+        ),  # same with bs=10
+        (
+            3,
+            lambda ids_: [i % 2 == 0 for i in ids_],
+            True,
+            None,
+            ["id"],
+        ),  # same with bs=None
+        (
+            3,
+            lambda ids_: [i % 2 == 0 for i in ids_],
+            True,
+            None,
+            ["id"],
+        ),  # same with bs=None
     ],
 )
-def test_filtered_examples_iterable_input_columns(n, func, batched, batch_size, input_columns):
+def test_filtered_examples_iterable_input_columns(
+    n, func, batched, batch_size, input_columns
+):
     base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": n})
     ex_iterable = FilteredExamplesIterable(
-        base_ex_iterable, func, batched=batched, batch_size=batch_size, input_columns=input_columns
+        base_ex_iterable,
+        func,
+        batched=batched,
+        batch_size=batch_size,
+        input_columns=input_columns,
     )
     all_examples = [x for _, x in generate_examples_fn(n=n)]
-    columns_to_input = input_columns if isinstance(input_columns, list) else [input_columns]
+    columns_to_input = (
+        input_columns if isinstance(input_columns, list) else [input_columns]
+    )
     if batched is False:
-        expected = [x for x in all_examples if func(*[x[col] for col in columns_to_input])]
+        expected = [
+            x for x in all_examples if func(*[x[col] for col in columns_to_input])
+        ]
     else:
         # For batched filter we have to format the examples as a batch (i.e. in one single dictionary) to pass the batch to the function
         expected = []
@@ -1207,9 +1722,10 @@ def test_skip_examples_iterable():
     skip_ex_iterable = SkipExamplesIterable(base_ex_iterable, n=count)
     expected = list(generate_examples_fn(n=total))[count:]
     assert list(skip_ex_iterable) == expected
-    assert skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable, (
-        "skip examples makes the shards order fixed"
-    )
+    assert (
+        skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
+        is skip_ex_iterable
+    ), "skip examples makes the shards order fixed"
     assert_load_state_dict_resumes_iteration(skip_ex_iterable)
 
 
@@ -1219,9 +1735,10 @@ def test_take_examples_iterable():
     take_ex_iterable = TakeExamplesIterable(base_ex_iterable, n=count)
     expected = list(generate_examples_fn(n=total))[:count]
     assert list(take_ex_iterable) == expected
-    assert take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable, (
-        "skip examples makes the shards order fixed"
-    )
+    assert (
+        take_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
+        is take_ex_iterable
+    ), "skip examples makes the shards order fixed"
     assert_load_state_dict_resumes_iteration(take_ex_iterable)
 
 
@@ -1244,13 +1761,17 @@ def test_repeat_examples_iterable(n, num_times):
         max_iters = 135
         iterator = iter(ex_iterable)
         for i in range(max_iters):
-            assert next(iterator)[1] == all_examples[i % len(all_examples)], f"iteration {i} failed,"
+            assert (
+                next(iterator)[1] == all_examples[i % len(all_examples)]
+            ), f"iteration {i} failed,"
 
 
 def test_vertically_concatenated_examples_iterable():
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"label": 10})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"label": 5})
-    concatenated_ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
+    concatenated_ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable(
+        [ex_iterable1, ex_iterable2]
+    )
     expected = [x for _, x in ex_iterable1] + [x for _, x in ex_iterable2]
     assert [x for _, x in concatenated_ex_iterable] == expected
     assert_load_state_dict_resumes_iteration(concatenated_ex_iterable)
@@ -1261,7 +1782,9 @@ def test_vertically_concatenated_examples_iterable_with_different_columns():
     # Though iterable datasets fill the missing data with nulls
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"label": 10})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {})
-    concatenated_ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
+    concatenated_ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable(
+        [ex_iterable1, ex_iterable2]
+    )
     expected = [x for _, x in ex_iterable1] + [x for _, x in ex_iterable2]
     assert [x for _, x in concatenated_ex_iterable] == expected
     assert_load_state_dict_resumes_iteration(concatenated_ex_iterable)
@@ -1270,7 +1793,9 @@ def test_vertically_concatenated_examples_iterable_with_different_columns():
 def test_vertically_concatenated_examples_iterable_shuffle_data_sources():
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"label": 10})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"label": 5})
-    concatenated_ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
+    concatenated_ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable(
+        [ex_iterable1, ex_iterable2]
+    )
     rng = np.random.default_rng(42)
     shuffled_ex_iterable = concatenated_ex_iterable.shuffle_data_sources(rng)
     # make sure the list of examples iterables is shuffled, and each examples iterable is shuffled
@@ -1284,16 +1809,23 @@ def test_vertically_concatenated_examples_iterable_shuffle_data_sources():
 def test_horizontally_concatenated_examples_iterable():
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"label1": 10})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"label2": 5})
-    concatenated_ex_iterable = HorizontallyConcatenatedMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
+    concatenated_ex_iterable = HorizontallyConcatenatedMultiSourcesExamplesIterable(
+        [ex_iterable1, ex_iterable2]
+    )
     with pytest.raises(ValueError):  # column "id" is duplicated -> raise an error
         list(concatenated_ex_iterable)
-    ex_iterable2 = MappedExamplesIterable(ex_iterable2, lambda x: x, remove_columns=["id"])
-    concatenated_ex_iterable = HorizontallyConcatenatedMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
+    ex_iterable2 = MappedExamplesIterable(
+        ex_iterable2, lambda x: x, remove_columns=["id"]
+    )
+    concatenated_ex_iterable = HorizontallyConcatenatedMultiSourcesExamplesIterable(
+        [ex_iterable1, ex_iterable2]
+    )
     expected = [{**x, **y} for (_, x), (_, y) in zip(ex_iterable1, ex_iterable2)]
     assert [x for _, x in concatenated_ex_iterable] == expected
-    assert concatenated_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is concatenated_ex_iterable, (
-        "horizontally concatenated examples makes the shards order fixed"
-    )
+    assert (
+        concatenated_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
+        is concatenated_ex_iterable
+    ), "horizontally concatenated examples makes the shards order fixed"
     assert_load_state_dict_resumes_iteration(concatenated_ex_iterable)
 
 
@@ -1301,24 +1833,43 @@ def test_horizontally_concatenated_examples_iterable():
     "ex_iterable",
     [
         ExamplesIterable(generate_examples_fn, {}),
-        ShuffledDataSourcesExamplesIterable(generate_examples_fn, {}, np.random.default_rng(42)),
+        ShuffledDataSourcesExamplesIterable(
+            generate_examples_fn, {}, np.random.default_rng(42)
+        ),
         SelectColumnsIterable(ExamplesIterable(generate_examples_fn, {}), ["id"]),
         StepExamplesIterable(ExamplesIterable(generate_examples_fn, {}), 2, 0),
-        CyclingMultiSourcesExamplesIterable([ExamplesIterable(generate_examples_fn, {})]),
-        VerticallyConcatenatedMultiSourcesExamplesIterable([ExamplesIterable(generate_examples_fn, {})]),
-        HorizontallyConcatenatedMultiSourcesExamplesIterable([ExamplesIterable(generate_examples_fn, {})]),
+        CyclingMultiSourcesExamplesIterable(
+            [ExamplesIterable(generate_examples_fn, {})]
+        ),
+        VerticallyConcatenatedMultiSourcesExamplesIterable(
+            [ExamplesIterable(generate_examples_fn, {})]
+        ),
+        HorizontallyConcatenatedMultiSourcesExamplesIterable(
+            [ExamplesIterable(generate_examples_fn, {})]
+        ),
         RandomlyCyclingMultiSourcesExamplesIterable(
             [ExamplesIterable(generate_examples_fn, {})], np.random.default_rng(42)
         ),
         MappedExamplesIterable(ExamplesIterable(generate_examples_fn, {}), lambda x: x),
-        MappedExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), lambda x: x),
-        FilteredExamplesIterable(ExamplesIterable(generate_examples_fn, {}), lambda x: True),
-        FilteredExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), lambda x: True),
-        BufferShuffledExamplesIterable(ExamplesIterable(generate_examples_fn, {}), 10, np.random.default_rng(42)),
+        MappedExamplesIterable(
+            ArrowExamplesIterable(generate_tables_fn, {}), lambda x: x
+        ),
+        FilteredExamplesIterable(
+            ExamplesIterable(generate_examples_fn, {}), lambda x: True
+        ),
+        FilteredExamplesIterable(
+            ArrowExamplesIterable(generate_tables_fn, {}), lambda x: True
+        ),
+        BufferShuffledExamplesIterable(
+            ExamplesIterable(generate_examples_fn, {}), 10, np.random.default_rng(42)
+        ),
         SkipExamplesIterable(ExamplesIterable(generate_examples_fn, {}), 10),
         TakeExamplesIterable(ExamplesIterable(generate_examples_fn, {}), 10),
         FormattedExamplesIterable(
-            ExamplesIterable(generate_examples_fn, {}), None, Features({"id": Value("int32")}), token_per_repo_id={}
+            ExamplesIterable(generate_examples_fn, {}),
+            None,
+            Features({"id": Value("int32")}),
+            token_per_repo_id={},
         ),
     ],
 )
@@ -1332,30 +1883,42 @@ def test_no_iter_arrow(ex_iterable: _BaseExamplesIterable):
     "ex_iterable",
     [
         ArrowExamplesIterable(generate_tables_fn, {}),
-        ShuffledDataSourcesArrowExamplesIterable(generate_tables_fn, {}, np.random.default_rng(42)),
+        ShuffledDataSourcesArrowExamplesIterable(
+            generate_tables_fn, {}, np.random.default_rng(42)
+        ),
         SelectColumnsIterable(ArrowExamplesIterable(generate_tables_fn, {}), ["id"]),
         # StepExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), 2, 0),  # not implemented
         # CyclingMultiSourcesExamplesIterable([ArrowExamplesIterable(generate_tables_fn, {})]),  # not implemented
-        VerticallyConcatenatedMultiSourcesExamplesIterable([ArrowExamplesIterable(generate_tables_fn, {})]),
+        VerticallyConcatenatedMultiSourcesExamplesIterable(
+            [ArrowExamplesIterable(generate_tables_fn, {})]
+        ),
         # HorizontallyConcatenatedMultiSourcesExamplesIterable([ArrowExamplesIterable(generate_tables_fn, {})]),  # not implemented
         # RandomlyCyclingMultiSourcesExamplesIterable([ArrowExamplesIterable(generate_tables_fn, {})], np.random.default_rng(42)),  # not implemented
         MappedExamplesIterable(
-            RebatchedArrowExamplesIterable(ExamplesIterable(generate_examples_fn, {}), batch_size=1),
+            RebatchedArrowExamplesIterable(
+                ExamplesIterable(generate_examples_fn, {}), batch_size=1
+            ),
             lambda t: t,
             formatting=FormattingConfig(format_type="arrow"),
         ),
         MappedExamplesIterable(
-            RebatchedArrowExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), batch_size=1),
+            RebatchedArrowExamplesIterable(
+                ArrowExamplesIterable(generate_tables_fn, {}), batch_size=1
+            ),
             lambda t: t,
             formatting=FormattingConfig(format_type="arrow"),
         ),
         FilteredExamplesIterable(
-            RebatchedArrowExamplesIterable(ExamplesIterable(generate_examples_fn, {}), batch_size=1),
+            RebatchedArrowExamplesIterable(
+                ExamplesIterable(generate_examples_fn, {}), batch_size=1
+            ),
             lambda t: True,
             formatting=FormattingConfig(format_type="arrow"),
         ),
         FilteredExamplesIterable(
-            RebatchedArrowExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), batch_size=1),
+            RebatchedArrowExamplesIterable(
+                ArrowExamplesIterable(generate_tables_fn, {}), batch_size=1
+            ),
             lambda t: True,
             formatting=FormattingConfig(format_type="arrow"),
         ),
@@ -1363,7 +1926,10 @@ def test_no_iter_arrow(ex_iterable: _BaseExamplesIterable):
         # SkipExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), 10),  # not implemented
         # TakeExamplesIterable(ArrowExamplesIterable(generate_tables_fn, {}), 10),  # not implemented
         FormattedExamplesIterable(
-            ArrowExamplesIterable(generate_tables_fn, {}), None, Features({"id": Value("int32")}), token_per_repo_id={}
+            ArrowExamplesIterable(generate_tables_fn, {}),
+            None,
+            Features({"id": Value("int32")}),
+            token_per_repo_id={},
         ),
     ],
 )
@@ -1411,7 +1977,9 @@ def test_iterable_dataset_from_generator_with_shards():
                 yield {"shard_name": shard_name, "i": i}
 
     shard_names = [f"data{shard_idx}.txt" for shard_idx in range(4)]
-    dataset = IterableDataset.from_generator(gen, gen_kwargs={"shard_names": shard_names})
+    dataset = IterableDataset.from_generator(
+        gen, gen_kwargs={"shard_names": shard_names}
+    )
     assert isinstance(dataset, IterableDataset)
     assert dataset.num_shards == len(shard_names)
 
@@ -1433,7 +2001,11 @@ def test_iterable_dataset_from_file(dataset: IterableDataset, arrow_file: str):
 def test_from_spark_streaming():
     import pyspark
 
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     data = [
         ("0", 0, 0.0),
         ("1", 1, 1.0),
@@ -1461,7 +2033,11 @@ def test_from_spark_streaming_features():
     import PIL.Image
     import pyspark
 
-    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark = (
+        pyspark.sql.SparkSession.builder.master("local[*]")
+        .appName("pyspark")
+        .getOrCreate()
+    )
     data = [(0, np.arange(4 * 4 * 3).reshape(4, 4, 3).tolist())]
     df = spark.createDataFrame(data, "idx: int, image: array<array<array<int>>>")
     features = Features({"idx": Value("int64"), "image": Image()})
@@ -1492,7 +2068,9 @@ def test_iterable_dataset_torch_picklable():
     import pickle
 
     ex_iterable = ExamplesIterable(generate_examples_fn, {})
-    dataset = IterableDataset(ex_iterable, formatting=FormattingConfig(format_type="torch"))
+    dataset = IterableDataset(
+        ex_iterable, formatting=FormattingConfig(format_type="torch")
+    )
     reloaded_dataset = pickle.loads(pickle.dumps(dataset))
 
     import torch.utils.data
@@ -1532,7 +2110,9 @@ def test_iterable_dataset_torch_dataloader_parallel():
 def test_sharded_iterable_dataset_torch_dataloader_parallel(num_shards, num_workers):
     from torch.utils.data import DataLoader
 
-    ex_iterable = ExamplesIterable(generate_examples_fn, {"filepaths": [f"{i}.txt" for i in range(num_shards)]})
+    ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"filepaths": [f"{i}.txt" for i in range(num_shards)]}
+    )
     dataset = IterableDataset(ex_iterable)
     dataloader = DataLoader(dataset, batch_size=None, num_workers=num_workers)
     result = list(dataloader)
@@ -1547,7 +2127,12 @@ def test_sharded_iterable_dataset_torch_dataloader_parallel(num_shards, num_work
 def test_iterable_dataset_from_hub_torch_dataloader_parallel(num_workers, tmp_path):
     from torch.utils.data import DataLoader
 
-    dataset = load_dataset(SAMPLE_DATASET_IDENTIFIER, cache_dir=str(tmp_path), streaming=True, split="train")
+    dataset = load_dataset(
+        SAMPLE_DATASET_IDENTIFIER,
+        cache_dir=str(tmp_path),
+        streaming=True,
+        split="train",
+    )
     dataloader = DataLoader(dataset, batch_size=None, num_workers=num_workers)
     result = list(dataloader)
     assert len(result) == 10
@@ -1564,7 +2149,10 @@ def test_iterable_dataset_iter_batch(batch_size, drop_last_batch):
         if len(all_examples[i : i + batch_size]) < batch_size and drop_last_batch:
             continue
         expected.append(_examples_to_batch(all_examples[i : i + batch_size]))
-    assert next(iter(dataset.iter(batch_size, drop_last_batch=drop_last_batch))) == expected[0]
+    assert (
+        next(iter(dataset.iter(batch_size, drop_last_batch=drop_last_batch)))
+        == expected[0]
+    )
     assert list(dataset.iter(batch_size, drop_last_batch=drop_last_batch)) == expected
 
 
@@ -1597,7 +2185,9 @@ def test_iterable_dataset_set_epoch_resuming(dataset: IterableDataset):
 
 @pytest.mark.parametrize("seed", [None, 42, 1337])
 @pytest.mark.parametrize("epoch", [None, 0, 1, 10])
-def test_iterable_dataset_set_epoch_of_shuffled_dataset(dataset: IterableDataset, seed, epoch):
+def test_iterable_dataset_set_epoch_of_shuffled_dataset(
+    dataset: IterableDataset, seed, epoch
+):
     buffer_size = 10
     shuffled_dataset = dataset.shuffle(seed, buffer_size=buffer_size)
     base_generator = shuffled_dataset._shuffling.generator
@@ -1610,7 +2200,10 @@ def test_iterable_dataset_set_epoch_of_shuffled_dataset(dataset: IterableDataset
     else:
         assert not is_rng_equal(base_generator, shuffled_dataset._effective_generator())
         effective_seed = deepcopy(base_generator).integers(0, 1 << 63) - epoch
-        assert is_rng_equal(np.random.default_rng(effective_seed), shuffled_dataset._effective_generator())
+        assert is_rng_equal(
+            np.random.default_rng(effective_seed),
+            shuffled_dataset._effective_generator(),
+        )
 
 
 def test_iterable_dataset_map(
@@ -1621,7 +2214,10 @@ def test_iterable_dataset_map(
     assert isinstance(mapped_dataset._ex_iterable, MappedExamplesIterable)
     assert mapped_dataset._ex_iterable.function is func
     assert mapped_dataset._ex_iterable.batched is False
-    assert next(iter(mapped_dataset)) == {**next(iter(dataset)), **func(next(iter(generate_examples_fn()))[1])}
+    assert next(iter(mapped_dataset)) == {
+        **next(iter(dataset)),
+        **func(next(iter(generate_examples_fn()))[1]),
+    }
 
 
 def test_iterable_dataset_map_batched(
@@ -1666,7 +2262,9 @@ def test_iterable_dataset_map_with_features(dataset: IterableDataset) -> None:
             "label": Value("string"),
         }
     )
-    dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features_before_map))
+    dataset = IterableDataset(
+        ex_iterable, info=DatasetInfo(features=features_before_map)
+    )
     assert dataset.info.features is not None
     assert dataset.info.features == features_before_map
     features_after_map = Features(
@@ -1683,12 +2281,17 @@ def test_iterable_dataset_map_with_features(dataset: IterableDataset) -> None:
 
 def test_iterable_dataset_map_with_fn_kwargs(dataset: IterableDataset) -> None:
     fn_kwargs = {"y": 1}
-    mapped_dataset = dataset.map(lambda x, y: {"id+y": x["id"] + y}, fn_kwargs=fn_kwargs)
+    mapped_dataset = dataset.map(
+        lambda x, y: {"id+y": x["id"] + y}, fn_kwargs=fn_kwargs
+    )
     assert mapped_dataset._ex_iterable.batched is False
     assert next(iter(mapped_dataset)) == {"id": 0, "id+y": 1}
     batch_size = 3
     mapped_dataset = dataset.map(
-        lambda x, y: {"id+y": [i + y for i in x["id"]]}, batched=True, batch_size=batch_size, fn_kwargs=fn_kwargs
+        lambda x, y: {"id+y": [i + y for i in x["id"]]},
+        batched=True,
+        batch_size=batch_size,
+        fn_kwargs=fn_kwargs,
     )
     assert isinstance(mapped_dataset._ex_iterable, MappedExamplesIterable)
     assert mapped_dataset._ex_iterable.batch_size == batch_size
@@ -1720,7 +2323,11 @@ def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):
         effective_seed = np.random.default_rng(seed).integers(0, 1 << 63) - epoch
     # Shuffling adds a shuffle buffer
     expected_first_example_index = next(
-        iter(BufferShuffledExamplesIterable._iter_random_indices(np.random.default_rng(effective_seed), buffer_size))
+        iter(
+            BufferShuffledExamplesIterable._iter_random_indices(
+                np.random.default_rng(effective_seed), buffer_size
+            )
+        )
     )
     assert isinstance(dataset._ex_iterable, BufferShuffledExamplesIterable)
     # It also shuffles the underlying examples iterable
@@ -1728,7 +2335,10 @@ def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):
         generate_examples_fn, {"filepaths": ["0.txt", "1.txt"]}
     ).shuffle_data_sources(np.random.default_rng(effective_seed))
     assert isinstance(dataset._ex_iterable.ex_iterable, ExamplesIterable)
-    assert next(iter(dataset)) == list(islice(expected_ex_iterable, expected_first_example_index + 1))[-1][1]
+    assert (
+        next(iter(dataset))
+        == list(islice(expected_ex_iterable, expected_first_example_index + 1))[-1][1]
+    )
 
 
 @pytest.mark.parametrize(
@@ -1761,7 +2371,8 @@ def test_iterable_dataset_features(features):
 
 def test_iterable_dataset_features_cast_to_python():
     ex_iterable = ExamplesIterable(
-        generate_examples_fn, {"timestamp": pd.Timestamp(2020, 1, 1), "array": np.ones(5), "n": 1}
+        generate_examples_fn,
+        {"timestamp": pd.Timestamp(2020, 1, 1), "array": np.ones(5), "n": 1},
     )
     features = Features(
         {
@@ -1771,18 +2382,39 @@ def test_iterable_dataset_features_cast_to_python():
         }
     )
     dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features))
-    assert list(dataset) == [{"timestamp": pd.Timestamp(2020, 1, 1).to_pydatetime(), "array": [1] * 5, "id": 0}]
+    assert list(dataset) == [
+        {
+            "timestamp": pd.Timestamp(2020, 1, 1).to_pydatetime(),
+            "array": [1] * 5,
+            "id": 0,
+        }
+    ]
 
 
 @require_torch
 @require_tf
 @require_jax
 @pytest.mark.parametrize(
-    "format_type", [None, "torch", "python", "tf", "tensorflow", "np", "numpy", "jax", "arrow", "pd", "pandas"]
+    "format_type",
+    [
+        None,
+        "torch",
+        "python",
+        "tf",
+        "tensorflow",
+        "np",
+        "numpy",
+        "jax",
+        "arrow",
+        "pd",
+        "pandas",
+    ],
 )
 def test_iterable_dataset_with_format(dataset: IterableDataset, format_type):
     formatted_dataset = dataset.with_format(format_type)
-    assert formatted_dataset._formatting.format_type == get_format_type_from_alias(format_type)
+    assert formatted_dataset._formatting.format_type == get_format_type_from_alias(
+        format_type
+    )
 
 
 @require_torch
@@ -1844,20 +2476,40 @@ def test_iterable_dataset_repeat(dataset: IterableDataset, n):
 def test_iterable_dataset_shard():
     num_examples = 20
     num_shards = 5
-    dataset = Dataset.from_dict({"a": range(num_examples)}).to_iterable_dataset(num_shards=num_shards)
-    assert sum(dataset.shard(num_shards, i).num_shards for i in range(num_shards)) == dataset.num_shards
-    assert list(concatenate_datasets([dataset.shard(num_shards, i) for i in range(num_shards)])) == list(dataset)
-    num_shards = 2
-    assert sum(dataset.shard(num_shards, i).num_shards for i in range(num_shards)) == dataset.num_shards
-    assert list(concatenate_datasets([dataset.shard(num_shards, i) for i in range(num_shards)])) == list(dataset)
+    dataset = Dataset.from_dict({"a": range(num_examples)}).to_iterable_dataset(
+        num_shards=num_shards
+    )
     assert (
-        sum(dataset.shard(num_shards, i, contiguous=False).num_shards for i in range(num_shards)) == dataset.num_shards
+        sum(dataset.shard(num_shards, i).num_shards for i in range(num_shards))
+        == dataset.num_shards
     )
     assert list(
-        concatenate_datasets([dataset.shard(num_shards, i, contiguous=False) for i in range(num_shards)])
+        concatenate_datasets([dataset.shard(num_shards, i) for i in range(num_shards)])
+    ) == list(dataset)
+    num_shards = 2
+    assert (
+        sum(dataset.shard(num_shards, i).num_shards for i in range(num_shards))
+        == dataset.num_shards
+    )
+    assert list(
+        concatenate_datasets([dataset.shard(num_shards, i) for i in range(num_shards)])
+    ) == list(dataset)
+    assert (
+        sum(
+            dataset.shard(num_shards, i, contiguous=False).num_shards
+            for i in range(num_shards)
+        )
+        == dataset.num_shards
+    )
+    assert list(
+        concatenate_datasets(
+            [dataset.shard(num_shards, i, contiguous=False) for i in range(num_shards)]
+        )
     ) != list(dataset)
     assert sorted(
-        concatenate_datasets([dataset.shard(num_shards, i, contiguous=False) for i in range(num_shards)]),
+        concatenate_datasets(
+            [dataset.shard(num_shards, i, contiguous=False) for i in range(num_shards)]
+        ),
         key=lambda x: x["a"],
     ) == list(dataset)
 
@@ -1869,53 +2521,89 @@ def test_iterable_dataset_skip_or_take_after_shuffle(method, after_shuffle, coun
     seed = 42
     n, num_shards = 3, 10
     ex_iterable = ExamplesIterable(
-        generate_examples_fn, {"n": n, "filepaths": [f"{i}.txt" for i in range(num_shards)]}
+        generate_examples_fn,
+        {"n": n, "filepaths": [f"{i}.txt" for i in range(num_shards)]},
     )
     dataset = IterableDataset(ex_iterable)
     shuffled_dataset = dataset
     if after_shuffle:
-        shuffled_dataset = shuffled_dataset.shuffle(seed, buffer_size=DEFAULT_N_EXAMPLES)
-        shuffled_dataset = shuffled_dataset.skip(count) if method == "skip" else shuffled_dataset.take(count)
+        shuffled_dataset = shuffled_dataset.shuffle(
+            seed, buffer_size=DEFAULT_N_EXAMPLES
+        )
+        shuffled_dataset = (
+            shuffled_dataset.skip(count)
+            if method == "skip"
+            else shuffled_dataset.take(count)
+        )
         # skip/take a shuffled dataset should not keep the same examples and shuffle the shards
         key = lambda x: f"{x['filepath']}_{x['id']}"  # noqa: E731
-        assert (len(list(dataset)) - count if method == "skip" else count) == len(list(shuffled_dataset))
-        assert sorted(list(dataset)[count:] if method == "skip" else list(dataset)[:count], key=key) != sorted(
-            shuffled_dataset, key=key
+        assert (len(list(dataset)) - count if method == "skip" else count) == len(
+            list(shuffled_dataset)
         )
+        assert sorted(
+            list(dataset)[count:] if method == "skip" else list(dataset)[:count],
+            key=key,
+        ) != sorted(shuffled_dataset, key=key)
     else:
-        shuffled_dataset = shuffled_dataset.skip(count) if method == "skip" else shuffled_dataset.take(count)
-        shuffled_dataset = shuffled_dataset.shuffle(seed, buffer_size=DEFAULT_N_EXAMPLES)
+        shuffled_dataset = (
+            shuffled_dataset.skip(count)
+            if method == "skip"
+            else shuffled_dataset.take(count)
+        )
+        shuffled_dataset = shuffled_dataset.shuffle(
+            seed, buffer_size=DEFAULT_N_EXAMPLES
+        )
         # shuffling a skip/take dataset should keep the same examples and don't shuffle the shards
         key = lambda x: f"{x['filepath']}_{x['id']}"  # noqa: E731
-        assert (len(list(dataset)) - count if method == "skip" else count) == len(list(shuffled_dataset))
-        assert sorted(list(dataset)[count:] if method == "skip" else list(dataset)[:count], key=key) == sorted(
-            shuffled_dataset, key=key
+        assert (len(list(dataset)) - count if method == "skip" else count) == len(
+            list(shuffled_dataset)
         )
+        assert sorted(
+            list(dataset)[count:] if method == "skip" else list(dataset)[:count],
+            key=key,
+        ) == sorted(shuffled_dataset, key=key)
 
 
 @pytest.mark.parametrize("method", ["skip", "take"])
 @pytest.mark.parametrize("after_split_by_node", [False, True])
 @pytest.mark.parametrize("count", [2, 5, 11])
-def test_iterable_dataset_skip_or_take_after_split_by_node(method, after_split_by_node, count):
+def test_iterable_dataset_skip_or_take_after_split_by_node(
+    method, after_split_by_node, count
+):
     n, num_shards = 3, 10
     rank, world_size = 1, 2
     ex_iterable = ExamplesIterable(
-        generate_examples_fn, {"n": n, "filepaths": [f"{i}.txt" for i in range(num_shards)]}
+        generate_examples_fn,
+        {"n": n, "filepaths": [f"{i}.txt" for i in range(num_shards)]},
     )
     dataset = IterableDataset(ex_iterable)
     distributed_dataset = dataset
-    true_distributed_dataset = split_dataset_by_node(dataset, rank=rank, world_size=world_size)
+    true_distributed_dataset = split_dataset_by_node(
+        dataset, rank=rank, world_size=world_size
+    )
     if after_split_by_node:
-        distributed_dataset = split_dataset_by_node(distributed_dataset, rank=rank, world_size=world_size)
-        distributed_dataset = distributed_dataset.skip(count) if method == "skip" else distributed_dataset.take(count)
+        distributed_dataset = split_dataset_by_node(
+            distributed_dataset, rank=rank, world_size=world_size
+        )
+        distributed_dataset = (
+            distributed_dataset.skip(count)
+            if method == "skip"
+            else distributed_dataset.take(count)
+        )
         assert (
             list(true_distributed_dataset)[count:]
             if method == "skip"
             else list(true_distributed_dataset)[:count] == list(distributed_dataset)
         )
     else:
-        distributed_dataset = distributed_dataset.skip(count) if method == "skip" else distributed_dataset.take(count)
-        distributed_dataset = split_dataset_by_node(distributed_dataset, rank=rank, world_size=world_size)
+        distributed_dataset = (
+            distributed_dataset.skip(count)
+            if method == "skip"
+            else distributed_dataset.take(count)
+        )
+        distributed_dataset = split_dataset_by_node(
+            distributed_dataset, rank=rank, world_size=world_size
+        )
         assert len(
             list(true_distributed_dataset)[count // world_size :]
             if method == "skip"
@@ -1927,7 +2615,8 @@ def test_iterable_dataset_add_column(dataset_with_several_columns: IterableDatas
     new_column = list(range(3 * DEFAULT_N_EXAMPLES))
     new_dataset = dataset_with_several_columns.add_column("new_column", new_column)
     assert list(new_dataset) == [
-        {**example, "new_column": idx} for idx, example in enumerate(dataset_with_several_columns)
+        {**example, "new_column": idx}
+        for idx, example in enumerate(dataset_with_several_columns)
     ]
     new_dataset = new_dataset._resolve_features()
     assert "new_column" in new_dataset.column_names
@@ -1936,12 +2625,15 @@ def test_iterable_dataset_add_column(dataset_with_several_columns: IterableDatas
 def test_iterable_dataset_rename_column(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.rename_column("id", "new_id")
     assert list(new_dataset) == [
-        {("new_id" if k == "id" else k): v for k, v in example.items()} for example in dataset_with_several_columns
+        {("new_id" if k == "id" else k): v for k, v in example.items()}
+        for example in dataset_with_several_columns
     ]
     assert new_dataset.features is None
     assert new_dataset.column_names is None
     # rename the column if ds.features was not None
-    new_dataset = dataset_with_several_columns._resolve_features().rename_column("id", "new_id")
+    new_dataset = dataset_with_several_columns._resolve_features().rename_column(
+        "id", "new_id"
+    )
     assert new_dataset.features is not None
     assert new_dataset.column_names is not None
     assert "id" not in new_dataset.column_names
@@ -1952,12 +2644,15 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns: IterableD
     column_mapping = {"id": "new_id", "filepath": "filename"}
     new_dataset = dataset_with_several_columns.rename_columns(column_mapping)
     assert list(new_dataset) == [
-        {column_mapping.get(k, k): v for k, v in example.items()} for example in dataset_with_several_columns
+        {column_mapping.get(k, k): v for k, v in example.items()}
+        for example in dataset_with_several_columns
     ]
     assert new_dataset.features is None
     assert new_dataset.column_names is None
     # rename the columns if ds.features was not None
-    new_dataset = dataset_with_several_columns._resolve_features().rename_columns(column_mapping)
+    new_dataset = dataset_with_several_columns._resolve_features().rename_columns(
+        column_mapping
+    )
     assert new_dataset.features is not None
     assert new_dataset.column_names is not None
     assert all(c not in new_dataset.column_names for c in ["id", "filepath"])
@@ -1967,17 +2662,21 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns: IterableD
 def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.remove_columns("id")
     assert list(new_dataset) == [
-        {k: v for k, v in example.items() if k != "id"} for example in dataset_with_several_columns
+        {k: v for k, v in example.items() if k != "id"}
+        for example in dataset_with_several_columns
     ]
     assert new_dataset.features is None
     new_dataset = dataset_with_several_columns.remove_columns(["id", "filepath"])
     assert list(new_dataset) == [
-        {k: v for k, v in example.items() if k != "id" and k != "filepath"} for example in dataset_with_several_columns
+        {k: v for k, v in example.items() if k != "id" and k != "filepath"}
+        for example in dataset_with_several_columns
     ]
     assert new_dataset.features is None
     assert new_dataset.column_names is None
     # remove the columns if ds.features was not None
-    new_dataset = dataset_with_several_columns._resolve_features().remove_columns(["id", "filepath"])
+    new_dataset = dataset_with_several_columns._resolve_features().remove_columns(
+        ["id", "filepath"]
+    )
     assert new_dataset.features is not None
     assert new_dataset.column_names is not None
     assert all(c not in new_dataset.features for c in ["id", "filepath"])
@@ -1987,16 +2686,20 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableD
 def test_iterable_dataset_select_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.select_columns("id")
     assert list(new_dataset) == [
-        {k: v for k, v in example.items() if k == "id"} for example in dataset_with_several_columns
+        {k: v for k, v in example.items() if k == "id"}
+        for example in dataset_with_several_columns
     ]
     assert new_dataset.features is None
     new_dataset = dataset_with_several_columns.select_columns(["id", "filepath"])
     assert list(new_dataset) == [
-        {k: v for k, v in example.items() if k in ("id", "filepath")} for example in dataset_with_several_columns
+        {k: v for k, v in example.items() if k in ("id", "filepath")}
+        for example in dataset_with_several_columns
     ]
     assert new_dataset.features is None
     # select the columns if ds.features was not None
-    new_dataset = dataset_with_several_columns._resolve_features().select_columns(["id", "filepath"])
+    new_dataset = dataset_with_several_columns._resolve_features().select_columns(
+        ["id", "filepath"]
+    )
     assert new_dataset.features is not None
     assert new_dataset.column_names is not None
     assert all(c in new_dataset.features for c in ["id", "filepath"])
@@ -2010,7 +2713,9 @@ def test_iterable_dataset_cast_column():
     casted_dataset = dataset.cast_column("label", Value("bool"))
     casted_features = features.copy()
     casted_features["label"] = Value("bool")
-    assert list(casted_dataset) == [casted_features.encode_example(ex) for _, ex in ex_iterable]
+    assert list(casted_dataset) == [
+        casted_features.encode_example(ex) for _, ex in ex_iterable
+    ]
 
 
 def test_iterable_dataset_cast():
@@ -2019,7 +2724,9 @@ def test_iterable_dataset_cast():
     dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features))
     new_features = Features({"id": Value("int64"), "label": Value("bool")})
     casted_dataset = dataset.cast(new_features)
-    assert list(casted_dataset) == [new_features.encode_example(ex) for _, ex in ex_iterable]
+    assert list(casted_dataset) == [
+        new_features.encode_example(ex) for _, ex in ex_iterable
+    ]
 
 
 def test_iterable_dataset_resolve_features():
@@ -2098,8 +2805,12 @@ def test_concatenate_datasets_axis_1():
     dataset2 = IterableDataset(ex_iterable2)
     with pytest.raises(ValueError):  # column "id" is duplicated -> raise an error
         concatenate_datasets([dataset1, dataset2], axis=1)
-    concatenated_dataset = concatenate_datasets([dataset1, dataset2.remove_columns("id")], axis=1)
-    assert list(concatenated_dataset) == [{**x, **y} for x, y in zip(dataset1, dataset2)]
+    concatenated_dataset = concatenate_datasets(
+        [dataset1, dataset2.remove_columns("id")], axis=1
+    )
+    assert list(concatenated_dataset) == [
+        {**x, **y} for x, y in zip(dataset1, dataset2)
+    ]
 
 
 def test_concatenate_datasets_axis_1_resolves_features():
@@ -2123,22 +2834,41 @@ def test_concatenate_datasets_axis_1_with_different_lengths():
     extended_dataset2_list = list(dataset2) + [{"label2": None}] * (n1 - n2)
 
     concatenated_dataset = concatenate_datasets([dataset1, dataset2], axis=1)
-    assert list(concatenated_dataset) == [{**x, **y} for x, y in zip(dataset1, extended_dataset2_list)]
+    assert list(concatenated_dataset) == [
+        {**x, **y} for x, y in zip(dataset1, extended_dataset2_list)
+    ]
     # change order
     concatenated_dataset = concatenate_datasets([dataset2, dataset1], axis=1)
-    assert list(concatenated_dataset) == [{**x, **y} for x, y in zip(extended_dataset2_list, dataset1)]
+    assert list(concatenated_dataset) == [
+        {**x, **y} for x, y in zip(extended_dataset2_list, dataset1)
+    ]
 
 
 @require_torch
 @require_tf
 @require_jax
 @pytest.mark.parametrize(
-    "format_type", [None, "torch", "python", "tf", "tensorflow", "np", "numpy", "jax", "arrow", "pd", "pandas"]
+    "format_type",
+    [
+        None,
+        "torch",
+        "python",
+        "tf",
+        "tensorflow",
+        "np",
+        "numpy",
+        "jax",
+        "arrow",
+        "pd",
+        "pandas",
+    ],
 )
 def test_concatenate_datasets_with_format(dataset: IterableDataset, format_type):
     formatted_dataset = dataset.with_format(format_type)
     concatenated_dataset = concatenate_datasets([formatted_dataset])
-    assert concatenated_dataset._formatting.format_type == get_format_type_from_alias(format_type)
+    assert concatenated_dataset._formatting.format_type == get_format_type_from_alias(
+        format_type
+    )
 
 
 @pytest.mark.parametrize(
@@ -2156,7 +2886,9 @@ def test_concatenate_datasets_with_format(dataset: IterableDataset, format_type)
         ([0.5, 0.2, 0.3], 101010, None, "all_exhausted"),
     ],
 )
-def test_interleave_datasets(dataset: IterableDataset, probas, seed, expected_length, stopping_strategy):
+def test_interleave_datasets(
+    dataset: IterableDataset, probas, seed, expected_length, stopping_strategy
+):
     d1 = dataset
     d2 = dataset.map(lambda x: {"id+1": x["id"] + 1, **x})
     d3 = dataset.with_format("python")
@@ -2171,23 +2903,35 @@ def test_interleave_datasets(dataset: IterableDataset, probas, seed, expected_le
 
     # Check the examples iterable
     assert isinstance(
-        merged_dataset._ex_iterable, (CyclingMultiSourcesExamplesIterable, RandomlyCyclingMultiSourcesExamplesIterable)
+        merged_dataset._ex_iterable,
+        (
+            CyclingMultiSourcesExamplesIterable,
+            RandomlyCyclingMultiSourcesExamplesIterable,
+        ),
     )
     # Check that it is deterministic
     if seed is not None:
         merged_dataset2 = interleave_datasets(
-            [d1, d2, d3], probabilities=probas, seed=seed, stopping_strategy=stopping_strategy
+            [d1, d2, d3],
+            probabilities=probas,
+            seed=seed,
+            stopping_strategy=stopping_strategy,
         )
         assert list(merged_dataset) == list(merged_dataset2)
     # Check features
-    assert merged_dataset.features == Features({"id": Value("int64"), "id+1": Value("int64")})
+    assert merged_dataset.features == Features(
+        {"id": Value("int64"), "id+1": Value("int64")}
+    )
     # Check first example
     if seed is not None:
         rng = np.random.default_rng(seed)
         i = next(iter(cycle(rng.choice(len(datasets), size=1000, p=probas))))
         assert next(iter(merged_dataset)) == fill_default(next(iter(datasets[i])))
     else:
-        assert any(next(iter(merged_dataset)) == fill_default(next(iter(dataset))) for dataset in datasets)
+        assert any(
+            next(iter(merged_dataset)) == fill_default(next(iter(dataset)))
+            for dataset in datasets
+        )
     # Compute length it case it's random
     if expected_length is None:
         expected_length = 0
@@ -2213,7 +2957,9 @@ def test_interleave_datasets_with_features(
         }
     )
     ex_iterable = ExamplesIterable(generate_examples_fn, {"label": 0})
-    dataset_with_features = IterableDataset(ex_iterable, info=DatasetInfo(features=features))
+    dataset_with_features = IterableDataset(
+        ex_iterable, info=DatasetInfo(features=features)
+    )
 
     merged_dataset = interleave_datasets([dataset, dataset_with_features])
     assert merged_dataset.features == features
@@ -2221,22 +2967,59 @@ def test_interleave_datasets_with_features(
 
 def test_interleave_datasets_with_oversampling():
     # Test hardcoded results
-    d1 = IterableDataset(ExamplesIterable((lambda: (yield from [(i, {"a": i}) for i in [0, 1, 2]])), {}))
-    d2 = IterableDataset(ExamplesIterable((lambda: (yield from [(i, {"a": i}) for i in [10, 11, 12, 13]])), {}))
-    d3 = IterableDataset(ExamplesIterable((lambda: (yield from [(i, {"a": i}) for i in [20, 21, 22, 23, 24]])), {}))
+    d1 = IterableDataset(
+        ExamplesIterable((lambda: (yield from [(i, {"a": i}) for i in [0, 1, 2]])), {})
+    )
+    d2 = IterableDataset(
+        ExamplesIterable(
+            (lambda: (yield from [(i, {"a": i}) for i in [10, 11, 12, 13]])), {}
+        )
+    )
+    d3 = IterableDataset(
+        ExamplesIterable(
+            (lambda: (yield from [(i, {"a": i}) for i in [20, 21, 22, 23, 24]])), {}
+        )
+    )
 
     expected_values = [0, 10, 20, 1, 11, 21, 2, 12, 22, 0, 13, 23, 1, 10, 24]
 
     # Check oversampling strategy without probabilities
-    assert [x["a"] for x in interleave_datasets([d1, d2, d3], stopping_strategy="all_exhausted")] == expected_values
+    assert [
+        x["a"]
+        for x in interleave_datasets([d1, d2, d3], stopping_strategy="all_exhausted")
+    ] == expected_values
 
     # Check oversampling strategy with probabilities
-    expected_values = [20, 0, 21, 10, 1, 22, 23, 24, 2, 0, 1, 20, 11, 21, 2, 0, 12, 1, 22, 13]
+    expected_values = [
+        20,
+        0,
+        21,
+        10,
+        1,
+        22,
+        23,
+        24,
+        2,
+        0,
+        1,
+        20,
+        11,
+        21,
+        2,
+        0,
+        12,
+        1,
+        22,
+        13,
+    ]
 
     values = [
         x["a"]
         for x in interleave_datasets(
-            [d1, d2, d3], probabilities=[0.5, 0.2, 0.3], seed=42, stopping_strategy="all_exhausted"
+            [d1, d2, d3],
+            probabilities=[0.5, 0.2, 0.3],
+            seed=42,
+            stopping_strategy="all_exhausted",
         )
     ]
 
@@ -2316,7 +3099,9 @@ def test_format_from_arrow():
     numpy_arrow_extractor = Formatter.numpy_arrow_extractor
 
     with (
-        patch.object(Formatter, "python_arrow_extractor") as mock_python_arrow_extractor,
+        patch.object(
+            Formatter, "python_arrow_extractor"
+        ) as mock_python_arrow_extractor,
         patch.object(Formatter, "numpy_arrow_extractor") as mock_numpy_arrow_extractor,
     ):
         mock_python_arrow_extractor.side_effect = python_arrow_extractor
@@ -2343,7 +3128,10 @@ def test_format_arrow(dataset: IterableDataset):
     assert len(next(iter(ds))) == 1
     assert len(next(iter(ds.iter(batch_size=4)))) == 4
     ds = ds.map(lambda t: t.append_column("new_col", pa.array([0] * len(t))))
-    ds = ds.map(lambda t: t.append_column("new_col_batched", pa.array([1] * len(t))), batched=True)
+    ds = ds.map(
+        lambda t: t.append_column("new_col_batched", pa.array([1] * len(t))),
+        batched=True,
+    )
     ds = ds.with_format(None)
     assert next(iter(ds)) == {**next(iter(dataset)), "new_col": 0, "new_col_batched": 1}
 
@@ -2370,26 +3158,39 @@ def test_format_polars(dataset: IterableDataset):
     assert len(next(iter(ds))) == 1
     assert len(next(iter(ds.iter(batch_size=4)))) == 4
     ds = ds.map(lambda df: df.with_columns(pl.Series([0] * len(df)).alias("new_col")))
-    ds = ds.map(lambda df: df.with_columns(pl.Series([1] * len(df)).alias("new_col_batched")), batched=True)
+    ds = ds.map(
+        lambda df: df.with_columns(pl.Series([1] * len(df)).alias("new_col_batched")),
+        batched=True,
+    )
     ds = ds.with_format(None)
     assert next(iter(ds)) == {**next(iter(dataset)), "new_col": 0, "new_col_batched": 1}
 
 
-@pytest.mark.parametrize("num_shards1, num_shards2, num_workers", [(2, 1, 1), (2, 2, 2), (1, 3, 1), (4, 3, 3)])
+@pytest.mark.parametrize(
+    "num_shards1, num_shards2, num_workers",
+    [(2, 1, 1), (2, 2, 2), (1, 3, 1), (4, 3, 3)],
+)
 def test_interleave_dataset_with_sharding(num_shards1, num_shards2, num_workers):
     from torch.utils.data import DataLoader
 
-    ex_iterable1 = ExamplesIterable(generate_examples_fn, {"filepaths": [f"{i}-1.txt" for i in range(num_shards1)]})
+    ex_iterable1 = ExamplesIterable(
+        generate_examples_fn, {"filepaths": [f"{i}-1.txt" for i in range(num_shards1)]}
+    )
     dataset1 = IterableDataset(ex_iterable1).with_format("torch")
-    ex_iterable2 = ExamplesIterable(generate_examples_fn, {"filepaths": [f"{i}-2.txt" for i in range(num_shards2)]})
+    ex_iterable2 = ExamplesIterable(
+        generate_examples_fn, {"filepaths": [f"{i}-2.txt" for i in range(num_shards2)]}
+    )
     dataset2 = IterableDataset(ex_iterable2).with_format("torch")
 
-    dataset_merged = interleave_datasets([dataset1, dataset2], stopping_strategy="first_exhausted")
+    dataset_merged = interleave_datasets(
+        [dataset1, dataset2], stopping_strategy="first_exhausted"
+    )
     assert dataset_merged.num_shards == min(num_shards1, num_shards2)
     dataloader = DataLoader(dataset_merged, batch_size=None, num_workers=num_workers)
     result = list(dataloader)
     expected_length = 2 * min(
-        len([example for _, example in ex_iterable1]), len([example for _, example in ex_iterable2])
+        len([example for _, example in ex_iterable1]),
+        len([example for _, example in ex_iterable2]),
     )
     # some samples may be missing because the stopping strategy is applied per process
     assert expected_length - num_workers <= len(result) <= expected_length
@@ -2453,7 +3254,11 @@ def test_iterable_dataset_batch():
         assert len(batch["id"]) == 3
         assert len(batch["text"]) == 3
         assert batch["id"] == [3 * i, 3 * i + 1, 3 * i + 2]
-        assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
+        assert batch["text"] == [
+            f"Text {3 * i}",
+            f"Text {3 * i + 1}",
+            f"Text {3 * i + 2}",
+        ]
 
     # Check last partial batch
     assert len(batches[3]["id"]) == 1
@@ -2470,7 +3275,11 @@ def test_iterable_dataset_batch():
         assert len(batch["id"]) == 3
         assert len(batch["text"]) == 3
         assert batch["id"] == [3 * i, 3 * i + 1, 3 * i + 2]
-        assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
+        assert batch["text"] == [
+            f"Text {3 * i}",
+            f"Text {3 * i + 1}",
+            f"Text {3 * i + 2}",
+        ]
 
     # Test with batch_size=4 (doesn't evenly divide dataset size)
     batched_ds = ds.batch(batch_size=4, drop_last_batch=False)
@@ -2481,7 +3290,12 @@ def test_iterable_dataset_batch():
         assert len(batch["id"]) == 4
         assert len(batch["text"]) == 4
         assert batch["id"] == [4 * i, 4 * i + 1, 4 * i + 2, 4 * i + 3]
-        assert batch["text"] == [f"Text {4 * i}", f"Text {4 * i + 1}", f"Text {4 * i + 2}", f"Text {4 * i + 3}"]
+        assert batch["text"] == [
+            f"Text {4 * i}",
+            f"Text {4 * i + 1}",
+            f"Text {4 * i + 2}",
+            f"Text {4 * i + 3}",
+        ]
 
     # Check last partial batch
     assert len(batches[2]["id"]) == 2
@@ -2499,7 +3313,11 @@ def test_iterable_dataset_batch():
         assert len(batch["id"]) == 3
         assert len(batch["text"]) == 3
         assert batch["id"] == [3 * i, 3 * i + 1, 3 * i + 2]
-        assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
+        assert batch["text"] == [
+            f"Text {3 * i}",
+            f"Text {3 * i + 1}",
+            f"Text {3 * i + 2}",
+        ]
 
 
 @dataclass

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -34,8 +34,14 @@ from datasets.load import (
     infer_module_for_data_files_list_in_archives,
     load_dataset_builder,
 )
-from datasets.packaged_modules.audiofolder.audiofolder import AudioFolder, AudioFolderConfig
-from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder, ImageFolderConfig
+from datasets.packaged_modules.audiofolder.audiofolder import (
+    AudioFolder,
+    AudioFolderConfig,
+)
+from datasets.packaged_modules.imagefolder.imagefolder import (
+    ImageFolder,
+    ImageFolderConfig,
+)
 from datasets.utils.logging import INFO, get_logger
 
 from .utils import (
@@ -49,8 +55,12 @@ from .utils import (
 )
 
 
-SAMPLE_DATASET_IDENTIFIER2 = "hf-internal-testing/dataset_with_data_files"  # only has data files
-SAMPLE_DATASET_IDENTIFIER3 = "hf-internal-testing/multi_dir_dataset"  # has multiple data directories
+SAMPLE_DATASET_IDENTIFIER2 = (
+    "hf-internal-testing/dataset_with_data_files"  # only has data files
+)
+SAMPLE_DATASET_IDENTIFIER3 = (
+    "hf-internal-testing/multi_dir_dataset"  # has multiple data directories
+)
 SAMPLE_DATASET_IDENTIFIER4 = "hf-internal-testing/imagefolder_with_metadata"  # imagefolder with a metadata file inside the train/test directories
 SAMPLE_DATASET_IDENTIFIER5 = "hf-internal-testing/imagefolder_with_metadata_no_splits"  # imagefolder with a metadata file and no default split names in data files
 
@@ -60,19 +70,35 @@ SAMPLE_DATASET_COMMIT_HASH3 = "aaa2d4bdd1d877d1c6178562cfc584bdfa90f6dc"
 SAMPLE_DATASET_COMMIT_HASH4 = "507fa72044169a5a1802b7ac2d6bd38d5f310739"
 SAMPLE_DATASET_COMMIT_HASH5 = "4971fa562942cab8263f56a448c3f831b18f1c27"
 
-SAMPLE_DATASET_NO_CONFIGS_IN_METADATA = "hf-internal-testing/audiofolder_no_configs_in_metadata"
-SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA = "hf-internal-testing/audiofolder_single_config_in_metadata"
-SAMPLE_DATASET_TWO_CONFIG_IN_METADATA = "hf-internal-testing/audiofolder_two_configs_in_metadata"
+SAMPLE_DATASET_NO_CONFIGS_IN_METADATA = (
+    "hf-internal-testing/audiofolder_no_configs_in_metadata"
+)
+SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA = (
+    "hf-internal-testing/audiofolder_single_config_in_metadata"
+)
+SAMPLE_DATASET_TWO_CONFIG_IN_METADATA = (
+    "hf-internal-testing/audiofolder_two_configs_in_metadata"
+)
 SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT = (
     "hf-internal-testing/audiofolder_two_configs_in_metadata_with_default"
 )
 SAMPLE_DATASET_CAPITAL_LETTERS_IN_NAME = "hf-internal-testing/DatasetWithCapitalLetters"
 
-SAMPLE_DATASET_NO_CONFIGS_IN_METADATA_COMMIT_HASH = "26cd5079bb0d3cd1521c6894765a0b8edb159d7f"
-SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA_COMMIT_HASH = "1668dfc91efae975e44457cdabef60fb9200820a"
-SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_COMMIT_HASH = "e71bce498e6c2bd2c58b20b097fdd3389793263f"
-SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT_COMMIT_HASH = "38937109bb4dc7067f575fe6e7b420158eb9cf32"
-SAMPLE_DATASET_CAPITAL_LETTERS_IN_NAME_COMMIT_HASH = "70aa36264a6954920a13dd0465156a60b9f8af4b"
+SAMPLE_DATASET_NO_CONFIGS_IN_METADATA_COMMIT_HASH = (
+    "26cd5079bb0d3cd1521c6894765a0b8edb159d7f"
+)
+SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA_COMMIT_HASH = (
+    "1668dfc91efae975e44457cdabef60fb9200820a"
+)
+SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_COMMIT_HASH = (
+    "e71bce498e6c2bd2c58b20b097fdd3389793263f"
+)
+SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT_COMMIT_HASH = (
+    "38937109bb4dc7067f575fe6e7b420158eb9cf32"
+)
+SAMPLE_DATASET_CAPITAL_LETTERS_IN_NAME_COMMIT_HASH = (
+    "70aa36264a6954920a13dd0465156a60b9f8af4b"
+)
 
 SAMPLE_NOT_EXISTING_DATASET_IDENTIFIER = "hf-internal-testing/_dummy"
 SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST = "_dummy"
@@ -283,7 +309,9 @@ def complex_data_dir(tmp_path):
         ([""], None, {}),
     ],
 )
-def test_infer_module_for_data_files(data_files, expected_module, expected_builder_kwargs):
+def test_infer_module_for_data_files(
+    data_files, expected_module, expected_builder_kwargs
+):
     module, builder_kwargs = infer_module_for_data_files_list(data_files)
     assert module == expected_module
     assert builder_kwargs == expected_builder_kwargs
@@ -299,7 +327,12 @@ def test_infer_module_for_data_files(data_files, expected_module, expected_build
     ],
 )
 def test_infer_module_for_data_files_in_archives(
-    data_file, expected_module, zip_csv_path, zip_csv_with_dir_path, zip_uppercase_csv_path, zip_unsupported_ext_path
+    data_file,
+    expected_module,
+    zip_csv_path,
+    zip_csv_with_dir_path,
+    zip_uppercase_csv_path,
+    zip_unsupported_ext_path,
 ):
     data_file_paths = {
         "zip_csv_path": zip_csv_path,
@@ -327,9 +360,13 @@ class ModuleFactoryTest(TestCase):
         self._jsonl_path = jsonl_path
         self._data_dir = data_dir
         self._data_dir_with_metadata = data_dir_with_metadata
-        self._data_dir_with_single_config_in_metadata = data_dir_with_single_config_in_metadata
+        self._data_dir_with_single_config_in_metadata = (
+            data_dir_with_single_config_in_metadata
+        )
         self._data_dir_with_config_and_data_files = data_dir_with_config_and_data_files
-        self._data_dir_with_two_config_in_metadata = data_dir_with_two_config_in_metadata
+        self._data_dir_with_two_config_in_metadata = (
+            data_dir_with_two_config_in_metadata
+        )
         self._data_dir2 = sub_data_dirs[0]
         self._sub_data_dir = sub_data_dirs[1]
 
@@ -344,10 +381,14 @@ class ModuleFactoryTest(TestCase):
         assert os.path.isdir(module_factory_result.builder_kwargs["base_path"])
 
     def test_LocalDatasetModuleFactory_with_data_dir(self):
-        factory = LocalDatasetModuleFactory(self._data_dir2, data_dir=self._sub_data_dir)
+        factory = LocalDatasetModuleFactory(
+            self._data_dir2, data_dir=self._sub_data_dir
+        )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        builder_config = module_factory_result.builder_configs_parameters.builder_configs[0]
+        builder_config = (
+            module_factory_result.builder_configs_parameters.builder_configs[0]
+        )
         assert (
             builder_config.data_files is not None
             and len(builder_config.data_files["train"]) == 1
@@ -355,21 +396,30 @@ class ModuleFactoryTest(TestCase):
         )
         assert all(
             self._sub_data_dir in Path(data_file).parts
-            for data_file in builder_config.data_files["train"] + builder_config.data_files["test"]
+            for data_file in builder_config.data_files["train"]
+            + builder_config.data_files["test"]
         )
 
     def test_LocalDatasetModuleFactory_with_metadata(self):
         factory = LocalDatasetModuleFactory(self._data_dir_with_metadata)
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        builder_config = module_factory_result.builder_configs_parameters.builder_configs[0]
+        builder_config = (
+            module_factory_result.builder_configs_parameters.builder_configs[0]
+        )
         assert (
             builder_config.data_files is not None
             and len(builder_config.data_files["train"]) > 0
             and len(builder_config.data_files["test"]) > 0
         )
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in builder_config.data_files["train"])
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in builder_config.data_files["test"])
+        assert any(
+            Path(data_file).name == "metadata.jsonl"
+            for data_file in builder_config.data_files["train"]
+        )
+        assert any(
+            Path(data_file).name == "metadata.jsonl"
+            for data_file in builder_config.data_files["test"]
+        )
 
     def test_LocalDatasetModuleFactory_with_single_config_in_metadata(self):
         factory = LocalDatasetModuleFactory(
@@ -378,28 +428,39 @@ class ModuleFactoryTest(TestCase):
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-        module_metadata_configs = module_factory_result.builder_configs_parameters.metadata_configs
+        module_metadata_configs = (
+            module_factory_result.builder_configs_parameters.metadata_configs
+        )
         assert module_metadata_configs is not None
         assert len(module_metadata_configs) == 1
         assert next(iter(module_metadata_configs)) == "custom"
         assert "drop_labels" in next(iter(module_metadata_configs.values()))
         assert next(iter(module_metadata_configs.values()))["drop_labels"] is True
 
-        module_builder_configs = module_factory_result.builder_configs_parameters.builder_configs
+        module_builder_configs = (
+            module_factory_result.builder_configs_parameters.builder_configs
+        )
         assert module_builder_configs is not None
         assert len(module_builder_configs) == 1
         assert isinstance(module_builder_configs[0], ImageFolderConfig)
         assert module_builder_configs[0].name == "custom"
         assert module_builder_configs[0].data_files is not None
         assert isinstance(module_builder_configs[0].data_files, DataFilesPatternsDict)
-        module_builder_configs[0]._resolve_data_files(self._data_dir_with_single_config_in_metadata, DownloadConfig())
+        module_builder_configs[0]._resolve_data_files(
+            self._data_dir_with_single_config_in_metadata, DownloadConfig()
+        )
         assert isinstance(module_builder_configs[0].data_files, DataFilesDict)
         assert len(module_builder_configs[0].data_files) == 1  # one train split
         assert len(module_builder_configs[0].data_files["train"]) == 2  # two files
-        assert module_builder_configs[0].drop_labels is True  # parameter is passed from metadata
+        assert (
+            module_builder_configs[0].drop_labels is True
+        )  # parameter is passed from metadata
 
         # config named "default" is automatically considered to be a default config
-        assert module_factory_result.builder_configs_parameters.default_config_name == "custom"
+        assert (
+            module_factory_result.builder_configs_parameters.default_config_name
+            == "custom"
+        )
 
         # we don't pass config params to builder in builder_kwargs, they are stored in builder_configs directly
         assert "drop_labels" not in module_factory_result.builder_kwargs
@@ -411,27 +472,39 @@ class ModuleFactoryTest(TestCase):
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-        module_metadata_configs = module_factory_result.builder_configs_parameters.metadata_configs
+        module_metadata_configs = (
+            module_factory_result.builder_configs_parameters.metadata_configs
+        )
         builder_kwargs = module_factory_result.builder_kwargs
         assert module_metadata_configs is not None
         assert len(module_metadata_configs) == 1
         assert next(iter(module_metadata_configs)) == "custom"
         assert "data_files" in next(iter(module_metadata_configs.values()))
-        assert next(iter(module_metadata_configs.values()))["data_files"] == "data/**/*.jpg"
+        assert (
+            next(iter(module_metadata_configs.values()))["data_files"]
+            == "data/**/*.jpg"
+        )
         assert "data_files" not in builder_kwargs
 
     def test_LocalDatasetModuleFactory_data_dir_with_config_and_data_files(self):
-        factory = LocalDatasetModuleFactory(self._data_dir_with_config_and_data_files, data_dir="data")
+        factory = LocalDatasetModuleFactory(
+            self._data_dir_with_config_and_data_files, data_dir="data"
+        )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-        module_metadata_configs = module_factory_result.builder_configs_parameters.metadata_configs
+        module_metadata_configs = (
+            module_factory_result.builder_configs_parameters.metadata_configs
+        )
         builder_kwargs = module_factory_result.builder_kwargs
         assert module_metadata_configs is not None
         assert len(module_metadata_configs) == 1
         assert next(iter(module_metadata_configs)) == "custom"
         assert "data_files" in next(iter(module_metadata_configs.values()))
-        assert next(iter(module_metadata_configs.values()))["data_files"] == "data/**/*.jpg"
+        assert (
+            next(iter(module_metadata_configs.values()))["data_files"]
+            == "data/**/*.jpg"
+        )
         assert "data_files" in builder_kwargs
         assert "train" in builder_kwargs["data_files"]
         assert len(builder_kwargs["data_files"]["train"]) == 2
@@ -443,7 +516,9 @@ class ModuleFactoryTest(TestCase):
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
 
-        module_metadata_configs = module_factory_result.builder_configs_parameters.metadata_configs
+        module_metadata_configs = (
+            module_factory_result.builder_configs_parameters.metadata_configs
+        )
         assert module_metadata_configs is not None
         assert len(module_metadata_configs) == 2
         assert list(module_metadata_configs) == ["v1", "v2"]
@@ -452,7 +527,9 @@ class ModuleFactoryTest(TestCase):
         assert "drop_labels" in module_metadata_configs["v2"]
         assert module_metadata_configs["v2"]["drop_labels"] is False
 
-        module_builder_configs = module_factory_result.builder_configs_parameters.builder_configs
+        module_builder_configs = (
+            module_factory_result.builder_configs_parameters.builder_configs
+        )
         assert module_builder_configs is not None
         assert len(module_builder_configs) == 2
         module_builder_config_v1, module_builder_config_v2 = module_builder_configs
@@ -462,16 +539,24 @@ class ModuleFactoryTest(TestCase):
         assert isinstance(module_builder_config_v2, ImageFolderConfig)
         assert isinstance(module_builder_config_v1.data_files, DataFilesPatternsDict)
         assert isinstance(module_builder_config_v2.data_files, DataFilesPatternsDict)
-        module_builder_config_v1._resolve_data_files(self._data_dir_with_two_config_in_metadata, DownloadConfig())
-        module_builder_config_v2._resolve_data_files(self._data_dir_with_two_config_in_metadata, DownloadConfig())
+        module_builder_config_v1._resolve_data_files(
+            self._data_dir_with_two_config_in_metadata, DownloadConfig()
+        )
+        module_builder_config_v2._resolve_data_files(
+            self._data_dir_with_two_config_in_metadata, DownloadConfig()
+        )
         assert isinstance(module_builder_config_v1.data_files, DataFilesDict)
         assert isinstance(module_builder_config_v2.data_files, DataFilesDict)
         assert sorted(module_builder_config_v1.data_files) == ["train"]
         assert len(module_builder_config_v1.data_files["train"]) == 2
         assert sorted(module_builder_config_v2.data_files) == ["train"]
         assert len(module_builder_config_v2.data_files["train"]) == 2
-        assert module_builder_config_v1.drop_labels is True  # parameter is passed from metadata
-        assert module_builder_config_v2.drop_labels is False  # parameter is passed from metadata
+        assert (
+            module_builder_config_v1.drop_labels is True
+        )  # parameter is passed from metadata
+        assert (
+            module_builder_config_v2.drop_labels is False
+        )  # parameter is passed from metadata
 
         assert (
             module_factory_result.builder_configs_parameters.default_config_name == "v1"
@@ -488,35 +573,58 @@ class ModuleFactoryTest(TestCase):
         assert importlib.import_module(module_factory_result.module_path) is not None
 
     def test_PackagedDatasetModuleFactory_with_data_dir(self):
-        factory = PackagedDatasetModuleFactory("json", data_dir=self._data_dir, download_config=self.download_config)
+        factory = PackagedDatasetModuleFactory(
+            "json", data_dir=self._data_dir, download_config=self.download_config
+        )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
         data_files = module_factory_result.builder_kwargs.get("data_files")
-        assert data_files is not None and len(data_files["train"]) > 0 and len(data_files["test"]) > 0
+        assert (
+            data_files is not None
+            and len(data_files["train"]) > 0
+            and len(data_files["test"]) > 0
+        )
         assert Path(data_files["train"][0]).parent.samefile(self._data_dir)
         assert Path(data_files["test"][0]).parent.samefile(self._data_dir)
 
     def test_PackagedDatasetModuleFactory_with_data_dir_and_metadata(self):
         factory = PackagedDatasetModuleFactory(
-            "imagefolder", data_dir=self._data_dir_with_metadata, download_config=self.download_config
+            "imagefolder",
+            data_dir=self._data_dir_with_metadata,
+            download_config=self.download_config,
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
         data_files = module_factory_result.builder_kwargs.get("data_files")
-        assert data_files is not None and len(data_files["train"]) > 0 and len(data_files["test"]) > 0
-        assert Path(self._data_dir_with_metadata) in Path(data_files["train"][0]).parents
+        assert (
+            data_files is not None
+            and len(data_files["train"]) > 0
+            and len(data_files["test"]) > 0
+        )
+        assert (
+            Path(self._data_dir_with_metadata) in Path(data_files["train"][0]).parents
+        )
         assert Path(self._data_dir_with_metadata) in Path(data_files["test"][0]).parents
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in data_files["train"])
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in data_files["test"])
+        assert any(
+            Path(data_file).name == "metadata.jsonl"
+            for data_file in data_files["train"]
+        )
+        assert any(
+            Path(data_file).name == "metadata.jsonl" for data_file in data_files["test"]
+        )
 
     @pytest.mark.integration
     def test_HubDatasetModuleFactory(self):
         factory = HubDatasetModuleFactory(
-            SAMPLE_DATASET_IDENTIFIER2, commit_hash=SAMPLE_DATASET_COMMIT_HASH2, download_config=self.download_config
+            SAMPLE_DATASET_IDENTIFIER2,
+            commit_hash=SAMPLE_DATASET_COMMIT_HASH2,
+            download_config=self.download_config,
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
+        assert module_factory_result.builder_kwargs["base_path"].startswith(
+            config.HF_ENDPOINT
+        )
 
     @pytest.mark.integration
     def test_HubDatasetModuleFactory_with_data_dir(self):
@@ -529,8 +637,12 @@ class ModuleFactoryTest(TestCase):
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        builder_config = module_factory_result.builder_configs_parameters.builder_configs[0]
-        assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
+        builder_config = (
+            module_factory_result.builder_configs_parameters.builder_configs[0]
+        )
+        assert module_factory_result.builder_kwargs["base_path"].startswith(
+            config.HF_ENDPOINT
+        )
         assert (
             builder_config.data_files is not None
             and len(builder_config.data_files["train"]) == 1
@@ -538,39 +650,61 @@ class ModuleFactoryTest(TestCase):
         )
         assert all(
             data_dir in Path(data_file).parts
-            for data_file in builder_config.data_files["train"] + builder_config.data_files["test"]
+            for data_file in builder_config.data_files["train"]
+            + builder_config.data_files["test"]
         )
 
     @pytest.mark.integration
     def test_HubDatasetModuleFactory_with_metadata(self):
         factory = HubDatasetModuleFactory(
-            SAMPLE_DATASET_IDENTIFIER4, commit_hash=SAMPLE_DATASET_COMMIT_HASH4, download_config=self.download_config
+            SAMPLE_DATASET_IDENTIFIER4,
+            commit_hash=SAMPLE_DATASET_COMMIT_HASH4,
+            download_config=self.download_config,
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        builder_config = module_factory_result.builder_configs_parameters.builder_configs[0]
-        assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
+        builder_config = (
+            module_factory_result.builder_configs_parameters.builder_configs[0]
+        )
+        assert module_factory_result.builder_kwargs["base_path"].startswith(
+            config.HF_ENDPOINT
+        )
         assert (
             builder_config.data_files is not None
             and len(builder_config.data_files["train"]) > 0
             and len(builder_config.data_files["test"]) > 0
         )
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in builder_config.data_files["train"])
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in builder_config.data_files["test"])
+        assert any(
+            Path(data_file).name == "metadata.jsonl"
+            for data_file in builder_config.data_files["train"]
+        )
+        assert any(
+            Path(data_file).name == "metadata.jsonl"
+            for data_file in builder_config.data_files["test"]
+        )
 
         factory = HubDatasetModuleFactory(
-            SAMPLE_DATASET_IDENTIFIER5, commit_hash=SAMPLE_DATASET_COMMIT_HASH5, download_config=self.download_config
+            SAMPLE_DATASET_IDENTIFIER5,
+            commit_hash=SAMPLE_DATASET_COMMIT_HASH5,
+            download_config=self.download_config,
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        builder_config = module_factory_result.builder_configs_parameters.builder_configs[0]
-        assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
+        builder_config = (
+            module_factory_result.builder_configs_parameters.builder_configs[0]
+        )
+        assert module_factory_result.builder_kwargs["base_path"].startswith(
+            config.HF_ENDPOINT
+        )
         assert (
             builder_config.data_files is not None
             and len(builder_config.data_files) == 1
             and len(builder_config.data_files["train"]) > 0
         )
-        assert any(Path(data_file).name == "metadata.jsonl" for data_file in builder_config.data_files["train"])
+        assert any(
+            Path(data_file).name == "metadata.jsonl"
+            for data_file in builder_config.data_files["train"]
+        )
 
     @pytest.mark.integration
     def test_HubDatasetModuleFactory_with_one_default_config_in_metadata(self):
@@ -581,16 +715,22 @@ class ModuleFactoryTest(TestCase):
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
-        assert module_factory_result.builder_kwargs["base_path"].startswith(config.HF_ENDPOINT)
+        assert module_factory_result.builder_kwargs["base_path"].startswith(
+            config.HF_ENDPOINT
+        )
 
-        module_metadata_configs = module_factory_result.builder_configs_parameters.metadata_configs
+        module_metadata_configs = (
+            module_factory_result.builder_configs_parameters.metadata_configs
+        )
         assert module_metadata_configs is not None
         assert len(module_metadata_configs) == 1
         assert next(iter(module_metadata_configs)) == "custom"
         assert "drop_labels" in next(iter(module_metadata_configs.values()))
         assert next(iter(module_metadata_configs.values()))["drop_labels"] is True
 
-        module_builder_configs = module_factory_result.builder_configs_parameters.builder_configs
+        module_builder_configs = (
+            module_factory_result.builder_configs_parameters.builder_configs
+        )
         assert module_builder_configs is not None
         assert len(module_builder_configs) == 1
         assert isinstance(module_builder_configs[0], AudioFolderConfig)
@@ -604,10 +744,15 @@ class ModuleFactoryTest(TestCase):
         assert sorted(module_builder_configs[0].data_files) == ["test", "train"]
         assert len(module_builder_configs[0].data_files["train"]) == 3
         assert len(module_builder_configs[0].data_files["test"]) == 3
-        assert module_builder_configs[0].drop_labels is True  # parameter is passed from metadata
+        assert (
+            module_builder_configs[0].drop_labels is True
+        )  # parameter is passed from metadata
 
         # config named "default" is automatically considered to be a default config
-        assert module_factory_result.builder_configs_parameters.default_config_name == "custom"
+        assert (
+            module_factory_result.builder_configs_parameters.default_config_name
+            == "custom"
+        )
 
         # we don't pass config params to builder in builder_kwargs, they are stored in builder_configs directly
         assert "drop_labels" not in module_factory_result.builder_kwargs
@@ -615,7 +760,10 @@ class ModuleFactoryTest(TestCase):
     @pytest.mark.integration
     def test_HubDatasetModuleFactory_with_two_configs_in_metadata(self):
         datasets_names = [
-            (SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_COMMIT_HASH),
+            (
+                SAMPLE_DATASET_TWO_CONFIG_IN_METADATA,
+                SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_COMMIT_HASH,
+            ),
             (
                 SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT,
                 SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT_COMMIT_HASH,
@@ -623,12 +771,18 @@ class ModuleFactoryTest(TestCase):
         ]
         for dataset_name, commit_hash in datasets_names:
             factory = HubDatasetModuleFactory(
-                dataset_name, commit_hash=commit_hash, download_config=self.download_config
+                dataset_name,
+                commit_hash=commit_hash,
+                download_config=self.download_config,
             )
             module_factory_result = factory.get_module()
-            assert importlib.import_module(module_factory_result.module_path) is not None
+            assert (
+                importlib.import_module(module_factory_result.module_path) is not None
+            )
 
-            module_metadata_configs = module_factory_result.builder_configs_parameters.metadata_configs
+            module_metadata_configs = (
+                module_factory_result.builder_configs_parameters.metadata_configs
+            )
             assert module_metadata_configs is not None
             assert len(module_metadata_configs) == 2
             assert list(module_metadata_configs) == ["v1", "v2"]
@@ -637,7 +791,9 @@ class ModuleFactoryTest(TestCase):
             assert "drop_labels" in module_metadata_configs["v2"]
             assert module_metadata_configs["v2"]["drop_labels"] is False
 
-            module_builder_configs = module_factory_result.builder_configs_parameters.builder_configs
+            module_builder_configs = (
+                module_factory_result.builder_configs_parameters.builder_configs
+            )
             assert module_builder_configs is not None
             assert len(module_builder_configs) == 2
             module_builder_config_v1, module_builder_config_v2 = module_builder_configs
@@ -645,8 +801,12 @@ class ModuleFactoryTest(TestCase):
             assert module_builder_config_v2.name == "v2"
             assert isinstance(module_builder_config_v1, AudioFolderConfig)
             assert isinstance(module_builder_config_v2, AudioFolderConfig)
-            assert isinstance(module_builder_config_v1.data_files, DataFilesPatternsDict)
-            assert isinstance(module_builder_config_v2.data_files, DataFilesPatternsDict)
+            assert isinstance(
+                module_builder_config_v1.data_files, DataFilesPatternsDict
+            )
+            assert isinstance(
+                module_builder_config_v2.data_files, DataFilesPatternsDict
+            )
             module_builder_config_v1._resolve_data_files(
                 module_factory_result.builder_kwargs["base_path"], DownloadConfig()
             )
@@ -661,15 +821,25 @@ class ModuleFactoryTest(TestCase):
             assert sorted(module_builder_config_v2.data_files) == ["test", "train"]
             assert len(module_builder_config_v2.data_files["train"]) == 2
             assert len(module_builder_config_v2.data_files["test"]) == 1
-            assert module_builder_config_v1.drop_labels is True  # parameter is passed from metadata
-            assert module_builder_config_v2.drop_labels is False  # parameter is passed from metadata
+            assert (
+                module_builder_config_v1.drop_labels is True
+            )  # parameter is passed from metadata
+            assert (
+                module_builder_config_v2.drop_labels is False
+            )  # parameter is passed from metadata
             # we don't pass config params to builder in builder_kwargs, they are stored in builder_configs directly
             assert "drop_labels" not in module_factory_result.builder_kwargs
 
             if dataset_name == SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT:
-                assert module_factory_result.builder_configs_parameters.default_config_name == "v1"
+                assert (
+                    module_factory_result.builder_configs_parameters.default_config_name
+                    == "v1"
+                )
             else:
-                assert module_factory_result.builder_configs_parameters.default_config_name is None
+                assert (
+                    module_factory_result.builder_configs_parameters.default_config_name
+                    is None
+                )
 
     @pytest.mark.integration
     def test_CachedDatasetModuleFactory(self):
@@ -682,7 +852,10 @@ class ModuleFactoryTest(TestCase):
                     cache_dir=self.cache_dir,
                 )
                 module_factory_result = factory.get_module()
-                assert importlib.import_module(module_factory_result.module_path) is not None
+                assert (
+                    importlib.import_module(module_factory_result.module_path)
+                    is not None
+                )
 
 
 @pytest.mark.parametrize(
@@ -724,9 +897,15 @@ class LoadTest(TestCase):
             with offline(offline_simulation_mode):
                 self._caplog.clear()
                 # allow provide the repo id without an explicit path to remote or local actual file
-                dataset_module = datasets.load.dataset_module_factory(repo_id, cache_dir=self.cache_dir)
-                self.assertEqual(dataset_module.module_path, "datasets.packaged_modules.cache.cache")
-                self.assertIn("Using the latest cached version of the dataset", self._caplog.text)
+                dataset_module = datasets.load.dataset_module_factory(
+                    repo_id, cache_dir=self.cache_dir
+                )
+                self.assertEqual(
+                    dataset_module.module_path, "datasets.packaged_modules.cache.cache"
+                )
+                self.assertIn(
+                    "Using the latest cached version of the dataset", self._caplog.text
+                )
 
     @pytest.mark.integration
     def test_offline_dataset_module_factory_with_capital_letters_in_name(self):
@@ -737,9 +916,15 @@ class LoadTest(TestCase):
             with offline(offline_simulation_mode):
                 self._caplog.clear()
                 # allow provide the repo id without an explicit path to remote or local actual file
-                dataset_module = datasets.load.dataset_module_factory(repo_id, cache_dir=self.cache_dir)
-                self.assertEqual(dataset_module.module_path, "datasets.packaged_modules.cache.cache")
-                self.assertIn("Using the latest cached version of the dataset", self._caplog.text)
+                dataset_module = datasets.load.dataset_module_factory(
+                    repo_id, cache_dir=self.cache_dir
+                )
+                self.assertEqual(
+                    dataset_module.module_path, "datasets.packaged_modules.cache.cache"
+                )
+                self.assertIn(
+                    "Using the latest cached version of the dataset", self._caplog.text
+                )
 
     def test_load_dataset_from_hub(self):
         with self.assertRaises(DatasetNotFoundError) as context:
@@ -758,7 +943,10 @@ class LoadTest(TestCase):
             with offline(offline_simulation_mode):
                 with self.assertRaises(ConnectionError) as context:
                     datasets.load_dataset("_dummy")
-                if offline_simulation_mode != OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
+                if (
+                    offline_simulation_mode
+                    != OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1
+                ):
                     self.assertIn(
                         "Couldn't reach '_dummy' on the Hub",
                         str(context.exception),
@@ -775,7 +963,11 @@ class LoadTest(TestCase):
             with offline(offline_simulation_mode):
                 with self.assertRaises(ConnectionError) as context:
                     datasets.load_dataset("hf-internal-testing/_dummy")
-                self.assertIn("hf-internal-testing/_dummy", str(context.exception), msg=offline_simulation_mode)
+                self.assertIn(
+                    "hf-internal-testing/_dummy",
+                    str(context.exception),
+                    msg=offline_simulation_mode,
+                )
 
 
 @pytest.mark.integration
@@ -786,13 +978,17 @@ def test_load_dataset_builder_with_metadata():
     assert builder.config.data_files is not None
     assert builder.config.drop_metadata is None
     with pytest.raises(ValueError):
-        builder = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER4, "non-existing-config")
+        builder = datasets.load_dataset_builder(
+            SAMPLE_DATASET_IDENTIFIER4, "non-existing-config"
+        )
 
 
 @pytest.mark.integration
 def test_load_dataset_builder_config_kwargs_passed_as_arguments():
     builder_default = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER4)
-    builder_custom = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER4, drop_metadata=True)
+    builder_custom = datasets.load_dataset_builder(
+        SAMPLE_DATASET_IDENTIFIER4, drop_metadata=True
+    )
     assert builder_custom.config.drop_metadata != builder_default.config.drop_metadata
     assert builder_custom.config.drop_metadata is True
 
@@ -806,7 +1002,9 @@ def test_load_dataset_builder_with_two_configs_in_metadata():
     with pytest.raises(ValueError):
         datasets.load_dataset_builder(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA)
     with pytest.raises(ValueError):
-        datasets.load_dataset_builder(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "non-existing-config")
+        datasets.load_dataset_builder(
+            SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "non-existing-config"
+        )
 
 
 @pytest.mark.parametrize("serializer", [pickle, dill])
@@ -817,9 +1015,15 @@ def test_load_dataset_builder_with_metadata_configs_pickable(serializer):
     assert list(builder_unpickled.builder_configs) == ["custom"]
     assert isinstance(builder_unpickled.builder_configs["custom"], AudioFolderConfig)
 
-    builder2 = datasets.load_dataset_builder(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v1")
+    builder2 = datasets.load_dataset_builder(
+        SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v1"
+    )
     builder2_unpickled = serializer.loads(serializer.dumps(builder2))
-    assert builder2.BUILDER_CONFIGS == builder2_unpickled.BUILDER_CONFIGS != builder_unpickled.BUILDER_CONFIGS
+    assert (
+        builder2.BUILDER_CONFIGS
+        == builder2_unpickled.BUILDER_CONFIGS
+        != builder_unpickled.BUILDER_CONFIGS
+    )
     assert list(builder2_unpickled.builder_configs) == ["v1", "v2"]
     assert isinstance(builder2_unpickled.builder_configs["v1"], AudioFolderConfig)
     assert isinstance(builder2_unpickled.builder_configs["v2"], AudioFolderConfig)
@@ -879,7 +1083,11 @@ def test_load_dataset_builder_fail():
 def test_load_dataset_from_hub(kwargs, expected_train_num_rows, expected_test_num_rows):
     dataset = load_dataset(SAMPLE_DATASET_IDENTIFIER3, **kwargs)
     assert dataset["train"].num_rows == expected_train_num_rows
-    assert (dataset["test"].num_rows == expected_test_num_rows) if expected_test_num_rows else ("test" not in dataset)
+    assert (
+        (dataset["test"].num_rows == expected_test_num_rows)
+        if expected_test_num_rows
+        else ("test" not in dataset)
+    )
 
 
 @pytest.mark.integration
@@ -894,13 +1102,18 @@ def test_load_dataset_cached_from_hub(stream_from_cache, caplog):
         with offline(offline_simulation_mode):
             caplog.clear()
             # Load dataset from cache
-            dataset = datasets.load_dataset(SAMPLE_DATASET_IDENTIFIER3, streaming=stream_from_cache)
+            dataset = datasets.load_dataset(
+                SAMPLE_DATASET_IDENTIFIER3, streaming=stream_from_cache
+            )
             assert len(dataset) == 2
             assert "Using the latest cached version of the dataset" in caplog.text
             assert isinstance(next(iter(dataset["train"])), dict)
     with pytest.raises(DatasetNotFoundError) as exc_info:
         datasets.load_dataset(SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST)
-    assert f"Dataset '{SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST}' doesn't exist on the Hub" in str(exc_info.value)
+    assert (
+        f"Dataset '{SAMPLE_DATASET_NAME_THAT_DOESNT_EXIST}' doesn't exist on the Hub"
+        in str(exc_info.value)
+    )
 
 
 def test_load_dataset_streaming_gz_json(jsonl_gz_path):
@@ -913,7 +1126,15 @@ def test_load_dataset_streaming_gz_json(jsonl_gz_path):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "path", ["sample.jsonl", "sample.jsonl.gz", "sample.tar", "sample.jsonl.xz", "sample.zip", "sample.jsonl.zst"]
+    "path",
+    [
+        "sample.jsonl",
+        "sample.jsonl.gz",
+        "sample.tar",
+        "sample.jsonl.xz",
+        "sample.zip",
+        "sample.jsonl.zst",
+    ],
 )
 def test_load_dataset_streaming_compressed_files(path):
     repo_id = "hf-internal-testing/compressed_files"
@@ -937,16 +1158,28 @@ def test_load_dataset_streaming_compressed_files(path):
 def test_load_dataset_streaming_csv(path_extension, streaming, csv_path, bz2_csv_path):
     paths = {"csv": csv_path, "csv.bz2": bz2_csv_path}
     data_files = str(paths[path_extension])
-    features = Features({"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")})
-    ds = load_dataset("csv", split="train", data_files=data_files, features=features, streaming=streaming)
+    features = Features(
+        {"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")}
+    )
+    ds = load_dataset(
+        "csv",
+        split="train",
+        data_files=data_files,
+        features=features,
+        streaming=streaming,
+    )
     assert isinstance(ds, IterableDataset if streaming else Dataset)
     ds_item = next(iter(ds))
     assert ds_item == {"col_1": "0", "col_2": 0, "col_3": 0.0}
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-@pytest.mark.parametrize("data_file", ["zip_csv_path", "zip_csv_with_dir_path", "csv_path"])
-def test_load_dataset_zip_csv(data_file, streaming, zip_csv_path, zip_csv_with_dir_path, csv_path):
+@pytest.mark.parametrize(
+    "data_file", ["zip_csv_path", "zip_csv_with_dir_path", "csv_path"]
+)
+def test_load_dataset_zip_csv(
+    data_file, streaming, zip_csv_path, zip_csv_with_dir_path, csv_path
+):
     data_file_paths = {
         "zip_csv_path": zip_csv_path,
         "zip_csv_with_dir_path": zip_csv_with_dir_path,
@@ -954,8 +1187,16 @@ def test_load_dataset_zip_csv(data_file, streaming, zip_csv_path, zip_csv_with_d
     }
     data_files = str(data_file_paths[data_file])
     expected_size = 8 if data_file.startswith("zip") else 4
-    features = Features({"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")})
-    ds = load_dataset("csv", split="train", data_files=data_files, features=features, streaming=streaming)
+    features = Features(
+        {"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")}
+    )
+    ds = load_dataset(
+        "csv",
+        split="train",
+        data_files=data_files,
+        features=features,
+        streaming=streaming,
+    )
     if streaming:
         ds_item_counter = 0
         for ds_item in ds:
@@ -970,8 +1211,12 @@ def test_load_dataset_zip_csv(data_file, streaming, zip_csv_path, zip_csv_with_d
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-@pytest.mark.parametrize("data_file", ["zip_jsonl_path", "zip_jsonl_with_dir_path", "jsonl_path"])
-def test_load_dataset_zip_jsonl(data_file, streaming, zip_jsonl_path, zip_jsonl_with_dir_path, jsonl_path):
+@pytest.mark.parametrize(
+    "data_file", ["zip_jsonl_path", "zip_jsonl_with_dir_path", "jsonl_path"]
+)
+def test_load_dataset_zip_jsonl(
+    data_file, streaming, zip_jsonl_path, zip_jsonl_with_dir_path, jsonl_path
+):
     data_file_paths = {
         "zip_jsonl_path": zip_jsonl_path,
         "zip_jsonl_with_dir_path": zip_jsonl_with_dir_path,
@@ -979,8 +1224,16 @@ def test_load_dataset_zip_jsonl(data_file, streaming, zip_jsonl_path, zip_jsonl_
     }
     data_files = str(data_file_paths[data_file])
     expected_size = 8 if data_file.startswith("zip") else 4
-    features = Features({"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")})
-    ds = load_dataset("json", split="train", data_files=data_files, features=features, streaming=streaming)
+    features = Features(
+        {"col_1": Value("string"), "col_2": Value("int32"), "col_3": Value("float32")}
+    )
+    ds = load_dataset(
+        "json",
+        split="train",
+        data_files=data_files,
+        features=features,
+        streaming=streaming,
+    )
     if streaming:
         ds_item_counter = 0
         for ds_item in ds:
@@ -995,8 +1248,12 @@ def test_load_dataset_zip_jsonl(data_file, streaming, zip_jsonl_path, zip_jsonl_
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-@pytest.mark.parametrize("data_file", ["zip_text_path", "zip_text_with_dir_path", "text_path"])
-def test_load_dataset_zip_text(data_file, streaming, zip_text_path, zip_text_with_dir_path, text_path):
+@pytest.mark.parametrize(
+    "data_file", ["zip_text_path", "zip_text_with_dir_path", "text_path"]
+)
+def test_load_dataset_zip_text(
+    data_file, streaming, zip_text_path, zip_text_with_dir_path, text_path
+):
     data_file_paths = {
         "zip_text_path": zip_text_path,
         "zip_text_with_dir_path": zip_text_with_dir_path,
@@ -1020,7 +1277,9 @@ def test_load_dataset_zip_text(data_file, streaming, zip_text_path, zip_text_wit
 
 @pytest.mark.parametrize("streaming", [False, True])
 def test_load_dataset_arrow(streaming, data_dir_with_arrow):
-    ds = load_dataset("arrow", split="train", data_dir=data_dir_with_arrow, streaming=streaming)
+    ds = load_dataset(
+        "arrow", split="train", data_dir=data_dir_with_arrow, streaming=streaming
+    )
     expected_size = 10
     if streaming:
         ds_item_counter = 0
@@ -1060,8 +1319,14 @@ def test_loading_from_the_datasets_hub_with_token():
         mock_request.side_effect = assert_auth
         with tempfile.TemporaryDirectory() as tmp_dir:
             with offline():
-                with pytest.raises((ConnectionError, requests.exceptions.ConnectionError)):
-                    load_dataset(SAMPLE_NOT_EXISTING_DATASET_IDENTIFIER, cache_dir=tmp_dir, token="foo")
+                with pytest.raises(
+                    (ConnectionError, requests.exceptions.ConnectionError)
+                ):
+                    load_dataset(
+                        SAMPLE_NOT_EXISTING_DATASET_IDENTIFIER,
+                        cache_dir=tmp_dir,
+                        token="foo",
+                    )
         mock_request.assert_called()
 
 
@@ -1072,14 +1337,20 @@ def test_load_streaming_private_dataset(hf_token, hf_private_dataset_repo_txt_da
 
 
 @pytest.mark.integration
-def test_load_dataset_builder_private_dataset(hf_token, hf_private_dataset_repo_txt_data):
+def test_load_dataset_builder_private_dataset(
+    hf_token, hf_private_dataset_repo_txt_data
+):
     builder = load_dataset_builder(hf_private_dataset_repo_txt_data, token=hf_token)
     assert isinstance(builder, DatasetBuilder)
 
 
 @pytest.mark.integration
-def test_load_streaming_private_dataset_with_zipped_data(hf_token, hf_private_dataset_repo_zipped_txt_data):
-    ds = load_dataset(hf_private_dataset_repo_zipped_txt_data, streaming=True, token=hf_token)
+def test_load_streaming_private_dataset_with_zipped_data(
+    hf_token, hf_private_dataset_repo_zipped_txt_data
+):
+    ds = load_dataset(
+        hf_private_dataset_repo_zipped_txt_data, streaming=True, token=hf_token
+    )
     assert next(iter(ds)) is not None
 
 
@@ -1096,15 +1367,24 @@ def test_load_dataset_config_kwargs_passed_as_arguments():
 def test_load_hub_dataset_with_single_config_in_metadata():
     # load the same dataset but with no configurations (=with default parameters)
     ds = load_dataset(SAMPLE_DATASET_NO_CONFIGS_IN_METADATA)
-    assert list(ds["train"].features) == ["audio", "label"]  # assert label feature is here as expected by default
+    assert list(ds["train"].features) == [
+        "audio",
+        "label",
+    ]  # assert label feature is here as expected by default
     assert len(ds["train"]) == 5 and len(ds["test"]) == 4
 
-    ds2 = load_dataset(SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA)  # single config -> no need to specify it
-    assert list(ds2["train"].features) == ["audio"]  # assert param `drop_labels=True` from metadata is passed
+    ds2 = load_dataset(
+        SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA
+    )  # single config -> no need to specify it
+    assert list(ds2["train"].features) == [
+        "audio"
+    ]  # assert param `drop_labels=True` from metadata is passed
     assert len(ds2["train"]) == 3 and len(ds2["test"]) == 3
 
     ds3 = load_dataset(SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA, "custom")
-    assert list(ds3["train"].features) == ["audio"]  # assert param `drop_labels=True` from metadata is passed
+    assert list(ds3["train"].features) == [
+        "audio"
+    ]  # assert param `drop_labels=True` from metadata is passed
     assert len(ds3["train"]) == 3 and len(ds3["test"]) == 3
 
     with pytest.raises(ValueError):
@@ -1116,7 +1396,9 @@ def test_load_hub_dataset_with_single_config_in_metadata():
 @pytest.mark.integration
 def test_load_hub_dataset_with_two_config_in_metadata():
     ds = load_dataset(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v1")
-    assert list(ds["train"].features) == ["audio"]  # assert param `drop_labels=True` from metadata is passed
+    assert list(ds["train"].features) == [
+        "audio"
+    ]  # assert param `drop_labels=True` from metadata is passed
     assert len(ds["train"]) == 3 and len(ds["test"]) == 3
 
     ds2 = load_dataset(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v2")
@@ -1137,7 +1419,9 @@ def test_load_hub_dataset_with_two_config_in_metadata():
     ds_with_default = load_dataset(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA_WITH_DEFAULT)
     # it's a dataset with the same data but "v1" config is marked as a default one
     assert list(ds_with_default["train"].features) == list(ds["train"].features)
-    assert len(ds_with_default["train"]) == len(ds["train"]) and len(ds_with_default["test"]) == len(ds["test"])
+    assert len(ds_with_default["train"]) == len(ds["train"]) and len(
+        ds_with_default["test"]
+    ) == len(ds["test"])
 
 
 @require_torchcodec
@@ -1145,11 +1429,15 @@ def test_load_hub_dataset_with_two_config_in_metadata():
 def test_load_hub_dataset_with_metadata_config_in_parallel():
     # assert it doesn't fail (pickling of dynamically created class works)
     ds = load_dataset(SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA, num_proc=2)
-    assert "label" not in ds["train"].features  # assert param `drop_labels=True` from metadata is passed
+    assert (
+        "label" not in ds["train"].features
+    )  # assert param `drop_labels=True` from metadata is passed
     assert len(ds["train"]) == 3 and len(ds["test"]) == 3
 
     ds = load_dataset(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v1", num_proc=2)
-    assert "label" not in ds["train"].features  # assert param `drop_labels=True` from metadata is passed
+    assert (
+        "label" not in ds["train"].features
+    )  # assert param `drop_labels=True` from metadata is passed
     assert len(ds["train"]) == 3 and len(ds["test"]) == 3
 
     ds = load_dataset(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v2", num_proc=2)
@@ -1160,8 +1448,15 @@ def test_load_hub_dataset_with_metadata_config_in_parallel():
 @require_pil
 @pytest.mark.integration
 @pytest.mark.parametrize("streaming", [True])
-def test_load_dataset_private_zipped_images(hf_private_dataset_repo_zipped_img_data, hf_token, streaming):
-    ds = load_dataset(hf_private_dataset_repo_zipped_img_data, split="train", streaming=streaming, token=hf_token)
+def test_load_dataset_private_zipped_images(
+    hf_private_dataset_repo_zipped_img_data, hf_token, streaming
+):
+    ds = load_dataset(
+        hf_private_dataset_repo_zipped_img_data,
+        split="train",
+        streaming=streaming,
+        token=hf_token,
+    )
     assert isinstance(ds, IterableDataset if streaming else Dataset)
     ds_items = list(ds)
     assert len(ds_items) == 2
@@ -1170,7 +1465,9 @@ def test_load_dataset_private_zipped_images(hf_private_dataset_repo_zipped_img_d
 def test_load_dataset_then_move_then_reload(data_dir, tmp_path, caplog):
     cache_dir1 = tmp_path / "cache1"
     cache_dir2 = tmp_path / "cache2"
-    dataset = load_dataset(data_dir, split="train", cache_dir=cache_dir1, trust_remote_code=True)
+    dataset = load_dataset(
+        data_dir, split="train", cache_dir=cache_dir1, trust_remote_code=True
+    )
     fingerprint1 = dataset._fingerprint
     del dataset
     os.rename(cache_dir1, cache_dir2)
@@ -1178,7 +1475,9 @@ def test_load_dataset_then_move_then_reload(data_dir, tmp_path, caplog):
     with caplog.at_level(INFO, logger=get_logger().name):
         dataset = load_dataset(data_dir, split="train", cache_dir=cache_dir2)
     assert "Found cached dataset" in caplog.text
-    assert dataset._fingerprint == fingerprint1, "for the caching mechanism to work, fingerprint should stay the same"
+    assert (
+        dataset._fingerprint == fingerprint1
+    ), "for the caching mechanism to work, fingerprint should stay the same"
     dataset = load_dataset(data_dir, split="test", cache_dir=cache_dir2)
     assert dataset._fingerprint != fingerprint1
 
@@ -1196,20 +1495,30 @@ def test_load_dataset_builder_then_edit_then_load_again(tmp_path: Path):
 
 
 @pytest.mark.parametrize("max_in_memory_dataset_size", ["default", 0, 50, 500])
-def test_load_dataset_local_with_default_in_memory(max_in_memory_dataset_size, data_dir, monkeypatch):
+def test_load_dataset_local_with_default_in_memory(
+    max_in_memory_dataset_size, data_dir, monkeypatch
+):
     current_dataset_size = 148
     if max_in_memory_dataset_size == "default":
         max_in_memory_dataset_size = 0  # default
     else:
-        monkeypatch.setattr(datasets.config, "IN_MEMORY_MAX_SIZE", max_in_memory_dataset_size)
+        monkeypatch.setattr(
+            datasets.config, "IN_MEMORY_MAX_SIZE", max_in_memory_dataset_size
+        )
     if max_in_memory_dataset_size:
         expected_in_memory = current_dataset_size < max_in_memory_dataset_size
     else:
         expected_in_memory = False
 
-    with assert_arrow_memory_increases() if expected_in_memory else assert_arrow_memory_doesnt_increase():
+    with (
+        assert_arrow_memory_increases()
+        if expected_in_memory
+        else assert_arrow_memory_doesnt_increase()
+    ):
         dataset = load_dataset(data_dir)
-    assert (dataset["train"].dataset_size < max_in_memory_dataset_size) is expected_in_memory
+    assert (
+        dataset["train"].dataset_size < max_in_memory_dataset_size
+    ) is expected_in_memory
 
 
 @pytest.mark.integration
@@ -1237,7 +1546,9 @@ def test_load_dataset_distributed(tmp_path, csv_path):
         assert len(datasets) == num_workers
         assert all(len(dataset) == len(datasets[0]) > 0 for dataset in datasets)
         assert len(datasets[0].cache_files) > 0
-        assert all(dataset.cache_files == datasets[0].cache_files for dataset in datasets)
+        assert all(
+            dataset.cache_files == datasets[0].cache_files for dataset in datasets
+        )
 
 
 def test_load_dataset_with_storage_options(mockfs):
@@ -1245,7 +1556,9 @@ def test_load_dataset_with_storage_options(mockfs):
         f.write("Hello there\n")
         f.write("General Kenobi !")
     data_files = {"train": ["mock://data.txt"]}
-    ds = load_dataset("text", data_files=data_files, storage_options=mockfs.storage_options)
+    ds = load_dataset(
+        "text", data_files=data_files, storage_options=mockfs.storage_options
+    )
     assert list(ds["train"]) == [{"text": "Hello there"}, {"text": "General Kenobi !"}]
 
 
@@ -1258,7 +1571,9 @@ def test_load_dataset_with_storage_options_with_decoding(mockfs, image_file):
         with open(image_file, "rb") as fin:
             fout.write(fin.read())
     data_files = {"train": ["mock://" + filename]}
-    ds = load_dataset("imagefolder", data_files=data_files, storage_options=mockfs.storage_options)
+    ds = load_dataset(
+        "imagefolder", data_files=data_files, storage_options=mockfs.storage_options
+    )
     assert len(ds["train"]) == 1
     assert isinstance(ds["train"][0]["image"], PIL.Image.Image)
 
@@ -1276,7 +1591,8 @@ def test_load_dataset_with_zip(zip_csv_path):
 def test_reload_old_cache_from_2_15(tmp_path: Path):
     cache_dir = tmp_path / "test_reload_old_cache_from_2_15"
     builder_cache_dir = (
-        cache_dir / "polinaeterna___audiofolder_two_configs_in_metadata/v2-374bfde4f55442bc/0.0.0/7896925d64deea5d"
+        cache_dir
+        / "polinaeterna___audiofolder_two_configs_in_metadata/v2-374bfde4f55442bc/0.0.0/7896925d64deea5d"
     )
     builder_cache_dir.mkdir(parents=True)
     arrow_path = builder_cache_dir / "audiofolder_two_configs_in_metadata-train.arrow"
@@ -1293,12 +1609,18 @@ def test_reload_old_cache_from_2_15(tmp_path: Path):
     assert builder.cache_dir == builder_cache_dir.as_posix()  # old cache from 2.15
 
     builder = load_dataset_builder(
-        "polinaeterna/audiofolder_two_configs_in_metadata", "v2", cache_dir=cache_dir.as_posix()
+        "polinaeterna/audiofolder_two_configs_in_metadata",
+        "v2",
+        cache_dir=cache_dir.as_posix(),
     )
     assert (
         builder.cache_dir
         == (
-            cache_dir / "polinaeterna___audiofolder_two_configs_in_metadata" / "v2" / "0.0.0" / str(builder.hash)
+            cache_dir
+            / "polinaeterna___audiofolder_two_configs_in_metadata"
+            / "v2"
+            / "0.0.0"
+            / str(builder.hash)
         ).as_posix()
     )  # new cache
 
@@ -1312,10 +1634,18 @@ def test_update_dataset_card_data_with_standalone_yaml():
         "datasets.utils.metadata.MetadataConfigs.from_dataset_card_data",
         side_effect=MetadataConfigs.from_dataset_card_data,
     ) as card_data_read_mock:
-        builder = load_dataset_builder("datasets-maintainers/dataset-with-standalone-yaml")
-    assert card_data_read_mock.call_args.args[0]["license"] is not None  # from README.md
-    assert card_data_read_mock.call_args.args[0]["dataset_info"] is not None  # from standalone yaml
-    assert card_data_read_mock.call_args.args[0]["tags"] == ["test"]  # standalone yaml has precedence
+        builder = load_dataset_builder(
+            "datasets-maintainers/dataset-with-standalone-yaml"
+        )
+    assert (
+        card_data_read_mock.call_args.args[0]["license"] is not None
+    )  # from README.md
+    assert (
+        card_data_read_mock.call_args.args[0]["dataset_info"] is not None
+    )  # from standalone yaml
+    assert card_data_read_mock.call_args.args[0]["tags"] == [
+        "test"
+    ]  # standalone yaml has precedence
     assert isinstance(
         builder.info.features["label"], datasets.ClassLabel
     )  # correctly loaded from long labels list in standalone yaml

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -15,8 +15,17 @@ from datasets.utils.metadata import MetadataConfigs
 
 
 def _dedent(string: str) -> str:
-    indent_level = min(re.search("^ +", t).end() if t.startswith(" ") else 0 for t in string.splitlines())
-    return "\n".join([line[indent_level:] for line in string.splitlines() if indent_level < len(line)])
+    indent_level = min(
+        re.search("^ +", t).end() if t.startswith(" ") else 0
+        for t in string.splitlines()
+    )
+    return "\n".join(
+        [
+            line[indent_level:]
+            for line in string.splitlines()
+            if indent_level < len(line)
+        ]
+    )
 
 
 README_YAML = """\
@@ -121,7 +130,11 @@ EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_NAME = {
 EXPECTED_METADATA_WITH_FEATURES = {
     "default": {
         "features": Features(
-            {"id": Value(dtype="int64"), "name": Value(dtype="string"), "score": Value(dtype="float64")}
+            {
+                "id": Value(dtype="int64"),
+                "name": Value(dtype="string"),
+                "score": Value(dtype="float64"),
+            }
         )
     }
 }
@@ -151,7 +164,8 @@ class TestMetadataUtils(unittest.TestCase):
                 readme_file.write(README_YAML)
             dataset_card_data = DatasetCard.load(path).data
             self.assertDictEqual(
-                dataset_card_data.to_dict(), {"language": ["zh", "en"], "task_ids": ["sentiment-classification"]}
+                dataset_card_data.to_dict(),
+                {"language": ["zh", "en"], "task_ids": ["sentiment-classification"]},
             )
 
             with open(path, "w+") as readme_file:
@@ -241,15 +255,25 @@ class TestMetadataUtils(unittest.TestCase):
               I agree to use this model for non-commerical use ONLY: checkbox
             """
         )
-        assert DatasetCardData(**yaml.safe_load(valid_yaml_with_optional_keys)).to_dict()
+        assert DatasetCardData(
+            **yaml.safe_load(valid_yaml_with_optional_keys)
+        ).to_dict()
 
 
 @pytest.mark.parametrize(
     "readme_content, expected_metadata_configs_dict, expected_default_config_name",
     [
         (README_METADATA_SINGLE_CONFIG, EXPECTED_METADATA_SINGLE_CONFIG, "custom"),
-        (README_METADATA_TWO_CONFIGS_WITH_DEFAULT_FLAG, EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_FLAG, "v2"),
-        (README_METADATA_TWO_CONFIGS_WITH_DEFAULT_NAME, EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_NAME, "default"),
+        (
+            README_METADATA_TWO_CONFIGS_WITH_DEFAULT_FLAG,
+            EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_FLAG,
+            "v2",
+        ),
+        (
+            README_METADATA_TWO_CONFIGS_WITH_DEFAULT_NAME,
+            EXPECTED_METADATA_TWO_CONFIGS_DEFAULT_NAME,
+            "default",
+        ),
         (README_METADATA_WITH_FEATURES, EXPECTED_METADATA_WITH_FEATURES, "default"),
     ],
 )
@@ -261,9 +285,14 @@ def test_metadata_configs_dataset_card_data(
         with open(path, "w+") as readme_file:
             readme_file.write(readme_content)
         dataset_card_data = DatasetCard.load(path).data
-        metadata_configs_dict = MetadataConfigs.from_dataset_card_data(dataset_card_data)
+        metadata_configs_dict = MetadataConfigs.from_dataset_card_data(
+            dataset_card_data
+        )
         assert metadata_configs_dict == expected_metadata_configs_dict
-        assert metadata_configs_dict.get_default_config_name() == expected_default_config_name
+        assert (
+            metadata_configs_dict.get_default_config_name()
+            == expected_default_config_name
+        )
 
 
 def test_metadata_configs_incorrect_yaml():
@@ -354,5 +383,7 @@ def test_split_order_in_metadata_configs_from_exported_parquet_files_and_dataset
     metadata_configs = MetadataConfigs._from_exported_parquet_files_and_dataset_infos(
         "123", exported_parquet_files, dataset_infos
     )
-    split_names = [data_file["split"] for data_file in metadata_configs["default"]["data_files"]]
+    split_names = [
+        data_file["split"] for data_file in metadata_configs["default"]["data_files"]
+    ]
     assert split_names == ["train", "validation", "test"]

--- a/tests/test_offline_util.py
+++ b/tests/test_offline_util.py
@@ -5,7 +5,12 @@ import requests
 
 from datasets.utils.file_utils import fsspec_get, fsspec_head
 
-from .utils import OfflineSimulationMode, RequestWouldHangIndefinitelyError, offline, require_not_windows
+from .utils import (
+    OfflineSimulationMode,
+    RequestWouldHangIndefinitelyError,
+    offline,
+    require_not_windows,
+)
 
 
 @pytest.mark.integration
@@ -16,7 +21,9 @@ def test_offline_with_timeout():
             requests.request("GET", "https://huggingface.co")
         with pytest.raises(requests.exceptions.Timeout):
             requests.request("GET", "https://huggingface.co", timeout=1.0)
-        with pytest.raises(requests.exceptions.Timeout), NamedTemporaryFile() as temp_file:
+        with pytest.raises(
+            requests.exceptions.Timeout
+        ), NamedTemporaryFile() as temp_file:
             fsspec_get("hf://dummy", temp_file=temp_file)
 
 
@@ -26,7 +33,9 @@ def test_offline_with_connection_error():
     with offline(OfflineSimulationMode.CONNECTION_FAILS):
         with pytest.raises(requests.exceptions.ConnectionError):
             requests.request("GET", "https://huggingface.co")
-        with pytest.raises(requests.exceptions.ConnectionError), NamedTemporaryFile() as temp_file:
+        with pytest.raises(
+            requests.exceptions.ConnectionError
+        ), NamedTemporaryFile() as temp_file:
             fsspec_get("hf://dummy", temp_file=temp_file)
 
 

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -145,7 +145,11 @@ def test_patch_submodule_successive():
 
 def test_patch_submodule_doesnt_exist():
     mock = "__test_patch_submodule_doesnt_exist_mock__"
-    with patch_submodule(_test_patching, "__module_that_doesn_exist__.__attribute_that_doesn_exist__", mock):
+    with patch_submodule(
+        _test_patching,
+        "__module_that_doesn_exist__.__attribute_that_doesn_exist__",
+        mock,
+    ):
         pass
     with patch_submodule(_test_patching, "os.__attribute_that_doesn_exist__", mock):
         pass

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -41,7 +41,9 @@ class A:
     y: str
 
 
-@pytest.mark.parametrize("batched, function", [(False, add_one), (True, add_one_to_batch)])
+@pytest.mark.parametrize(
+    "batched, function", [(False, add_one), (True, add_one_to_batch)]
+)
 @pytest.mark.parametrize("num_proc", [None, 2])
 @pytest.mark.parametrize(
     "data_struct, expected_result",
@@ -58,7 +60,10 @@ class A:
     ],
 )
 def test_map_nested(data_struct, expected_result, num_proc, batched, function):
-    assert map_nested(function, data_struct, num_proc=num_proc, batched=batched) == expected_result
+    assert (
+        map_nested(function, data_struct, num_proc=num_proc, batched=batched)
+        == expected_result
+    )
 
 
 class PyUtilsTest(TestCase):
@@ -71,14 +76,24 @@ class PyUtilsTest(TestCase):
             "b": np.zeros(3).astype(int),
             "c": np.ones(2).astype(int),
         }
-        self.assertEqual(map_nested(np_sum, sn1, map_numpy=False), expected_map_nested_sn1_sum)
+        self.assertEqual(
+            map_nested(np_sum, sn1, map_numpy=False), expected_map_nested_sn1_sum
+        )
         self.assertEqual(
             {k: v.tolist() for k, v in map_nested(int, sn1, map_numpy=True).items()},
             {k: v.tolist() for k, v in expected_map_nested_sn1_int.items()},
         )
-        self.assertEqual(map_nested(np_sum, sn1, map_numpy=False, num_proc=num_proc), expected_map_nested_sn1_sum)
         self.assertEqual(
-            {k: v.tolist() for k, v in map_nested(int, sn1, map_numpy=True, num_proc=num_proc).items()},
+            map_nested(np_sum, sn1, map_numpy=False, num_proc=num_proc),
+            expected_map_nested_sn1_sum,
+        )
+        self.assertEqual(
+            {
+                k: v.tolist()
+                for k, v in map_nested(
+                    int, sn1, map_numpy=True, num_proc=num_proc
+                ).items()
+            },
             {k: v.tolist() for k, v in expected_map_nested_sn1_int.items()},
         )
         with self.assertRaises(AttributeError):  # can't pickle a local lambda
@@ -123,7 +138,9 @@ def test_map_nested_num_proc(iterable_length, num_proc, expected_num_proc):
         patch("datasets.parallel.parallel.Pool") as mock_multiprocessing_pool,
     ):
         data_struct = {f"{i}": i for i in range(iterable_length)}
-        _ = map_nested(lambda x: x + 10, data_struct, num_proc=num_proc, parallel_min_length=16)
+        _ = map_nested(
+            lambda x: x + 10, data_struct, num_proc=num_proc, parallel_min_length=16
+        )
         if expected_num_proc == 1:
             assert mock_single_map_nested.called
             assert not mock_multiprocessing_pool.called
@@ -246,14 +263,22 @@ def _2seconds_generator_of_2items_with_timing(content):
 
 def test_iflatmap_unordered():
     with Pool(2) as pool:
-        out = list(iflatmap_unordered(pool, _split_text, kwargs_iterable=[{"text": "hello there"}] * 10))
+        out = list(
+            iflatmap_unordered(
+                pool, _split_text, kwargs_iterable=[{"text": "hello there"}] * 10
+            )
+        )
         assert out.count("hello") == 10
         assert out.count("there") == 10
         assert len(out) == 20
 
     # check multiprocess from pathos (uses dill for pickling)
     with multiprocess.Pool(2) as pool:
-        out = list(iflatmap_unordered(pool, _split_text, kwargs_iterable=[{"text": "hello there"}] * 10))
+        out = list(
+            iflatmap_unordered(
+                pool, _split_text, kwargs_iterable=[{"text": "hello there"}] * 10
+            )
+        )
         assert out.count("hello") == 10
         assert out.count("there") == 10
         assert len(out) == 20
@@ -262,9 +287,13 @@ def test_iflatmap_unordered():
     with Pool(2) as pool:
         out = []
         for yield_time, content in iflatmap_unordered(
-            pool, _2seconds_generator_of_2items_with_timing, kwargs_iterable=[{"content": "a"}, {"content": "b"}]
+            pool,
+            _2seconds_generator_of_2items_with_timing,
+            kwargs_iterable=[{"content": "a"}, {"content": "b"}],
         ):
-            assert yield_time < time.time() + 0.1, "we should each item directly after it was yielded"
+            assert (
+                yield_time < time.time() + 0.1
+            ), "we should each item directly after it was yielded"
             out.append(content)
         assert out.count("a") == 2
         assert out.count("b") == 2
@@ -283,7 +312,11 @@ def test_string_to_dict():
 
     rank = 1
     num_proc = 2
-    file_name = file_name_prefix + suffix_template.format(rank=rank, num_proc=num_proc) + file_name_ext
+    file_name = (
+        file_name_prefix
+        + suffix_template.format(rank=rank, num_proc=num_proc)
+        + file_name_ext
+    )
     file_name_parts = string_to_dict(file_name, cache_file_name_pattern)
     assert file_name_parts is not None
     assert file_name_parts == {"rank": f"{rank:05d}", "num_proc": f"{num_proc:05d}"}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -19,7 +19,13 @@ pytestmark = pytest.mark.integration
 @require_faiss
 class IndexableDatasetTest(TestCase):
     def _create_dummy_dataset(self):
-        dset = Dataset.from_dict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
+        dset = Dataset.from_dict(
+            {
+                "filename": [
+                    "my_name-train" + "_" + str(x) for x in np.arange(30).tolist()
+                ]
+            }
+        )
         return dset
 
     def test_add_faiss_index(self):
@@ -27,10 +33,16 @@ class IndexableDatasetTest(TestCase):
 
         dset: Dataset = self._create_dummy_dataset()
         dset = dset.map(
-            lambda ex, i: {"vecs": i * np.ones(5, dtype=np.float32)}, with_indices=True, keep_in_memory=True
+            lambda ex, i: {"vecs": i * np.ones(5, dtype=np.float32)},
+            with_indices=True,
+            keep_in_memory=True,
         )
-        dset = dset.add_faiss_index("vecs", batch_size=100, metric_type=faiss.METRIC_INNER_PRODUCT)
-        scores, examples = dset.get_nearest_examples("vecs", np.ones(5, dtype=np.float32))
+        dset = dset.add_faiss_index(
+            "vecs", batch_size=100, metric_type=faiss.METRIC_INNER_PRODUCT
+        )
+        scores, examples = dset.get_nearest_examples(
+            "vecs", np.ones(5, dtype=np.float32)
+        )
         self.assertEqual(examples["filename"][0], "my_name-train_29")
         dset.drop_index("vecs")
 
@@ -38,8 +50,12 @@ class IndexableDatasetTest(TestCase):
         import faiss
 
         dset: Dataset = self._create_dummy_dataset()
-        with pytest.raises(ValueError, match="Wrong feature type for column 'filename'"):
-            _ = dset.add_faiss_index("filename", batch_size=100, metric_type=faiss.METRIC_INNER_PRODUCT)
+        with pytest.raises(
+            ValueError, match="Wrong feature type for column 'filename'"
+        ):
+            _ = dset.add_faiss_index(
+                "filename", batch_size=100, metric_type=faiss.METRIC_INNER_PRODUCT
+            )
 
     def test_add_faiss_index_from_external_arrays(self):
         import faiss
@@ -51,7 +67,9 @@ class IndexableDatasetTest(TestCase):
             batch_size=100,
             metric_type=faiss.METRIC_INNER_PRODUCT,
         )
-        scores, examples = dset.get_nearest_examples("vecs", np.ones(5, dtype=np.float32))
+        scores, examples = dset.get_nearest_examples(
+            "vecs", np.ones(5, dtype=np.float32)
+        )
         self.assertEqual(examples["filename"][0], "my_name-train_29")
 
     def test_serialization(self):
@@ -73,16 +91,22 @@ class IndexableDatasetTest(TestCase):
             dset.load_faiss_index("vecs2", tmp_file.name)
         os.unlink(tmp_file.name)
 
-        scores, examples = dset.get_nearest_examples("vecs2", np.ones(5, dtype=np.float32))
+        scores, examples = dset.get_nearest_examples(
+            "vecs2", np.ones(5, dtype=np.float32)
+        )
         self.assertEqual(examples["filename"][0], "my_name-train_29")
 
     def test_drop_index(self):
         dset: Dataset = self._create_dummy_dataset()
         dset.add_faiss_index_from_external_arrays(
-            external_arrays=np.ones((30, 5)) * np.arange(30).reshape(-1, 1), index_name="vecs"
+            external_arrays=np.ones((30, 5)) * np.arange(30).reshape(-1, 1),
+            index_name="vecs",
         )
         dset.drop_index("vecs")
-        self.assertRaises(MissingIndex, partial(dset.get_nearest_examples, "vecs2", np.ones(5, dtype=np.float32)))
+        self.assertRaises(
+            MissingIndex,
+            partial(dset.get_nearest_examples, "vecs2", np.ones(5, dtype=np.float32)),
+        )
 
     def test_add_elasticsearch_index(self):
         from elasticsearch import Elasticsearch
@@ -237,7 +261,9 @@ class ElasticSearchIndexTest(TestCase):
             # batched queries with timeout
             queries = ["foo", "bar", "foobar"]
             mocked_search.return_value = {"hits": {"hits": [{"_score": 1, "_id": 1}]}}
-            total_scores, total_indices = index.search_batch(queries, request_timeout=30)
+            total_scores, total_indices = index.search_batch(
+                queries, request_timeout=30
+            )
             best_scores = [scores[0] for scores in total_scores]
             best_indices = [indices[0] for indices in total_indices]
             self.assertGreater(np.min(best_scores), 0)

--- a/tests/test_sharding_utils.py
+++ b/tests/test_sharding_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from datasets.utils.sharding import _distribute_shards, _number_of_shards_in_gen_kwargs, _split_gen_kwargs
+from datasets.utils.sharding import (
+    _distribute_shards,
+    _number_of_shards_in_gen_kwargs,
+    _split_gen_kwargs,
+)
 
 
 @pytest.mark.parametrize(
@@ -10,8 +14,14 @@ from datasets.utils.sharding import _distribute_shards, _number_of_shards_in_gen
         ({"num_shards": 10, "max_num_jobs": 1}, [range(10)]),
         ({"num_shards": 10, "max_num_jobs": 10}, [range(i, i + 1) for i in range(10)]),
         ({"num_shards": 1, "max_num_jobs": 10}, [range(1)]),
-        ({"num_shards": 10, "max_num_jobs": 3}, [range(0, 4), range(4, 7), range(7, 10)]),
-        ({"num_shards": 3, "max_num_jobs": 10}, [range(0, 1), range(1, 2), range(2, 3)]),
+        (
+            {"num_shards": 10, "max_num_jobs": 3},
+            [range(0, 4), range(4, 7), range(7, 10)],
+        ),
+        (
+            {"num_shards": 3, "max_num_jobs": 10},
+            [range(0, 1), range(1, 2), range(2, 3)],
+        ),
     ],
 )
 def test_distribute_shards(kwargs, expected):
@@ -24,7 +34,11 @@ def test_distribute_shards(kwargs, expected):
     [
         ({"foo": 0}, 10, [{"foo": 0}]),
         ({"shards": [0, 1, 2, 3]}, 1, [{"shards": [0, 1, 2, 3]}]),
-        ({"shards": [0, 1, 2, 3]}, 4, [{"shards": [0]}, {"shards": [1]}, {"shards": [2]}, {"shards": [3]}]),
+        (
+            {"shards": [0, 1, 2, 3]},
+            4,
+            [{"shards": [0]}, {"shards": [1]}, {"shards": [2]}, {"shards": [3]}],
+        ),
         ({"shards": [0, 1]}, 4, [{"shards": [0]}, {"shards": [1]}]),
         ({"shards": [0, 1, 2, 3]}, 2, [{"shards": [0, 1]}, {"shards": [2, 3]}]),
     ],

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -10,7 +10,16 @@ from datasets.utils.py_utils import asdict
     "split_dict",
     [
         SplitDict(),
-        SplitDict({"train": SplitInfo(name="train", num_bytes=1337, num_examples=42, dataset_name="my_dataset")}),
+        SplitDict(
+            {
+                "train": SplitInfo(
+                    name="train",
+                    num_bytes=1337,
+                    num_examples=42,
+                    dataset_name="my_dataset",
+                )
+            }
+        ),
         SplitDict({"train": SplitInfo(name="train", num_bytes=1337, num_examples=42)}),
         SplitDict({"train": SplitInfo()}),
     ],
@@ -28,7 +37,8 @@ def test_split_dict_to_yaml_list(split_dict: SplitDict):
 
 
 @pytest.mark.parametrize(
-    "split_info", [SplitInfo(), SplitInfo(dataset_name=None), SplitInfo(dataset_name="my_dataset")]
+    "split_info",
+    [SplitInfo(), SplitInfo(dataset_name=None), SplitInfo(dataset_name="my_dataset")],
 )
 def test_split_dict_asdict_has_dataset_name(split_info):
     # For backward compatibility, we need asdict(split_dict) to return split info dictrionaries with the "dataset_name"

--- a/tests/test_streaming_download_manager.py
+++ b/tests/test_streaming_download_manager.py
@@ -16,9 +16,15 @@ from .utils import require_lz4, require_zstandard, slow
 
 
 TEST_GG_DRIVE_FILENAME = "train.tsv"
-TEST_GG_DRIVE_URL = "https://drive.google.com/uc?export=download&id=17bOgBDc3hRCoPZ89EYtKDzK-yXAWat94"
-TEST_GG_DRIVE_GZIPPED_URL = "https://drive.google.com/uc?export=download&id=1Bt4Garpf0QLiwkJhHJzXaVa0I0H5Qhwz"
-TEST_GG_DRIVE_ZIPPED_URL = "https://drive.google.com/uc?export=download&id=1k92sUfpHxKq8PXWRr7Y5aNHXwOCNUmqh"
+TEST_GG_DRIVE_URL = (
+    "https://drive.google.com/uc?export=download&id=17bOgBDc3hRCoPZ89EYtKDzK-yXAWat94"
+)
+TEST_GG_DRIVE_GZIPPED_URL = (
+    "https://drive.google.com/uc?export=download&id=1Bt4Garpf0QLiwkJhHJzXaVa0I0H5Qhwz"
+)
+TEST_GG_DRIVE_ZIPPED_URL = (
+    "https://drive.google.com/uc?export=download&id=1k92sUfpHxKq8PXWRr7Y5aNHXwOCNUmqh"
+)
 TEST_GG_DRIVE_CONTENT = """\
 pokemon_name, type
 Charmander, fire
@@ -26,7 +32,9 @@ Squirtle, water
 Bulbasaur, grass"""
 
 
-@pytest.mark.parametrize("urlpath", [r"C:\\foo\bar.txt", "/foo/bar.txt", "https://f.oo/bar.txt"])
+@pytest.mark.parametrize(
+    "urlpath", [r"C:\\foo\bar.txt", "/foo/bar.txt", "https://f.oo/bar.txt"]
+)
 def test_streaming_dl_manager_download_dummy_path(urlpath):
     dl_manager = StreamingDownloadManager()
     assert dl_manager.download(urlpath) == urlpath
@@ -50,11 +58,15 @@ def test_streaming_dl_manager_download(text_path):
     dl_manager = StreamingDownloadManager()
     out = dl_manager.download(text_path)
     assert out == text_path
-    with xopen(out, encoding="utf-8") as f, open(text_path, encoding="utf-8") as expected_file:
+    with xopen(out, encoding="utf-8") as f, open(
+        text_path, encoding="utf-8"
+    ) as expected_file:
         assert f.read() == expected_file.read()
 
 
-@pytest.mark.parametrize("urlpath", [r"C:\\foo\bar.txt", "/foo/bar.txt", "https://f.oo/bar.txt"])
+@pytest.mark.parametrize(
+    "urlpath", [r"C:\\foo\bar.txt", "/foo/bar.txt", "https://f.oo/bar.txt"]
+)
 def test_streaming_dl_manager_download_and_extract_no_extraction(urlpath):
     dl_manager = StreamingDownloadManager()
     assert dl_manager.download_and_extract(urlpath) == urlpath
@@ -71,7 +83,9 @@ def test_streaming_dl_manager_extract(text_gz_path, text_path):
         assert f.read() == expected_file.read()
 
 
-def test_streaming_dl_manager_download_and_extract_with_extraction(text_gz_path, text_path):
+def test_streaming_dl_manager_download_and_extract_with_extraction(
+    text_gz_path, text_path
+):
     dl_manager = StreamingDownloadManager()
     output_path = dl_manager.download_and_extract(text_gz_path)
     path = os.path.basename(text_gz_path)
@@ -84,9 +98,17 @@ def test_streaming_dl_manager_download_and_extract_with_extraction(text_gz_path,
 
 @pytest.mark.parametrize(
     "input_path, filename, expected_path",
-    [("https://domain.org/archive.zip", "filename.jsonl", "zip://filename.jsonl::https://domain.org/archive.zip")],
+    [
+        (
+            "https://domain.org/archive.zip",
+            "filename.jsonl",
+            "zip://filename.jsonl::https://domain.org/archive.zip",
+        )
+    ],
 )
-def test_streaming_dl_manager_download_and_extract_with_join(input_path, filename, expected_path):
+def test_streaming_dl_manager_download_and_extract_with_join(
+    input_path, filename, expected_path
+):
     dl_manager = StreamingDownloadManager()
     extracted_path = dl_manager.download_and_extract(input_path)
     output_path = xjoin(extracted_path, filename)
@@ -97,7 +119,13 @@ def test_streaming_dl_manager_download_and_extract_with_join(input_path, filenam
 def test_streaming_dl_manager_extract_all_supported_single_file_compression_types(
     compression_fs_class, gz_file, xz_file, zstd_file, bz2_file, lz4_file, text_file
 ):
-    input_paths = {"gzip": gz_file, "xz": xz_file, "zstd": zstd_file, "bz2": bz2_file, "lz4": lz4_file}
+    input_paths = {
+        "gzip": gz_file,
+        "xz": xz_file,
+        "zstd": zstd_file,
+        "bz2": bz2_file,
+        "lz4": lz4_file,
+    }
     input_path = input_paths[compression_fs_class.protocol]
     if input_path is None:
         reason = f"for '{compression_fs_class.protocol}' compression protocol, "
@@ -167,21 +195,27 @@ def test_iter_archive_path(archive_jsonl, request):
     assert num_jsonl == 2
 
 
-@pytest.mark.parametrize("archive_nested_jsonl", ["tar_nested_jsonl_path", "zip_nested_jsonl_path"])
+@pytest.mark.parametrize(
+    "archive_nested_jsonl", ["tar_nested_jsonl_path", "zip_nested_jsonl_path"]
+)
 def test_iter_archive_file(archive_nested_jsonl, request):
     archive_nested_jsonl_path = request.getfixturevalue(archive_nested_jsonl)
     dl_manager = StreamingDownloadManager()
     files_iterable = dl_manager.iter_archive(archive_nested_jsonl_path)
     num_tar, num_jsonl = 0, 0
     for num_tar, (path, file) in enumerate(files_iterable, start=1):
-        for num_jsonl, (subpath, subfile) in enumerate(dl_manager.iter_archive(file), start=1):
+        for num_jsonl, (subpath, subfile) in enumerate(
+            dl_manager.iter_archive(file), start=1
+        ):
             _test_jsonl(subpath, subfile)
     assert num_tar == 1
     assert num_jsonl == 2
     # do it twice to make sure it's reset correctly
     num_tar, num_jsonl = 0, 0
     for num_tar, (path, file) in enumerate(files_iterable, start=1):
-        for num_jsonl, (subpath, subfile) in enumerate(dl_manager.iter_archive(file), start=1):
+        for num_jsonl, (subpath, subfile) in enumerate(
+            dl_manager.iter_archive(file), start=1
+        ):
             _test_jsonl(subpath, subfile)
     assert num_tar == 1
     assert num_jsonl == 2
@@ -189,6 +223,8 @@ def test_iter_archive_file(archive_nested_jsonl, request):
 
 def test_iter_files(data_dir_with_hidden_files):
     dl_manager = StreamingDownloadManager()
-    for num_file, file in enumerate(dl_manager.iter_files(data_dir_with_hidden_files), start=1):
+    for num_file, file in enumerate(
+        dl_manager.iter_files(data_dir_with_hidden_files), start=1
+    ):
         assert os.path.basename(file) == ("test.txt" if num_file == 1 else "train.txt")
     assert num_file == 2

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,7 +9,15 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from datasets.features import Array2D, ClassLabel, Features, Image, LargeList, List, Value
+from datasets.features import (
+    Array2D,
+    ClassLabel,
+    Features,
+    Image,
+    LargeList,
+    List,
+    Value,
+)
 from datasets.features.features import Array2DExtensionType, get_nested_type
 from datasets.table import (
     ConcatenationTable,
@@ -32,7 +40,11 @@ from datasets.table import (
     table_iter,
 )
 
-from .utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases, slow
+from .utils import (
+    assert_arrow_memory_doesnt_increase,
+    assert_arrow_memory_increases,
+    slow,
+)
 
 
 @pytest.fixture(scope="session")
@@ -44,7 +56,10 @@ def _to_testing_blocks(table: TableBlock) -> list[list[TableBlock]]:
     assert len(table) > 2
     blocks = [
         [table.slice(0, 2)],
-        [table.slice(2).drop([c for c in table.column_names if c != "tokens"]), table.slice(2).drop(["tokens"])],
+        [
+            table.slice(2).drop([c for c in table.column_names if c != "tokens"]),
+            table.slice(2).drop(["tokens"]),
+        ],
     ]
     return blocks
 
@@ -114,7 +129,9 @@ def test_inject_arrow_table_documentation(in_memory_pa_table):
 
     args = (0, 1)
     wrapped_method = inject_arrow_table_documentation(method)(function_to_wrap)
-    assert method(in_memory_pa_table, *args) == wrapped_method(in_memory_pa_table, *args)
+    assert method(in_memory_pa_table, *args) == wrapped_method(
+        in_memory_pa_table, *args
+    )
     assert "pyarrow.Table" not in wrapped_method.__doc__
     assert "Table" in wrapped_method.__doc__
 
@@ -128,7 +145,9 @@ def test_in_memory_arrow_table_from_file(arrow_file, in_memory_pa_table):
 def test_in_memory_arrow_table_from_buffer(in_memory_pa_table):
     with assert_arrow_memory_increases():
         buf_writer = pa.BufferOutputStream()
-        writer = pa.RecordBatchStreamWriter(buf_writer, schema=in_memory_pa_table.schema)
+        writer = pa.RecordBatchStreamWriter(
+            buf_writer, schema=in_memory_pa_table.schema
+        )
         writer.write_table(in_memory_pa_table)
         writer.close()
         buf_writer.close()
@@ -207,7 +226,8 @@ def test_table_str(in_memory_pa_table):
 
 
 @pytest.mark.parametrize(
-    "attribute", ["schema", "columns", "num_columns", "num_rows", "shape", "nbytes", "column_names"]
+    "attribute",
+    ["schema", "columns", "num_columns", "num_rows", "shape", "nbytes", "column_names"],
 )
 def test_table_attributes(in_memory_pa_table, attribute):
     table = Table(in_memory_pa_table)
@@ -224,7 +244,9 @@ def test_in_memory_table_from_file(arrow_file, in_memory_pa_table):
 def test_in_memory_table_from_buffer(in_memory_pa_table):
     with assert_arrow_memory_increases():
         buf_writer = pa.BufferOutputStream()
-        writer = pa.RecordBatchStreamWriter(buf_writer, schema=in_memory_pa_table.schema)
+        writer = pa.RecordBatchStreamWriter(
+            buf_writer, schema=in_memory_pa_table.schema
+        )
         writer.write_table(in_memory_pa_table)
         writer.close()
         buf_writer.close()
@@ -282,7 +304,10 @@ def test_in_memory_table_deepcopy(in_memory_pa_table):
     assert_index_attributes_equal(table, copied_table)
     # deepcopy must return the exact same arrow objects since they are immutable
     assert table.table is copied_table.table
-    assert all(batch1 is batch2 for batch1, batch2 in zip(table._batches, copied_table._batches))
+    assert all(
+        batch1 is batch2
+        for batch1, batch2 in zip(table._batches, copied_table._batches)
+    )
 
 
 def test_in_memory_table_pickle(in_memory_pa_table):
@@ -332,7 +357,9 @@ def test_in_memory_table_cast(in_memory_pa_table):
     schema = pa.schema(
         {
             k: v if v != pa.list_(pa.int64()) else pa.list_(pa.int32())
-            for k, v in zip(in_memory_pa_table.schema.names, in_memory_pa_table.schema.types)
+            for k, v in zip(
+                in_memory_pa_table.schema.names, in_memory_pa_table.schema.types
+            )
         }
     )
     table = InMemoryTable(in_memory_pa_table).cast(schema)
@@ -368,7 +395,10 @@ def test_in_memory_table_cast_with_hf_features():
 def test_in_memory_table_replace_schema_metadata(in_memory_pa_table):
     metadata = {"huggingface": "{}"}
     table = InMemoryTable(in_memory_pa_table).replace_schema_metadata(metadata)
-    assert table.table.schema.metadata == in_memory_pa_table.replace_schema_metadata(metadata).schema.metadata
+    assert (
+        table.table.schema.metadata
+        == in_memory_pa_table.replace_schema_metadata(metadata).schema.metadata
+    )
     assert isinstance(table, InMemoryTable)
 
 
@@ -406,7 +436,10 @@ def test_in_memory_table_set_column(in_memory_pa_table):
 
 def test_in_memory_table_rename_columns(in_memory_pa_table):
     assert "tokens" in in_memory_pa_table.column_names
-    names = [name if name != "tokens" else "new_tokens" for name in in_memory_pa_table.column_names]
+    names = [
+        name if name != "tokens" else "new_tokens"
+        for name in in_memory_pa_table.column_names
+    ]
     table = InMemoryTable(in_memory_pa_table).rename_columns(names)
     assert table.table == in_memory_pa_table.rename_columns(names)
     assert isinstance(table, InMemoryTable)
@@ -420,7 +453,9 @@ def test_in_memory_table_drop(in_memory_pa_table):
 
 
 def test_memory_mapped_table_init(arrow_file, in_memory_pa_table):
-    table = MemoryMappedTable(_memory_mapped_arrow_table_from_file(arrow_file), arrow_file)
+    table = MemoryMappedTable(
+        _memory_mapped_arrow_table_from_file(arrow_file), arrow_file
+    )
     assert table.table == in_memory_pa_table
     assert isinstance(table, MemoryMappedTable)
     assert_deepcopy_without_bringing_data_in_memory(table)
@@ -456,7 +491,10 @@ def test_memory_mapped_table_deepcopy(arrow_file):
     assert_index_attributes_equal(table, copied_table)
     # deepcopy must return the exact same arrow objects since they are immutable
     assert table.table is copied_table.table
-    assert all(batch1 is batch2 for batch1, batch2 in zip(table._batches, copied_table._batches))
+    assert all(
+        batch1 is batch2
+        for batch1, batch2 in zip(table._batches, copied_table._batches)
+    )
 
 
 def test_memory_mapped_table_pickle(arrow_file):
@@ -529,7 +567,9 @@ def test_memory_mapped_table_cast(arrow_file, in_memory_pa_table):
     schema = pa.schema(
         {
             k: v if v != pa.list_(pa.int64()) else pa.list_(pa.int32())
-            for k, v in zip(in_memory_pa_table.schema.names, in_memory_pa_table.schema.types)
+            for k, v in zip(
+                in_memory_pa_table.schema.names, in_memory_pa_table.schema.types
+            )
         }
     )
     table = MemoryMappedTable.from_file(arrow_file).cast(schema)
@@ -545,7 +585,10 @@ def test_memory_mapped_table_cast(arrow_file, in_memory_pa_table):
 def test_memory_mapped_table_replace_schema_metadata(arrow_file, in_memory_pa_table):
     metadata = {"huggingface": "{}"}
     table = MemoryMappedTable.from_file(arrow_file).replace_schema_metadata(metadata)
-    assert table.table.schema.metadata == in_memory_pa_table.replace_schema_metadata(metadata).schema.metadata
+    assert (
+        table.table.schema.metadata
+        == in_memory_pa_table.replace_schema_metadata(metadata).schema.metadata
+    )
     assert isinstance(table, MemoryMappedTable)
     assert table.replays == [("replace_schema_metadata", (metadata,), {})]
     assert_deepcopy_without_bringing_data_in_memory(table)
@@ -598,7 +641,10 @@ def test_memory_mapped_table_set_column(arrow_file, in_memory_pa_table):
 
 def test_memory_mapped_table_rename_columns(arrow_file, in_memory_pa_table):
     assert "tokens" in in_memory_pa_table.column_names
-    names = [name if name != "tokens" else "new_tokens" for name in in_memory_pa_table.column_names]
+    names = [
+        name if name != "tokens" else "new_tokens"
+        for name in in_memory_pa_table.column_names
+    ]
     table = MemoryMappedTable.from_file(arrow_file).rename_columns(names)
     assert table.table == in_memory_pa_table.rename_columns(names)
     assert isinstance(table, MemoryMappedTable)
@@ -619,14 +665,20 @@ def test_memory_mapped_table_drop(arrow_file, in_memory_pa_table):
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_init(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = (
         in_memory_blocks
         if blocks_type == "in_memory"
-        else memory_mapped_blocks
-        if blocks_type == "memory_mapped"
-        else mixed_in_memory_and_memory_mapped_blocks
+        else (
+            memory_mapped_blocks
+            if blocks_type == "memory_mapped"
+            else mixed_in_memory_and_memory_mapped_blocks
+        )
     )
     table = ConcatenationTable(in_memory_pa_table, blocks)
     assert table.table == in_memory_pa_table
@@ -657,7 +709,11 @@ def test_concatenation_table_from_blocks(in_memory_pa_table, in_memory_blocks):
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_from_blocks_doesnt_increase_memory(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -679,12 +735,20 @@ def test_concatenation_table_from_tables(axis, in_memory_pa_table, arrow_file):
     in_memory_table = InMemoryTable(in_memory_pa_table)
     concatenation_table = ConcatenationTable.from_blocks(in_memory_table)
     memory_mapped_table = MemoryMappedTable.from_file(arrow_file)
-    tables = [in_memory_pa_table, in_memory_table, concatenation_table, memory_mapped_table]
+    tables = [
+        in_memory_pa_table,
+        in_memory_table,
+        concatenation_table,
+        memory_mapped_table,
+    ]
     if axis == 0:
         expected_table = pa.concat_tables([in_memory_pa_table] * len(tables))
     else:
         # avoids error due to duplicate column names
-        tables[1:] = [add_suffix_to_column_names(table, i) for i, table in enumerate(tables[1:], 1)]
+        tables[1:] = [
+            add_suffix_to_column_names(table, i)
+            for i, table in enumerate(tables[1:], 1)
+        ]
         expected_table = in_memory_pa_table
         for table in tables[1:]:
             for name, col in zip(table.column_names, table.columns):
@@ -699,7 +763,9 @@ def test_concatenation_table_from_tables(axis, in_memory_pa_table, arrow_file):
     assert len(table.blocks[0]) == 1 if axis == 0 else 2
     assert axis == 1 or len(table.blocks[1]) == 1
     assert isinstance(table.blocks[0][0], InMemoryTable)
-    assert isinstance(table.blocks[1][0] if axis == 0 else table.blocks[0][1], MemoryMappedTable)
+    assert isinstance(
+        table.blocks[1][0] if axis == 0 else table.blocks[0][1], MemoryMappedTable
+    )
 
 
 def test_concatenation_table_from_tables_axis1_misaligned_blocks(arrow_file):
@@ -728,7 +794,10 @@ def test_concatenation_table_from_tables_axis1_misaligned_blocks(arrow_file):
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_deepcopy(
-    blocks_type, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -742,12 +811,18 @@ def test_concatenation_table_deepcopy(
     assert_index_attributes_equal(table, copied_table)
     # deepcopy must return the exact same arrow objects since they are immutable
     assert table.table is copied_table.table
-    assert all(batch1 is batch2 for batch1, batch2 in zip(table._batches, copied_table._batches))
+    assert all(
+        batch1 is batch2
+        for batch1, batch2 in zip(table._batches, copied_table._batches)
+    )
 
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_pickle(
-    blocks_type, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -780,7 +855,11 @@ def test_concat_tables_with_features_metadata(arrow_file, in_memory_pa_table):
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_slice(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -815,7 +894,11 @@ def test_concatenation_table_slice_mixed_schemas_vertically(arrow_file):
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_filter(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -830,7 +913,11 @@ def test_concatenation_table_filter(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_flatten(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -844,7 +931,11 @@ def test_concatenation_table_flatten(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_combine_chunks(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -858,7 +949,11 @@ def test_concatenation_table_combine_chunks(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_cast(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -870,7 +965,9 @@ def test_concatenation_table_cast(
     schema = pa.schema(
         {
             k: v if v != pa.list_(pa.int64()) else pa.list_(pa.int32())
-            for k, v in zip(in_memory_pa_table.schema.names, in_memory_pa_table.schema.types)
+            for k, v in zip(
+                in_memory_pa_table.schema.names, in_memory_pa_table.schema.types
+            )
         }
     )
     table = ConcatenationTable.from_blocks(blocks).cast(schema)
@@ -879,7 +976,9 @@ def test_concatenation_table_cast(
     schema = pa.schema(
         {
             k: v if v != pa.int64() else pa.int32()
-            for k, v in zip(in_memory_pa_table.schema.names, in_memory_pa_table.schema.types)
+            for k, v in zip(
+                in_memory_pa_table.schema.names, in_memory_pa_table.schema.types
+            )
         }
     )
     table = ConcatenationTable.from_blocks(blocks).cast(schema)
@@ -889,7 +988,11 @@ def test_concatenation_table_cast(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concat_tables_cast_with_features_metadata(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -910,7 +1013,11 @@ def test_concat_tables_cast_with_features_metadata(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_replace_schema_metadata(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -919,13 +1026,20 @@ def test_concatenation_table_replace_schema_metadata(
     }[blocks_type]
     metadata = {"huggingface": "{}"}
     table = ConcatenationTable.from_blocks(blocks).replace_schema_metadata(metadata)
-    assert table.table.schema.metadata == in_memory_pa_table.replace_schema_metadata(metadata).schema.metadata
+    assert (
+        table.table.schema.metadata
+        == in_memory_pa_table.replace_schema_metadata(metadata).schema.metadata
+    )
     assert isinstance(table, ConcatenationTable)
 
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_add_column(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -944,7 +1058,11 @@ def test_concatenation_table_add_column(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_append_column(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -962,7 +1080,11 @@ def test_concatenation_table_append_column(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_remove_column(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -976,7 +1098,11 @@ def test_concatenation_table_remove_column(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_set_column(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -995,7 +1121,11 @@ def test_concatenation_table_set_column(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_rename_columns(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -1003,7 +1133,10 @@ def test_concatenation_table_rename_columns(
         "mixed": mixed_in_memory_and_memory_mapped_blocks,
     }[blocks_type]
     assert "tokens" in in_memory_pa_table.column_names
-    names = [name if name != "tokens" else "new_tokens" for name in in_memory_pa_table.column_names]
+    names = [
+        name if name != "tokens" else "new_tokens"
+        for name in in_memory_pa_table.column_names
+    ]
     table = ConcatenationTable.from_blocks(blocks).rename_columns(names)
     assert isinstance(table, ConcatenationTable)
     assert table.table == in_memory_pa_table.rename_columns(names)
@@ -1011,7 +1144,11 @@ def test_concatenation_table_rename_columns(
 
 @pytest.mark.parametrize("blocks_type", ["in_memory", "memory_mapped", "mixed"])
 def test_concatenation_table_drop(
-    blocks_type, in_memory_pa_table, in_memory_blocks, memory_mapped_blocks, mixed_in_memory_and_memory_mapped_blocks
+    blocks_type,
+    in_memory_pa_table,
+    in_memory_blocks,
+    memory_mapped_blocks,
+    mixed_in_memory_and_memory_mapped_blocks,
 ):
     blocks = {
         "in_memory": in_memory_blocks,
@@ -1034,7 +1171,9 @@ def test_concat_tables(arrow_file, in_memory_pa_table):
     assert concatenated_table.table == pa.concat_tables([t0] * 4)
     assert concatenated_table.table.shape == (40, 4)
     assert isinstance(concatenated_table, ConcatenationTable)
-    assert len(concatenated_table.blocks) == 3  # t0 and t1 are consolidated as a single InMemoryTable
+    assert (
+        len(concatenated_table.blocks) == 3
+    )  # t0 and t1 are consolidated as a single InMemoryTable
     assert isinstance(concatenated_table.blocks[0][0], InMemoryTable)
     assert isinstance(concatenated_table.blocks[1][0], MemoryMappedTable)
     assert isinstance(concatenated_table.blocks[2][0], InMemoryTable)
@@ -1043,13 +1182,17 @@ def test_concat_tables(arrow_file, in_memory_pa_table):
         [add_suffix_to_column_names(table, i) for i, table in enumerate(tables)], axis=1
     )
     assert concatenated_table.table.shape == (10, 16)
-    assert len(concatenated_table.blocks[0]) == 3  # t0 and t1 are consolidated as a single InMemoryTable
+    assert (
+        len(concatenated_table.blocks[0]) == 3
+    )  # t0 and t1 are consolidated as a single InMemoryTable
     assert isinstance(concatenated_table.blocks[0][0], InMemoryTable)
     assert isinstance(concatenated_table.blocks[0][1], MemoryMappedTable)
     assert isinstance(concatenated_table.blocks[0][2], InMemoryTable)
 
 
-def _interpolation_search_ground_truth(arr: list[int], x: int) -> Union[int, IndexError]:
+def _interpolation_search_ground_truth(
+    arr: list[int], x: int
+) -> Union[int, IndexError]:
     for i in range(len(arr) - 1):
         if arr[i] <= x < arr[i + 1]:
             return i
@@ -1075,7 +1218,10 @@ class _ListWithGetitemCounter(list):
     "arr, x",
     [(np.arange(0, 14, 3), x) for x in range(-1, 22)]
     + [(list(np.arange(-5, 5)), x) for x in range(-6, 6)]
-    + [([0, 1_000, 1_001, 1_003], x) for x in [-1, 0, 2, 100, 999, 1_000, 1_001, 1_002, 1_003, 1_004]]
+    + [
+        ([0, 1_000, 1_001, 1_003], x)
+        for x in [-1, 0, 2, 100, 999, 1_000, 1_001, 1_002, 1_003, 1_004]
+    ]
     + [(list(range(1_000)), x) for x in [-1, 0, 1, 10, 666, 999, 1_000, 1_0001]],
 )
 def test_interpolation_search(arr, x):
@@ -1098,41 +1244,57 @@ def test_indexed_table_mixin():
     pa_table = pa.Table.from_pydict({"col": [0] * n_rows_per_chunk})
     pa_table = pa.concat_tables([pa_table] * n_chunks)
     table = Table(pa_table)
-    assert all(table._offsets.tolist() == np.cumsum([0] + [n_rows_per_chunk] * n_chunks))
+    assert all(
+        table._offsets.tolist() == np.cumsum([0] + [n_rows_per_chunk] * n_chunks)
+    )
     assert table.fast_slice(5) == pa_table.slice(5)
     assert table.fast_slice(2, 13) == pa_table.slice(2, 13)
 
 
 def test_cast_integer_array_to_features():
     arr = pa.array([[0, 1]])
-    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(pa.string())
-    assert cast_array_to_feature(arr, List(Value("string")), allow_decimal_to_str=False).type == pa.list_(pa.string())
+    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(
+        pa.string()
+    )
+    assert cast_array_to_feature(
+        arr, List(Value("string")), allow_decimal_to_str=False
+    ).type == pa.list_(pa.string())
     with pytest.raises(TypeError):
         cast_array_to_feature(arr, List(Value("string")), allow_primitive_to_str=False)
 
 
 def test_cast_float_array_to_features():
     arr = pa.array([[0.0, 1.0]])
-    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(pa.string())
-    assert cast_array_to_feature(arr, List(Value("string")), allow_decimal_to_str=False).type == pa.list_(pa.string())
+    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(
+        pa.string()
+    )
+    assert cast_array_to_feature(
+        arr, List(Value("string")), allow_decimal_to_str=False
+    ).type == pa.list_(pa.string())
     with pytest.raises(TypeError):
         cast_array_to_feature(arr, List(Value("string")), allow_primitive_to_str=False)
 
 
 def test_cast_boolean_array_to_features():
     arr = pa.array([[False, True]])
-    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(pa.string())
-    assert cast_array_to_feature(arr, List(Value("string")), allow_decimal_to_str=False).type == pa.list_(pa.string())
+    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(
+        pa.string()
+    )
+    assert cast_array_to_feature(
+        arr, List(Value("string")), allow_decimal_to_str=False
+    ).type == pa.list_(pa.string())
     with pytest.raises(TypeError):
         cast_array_to_feature(arr, List(Value("string")), allow_primitive_to_str=False)
 
 
 def test_cast_decimal_array_to_features():
     arr = pa.array([[Decimal(0), Decimal(1)]])
-    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(pa.string())
-    assert cast_array_to_feature(arr, List(Value("string")), allow_primitive_to_str=False).type == pa.list_(
+    assert cast_array_to_feature(arr, List(Value("string"))).type == pa.list_(
         pa.string()
     )
+    assert cast_array_to_feature(
+        arr, List(Value("string")), allow_primitive_to_str=False
+    ).type == pa.list_(pa.string())
     with pytest.raises(TypeError):
         cast_array_to_feature(arr, List(Value("string")), allow_decimal_to_str=False)
 
@@ -1140,11 +1302,19 @@ def test_cast_decimal_array_to_features():
 @pytest.mark.parametrize(
     "array_list, expected_list",
     [
-        ([{"age": 25}, {"age": 63}], [{"age": 25, "name": None}, {"age": 63, "name": None}]),
-        ([{}, {}], [{"age": None, "name": None}, {"age": None, "name": None}]),  # completely empty struct
+        (
+            [{"age": 25}, {"age": 63}],
+            [{"age": 25, "name": None}, {"age": 63, "name": None}],
+        ),
+        (
+            [{}, {}],
+            [{"age": None, "name": None}, {"age": None, "name": None}],
+        ),  # completely empty struct
     ],
 )
-def test_cast_array_to_feature_with_struct_with_missing_fields(array_list, expected_list):
+def test_cast_array_to_feature_with_struct_with_missing_fields(
+    array_list, expected_list
+):
     arr = pa.array(array_list)
     feature = {"age": Value("int32"), "name": Value("string")}
     cast_array = cast_array_to_feature(arr, feature)
@@ -1154,9 +1324,9 @@ def test_cast_array_to_feature_with_struct_with_missing_fields(array_list, expec
 
 def test_cast_array_to_features_nested():
     arr = pa.array([[{"foo": [0]}]])
-    assert cast_array_to_feature(arr, List({"foo": List(Value("string"))})).type == pa.list_(
-        pa.struct({"foo": pa.list_(pa.string())})
-    )
+    assert cast_array_to_feature(
+        arr, List({"foo": List(Value("string"))})
+    ).type == pa.list_(pa.struct({"foo": pa.list_(pa.string())}))
 
 
 def test_cast_array_to_features_to_nested_with_no_fields():
@@ -1167,12 +1337,16 @@ def test_cast_array_to_features_to_nested_with_no_fields():
 
 def test_cast_array_to_features_nested_with_nulls():
     # same type
-    arr = pa.array([{"foo": [None, [0]]}], pa.struct({"foo": pa.list_(pa.list_(pa.int64()))}))
+    arr = pa.array(
+        [{"foo": [None, [0]]}], pa.struct({"foo": pa.list_(pa.list_(pa.int64()))})
+    )
     casted_array = cast_array_to_feature(arr, {"foo": List(List(Value("int64")))})
     assert casted_array.type == pa.struct({"foo": pa.list_(pa.list_(pa.int64()))})
     assert casted_array.to_pylist() == arr.to_pylist()
     # different type
-    arr = pa.array([{"foo": [None, [0]]}], pa.struct({"foo": pa.list_(pa.list_(pa.int64()))}))
+    arr = pa.array(
+        [{"foo": [None, [0]]}], pa.struct({"foo": pa.list_(pa.list_(pa.int64()))})
+    )
     casted_array = cast_array_to_feature(arr, {"foo": List(List(Value("int32")))})
     assert casted_array.type == pa.struct({"foo": pa.list_(pa.list_(pa.int32()))})
     assert casted_array.to_pylist() == [{"foo": [None, [0]]}]
@@ -1191,7 +1365,9 @@ def test_cast_array_to_features_to_null_type():
 
 def test_cast_array_to_features_array_xd():
     # same storage type
-    arr = pa.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]], pa.list_(pa.list_(pa.int32(), 2), 2))
+    arr = pa.array(
+        [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], pa.list_(pa.list_(pa.int32(), 2), 2)
+    )
     casted_array = cast_array_to_feature(arr, Array2D(shape=(2, 2), dtype="int32"))
     assert casted_array.type == Array2DExtensionType(shape=(2, 2), dtype="int32")
     # different storage type
@@ -1201,17 +1377,25 @@ def test_cast_array_to_features_array_xd():
 
 def test_cast_array_to_features_sequence_classlabel():
     arr = pa.array([[], [1], [0, 1]], pa.list_(pa.int64()))
-    assert cast_array_to_feature(arr, List(ClassLabel(names=["foo", "bar"]))).type == pa.list_(pa.int64())
+    assert cast_array_to_feature(
+        arr, List(ClassLabel(names=["foo", "bar"]))
+    ).type == pa.list_(pa.int64())
 
     arr = pa.array([[], ["bar"], ["foo", "bar"]], pa.list_(pa.string()))
-    assert cast_array_to_feature(arr, List(ClassLabel(names=["foo", "bar"]))).type == pa.list_(pa.int64())
+    assert cast_array_to_feature(
+        arr, List(ClassLabel(names=["foo", "bar"]))
+    ).type == pa.list_(pa.int64())
 
     # Test empty arrays
     arr = pa.array([[], []], pa.list_(pa.int64()))
-    assert cast_array_to_feature(arr, List(ClassLabel(names=["foo", "bar"]))).type == pa.list_(pa.int64())
+    assert cast_array_to_feature(
+        arr, List(ClassLabel(names=["foo", "bar"]))
+    ).type == pa.list_(pa.int64())
 
     arr = pa.array([[], []], pa.list_(pa.string()))
-    assert cast_array_to_feature(arr, List(ClassLabel(names=["foo", "bar"]))).type == pa.list_(pa.int64())
+    assert cast_array_to_feature(
+        arr, List(ClassLabel(names=["foo", "bar"]))
+    ).type == pa.list_(pa.int64())
 
     # Test invalid class labels
     arr = pa.array([[2]], pa.list_(pa.int64()))
@@ -1226,19 +1410,31 @@ def test_cast_array_to_features_sequence_classlabel():
 @pytest.mark.parametrize(
     "arr",
     [
-        pa.array([[0, 1, 2], [3, None, 5], None, [6, 7, 8], None], pa.list_(pa.int32(), 3)),
+        pa.array(
+            [[0, 1, 2], [3, None, 5], None, [6, 7, 8], None], pa.list_(pa.int32(), 3)
+        ),
     ],
 )
-@pytest.mark.parametrize("slice", [None, slice(1, None), slice(-1), slice(1, 3), slice(2, 3), slice(1, 1)])
+@pytest.mark.parametrize(
+    "slice", [None, slice(1, None), slice(-1), slice(1, 3), slice(2, 3), slice(1, 1)]
+)
 @pytest.mark.parametrize("target_value_feature", [Value("int64")])
-def test_cast_fixed_size_list_array_to_features_sequence(arr, slice, target_value_feature):
+def test_cast_fixed_size_list_array_to_features_sequence(
+    arr, slice, target_value_feature
+):
     arr = arr if slice is None else arr[slice]
     # Fixed size list
-    casted_array = cast_array_to_feature(arr, List(target_value_feature, length=arr.type.list_size))
-    assert casted_array.type == get_nested_type(List(target_value_feature, length=arr.type.list_size))
+    casted_array = cast_array_to_feature(
+        arr, List(target_value_feature, length=arr.type.list_size)
+    )
+    assert casted_array.type == get_nested_type(
+        List(target_value_feature, length=arr.type.list_size)
+    )
     assert casted_array.to_pylist() == arr.to_pylist()
     with pytest.raises(TypeError):
-        cast_array_to_feature(arr, List(target_value_feature, length=arr.type.list_size + 1))
+        cast_array_to_feature(
+            arr, List(target_value_feature, length=arr.type.list_size + 1)
+        )
     # Variable size list
     casted_array = cast_array_to_feature(arr, List(target_value_feature))
     assert casted_array.type == get_nested_type(List(target_value_feature))
@@ -1251,10 +1447,14 @@ def test_cast_fixed_size_list_array_to_features_sequence(arr, slice, target_valu
 @pytest.mark.parametrize(
     "arr",
     [
-        pa.array([[0, 1, 2], [3, None, 5], None, [6, 7, 8], None], pa.list_(pa.int32())),
+        pa.array(
+            [[0, 1, 2], [3, None, 5], None, [6, 7, 8], None], pa.list_(pa.int32())
+        ),
     ],
 )
-@pytest.mark.parametrize("slice", [None, slice(1, None), slice(-1), slice(1, 3), slice(2, 3), slice(1, 1)])
+@pytest.mark.parametrize(
+    "slice", [None, slice(1, None), slice(-1), slice(1, 3), slice(2, 3), slice(1, 1)]
+)
 @pytest.mark.parametrize("target_value_feature", [Value("int64")])
 def test_cast_list_array_to_features_sequence(arr, slice, target_value_feature):
     arr = arr if slice is None else arr[slice]
@@ -1266,9 +1466,17 @@ def test_cast_list_array_to_features_sequence(arr, slice, target_value_feature):
     assert casted_array.type == get_nested_type(List(target_value_feature))
     assert casted_array.to_pylist() == arr.to_pylist()
     # Fixed size list
-    list_size = arr.value_lengths().drop_null()[0].as_py() if arr.value_lengths().drop_null() else 2
-    casted_array = cast_array_to_feature(arr, List(target_value_feature, length=list_size))
-    assert casted_array.type == get_nested_type(List(target_value_feature, length=list_size))
+    list_size = (
+        arr.value_lengths().drop_null()[0].as_py()
+        if arr.value_lengths().drop_null()
+        else 2
+    )
+    casted_array = cast_array_to_feature(
+        arr, List(target_value_feature, length=list_size)
+    )
+    assert casted_array.type == get_nested_type(
+        List(target_value_feature, length=list_size)
+    )
     assert casted_array.to_pylist() == arr.to_pylist()
 
 
@@ -1296,7 +1504,9 @@ def test_cast_array_to_feature_with_list_array_and_sequence_feature(
     array_data = [0, 1]
     array_type = list_type[from_list_type](pa.int64())
     sequence_feature = list_feature[from_list_type](Value(sequence_feature_dtype))
-    expected_array_type = list_type[from_list_type](primitive_type[sequence_feature_dtype])
+    expected_array_type = list_type[from_list_type](
+        primitive_type[sequence_feature_dtype]
+    )
     if list_within_struct:
         array_data = {"col_1": array_data}
         array_type = pa.struct({"col_1": array_type})
@@ -1313,7 +1523,9 @@ def test_cast_array_to_feature_with_list_array_and_sequence_feature(
 
 @pytest.mark.parametrize("large_list_feature_value_type", ["string", "int64"])
 @pytest.mark.parametrize("from_list_type", ["list", "fixed_size_list", "large_list"])
-def test_cast_array_to_feature_with_list_array_and_large_list_feature(from_list_type, large_list_feature_value_type):
+def test_cast_array_to_feature_with_list_array_and_large_list_feature(
+    from_list_type, large_list_feature_value_type
+):
     list_type = {
         "list": pa.list_,
         "fixed_size_list": partial(pa.list_, list_size=2),
@@ -1327,7 +1539,9 @@ def test_cast_array_to_feature_with_list_array_and_large_list_feature(from_list_
     array_data = [0, 1]
     array_type = list_type[from_list_type](pa.int64())
     large_list_feature_value = Value(large_list_feature_value_type)
-    expected_array_type = list_type[to_type](primitive_type[large_list_feature_value_type])
+    expected_array_type = list_type[to_type](
+        primitive_type[large_list_feature_value_type]
+    )
     feature = LargeList(large_list_feature_value)
     array = pa.array([array_data], type=array_type)
     cast_array = cast_array_to_feature(array, feature)
@@ -1336,15 +1550,25 @@ def test_cast_array_to_feature_with_list_array_and_large_list_feature(from_list_
 
 def test_cast_array_xd_to_features_sequence():
     arr = np.random.randint(0, 10, size=(8, 2, 3)).tolist()
-    arr = Array2DExtensionType(shape=(2, 3), dtype="int64").wrap_array(pa.array(arr, pa.list_(pa.list_(pa.int64()))))
+    arr = Array2DExtensionType(shape=(2, 3), dtype="int64").wrap_array(
+        pa.array(arr, pa.list_(pa.list_(pa.int64())))
+    )
     arr = pa.ListArray.from_arrays([0, None, 4, 8], arr)
     # Variable size list
-    casted_array = cast_array_to_feature(arr, List(Array2D(shape=(2, 3), dtype="int32")))
-    assert casted_array.type == get_nested_type(List(Array2D(shape=(2, 3), dtype="int32")))
+    casted_array = cast_array_to_feature(
+        arr, List(Array2D(shape=(2, 3), dtype="int32"))
+    )
+    assert casted_array.type == get_nested_type(
+        List(Array2D(shape=(2, 3), dtype="int32"))
+    )
     assert casted_array.to_pylist() == arr.to_pylist()
     # Fixed size list
-    casted_array = cast_array_to_feature(arr, List(Array2D(shape=(2, 3), dtype="int32"), length=4))
-    assert casted_array.type == get_nested_type(List(Array2D(shape=(2, 3), dtype="int32"), length=4))
+    casted_array = cast_array_to_feature(
+        arr, List(Array2D(shape=(2, 3), dtype="int32"), length=4)
+    )
+    assert casted_array.type == get_nested_type(
+        List(Array2D(shape=(2, 3), dtype="int32"), length=4)
+    )
     assert casted_array.to_pylist() == arr.to_pylist()
 
 
@@ -1357,11 +1581,16 @@ def test_embed_array_storage(image_file):
 
 
 def test_embed_array_storage_nested(image_file):
-    array = pa.array([[{"bytes": None, "path": image_file}]], type=pa.list_(Image.pa_type))
+    array = pa.array(
+        [[{"bytes": None, "path": image_file}]], type=pa.list_(Image.pa_type)
+    )
     embedded_images_array = embed_array_storage(array, List(Image()))
     assert isinstance(embedded_images_array.to_pylist()[0][0]["path"], str)
     assert isinstance(embedded_images_array.to_pylist()[0][0]["bytes"], bytes)
-    array = pa.array([{"foo": {"bytes": None, "path": image_file}}], type=pa.struct({"foo": Image.pa_type}))
+    array = pa.array(
+        [{"foo": {"bytes": None, "path": image_file}}],
+        type=pa.struct({"foo": Image.pa_type}),
+    )
     embedded_images_array = embed_array_storage(array, {"foo": Image()})
     assert isinstance(embedded_images_array.to_pylist()[0]["foo"]["path"], str)
     assert isinstance(embedded_images_array.to_pylist()[0]["foo"]["bytes"], bytes)
@@ -1382,17 +1611,24 @@ def test_embed_array_storage_nested(image_file):
         ),
     ],
 )
-def test_embed_array_storage_with_list_types(array, feature, expected_embedded_array_type, monkeypatch):
+def test_embed_array_storage_with_list_types(
+    array, feature, expected_embedded_array_type, monkeypatch
+):
     mock_embed_storage = MagicMock(
         return_value=pa.StructArray.from_arrays(
-            [pa.array([b"image_bytes"], type=pa.binary()), pa.array(["image_path"], type=pa.string())],
+            [
+                pa.array([b"image_bytes"], type=pa.binary()),
+                pa.array(["image_path"], type=pa.string()),
+            ],
             ["bytes", "path"],
         )
     )
     monkeypatch.setattr(Image, "embed_storage", mock_embed_storage)
     embedded_images_array = embed_array_storage(array, feature)
     assert expected_embedded_array_type(embedded_images_array.type)
-    assert embedded_images_array.to_pylist() == [[{"bytes": b"image_bytes", "path": "image_path"}]]
+    assert embedded_images_array.to_pylist() == [
+        [{"bytes": b"image_bytes", "path": "image_path"}]
+    ]
 
 
 def test_embed_table_storage(image_file):
@@ -1407,16 +1643,28 @@ def test_embed_table_storage(image_file):
     "table",
     [
         InMemoryTable(pa.table({"foo": range(10)})),
-        InMemoryTable(pa.concat_tables([pa.table({"foo": range(0, 5)}), pa.table({"foo": range(5, 10)})])),
+        InMemoryTable(
+            pa.concat_tables(
+                [pa.table({"foo": range(0, 5)}), pa.table({"foo": range(5, 10)})]
+            )
+        ),
         InMemoryTable(pa.concat_tables([pa.table({"foo": [i]}) for i in range(10)])),
     ],
 )
 @pytest.mark.parametrize("batch_size", [1, 2, 3, 9, 10, 11, 20])
 @pytest.mark.parametrize("drop_last_batch", [False, True])
 def test_table_iter(table, batch_size, drop_last_batch):
-    num_rows = len(table) if not drop_last_batch else len(table) // batch_size * batch_size
-    num_batches = (num_rows // batch_size) + 1 if num_rows % batch_size else num_rows // batch_size
-    subtables = list(table_iter(table, batch_size=batch_size, drop_last_batch=drop_last_batch))
+    num_rows = (
+        len(table) if not drop_last_batch else len(table) // batch_size * batch_size
+    )
+    num_batches = (
+        (num_rows // batch_size) + 1
+        if num_rows % batch_size
+        else num_rows // batch_size
+    )
+    subtables = list(
+        table_iter(table, batch_size=batch_size, drop_last_batch=drop_last_batch)
+    )
     assert len(subtables) == num_batches
     if drop_last_batch:
         assert all(len(subtable) == batch_size for subtable in subtables)

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -39,7 +39,12 @@ from datasets.utils.file_utils import cached_path
 from datasets.utils.hub import hf_dataset_url
 
 from .fixtures.hub import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
-from .utils import for_all_test_methods, require_pil, require_torchcodec, xfail_if_500_502_http_error
+from .utils import (
+    for_all_test_methods,
+    require_pil,
+    require_torchcodec,
+    xfail_if_500_502_http_error,
+)
 
 
 pytestmark = pytest.mark.integration
@@ -51,7 +56,9 @@ class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)
     _token = CI_HUB_USER_TOKEN
 
-    def test_push_dataset_dict_to_hub_no_token(self, temporary_repo, set_ci_hub_access_token):
+    def test_push_dataset_dict_to_hub_no_token(
+        self, temporary_repo, set_ci_hub_access_token
+    ):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
         local_ds = DatasetDict({"train": ds})
@@ -61,12 +68,18 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
     def test_push_dataset_dict_to_hub_name_without_namespace(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -78,14 +91,22 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
-    def test_push_dataset_dict_to_hub_datasets_with_different_features(self, cleanup_repo):
+    def test_push_dataset_dict_to_hub_datasets_with_different_features(
+        self, cleanup_repo
+    ):
         ds_train = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_test = Dataset.from_dict({"x": [True, False, True], "y": ["a", "b", "c"]})
 
@@ -106,15 +127,27 @@ class TestPushToHub:
 
         with temporary_repo() as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, private=True)
-            hub_ds = load_dataset(ds_name, download_mode="force_redownload", token=self._token)
+            hub_ds = load_dataset(
+                ds_name, download_mode="force_redownload", token=self._token
+            )
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
     def test_push_dataset_dict_to_hub(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -126,12 +159,22 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
     def test_push_dataset_dict_to_hub_with_pull_request(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -140,7 +183,9 @@ class TestPushToHub:
 
         with temporary_repo() as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, create_pr=True)
-            hub_ds = load_dataset(ds_name, revision="refs/pr/1", download_mode="force_redownload")
+            hub_ds = load_dataset(
+                ds_name, revision="refs/pr/1", download_mode="force_redownload"
+            )
 
             assert local_ds["train"].features == hub_ds["train"].features
             assert list(local_ds.keys()) == list(hub_ds.keys())
@@ -148,9 +193,18 @@ class TestPushToHub:
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(
-                self._api.list_repo_files(ds_name, revision="refs/pr/1", repo_type="dataset", token=self._token)
+                self._api.list_repo_files(
+                    ds_name,
+                    revision="refs/pr/1",
+                    repo_type="dataset",
+                    token=self._token,
+                )
             )
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
     def test_push_dataset_dict_to_hub_with_revision(self, temporary_repo):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
@@ -159,15 +213,25 @@ class TestPushToHub:
 
         with temporary_repo() as ds_name:
             local_ds.push_to_hub(ds_name, token=self._token, revision="dev")
-            hub_ds = load_dataset(ds_name, revision="dev", download_mode="force_redownload")
+            hub_ds = load_dataset(
+                ds_name, revision="dev", download_mode="force_redownload"
+            )
 
             assert local_ds["train"].features == hub_ds["train"].features
             assert list(local_ds.keys()) == list(hub_ds.keys())
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
-            files = sorted(self._api.list_repo_files(ds_name, revision="dev", repo_type="dataset", token=self._token))
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, revision="dev", repo_type="dataset", token=self._token
+                )
+            )
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
     def test_push_dataset_dict_to_hub_multiple_files(self, temporary_repo):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
@@ -180,11 +244,17 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there are two files on the repository that have the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert files == [
                 ".gitattributes",
                 "README.md",
@@ -192,7 +262,9 @@ class TestPushToHub:
                 "data/train-00001-of-00002.parquet",
             ]
 
-    def test_push_dataset_dict_to_hub_multiple_files_with_max_shard_size(self, temporary_repo):
+    def test_push_dataset_dict_to_hub_multiple_files_with_max_shard_size(
+        self, temporary_repo
+    ):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
 
         local_ds = DatasetDict({"train": ds})
@@ -202,11 +274,17 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there are two files on the repository that have the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert files == [
                 ".gitattributes",
                 "README.md",
@@ -214,7 +292,9 @@ class TestPushToHub:
                 "data/train-00001-of-00002.parquet",
             ]
 
-    def test_push_dataset_dict_to_hub_multiple_files_with_num_shards(self, temporary_repo):
+    def test_push_dataset_dict_to_hub_multiple_files_with_num_shards(
+        self, temporary_repo
+    ):
         ds = Dataset.from_dict({"x": list(range(1000)), "y": list(range(1000))})
 
         local_ds = DatasetDict({"train": ds})
@@ -224,11 +304,17 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there are two files on the repository that have the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert files == [
                 ".gitattributes",
                 "README.md",
@@ -243,7 +329,11 @@ class TestPushToHub:
 
         with temporary_repo() as ds_name:
             self._api.create_repo(ds_name, token=self._token, repo_type="dataset")
-            num_commits_before_push = len(self._api.list_repo_commits(ds_name, repo_type="dataset", token=self._token))
+            num_commits_before_push = len(
+                self._api.list_repo_commits(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             with (
                 patch("datasets.config.MAX_SHARD_SIZE", "16KB"),
                 patch("datasets.config.UPLOADS_MAX_NUMBER_PER_COMMIT", 1),
@@ -252,11 +342,17 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there are two files on the repository that have the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert files == [
                 ".gitattributes",
                 "README.md",
@@ -264,7 +360,11 @@ class TestPushToHub:
                 "data/train-00001-of-00002.parquet",
             ]
 
-            num_commits_after_push = len(self._api.list_repo_commits(ds_name, repo_type="dataset", token=self._token))
+            num_commits_after_push = len(
+                self._api.list_repo_commits(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert num_commits_after_push - num_commits_before_push > 1
 
     def test_push_dataset_dict_to_hub_overwrite_files(self, temporary_repo):
@@ -295,7 +395,11 @@ class TestPushToHub:
             local_ds.push_to_hub(ds_name, token=self._token, max_shard_size=500 << 5)
 
             # Ensure that there are two files on the repository that have the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert files == [
                 ".gitattributes",
                 "README.md",
@@ -305,12 +409,16 @@ class TestPushToHub:
                 "datafile.txt",
             ]
 
-            self._api.delete_file("datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token)
+            self._api.delete_file(
+                "datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token
+            )
 
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
         del hub_ds
@@ -340,7 +448,11 @@ class TestPushToHub:
             local_ds.push_to_hub(ds_name, token=self._token)
 
             # Ensure that there are two files on the repository that have the correct name
-            files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
+            files = sorted(
+                self._api.list_repo_files(
+                    ds_name, repo_type="dataset", token=self._token
+                )
+            )
             assert files == [
                 ".gitattributes",
                 "README.md",
@@ -350,12 +462,16 @@ class TestPushToHub:
             ]
 
             # Keeping the "datafile.txt" breaks the load_dataset to think it's a text-based dataset
-            self._api.delete_file("datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token)
+            self._api.delete_file(
+                "datafile.txt", repo_id=ds_name, repo_type="dataset", token=self._token
+            )
 
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
     def test_push_dataset_to_hub(self, temporary_repo):
@@ -376,12 +492,16 @@ class TestPushToHub:
                 assert local_ds.features == hub_ds.features
 
     def test_push_dataset_to_hub_custom_features(self, temporary_repo):
-        features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})
+        features = Features(
+            {"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])}
+        )
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [0, 0, 1]}, features=features)
 
         with temporary_repo() as ds_name:
             ds.push_to_hub(ds_name, token=self._token)
-            hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+            hub_ds = load_dataset(
+                ds_name, split="train", download_mode="force_redownload"
+            )
 
             assert ds.column_names == hub_ds.column_names
             assert list(ds.features.keys()) == list(hub_ds.features.keys())
@@ -391,15 +511,23 @@ class TestPushToHub:
     @require_torchcodec
     @require_torchcodec
     def test_push_dataset_to_hub_custom_features_audio(self, temporary_repo):
-        audio_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_audio_44100.wav")
+        audio_path = os.path.join(
+            os.path.dirname(__file__), "features", "data", "test_audio_44100.wav"
+        )
         data = {"x": [audio_path, None], "y": [0, -1]}
         features = Features({"x": Audio(), "y": Value("int32")})
         ds = Dataset.from_dict(data, features=features)
 
         for embed_external_files in [True, False]:
             with temporary_repo() as ds_name:
-                ds.push_to_hub(ds_name, embed_external_files=embed_external_files, token=self._token)
-                hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+                ds.push_to_hub(
+                    ds_name,
+                    embed_external_files=embed_external_files,
+                    token=self._token,
+                )
+                hub_ds = load_dataset(
+                    ds_name, split="train", download_mode="force_redownload"
+                )
 
                 assert ds.column_names == hub_ds.column_names
                 assert list(ds.features.keys()) == list(hub_ds.features.keys())
@@ -408,7 +536,9 @@ class TestPushToHub:
                     ds[0]["x"].get_all_samples().data.cpu().numpy(),
                     hub_ds[0]["x"].get_all_samples().data.cpu().numpy(),
                 )
-                assert ds[1] == hub_ds[1]  # don't test hub_ds[0] since audio decoding might be slightly different
+                assert (
+                    ds[1] == hub_ds[1]
+                )  # don't test hub_ds[0] since audio decoding might be slightly different
                 hub_ds = hub_ds.cast_column("x", Audio(decode=False))
                 elem = hub_ds[0]["x"]
                 path, bytes_ = elem["path"], elem["bytes"]
@@ -418,15 +548,23 @@ class TestPushToHub:
 
     @require_pil
     def test_push_dataset_to_hub_custom_features_image(self, temporary_repo):
-        image_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg")
+        image_path = os.path.join(
+            os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg"
+        )
         data = {"x": [image_path, None], "y": [0, -1]}
         features = Features({"x": Image(), "y": Value("int32")})
         ds = Dataset.from_dict(data, features=features)
 
         for embed_external_files in [True, False]:
             with temporary_repo() as ds_name:
-                ds.push_to_hub(ds_name, embed_external_files=embed_external_files, token=self._token)
-                hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+                ds.push_to_hub(
+                    ds_name,
+                    embed_external_files=embed_external_files,
+                    token=self._token,
+                )
+                hub_ds = load_dataset(
+                    ds_name, split="train", download_mode="force_redownload"
+                )
 
                 assert ds.column_names == hub_ds.column_names
                 assert list(ds.features.keys()) == list(hub_ds.features.keys())
@@ -440,15 +578,23 @@ class TestPushToHub:
 
     @require_pil
     def test_push_dataset_to_hub_custom_features_image_list(self, temporary_repo):
-        image_path = os.path.join(os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg")
+        image_path = os.path.join(
+            os.path.dirname(__file__), "features", "data", "test_image_rgb.jpg"
+        )
         data = {"x": [[image_path], [image_path, image_path]], "y": [0, -1]}
         features = Features({"x": List(Image()), "y": Value("int32")})
         ds = Dataset.from_dict(data, features=features)
 
         for embed_external_files in [True, False]:
             with temporary_repo() as ds_name:
-                ds.push_to_hub(ds_name, embed_external_files=embed_external_files, token=self._token)
-                hub_ds = load_dataset(ds_name, split="train", download_mode="force_redownload")
+                ds.push_to_hub(
+                    ds_name,
+                    embed_external_files=embed_external_files,
+                    token=self._token,
+                )
+                hub_ds = load_dataset(
+                    ds_name, split="train", download_mode="force_redownload"
+                )
 
                 assert ds.column_names == hub_ds.column_names
                 assert list(ds.features.keys()) == list(hub_ds.features.keys())
@@ -461,7 +607,9 @@ class TestPushToHub:
                 assert bool(bytes_) == embed_external_files
 
     def test_push_dataset_dict_to_hub_custom_features(self, temporary_repo):
-        features = Features({"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])})
+        features = Features(
+            {"x": Value("int64"), "y": ClassLabel(names=["neg", "pos"])}
+        )
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [0, 0, 1]}, features=features)
 
         local_ds = DatasetDict({"test": ds})
@@ -471,7 +619,9 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["test"].features.keys()) == list(hub_ds["test"].features.keys())
+            assert list(local_ds["test"].features.keys()) == list(
+                hub_ds["test"].features.keys()
+            )
             assert local_ds["test"].features == hub_ds["test"].features
 
     def test_push_dataset_to_hub_custom_splits(self, temporary_repo):
@@ -506,7 +656,9 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["random"].features.keys()) == list(hub_ds["random"].features.keys())
+            assert list(local_ds["random"].features.keys()) == list(
+                hub_ds["random"].features.keys()
+            )
             assert local_ds["random"].features == hub_ds["random"].features
 
     @unittest.skip("This test cannot pass until iterable datasets have push to hub")
@@ -522,10 +674,14 @@ class TestPushToHub:
                 hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
                 assert local_ds.column_names == hub_ds.column_names
-                assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+                assert list(local_ds["train"].features.keys()) == list(
+                    hub_ds["train"].features.keys()
+                )
                 assert local_ds["train"].features == hub_ds["train"].features
 
-    def test_push_multiple_dataset_configs_to_hub_load_dataset_builder(self, temporary_repo):
+    def test_push_multiple_dataset_configs_to_hub_load_dataset_builder(
+        self, temporary_repo
+    ):
         ds_default = Dataset.from_dict({"a": [0], "b": [1]})
         ds_config1 = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_config2 = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
@@ -534,21 +690,27 @@ class TestPushToHub:
             ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
-            ds_builder_default = load_dataset_builder(ds_name, download_mode="force_redownload")  # default config
+            ds_builder_default = load_dataset_builder(
+                ds_name, download_mode="force_redownload"
+            )  # default config
             assert len(ds_builder_default.BUILDER_CONFIGS) == 3
             assert len(ds_builder_default.config.data_files["train"]) == 1
             assert fnmatch.fnmatch(
                 ds_builder_default.config.data_files["train"][0],
                 "*/data/train-*",
             )
-            ds_builder_config1 = load_dataset_builder(ds_name, "config1", download_mode="force_redownload")
+            ds_builder_config1 = load_dataset_builder(
+                ds_name, "config1", download_mode="force_redownload"
+            )
             assert len(ds_builder_config1.BUILDER_CONFIGS) == 3
             assert len(ds_builder_config1.config.data_files["train"]) == 1
             assert fnmatch.fnmatch(
                 ds_builder_config1.config.data_files["train"][0],
                 "*/config1/train-*",
             )
-            ds_builder_config2 = load_dataset_builder(ds_name, "config2", download_mode="force_redownload")
+            ds_builder_config2 = load_dataset_builder(
+                ds_name, "config2", download_mode="force_redownload"
+            )
             assert len(ds_builder_config2.BUILDER_CONFIGS) == 3
             assert len(ds_builder_config2.config.data_files["train"]) == 1
             assert fnmatch.fnmatch(
@@ -557,7 +719,9 @@ class TestPushToHub:
             )
 
             with pytest.raises(ValueError):  # no config 'config3'
-                load_dataset_builder(ds_name, "config3", download_mode="force_redownload")
+                load_dataset_builder(
+                    ds_name, "config3", download_mode="force_redownload"
+                )
 
     def test_push_multiple_dataset_configs_to_hub_load_dataset(self, temporary_repo):
         ds_default = Dataset.from_dict({"a": [0], "b": [1]})
@@ -579,15 +743,33 @@ class TestPushToHub:
             ]
 
             hub_ds_default = load_dataset(ds_name, download_mode="force_redownload")
-            hub_ds_config1 = load_dataset(ds_name, "config1", download_mode="force_redownload")
-            hub_ds_config2 = load_dataset(ds_name, "config2", download_mode="force_redownload")
+            hub_ds_config1 = load_dataset(
+                ds_name, "config1", download_mode="force_redownload"
+            )
+            hub_ds_config2 = load_dataset(
+                ds_name, "config2", download_mode="force_redownload"
+            )
 
             # only "train" split
-            assert len(hub_ds_default) == len(hub_ds_config1) == len(hub_ds_config2) == 1
+            assert (
+                len(hub_ds_default) == len(hub_ds_config1) == len(hub_ds_config2) == 1
+            )
 
-            assert ds_default.column_names == hub_ds_default["train"].column_names == ["a", "b"]
-            assert ds_config1.column_names == hub_ds_config1["train"].column_names == ["x", "y"]
-            assert ds_config2.column_names == hub_ds_config2["train"].column_names == ["foo", "bar"]
+            assert (
+                ds_default.column_names
+                == hub_ds_default["train"].column_names
+                == ["a", "b"]
+            )
+            assert (
+                ds_config1.column_names
+                == hub_ds_config1["train"].column_names
+                == ["x", "y"]
+            )
+            assert (
+                ds_config2.column_names
+                == hub_ds_config2["train"].column_names
+                == ["foo", "bar"]
+            )
 
             assert ds_default.features == hub_ds_default["train"].features
             assert ds_config1.features == hub_ds_config1["train"].features
@@ -610,7 +792,9 @@ class TestPushToHub:
 
         with temporary_repo() as ds_name:
             if specific_default_config_name:
-                ds_default.push_to_hub(ds_name, config_name="config0", set_default=True, token=self._token)
+                ds_default.push_to_hub(
+                    ds_name, config_name="config0", set_default=True, token=self._token
+                )
             else:
                 ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
@@ -621,7 +805,10 @@ class TestPushToHub:
             dataset_card_data = DatasetCard.load(ds_readme_path).data
             assert METADATA_CONFIGS_FIELD in dataset_card_data
             assert isinstance(dataset_card_data[METADATA_CONFIGS_FIELD], list)
-            assert sorted(dataset_card_data[METADATA_CONFIGS_FIELD], key=lambda x: x["config_name"]) == (
+            assert sorted(
+                dataset_card_data[METADATA_CONFIGS_FIELD],
+                key=lambda x: x["config_name"],
+            ) == (
                 [
                     {
                         "config_name": "config0",
@@ -659,7 +846,9 @@ class TestPushToHub:
                 ]
             )
 
-    def test_push_multiple_dataset_dict_configs_to_hub_load_dataset_builder(self, temporary_repo):
+    def test_push_multiple_dataset_dict_configs_to_hub_load_dataset_builder(
+        self, temporary_repo
+    ):
         ds_default = Dataset.from_dict({"a": [0], "b": [1]})
         ds_config1 = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_config2 = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
@@ -672,21 +861,27 @@ class TestPushToHub:
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
             ds_config2.push_to_hub(ds_name, "config2", token=self._token)
 
-            ds_builder_default = load_dataset_builder(ds_name, download_mode="force_redownload")  # default config
+            ds_builder_default = load_dataset_builder(
+                ds_name, download_mode="force_redownload"
+            )  # default config
             assert len(ds_builder_default.BUILDER_CONFIGS) == 3
             assert len(ds_builder_default.config.data_files["random"]) == 1
             assert fnmatch.fnmatch(
                 ds_builder_default.config.data_files["random"][0],
                 "*/data/random-*",
             )
-            ds_builder_config1 = load_dataset_builder(ds_name, "config1", download_mode="force_redownload")
+            ds_builder_config1 = load_dataset_builder(
+                ds_name, "config1", download_mode="force_redownload"
+            )
             assert len(ds_builder_config1.BUILDER_CONFIGS) == 3
             assert len(ds_builder_config1.config.data_files["random"]) == 1
             assert fnmatch.fnmatch(
                 ds_builder_config1.config.data_files["random"][0],
                 "*/config1/random-*",
             )
-            ds_builder_config2 = load_dataset_builder(ds_name, "config2", download_mode="force_redownload")
+            ds_builder_config2 = load_dataset_builder(
+                ds_name, "config2", download_mode="force_redownload"
+            )
             assert len(ds_builder_config2.BUILDER_CONFIGS) == 3
             assert len(ds_builder_config2.config.data_files["random"]) == 1
             assert fnmatch.fnmatch(
@@ -694,9 +889,13 @@ class TestPushToHub:
                 "*/config2/random-*",
             )
             with pytest.raises(ValueError):  # no config named 'config3'
-                load_dataset_builder(ds_name, "config3", download_mode="force_redownload")
+                load_dataset_builder(
+                    ds_name, "config3", download_mode="force_redownload"
+                )
 
-    def test_push_multiple_dataset_dict_configs_to_hub_load_dataset(self, temporary_repo):
+    def test_push_multiple_dataset_dict_configs_to_hub_load_dataset(
+        self, temporary_repo
+    ):
         ds_default = Dataset.from_dict({"a": [0], "b": [1]})
         ds_config1 = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_config2 = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
@@ -722,18 +921,41 @@ class TestPushToHub:
             ]
 
             hub_ds_default = load_dataset(ds_name, download_mode="force_redownload")
-            hub_ds_config1 = load_dataset(ds_name, "config1", download_mode="force_redownload")
-            hub_ds_config2 = load_dataset(ds_name, "config2", download_mode="force_redownload")
+            hub_ds_config1 = load_dataset(
+                ds_name, "config1", download_mode="force_redownload"
+            )
+            hub_ds_config2 = load_dataset(
+                ds_name, "config2", download_mode="force_redownload"
+            )
 
             # two splits
             expected_splits = ["random", "train"]
-            assert len(hub_ds_default) == len(hub_ds_config1) == len(hub_ds_config2) == 2
-            assert sorted(hub_ds_default) == sorted(hub_ds_config1) == sorted(hub_ds_config2) == expected_splits
+            assert (
+                len(hub_ds_default) == len(hub_ds_config1) == len(hub_ds_config2) == 2
+            )
+            assert (
+                sorted(hub_ds_default)
+                == sorted(hub_ds_config1)
+                == sorted(hub_ds_config2)
+                == expected_splits
+            )
 
             for split in expected_splits:
-                assert ds_default[split].column_names == hub_ds_default[split].column_names == ["a", "b"]
-                assert ds_config1[split].column_names == hub_ds_config1[split].column_names == ["x", "y"]
-                assert ds_config2[split].column_names == hub_ds_config2[split].column_names == ["foo", "bar"]
+                assert (
+                    ds_default[split].column_names
+                    == hub_ds_default[split].column_names
+                    == ["a", "b"]
+                )
+                assert (
+                    ds_config1[split].column_names
+                    == hub_ds_config1[split].column_names
+                    == ["x", "y"]
+                )
+                assert (
+                    ds_config2[split].column_names
+                    == hub_ds_config2[split].column_names
+                    == ["foo", "bar"]
+                )
 
                 assert ds_default[split].features == hub_ds_default[split].features
                 assert ds_config1[split].features == hub_ds_config1[split].features
@@ -759,7 +981,9 @@ class TestPushToHub:
 
         with temporary_repo() as ds_name:
             if specific_default_config_name:
-                ds_default.push_to_hub(ds_name, config_name="config0", set_default=True, token=self._token)
+                ds_default.push_to_hub(
+                    ds_name, config_name="config0", set_default=True, token=self._token
+                )
             else:
                 ds_default.push_to_hub(ds_name, token=self._token)
             ds_config1.push_to_hub(ds_name, "config1", token=self._token)
@@ -770,7 +994,10 @@ class TestPushToHub:
             dataset_card_data = DatasetCard.load(ds_readme_path).data
             assert METADATA_CONFIGS_FIELD in dataset_card_data
             assert isinstance(dataset_card_data[METADATA_CONFIGS_FIELD], list)
-            assert sorted(dataset_card_data[METADATA_CONFIGS_FIELD], key=lambda x: x["config_name"]) == (
+            assert sorted(
+                dataset_card_data[METADATA_CONFIGS_FIELD],
+                key=lambda x: x["config_name"],
+            ) == (
                 [
                     {
                         "config_name": "config0",
@@ -833,7 +1060,10 @@ class TestPushToHub:
             ds_builder = load_dataset_builder(ds_name, download_mode="force_redownload")
             assert len(ds_builder.config.data_files) == 1
             assert len(ds_builder.config.data_files["train"]) == 1
-            assert fnmatch.fnmatch(ds_builder.config.data_files["train"][0], "*/data/train-00000-of-00001.parquet")
+            assert fnmatch.fnmatch(
+                ds_builder.config.data_files["train"][0],
+                "*/data/train-00000-of-00001.parquet",
+            )
             ds_another_config_builder = load_dataset_builder(
                 ds_name, "another_config", download_mode="force_redownload"
             )
@@ -844,7 +1074,9 @@ class TestPushToHub:
                 "*/another_config/train-00000-of-00001.parquet",
             )
 
-    def test_push_dataset_dict_to_hub_with_config_no_metadata_configs(self, temporary_repo):
+    def test_push_dataset_dict_to_hub_with_config_no_metadata_configs(
+        self, temporary_repo
+    ):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
         ds_another_config = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
         parquet_buf = BytesIO()
@@ -863,11 +1095,16 @@ class TestPushToHub:
                 repo_type="dataset",
                 token=self._token,
             )
-            local_ds_another_config.push_to_hub(ds_name, "another_config", token=self._token)
+            local_ds_another_config.push_to_hub(
+                ds_name, "another_config", token=self._token
+            )
             ds_builder = load_dataset_builder(ds_name, download_mode="force_redownload")
             assert len(ds_builder.config.data_files) == 1
             assert len(ds_builder.config.data_files["random"]) == 1
-            assert fnmatch.fnmatch(ds_builder.config.data_files["random"][0], "*/data/random-00000-of-00001.parquet")
+            assert fnmatch.fnmatch(
+                ds_builder.config.data_files["random"][0],
+                "*/data/random-00000-of-00001.parquet",
+            )
             ds_another_config_builder = load_dataset_builder(
                 ds_name, "another_config", download_mode="force_redownload"
             )
@@ -878,7 +1115,9 @@ class TestPushToHub:
                 "*/another_config/random-00000-of-00001.parquet",
             )
 
-    def test_push_dataset_dict_to_hub_num_proc(self, temporary_repo, set_ci_hub_access_token):
+    def test_push_dataset_dict_to_hub_num_proc(
+        self, temporary_repo, set_ci_hub_access_token
+    ):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
         local_ds = DatasetDict({"train": ds})
@@ -888,7 +1127,9 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
@@ -900,7 +1141,9 @@ class TestPushToHub:
                 "data/train-00001-of-00002.parquet",
             ]
 
-    def test_push_dataset_dict_to_hub_iterable(self, temporary_repo, set_ci_hub_access_token):
+    def test_push_dataset_dict_to_hub_iterable(
+        self, temporary_repo, set_ci_hub_access_token
+    ):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}).to_iterable_dataset()
 
         local_ds = IterableDatasetDict({"train": ds})
@@ -910,15 +1153,25 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset"))
-            assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
+            assert files == [
+                ".gitattributes",
+                "README.md",
+                "data/train-00000-of-00001.parquet",
+            ]
 
-    def test_push_dataset_dict_to_hub_iterable_num_proc(self, temporary_repo, set_ci_hub_access_token):
-        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}).to_iterable_dataset(num_shards=3)
+    def test_push_dataset_dict_to_hub_iterable_num_proc(
+        self, temporary_repo, set_ci_hub_access_token
+    ):
+        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}).to_iterable_dataset(
+            num_shards=3
+        )
 
         local_ds = IterableDatasetDict({"train": ds})
 
@@ -927,7 +1180,9 @@ class TestPushToHub:
             hub_ds = load_dataset(ds_name, download_mode="force_redownload")
 
             assert local_ds.column_names == hub_ds.column_names
-            assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
+            assert list(local_ds["train"].features.keys()) == list(
+                hub_ds["train"].features.keys()
+            )
             assert local_ds["train"].features == hub_ds["train"].features
 
             # Ensure that there is a single file on the repository that has the correct name
@@ -978,7 +1233,9 @@ class TestLoadFromHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)
     _token = CI_HUB_USER_TOKEN
 
-    def test_load_dataset_with_metadata_file(self, temporary_repo, text_file_with_metadata, tmp_path):
+    def test_load_dataset_with_metadata_file(
+        self, temporary_repo, text_file_with_metadata, tmp_path
+    ):
         text_file_path, metadata_file_path = text_file_with_metadata
         data_dir_path = text_file_path.parent
         cache_dir_path = tmp_path / ".cache"
@@ -996,7 +1253,9 @@ class TestLoadFromHub:
                 f"hf://datasets/{repo_id}/{metadata_file_path.name}",
             ]
             builder = DummyFolderBasedBuilder(
-                dataset_name=repo_id.split("/")[-1], data_files=data_files, cache_dir=str(cache_dir_path)
+                dataset_name=repo_id.split("/")[-1],
+                data_files=data_files,
+                cache_dir=str(cache_dir_path),
             )
             download_manager = DownloadManager()
             gen_kwargs = builder._split_generators(download_manager)[0].gen_kwargs
@@ -1020,7 +1279,9 @@ class TestLoadFromHub:
             )
             data_file_patterns = get_data_patterns(f"hf://datasets/{repo_id}")
             assert data_file_patterns == {
-                "train": ["data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"]
+                "train": [
+                    "data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"
+                ]
             }
 
     @pytest.mark.parametrize("dataset", ["gated", "private"])

--- a/tests/test_wmt21.py
+++ b/tests/test_wmt21.py
@@ -1,0 +1,53 @@
+import os
+import pytest
+from local_datasets.wmt21.wmt21_dataset import WMT21Dataset
+
+# Path to dummy data
+DATASET_PATH = os.path.join("local_datasets", "wmt21", "dummy_data")
+
+
+def test_wmt21_loads():
+    """Test that the WMT21 dataset loads correctly for all splits."""
+    wmt21 = WMT21Dataset(DATASET_PATH)
+    ds = wmt21.load()
+
+    # Ensure splits exist
+    for split in ["train", "validation", "test"]:
+        assert split in ds, f"{split} split missing"
+        assert len(ds[split]) > 0, f"{split} split is empty"
+
+
+def test_empty_lines_ignored():
+    """Test that empty lines in .tsv files are ignored."""
+    # Add a temporary empty line in train.tsv
+    train_file = os.path.join(DATASET_PATH, "train.tsv")
+    with open(train_file, "a", encoding="utf-8") as f:
+        f.write("\n")
+
+    wmt21 = WMT21Dataset(DATASET_PATH)
+    ds = wmt21.load()
+
+    # No extra empty example should be added
+    assert all(
+        e["source"].strip() != "" and e["target"].strip() != "" for e in ds["train"]
+    )
+
+    # Clean up: remove the empty line
+    with open(train_file, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    with open(train_file, "w", encoding="utf-8") as f:
+        f.writelines(lines[:-1])
+
+
+def test_num_examples_matches_lines():
+    """Check that number of examples matches the number of valid lines in each .tsv."""
+    wmt21 = WMT21Dataset(DATASET_PATH)
+    ds = wmt21.load()
+
+    for split in ["train", "validation", "test"]:
+        file_path = os.path.join(DATASET_PATH, f"{split}.tsv")
+        with open(file_path, encoding="utf-8") as f:
+            n_lines = sum(
+                1 for line in f if line.strip() and len(line.split("\t")) == 2
+            )
+        assert len(ds[split]) == n_lines, f"{split} split length mismatch"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,8 +44,12 @@ _run_packaged_tests = parse_flag_from_env("RUN_PACKAGED", default=True)
 
 # Compression
 require_lz4 = pytest.mark.skipif(not config.LZ4_AVAILABLE, reason="test requires lz4")
-require_py7zr = pytest.mark.skipif(not config.PY7ZR_AVAILABLE, reason="test requires py7zr")
-require_zstandard = pytest.mark.skipif(not config.ZSTANDARD_AVAILABLE, reason="test requires zstandard")
+require_py7zr = pytest.mark.skipif(
+    not config.PY7ZR_AVAILABLE, reason="test requires py7zr"
+)
+require_zstandard = pytest.mark.skipif(
+    not config.ZSTANDARD_AVAILABLE, reason="test requires zstandard"
+)
 
 # Dill-cloudpickle compatibility
 require_dill_gt_0_3_2 = pytest.mark.skipif(
@@ -60,10 +64,15 @@ require_not_windows = pytest.mark.skipif(
 )
 
 
-require_faiss = pytest.mark.skipif(find_spec("faiss") is None or sys.platform == "win32", reason="test requires faiss")
-require_moto = pytest.mark.skipif(find_spec("moto") is None, reason="test requires moto")
+require_faiss = pytest.mark.skipif(
+    find_spec("faiss") is None or sys.platform == "win32", reason="test requires faiss"
+)
+require_moto = pytest.mark.skipif(
+    find_spec("moto") is None, reason="test requires moto"
+)
 require_numpy1_on_windows = pytest.mark.skipif(
-    version.parse(importlib.metadata.version("numpy")) >= version.parse("2.0.0") and sys.platform == "win32",
+    version.parse(importlib.metadata.version("numpy")) >= version.parse("2.0.0")
+    and sys.platform == "win32",
     reason="test requires numpy < 2.0 on windows",
 )
 
@@ -398,12 +407,16 @@ def offline(mode=OfflineSimulationMode.CONNECTION_FAILS, timeout=1e-16):
             # The following changes in the error are just here to make the offline timeout error prettier
             e.request.url = url
             max_retry_error = e.args[0]
-            max_retry_error.args = (max_retry_error.args[0].replace("10.255.255.1", f"OfflineMock[{url}]"),)
+            max_retry_error.args = (
+                max_retry_error.args[0].replace("10.255.255.1", f"OfflineMock[{url}]"),
+            )
             e.args = (max_retry_error,)
             raise
 
     def raise_connection_error(session, prepared_request, **kwargs):
-        raise requests.ConnectionError("Offline mode is enabled.", request=prepared_request)
+        raise requests.ConnectionError(
+            "Offline mode is enabled.", request=prepared_request
+        )
 
     if mode is OfflineSimulationMode.CONNECTION_FAILS:
         with patch("requests.Session.send", raise_connection_error):
@@ -437,7 +450,9 @@ def assert_arrow_memory_increases():
     gc.collect()
     previous_allocated_memory = pa.total_allocated_bytes()
     yield
-    assert pa.total_allocated_bytes() - previous_allocated_memory > 0, "Arrow memory didn't increase."
+    assert (
+        pa.total_allocated_bytes() - previous_allocated_memory > 0
+    ), "Arrow memory didn't increase."
 
 
 @contextmanager
@@ -447,11 +462,16 @@ def assert_arrow_memory_doesnt_increase():
     gc.collect()
     previous_allocated_memory = pa.total_allocated_bytes()
     yield
-    assert pa.total_allocated_bytes() - previous_allocated_memory <= 0, "Arrow memory wasn't expected to increase."
+    assert (
+        pa.total_allocated_bytes() - previous_allocated_memory <= 0
+    ), "Arrow memory wasn't expected to increase."
 
 
 def is_rng_equal(rng1, rng2):
-    return deepcopy(rng1).integers(0, 100, 10).tolist() == deepcopy(rng2).integers(0, 100, 10).tolist()
+    return (
+        deepcopy(rng1).integers(0, 100, 10).tolist()
+        == deepcopy(rng2).integers(0, 100, 10).tolist()
+    )
 
 
 def xfail_if_500_502_http_error(func):
@@ -491,7 +511,9 @@ async def _read_stream(stream, callback):
             break
 
 
-async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=False, echo=False) -> _RunOutput:
+async def _stream_subprocess(
+    cmd, env=None, stdin=None, timeout=None, quiet=False, echo=False
+) -> _RunOutput:
     if echo:
         print("\nRunning: ", " ".join(cmd))
 
@@ -524,18 +546,26 @@ async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=Fals
     # XXX: the timeout doesn't seem to make any difference here
     await asyncio.wait(
         [
-            _read_stream(p.stdout, lambda line: tee(line, out, sys.stdout, label="stdout:")),
-            _read_stream(p.stderr, lambda line: tee(line, err, sys.stderr, label="stderr:")),
+            _read_stream(
+                p.stdout, lambda line: tee(line, out, sys.stdout, label="stdout:")
+            ),
+            _read_stream(
+                p.stderr, lambda line: tee(line, err, sys.stderr, label="stderr:")
+            ),
         ],
         timeout=timeout,
     )
     return _RunOutput(await p.wait(), out, err)
 
 
-def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
+def execute_subprocess_async(
+    cmd, env=None, stdin=None, timeout=180, quiet=False, echo=True
+) -> _RunOutput:
     loop = asyncio.get_event_loop()
     result = loop.run_until_complete(
-        _stream_subprocess(cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo)
+        _stream_subprocess(
+            cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo
+        )
     )
 
     cmd_str = " ".join(cmd)

--- a/utils/release.py
+++ b/utils/release.py
@@ -19,8 +19,14 @@ import packaging.version
 
 
 REPLACE_PATTERNS = {
-    "init": (re.compile(r'^__version__\s+=\s+"([^"]+)"\s*$', re.MULTILINE), '__version__ = "VERSION"\n'),
-    "setup": (re.compile(r'^(\s*)version\s*=\s*"[^"]+",', re.MULTILINE), r'\1version="VERSION",'),
+    "init": (
+        re.compile(r'^__version__\s+=\s+"([^"]+)"\s*$', re.MULTILINE),
+        '__version__ = "VERSION"\n',
+    ),
+    "setup": (
+        re.compile(r'^(\s*)version\s*=\s*"[^"]+",', re.MULTILINE),
+        r'\1version="VERSION",',
+    ),
 }
 REPLACE_FILES = {
     "init": "src/datasets/__init__.py",
@@ -58,7 +64,9 @@ def pre_release_work(patch=False):
     # First let's get the default version: base version if we are in dev, bump minor otherwise.
     default_version = get_version()
     if patch and default_version.is_devrelease:
-        raise ValueError("Can't create a patch version from the dev branch, checkout a released version!")
+        raise ValueError(
+            "Can't create a patch version from the dev branch, checkout a released version!"
+        )
     if default_version.is_devrelease:
         default_version = default_version.base_version
     elif patch:
@@ -93,8 +101,14 @@ def post_release_work():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--post_release", action="store_true", help="Whether or not this is post release.")
-    parser.add_argument("--patch", action="store_true", help="Whether or not this is a patch release.")
+    parser.add_argument(
+        "--post_release",
+        action="store_true",
+        help="Whether or not this is post release.",
+    )
+    parser.add_argument(
+        "--patch", action="store_true", help="Whether or not this is a patch release."
+    )
     args = parser.parse_args()
     if not args.post_release:
         pre_release_work(patch=args.patch)


### PR DESCRIPTION
What I did:
Added local_datasets/wmt21/wmt21_dataset.py — a dataset loader for source-target TSV pairs.
Included local_datasets/wmt21/dummy_data/ with small sample train.tsv, validation.tsv, and test.tsv for local testing & CI.
Added tests/test_wmt21.py to validate loading, splits, and edge cases.
Added local_datasets/wmt21/README.md with usage instructions, citation placeholders, and notes on the sample data.

How to test locally:
1. Activate your environment:
`
conda activate hf-dev
`
2. Run tests:
`
pytest tests/test_wmt21.py -v
`
3. Experiment with the dataset in Python:
```
from local_datasets.wmt21.wmt21_dataset import WMT21Dataset

dataset_path = "local_datasets/wmt21/dummy_data"
wmt21 = WMT21Dataset(dataset_path)
ds = wmt21.load()

print(ds["train"][0])
print(ds["validation"][0])
print(ds["test"][0])
```