### PR TITLE
docs: making PyPi to PyPI ensuring no spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ## With pip
 
-🤗 Datasets can be installed from PyPi and has to be installed in a virtual environment (venv or conda for instance)
+🤗 Datasets can be installed from PyPI & has to be installed in a virtual environment (venv or conda for instance)
 
 ```bash
 pip install datasets


### PR DESCRIPTION
This PR adds a short clarification in the README section wherein PyPI the python package was mistakenly typed as PyPi which i have fixed 
