### PR TITLE
Fix: Properly render [!TIP] block in stream.shuffle documentation

### DIFF
--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -114,6 +114,7 @@ The `buffer_size` argument controls the size of the buffer to randomly sample ex
 ```
 
 > [!TIP]
+> 
 > [`IterableDataset.shuffle`] will also shuffle the order of the shards if the dataset is sharded into multiple files.
 
 ## Reshuffle


### PR DESCRIPTION
The second line starting with the bracket doesn't properly render on huggingface/docs. Added "> " to address it.

In the client documentation, the markdown 'TIP' paragraph in docs/stream#shuffle is not well executed, not as the other in the same page / while markdown is correctly considering it.

Documentation:
https://huggingface.co/docs/datasets/v4.3.0/en/stream#shuffle:~:text=%5B!TIP%5D%5BIterableDataset.shuffle()%5D(/docs/datasets/v4.3.0/en/package_reference/main_classes%23datasets.IterableDataset.shuffle)%20will%20also%20shuffle%20the%20order%20of%20the%20shards%20if%20the%20dataset%20is%20sharded%20into%20multiple%20files.

Github source:
https://github.com/huggingface/datasets/blob/main/docs/source/stream.mdx#:~:text=Casting%20only%20works%20if%20the%20original%20feature%20type%20and%20new%20feature%20type%20are%20compatible.%20For%20example%2C%20you%20can%20cast%20a%20column%20with%20the%20feature%20type%20Value(%27int32%27)%20to%20Value(%27bool%27)%20if%20the%20original%20column%20only%20contains%20ones%20and%20zeros.