### PR TITLE
feat(fasta): add lightweight FASTA file format support

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -267,6 +267,30 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 >>> dataset = load_dataset("webdataset", data_files={"train": urls}, split="train", streaming=True)
 ```
 
+### FASTA
+
+[FASTA](https://en.wikipedia.org/wiki/FASTA_format) is a text-based format for representing nucleotide sequences (DNA/RNA) or peptide sequences (proteins), widely used in bioinformatics.
+
+To load a FASTA file:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("fasta", data_files="sequences.fasta")
+```
+
+This returns a dataset with the following columns:
+- `id`: Sequence identifier (first word after `>`)
+- `description`: Full description line (everything after the id)
+- `sequence`: The biological sequence (DNA/RNA/protein)
+
+You can also load only specific columns:
+
+```py
+>>> dataset = load_dataset("fasta", data_files="sequences.fa", columns=["id", "sequence"])
+```
+
+FASTA files with various extensions are supported: `.fa`, `.fasta`, `.fna` (nucleic acid), `.ffn` (nucleotide of gene regions), `.faa` (amino acid), and `.frn` (non-coding RNA). Compressed files (gzip, bzip2, xz) are automatically detected and decompressed.
+
 ## Remote files
 
 If you have remote files likely stored as a `csv`, `json`, `txt`, `parquet` or any supported format, the [`load_dataset`] function can load load them if you specify their remote paths:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -292,6 +292,30 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 >>> dataset = load_dataset("webdataset", data_files={"train": urls}, split="train", streaming=True)
 ```
 
+### FASTA
+
+[FASTA](https://en.wikipedia.org/wiki/FASTA_format) is a text-based format for representing nucleotide sequences (DNA/RNA) or peptide sequences (proteins), widely used in bioinformatics.
+
+To load a FASTA file:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("fasta", data_files="sequences.fasta")
+```
+
+This returns a dataset with the following columns:
+- `id`: Sequence identifier (first word after `>`)
+- `description`: Full description line (everything after the id)
+- `sequence`: The biological sequence (DNA/RNA/protein)
+
+You can also load only specific columns:
+
+```py
+>>> dataset = load_dataset("fasta", data_files="sequences.fa", columns=["id", "sequence"])
+```
+
+FASTA files with various extensions are supported: `.fa`, `.fasta`, `.fna` (nucleic acid), `.ffn` (nucleotide of gene regions), `.faa` (amino acid), and `.frn` (non-coding RNA). Compressed files (gzip, bzip2, xz) are automatically detected and decompressed.
+
 ## Remote files
 
 If you have remote files likely stored as a `csv`, `json`, `txt`, `parquet` or any supported format, the [`load_dataset`] function can load load them if you specify their remote paths:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -307,6 +307,9 @@ This returns a dataset with the following columns:
 - `id`: Sequence identifier (first word after `>`)
 - `description`: Full description line (everything after the id)
 - `sequence`: The biological sequence (DNA/RNA/protein)
+- `record`: A [`BioSequence`] with `format="fasta"` storing each record's original bytes, decoded to a Biopython `SeqRecord` when accessed.
+
+Reading the parsed columns requires no Biopython; exclude `record` with `columns`, or use `dataset.cast_column("record", BioSequence(decode=False))` (imported from `datasets`) to access its `{"bytes": ..., "path": None}` storage without decoding.
 
 You can also load only specific columns:
 

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -10,6 +10,7 @@ from .cache import cache
 from .conll import conll
 from .csv import csv
 from .eval import eval
+from .fasta import fasta
 from .hdf5 import hdf5
 from .iceberg import iceberg
 from .imagefolder import imagefolder
