### PR TITLE
Add lightweight FASTQ file format support

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -267,6 +267,34 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 >>> dataset = load_dataset("webdataset", data_files={"train": urls}, split="train", streaming=True)
 ```
 
+### FASTQ
+
+[FASTQ](https://en.wikipedia.org/wiki/FASTQ_format) is a text-based format for storing nucleotide sequences together with their quality scores, widely used for high-throughput sequencing data.
+
+Load a FASTQ file:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("fastq", data_files="reads.fq")
+```
+
+The loader returns four columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | Sequence identifier (first word after `@`) |
+| `description` | string | Full description line (everything after id) |
+| `sequence` | large_string | The nucleotide sequence |
+| `quality` | large_string | ASCII-encoded quality scores |
+
+Load only specific columns:
+
+```py
+>>> dataset = load_dataset("fastq", data_files="reads.fq", columns=["sequence", "quality"])
+```
+
+Compressed files (.fq.gz, .fastq.gz, .fq.bz2, .fq.xz) are automatically detected and decompressed.
+
 ## Remote files
 
 If you have remote files likely stored as a `csv`, `json`, `txt`, `parquet` or any supported format, the [`load_dataset`] function can load load them if you specify their remote paths:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -292,6 +292,34 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 >>> dataset = load_dataset("webdataset", data_files={"train": urls}, split="train", streaming=True)
 ```
 
+### FASTQ
+
+[FASTQ](https://en.wikipedia.org/wiki/FASTQ_format) is a text-based format for storing nucleotide sequences together with their quality scores, widely used for high-throughput sequencing data.
+
+Load a FASTQ file:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("fastq", data_files="reads.fq")
+```
+
+The loader returns four columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | Sequence identifier (first word after `@`) |
+| `description` | string | Full description line (everything after id) |
+| `sequence` | large_string | The nucleotide sequence |
+| `quality` | large_string | ASCII-encoded quality scores |
+
+Load only specific columns:
+
+```py
+>>> dataset = load_dataset("fastq", data_files="reads.fq", columns=["sequence", "quality"])
+```
+
+Compressed files (.fq.gz, .fastq.gz, .fq.bz2, .fq.xz) are automatically detected and decompressed.
+
 ## Remote files
 
 If you have remote files likely stored as a `csv`, `json`, `txt`, `parquet` or any supported format, the [`load_dataset`] function can load load them if you specify their remote paths:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -303,7 +303,7 @@ Load a FASTQ file:
 >>> dataset = load_dataset("fastq", data_files="reads.fq")
 ```
 
-The loader returns four columns:
+The loader returns five columns:
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -311,6 +311,9 @@ The loader returns four columns:
 | `description` | string | Full description line (everything after id) |
 | `sequence` | large_string | The nucleotide sequence |
 | `quality` | large_string | ASCII-encoded quality scores |
+| `record` | [`BioSequence`] | With `format="fastq"`, stores each record's original bytes, decoded to a Biopython `SeqRecord` when accessed. |
+
+Reading the parsed columns requires no Biopython; exclude `record` with `columns`, or use `dataset.cast_column("record", BioSequence(decode=False))` (imported from `datasets`) to access its `{"bytes": ..., "path": None}` storage without decoding.
 
 Load only specific columns:
 

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -10,6 +10,7 @@ from .cache import cache
 from .conll import conll
 from .csv import csv
 from .eval import eval
+from .fastq import fastq
 from .hdf5 import hdf5
 from .iceberg import iceberg
 from .imagefolder import imagefolder
@@ -63,6 +64,7 @@ _PACKAGED_DATASETS_MODULES = {
     "lance": (lance.__name__, _hash_python_lines(inspect.getsource(lance).splitlines())),
     "tsfile": (tsfile.__name__, _hash_python_lines(inspect.getsource(tsfile).splitlines())),
     "iceberg": (iceberg.__name__, _hash_python_lines(inspect.getsource(iceberg).splitlines())),
+    "fastq": (fastq.__name__, _hash_python_lines(inspect.getsource(fastq).splitlines())),
 }
 
 # get importable module names and hash for caching
@@ -99,6 +101,8 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".eval": ("eval", {}),
     ".lance": ("lance", {}),
     ".tsfile": ("tsfile", {}),
+    ".fq": ("fastq", {}),
+    ".fastq": ("fastq", {}),
 }
 _EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -10,6 +10,7 @@ from .cache import cache
 from .conll import conll
 from .csv import csv
 from .eval import eval
+from .fastq import fastq
 from .hdf5 import hdf5
 from .iceberg import iceberg
 from .imagefolder import imagefolder
@@ -65,6 +66,7 @@ _PACKAGED_DATASETS_MODULES = {
     "tsfile": (tsfile.__name__, _hash_python_lines(inspect.getsource(tsfile).splitlines())),
     "iceberg": (iceberg.__name__, _hash_python_lines(inspect.getsource(iceberg).splitlines())),
     "vortex": (vortex.__name__, _hash_python_lines(inspect.getsource(vortex).splitlines())),
+    "fastq": (fastq.__name__, _hash_python_lines(inspect.getsource(fastq).splitlines())),
 }
 
 # get importable module names and hash for caching
@@ -102,6 +104,8 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".lance": ("lance", {}),
     ".tsfile": ("tsfile", {}),
     ".vortex": ("vortex", {}),
+    ".fq": ("fastq", {}),
+    ".fastq": ("fastq", {}),
 }
 _EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})

--- a/src/datasets/packaged_modules/fastq/fastq.py
+++ b/src/datasets/packaged_modules/fastq/fastq.py
@@ -1,0 +1,270 @@
+"""FASTQ file loader for sequencing data with quality scores.
+
+FASTQ is a text-based format for storing nucleotide sequences together with
+their quality scores, widely used for high-throughput sequencing data.
+
+This implementation uses a lightweight pure Python parser based on Heng Li's readfq.py,
+requiring zero external dependencies.
+"""
+
+import bz2
+import gzip
+import itertools
+import lzma
+from dataclasses import dataclass
+from typing import Optional
+
+import pyarrow as pa
+
+import datasets
+from datasets.builder import Key
+from datasets.features.features import require_storage_cast
+from datasets.table import table_cast
+
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+# Conservative limit to stay well under Parquet's i32::MAX page limit (~2GB)
+# Using 256MB as default since Parquet compresses data and we want headroom
+DEFAULT_MAX_BATCH_BYTES = 256 * 1024 * 1024  # 256 MB
+
+
+@dataclass
+class FastqConfig(datasets.BuilderConfig):
+    """BuilderConfig for FASTQ files.
+
+    Args:
+        features: Dataset features (optional, will be inferred if not provided).
+        batch_size: Maximum number of records per batch. Works in conjunction with
+            max_batch_bytes - a batch is flushed when either limit is reached.
+        max_batch_bytes: Maximum cumulative bytes per batch. This prevents Parquet
+            page size errors when dealing with very large sequences. Set to None
+            to disable byte-based batching.
+        columns: Subset of columns to include. Options: ["id", "description", "sequence", "quality"].
+    """
+
+    features: Optional[datasets.Features] = None
+    batch_size: int = 10000
+    max_batch_bytes: Optional[int] = DEFAULT_MAX_BATCH_BYTES
+    columns: Optional[list[str]] = None
+
+
+class Fastq(datasets.ArrowBasedBuilder):
+    """Dataset builder for FASTQ files."""
+
+    BUILDER_CONFIG_CLASS = FastqConfig
+
+    # All supported FASTQ extensions
+    EXTENSIONS: list[str] = [".fq", ".fastq"]
+
+    def _info(self):
+        return datasets.DatasetInfo(features=self.config.features)
+
+    def _split_generators(self, dl_manager):
+        """Generate splits from data files.
+
+        The `data_files` kwarg in load_dataset() can be a str, List[str],
+        Dict[str,str], or Dict[str,List[str]].
+
+        If str or List[str], then the dataset returns only the 'train' split.
+        If dict, then keys should be from the `datasets.Split` enum.
+        """
+        if not self.config.data_files:
+            raise ValueError(
+                f"At least one data file must be specified, but got data_files={self.config.data_files}"
+            )
+        dl_manager.download_config.extract_on_the_fly = True
+        data_files = dl_manager.download_and_extract(self.config.data_files)
+        splits = []
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            files = [dl_manager.iter_files(file) for file in files]
+            splits.append(
+                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
+            )
+        return splits
+
+    def _cast_table(self, pa_table: pa.Table) -> pa.Table:
+        """Cast Arrow table to configured features schema."""
+        if self.config.features is not None:
+            schema = self.config.features.arrow_schema
+            if all(
+                not require_storage_cast(feature)
+                for feature in self.config.features.values()
+            ):
+                pa_table = pa_table.cast(schema)
+            else:
+                pa_table = table_cast(pa_table, schema)
+            return pa_table
+        return pa_table
+
+    def _open_file(self, filepath: str):
+        """Open file with automatic compression detection based on magic bytes.
+
+        Supports gzip, bzip2, and xz/lzma compression formats.
+        """
+        with open(filepath, "rb") as f:
+            magic = f.read(6)
+
+        if magic[:2] == b"\x1f\x8b":  # gzip magic number
+            return gzip.open(filepath, "rt", encoding="utf-8")
+        elif magic[:3] == b"BZh":  # bzip2 magic number
+            return bz2.open(filepath, "rt", encoding="utf-8")
+        elif magic[:6] == b"\xfd7zXZ\x00":  # xz magic number
+            return lzma.open(filepath, "rt", encoding="utf-8")
+        else:
+            return open(filepath, "r", encoding="utf-8")
+
+    def _parse_fastq(self, fp):
+        """Lightweight FASTQ parser based on Heng Li's readfq.py.
+
+        FASTQ format uses 4 lines per record:
+        1. Header line starting with '@' (sequence identifier and optional description)
+        2. Sequence line (nucleotide sequence)
+        3. '+' line (optionally followed by the same identifier)
+        4. Quality line (ASCII-encoded quality scores, same length as sequence)
+
+        Reference: https://github.com/lh3/readfq
+
+        Args:
+            fp: File-like object opened in text mode.
+
+        Yields:
+            Tuple of (seq_id, description, sequence, quality) for each FASTQ record.
+        """
+        while True:
+            # Read header line
+            header = fp.readline()
+            if not header:
+                break
+
+            # Skip empty lines or lines that don't start with @
+            if not header.startswith("@"):
+                continue
+
+            # Parse header: @id description
+            header = header[1:].rstrip()  # Remove '@' and trailing whitespace
+            parts = header.split(None, 1)  # Split on first whitespace
+            seq_id = parts[0] if parts else ""
+            description = parts[1] if len(parts) > 1 else ""
+
+            # Read sequence (may be multi-line)
+            seqs = []
+            while True:
+                line = fp.readline()
+                if not line:
+                    break
+                line = line.rstrip()
+                if line.startswith("+"):
+                    break
+                seqs.append(line)
+            sequence = "".join(seqs)
+
+            # Read quality scores (same number of characters as sequence)
+            quals = []
+            qual_len = 0
+            seq_len = len(sequence)
+            while qual_len < seq_len:
+                line = fp.readline()
+                if not line:
+                    break
+                line = line.rstrip()
+                quals.append(line)
+                qual_len += len(line)
+            quality = "".join(quals)
+
+            yield seq_id, description, sequence, quality
+
+    def _get_columns(self) -> list[str]:
+        """Get the list of columns to include in output."""
+        default_columns = ["id", "description", "sequence", "quality"]
+        if self.config.columns is not None:
+            # Validate columns
+            for col in self.config.columns:
+                if col not in default_columns:
+                    raise ValueError(
+                        f"Invalid column '{col}'. Valid columns are: {default_columns}"
+                    )
+            return self.config.columns
+        return default_columns
+
+    def _get_schema(self, columns: list[str]) -> pa.Schema:
+        """Return Arrow schema with large_string for sequence and quality columns.
+
+        Uses large_string for sequence and quality columns to handle very long reads
+        that can exceed the 2GB limit of regular string type.
+        """
+        fields = []
+        for col in columns:
+            if col in ("sequence", "quality"):
+                # Use large_string for sequences and quality that can be very long
+                fields.append(pa.field(col, pa.large_string()))
+            else:
+                fields.append(pa.field(col, pa.string()))
+        return pa.schema(fields)
+
+    def _generate_tables(self, files):
+        """Generate Arrow tables from FASTQ files.
+
+        Yields batches of records as Arrow tables for memory-efficient processing
+        of large sequencing files. Uses dual-threshold batching: flushes when either
+        batch_size (record count) or max_batch_bytes (cumulative size) is reached.
+
+        Args:
+            files: Iterable of file iterables from _split_generators.
+
+        Yields:
+            Tuple of (Key, pa.Table) for each batch.
+        """
+        columns = self._get_columns()
+        schema = self._get_schema(columns)
+        max_batch_bytes = self.config.max_batch_bytes
+
+        for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
+            batch_idx = 0
+            batch = {col: [] for col in columns}
+            batch_bytes = 0
+
+            with self._open_file(file) as fp:
+                for seq_id, description, sequence, quality in self._parse_fastq(fp):
+                    # Calculate record size (approximate UTF-8 byte size)
+                    record_bytes = len(seq_id) + len(description) + len(sequence) + len(quality)
+
+                    # Check if adding this record would exceed byte limit
+                    # Flush current batch first if needed (but only if batch is non-empty)
+                    if (
+                        max_batch_bytes is not None
+                        and batch_bytes > 0
+                        and batch_bytes + record_bytes > max_batch_bytes
+                    ):
+                        pa_table = pa.Table.from_pydict(batch, schema=schema)
+                        yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+                        batch = {col: [] for col in columns}
+                        batch_bytes = 0
+                        batch_idx += 1
+
+                    # Add record to batch
+                    if "id" in columns:
+                        batch["id"].append(seq_id)
+                    if "description" in columns:
+                        batch["description"].append(description)
+                    if "sequence" in columns:
+                        batch["sequence"].append(sequence)
+                    if "quality" in columns:
+                        batch["quality"].append(quality)
+                    batch_bytes += record_bytes
+
+                    # Yield batch when it reaches batch_size (record count limit)
+                    if len(batch[columns[0]]) >= self.config.batch_size:
+                        pa_table = pa.Table.from_pydict(batch, schema=schema)
+                        yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+                        batch = {col: [] for col in columns}
+                        batch_bytes = 0
+                        batch_idx += 1
+
+            # Yield remaining records in final batch
+            if batch[columns[0]]:
+                pa_table = pa.Table.from_pydict(batch, schema=schema)
+                yield Key(file_idx, batch_idx), self._cast_table(pa_table)

--- a/src/datasets/packaged_modules/fastq/fastq.py
+++ b/src/datasets/packaged_modules/fastq/fastq.py
@@ -49,6 +49,9 @@ class FastqConfig(datasets.BuilderConfig):
     max_batch_bytes: Optional[int] = DEFAULT_MAX_BATCH_BYTES
     columns: Optional[list[str]] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+
 
 class Fastq(datasets.ArrowBasedBuilder):
     """Dataset builder for FASTQ files."""
@@ -71,9 +74,7 @@ class Fastq(datasets.ArrowBasedBuilder):
         If dict, then keys should be from the `datasets.Split` enum.
         """
         if not self.config.data_files:
-            raise ValueError(
-                f"At least one data file must be specified, but got data_files={self.config.data_files}"
-            )
+            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
         dl_manager.download_config.extract_on_the_fly = True
         data_files = dl_manager.download_and_extract(self.config.data_files)
         splits = []
@@ -81,19 +82,14 @@ class Fastq(datasets.ArrowBasedBuilder):
             if isinstance(files, str):
                 files = [files]
             files = [dl_manager.iter_files(file) for file in files]
-            splits.append(
-                datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files})
-            )
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast Arrow table to configured features schema."""
         if self.config.features is not None:
             schema = self.config.features.arrow_schema
-            if all(
-                not require_storage_cast(feature)
-                for feature in self.config.features.values()
-            ):
+            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
                 pa_table = pa_table.cast(schema)
             else:
                 pa_table = table_cast(pa_table, schema)
@@ -184,9 +180,7 @@ class Fastq(datasets.ArrowBasedBuilder):
             # Validate columns
             for col in self.config.columns:
                 if col not in default_columns:
-                    raise ValueError(
-                        f"Invalid column '{col}'. Valid columns are: {default_columns}"
-                    )
+                    raise ValueError(f"Invalid column '{col}'. Valid columns are: {default_columns}")
             return self.config.columns
         return default_columns
 

--- a/src/datasets/packaged_modules/fastq/fastq.py
+++ b/src/datasets/packaged_modules/fastq/fastq.py
@@ -7,10 +7,7 @@ This implementation uses a lightweight pure Python parser based on Heng Li's rea
 requiring zero external dependencies.
 """
 
-import bz2
-import gzip
 import itertools
-import lzma
 from dataclasses import dataclass
 from typing import Optional
 
@@ -95,23 +92,6 @@ class Fastq(datasets.ArrowBasedBuilder):
                 pa_table = table_cast(pa_table, schema)
             return pa_table
         return pa_table
-
-    def _open_file(self, filepath: str):
-        """Open file with automatic compression detection based on magic bytes.
-
-        Supports gzip, bzip2, and xz/lzma compression formats.
-        """
-        with open(filepath, "rb") as f:
-            magic = f.read(6)
-
-        if magic[:2] == b"\x1f\x8b":  # gzip magic number
-            return gzip.open(filepath, "rt", encoding="utf-8")
-        elif magic[:3] == b"BZh":  # bzip2 magic number
-            return bz2.open(filepath, "rt", encoding="utf-8")
-        elif magic[:6] == b"\xfd7zXZ\x00":  # xz magic number
-            return lzma.open(filepath, "rt", encoding="utf-8")
-        else:
-            return open(filepath, "r", encoding="utf-8")
 
     def _parse_fastq(self, fp):
         """Lightweight FASTQ parser based on Heng Li's readfq.py.
@@ -221,7 +201,7 @@ class Fastq(datasets.ArrowBasedBuilder):
             batch = {col: [] for col in columns}
             batch_bytes = 0
 
-            with self._open_file(file) as fp:
+            with open(file, encoding="utf-8") as fp:
                 for seq_id, description, sequence, quality in self._parse_fastq(fp):
                     # Calculate record size (approximate UTF-8 byte size)
                     record_bytes = len(seq_id) + len(description) + len(sequence) + len(quality)

--- a/src/datasets/packaged_modules/fastq/fastq.py
+++ b/src/datasets/packaged_modules/fastq/fastq.py
@@ -59,7 +59,13 @@ class Fastq(datasets.ArrowBasedBuilder):
     EXTENSIONS: list[str] = [".fq", ".fastq"]
 
     def _info(self):
-        return datasets.DatasetInfo(features=self.config.features)
+        features = self.config.features
+        if features is not None and self.config.columns is not None:
+            missing = [col for col in self.config.columns if col not in features]
+            if missing:
+                raise ValueError(f"columns {missing} are not in features {list(features)}")
+            features = datasets.Features({col: features[col] for col in self.config.columns})
+        return datasets.DatasetInfo(features=features)
 
     def _split_generators(self, dl_manager):
         """Generate splits from data files.
@@ -84,9 +90,10 @@ class Fastq(datasets.ArrowBasedBuilder):
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast Arrow table to configured features schema."""
-        if self.config.features is not None:
-            schema = self.config.features.arrow_schema
-            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
+        features = self._info().features
+        if features is not None:
+            schema = features.arrow_schema
+            if all(not require_storage_cast(feature) for feature in features.values()):
                 pa_table = pa_table.cast(schema)
             else:
                 pa_table = table_cast(pa_table, schema)
@@ -136,6 +143,9 @@ class Fastq(datasets.ArrowBasedBuilder):
                 line = line.rstrip()
                 if line.startswith("+"):
                     separator_seen = True
+                    # The separator may repeat the header; if it does, it must agree with it.
+                    if len(line) > 1 and line[1:] != header:
+                        raise ValueError(f"FASTQ record '{seq_id}' has a '+' line naming '{line[1:]}'.")
                     break
                 seqs.append(line)
             sequence = "".join(seqs)
@@ -167,6 +177,8 @@ class Fastq(datasets.ArrowBasedBuilder):
         """Get the list of columns to include in output."""
         default_columns = ["id", "description", "sequence", "quality"]
         if self.config.columns is not None:
+            if not self.config.columns:
+                raise ValueError("columns must list at least one column when given.")
             # Validate columns
             for col in self.config.columns:
                 if col not in default_columns:

--- a/src/datasets/packaged_modules/fastq/fastq.py
+++ b/src/datasets/packaged_modules/fastq/fastq.py
@@ -128,15 +128,21 @@ class Fastq(datasets.ArrowBasedBuilder):
 
             # Read sequence (may be multi-line)
             seqs = []
+            separator_seen = False
             while True:
                 line = fp.readline()
                 if not line:
                     break
                 line = line.rstrip()
                 if line.startswith("+"):
+                    separator_seen = True
                     break
                 seqs.append(line)
             sequence = "".join(seqs)
+            if not separator_seen:
+                raise ValueError(
+                    f"FASTQ record '{seq_id}' has no '+' separator line; the file is truncated or not FASTQ."
+                )
 
             # Read quality scores (same number of characters as sequence)
             quals = []
@@ -150,6 +156,10 @@ class Fastq(datasets.ArrowBasedBuilder):
                 quals.append(line)
                 qual_len += len(line)
             quality = "".join(quals)
+            # The format requires one quality character per base; a mismatch means the
+            # file is truncated or corrupt, and yielding it would misalign the columns.
+            if len(quality) != seq_len:
+                raise ValueError(f"FASTQ record '{seq_id}' has {len(quality)} quality characters for {seq_len} bases.")
 
             yield seq_id, description, sequence, quality
 

--- a/src/datasets/packaged_modules/fastq/fastq.py
+++ b/src/datasets/packaged_modules/fastq/fastq.py
@@ -3,12 +3,15 @@
 FASTQ is a text-based format for storing nucleotide sequences together with
 their quality scores, widely used for high-throughput sequencing data.
 
-This implementation uses a lightweight pure Python parser based on Heng Li's readfq.py,
-requiring zero external dependencies.
+This implementation uses a lightweight pure Python parser based on Heng Li's readfq.py.
+The parsed columns need no external dependency; the ``record`` column holds each
+record's raw bytes as a ``BioSequence`` and decodes to a Biopython ``SeqRecord``
+when biopython is installed (drop it with ``columns`` to stay dependency-free).
 """
 
 import itertools
 from dataclasses import dataclass
+from io import TextIOWrapper
 from typing import Optional
 
 import pyarrow as pa
@@ -38,7 +41,7 @@ class FastqConfig(datasets.BuilderConfig):
         max_batch_bytes: Maximum cumulative bytes per batch. This prevents Parquet
             page size errors when dealing with very large sequences. Set to None
             to disable byte-based batching.
-        columns: Subset of columns to include. Options: ["id", "description", "sequence", "quality"].
+        columns: Subset of columns to include. Options: ["id", "description", "sequence", "quality", "record"].
     """
 
     features: Optional[datasets.Features] = None
@@ -58,8 +61,19 @@ class Fastq(datasets.ArrowBasedBuilder):
     # All supported FASTQ extensions
     EXTENSIONS: list[str] = [".fq", ".fastq"]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # DatasetBuilder applies features= after _info(); project the effective
+        # schema again, preserving features supplied through info= as well.
+        self.info.features = self._info().features
+
     def _info(self):
-        features = self.config.features
+        features = self.info.features if hasattr(self, "info") else self.config.features
+        columns = self._get_columns()
+        if features is None:
+            features = datasets.Features.from_arrow_schema(self._get_schema(columns))
+            if "record" in features:
+                features["record"] = datasets.BioSequence(format="fastq")
         if features is not None and self.config.columns is not None:
             missing = [col for col in self.config.columns if col not in features]
             if missing:
@@ -90,7 +104,7 @@ class Fastq(datasets.ArrowBasedBuilder):
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast Arrow table to configured features schema."""
-        features = self._info().features
+        features = self.info.features
         if features is not None:
             schema = features.arrow_schema
             if all(not require_storage_cast(feature) for feature in features.values()):
@@ -100,7 +114,7 @@ class Fastq(datasets.ArrowBasedBuilder):
             return pa_table
         return pa_table
 
-    def _parse_fastq(self, fp):
+    def _parse_fastq(self, fp, include_record=False):
         """Lightweight FASTQ parser based on Heng Li's readfq.py.
 
         FASTQ format uses 4 lines per record:
@@ -113,9 +127,12 @@ class Fastq(datasets.ArrowBasedBuilder):
 
         Args:
             fp: File-like object opened in text mode.
+            include_record: Append the original UTF-8 record bytes to each tuple.
+                The file must be opened with newline="" to preserve line endings.
 
         Yields:
             Tuple of (seq_id, description, sequence, quality) for each FASTQ record.
+            When include_record=True, a fifth item contains the record's bytes as read.
         """
         while True:
             # Read header line
@@ -128,6 +145,7 @@ class Fastq(datasets.ArrowBasedBuilder):
                 continue
 
             # Parse header: @id description
+            record_lines = [header] if include_record else None
             header = header[1:].rstrip()  # Remove '@' and trailing whitespace
             parts = header.split(None, 1)  # Split on first whitespace
             seq_id = parts[0] if parts else ""
@@ -140,6 +158,8 @@ class Fastq(datasets.ArrowBasedBuilder):
                 line = fp.readline()
                 if not line:
                     break
+                if include_record:
+                    record_lines.append(line)
                 line = line.rstrip()
                 if line.startswith("+"):
                     separator_seen = True
@@ -158,10 +178,13 @@ class Fastq(datasets.ArrowBasedBuilder):
             quals = []
             qual_len = 0
             seq_len = len(sequence)
-            while qual_len < seq_len:
+            # Even an empty sequence has a quality line that belongs to the raw record.
+            while qual_len < seq_len or not quals:
                 line = fp.readline()
                 if not line:
                     break
+                if include_record:
+                    record_lines.append(line)
                 line = line.rstrip()
                 quals.append(line)
                 qual_len += len(line)
@@ -171,18 +194,33 @@ class Fastq(datasets.ArrowBasedBuilder):
             if len(quality) != seq_len:
                 raise ValueError(f"FASTQ record '{seq_id}' has {len(quality)} quality characters for {seq_len} bases.")
 
-            yield seq_id, description, sequence, quality
+            record = (seq_id, description, sequence, quality)
+            if include_record:
+                record += ("".join(record_lines).encode("utf-8"),)
+            yield record
 
     def _get_columns(self) -> list[str]:
         """Get the list of columns to include in output."""
-        default_columns = ["id", "description", "sequence", "quality"]
+        default_columns = ["id", "description", "sequence", "quality", "record"]
+        features = self.info.features if hasattr(self, "info") else self.config.features
+        if self.config.columns is None and features is not None:
+            # A user-supplied schema selects its own columns, so a schema naming a
+            # subset stays valid when the default schema grows.
+            unknown = [col for col in features if col not in default_columns]
+            if unknown:
+                raise ValueError(f"Invalid feature column(s) {unknown}. Valid columns are: {default_columns}")
+            return list(features)
         if self.config.columns is not None:
             if not self.config.columns:
                 raise ValueError("columns must list at least one column when given.")
             # Validate columns
+            seen = set()
             for col in self.config.columns:
                 if col not in default_columns:
                     raise ValueError(f"Invalid column '{col}'. Valid columns are: {default_columns}")
+                if col in seen:
+                    raise ValueError(f"Duplicate column '{col}' in columns.")
+                seen.add(col)
             return self.config.columns
         return default_columns
 
@@ -197,6 +235,8 @@ class Fastq(datasets.ArrowBasedBuilder):
             if col in ("sequence", "quality"):
                 # Use large_string for sequences and quality that can be very long
                 fields.append(pa.field(col, pa.large_string()))
+            elif col == "record":
+                fields.append(pa.field(col, datasets.BioSequence().pa_type))
             else:
                 fields.append(pa.field(col, pa.string()))
         return pa.schema(fields)
@@ -215,6 +255,7 @@ class Fastq(datasets.ArrowBasedBuilder):
             Tuple of (Key, pa.Table) for each batch.
         """
         columns = self._get_columns()
+        include_record = "record" in columns
         schema = self._get_schema(columns)
         max_batch_bytes = self.config.max_batch_bytes
 
@@ -223,10 +264,14 @@ class Fastq(datasets.ArrowBasedBuilder):
             batch = {col: [] for col in columns}
             batch_bytes = 0
 
-            with open(file, encoding="utf-8") as fp:
-                for seq_id, description, sequence, quality in self._parse_fastq(fp):
+            # Keep the streaming-patched open for compressed inputs, and preserve line endings.
+            with open(file, "rb") as f, TextIOWrapper(f, encoding="utf-8", newline="") as fp:
+                for record in self._parse_fastq(fp, include_record=include_record):
+                    seq_id, description, sequence, quality = record[:4]
                     # Calculate record size (approximate UTF-8 byte size)
                     record_bytes = len(seq_id) + len(description) + len(sequence) + len(quality)
+                    if include_record:
+                        record_bytes += len(record[4])
 
                     # Check if adding this record would exceed byte limit
                     # Flush current batch first if needed (but only if batch is non-empty)
@@ -250,6 +295,8 @@ class Fastq(datasets.ArrowBasedBuilder):
                         batch["sequence"].append(sequence)
                     if "quality" in columns:
                         batch["quality"].append(quality)
+                    if include_record:
+                        batch["record"].append({"bytes": record[4], "path": None})
                     batch_bytes += record_bytes
 
                     # Yield batch when it reaches batch_size (record count limit)

--- a/tests/packaged_modules/test_fastq.py
+++ b/tests/packaged_modules/test_fastq.py
@@ -1,0 +1,385 @@
+"""Tests for FASTQ file loader."""
+
+import gzip
+import textwrap
+
+import pyarrow as pa
+import pytest
+
+from datasets import Features, Value
+from datasets.builder import InvalidConfigName
+from datasets.data_files import DataFilesList
+from datasets.packaged_modules.fastq.fastq import Fastq, FastqConfig
+
+
+@pytest.fixture
+def fastq_file(tmp_path):
+    """Create a simple FASTQ file with multiple records."""
+    filename = tmp_path / "reads.fq"
+    data = textwrap.dedent(
+        """\
+        @SEQ_ID_1 description 1
+        GATCGATCGATCGATC
+        +
+        IIIIIIIIIIIIIIII
+        @SEQ_ID_2 description 2
+        ATCGATCGATCGATCG
+        +
+        HHHHHHHHHHHHHHHH
+        @SEQ_ID_3
+        TCGATCGATCGATCGA
+        +
+        GGGGGGGGGGGGGGGG
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def fastq_file_multiline(tmp_path):
+    """Create a FASTQ file with multi-line sequences and quality scores."""
+    filename = tmp_path / "reads_multiline.fastq"
+    data = textwrap.dedent(
+        """\
+        @SEQ_ID_1 multi-line sequence
+        GATCGATCGATCGATC
+        ATCGATCGATCGATCG
+        +
+        IIIIIIIIIIIIIIII
+        HHHHHHHHHHHHHHHH
+        @SEQ_ID_2
+        AAAA
+        TTTT
+        GGGG
+        CCCC
+        +
+        !!!!
+        ####
+        $$$$
+        %%%%
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def fastq_file_gzipped(tmp_path):
+    """Create a gzipped FASTQ file."""
+    filename = tmp_path / "reads.fq.gz"
+    data = textwrap.dedent(
+        """\
+        @SEQ_ID_1 gzipped read
+        GATCGATCGATCGATC
+        +
+        IIIIIIIIIIIIIIII
+        @SEQ_ID_2
+        ATCGATCGATCGATCG
+        +
+        HHHHHHHHHHHHHHHH
+        """
+    )
+    with gzip.open(filename, "wt", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def fastq_file_large_sequences(tmp_path):
+    """Create a FASTQ file with large sequences to test batching."""
+    filename = tmp_path / "large_reads.fq"
+    # Create sequences of varying sizes
+    sequences = []
+    for i in range(5):
+        seq_len = 1000 * (i + 1)  # 1K, 2K, 3K, 4K, 5K bases
+        seq = "ACGT" * (seq_len // 4)
+        qual = "I" * seq_len
+        sequences.append(f"@SEQ_{i} large sequence {i}\n{seq}\n+\n{qual}\n")
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("".join(sequences))
+    return str(filename)
+
+
+def test_config_raises_when_invalid_name() -> None:
+    with pytest.raises(InvalidConfigName, match="Bad characters"):
+        _ = FastqConfig(name="name-with-*-invalid-character")
+
+
+@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+def test_config_raises_when_invalid_data_files(data_files) -> None:
+    with pytest.raises(ValueError, match="Expected a DataFilesDict"):
+        _ = FastqConfig(name="name", data_files=data_files)
+
+
+def test_fastq_basic_loading(fastq_file):
+    """Test basic FASTQ file loading."""
+    fastq = Fastq()
+    generator = fastq._generate_tables([[fastq_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["id"]) == 3
+    assert result["id"] == ["SEQ_ID_1", "SEQ_ID_2", "SEQ_ID_3"]
+    assert result["description"] == ["description 1", "description 2", ""]
+    assert result["sequence"] == ["GATCGATCGATCGATC", "ATCGATCGATCGATCG", "TCGATCGATCGATCGA"]
+    assert result["quality"] == ["IIIIIIIIIIIIIIII", "HHHHHHHHHHHHHHHH", "GGGGGGGGGGGGGGGG"]
+
+
+def test_fastq_multiline_sequences(fastq_file_multiline):
+    """Test FASTQ with multi-line sequences and quality scores."""
+    fastq = Fastq()
+    generator = fastq._generate_tables([[fastq_file_multiline]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["id"]) == 2
+    assert result["id"] == ["SEQ_ID_1", "SEQ_ID_2"]
+    # Multi-line sequences should be concatenated
+    assert result["sequence"][0] == "GATCGATCGATCGATCATCGATCGATCGATCG"
+    assert result["quality"][0] == "IIIIIIIIIIIIIIIIHHHHHHHHHHHHHHHH"
+    assert result["sequence"][1] == "AAAATTTTGGGGCCCC"
+    assert result["quality"][1] == "!!!!####$$$$%%%%"
+
+
+def test_fastq_gzipped(fastq_file_gzipped):
+    """Test loading gzipped FASTQ files."""
+    fastq = Fastq()
+    generator = fastq._generate_tables([[fastq_file_gzipped]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["id"]) == 2
+    assert result["id"] == ["SEQ_ID_1", "SEQ_ID_2"]
+    assert result["description"][0] == "gzipped read"
+
+
+def test_fastq_column_filtering(fastq_file):
+    """Test loading with column subset."""
+    fastq = Fastq(columns=["sequence", "quality"])
+    generator = fastq._generate_tables([[fastq_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    # Should only have sequence and quality columns
+    assert list(result.keys()) == ["sequence", "quality"]
+    assert len(result["sequence"]) == 3
+    assert len(result["quality"]) == 3
+
+
+def test_fastq_column_filtering_single(fastq_file):
+    """Test loading with single column."""
+    fastq = Fastq(columns=["sequence"])
+    generator = fastq._generate_tables([[fastq_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert list(result.keys()) == ["sequence"]
+    assert len(result["sequence"]) == 3
+
+
+def test_fastq_invalid_column():
+    """Test that invalid column names raise an error."""
+    fastq = Fastq(columns=["sequence", "invalid_column"])
+    with pytest.raises(ValueError, match="Invalid column 'invalid_column'"):
+        list(fastq._generate_tables([[]]))
+
+
+def test_fastq_batch_size(fastq_file):
+    """Test batch size configuration."""
+    # Use batch_size=1 to create multiple batches
+    fastq = Fastq(batch_size=1)
+    generator = fastq._generate_tables([[fastq_file]])
+    tables = [table for _, table in generator]
+
+    # Should have 3 batches (one per record)
+    assert len(tables) == 3
+
+    # Each batch should have 1 record
+    for table in tables:
+        assert table.num_rows == 1
+
+
+def test_fastq_batch_size_multiple(fastq_file):
+    """Test batch size with multiple records per batch."""
+    fastq = Fastq(batch_size=2)
+    generator = fastq._generate_tables([[fastq_file]])
+    tables = [table for _, table in generator]
+
+    # Should have 2 batches (2 records, then 1 record)
+    assert len(tables) == 2
+    assert tables[0].num_rows == 2
+    assert tables[1].num_rows == 1
+
+
+def test_fastq_max_batch_bytes(fastq_file_large_sequences):
+    """Test byte-based batching with max_batch_bytes."""
+    # Set a small byte limit to force multiple batches
+    fastq = Fastq(batch_size=1000, max_batch_bytes=5000)
+    generator = fastq._generate_tables([[fastq_file_large_sequences]])
+    tables = [table for _, table in generator]
+
+    # Should create multiple batches due to byte limit
+    assert len(tables) > 1
+
+
+def test_fastq_no_byte_limit(fastq_file_large_sequences):
+    """Test disabling byte-based batching."""
+    fastq = Fastq(batch_size=1000, max_batch_bytes=None)
+    generator = fastq._generate_tables([[fastq_file_large_sequences]])
+    tables = [table for _, table in generator]
+
+    # Should create single batch since batch_size is high
+    assert len(tables) == 1
+    assert tables[0].num_rows == 5
+
+
+def test_fastq_schema_types(fastq_file):
+    """Test that schema uses correct Arrow types."""
+    fastq = Fastq()
+    generator = fastq._generate_tables([[fastq_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    schema = pa_table.schema
+
+    # id and description should be string
+    assert schema.field("id").type == pa.string()
+    assert schema.field("description").type == pa.string()
+    # sequence and quality should be large_string for long reads
+    assert schema.field("sequence").type == pa.large_string()
+    assert schema.field("quality").type == pa.large_string()
+
+
+def test_fastq_feature_casting(fastq_file):
+    """Test feature casting to custom schema."""
+    features = Features({
+        "id": Value("string"),
+        "description": Value("string"),
+        "sequence": Value("large_string"),
+        "quality": Value("large_string"),
+    })
+    fastq = Fastq(features=features)
+    generator = fastq._generate_tables([[fastq_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    assert pa_table.schema.field("id").type == pa.string()
+    assert pa_table.schema.field("sequence").type == pa.large_string()
+
+
+def test_fastq_empty_file(tmp_path):
+    """Test handling of empty FASTQ file."""
+    filename = tmp_path / "empty.fq"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("")
+
+    fastq = Fastq()
+    generator = fastq._generate_tables([[str(filename)]])
+    tables = list(generator)
+
+    # Empty file should produce no tables
+    assert len(tables) == 0
+
+
+def test_fastq_empty_lines(tmp_path):
+    """Test FASTQ file with empty lines between records."""
+    filename = tmp_path / "empty_lines.fq"
+    data = textwrap.dedent(
+        """\
+
+        @SEQ_ID_1
+        GATCGATC
+        +
+
+        IIIIIIII
+
+        @SEQ_ID_2
+        ATCGATCG
+        +
+        HHHHHHHH
+
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+
+    fastq = Fastq()
+    generator = fastq._generate_tables([[str(filename)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    # Parser should handle empty lines gracefully
+    assert len(result["id"]) == 2
+
+
+def test_fastq_special_characters_in_header(tmp_path):
+    """Test FASTQ with special characters in header."""
+    filename = tmp_path / "special.fq"
+    data = textwrap.dedent(
+        """\
+        @SEQ:ID:1:2:3 length=16 organism="E. coli"
+        GATCGATCGATCGATC
+        +
+        IIIIIIIIIIIIIIII
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+
+    fastq = Fastq()
+    generator = fastq._generate_tables([[str(filename)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert result["id"][0] == "SEQ:ID:1:2:3"
+    assert result["description"][0] == 'length=16 organism="E. coli"'
+
+
+def test_fastq_quality_length_matches_sequence(fastq_file):
+    """Test that quality scores match sequence length."""
+    fastq = Fastq()
+    generator = fastq._generate_tables([[fastq_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    for seq, qual in zip(result["sequence"], result["quality"]):
+        assert len(seq) == len(qual), f"Sequence length {len(seq)} != quality length {len(qual)}"
+
+
+def test_fastq_multiple_files(tmp_path):
+    """Test loading multiple FASTQ files."""
+    # Create two files
+    file1 = tmp_path / "reads1.fq"
+    file2 = tmp_path / "reads2.fq"
+
+    with open(file1, "w", encoding="utf-8") as f:
+        f.write("@SEQ1\nACGT\n+\nIIII\n")
+
+    with open(file2, "w", encoding="utf-8") as f:
+        f.write("@SEQ2\nTGCA\n+\nHHHH\n")
+
+    fastq = Fastq()
+    generator = fastq._generate_tables([[str(file1)], [str(file2)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["id"]) == 2
+    assert "SEQ1" in result["id"]
+    assert "SEQ2" in result["id"]
+
+
+def test_fastq_extensions():
+    """Test that correct extensions are defined."""
+    assert ".fq" in Fastq.EXTENSIONS
+    assert ".fastq" in Fastq.EXTENSIONS

--- a/tests/packaged_modules/test_fastq.py
+++ b/tests/packaged_modules/test_fastq.py
@@ -260,12 +260,14 @@ def test_fastq_schema_types(fastq_file):
 
 def test_fastq_feature_casting(fastq_file):
     """Test feature casting to custom schema."""
-    features = Features({
-        "id": Value("string"),
-        "description": Value("string"),
-        "sequence": Value("large_string"),
-        "quality": Value("large_string"),
-    })
+    features = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+            "quality": Value("large_string"),
+        }
+    )
     fastq = Fastq(features=features)
     generator = fastq._generate_tables([[fastq_file]])
     pa_table = pa.concat_tables([table for _, table in generator])

--- a/tests/packaged_modules/test_fastq.py
+++ b/tests/packaged_modules/test_fastq.py
@@ -401,3 +401,21 @@ def test_fastq_extensions():
     """Test that correct extensions are defined."""
     assert ".fq" in Fastq.EXTENSIONS
     assert ".fastq" in Fastq.EXTENSIONS
+
+
+@pytest.mark.parametrize(
+    "text, reason",
+    [
+        ("@r1\nACGT\n+\n!!\n", "quality shorter than sequence"),
+        ("@r1\nACGT\n+\n!!!!!!\n@r2\nA\n+\n!\n", "quality longer than sequence"),
+        ("@r1\nACGT\nACGT\n", "no '+' separator before end of file"),
+    ],
+)
+def test_fastq_parser_rejects_corrupt_record(text, reason):
+    """A FASTQ record whose quality length differs from its sequence length is corrupt
+    (typically a truncated download). It must raise rather than be yielded with
+    mismatched columns."""
+    import io
+
+    with pytest.raises(ValueError, match="r1"):
+        list(Fastq()._parse_fastq(io.StringIO(text)))

--- a/tests/packaged_modules/test_fastq.py
+++ b/tests/packaged_modules/test_fastq.py
@@ -1,6 +1,7 @@
 """Tests for FASTQ file loader."""
 
 import gzip
+import os
 import textwrap
 
 import pyarrow as pa
@@ -9,7 +10,22 @@ import pytest
 from datasets import Features, Value
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
+from datasets.download.streaming_download_manager import _get_extraction_protocol
 from datasets.packaged_modules.fastq.fastq import Fastq, FastqConfig
+
+
+def _compression_uri(path):
+    """Build the chained fsspec URI datasets uses to read a single compressed file.
+
+    The builder opens files with the streaming-patched ``open()`` (``xopen``), which
+    handles compression via ``<protocol>://<inner>::<outer>`` URIs rather than by
+    sniffing magic bytes. The protocol is derived from datasets' own extraction logic
+    so the test tracks the loader's real behavior. ``inner`` is the decompressed name.
+    """
+    path = str(path)
+    protocol = _get_extraction_protocol(path)
+    inner = os.path.basename(path).rsplit(".", 1)[0]
+    return f"{protocol}://{inner}::{path}"
 
 
 @pytest.fixture
@@ -84,7 +100,7 @@ def fastq_file_gzipped(tmp_path):
     )
     with gzip.open(filename, "wt", encoding="utf-8") as f:
         f.write(data)
-    return str(filename)
+    return _compression_uri(filename)
 
 
 @pytest.fixture

--- a/tests/packaged_modules/test_fastq.py
+++ b/tests/packaged_modules/test_fastq.py
@@ -419,3 +419,28 @@ def test_fastq_parser_rejects_corrupt_record(text, reason):
 
     with pytest.raises(ValueError, match="r1"):
         list(Fastq()._parse_fastq(io.StringIO(text)))
+
+
+def test_fastq_parser_rejects_mismatched_separator_id():
+    """When the '+' line repeats an identifier it must match the header's identifier."""
+    import io
+
+    with pytest.raises(ValueError, match="r2"):
+        list(Fastq()._parse_fastq(io.StringIO("@r1\nAC\n+r2\n!!\n")))
+    assert list(Fastq()._parse_fastq(io.StringIO("@r1 d\nAC\n+r1 d\n!!\n"))) == [("r1", "d", "AC", "!!")]
+
+
+def test_fastq_empty_columns_is_rejected():
+    with pytest.raises(ValueError, match="at least one column"):
+        Fastq(columns=[])._get_columns()
+
+
+def test_fastq_columns_project_custom_features(tmp_path):
+    """columns= applies to a user-supplied features schema too."""
+    filename = tmp_path / "proj.fq"
+    filename.write_text("@r\nAC\n+\n!!\n", encoding="utf-8")
+    features = Features({col: Value("string") for col in ["id", "description", "sequence", "quality"]})
+    table = next(iter(Fastq(columns=["sequence"], features=features)._generate_tables([[str(filename)]])))[1]
+    assert table.column_names == ["sequence"]
+    with pytest.raises(ValueError, match="not in features"):
+        Fastq(columns=["sequence"], features=Features({"id": Value("string")}))._info()

--- a/tests/packaged_modules/test_fastq.py
+++ b/tests/packaged_modules/test_fastq.py
@@ -7,11 +7,16 @@ import textwrap
 import pyarrow as pa
 import pytest
 
-from datasets import Features, Value
+from datasets import BioSequence, DatasetInfo, Features, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.download.streaming_download_manager import _get_extraction_protocol
 from datasets.packaged_modules.fastq.fastq import Fastq, FastqConfig
+
+
+require_biopython = pytest.mark.skipif(
+    not __import__("datasets").config.BIOPYTHON_AVAILABLE, reason="biopython is not installed"
+)
 
 
 def _compression_uri(path):
@@ -48,7 +53,7 @@ def fastq_file(tmp_path):
         GGGGGGGGGGGGGGGG
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
     return str(filename)
 
@@ -77,7 +82,7 @@ def fastq_file_multiline(tmp_path):
         %%%%
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
     return str(filename)
 
@@ -98,7 +103,7 @@ def fastq_file_gzipped(tmp_path):
         HHHHHHHHHHHHHHHH
         """
     )
-    with gzip.open(filename, "wt", encoding="utf-8") as f:
+    with gzip.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(data)
     return _compression_uri(filename)
 
@@ -115,7 +120,7 @@ def fastq_file_large_sequences(tmp_path):
         qual = "I" * seq_len
         sequences.append(f"@SEQ_{i} large sequence {i}\n{seq}\n+\n{qual}\n")
 
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write("".join(sequences))
     return str(filename)
 
@@ -204,9 +209,8 @@ def test_fastq_column_filtering_single(fastq_file):
 
 def test_fastq_invalid_column():
     """Test that invalid column names raise an error."""
-    fastq = Fastq(columns=["sequence", "invalid_column"])
     with pytest.raises(ValueError, match="Invalid column 'invalid_column'"):
-        list(fastq._generate_tables([[]]))
+        Fastq(columns=["sequence", "invalid_column"])
 
 
 def test_fastq_batch_size(fastq_file):
@@ -295,7 +299,7 @@ def test_fastq_feature_casting(fastq_file):
 def test_fastq_empty_file(tmp_path):
     """Test handling of empty FASTQ file."""
     filename = tmp_path / "empty.fq"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write("")
 
     fastq = Fastq()
@@ -325,7 +329,7 @@ def test_fastq_empty_lines(tmp_path):
 
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
 
     fastq = Fastq()
@@ -349,7 +353,7 @@ def test_fastq_special_characters_in_header(tmp_path):
         IIIIIIIIIIIIIIII
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
 
     fastq = Fastq()
@@ -380,10 +384,10 @@ def test_fastq_multiple_files(tmp_path):
     file1 = tmp_path / "reads1.fq"
     file2 = tmp_path / "reads2.fq"
 
-    with open(file1, "w", encoding="utf-8") as f:
+    with open(file1, "w", encoding="utf-8", newline="") as f:
         f.write("@SEQ1\nACGT\n+\nIIII\n")
 
-    with open(file2, "w", encoding="utf-8") as f:
+    with open(file2, "w", encoding="utf-8", newline="") as f:
         f.write("@SEQ2\nTGCA\n+\nHHHH\n")
 
     fastq = Fastq()
@@ -435,12 +439,162 @@ def test_fastq_empty_columns_is_rejected():
         Fastq(columns=[])._get_columns()
 
 
+@pytest.mark.parametrize("features", [None, Features({"id": Value("string")})])
+def test_fastq_duplicate_columns_is_rejected(features):
+    with pytest.raises(ValueError, match="Duplicate column 'id'"):
+        Fastq(columns=["id", "id"], features=features)
+
+
 def test_fastq_columns_project_custom_features(tmp_path):
     """columns= applies to a user-supplied features schema too."""
     filename = tmp_path / "proj.fq"
-    filename.write_text("@r\nAC\n+\n!!\n", encoding="utf-8")
+    filename.write_bytes(b"@r\nAC\n+\n!!\n")
     features = Features({col: Value("string") for col in ["id", "description", "sequence", "quality"]})
-    table = next(iter(Fastq(columns=["sequence"], features=features)._generate_tables([[str(filename)]])))[1]
+    fastq = Fastq(columns=["sequence"], features=features)
+    assert fastq.info.features == Features({"sequence": Value("string")})
+    table = next(iter(fastq._generate_tables([[str(filename)]])))[1]
     assert table.column_names == ["sequence"]
+    assert Features.from_arrow_schema(table.schema) == fastq.info.features
     with pytest.raises(ValueError, match="not in features"):
         Fastq(columns=["sequence"], features=Features({"id": Value("string")}))._info()
+
+
+@pytest.mark.parametrize("columns", [None, ["record"]])
+def test_fastq_preserves_supplied_info_features(fastq_file, columns):
+    features = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+            "quality": Value("large_string"),
+            "record": BioSequence(format="fastq", decode=False),
+        }
+    )
+    fastq = Fastq(info=DatasetInfo(features=features, description="custom info"), columns=columns)
+    expected = features if columns is None else Features({"record": features["record"]})
+    assert fastq.info.features == expected
+    assert fastq.info.description == "custom info"
+    _, table = next(fastq._generate_tables([[fastq_file]]))
+    assert Features.from_arrow_schema(table.schema) == expected
+
+
+def test_fastq_record_features(fastq_file):
+    fastq = Fastq()
+    expected = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+            "quality": Value("large_string"),
+            "record": BioSequence(format="fastq"),
+        }
+    )
+    assert fastq.info.features == expected
+    _, table = next(fastq._generate_tables([[fastq_file]]))
+    assert table.schema.field("record").type == BioSequence().pa_type
+    assert Features.from_arrow_schema(table.schema) == expected
+
+
+@require_biopython
+@pytest.mark.parametrize("streaming", [False, True])
+def test_fastq_record_decoding(fastq_file, streaming):
+    from Bio.SeqRecord import SeqRecord
+
+    dataset = load_dataset("fastq", data_files=fastq_file, split="train", streaming=streaming)
+    assert dataset.features["record"] == BioSequence(format="fastq")
+    rows = list(dataset)
+    assert len(rows) == 3
+    for row in rows:
+        assert isinstance(row["record"], SeqRecord)
+        assert row["record"].id == row["id"]
+        assert str(row["record"].seq) == row["sequence"]
+        assert row["record"].letter_annotations["phred_quality"] == [ord(char) - 33 for char in row["quality"]]
+
+
+@pytest.mark.parametrize("fixture_name", ["fastq_file", "fastq_file_multiline", "fastq_file_gzipped"])
+def test_fastq_record_bytes(fixture_name, request):
+    filename = request.getfixturevalue(fixture_name)
+    tables = list(Fastq(batch_size=1)._generate_tables([[filename]]))
+    records = [table.to_pydict()["record"][0] for _, table in tables]
+    opener = gzip.open if "::" in filename else open
+    with opener(filename.split("::")[-1], "rb") as f:
+        expected = [b"@" + record for record in f.read().split(b"@")[1:]]
+    assert records == [{"bytes": record, "path": None} for record in expected]
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"])
+@pytest.mark.parametrize("compressed", [False, True])
+def test_fastq_record_preserves_raw_lines(tmp_path, newline, compressed):
+    # Preserve header whitespace, UTF-8, blank lines, wrapping and the '+' line.
+    first = b"@a caf\xc3\xa9 \t\nAC\n\nGT  \n+a caf\xc3\xa9 \t\nII\n\n@@\n".replace(b"\n", newline)
+    second = b"@b\nTT\nAA\n+\n++\nII".replace(b"\n", newline)
+    content = newline + first + newline + second
+    filename = tmp_path / ("raw.fq.gz" if compressed else "raw.fq")
+    filename.write_bytes(gzip.compress(content) if compressed else content)
+    path = _compression_uri(filename) if compressed else str(filename)
+    _, table = next(Fastq(columns=["record"])._generate_tables([[path]]))
+    assert table.to_pydict() == {"record": [{"bytes": first, "path": None}, {"bytes": second, "path": None}]}
+
+
+def test_fastq_record_cast_decode_false(fastq_file, monkeypatch):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    dataset = load_dataset("fastq", data_files=fastq_file, split="train")
+    dataset = dataset.cast_column("record", BioSequence(decode=False))
+    with open(fastq_file, "rb") as f:
+        expected = [b"@" + record for record in f.read().split(b"@")[1:]]
+    assert dataset["record"] == [{"bytes": record, "path": None} for record in expected]
+
+
+def test_fastq_record_preserves_empty_quality_line(tmp_path):
+    first = b"@empty\n\n+\n\n"
+    second = b"@next\nA\n+\nI\n"
+    filename = tmp_path / "empty_read.fq"
+    filename.write_bytes(first + second)
+    _, table = next(Fastq()._generate_tables([[str(filename)]]))
+    expected = [b"@" + record for record in filename.read_bytes().split(b"@")[1:]]
+    assert table.to_pydict()["record"] == [{"bytes": record, "path": None} for record in expected]
+
+
+def test_fastq_columns_drop_record_without_biopython(fastq_file, monkeypatch):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    dataset = load_dataset("fastq", data_files=fastq_file, split="train", columns=["id", "sequence"])
+    assert dataset.features == Features({"id": Value("string"), "sequence": Value("large_string")})
+    assert len(list(dataset)) == 3
+    assert dataset.column_names == ["id", "sequence"]
+
+
+def test_fastq_record_column_validation():
+    with pytest.raises(ValueError, match="Invalid column.*Valid columns are:.*record"):
+        Fastq(columns=["invalid_column"])._get_columns()
+    with pytest.raises(ValueError, match="columns.*record.*not in features"):
+        Fastq(columns=["record"], features=Features({"id": Value("string")}))
+
+
+def test_fastq_record_bytes_count_toward_batch_limit(tmp_path):
+    filename = tmp_path / "batch.fq"
+    # Parsed fields fit in one batch; their raw records push the total over the limit.
+    filename.write_bytes(b"@a\nACGT\n+\nIIII\n@b\nTGCA\n+\nHHHH\n")
+    tables = list(Fastq(max_batch_bytes=30)._generate_tables([[str(filename)]]))
+    assert [table.num_rows for _, table in tables] == [1, 1]
+    tables = list(Fastq(columns=["id", "sequence"], max_batch_bytes=30)._generate_tables([[str(filename)]]))
+    assert [table.num_rows for _, table in tables] == [2]
+
+
+def test_fastq_explicit_features_without_record(fastq_file):
+    """A user-supplied schema selects its own columns, so pinning the four parsed columns still works."""
+    features = Features(
+        {
+            "id": Value("string"),
+            "description": Value("string"),
+            "sequence": Value("large_string"),
+            "quality": Value("large_string"),
+        }
+    )
+    fastq = Fastq(features=features)
+    assert fastq._get_columns() == ["id", "description", "sequence", "quality"]
+    assert fastq.info.features == features
+    generator = fastq._generate_tables([[fastq_file]])
+    table = pa.concat_tables([table for _, table in generator])
+    assert table.column_names == ["id", "description", "sequence", "quality"]
+    with pytest.raises(ValueError, match="Invalid feature column"):
+        Fastq(features=Features({"id": Value("string"), "invalid_column": Value("string")}))


### PR DESCRIPTION
## Summary

This PR adds support for loading FASTQ files directly with `load_dataset()`.

FASTQ is an extension of FASTA that includes quality scores for each base, widely used for storing output from high-throughput sequencing instruments.

### Key Features
- **Zero external dependencies** - Pure Python parser based on [readfq.py](https://github.com/lh3/readfq) by Heng Li
- **Quality score support** - Preserves per-base quality scores as ASCII-encoded strings
- **Streaming support** - Generator-based parsing for memory efficiency with large NGS files
- **Compression support** - Automatic detection of gzip, bzip2, and xz compressed files
- **Large sequence support** - Uses `large_string` for both sequence and quality columns
- **Parquet-safe batching** - Dual-threshold batching (batch_size + max_batch_bytes) prevents page size errors

### Columns
| Column | Type | Description |
|--------|------|-------------|
| `id` | string | Sequence identifier (first word after `@`) |
| `description` | string | Full description line (everything after id) |
| `sequence` | large_string | The nucleotide sequence |
| `quality` | large_string | ASCII-encoded quality scores (Phred+33 by default) |

### Supported Extensions
`.fq`, `.fastq` (and compressed variants: `.fq.gz`, `.fastq.gz`, `.fq.bz2`, `.fq.xz`)

### Usage
```python
from datasets import load_dataset

# Load FASTQ file
dataset = load_dataset("fastq", data_files="reads.fastq")

# Load gzipped file
dataset = load_dataset("fastq", data_files="reads.fq.gz")

# Filter columns
dataset = load_dataset("fastq", data_files="reads.fq", columns=["sequence", "quality"])
```

### Quality Score Format
Quality scores use Sanger/Illumina 1.8+ encoding (Phred+33):
- ASCII character `\!` (33) = quality 0
- ASCII character `I` (73) = quality 40

### Testing
- 22 comprehensive tests covering basic loading, multi-line sequences, compression, batching, schema types, and edge cases
- All tests passing
- Linting clean

### References
- Follows pattern established in #7923 (FASTA support)
- Parser based on: https://github.com/lh3/readfq
- Addresses feedback from #7851

cc: @georgia-hf