### PR TITLE
Bug fix: Add HDFS hostname to protocol prefix

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -358,6 +358,8 @@ def resolve_pattern(
         else (fs.protocol if isinstance(fs.protocol, str) else fs.protocol[0])
     )
     protocol_prefix = protocol + "://" if protocol != "file" else ""
+    if protocol == "hdfs" and "host" in fs.storage_options:
+        protocol_prefix += f"{fs.storage_options['host']}"
     glob_kwargs = {}
     if protocol == "hf":
         # 10 times faster glob with detail=True (ignores costly info like lastCommit)


### PR DESCRIPTION
For HDFS url with hostname like `hdfs://hostname/user/xxx`, the function `resolve_pattern` would drop the hostname, and outputs  `hdfs:///user/xxx`. This may break later file operations by trying to connect to wrong HDFS cluster.