### PR TITLE
Add num channels to audio

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -51,7 +51,11 @@ class Audio:
             Target sampling rate. If `None`, the native sampling rate is used.
         num_channels (`int`, *optional*):
              The desired number of channels of the samples. By default, the number of channels of the source is used.
-             Currently `None` (number of channels of the source), `1` (mono) or `2` (stereo) channels are supported.
+             Audio decoding will return samples with shape (num_channels, num_samples)
+             Currently `None` (number of channels of the source, default), `1` (mono) or `2` (stereo) channels are supported.
+             The `num_channels` argument is passed to `torchcodec.decoders.AudioDecoder`.
+
+             <Added version="4.4.0"/>
         decode (`bool`, defaults to `True`):
             Whether to decode the audio data. If `False`,
             returns the underlying dictionary in the format `{"path": audio_path, "bytes": audio_bytes}`.

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -796,10 +796,24 @@ def test_audio_decode_example_opus_convert_to_stereo(shared_datadir):
     # GH 7837
     from torchcodec.decoders import AudioDecoder
 
-    audio_path = str(shared_datadir / "test_audio_48000.opus")
+    audio_path = str(shared_datadir / "test_audio_48000.opus")  # mono file
     audio = Audio(num_channels=2)
     decoded_example = audio.decode_example(audio.encode_example(audio_path))
     assert isinstance(decoded_example, AudioDecoder)
     samples = decoded_example.get_all_samples()
     assert samples.sample_rate == 48000
     assert samples.data.shape == (2, 48000)
+
+
+@require_torchcodec
+def test_audio_decode_example_opus_convert_to_mono(shared_datadir):
+    # GH 7837
+    from torchcodec.decoders import AudioDecoder
+
+    audio_path = str(shared_datadir / "test_audio_44100.wav")  # stereo file
+    audio = Audio(num_channels=1)
+    decoded_example = audio.decode_example(audio.encode_example(audio_path))
+    assert isinstance(decoded_example, AudioDecoder)
+    samples = decoded_example.get_all_samples()
+    assert samples.sample_rate == 44100
+    assert samples.data.shape == (1, 202311)


### PR DESCRIPTION
Fixes #7837

We currently have the [mono attribute for Audio documented](https://github.com/huggingface/datasets/blob/41c05299348a499807432ab476e1cdc4143c8772/src/datasets/features/audio.py#L52C1-L54C22) but not used anywhere resulting in confusion for users. Since torchcodec does not know this attribute I suggest using `num_channels` (currently supported `None` (leave unchanged), mono: `1`, stereo: `2`).

I could also add a mono attribute but found that to be more confusing for developers and would restrict us if at any point in the future more than 2 channels are supported.