### PR TITLE
fix: force contiguous copy for sliced list arrays in embed_array_storage

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -2125,7 +2125,6 @@ def embed_array_storage(array: pa.Array, feature: "FeatureType", token_per_repo_
     # When ds.shard() or ds.select() creates a sliced view, array.values returns
     # values with internal offset references that can cause PyArrow's C++ layer
     # to crash when processing nested types like Sequence(Nifti()).
-    # See: https://github.com/huggingface/datasets/issues/XXXX
     if pa.types.is_list(array.type) or pa.types.is_large_list(array.type):
         if hasattr(array, "offset") and array.offset > 0:
             array = pa.concat_arrays([array])


### PR DESCRIPTION
## Summary

Fixes SIGKILL crash in `embed_array_storage` when processing sliced/sharded datasets with nested types like `Sequence(Nifti())` or `Sequence(Image())`.

**Root cause**: When `ds.shard()` or `ds.select()` creates a sliced view, `array.values` on a sliced `ListArray` returns values with internal offset references. For nested types, PyArrow's C++ layer can crash (SIGKILL, exit code 137) when materializing these sliced nested structs.

**Fix**: Force a contiguous copy via `pa.concat_arrays([array])` when the array has a non-zero offset before processing list/large_list arrays.

## Changes

- Add offset check in `embed_array_storage` for list/large_list arrays
- Force contiguous copy when `array.offset > 0` to break internal references
- Add regression tests for sliced arrays with Image, Nifti, and LargeList types

## Test plan

- [x] Added `tests/features/test_embed_storage_sliced.py` with 3 tests:
  - `test_embed_array_storage_sliced_list_image`
  - `test_embed_array_storage_sliced_list_nifti`
  - `test_embed_array_storage_sliced_large_list`
- [x] All tests verify `embedded.offset == 0` (contiguous result)
- [x] All tests pass locally
- [x] ruff check passes

## Context

This was discovered while uploading a 270GB neuroimaging dataset (ARC) with `Sequence(Nifti())` columns. The process crashed with SIGKILL (no Python traceback) when `embed_table_storage` was called on sharded data.

Workaround that confirmed the fix: pandas round-trip (`shard.to_pandas()` → `Dataset.from_pandas()`) which forces a contiguous copy.

Fixes #7894
Related: #6686, #7852, #6790