### PR TITLE
fix: use temp files in push_to_hub to prevent OOM on large datasets

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5551,7 +5551,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             shard_path_in_repo = f"{data_dir}/{split}-{index:05d}-of-{num_shards:05d}.parquet"
             # Write to temp file instead of BytesIO to avoid holding all shard bytes in memory.
             # This fixes OOM when uploading large datasets with many shards.
-            # See: https://github.com/The-Obstacle-Is-The-Way/datasets/issues/5
             with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
                 temp_path = f.name
             try:

--- a/tests/test_push_to_hub_memory.py
+++ b/tests/test_push_to_hub_memory.py
@@ -1,7 +1,7 @@
 """Tests for memory-safe push_to_hub with large datasets.
 
-Regression tests for https://github.com/The-Obstacle-Is-The-Way/datasets/issues/5
-(OOM when uploading large datasets due to memory accumulation in additions list)
+Regression tests for OOM when uploading large datasets due to memory
+accumulation in the additions list.
 """
 
 import tempfile


### PR DESCRIPTION
## Summary

Fixes memory accumulation in `_push_parquet_shards_to_hub_single` that causes OOM when uploading large datasets with many shards.

**Root cause**: The current implementation stores ALL parquet shard bytes in memory via `BytesIO`, accumulating in the `additions` list. For N shards of ~300MB each, this requires N × 300MB RAM.

**Fix**: Write parquet to temp file instead of `BytesIO`, pass file path to `CommitOperationAdd`. Delete temp file after `preupload_lfs_files` completes (for LFS uploads only - regular uploads need the file until `create_commit`).

## Changes

- Replace `BytesIO` with `tempfile.NamedTemporaryFile` in `_push_parquet_shards_to_hub_single`
- Use file path in `CommitOperationAdd.path_or_fileobj` instead of bytes
- Delete temp file after upload (only for LFS mode - regular uploads keep file for `create_commit`)
- Add `try...finally` for safe cleanup even on errors
- Remove unused `BytesIO` import

## Test plan

- [x] Added `tests/test_push_to_hub_memory.py` with 4 tests:
  - `test_push_to_hub_uses_file_path_not_bytes_in_commit_operation`
  - `test_push_to_hub_cleans_up_temp_files_for_lfs_uploads`
  - `test_push_to_hub_keeps_temp_files_for_regular_uploads`
  - `test_push_to_hub_uploaded_size_still_calculated`
- [x] All tests pass locally
- [x] ruff check passes

## Context

This was discovered while uploading a 270GB neuroimaging dataset (ARC) with 902 shards. The process was killed by OOM after accumulating ~270GB in the `additions` list.

Fixes #7893
Related: #5990, #7400