### PR TITLE
DOC: remove mode parameter in docstring of pdf and video feature

### DIFF
--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -44,8 +44,6 @@ class Pdf:
     - A `pdfplumber.pdf.PDF`: pdfplumber pdf object.
 
     Args:
-        mode (`str`, *optional*):
-            The mode to convert the pdf to. If `None`, the native mode of the pdf is used.
         decode (`bool`, defaults to `True`):
             Whether to decode the pdf data. If `False`,
             returns the underlying dictionary in the format `{"path": pdf_path, "bytes": pdf_bytes}`.

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -45,8 +45,6 @@ class Video:
     Output: The Video features output data as `torchcodec.decoders.VideoDecoder` objects.
 
     Args:
-        mode (`str`, *optional*):
-            The mode to convert the video to. If `None`, the native mode of the video is used.
         decode (`bool`, defaults to `True`):
             Whether to decode the video data. If `False`,
             returns the underlying dictionary in the format `{"path": video_path, "bytes": video_bytes}`.


### PR DESCRIPTION
closes #7841

As mentioned in the issue `mode` has been copy-pasted but isn't used in these files.