### PR TITLE
Nifti visualization support

### DIFF
--- a/src/datasets/features/nifti.py
+++ b/src/datasets/features/nifti.py
@@ -223,11 +223,7 @@ class Nifti:
                 bytes_ = gzip.decompress(bytes_)
 
             nifti = nib.Nifti1Image.from_bytes(bytes_)
-            # bio = BytesIO(bytes_)
-            # fh = nib.FileHolder(fileobj=bio)
-            # nifti = nib.Nifti1Image.from_file_map({"header": fh, "image": fh})
 
-        # return nifti
         return Nifti1ImageWrapper(nifti)
 
     def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:


### PR DESCRIPTION
closes #7870 

leverage Papaya to visualize nifti images. For this I created a Wrapper class for `nibabel.nifti1.Nifti1Image` that provides the same interface but exposes an additional `_repr_html_` method, which is needed to visualize the image in jupyter (didn't test in colab, but that should work equivalently).

Code to test (execute in a notebook):
```python
from datasets import load_dataset

ds = load_dataset("TobiasPitters/nifti-nitest-extracted",
              split="train")
image = ds[1]

image
```

Here a small video, not the most exciting scan though:
https://github.com/user-attachments/assets/1cca5f01-6fd2-48ef-a4d7-a92c1259c224

Am open to good ways to test this.

EDIT: papaya also supports dicom, didn't test it yet though