### PR TITLE
fix: better args passthrough for `_batch_setitems()`

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -69,9 +69,7 @@ class Pickler(dill.Pickler):
             obj = getattr(obj, "_torchdynamo_orig_callable", obj)
         dill.Pickler.save(self, obj, save_persistent_id=save_persistent_id)
 
-    def _batch_setitems(self, items, obj):
-        if self._legacy_no_dict_keys_sorting:
-            return super()._batch_setitems(items, obj)
+    def _batch_setitems(self, items, *args, **kwargs):
         # Ignore the order of keys in a dict
         try:
             # Faster, but fails for unorderable elements
@@ -80,7 +78,7 @@ class Pickler(dill.Pickler):
             from datasets.fingerprint import Hasher
 
             items = sorted(items, key=lambda x: Hasher.hash(x[0]))
-        dill.Pickler._batch_setitems(self, items, obj)
+        return super()._batch_setitems(items, *args, **kwargs)
 
     def memoize(self, obj):
         # Don't memoize strings since two identical strings can have different Python ids


### PR DESCRIPTION
In Python 3.14, there's a change in the signature of `_Pickler._batch_setitems`.

It's changed to:

```python
# pickle.py

def _batch_setitems(self, items, obj):
    # Helper to batch up SETITEMS sequences; proto >= 1 only
    save = self.save
    write = self.write
```

To accomodate this, in `dill`, we have this compatibility code:

```python
if sys.hexversion < 0x30E00A1:
    pickler._batch_setitems(iter(source.items()))
else:
    pickler._batch_setitems(iter(source.items()), obj=obj)
```

Thus, the datasets package will emit this error

```
│ /Users/sghuang/mamba/envs/ds/lib/python3.14/site-packages/dill/_dill.py:1262 in save_module_dict │
│                                                                                                  │
│   1259 │   │   if is_dill(pickler, child=False) and pickler._session:                            │
│   1260 │   │   │   # we only care about session the first pass thru                              │
│   1261 │   │   │   pickler._first_pass = False                                                   │
│ ❱ 1262 │   │   StockPickler.save_dict(pickler, obj)                                              │
│   1263 │   │   logger.trace(pickler, "# D2")                                                     │
│   1264 │   return                                                                                │
│   1265                                                                                           │
│                                                                                                  │
│ /Users/sghuang/mamba/envs/ds/lib/python3.14/pickle.py:1133 in save_dict                          │
│                                                                                                  │
│   1130 │   │   print(f"Line number: {inspect.getsourcelines(method)[1]}")                        │
│   1131 │   │   print(f"Full path: {inspect.getmodule(method)}")                                  │
│   1132 │   │   print(f"Class: {method.__qualname__}")                                            │
│ ❱ 1133 │   │   self._batch_setitems(obj.items(), obj)                                            │
│   1134 │                                                                                         │
│   1135 │   dispatch[dict] = save_dict                                                            │
│   1136                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: Pickler._batch_setitems() takes 2 positional arguments but 3 were given
[NOTE] when serializing datasets.table.InMemoryTable state
[NOTE] when serializing datasets.table.InMemoryTable object
```

To fix it, we update the signature of the `_batch_setitems` method defined in `utils/_dill.py`.

This fix should be backward compatible, since the compatibility is handled by `dill`.

This should close #7813.

Similar to https://github.com/joblib/joblib/issues/1658.

Related to https://github.com/uqfoundation/dill/pull/724.