@@ -44,6 +45,7 @@ def _hash_python_lines(lines: list[str]) -> str:
 # get importable module names and hash for caching
 _PACKAGED_DATASETS_MODULES = {
     "csv": (csv.__name__, _hash_python_lines(inspect.getsource(csv).splitlines())),
+    "fasta": (fasta.__name__, _hash_python_lines(inspect.getsource(fasta).splitlines())),
     "json": (json.__name__, _hash_python_lines(inspect.getsource(json).splitlines())),
     "pandas": (pandas.__name__, _hash_python_lines(inspect.getsource(pandas).splitlines())),
     "parquet": (parquet.__name__, _hash_python_lines(inspect.getsource(parquet).splitlines())),
@@ -81,6 +83,13 @@ _PACKAGED_DATASETS_MODULES_2_15_HASHES = {
 _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".csv": ("csv", {}),
     ".tsv": ("csv", {"sep": "\t"}),
+    # FASTA biological sequence formats
+    ".fa": ("fasta", {}),
+    ".fasta": ("fasta", {}),
+    ".fna": ("fasta", {}),  # FASTA nucleic acid
+    ".ffn": ("fasta", {}),  # FASTA nucleotide of gene regions
+    ".faa": ("fasta", {}),  # FASTA amino acid
+    ".frn": ("fasta", {}),  # FASTA non-coding RNA
     ".json": ("json", {}),
     ".jsonl": ("json", {}),
     # ndjson is no longer maintained (see: https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417)

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -90,6 +90,7 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".ffn": ("fasta", {}),  # FASTA nucleotide of gene regions
     ".faa": ("fasta", {}),  # FASTA amino acid
     ".frn": ("fasta", {}),  # FASTA non-coding RNA
+    ".afa": ("fasta", {}),  # aligned FASTA (multiple sequence alignment)
     ".json": ("json", {}),
     ".jsonl": ("json", {}),
     # ndjson is no longer maintained (see: https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417)

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -10,6 +10,7 @@ from .cache import cache
 from .conll import conll
 from .csv import csv
 from .eval import eval
+from .fasta import fasta
 from .hdf5 import hdf5
 from .iceberg import iceberg
 from .imagefolder import imagefolder
@@ -45,6 +46,7 @@ def _hash_python_lines(lines: list[str]) -> str:
 # get importable module names and hash for caching
 _PACKAGED_DATASETS_MODULES = {
     "csv": (csv.__name__, _hash_python_lines(inspect.getsource(csv).splitlines())),
+    "fasta": (fasta.__name__, _hash_python_lines(inspect.getsource(fasta).splitlines())),
     "json": (json.__name__, _hash_python_lines(inspect.getsource(json).splitlines())),
     "pandas": (pandas.__name__, _hash_python_lines(inspect.getsource(pandas).splitlines())),
     "parquet": (parquet.__name__, _hash_python_lines(inspect.getsource(parquet).splitlines())),
@@ -83,6 +85,13 @@ _PACKAGED_DATASETS_MODULES_2_15_HASHES = {
 _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".csv": ("csv", {}),
     ".tsv": ("csv", {"sep": "\t"}),
+    # FASTA biological sequence formats
+    ".fa": ("fasta", {}),
+    ".fasta": ("fasta", {}),
+    ".fna": ("fasta", {}),  # FASTA nucleic acid
+    ".ffn": ("fasta", {}),  # FASTA nucleotide of gene regions
+    ".faa": ("fasta", {}),  # FASTA amino acid
+    ".frn": ("fasta", {}),  # FASTA non-coding RNA
     ".json": ("json", {}),
     ".jsonl": ("json", {}),
     # ndjson is no longer maintained (see: https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417)

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -92,6 +92,7 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".ffn": ("fasta", {}),  # FASTA nucleotide of gene regions
     ".faa": ("fasta", {}),  # FASTA amino acid
     ".frn": ("fasta", {}),  # FASTA non-coding RNA
+    ".afa": ("fasta", {}),  # aligned FASTA (multiple sequence alignment)
     ".json": ("json", {}),
     ".jsonl": ("json", {}),
     # ndjson is no longer maintained (see: https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417)

--- a/src/datasets/packaged_modules/fasta/fasta.py
+++ b/src/datasets/packaged_modules/fasta/fasta.py
@@ -49,6 +49,9 @@ class FastaConfig(datasets.BuilderConfig):
     max_batch_bytes: Optional[int] = DEFAULT_MAX_BATCH_BYTES
     columns: Optional[list[str]] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class Fasta(datasets.ArrowBasedBuilder):
     """Dataset builder for FASTA files."""
@@ -71,9 +74,7 @@ class Fasta(datasets.ArrowBasedBuilder):
         If dict, then keys should be from the `datasets.Split` enum.
         """
         if not self.config.data_files:
-            raise ValueError(
-                f"At least one data file must be specified, but got data_files={self.config.data_files}"
-            )
+            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
         dl_manager.download_config.extract_on_the_fly = True
         data_files = dl_manager.download_and_extract(self.config.data_files)
         splits = []
@@ -81,19 +82,14 @@ class Fasta(datasets.ArrowBasedBuilder):
             if isinstance(files, str):
                 files = [files]
             files = [dl_manager.iter_files(file) for file in files]
-            splits.append(
-                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
-            )
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast Arrow table to configured features schema."""
         if self.config.features is not None:
             schema = self.config.features.arrow_schema
-            if all(
-                not require_storage_cast(feature)
-                for feature in self.config.features.values()
-            ):
+            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
                 pa_table = pa_table.cast(schema)
             else:
                 pa_table = table_cast(pa_table, schema)
@@ -171,9 +167,7 @@ class Fasta(datasets.ArrowBasedBuilder):
             # Validate columns
             for col in self.config.columns:
                 if col not in default_columns:
-                    raise ValueError(
-                        f"Invalid column '{col}'. Valid columns are: {default_columns}"
-                    )
+                    raise ValueError(f"Invalid column '{col}'. Valid columns are: {default_columns}")
             return self.config.columns
         return default_columns
 

--- a/src/datasets/packaged_modules/fasta/fasta.py
+++ b/src/datasets/packaged_modules/fasta/fasta.py
@@ -1,0 +1,259 @@
+"""FASTA file loader for biological sequence data.
+
+FASTA is a text-based format for representing nucleotide sequences (DNA/RNA)
+or peptide sequences (proteins), widely used in bioinformatics.
+
+This implementation uses a lightweight pure Python parser based on Heng Li's readfq.py,
+requiring zero external dependencies.
+"""
+
+import bz2
+import gzip
+import itertools
+import lzma
+from dataclasses import dataclass
+from typing import Optional
+
+import pyarrow as pa
+
+import datasets
+from datasets.builder import Key
+from datasets.features.features import require_storage_cast
+from datasets.table import table_cast
+
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+# Conservative limit to stay well under Parquet's i32::MAX page limit (~2GB)
+# Using 256MB as default since Parquet compresses data and we want headroom
+DEFAULT_MAX_BATCH_BYTES = 256 * 1024 * 1024  # 256 MB
+
+
+@dataclass
+class FastaConfig(datasets.BuilderConfig):
+    """BuilderConfig for FASTA files.
+
+    Args:
+        features: Dataset features (optional, will be inferred if not provided).
+        batch_size: Maximum number of records per batch. Works in conjunction with
+            max_batch_bytes - a batch is flushed when either limit is reached.
+        max_batch_bytes: Maximum cumulative bytes per batch. This prevents Parquet
+            page size errors when dealing with very large sequences (e.g., complete
+            genomes). Set to None to disable byte-based batching.
+        columns: Subset of columns to include. Options: ["id", "description", "sequence"].
+    """
+
+    features: Optional[datasets.Features] = None
+    batch_size: int = 10000
+    max_batch_bytes: Optional[int] = DEFAULT_MAX_BATCH_BYTES
+    columns: Optional[list[str]] = None
+
+
+class Fasta(datasets.ArrowBasedBuilder):
+    """Dataset builder for FASTA files."""
+
+    BUILDER_CONFIG_CLASS = FastaConfig
+
+    # All supported FASTA extensions
+    EXTENSIONS: list[str] = [".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn"]
+
+    def _info(self):
+        return datasets.DatasetInfo(features=self.config.features)
+
+    def _split_generators(self, dl_manager):
+        """Generate splits from data files.
+
+        The `data_files` kwarg in load_dataset() can be a str, List[str],
+        Dict[str,str], or Dict[str,List[str]].
+
+        If str or List[str], then the dataset returns only the 'train' split.
+        If dict, then keys should be from the `datasets.Split` enum.
+        """
+        if not self.config.data_files:
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
+        dl_manager.download_config.extract_on_the_fly = True
+        data_files = dl_manager.download_and_extract(self.config.data_files)
+        splits = []
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            files = [dl_manager.iter_files(file) for file in files]
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
+        return splits
+
+    def _cast_table(self, pa_table: pa.Table) -> pa.Table:
+        """Cast Arrow table to configured features schema."""
+        if self.config.features is not None:
+            schema = self.config.features.arrow_schema
+            if all(
+                not require_storage_cast(feature)
+                for feature in self.config.features.values()
+            ):
+                pa_table = pa_table.cast(schema)
+            else:
+                pa_table = table_cast(pa_table, schema)
+            return pa_table
+        return pa_table
+
+    def _open_file(self, filepath: str):
+        """Open file with automatic compression detection based on magic bytes.
+
+        Supports gzip, bzip2, and xz/lzma compression formats.
+        """
+        with open(filepath, "rb") as f:
+            magic = f.read(6)
+
+        if magic[:2] == b"\x1f\x8b":  # gzip magic number
+            return gzip.open(filepath, "rt", encoding="utf-8")
+        elif magic[:3] == b"BZh":  # bzip2 magic number
+            return bz2.open(filepath, "rt", encoding="utf-8")
+        elif magic[:6] == b"\xfd7zXZ\x00":  # xz magic number
+            return lzma.open(filepath, "rt", encoding="utf-8")
+        else:
+            return open(filepath, "r", encoding="utf-8")
+
+    def _parse_fasta(self, fp):
+        """Lightweight FASTA parser based on Heng Li's readfq.py.
+
+        This generator yields (seq_id, description, sequence) tuples for each
+        record in the FASTA file. Handles multi-line sequences and various
+        header formats.
+
+        Reference: https://github.com/lh3/readfq
+
+        Args:
+            fp: File-like object opened in text mode.
+
+        Yields:
+            Tuple of (seq_id, description, sequence) for each FASTA record.
+        """
+        last = None  # Store the last header line
+
+        while True:
+            # Find the next header line (starts with '>')
+            if not last:
+                for line in fp:
+                    if line.startswith(">"):
+                        last = line.rstrip()
+                        break
+            if not last:
+                break
+
+            # Parse header: >id description
+            header = last[1:]  # Remove '>'
+            parts = header.split(None, 1)  # Split on first whitespace
+            seq_id = parts[0] if parts else ""
+            description = parts[1] if len(parts) > 1 else ""
+
+            # Collect sequence lines until next header or EOF
+            seqs = []
+            last = None
+            for line in fp:
+                if line.startswith(">"):
+                    last = line.rstrip()
+                    break
+                seqs.append(line.rstrip())
+
+            yield seq_id, description, "".join(seqs)
+
+            if not last:
+                break
+
+    def _get_columns(self) -> list[str]:
+        """Get the list of columns to include in output."""
+        default_columns = ["id", "description", "sequence"]
+        if self.config.columns is not None:
+            # Validate columns
+            for col in self.config.columns:
+                if col not in default_columns:
+                    raise ValueError(
+                        f"Invalid column '{col}'. Valid columns are: {default_columns}"
+                    )
+            return self.config.columns
+        return default_columns
+
+    def _get_schema(self, columns: list[str]) -> pa.Schema:
+        """Return Arrow schema with large_string for sequence column.
+
+        Uses large_string for the sequence column to handle very long sequences
+        (e.g., viral genomes) that can exceed the 2GB limit of regular string type.
+        """
+        fields = []
+        for col in columns:
+            if col == "sequence":
+                # Use large_string for sequences that can be very long
+                fields.append(pa.field(col, pa.large_string()))
+            else:
+                fields.append(pa.field(col, pa.string()))
+        return pa.schema(fields)
+
+    def _generate_tables(self, files):
+        """Generate Arrow tables from FASTA files.
+
+        Yields batches of records as Arrow tables for memory-efficient processing
+        of large genomic files. Uses dual-threshold batching: flushes when either
+        batch_size (record count) or max_batch_bytes (cumulative size) is reached.
+
+        This adaptive approach prevents Parquet page size errors when dealing with
+        very large sequences (e.g., complete viral or bacterial genomes) while
+        maintaining efficiency for typical short sequences.
+
+        Args:
+            files: Iterable of file iterables from _split_generators.
+
+        Yields:
+            Tuple of (Key, pa.Table) for each batch.
+        """
+        columns = self._get_columns()
+        schema = self._get_schema(columns)
+        max_batch_bytes = self.config.max_batch_bytes
+
+        for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
+            batch_idx = 0
+            batch = {col: [] for col in columns}
+            batch_bytes = 0
+
+            with self._open_file(file) as fp:
+                for seq_id, description, sequence in self._parse_fasta(fp):
+                    # Calculate record size (approximate UTF-8 byte size)
+                    record_bytes = len(seq_id) + len(description) + len(sequence)
+
+                    # Check if adding this record would exceed byte limit
+                    # Flush current batch first if needed (but only if batch is non-empty)
+                    if (
+                        max_batch_bytes is not None
+                        and batch_bytes > 0
+                        and batch_bytes + record_bytes > max_batch_bytes
+                    ):
+                        pa_table = pa.Table.from_pydict(batch, schema=schema)
+                        yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+                        batch = {col: [] for col in columns}
+                        batch_bytes = 0
+                        batch_idx += 1
+
+                    # Add record to batch
+                    if "id" in columns:
+                        batch["id"].append(seq_id)
+                    if "description" in columns:
+                        batch["description"].append(description)
+                    if "sequence" in columns:
+                        batch["sequence"].append(sequence)
+                    batch_bytes += record_bytes
+
+                    # Yield batch when it reaches batch_size (record count limit)
+                    if len(batch[columns[0]]) >= self.config.batch_size:
+                        pa_table = pa.Table.from_pydict(batch, schema=schema)
+                        yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+                        batch = {col: [] for col in columns}
+                        batch_bytes = 0
+                        batch_idx += 1
+
+            # Yield remaining records in final batch
+            if batch[columns[0]]:
+                pa_table = pa.Table.from_pydict(batch, schema=schema)
+                yield Key(file_idx, batch_idx), self._cast_table(pa_table)

--- a/src/datasets/packaged_modules/fasta/fasta.py
+++ b/src/datasets/packaged_modules/fasta/fasta.py
@@ -59,7 +59,7 @@ class Fasta(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = FastaConfig
 
     # All supported FASTA extensions
-    EXTENSIONS: list[str] = [".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn"]
+    EXTENSIONS: list[str] = [".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn", ".afa"]
 
     def _info(self):
         return datasets.DatasetInfo(features=self.config.features)

--- a/src/datasets/packaged_modules/fasta/fasta.py
+++ b/src/datasets/packaged_modules/fasta/fasta.py
@@ -7,10 +7,7 @@ This implementation uses a lightweight pure Python parser based on Heng Li's rea
 requiring zero external dependencies.
 """
 
-import bz2
-import gzip
 import itertools
-import lzma
 from dataclasses import dataclass
 from typing import Optional
 
@@ -95,23 +92,6 @@ class Fasta(datasets.ArrowBasedBuilder):
                 pa_table = table_cast(pa_table, schema)
             return pa_table
         return pa_table
-
-    def _open_file(self, filepath: str):
-        """Open file with automatic compression detection based on magic bytes.
-
-        Supports gzip, bzip2, and xz/lzma compression formats.
-        """
-        with open(filepath, "rb") as f:
-            magic = f.read(6)
-
-        if magic[:2] == b"\x1f\x8b":  # gzip magic number
-            return gzip.open(filepath, "rt", encoding="utf-8")
-        elif magic[:3] == b"BZh":  # bzip2 magic number
-            return bz2.open(filepath, "rt", encoding="utf-8")
-        elif magic[:6] == b"\xfd7zXZ\x00":  # xz magic number
-            return lzma.open(filepath, "rt", encoding="utf-8")
-        else:
-            return open(filepath, "r", encoding="utf-8")
 
     def _parse_fasta(self, fp):
         """Lightweight FASTA parser based on Heng Li's readfq.py.
@@ -212,7 +192,7 @@ class Fasta(datasets.ArrowBasedBuilder):
             batch = {col: [] for col in columns}
             batch_bytes = 0
 
-            with self._open_file(file) as fp:
+            with open(file, encoding="utf-8") as fp:
                 for seq_id, description, sequence in self._parse_fasta(fp):
                     # Calculate record size (approximate UTF-8 byte size)
                     record_bytes = len(seq_id) + len(description) + len(sequence)

--- a/src/datasets/packaged_modules/fasta/fasta.py
+++ b/src/datasets/packaged_modules/fasta/fasta.py
@@ -59,7 +59,13 @@ class Fasta(datasets.ArrowBasedBuilder):
     EXTENSIONS: list[str] = [".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn", ".afa"]
 
     def _info(self):
-        return datasets.DatasetInfo(features=self.config.features)
+        features = self.config.features
+        if features is not None and self.config.columns is not None:
+            missing = [col for col in self.config.columns if col not in features]
+            if missing:
+                raise ValueError(f"columns {missing} are not in features {list(features)}")
+            features = datasets.Features({col: features[col] for col in self.config.columns})
+        return datasets.DatasetInfo(features=features)
 
     def _split_generators(self, dl_manager):
         """Generate splits from data files.
@@ -84,9 +90,10 @@ class Fasta(datasets.ArrowBasedBuilder):
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast Arrow table to configured features schema."""
-        if self.config.features is not None:
-            schema = self.config.features.arrow_schema
-            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
+        features = self._info().features
+        if features is not None:
+            schema = features.arrow_schema
+            if all(not require_storage_cast(feature) for feature in features.values()):
                 pa_table = pa_table.cast(schema)
             else:
                 pa_table = table_cast(pa_table, schema)
@@ -133,7 +140,10 @@ class Fasta(datasets.ArrowBasedBuilder):
                 if line.startswith(">"):
                     last = line.rstrip()
                     break
-                seqs.append(line.rstrip())
+                if line.startswith(";"):
+                    continue  # Pearson FASTA comment line, not sequence.
+                # Whitespace inside a sequence line is not sequence (Biopython drops it too).
+                seqs.append("".join(line.split()))
 
             yield seq_id, description, "".join(seqs)
 
@@ -144,6 +154,8 @@ class Fasta(datasets.ArrowBasedBuilder):
         """Get the list of columns to include in output."""
         default_columns = ["id", "description", "sequence"]
         if self.config.columns is not None:
+            if not self.config.columns:
+                raise ValueError("columns must list at least one column when given.")
             # Validate columns
             for col in self.config.columns:
                 if col not in default_columns:

--- a/src/datasets/packaged_modules/fasta/fasta.py
+++ b/src/datasets/packaged_modules/fasta/fasta.py
@@ -3,12 +3,15 @@
 FASTA is a text-based format for representing nucleotide sequences (DNA/RNA)
 or peptide sequences (proteins), widely used in bioinformatics.
 
-This implementation uses a lightweight pure Python parser based on Heng Li's readfq.py,
-requiring zero external dependencies.
+This implementation uses a lightweight pure Python parser based on Heng Li's readfq.py.
+The parsed columns need no external dependency; the ``record`` column holds each
+record's raw bytes as a ``BioSequence`` and decodes to a Biopython ``SeqRecord``
+when biopython is installed (drop it with ``columns`` to stay dependency-free).
 """
 
 import itertools
 from dataclasses import dataclass
+from io import TextIOWrapper
 from typing import Optional
 
 import pyarrow as pa
@@ -38,7 +41,7 @@ class FastaConfig(datasets.BuilderConfig):
         max_batch_bytes: Maximum cumulative bytes per batch. This prevents Parquet
             page size errors when dealing with very large sequences (e.g., complete
             genomes). Set to None to disable byte-based batching.
-        columns: Subset of columns to include. Options: ["id", "description", "sequence"].
+        columns: Subset of columns to include. Options: ["id", "description", "sequence", "record"].
     """
 
     features: Optional[datasets.Features] = None
@@ -58,8 +61,19 @@ class Fasta(datasets.ArrowBasedBuilder):
     # All supported FASTA extensions
     EXTENSIONS: list[str] = [".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn", ".afa"]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # DatasetBuilder applies features= after _info(); project the effective
+        # schema again, preserving features supplied through info= as well.
+        self.info.features = self._info().features
+
     def _info(self):
-        features = self.config.features
+        features = self.info.features if hasattr(self, "info") else self.config.features
+        columns = self._get_columns()
+        if features is None:
+            features = datasets.Features.from_arrow_schema(self._get_schema(columns))
+            if "record" in features:
+                features["record"] = datasets.BioSequence(format="fasta")
         if features is not None and self.config.columns is not None:
             missing = [col for col in self.config.columns if col not in features]
             if missing:
@@ -90,7 +104,7 @@ class Fasta(datasets.ArrowBasedBuilder):
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast Arrow table to configured features schema."""
-        features = self._info().features
+        features = self.info.features
         if features is not None:
             schema = features.arrow_schema
             if all(not require_storage_cast(feature) for feature in features.values()):
@@ -100,7 +114,7 @@ class Fasta(datasets.ArrowBasedBuilder):
             return pa_table
         return pa_table
 
-    def _parse_fasta(self, fp):
+    def _parse_fasta(self, fp, include_record=False):
         """Lightweight FASTA parser based on Heng Li's readfq.py.
 
         This generator yields (seq_id, description, sequence) tuples for each
@@ -111,9 +125,12 @@ class Fasta(datasets.ArrowBasedBuilder):
 
         Args:
             fp: File-like object opened in text mode.
+            include_record: Append the original UTF-8 record bytes to each tuple.
+                The file must be opened with newline="" to preserve line endings.
 
         Yields:
             Tuple of (seq_id, description, sequence) for each FASTA record.
+            When include_record=True, a fourth item contains the record's bytes as read.
         """
         last = None  # Store the last header line
 
@@ -122,44 +139,62 @@ class Fasta(datasets.ArrowBasedBuilder):
             if not last:
                 for line in fp:
                     if line.startswith(">"):
-                        last = line.rstrip()
+                        last = line
                         break
             if not last:
                 break
 
             # Parse header: >id description
-            header = last[1:]  # Remove '>'
+            header = last.rstrip()[1:]  # Remove '>'
             parts = header.split(None, 1)  # Split on first whitespace
             seq_id = parts[0] if parts else ""
             description = parts[1] if len(parts) > 1 else ""
 
             # Collect sequence lines until next header or EOF
             seqs = []
+            record_lines = [last] if include_record else None
             last = None
             for line in fp:
                 if line.startswith(">"):
-                    last = line.rstrip()
+                    last = line
                     break
+                if include_record:
+                    record_lines.append(line)
                 if line.startswith(";"):
                     continue  # Pearson FASTA comment line, not sequence.
                 # Whitespace inside a sequence line is not sequence (Biopython drops it too).
                 seqs.append("".join(line.split()))
 
-            yield seq_id, description, "".join(seqs)
+            record = (seq_id, description, "".join(seqs))
+            if include_record:
+                record += ("".join(record_lines).encode("utf-8"),)
+            yield record
 
             if not last:
                 break
 
     def _get_columns(self) -> list[str]:
         """Get the list of columns to include in output."""
-        default_columns = ["id", "description", "sequence"]
+        default_columns = ["id", "description", "sequence", "record"]
+        features = self.info.features if hasattr(self, "info") else self.config.features
+        if self.config.columns is None and features is not None:
+            # A user-supplied schema selects its own columns, so a schema naming a
+            # subset stays valid when the default schema grows.
+            unknown = [col for col in features if col not in default_columns]
+            if unknown:
+                raise ValueError(f"Invalid feature column(s) {unknown}. Valid columns are: {default_columns}")
+            return list(features)
         if self.config.columns is not None:
             if not self.config.columns:
                 raise ValueError("columns must list at least one column when given.")
             # Validate columns
+            seen = set()
             for col in self.config.columns:
                 if col not in default_columns:
                     raise ValueError(f"Invalid column '{col}'. Valid columns are: {default_columns}")
+                if col in seen:
+                    raise ValueError(f"Duplicate column '{col}' in columns.")
+                seen.add(col)
             return self.config.columns
         return default_columns
 
@@ -174,6 +209,8 @@ class Fasta(datasets.ArrowBasedBuilder):
             if col == "sequence":
                 # Use large_string for sequences that can be very long
                 fields.append(pa.field(col, pa.large_string()))
+            elif col == "record":
+                fields.append(pa.field(col, datasets.BioSequence().pa_type))
             else:
                 fields.append(pa.field(col, pa.string()))
         return pa.schema(fields)
@@ -196,6 +233,7 @@ class Fasta(datasets.ArrowBasedBuilder):
             Tuple of (Key, pa.Table) for each batch.
         """
         columns = self._get_columns()
+        include_record = "record" in columns
         schema = self._get_schema(columns)
         max_batch_bytes = self.config.max_batch_bytes
 
@@ -204,10 +242,14 @@ class Fasta(datasets.ArrowBasedBuilder):
             batch = {col: [] for col in columns}
             batch_bytes = 0
 
-            with open(file, encoding="utf-8") as fp:
-                for seq_id, description, sequence in self._parse_fasta(fp):
+            # Keep the streaming-patched open for compressed inputs, and preserve line endings.
+            with open(file, "rb") as f, TextIOWrapper(f, encoding="utf-8", newline="") as fp:
+                for record in self._parse_fasta(fp, include_record=include_record):
+                    seq_id, description, sequence = record[:3]
                     # Calculate record size (approximate UTF-8 byte size)
                     record_bytes = len(seq_id) + len(description) + len(sequence)
+                    if include_record:
+                        record_bytes += len(record[3])
 
                     # Check if adding this record would exceed byte limit
                     # Flush current batch first if needed (but only if batch is non-empty)
@@ -229,6 +271,8 @@ class Fasta(datasets.ArrowBasedBuilder):
                         batch["description"].append(description)
                     if "sequence" in columns:
                         batch["sequence"].append(sequence)
+                    if include_record:
+                        batch["record"].append({"bytes": record[3], "path": None})
                     batch_bytes += record_bytes
 
                     # Yield batch when it reaches batch_size (record count limit)

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -727,9 +727,13 @@ def fasta_xz_path(tmp_path_factory):
     return path
 
 
-FASTA_LONG_SEQUENCE = """\
+FASTA_LONG_SEQUENCE = (
+    """\
 >long_seq Very long sequence for testing large_string type
-""" + "ATGCATGCATGCATGC" * 1000 + "\n"
+"""
+    + "ATGCATGCATGCATGC" * 1000
+    + "\n"
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -663,3 +663,78 @@ def mesh_file_ply():
 @pytest.fixture(scope="session")
 def mesh_file_stl():
     return os.path.join("tests", "features", "data", "test_mesh_stl.stl")
+
+
+# FASTA biological sequence files
+
+
+FASTA_CONTENT = """\
+>seq1 Example protein sequence
+MKWVTFISLLFLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPF
+EDHVKLVNEVTEFAKTCVADESHAGCEKSLHTLFGDELCKVASLRETYGDMADCCEKQEP
+>seq2 Another sequence with multi-line
+MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSH
+GSAQVKGHGKKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLL
+SHCLLVTLAAHLPAEFTPAVHASLDKFLASVSTVLTSKYR
+>seq3
+ATGCATGCATGCATGCATGCATGCATGC
+"""
+
+
+@pytest.fixture(scope="session")
+def fasta_path(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "sequences.fasta")
+    with open(path, "w") as f:
+        f.write(FASTA_CONTENT)
+    return path
+
+
+@pytest.fixture(scope="session")
+def fasta_path_fa(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "sequences.fa")
+    with open(path, "w") as f:
+        f.write(FASTA_CONTENT)
+    return path
+
+
+@pytest.fixture(scope="session")
+def fasta_gz_path(tmp_path_factory):
+    import gzip
+
+    path = str(tmp_path_factory.mktemp("data") / "sequences.fasta.gz")
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return path
+
+
+@pytest.fixture(scope="session")
+def fasta_bz2_path(tmp_path_factory):
+    import bz2
+
+    path = str(tmp_path_factory.mktemp("data") / "sequences.fasta.bz2")
+    with bz2.open(path, "wt", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return path
+
+
+@pytest.fixture(scope="session")
+def fasta_xz_path(tmp_path_factory):
+    import lzma
+
+    path = str(tmp_path_factory.mktemp("data") / "sequences.fasta.xz")
+    with lzma.open(path, "wt", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return path
+
+
+FASTA_LONG_SEQUENCE = """\
+>long_seq Very long sequence for testing large_string type
+""" + "ATGCATGCATGCATGC" * 1000 + "\n"
+
+
+@pytest.fixture(scope="session")
+def fasta_long_sequence_path(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "long_sequence.fasta")
+    with open(path, "w") as f:
+        f.write(FASTA_LONG_SEQUENCE)
+    return path

--- a/tests/packaged_modules/test_fasta.py
+++ b/tests/packaged_modules/test_fasta.py
@@ -1,0 +1,386 @@
+"""Tests for the FASTA file loader."""
+
+import pyarrow as pa
+import pytest
+
+from datasets import Features, Value
+from datasets.builder import InvalidConfigName
+from datasets.data_files import DataFilesList
+from datasets.packaged_modules.fasta.fasta import Fasta, FastaConfig
+
+
+# Sample FASTA content for inline fixtures
+FASTA_CONTENT = """\
+>seq1 Example protein sequence
+MKWVTFISLLFLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPF
+EDHVKLVNEVTEFAKTCVADESHAGCEKSLHTLFGDELCKVASLRETYGDMADCCEKQEP
+>seq2 Another sequence with multi-line
+MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSH
+GSAQVKGHGKKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLL
+SHCLLVTLAAHLPAEFTPAVHASLDKFLASVSTVLTSKYR
+>seq3
+ATGCATGCATGCATGCATGCATGCATGC
+"""
+
+
+@pytest.fixture
+def fasta_file(tmp_path):
+    filename = tmp_path / "sequences.fasta"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return str(filename)
+
+
+@pytest.fixture
+def fasta_file_fa(tmp_path):
+    filename = tmp_path / "sequences.fa"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return str(filename)
+
+
+@pytest.fixture
+def fasta_gz_file(tmp_path):
+    import gzip
+
+    filename = tmp_path / "sequences.fasta.gz"
+    with gzip.open(filename, "wt", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return str(filename)
+
+
+@pytest.fixture
+def fasta_bz2_file(tmp_path):
+    import bz2
+
+    filename = tmp_path / "sequences.fasta.bz2"
+    with bz2.open(filename, "wt", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return str(filename)
+
+
+@pytest.fixture
+def fasta_xz_file(tmp_path):
+    import lzma
+
+    filename = tmp_path / "sequences.fasta.xz"
+    with lzma.open(filename, "wt", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+    return str(filename)
+
+
+@pytest.fixture
+def fasta_long_sequence_file(tmp_path):
+    """Create a file with a very long sequence to test large_string handling."""
+    filename = tmp_path / "long_sequence.fasta"
+    long_seq = "ATGCATGCATGCATGC" * 1000  # 16KB sequence
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f">long_seq Very long sequence\n{long_seq}\n")
+    return str(filename)
+
+
+@pytest.fixture
+def fasta_empty_description_file(tmp_path):
+    """Create a FASTA file with sequences that have no description."""
+    filename = tmp_path / "no_description.fasta"
+    content = """\
+>seq1
+ATGCATGC
+>seq2
+GCTAGCTA
+"""
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(content)
+    return str(filename)
+
+
+def test_config_raises_when_invalid_name() -> None:
+    with pytest.raises(InvalidConfigName, match="Bad characters"):
+        _ = FastaConfig(name="name-with-*-invalid-character")
+
+
+@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+def test_config_raises_when_invalid_data_files(data_files) -> None:
+    with pytest.raises(ValueError, match="Expected a DataFilesDict"):
+        _ = FastaConfig(name="name", data_files=data_files)
+
+
+def test_fasta_basic_loading(fasta_file):
+    """Test basic FASTA file loading."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    key, pa_table = tables[0]
+
+    # Check columns
+    assert pa_table.column_names == ["id", "description", "sequence"]
+
+    # Check data
+    data = pa_table.to_pydict()
+    assert data["id"] == ["seq1", "seq2", "seq3"]
+    assert data["description"] == [
+        "Example protein sequence",
+        "Another sequence with multi-line",
+        "",
+    ]
+    # Sequences should be concatenated (multi-line merged)
+    assert data["sequence"][0] == (
+        "MKWVTFISLLFLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPF"
+        "EDHVKLVNEVTEFAKTCVADESHAGCEKSLHTLFGDELCKVASLRETYGDMADCCEKQEP"
+    )
+    assert data["sequence"][2] == "ATGCATGCATGCATGCATGCATGCATGC"
+
+
+def test_fasta_fa_extension(fasta_file_fa):
+    """Test loading with .fa extension."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_file_fa]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    assert pa_table.num_rows == 3
+
+
+def test_fasta_gzip_compression(fasta_gz_file):
+    """Test loading gzipped FASTA files."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_gz_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    data = pa_table.to_pydict()
+    assert data["id"] == ["seq1", "seq2", "seq3"]
+
+
+def test_fasta_bz2_compression(fasta_bz2_file):
+    """Test loading bz2-compressed FASTA files."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_bz2_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    data = pa_table.to_pydict()
+    assert data["id"] == ["seq1", "seq2", "seq3"]
+
+
+def test_fasta_xz_compression(fasta_xz_file):
+    """Test loading xz-compressed FASTA files."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_xz_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    data = pa_table.to_pydict()
+    assert data["id"] == ["seq1", "seq2", "seq3"]
+
+
+def test_fasta_long_sequence(fasta_long_sequence_file):
+    """Test handling of very long sequences with large_string type."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_long_sequence_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+
+    # Check that sequence column uses large_string type
+    assert pa_table.schema.field("sequence").type == pa.large_string()
+
+    data = pa_table.to_pydict()
+    expected_length = len("ATGCATGCATGCATGC" * 1000)
+    assert len(data["sequence"][0]) == expected_length
+
+
+def test_fasta_column_filtering(fasta_file):
+    """Test loading only specific columns."""
+    fasta = Fasta(columns=["id", "sequence"])
+    generator = fasta._generate_tables([[fasta_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+
+    # Only selected columns should be present
+    assert pa_table.column_names == ["id", "sequence"]
+    data = pa_table.to_pydict()
+    assert "description" not in data
+
+
+def test_fasta_sequence_only(fasta_file):
+    """Test loading only the sequence column."""
+    fasta = Fasta(columns=["sequence"])
+    generator = fasta._generate_tables([[fasta_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    assert pa_table.column_names == ["sequence"]
+
+
+def test_fasta_invalid_column():
+    """Test that invalid column names raise an error."""
+    with pytest.raises(ValueError, match="Invalid column"):
+        fasta = Fasta(columns=["invalid_column"])
+        list(fasta._generate_tables([[]]))
+
+
+def test_fasta_batch_size(fasta_file):
+    """Test batch size configuration."""
+    fasta = Fasta(batch_size=1)
+    generator = fasta._generate_tables([[fasta_file]])
+    tables = list(generator)
+
+    # With batch_size=1, we should get 3 separate tables
+    assert len(tables) == 3
+    for _, pa_table in tables:
+        assert pa_table.num_rows == 1
+
+
+def test_fasta_empty_description(fasta_empty_description_file):
+    """Test sequences with no description."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_empty_description_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    data = pa_table.to_pydict()
+    assert data["description"] == ["", ""]
+
+
+def test_fasta_schema_types(fasta_file):
+    """Test that the Arrow schema has correct types."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_file]])
+    tables = list(generator)
+
+    _, pa_table = tables[0]
+    schema = pa_table.schema
+
+    # id and description should be string
+    assert schema.field("id").type == pa.string()
+    assert schema.field("description").type == pa.string()
+    # sequence should be large_string to handle long sequences
+    assert schema.field("sequence").type == pa.large_string()
+
+
+def test_fasta_feature_casting(fasta_file):
+    """Test custom feature casting."""
+    features = Features({
+        "id": Value("string"),
+        "sequence": Value("large_string"),
+    })
+    fasta = Fasta(columns=["id", "sequence"], features=features)
+    generator = fasta._generate_tables([[fasta_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    assert pa_table.num_rows == 3
+
+
+def test_fasta_multiple_files(fasta_file, fasta_file_fa):
+    """Test loading multiple FASTA files."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_file], [fasta_file_fa]])
+    tables = list(generator)
+
+    # Should get one batch from each file
+    assert len(tables) == 2
+
+    total_rows = sum(pa_table.num_rows for _, pa_table in tables)
+    assert total_rows == 6  # 3 sequences per file * 2 files
+
+
+def test_fasta_max_batch_bytes(tmp_path):
+    """Test byte-based batching for handling large sequences.
+
+    This tests the adaptive batching that prevents Parquet page size errors
+    when dealing with very large sequences (e.g., complete genomes).
+    """
+    # Create sequences of known sizes
+    # Each sequence is ~100 bytes (id + description + sequence)
+    filename = tmp_path / "batch_test.fasta"
+    with open(filename, "w", encoding="utf-8") as f:
+        for i in range(5):
+            seq = "A" * 80  # 80 byte sequence
+            f.write(f">seq{i} description{i}\n{seq}\n")
+
+    # With max_batch_bytes=200, we should get multiple batches
+    # Each record is ~100 bytes, so ~2 records per batch
+    fasta = Fasta(batch_size=10000, max_batch_bytes=200)
+    generator = fasta._generate_tables([[str(filename)]])
+    tables = list(generator)
+
+    # Should have multiple batches due to byte limit
+    assert len(tables) >= 2
+
+    # Total rows should still be 5
+    total_rows = sum(pa_table.num_rows for _, pa_table in tables)
+    assert total_rows == 5
+
+
+def test_fasta_max_batch_bytes_disabled(tmp_path):
+    """Test that max_batch_bytes=None disables byte-based batching."""
+    filename = tmp_path / "large_seqs.fasta"
+    # Create 3 sequences with 1KB each
+    with open(filename, "w", encoding="utf-8") as f:
+        for i in range(3):
+            seq = "ATGC" * 256  # 1KB sequence
+            f.write(f">seq{i}\n{seq}\n")
+
+    # With max_batch_bytes=None, only batch_size matters
+    fasta = Fasta(batch_size=10000, max_batch_bytes=None)
+    generator = fasta._generate_tables([[str(filename)]])
+    tables = list(generator)
+
+    # Should be single batch since batch_size is large and byte limit is disabled
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    assert pa_table.num_rows == 3
+
+
+def test_fasta_large_genome_batching(tmp_path):
+    """Test handling of genome-scale sequences that would exceed Parquet page limits.
+
+    This simulates the scenario described in PR #7851 where very large sequences
+    (e.g., viral genomes of 30KB+) could cause Parquet page size errors.
+    """
+    filename = tmp_path / "genome.fasta"
+    # Create a "genome" of 50KB - this would cause issues without byte-based batching
+    genome_seq = "ATGCGTACGT" * 5000  # 50KB sequence
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f">genome1 Large viral genome\n{genome_seq}\n")
+        f.write(f">genome2 Another large genome\n{genome_seq}\n")
+
+    # With small max_batch_bytes, each genome should be in its own batch
+    fasta = Fasta(batch_size=10000, max_batch_bytes=60000)  # 60KB limit
+    generator = fasta._generate_tables([[str(filename)]])
+    tables = list(generator)
+
+    # Each 50KB genome should be in separate batch
+    assert len(tables) == 2
+
+    for _, pa_table in tables:
+        assert pa_table.num_rows == 1
+        data = pa_table.to_pydict()
+        assert len(data["sequence"][0]) == 50000
+
+
+def test_fasta_default_max_batch_bytes():
+    """Test that default max_batch_bytes is set correctly."""
+    from datasets.packaged_modules.fasta.fasta import DEFAULT_MAX_BATCH_BYTES
+
+    # Default should be 256MB
+    assert DEFAULT_MAX_BATCH_BYTES == 256 * 1024 * 1024
+
+    # Config should use this default
+    config = FastaConfig(name="test")
+    assert config.max_batch_bytes == DEFAULT_MAX_BATCH_BYTES

--- a/tests/packaged_modules/test_fasta.py
+++ b/tests/packaged_modules/test_fasta.py
@@ -272,10 +272,12 @@ def test_fasta_schema_types(fasta_file):
 
 def test_fasta_feature_casting(fasta_file):
     """Test custom feature casting."""
-    features = Features({
-        "id": Value("string"),
-        "sequence": Value("large_string"),
-    })
+    features = Features(
+        {
+            "id": Value("string"),
+            "sequence": Value("large_string"),
+        }
+    )
     fasta = Fasta(columns=["id", "sequence"], features=features)
     generator = fasta._generate_tables([[fasta_file]])
     tables = list(generator)

--- a/tests/packaged_modules/test_fasta.py
+++ b/tests/packaged_modules/test_fasta.py
@@ -144,6 +144,25 @@ def test_fasta_fa_extension(fasta_file_fa):
     assert pa_table.num_rows == 3
 
 
+def test_fasta_afa_extension(tmp_path):
+    """Test that .afa (aligned FASTA) files are recognized and loaded."""
+    from datasets.packaged_modules import _EXTENSION_TO_MODULE
+
+    # .afa routes to the FASTA builder in auto-detection and is a supported extension
+    assert _EXTENSION_TO_MODULE.get(".afa") == ("fasta", {})
+    assert ".afa" in Fasta.EXTENSIONS
+
+    filename = tmp_path / "alignment.afa"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(FASTA_CONTENT)
+
+    fasta = Fasta()
+    tables = list(fasta._generate_tables([[str(filename)]]))
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    assert pa_table.num_rows == 3
+
+
 def test_fasta_gzip_compression(fasta_gz_file):
     """Test loading gzipped FASTA files."""
     fasta = Fasta()

--- a/tests/packaged_modules/test_fasta.py
+++ b/tests/packaged_modules/test_fasta.py
@@ -447,3 +447,35 @@ def test_fasta_default_max_batch_bytes():
     # Config should use this default
     config = FastaConfig(name="test")
     assert config.max_batch_bytes == DEFAULT_MAX_BATCH_BYTES
+
+
+def test_fasta_parser_drops_whitespace_inside_sequence_lines():
+    """Whitespace inside a sequence line is not sequence (Biopython: ''.join(lines).replace(' ', ''))."""
+    import io
+
+    assert list(Fasta()._parse_fasta(io.StringIO(">a\nA C-G*\nT T\n"))) == [("a", "", "AC-G*TT")]
+
+
+def test_fasta_parser_skips_semicolon_comment_lines():
+    """Pearson FASTA defines lines starting with ';' as comments, not sequence."""
+    import io
+
+    assert list(Fasta()._parse_fasta(io.StringIO(";file comment\n>a\n; record comment\nACGT\n"))) == [
+        ("a", "", "ACGT")
+    ]
+
+
+def test_fasta_empty_columns_is_rejected():
+    with pytest.raises(ValueError, match="at least one column"):
+        Fasta(columns=[])._get_columns()
+
+
+def test_fasta_columns_project_custom_features(tmp_path):
+    """columns= applies to a user-supplied features schema too."""
+    filename = tmp_path / "proj.fa"
+    filename.write_text(">a\nAC\n", encoding="utf-8")
+    features = Features({col: Value("string") for col in ["id", "description", "sequence"]})
+    table = next(iter(Fasta(columns=["sequence"], features=features)._generate_tables([[str(filename)]])))[1]
+    assert table.column_names == ["sequence"]
+    with pytest.raises(ValueError, match="not in features"):
+        Fasta(columns=["sequence"], features=Features({"id": Value("string")}))._info()

--- a/tests/packaged_modules/test_fasta.py
+++ b/tests/packaged_modules/test_fasta.py
@@ -1,12 +1,31 @@
 """Tests for the FASTA file loader."""
 
+import os
+
 import pyarrow as pa
 import pytest
 
 from datasets import Features, Value
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
+from datasets.download.streaming_download_manager import _get_extraction_protocol
 from datasets.packaged_modules.fasta.fasta import Fasta, FastaConfig
+
+from ..utils import require_zstandard
+
+
+def _compression_uri(path):
+    """Build the chained fsspec URI datasets uses to read a single compressed file.
+
+    The builder opens files with the streaming-patched ``open()`` (``xopen``), which
+    handles compression via ``<protocol>://<inner>::<outer>`` URIs rather than by
+    sniffing magic bytes. The protocol is derived from datasets' own extraction logic
+    so the test tracks the loader's real behavior. ``inner`` is the decompressed name.
+    """
+    path = str(path)
+    protocol = _get_extraction_protocol(path)
+    inner = os.path.basename(path).rsplit(".", 1)[0]
+    return f"{protocol}://{inner}::{path}"
 
 
 # Sample FASTA content for inline fixtures
@@ -46,7 +65,7 @@ def fasta_gz_file(tmp_path):
     filename = tmp_path / "sequences.fasta.gz"
     with gzip.open(filename, "wt", encoding="utf-8") as f:
         f.write(FASTA_CONTENT)
-    return str(filename)
+    return _compression_uri(filename)
 
 
 @pytest.fixture
@@ -56,7 +75,7 @@ def fasta_bz2_file(tmp_path):
     filename = tmp_path / "sequences.fasta.bz2"
     with bz2.open(filename, "wt", encoding="utf-8") as f:
         f.write(FASTA_CONTENT)
-    return str(filename)
+    return _compression_uri(filename)
 
 
 @pytest.fixture
@@ -66,7 +85,17 @@ def fasta_xz_file(tmp_path):
     filename = tmp_path / "sequences.fasta.xz"
     with lzma.open(filename, "wt", encoding="utf-8") as f:
         f.write(FASTA_CONTENT)
-    return str(filename)
+    return _compression_uri(filename)
+
+
+@pytest.fixture
+def fasta_zst_file(tmp_path):
+    import zstandard
+
+    filename = tmp_path / "sequences.fasta.zst"
+    with open(filename, "wb") as f:
+        f.write(zstandard.ZstdCompressor().compress(FASTA_CONTENT.encode("utf-8")))
+    return _compression_uri(filename)
 
 
 @pytest.fixture
@@ -191,6 +220,19 @@ def test_fasta_xz_compression(fasta_xz_file):
     """Test loading xz-compressed FASTA files."""
     fasta = Fasta()
     generator = fasta._generate_tables([[fasta_xz_file]])
+    tables = list(generator)
+
+    assert len(tables) == 1
+    _, pa_table = tables[0]
+    data = pa_table.to_pydict()
+    assert data["id"] == ["seq1", "seq2", "seq3"]
+
+
+@require_zstandard
+def test_fasta_zstd_compression(fasta_zst_file):
+    """Test loading zstd-compressed FASTA files, which is common for large FASTA data."""
+    fasta = Fasta()
+    generator = fasta._generate_tables([[fasta_zst_file]])
     tables = list(generator)
 
     assert len(tables) == 1

--- a/tests/packaged_modules/test_fasta.py
+++ b/tests/packaged_modules/test_fasta.py
@@ -5,13 +5,19 @@ import os
 import pyarrow as pa
 import pytest
 
-from datasets import Features, Value
+from datasets import BioSequence, DatasetInfo, Features, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.download.streaming_download_manager import _get_extraction_protocol
 from datasets.packaged_modules.fasta.fasta import Fasta, FastaConfig
+from datasets.utils.file_utils import xopen
 
 from ..utils import require_zstandard
+
+
+require_biopython = pytest.mark.skipif(
+    not __import__("datasets").config.BIOPYTHON_AVAILABLE, reason="biopython is not installed"
+)
 
 
 def _compression_uri(path):
@@ -45,7 +51,7 @@ ATGCATGCATGCATGCATGCATGCATGC
 @pytest.fixture
 def fasta_file(tmp_path):
     filename = tmp_path / "sequences.fasta"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(FASTA_CONTENT)
     return str(filename)
 
@@ -53,7 +59,7 @@ def fasta_file(tmp_path):
 @pytest.fixture
 def fasta_file_fa(tmp_path):
     filename = tmp_path / "sequences.fa"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(FASTA_CONTENT)
     return str(filename)
 
@@ -63,7 +69,7 @@ def fasta_gz_file(tmp_path):
     import gzip
 
     filename = tmp_path / "sequences.fasta.gz"
-    with gzip.open(filename, "wt", encoding="utf-8") as f:
+    with gzip.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(FASTA_CONTENT)
     return _compression_uri(filename)
 
@@ -73,7 +79,7 @@ def fasta_bz2_file(tmp_path):
     import bz2
 
     filename = tmp_path / "sequences.fasta.bz2"
-    with bz2.open(filename, "wt", encoding="utf-8") as f:
+    with bz2.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(FASTA_CONTENT)
     return _compression_uri(filename)
 
@@ -83,7 +89,7 @@ def fasta_xz_file(tmp_path):
     import lzma
 
     filename = tmp_path / "sequences.fasta.xz"
-    with lzma.open(filename, "wt", encoding="utf-8") as f:
+    with lzma.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(FASTA_CONTENT)
     return _compression_uri(filename)
 
@@ -103,7 +109,7 @@ def fasta_long_sequence_file(tmp_path):
     """Create a file with a very long sequence to test large_string handling."""
     filename = tmp_path / "long_sequence.fasta"
     long_seq = "ATGCATGCATGCATGC" * 1000  # 16KB sequence
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(f">long_seq Very long sequence\n{long_seq}\n")
     return str(filename)
 
@@ -118,7 +124,7 @@ ATGCATGC
 >seq2
 GCTAGCTA
 """
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(content)
     return str(filename)
 
@@ -144,7 +150,7 @@ def test_fasta_basic_loading(fasta_file):
     key, pa_table = tables[0]
 
     # Check columns
-    assert pa_table.column_names == ["id", "description", "sequence"]
+    assert pa_table.column_names == ["id", "description", "sequence", "record"]
 
     # Check data
     data = pa_table.to_pydict()
@@ -182,7 +188,7 @@ def test_fasta_afa_extension(tmp_path):
     assert ".afa" in Fasta.EXTENSIONS
 
     filename = tmp_path / "alignment.afa"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(FASTA_CONTENT)
 
     fasta = Fasta()
@@ -370,7 +376,7 @@ def test_fasta_max_batch_bytes(tmp_path):
     # Create sequences of known sizes
     # Each sequence is ~100 bytes (id + description + sequence)
     filename = tmp_path / "batch_test.fasta"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         for i in range(5):
             seq = "A" * 80  # 80 byte sequence
             f.write(f">seq{i} description{i}\n{seq}\n")
@@ -393,7 +399,7 @@ def test_fasta_max_batch_bytes_disabled(tmp_path):
     """Test that max_batch_bytes=None disables byte-based batching."""
     filename = tmp_path / "large_seqs.fasta"
     # Create 3 sequences with 1KB each
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         for i in range(3):
             seq = "ATGC" * 256  # 1KB sequence
             f.write(f">seq{i}\n{seq}\n")
@@ -419,7 +425,7 @@ def test_fasta_large_genome_batching(tmp_path):
     # Create a "genome" of 50KB - this would cause issues without byte-based batching
     genome_seq = "ATGCGTACGT" * 5000  # 50KB sequence
 
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(f">genome1 Large viral genome\n{genome_seq}\n")
         f.write(f">genome2 Another large genome\n{genome_seq}\n")
 
@@ -470,12 +476,158 @@ def test_fasta_empty_columns_is_rejected():
         Fasta(columns=[])._get_columns()
 
 
+@pytest.mark.parametrize("features", [None, Features({"id": Value("string")})])
+def test_fasta_duplicate_columns_is_rejected(features):
+    with pytest.raises(ValueError, match="Duplicate column 'id'"):
+        Fasta(columns=["id", "id"], features=features)
+
+
 def test_fasta_columns_project_custom_features(tmp_path):
     """columns= applies to a user-supplied features schema too."""
     filename = tmp_path / "proj.fa"
-    filename.write_text(">a\nAC\n", encoding="utf-8")
+    filename.write_bytes(b">a\nAC\n")
     features = Features({col: Value("string") for col in ["id", "description", "sequence"]})
-    table = next(iter(Fasta(columns=["sequence"], features=features)._generate_tables([[str(filename)]])))[1]
+    fasta = Fasta(columns=["sequence"], features=features)
+    assert fasta.info.features == Features({"sequence": Value("string")})
+    table = next(iter(fasta._generate_tables([[str(filename)]])))[1]
     assert table.column_names == ["sequence"]
+    assert Features.from_arrow_schema(table.schema) == fasta.info.features
     with pytest.raises(ValueError, match="not in features"):
         Fasta(columns=["sequence"], features=Features({"id": Value("string")}))._info()
+
+
+@pytest.mark.parametrize("columns", [None, ["record"]])
+def test_fasta_preserves_supplied_info_features(fasta_file, columns):
+    features = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+            "record": BioSequence(format="fasta", decode=False),
+        }
+    )
+    fasta = Fasta(info=DatasetInfo(features=features, description="custom info"), columns=columns)
+    expected = features if columns is None else Features({"record": features["record"]})
+    assert fasta.info.features == expected
+    assert fasta.info.description == "custom info"
+    _, table = next(fasta._generate_tables([[fasta_file]]))
+    assert Features.from_arrow_schema(table.schema) == expected
+
+
+def test_fasta_record_features(fasta_file):
+    fasta = Fasta()
+    expected = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+            "record": BioSequence(format="fasta"),
+        }
+    )
+    assert fasta.info.features == expected
+    _, table = next(fasta._generate_tables([[fasta_file]]))
+    assert table.schema.field("record").type == BioSequence().pa_type
+    assert Features.from_arrow_schema(table.schema) == expected
+
+
+@require_biopython
+@pytest.mark.parametrize("streaming", [False, True])
+def test_fasta_record_decoding(fasta_file, streaming):
+    from Bio.SeqRecord import SeqRecord
+
+    dataset = load_dataset("fasta", data_files=fasta_file, split="train", streaming=streaming)
+    assert dataset.features["record"] == BioSequence(format="fasta")
+    rows = list(dataset)
+    assert len(rows) == 3
+    for row in rows:
+        assert isinstance(row["record"], SeqRecord)
+        assert row["record"].id == row["id"]
+        assert str(row["record"].seq) == row["sequence"]
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "fasta_file",
+        "fasta_gz_file",
+        "fasta_bz2_file",
+        "fasta_xz_file",
+        pytest.param("fasta_zst_file", marks=require_zstandard),
+    ],
+)
+def test_fasta_record_bytes(fixture_name, request):
+    filename = request.getfixturevalue(fixture_name)
+    tables = list(Fasta(batch_size=1)._generate_tables([[filename]]))
+    records = [table.to_pydict()["record"][0] for _, table in tables]
+    with xopen(filename, "rb") as f:
+        expected = [b">" + record for record in f.read().split(b">")[1:]]
+    assert records == [{"bytes": record, "path": None} for record in expected]
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"])
+@pytest.mark.parametrize("compressed", [False, True])
+def test_fasta_record_preserves_raw_lines(tmp_path, newline, compressed):
+    import gzip
+
+    # Preserve header whitespace, UTF-8, comments, blank lines and sequence wrapping.
+    first = b">a caf\xc3\xa9 \t\n; comment\nA C\n\nGT  \n".replace(b"\n", newline)
+    second = b">b\nTT\nAA".replace(b"\n", newline)
+    content = b"; file comment" + newline + first + second
+    filename = tmp_path / ("raw.fa.gz" if compressed else "raw.fa")
+    filename.write_bytes(gzip.compress(content) if compressed else content)
+    path = _compression_uri(filename) if compressed else str(filename)
+    _, table = next(Fasta(columns=["record"])._generate_tables([[path]]))
+    assert table.to_pydict() == {"record": [{"bytes": first, "path": None}, {"bytes": second, "path": None}]}
+
+
+def test_fasta_record_cast_decode_false(fasta_file, monkeypatch):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    dataset = load_dataset("fasta", data_files=fasta_file, split="train")
+    dataset = dataset.cast_column("record", BioSequence(decode=False))
+    with open(fasta_file, "rb") as f:
+        expected = [b">" + record for record in f.read().split(b">")[1:]]
+    assert dataset["record"] == [{"bytes": record, "path": None} for record in expected]
+
+
+def test_fasta_columns_drop_record_without_biopython(fasta_file, monkeypatch):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    dataset = load_dataset("fasta", data_files=fasta_file, split="train", columns=["id", "sequence"])
+    assert dataset.features == Features({"id": Value("string"), "sequence": Value("large_string")})
+    assert len(list(dataset)) == 3
+    assert dataset.column_names == ["id", "sequence"]
+
+
+def test_fasta_record_column_validation():
+    with pytest.raises(ValueError, match="Invalid column.*Valid columns are:.*record"):
+        Fasta(columns=["invalid_column"])._get_columns()
+    with pytest.raises(ValueError, match="columns.*record.*not in features"):
+        Fasta(columns=["record"], features=Features({"id": Value("string")}))
+
+
+def test_fasta_record_bytes_count_toward_batch_limit(tmp_path):
+    filename = tmp_path / "batch.fa"
+    # Parsed fields fit in one batch; their raw records push the total over the limit.
+    filename.write_bytes(b">a\nACGT\n>b\nTGCA\n")
+    tables = list(Fasta(max_batch_bytes=20)._generate_tables([[str(filename)]]))
+    assert [table.num_rows for _, table in tables] == [1, 1]
+    tables = list(Fasta(columns=["id", "sequence"], max_batch_bytes=20)._generate_tables([[str(filename)]]))
+    assert [table.num_rows for _, table in tables] == [2]
+
+
+def test_fasta_explicit_features_without_record(fasta_file):
+    """A user-supplied schema selects its own columns, so pinning the three parsed columns still works."""
+    features = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+        }
+    )
+    fasta = Fasta(features=features)
+    assert fasta._get_columns() == ["id", "description", "sequence"]
+    assert fasta.info.features == features
+    generator = fasta._generate_tables([[fasta_file]])
+    table = pa.concat_tables([table for _, table in generator])
+    assert table.column_names == ["id", "description", "sequence"]
+    with pytest.raises(ValueError, match="Invalid feature column"):
+        Fasta(features=Features({"id": Value("string"), "quality": Value("string")}))


### PR DESCRIPTION
## Summary

This PR adds support for loading FASTA files directly with `load_dataset()`, addressing feedback from #7851.

FASTA is a text-based format for representing nucleotide sequences (DNA/RNA) or peptide sequences (proteins), widely used in bioinformatics.

## Key Features

- **Zero external dependencies** - Uses a lightweight pure Python parser based on [readfq.py](https://github.com/lh3/readfq) by Heng Li
- **Streaming support** - Generator-based parsing for memory efficiency with large genomic files
- **Compression support** - Automatic detection and handling of gzip, bzip2, and xz compressed files via magic bytes
- **Large sequence support** - Uses `large_string` Arrow type to handle viral genomes and long sequences (fixes UTF-8 overflow)
- **Adaptive batching** - `max_batch_bytes` parameter (default 256MB) prevents Parquet page size errors with very large sequences

## Technical Decisions (Addressing #7851 Feedback)

| Concern | Solution |
|---------|----------|
| Long sequences → UTF-8 overflow (@apcamargo, @UriNeri) | Uses `pa.large_string()` for sequence column |
| BioPython is overkill (@apcamargo) | Pure Python parser based on Heng Li's readfq.py |
| Parquet page size limit i32::MAX (@UriNeri) | Adaptive dual-threshold batching with `max_batch_bytes` |

## Columns

| Column | Type | Description |
|--------|------|-------------|
| `id` | string | Sequence identifier (first word after `>`) |
| `description` | string | Full description line (everything after id) |
| `sequence` | large_string | The biological sequence (DNA/RNA/protein) |

## Supported Extensions

`.fa`, `.fasta`, `.fna`, `.ffn`, `.faa`, `.frn` (and compressed variants)

## Usage

```python
from datasets import load_dataset

# Load FASTA file
dataset = load_dataset("fasta", data_files="sequences.fasta")

# Load with column filtering
dataset = load_dataset("fasta", data_files="sequences.fa", columns=["id", "sequence"])

# Load gzipped file
dataset = load_dataset("fasta", data_files="sequences.fa.gz")

# Configure batching for very large genomes
dataset = load_dataset("fasta", data_files="genome.fasta", max_batch_bytes=128*1024*1024)
```

## Test Plan

- [x] Basic FASTA loading (3 sequences, multi-line)
- [x] Multiple extension support (.fa, .fasta, .fna, .ffn, .faa, .frn)
- [x] Compression formats (gzip, bz2, xz)
- [x] Long sequences with `large_string` type
- [x] Column filtering
- [x] Batch size configuration
- [x] Byte-based batching (`max_batch_bytes`)
- [x] Large genome handling (simulated 50KB sequences)
- [x] Empty description handling
- [x] Multiple files loading
- [x] Custom feature casting

All 22 tests passing.

cc: @georgia-hf