### PR TITLE
feat: Add GenBank file format support for biological sequence data

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -267,6 +267,25 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 >>> dataset = load_dataset("webdataset", data_files={"train": urls}, split="train", streaming=True)
 ```
 
+### GenBank
+
+[GenBank](https://www.ncbi.nlm.nih.gov/genbank/) is a text-based format from NCBI for nucleotide and protein sequences together with their annotations. Files use the `.gb`, `.gbk`, or `.genbank` extension (optionally compressed), and each record's `FEATURES` section is decoded into structured objects.
+
+To load GenBank files:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("genbank", data_files="*.gb", split="train")
+```
+
+You can try it on a small example dataset of real NCBI records (one of them is gzipped to show that compressed files load transparently):
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("ermiaazarkhalili/datasets-genbank-test", data_files="*.gb*", split="train")
+>>> dataset[0]["locus_name"], dataset[0]["organism"], dataset[0]["length"]
+```
+
 ## Remote files
 
 If you have remote files likely stored as a `csv`, `json`, `txt`, `parquet` or any supported format, the [`load_dataset`] function can load load them if you specify their remote paths:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -292,6 +292,25 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 >>> dataset = load_dataset("webdataset", data_files={"train": urls}, split="train", streaming=True)
 ```
 
+### GenBank
+
+[GenBank](https://www.ncbi.nlm.nih.gov/genbank/) is a text-based format from NCBI for nucleotide and protein sequences together with their annotations. Files use the `.gb`, `.gbk`, or `.genbank` extension (optionally compressed), and each record's `FEATURES` section is decoded into structured objects.
+
+To load GenBank files:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("genbank", data_files="*.gb", split="train")
+```
+
+You can try it on a small example dataset of real NCBI records (one of them is gzipped to show that compressed files load transparently):
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("ermiaazarkhalili/datasets-genbank-test", data_files="*.gb*", split="train")
+>>> dataset[0]["locus_name"], dataset[0]["organism"], dataset[0]["length"]
+```
+
 ## Remote files
 
 If you have remote files likely stored as a `csv`, `json`, `txt`, `parquet` or any supported format, the [`load_dataset`] function can load load them if you specify their remote paths:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -296,6 +296,8 @@ To load remote WebDatasets via HTTP, pass the URLs instead:
 
 [GenBank](https://www.ncbi.nlm.nih.gov/genbank/) is a text-based format from NCBI for nucleotide and protein sequences together with their annotations. Files use the `.gb`, `.gbk`, or `.genbank` extension (optionally compressed), and each record's `FEATURES` section is decoded into structured objects.
 
+Alongside the lightweight parsed columns, each row includes a `record` column of type `BioSequence(format="genbank")`, which decodes to a `Bio.SeqRecord.SeqRecord` when `biopython` is installed. Cast this column to `BioSequence(format="genbank", decode=False)` to access the original record bytes as `{"bytes": ..., "path": None}`, or omit it with `columns=[...]` to use only the parsed columns without `biopython`.
+
 To load GenBank files:
 
 ```py

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -10,6 +10,7 @@ from .cache import cache
 from .conll import conll
 from .csv import csv
 from .eval import eval
+from .genbank import genbank
 from .hdf5 import hdf5
 from .iceberg import iceberg
 from .imagefolder import imagefolder
@@ -63,6 +64,7 @@ _PACKAGED_DATASETS_MODULES = {
     "lance": (lance.__name__, _hash_python_lines(inspect.getsource(lance).splitlines())),
     "tsfile": (tsfile.__name__, _hash_python_lines(inspect.getsource(tsfile).splitlines())),
     "iceberg": (iceberg.__name__, _hash_python_lines(inspect.getsource(iceberg).splitlines())),
+    "genbank": (genbank.__name__, _hash_python_lines(inspect.getsource(genbank).splitlines())),
 }
 
 # get importable module names and hash for caching
@@ -99,6 +101,9 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".eval": ("eval", {}),
     ".lance": ("lance", {}),
     ".tsfile": ("tsfile", {}),
+    ".gb": ("genbank", {}),
+    ".gbk": ("genbank", {}),
+    ".genbank": ("genbank", {}),
 }
 _EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -10,6 +10,7 @@ from .cache import cache
 from .conll import conll
 from .csv import csv
 from .eval import eval
+from .genbank import genbank
 from .hdf5 import hdf5
 from .iceberg import iceberg
 from .imagefolder import imagefolder
@@ -65,6 +66,7 @@ _PACKAGED_DATASETS_MODULES = {
     "tsfile": (tsfile.__name__, _hash_python_lines(inspect.getsource(tsfile).splitlines())),
     "iceberg": (iceberg.__name__, _hash_python_lines(inspect.getsource(iceberg).splitlines())),
     "vortex": (vortex.__name__, _hash_python_lines(inspect.getsource(vortex).splitlines())),
+    "genbank": (genbank.__name__, _hash_python_lines(inspect.getsource(genbank).splitlines())),
 }
 
 # get importable module names and hash for caching
@@ -102,6 +104,9 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".lance": ("lance", {}),
     ".tsfile": ("tsfile", {}),
     ".vortex": ("vortex", {}),
+    ".gb": ("genbank", {}),
+    ".gbk": ("genbank", {}),
+    ".genbank": ("genbank", {}),
 }
 _EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})

--- a/src/datasets/packaged_modules/genbank/__init__.py
+++ b/src/datasets/packaged_modules/genbank/__init__.py
@@ -1,3 +1,0 @@
-from .genbank import GenBank, GenBankConfig
-
-__all__ = ["GenBank", "GenBankConfig"]

--- a/src/datasets/packaged_modules/genbank/__init__.py
+++ b/src/datasets/packaged_modules/genbank/__init__.py
@@ -1,0 +1,3 @@
+from .genbank import GenBank, GenBankConfig
+
+__all__ = ["GenBank", "GenBankConfig"]

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -1,0 +1,480 @@
+"""GenBank file loader for biological sequence data with annotations.
+
+GenBank is a text-based format for storing nucleotide or protein sequences together with
+their annotations and metadata, widely used in bioinformatics and maintained by NCBI.
+
+This implementation uses a lightweight pure Python state machine parser,
+requiring zero external dependencies.
+"""
+
+import bz2
+import gzip
+import itertools
+import json
+import lzma
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import pyarrow as pa
+
+import datasets
+from datasets.builder import Key
+from datasets.features.features import require_storage_cast
+from datasets.table import table_cast
+
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+# Conservative limit to stay well under Parquet's i32::MAX page limit (~2GB)
+# Using 256MB as default since Parquet compresses data and we want headroom
+DEFAULT_MAX_BATCH_BYTES = 256 * 1024 * 1024  # 256 MB
+
+
+# Parser states for the GenBank state machine
+class ParserState:
+    HEADER = "HEADER"
+    FEATURES = "FEATURES"
+    ORIGIN = "ORIGIN"
+    COMPLETE = "COMPLETE"
+
+
+@dataclass
+class GenBankConfig(datasets.BuilderConfig):
+    """BuilderConfig for GenBank files.
+
+    Args:
+        features: Dataset features (optional, will be inferred if not provided).
+        batch_size: Maximum number of records per batch. Works in conjunction with
+            max_batch_bytes - a batch is flushed when either limit is reached.
+        max_batch_bytes: Maximum cumulative bytes per batch. This prevents Parquet
+            page size errors when dealing with very large sequences. Set to None
+            to disable byte-based batching.
+        columns: Subset of columns to include. Options: ["locus_name", "accession",
+            "version", "definition", "organism", "taxonomy", "keywords", "sequence",
+            "features", "length", "molecule_type"].
+        parse_features: Whether to parse FEATURES section into structured JSON.
+            If False, stores raw text.
+    """
+
+    features: Optional[datasets.Features] = None
+    batch_size: int = 10000
+    max_batch_bytes: Optional[int] = DEFAULT_MAX_BATCH_BYTES
+    columns: Optional[list[str]] = None
+    parse_features: bool = True
+
+    def __post_init__(self):
+        super().__post_init__()
+
+
+class GenBank(datasets.ArrowBasedBuilder):
+    """Dataset builder for GenBank files."""
+
+    BUILDER_CONFIG_CLASS = GenBankConfig
+
+    # All supported GenBank extensions
+    EXTENSIONS: list[str] = [".gb", ".gbk", ".genbank"]
+
+    # All available columns
+    ALL_COLUMNS: list[str] = [
+        "locus_name",
+        "accession",
+        "version",
+        "definition",
+        "organism",
+        "taxonomy",
+        "keywords",
+        "sequence",
+        "features",
+        "length",
+        "molecule_type",
+    ]
+
+    def _info(self):
+        return datasets.DatasetInfo(features=self.config.features)
+
+    def _split_generators(self, dl_manager):
+        """Generate splits from data files.
+
+        The `data_files` kwarg in load_dataset() can be a str, List[str],
+        Dict[str,str], or Dict[str,List[str]].
+
+        If str or List[str], then the dataset returns only the 'train' split.
+        If dict, then keys should be from the `datasets.Split` enum.
+        """
+        if not self.config.data_files:
+            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+        dl_manager.download_config.extract_on_the_fly = True
+        data_files = dl_manager.download_and_extract(self.config.data_files)
+        splits = []
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                files = [files]
+            files = [dl_manager.iter_files(file) for file in files]
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+        return splits
+
+    def _cast_table(self, pa_table: pa.Table) -> pa.Table:
+        """Cast Arrow table to configured features schema."""
+        if self.config.features is not None:
+            schema = self.config.features.arrow_schema
+            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
+                pa_table = pa_table.cast(schema)
+            else:
+                pa_table = table_cast(pa_table, schema)
+            return pa_table
+        return pa_table
+
+    def _open_file(self, filepath: str):
+        """Open file with automatic compression detection based on magic bytes.
+
+        Supports gzip, bzip2, and xz/lzma compression formats.
+        """
+        with open(filepath, "rb") as f:
+            magic = f.read(6)
+
+        if magic[:2] == b"\x1f\x8b":  # gzip magic number
+            return gzip.open(filepath, "rt", encoding="utf-8")
+        elif magic[:3] == b"BZh":  # bzip2 magic number
+            return bz2.open(filepath, "rt", encoding="utf-8")
+        elif magic[:6] == b"\xfd7zXZ\x00":  # xz magic number
+            return lzma.open(filepath, "rt", encoding="utf-8")
+        else:
+            return open(filepath, "r", encoding="utf-8")
+
+    def _parse_feature_location(self, location_str: str) -> dict:
+        """Parse a GenBank feature location string into a structured dict.
+
+        Examples:
+            "100..200" -> {"start": 100, "end": 200, "strand": 1}
+            "complement(100..200)" -> {"start": 100, "end": 200, "strand": -1}
+            "join(1..100,200..300)" -> {"start": 1, "end": 300, "strand": 1, "parts": [[1,100],[200,300]]}
+        """
+        location = {"strand": 1}
+
+        # Check for complement
+        if location_str.startswith("complement("):
+            location["strand"] = -1
+            location_str = location_str[11:-1]  # Remove "complement(" and ")"
+
+        # Check for join
+        if location_str.startswith("join("):
+            location_str = location_str[5:-1]  # Remove "join(" and ")"
+            parts = []
+            for part in location_str.split(","):
+                part = part.strip()
+                if ".." in part:
+                    start, end = part.split("..")
+                    # Handle < and > symbols for partial sequences
+                    start = int(start.lstrip("<>"))
+                    end = int(end.lstrip("<>"))
+                    parts.append([start, end])
+            if parts:
+                location["parts"] = parts
+                location["start"] = parts[0][0]
+                location["end"] = parts[-1][1]
+            return location
+
+        # Simple location
+        if ".." in location_str:
+            start, end = location_str.split("..")
+            location["start"] = int(start.lstrip("<>"))
+            location["end"] = int(end.lstrip("<>"))
+        elif location_str.isdigit():
+            location["start"] = int(location_str)
+            location["end"] = int(location_str)
+
+        return location
+
+    def _parse_genbank(self, fp):
+        """State machine parser for GenBank format.
+
+        GenBank format has several sections:
+        - LOCUS: Contains name, length, molecule type, etc.
+        - DEFINITION: Description of the sequence
+        - ACCESSION: Database accession number
+        - VERSION: Version with GI number
+        - KEYWORDS: Associated keywords
+        - SOURCE/ORGANISM: Organism information and taxonomy
+        - FEATURES: Detailed annotations
+        - ORIGIN: The actual sequence data
+        - // : Record terminator
+
+        Args:
+            fp: File-like object opened in text mode.
+
+        Yields:
+            Dict with parsed record fields for each GenBank record.
+        """
+        state = ParserState.HEADER
+        record = self._new_record()
+        current_feature = None
+        current_qualifier_key = None
+        current_qualifier_value = []
+        features_list = []
+
+        for line in fp:
+            # Record terminator
+            if line.startswith("//"):
+                # Finalize any pending feature
+                if current_feature is not None:
+                    if current_qualifier_key is not None:
+                        current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
+                    features_list.append(current_feature)
+
+                # Store features
+                if self.config.parse_features:
+                    record["features"] = json.dumps(features_list)
+                else:
+                    record["features"] = ""
+
+                yield record
+
+                # Reset for next record
+                state = ParserState.HEADER
+                record = self._new_record()
+                current_feature = None
+                current_qualifier_key = None
+                current_qualifier_value = []
+                features_list = []
+                continue
+
+            # State: HEADER - Parse metadata fields
+            if state == ParserState.HEADER:
+                if line.startswith("LOCUS"):
+                    self._parse_locus_line(line, record)
+                elif line.startswith("DEFINITION"):
+                    record["definition"] = line[12:].strip()
+                elif line.startswith("ACCESSION"):
+                    record["accession"] = line[12:].strip().split()[0]
+                elif line.startswith("VERSION"):
+                    record["version"] = line[12:].strip()
+                elif line.startswith("KEYWORDS"):
+                    keywords = line[12:].strip()
+                    if keywords != ".":
+                        record["keywords"] = keywords
+                elif line.startswith("SOURCE"):
+                    pass  # SOURCE line itself is less useful than ORGANISM
+                elif line.startswith("  ORGANISM"):
+                    record["organism"] = line[12:].strip()
+                elif line.startswith("            ") and record["organism"]:
+                    # Continuation of taxonomy
+                    taxonomy_part = line.strip()
+                    if taxonomy_part and not taxonomy_part.endswith("."):
+                        taxonomy_part += ";"
+                    if record["taxonomy"]:
+                        record["taxonomy"] += " " + taxonomy_part
+                    else:
+                        record["taxonomy"] = taxonomy_part
+                elif line.startswith("FEATURES"):
+                    state = ParserState.FEATURES
+                elif line.startswith("ORIGIN"):
+                    state = ParserState.ORIGIN
+
+            # State: FEATURES - Parse feature annotations
+            elif state == ParserState.FEATURES:
+                if line.startswith("ORIGIN"):
+                    # Finalize any pending feature before transitioning
+                    if current_feature is not None:
+                        if current_qualifier_key is not None:
+                            current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
+                        features_list.append(current_feature)
+                        current_feature = None
+                        current_qualifier_key = None
+                        current_qualifier_value = []
+                    state = ParserState.ORIGIN
+                    continue
+
+                # Feature line starts at column 5 with feature type
+                if len(line) > 5 and line[5] != " " and not line.startswith("FEATURES"):
+                    # Finalize previous feature
+                    if current_feature is not None:
+                        if current_qualifier_key is not None:
+                            current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
+                        features_list.append(current_feature)
+
+                    # Parse new feature
+                    parts = line[5:].split()
+                    if len(parts) >= 2:
+                        feature_type = parts[0]
+                        location_str = parts[1]
+                        current_feature = {
+                            "type": feature_type,
+                            "location": self._parse_feature_location(location_str),
+                            "qualifiers": {},
+                        }
+                    current_qualifier_key = None
+                    current_qualifier_value = []
+
+                # Qualifier line starts at column 21
+                elif len(line) > 21 and line[21] == "/":
+                    # Save previous qualifier
+                    if current_qualifier_key is not None and current_feature is not None:
+                        current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
+
+                    # Parse new qualifier
+                    qualifier_line = line[21:].strip()
+                    if "=" in qualifier_line:
+                        key, value = qualifier_line.split("=", 1)
+                        current_qualifier_key = key[1:]  # Remove leading /
+                        # Remove surrounding quotes if present
+                        value = value.strip('"')
+                        current_qualifier_value = [value]
+                    else:
+                        # Boolean qualifier like /pseudo
+                        current_qualifier_key = qualifier_line[1:]
+                        current_qualifier_value = ["true"]
+
+                # Continuation line for qualifier
+                elif len(line) > 21 and line[21] != "/" and current_qualifier_key is not None:
+                    continuation = line[21:].strip().strip('"')
+                    current_qualifier_value.append(continuation)
+
+            # State: ORIGIN - Parse sequence data
+            elif state == ParserState.ORIGIN:
+                if line.startswith("//"):
+                    continue  # Will be handled at top of loop
+
+                # Sequence lines have format: "   123 atcgatcg atcgatcg ..."
+                # Remove numbers and spaces, keep only sequence characters
+                seq_chars = re.sub(r"[\s\d]", "", line)
+                if seq_chars:
+                    record["sequence"] += seq_chars.upper()
+
+    def _new_record(self) -> dict:
+        """Create a new empty record with default values."""
+        return {
+            "locus_name": "",
+            "accession": "",
+            "version": "",
+            "definition": "",
+            "organism": "",
+            "taxonomy": "",
+            "keywords": "",
+            "sequence": "",
+            "features": "",
+            "length": 0,
+            "molecule_type": "",
+        }
+
+    def _parse_locus_line(self, line: str, record: dict) -> None:
+        """Parse the LOCUS line which contains key metadata.
+
+        LOCUS format (fixed width columns):
+        LOCUS       name          length bp    type     topology  division  date
+
+        Example:
+        LOCUS       SCU49845     5028 bp    DNA             PLN       21-JUN-1999
+        """
+        # Split by whitespace and extract fields
+        parts = line.split()
+        if len(parts) >= 2:
+            record["locus_name"] = parts[1]
+
+        # Find length (number followed by 'bp' or 'aa')
+        for i, part in enumerate(parts):
+            if part in ("bp", "aa") and i > 0:
+                try:
+                    record["length"] = int(parts[i - 1])
+                except ValueError:
+                    pass
+                break
+
+        # Find molecule type (DNA, RNA, mRNA, etc.)
+        molecule_types = {"DNA", "RNA", "mRNA", "rRNA", "tRNA", "protein", "AA"}
+        for part in parts:
+            if part in molecule_types:
+                record["molecule_type"] = part
+                break
+
+    def _get_columns(self) -> list[str]:
+        """Get the list of columns to include in output."""
+        if self.config.columns is not None:
+            # Validate columns
+            for col in self.config.columns:
+                if col not in self.ALL_COLUMNS:
+                    raise ValueError(f"Invalid column '{col}'. Valid columns are: {self.ALL_COLUMNS}")
+            return self.config.columns
+        return self.ALL_COLUMNS
+
+    def _get_schema(self, columns: list[str]) -> pa.Schema:
+        """Return Arrow schema with appropriate types for each column.
+
+        Uses large_string for sequence and features columns to handle very long data
+        that can exceed the 2GB limit of regular string type.
+        """
+        fields = []
+        for col in columns:
+            if col in ("sequence", "features"):
+                # Use large_string for potentially very long data
+                fields.append(pa.field(col, pa.large_string()))
+            elif col == "length":
+                fields.append(pa.field(col, pa.int64()))
+            else:
+                fields.append(pa.field(col, pa.string()))
+        return pa.schema(fields)
+
+    def _generate_tables(self, files):
+        """Generate Arrow tables from GenBank files.
+
+        Yields batches of records as Arrow tables for memory-efficient processing
+        of large sequence files. Uses dual-threshold batching: flushes when either
+        batch_size (record count) or max_batch_bytes (cumulative size) is reached.
+
+        Args:
+            files: Iterable of file iterables from _split_generators.
+
+        Yields:
+            Tuple of (Key, pa.Table) for each batch.
+        """
+        columns = self._get_columns()
+        schema = self._get_schema(columns)
+        max_batch_bytes = self.config.max_batch_bytes
+
+        for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
+            batch_idx = 0
+            batch = {col: [] for col in columns}
+            batch_bytes = 0
+
+            with self._open_file(file) as fp:
+                for record in self._parse_genbank(fp):
+                    # Update length from actual sequence if not set
+                    if record["length"] == 0 and record["sequence"]:
+                        record["length"] = len(record["sequence"])
+
+                    # Calculate record size (approximate UTF-8 byte size)
+                    record_bytes = sum(
+                        len(str(record.get(col, ""))) for col in columns if col != "length"
+                    ) + 8  # 8 bytes for int64 length
+
+                    # Check if adding this record would exceed byte limit
+                    # Flush current batch first if needed (but only if batch is non-empty)
+                    if (
+                        max_batch_bytes is not None
+                        and batch_bytes > 0
+                        and batch_bytes + record_bytes > max_batch_bytes
+                    ):
+                        pa_table = pa.Table.from_pydict(batch, schema=schema)
+                        yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+                        batch = {col: [] for col in columns}
+                        batch_bytes = 0
+                        batch_idx += 1
+
+                    # Add record to batch
+                    for col in columns:
+                        batch[col].append(record.get(col, "" if col != "length" else 0))
+                    batch_bytes += record_bytes
+
+                    # Yield batch when it reaches batch_size (record count limit)
+                    if len(batch[columns[0]]) >= self.config.batch_size:
+                        pa_table = pa.Table.from_pydict(batch, schema=schema)
+                        yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+                        batch = {col: [] for col in columns}
+                        batch_bytes = 0
+                        batch_idx += 1
+
+            # Yield remaining records in final batch
+            if batch[columns[0]]:
+                pa_table = pa.Table.from_pydict(batch, schema=schema)
+                yield Key(file_idx, batch_idx), self._cast_table(pa_table)

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -40,6 +40,55 @@ class ParserState:
     COMPLETE = "COMPLETE"
 
 
+class _FeatureAccumulator:
+    """Collects the multi-line state of a GenBank FEATURES section.
+
+    A feature spans a feature line (type + location) followed by ``/key=value``
+    qualifier lines and their continuations. This buffers the feature and the
+    qualifier currently being read, flushing them onto ``features`` at the right
+    boundaries so the parser loop doesn't have to repeat that bookkeeping.
+    """
+
+    def __init__(self) -> None:
+        self.features: list[dict] = []
+        self._feature: Optional[dict] = None
+        self._qualifier_key: Optional[str] = None
+        self._qualifier_value: list[str] = []
+
+    @property
+    def has_open_qualifier(self) -> bool:
+        return self._qualifier_key is not None
+
+    def _commit_qualifier(self) -> None:
+        """Write the buffered qualifier (if any) onto the current feature."""
+        if self._feature is not None and self._qualifier_key is not None:
+            self._feature["qualifiers"][self._qualifier_key] = "".join(self._qualifier_value)
+        self._qualifier_key = None
+        self._qualifier_value = []
+
+    def finalize_feature(self) -> None:
+        """Flush the pending qualifier and append the current feature, if any."""
+        self._commit_qualifier()
+        if self._feature is not None:
+            self.features.append(self._feature)
+            self._feature = None
+
+    def begin_feature(self, feature_type: str, location: dict) -> None:
+        """Finalize the previous feature and start a new one."""
+        self.finalize_feature()
+        self._feature = {"type": feature_type, "location": location, "qualifiers": {}}
+
+    def begin_qualifier(self, key: str, value: str) -> None:
+        """Commit the previous qualifier and start buffering a new one."""
+        self._commit_qualifier()
+        self._qualifier_key = key
+        self._qualifier_value = [value]
+
+    def add_continuation(self, text: str) -> None:
+        """Append a continuation line to the qualifier currently being read."""
+        self._qualifier_value.append(text)
+
+
 @dataclass
 class GenBankConfig(datasets.BuilderConfig):
     """BuilderConfig for GenBank files.
@@ -209,138 +258,104 @@ class GenBank(datasets.ArrowBasedBuilder):
         """
         state = ParserState.HEADER
         record = self._new_record()
-        current_feature = None
-        current_qualifier_key = None
-        current_qualifier_value = []
-        features_list = []
+        features = _FeatureAccumulator()
 
         for line in fp:
-            # Record terminator
+            # Record terminator: finalize the pending feature and emit the record.
             if line.startswith("//"):
-                # Finalize any pending feature
-                if current_feature is not None:
-                    if current_qualifier_key is not None:
-                        current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
-                    features_list.append(current_feature)
-
-                # Store features
-                if self.config.parse_features:
-                    record["features"] = json.dumps(features_list)
-                else:
-                    record["features"] = ""
-
+                features.finalize_feature()
+                record["features"] = json.dumps(features.features) if self.config.parse_features else ""
                 yield record
-
-                # Reset for next record
                 state = ParserState.HEADER
                 record = self._new_record()
-                current_feature = None
-                current_qualifier_key = None
-                current_qualifier_value = []
-                features_list = []
+                features = _FeatureAccumulator()
                 continue
 
-            # State: HEADER - Parse metadata fields
             if state == ParserState.HEADER:
-                if line.startswith("LOCUS"):
-                    self._parse_locus_line(line, record)
-                elif line.startswith("DEFINITION"):
-                    record["definition"] = line[12:].strip()
-                elif line.startswith("ACCESSION"):
-                    record["accession"] = line[12:].strip().split()[0]
-                elif line.startswith("VERSION"):
-                    record["version"] = line[12:].strip()
-                elif line.startswith("KEYWORDS"):
-                    keywords = line[12:].strip()
-                    if keywords != ".":
-                        record["keywords"] = keywords
-                elif line.startswith("SOURCE"):
-                    pass  # SOURCE line itself is less useful than ORGANISM
-                elif line.startswith("  ORGANISM"):
-                    record["organism"] = line[12:].strip()
-                elif line.startswith("            ") and record["organism"]:
-                    # Continuation of taxonomy
-                    taxonomy_part = line.strip()
-                    if taxonomy_part and not taxonomy_part.endswith("."):
-                        taxonomy_part += ";"
-                    if record["taxonomy"]:
-                        record["taxonomy"] += " " + taxonomy_part
-                    else:
-                        record["taxonomy"] = taxonomy_part
-                elif line.startswith("FEATURES"):
-                    state = ParserState.FEATURES
-                elif line.startswith("ORIGIN"):
-                    state = ParserState.ORIGIN
-
-            # State: FEATURES - Parse feature annotations
+                state = self._handle_header_line(line, record) or state
             elif state == ParserState.FEATURES:
-                if line.startswith("ORIGIN"):
-                    # Finalize any pending feature before transitioning
-                    if current_feature is not None:
-                        if current_qualifier_key is not None:
-                            current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
-                        features_list.append(current_feature)
-                        current_feature = None
-                        current_qualifier_key = None
-                        current_qualifier_value = []
-                    state = ParserState.ORIGIN
-                    continue
-
-                # Feature line starts at column 5 with feature type
-                if len(line) > 5 and line[5] != " " and not line.startswith("FEATURES"):
-                    # Finalize previous feature
-                    if current_feature is not None:
-                        if current_qualifier_key is not None:
-                            current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
-                        features_list.append(current_feature)
-
-                    # Parse new feature
-                    parts = line[5:].split()
-                    if len(parts) >= 2:
-                        feature_type = parts[0]
-                        location_str = parts[1]
-                        current_feature = {
-                            "type": feature_type,
-                            "location": self._parse_feature_location(location_str),
-                            "qualifiers": {},
-                        }
-                    current_qualifier_key = None
-                    current_qualifier_value = []
-
-                # Qualifier line starts at column 21
-                elif len(line) > 21 and line[21] == "/":
-                    # Save previous qualifier
-                    if current_qualifier_key is not None and current_feature is not None:
-                        current_feature["qualifiers"][current_qualifier_key] = "".join(current_qualifier_value)
-
-                    # Parse new qualifier
-                    qualifier_line = line[21:].strip()
-                    if "=" in qualifier_line:
-                        key, value = qualifier_line.split("=", 1)
-                        current_qualifier_key = key[1:]  # Remove leading /
-                        # Remove surrounding quotes if present
-                        value = value.strip('"')
-                        current_qualifier_value = [value]
-                    else:
-                        # Boolean qualifier like /pseudo
-                        current_qualifier_key = qualifier_line[1:]
-                        current_qualifier_value = ["true"]
-
-                # Continuation line for qualifier
-                elif len(line) > 21 and line[21] != "/" and current_qualifier_key is not None:
-                    continuation = line[21:].strip().strip('"')
-                    current_qualifier_value.append(continuation)
-
-            # State: ORIGIN - Parse sequence data
+                state = self._handle_features_line(line, features) or state
             elif state == ParserState.ORIGIN:
-                if line.startswith("//"):
-                    continue  # Will be handled at top of loop
+                self._handle_origin_line(line, record)
 
-                # Sequence lines have format: "   123 atcgatcg atcgatcg ..."
-                # Remove numbers and spaces, keep only sequence characters
-                seq_chars = re.sub(r"[\s\d]", "", line)
-                if seq_chars:
-                    record["sequence"] += seq_chars.upper()
+    def _handle_header_line(self, line: str, record: dict) -> Optional[str]:
+        """Parse one HEADER line into ``record``.
+
+        Returns the next parser state when a section boundary (FEATURES or
+        ORIGIN) is reached, otherwise ``None`` to stay in the HEADER state.
+        """
+        if line.startswith("LOCUS"):
+            self._parse_locus_line(line, record)
+        elif line.startswith("DEFINITION"):
+            record["definition"] = line[12:].strip()
+        elif line.startswith("ACCESSION"):
+            record["accession"] = line[12:].strip().split()[0]
+        elif line.startswith("VERSION"):
+            record["version"] = line[12:].strip()
+        elif line.startswith("KEYWORDS"):
+            keywords = line[12:].strip()
+            if keywords != ".":
+                record["keywords"] = keywords
+        elif line.startswith("SOURCE"):
+            pass  # The SOURCE line itself is less useful than ORGANISM.
+        elif line.startswith("  ORGANISM"):
+            record["organism"] = line[12:].strip()
+        elif line.startswith("            ") and record["organism"]:
+            # Continuation of the taxonomy listing under ORGANISM.
+            taxonomy_part = line.strip()
+            if taxonomy_part and not taxonomy_part.endswith("."):
+                taxonomy_part += ";"
+            if record["taxonomy"]:
+                record["taxonomy"] += " " + taxonomy_part
+            else:
+                record["taxonomy"] = taxonomy_part
+        elif line.startswith("FEATURES"):
+            return ParserState.FEATURES
+        elif line.startswith("ORIGIN"):
+            return ParserState.ORIGIN
+        return None
+
+    def _handle_features_line(self, line: str, features: "_FeatureAccumulator") -> Optional[str]:
+        """Parse one FEATURES line into ``features``.
+
+        Returns ``ParserState.ORIGIN`` when the ORIGIN section starts, otherwise
+        ``None`` to stay in the FEATURES state.
+        """
+        if line.startswith("ORIGIN"):
+            features.finalize_feature()
+            return ParserState.ORIGIN
+
+        # A feature starts with its type at column 5, e.g. "     gene   1..100".
+        if len(line) > 5 and line[5] != " " and not line.startswith("FEATURES"):
+            parts = line[5:].split()
+            if len(parts) >= 2:
+                features.begin_feature(parts[0], self._parse_feature_location(parts[1]))
+            else:
+                features.finalize_feature()
+
+        # A qualifier starts with "/key=value" at column 21.
+        elif len(line) > 21 and line[21] == "/":
+            qualifier_line = line[21:].strip()
+            if "=" in qualifier_line:
+                key, value = qualifier_line.split("=", 1)
+                features.begin_qualifier(key[1:], value.strip('"'))  # key[1:] drops the leading '/'
+            else:
+                features.begin_qualifier(qualifier_line[1:], "true")  # boolean qualifier, e.g. /pseudo
+
+        # Anything else at column 21+ is a continuation of the current qualifier's value.
+        elif len(line) > 21 and line[21] != "/" and features.has_open_qualifier:
+            features.add_continuation(line[21:].strip().strip('"'))
+
+        return None
+
+    def _handle_origin_line(self, line: str, record: dict) -> None:
+        """Accumulate sequence characters from one ORIGIN line into ``record``."""
+        if line.startswith("//"):
+            return  # Handled by the terminator at the top of the parse loop.
+        # ORIGIN lines look like "   123 atcgatcg atcgatcg ..."; keep only the bases.
+        seq_chars = re.sub(r"[\s\d]", "", line)
+        if seq_chars:
+            record["sequence"] += seq_chars.upper()
 
     def _new_record(self) -> dict:
         """Create a new empty record with default values."""
@@ -444,9 +459,9 @@ class GenBank(datasets.ArrowBasedBuilder):
                         record["length"] = len(record["sequence"])
 
                     # Calculate record size (approximate UTF-8 byte size)
-                    record_bytes = sum(
-                        len(str(record.get(col, ""))) for col in columns if col != "length"
-                    ) + 8  # 8 bytes for int64 length
+                    record_bytes = (
+                        sum(len(str(record.get(col, ""))) for col in columns if col != "length") + 8
+                    )  # 8 bytes for int64 length
 
                     # Check if adding this record would exceed byte limit
                     # Flush current batch first if needed (but only if batch is non-empty)

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -103,15 +103,12 @@ class GenBankConfig(datasets.BuilderConfig):
         columns: Subset of columns to include. Options: ["locus_name", "accession",
             "version", "definition", "organism", "taxonomy", "keywords", "sequence",
             "features", "length", "molecule_type"].
-        parse_features: Whether to parse FEATURES section into structured JSON.
-            If False, stores raw text.
     """
 
     features: Optional[datasets.Features] = None
     batch_size: int = 10000
     max_batch_bytes: Optional[int] = DEFAULT_MAX_BATCH_BYTES
     columns: Optional[list[str]] = None
-    parse_features: bool = True
 
     def __post_init__(self):
         super().__post_init__()
@@ -125,23 +122,33 @@ class GenBank(datasets.ArrowBasedBuilder):
     # All supported GenBank extensions
     EXTENSIONS: list[str] = [".gb", ".gbk", ".genbank"]
 
-    # All available columns
-    ALL_COLUMNS: list[str] = [
-        "locus_name",
-        "accession",
-        "version",
-        "definition",
-        "organism",
-        "taxonomy",
-        "keywords",
-        "sequence",
-        "features",
-        "length",
-        "molecule_type",
-    ]
+    # Canonical features for a GenBank record. The schema is always the same, so it is
+    # declared here and passed to DatasetInfo; users can still override via config.features.
+    DEFAULT_FEATURES: "datasets.Features" = datasets.Features(
+        {
+            "locus_name": datasets.Value("string"),
+            "accession": datasets.Value("string"),
+            "version": datasets.Value("string"),
+            "definition": datasets.Value("string"),
+            "organism": datasets.Value("string"),
+            "taxonomy": datasets.Value("string"),
+            "keywords": datasets.Value("string"),
+            "sequence": datasets.Value("large_string"),
+            "features": datasets.Json(),
+            "length": datasets.Value("int64"),
+            "molecule_type": datasets.Value("string"),
+        }
+    )
+
+    # All available columns (the canonical feature order).
+    ALL_COLUMNS: list[str] = list(DEFAULT_FEATURES)
 
     def _info(self):
-        return datasets.DatasetInfo(features=self.config.features)
+        if self.config.features is not None:
+            features = self.config.features
+        else:
+            features = datasets.Features({col: self.DEFAULT_FEATURES[col] for col in self._get_columns()})
+        return datasets.DatasetInfo(features=features)
 
     def _split_generators(self, dl_manager):
         """Generate splits from data files.
@@ -165,15 +172,16 @@ class GenBank(datasets.ArrowBasedBuilder):
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
-        """Cast Arrow table to configured features schema."""
-        if self.config.features is not None:
-            schema = self.config.features.arrow_schema
-            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
-                pa_table = pa_table.cast(schema)
-            else:
-                pa_table = table_cast(pa_table, schema)
-            return pa_table
-        return pa_table
+        """Cast the raw Arrow table to the resolved features schema.
+
+        The resolved features are ``config.features`` if the user provided them,
+        otherwise the canonical ``DEFAULT_FEATURES`` projected to the selected columns.
+        This is what turns the JSON-encoded ``features`` column into the ``Json()`` type.
+        """
+        features = self._info().features
+        if all(not require_storage_cast(feature) for feature in features.values()):
+            return pa_table.cast(features.arrow_schema)
+        return table_cast(pa_table, features.arrow_schema)
 
     def _open_file(self, filepath: str):
         """Open file with automatic compression detection based on magic bytes.
@@ -264,7 +272,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             # Record terminator: finalize the pending feature and emit the record.
             if line.startswith("//"):
                 features.finalize_feature()
-                record["features"] = json.dumps(features.features) if self.config.parse_features else ""
+                record["features"] = features.features
                 yield record
                 state = ParserState.HEADER
                 record = self._new_record()
@@ -368,7 +376,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             "taxonomy": "",
             "keywords": "",
             "sequence": "",
-            "features": "",
+            "features": [],
             "length": 0,
             "molecule_type": "",
         }
@@ -413,16 +421,21 @@ class GenBank(datasets.ArrowBasedBuilder):
             return self.config.columns
         return self.ALL_COLUMNS
 
-    def _get_schema(self, columns: list[str]) -> pa.Schema:
-        """Return Arrow schema with appropriate types for each column.
+    def _get_storage_schema(self, columns: list[str]) -> pa.Schema:
+        """Return the Arrow schema used to build raw batches before casting to features.
 
-        Uses large_string for sequence and features columns to handle very long data
-        that can exceed the 2GB limit of regular string type.
+        The ``features`` column is built directly as the JSON arrow type from JSON-encoded
+        strings, so casting to the ``Json()`` feature is a no-op (no double-encoding).
+        ``sequence`` uses large_string to handle data that can exceed the 2GB limit of
+        regular string type.
         """
         fields = []
         for col in columns:
-            if col in ("sequence", "features"):
-                # Use large_string for potentially very long data
+            if col == "features":
+                # JSON arrow type; matches the Json() feature so _cast_table won't re-encode.
+                fields.append(pa.field(col, pa.json_()))
+            elif col == "sequence":
+                # Use large_string for potentially very long sequence data.
                 fields.append(pa.field(col, pa.large_string()))
             elif col == "length":
                 fields.append(pa.field(col, pa.int64()))
@@ -444,7 +457,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             Tuple of (Key, pa.Table) for each batch.
         """
         columns = self._get_columns()
-        schema = self._get_schema(columns)
+        schema = self._get_storage_schema(columns)
         max_batch_bytes = self.config.max_batch_bytes
 
         for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
@@ -457,6 +470,11 @@ class GenBank(datasets.ArrowBasedBuilder):
                     # Update length from actual sequence if not set
                     if record["length"] == 0 and record["sequence"]:
                         record["length"] = len(record["sequence"])
+
+                    # Serialize the features list to a JSON string for storage; the
+                    # Json() feature parses it back into an object on read.
+                    if "features" in record:
+                        record["features"] = json.dumps(record["features"])
 
                     # Calculate record size (approximate UTF-8 byte size)
                     record_bytes = (

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -7,11 +7,8 @@ This implementation uses a lightweight pure Python state machine parser,
 requiring zero external dependencies.
 """
 
-import bz2
-import gzip
 import itertools
 import json
-import lzma
 import re
 from dataclasses import dataclass
 from typing import Optional
@@ -182,23 +179,6 @@ class GenBank(datasets.ArrowBasedBuilder):
         if all(not require_storage_cast(feature) for feature in features.values()):
             return pa_table.cast(features.arrow_schema)
         return table_cast(pa_table, features.arrow_schema)
-
-    def _open_file(self, filepath: str):
-        """Open file with automatic compression detection based on magic bytes.
-
-        Supports gzip, bzip2, and xz/lzma compression formats.
-        """
-        with open(filepath, "rb") as f:
-            magic = f.read(6)
-
-        if magic[:2] == b"\x1f\x8b":  # gzip magic number
-            return gzip.open(filepath, "rt", encoding="utf-8")
-        elif magic[:3] == b"BZh":  # bzip2 magic number
-            return bz2.open(filepath, "rt", encoding="utf-8")
-        elif magic[:6] == b"\xfd7zXZ\x00":  # xz magic number
-            return lzma.open(filepath, "rt", encoding="utf-8")
-        else:
-            return open(filepath, "r", encoding="utf-8")
 
     def _parse_feature_location(self, location_str: str) -> dict:
         """Parse a GenBank feature location string into a structured dict.
@@ -465,7 +445,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             batch = {col: [] for col in columns}
             batch_bytes = 0
 
-            with self._open_file(file) as fp:
+            with open(file, encoding="utf-8") as fp:
                 for record in self._parse_genbank(fp):
                     # Update length from actual sequence if not set
                     if record["length"] == 0 and record["sequence"]:

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -10,6 +10,7 @@ requiring zero external dependencies.
 import itertools
 import json
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Optional
 
@@ -46,9 +47,12 @@ class _FeatureAccumulator:
     boundaries so the parser loop doesn't have to repeat that bookkeeping.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, location_parser: Callable[[str], dict]) -> None:
         self.features: list[dict] = []
+        self._location_parser = location_parser
         self._feature: Optional[dict] = None
+        self._location_text: list[str] = []
+        self._qualifier_seen = False
         self._qualifier_key: Optional[str] = None
         self._qualifier_value: list[str] = []
 
@@ -56,10 +60,30 @@ class _FeatureAccumulator:
     def has_open_qualifier(self) -> bool:
         return self._qualifier_key is not None
 
+    @property
+    def has_open_location(self) -> bool:
+        """Whether the current feature's location is still being read.
+
+        An operator location such as ``join(1..10,20..30,\n 40..50)`` may wrap, and
+        it is incomplete for exactly as long as its parentheses are unbalanced. Once
+        a qualifier line has been seen the location cannot continue, so that also
+        closes it.
+        """
+        if self._feature is None or self._qualifier_seen:
+            return False
+        text = "".join(self._location_text)
+        return text.count("(") > text.count(")")
+
     def _commit_qualifier(self) -> None:
-        """Write the buffered qualifier (if any) onto the current feature."""
+        """Write the buffered qualifier (if any) onto the current feature.
+
+        A qualifier key may repeat within one feature -- ``/db_xref`` routinely does --
+        so each key holds the list of its values, as Biopython's
+        ``SeqFeature.qualifiers`` does, instead of the last value overwriting the rest.
+        """
         if self._feature is not None and self._qualifier_key is not None:
-            self._feature["qualifiers"][self._qualifier_key] = "".join(self._qualifier_value)
+            values = self._feature["qualifiers"].setdefault(self._qualifier_key, [])
+            values.append("".join(self._qualifier_value))
         self._qualifier_key = None
         self._qualifier_value = []
 
@@ -67,23 +91,54 @@ class _FeatureAccumulator:
         """Flush the pending qualifier and append the current feature, if any."""
         self._commit_qualifier()
         if self._feature is not None:
+            self._feature["location"] = self._location_parser("".join(self._location_text))
             self.features.append(self._feature)
             self._feature = None
+            self._location_text = []
 
-    def begin_feature(self, feature_type: str, location: dict) -> None:
-        """Finalize the previous feature and start a new one."""
+    def begin_feature(self, feature_type: str, location_text: str) -> None:
+        """Finalize the previous feature and start a new one.
+
+        The location is kept as text and parsed on finalize, because it may still
+        gain continuation lines.
+        """
         self.finalize_feature()
-        self._feature = {"type": feature_type, "location": location, "qualifiers": {}}
+        self._feature = {"type": feature_type, "location": None, "qualifiers": {}}
+        self._location_text = [location_text]
+        self._qualifier_seen = False
+
+    def add_location_continuation(self, text: str) -> None:
+        """Append a wrapped line to the location currently being read."""
+        self._location_text.append(text)
 
     def begin_qualifier(self, key: str, value: str) -> None:
         """Commit the previous qualifier and start buffering a new one."""
         self._commit_qualifier()
+        self._qualifier_seen = True
         self._qualifier_key = key
         self._qualifier_value = [value]
 
     def add_continuation(self, text: str) -> None:
         """Append a continuation line to the qualifier currently being read."""
         self._qualifier_value.append(text)
+
+
+@dataclass
+class _HeaderState:
+    """Tracks which header field the next continuation line belongs to.
+
+    A header value may wrap onto following lines indented into the value column, and a
+    continuation belongs to the field whose keyword opened it. Each keyword handler
+    records that field here; keywords this loader does not read (REFERENCE, COMMENT and
+    the rest) clear it, so their continuation lines are dropped rather than appended to
+    whichever field happened to come before them.
+    """
+
+    #: Column at which header values start. Keywords occupy the margin to its left,
+    #: so a line that is blank up to this column is a continuation.
+    VALUE_COLUMN = 12
+
+    active_field: Optional[str] = None
 
 
 @dataclass
@@ -246,7 +301,8 @@ class GenBank(datasets.ArrowBasedBuilder):
         """
         state = ParserState.HEADER
         record = self._new_record()
-        features = _FeatureAccumulator()
+        header = _HeaderState()
+        features = _FeatureAccumulator(self._parse_feature_location)
 
         for line in fp:
             # Record terminator: finalize the pending feature and emit the record.
@@ -256,52 +312,79 @@ class GenBank(datasets.ArrowBasedBuilder):
                 yield record
                 state = ParserState.HEADER
                 record = self._new_record()
-                features = _FeatureAccumulator()
+                header = _HeaderState()
+                features = _FeatureAccumulator(self._parse_feature_location)
                 continue
 
             if state == ParserState.HEADER:
-                state = self._handle_header_line(line, record) or state
+                state = self._handle_header_line(line, record, header) or state
             elif state == ParserState.FEATURES:
                 state = self._handle_features_line(line, features) or state
             elif state == ParserState.ORIGIN:
                 self._handle_origin_line(line, record)
 
-    def _handle_header_line(self, line: str, record: dict) -> Optional[str]:
+    def _handle_header_line(self, line: str, record: dict, header: "_HeaderState") -> Optional[str]:
         """Parse one HEADER line into ``record``.
+
+        ``header`` carries the field that a continuation line would extend, and this
+        updates it on every keyword line.
 
         Returns the next parser state when a section boundary (FEATURES or
         ORIGIN) is reached, otherwise ``None`` to stay in the HEADER state.
         """
+        value = line[header.VALUE_COLUMN :].strip()
+        if not line.strip():
+            return None
+
+        # Blank in the keyword margin means this line continues the field above it.
+        if not line[: header.VALUE_COLUMN].strip():
+            if header.active_field:
+                self._append_header_continuation(record, header.active_field, line.strip())
+            return None
+
+        if line.startswith("FEATURES"):
+            header.active_field = None
+            return ParserState.FEATURES
+        if line.startswith("ORIGIN"):
+            header.active_field = None
+            return ParserState.ORIGIN
+
         if line.startswith("LOCUS"):
             self._parse_locus_line(line, record)
+            header.active_field = None
         elif line.startswith("DEFINITION"):
-            record["definition"] = line[12:].strip()
+            record["definition"] = value
+            header.active_field = "definition"
         elif line.startswith("ACCESSION"):
-            record["accession"] = line[12:].strip().split()[0]
+            record["accession"] = value.split()[0] if value else ""
+            header.active_field = None
         elif line.startswith("VERSION"):
-            record["version"] = line[12:].strip()
+            record["version"] = value
+            header.active_field = None
         elif line.startswith("KEYWORDS"):
-            keywords = line[12:].strip()
-            if keywords != ".":
-                record["keywords"] = keywords
+            if value != ".":
+                record["keywords"] = value
+            header.active_field = "keywords"
         elif line.startswith("SOURCE"):
-            pass  # The SOURCE line itself is less useful than ORGANISM.
+            # The SOURCE line itself is less useful than ORGANISM.
+            header.active_field = None
         elif line.startswith("  ORGANISM"):
-            record["organism"] = line[12:].strip()
-        elif line.startswith("            ") and record["organism"]:
-            # Continuation of the taxonomy listing under ORGANISM.
-            taxonomy_part = line.strip()
-            if taxonomy_part and not taxonomy_part.endswith("."):
-                taxonomy_part += ";"
-            if record["taxonomy"]:
-                record["taxonomy"] += " " + taxonomy_part
-            else:
-                record["taxonomy"] = taxonomy_part
-        elif line.startswith("FEATURES"):
-            return ParserState.FEATURES
-        elif line.startswith("ORIGIN"):
-            return ParserState.ORIGIN
+            record["organism"] = value
+            # The lines under ORGANISM are the taxonomy listing, not more organism name.
+            header.active_field = "taxonomy"
+        else:
+            # A keyword this loader does not read; its continuations belong to nothing.
+            header.active_field = None
         return None
+
+    @staticmethod
+    def _append_header_continuation(record: dict, field: str, text: str) -> None:
+        """Append a wrapped line to ``field``, joining with a single space.
+
+        No delimiter is inserted: a wrapped value already carries its own punctuation,
+        so a taxonomy listing that ends a line with ``;`` keeps exactly that one ``;``.
+        """
+        record[field] = f"{record[field]} {text}".strip() if record[field] else text
 
     def _handle_features_line(self, line: str, features: "_FeatureAccumulator") -> Optional[str]:
         """Parse one FEATURES line into ``features``.
@@ -315,9 +398,9 @@ class GenBank(datasets.ArrowBasedBuilder):
 
         # A feature starts with its type at column 5, e.g. "     gene   1..100".
         if len(line) > 5 and line[5] != " " and not line.startswith("FEATURES"):
-            parts = line[5:].split()
+            parts = line[5:].split(None, 1)
             if len(parts) >= 2:
-                features.begin_feature(parts[0], self._parse_feature_location(parts[1]))
+                features.begin_feature(parts[0], parts[1].strip())
             else:
                 features.finalize_feature()
 
@@ -329,6 +412,10 @@ class GenBank(datasets.ArrowBasedBuilder):
                 features.begin_qualifier(key[1:], value.strip('"'))  # key[1:] drops the leading '/'
             else:
                 features.begin_qualifier(qualifier_line[1:], "true")  # boolean qualifier, e.g. /pseudo
+
+        # An unbalanced location wraps onto the next line before any qualifier appears.
+        elif len(line) > 21 and line[21] != "/" and features.has_open_location:
+            features.add_location_continuation(line[21:].strip())
 
         # Anything else at column 21+ is a continuation of the current qualifier's value.
         elif len(line) > 21 and line[21] != "/" and features.has_open_qualifier:
@@ -375,21 +462,28 @@ class GenBank(datasets.ArrowBasedBuilder):
         if len(parts) >= 2:
             record["locus_name"] = parts[1]
 
-        # Find length (number followed by 'bp' or 'aa')
+        # The length is a number followed by its unit: "bp" for nucleotides, "aa" for
+        # amino acids. The unit is also what identifies a protein record, whose LOCUS
+        # line carries no molecule-type token of its own.
+        unit = None
         for i, part in enumerate(parts):
-            if part in ("bp", "aa") and i > 0:
+            if part.lower() in ("bp", "aa") and i > 0:
+                unit = part.lower()
                 try:
                     record["length"] = int(parts[i - 1])
                 except ValueError:
                     pass
                 break
 
-        # Find molecule type (DNA, RNA, mRNA, etc.)
-        molecule_types = {"DNA", "RNA", "mRNA", "rRNA", "tRNA", "protein", "AA"}
+        # Nucleotide records name their molecule type explicitly.
+        molecule_types = {"DNA", "RNA", "mRNA", "rRNA", "tRNA", "protein"}
         for part in parts:
             if part in molecule_types:
                 record["molecule_type"] = part
                 break
+        else:
+            if unit == "aa":
+                record["molecule_type"] = "protein"
 
     def _get_columns(self) -> list[str]:
         """Get the list of columns to include in output."""

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -213,6 +213,8 @@ class GenBank(datasets.ArrowBasedBuilder):
             "features": datasets.Json(),
             "length": datasets.Value("int64"),
             "molecule_type": datasets.Value("string"),
+            "secondary_accessions": datasets.List(datasets.Value("string")),
+            "contig": datasets.Value("string"),
         }
     )
 
@@ -268,14 +270,15 @@ class GenBank(datasets.ArrowBasedBuilder):
         """Parse a GenBank feature location string into a structured dict.
 
         Examples:
-            "100..200" -> {"start": 100, "end": 200, "strand": 1}
-            "complement(100..200)" -> {"start": 100, "end": 200, "strand": -1}
+            "100..200" -> {"start": 100, "end": 200, "strand": 1, "start_partial": False, "end_partial": False}
+            "<100..>200" -> same, with "start_partial": True, "end_partial": True
+            "complement(100..200)" -> {"start": 100, "end": 200, "strand": -1, ...}
             "join(1..100,200..300)" -> {"start": 1, "end": 300, "strand": 1, "operator": "join", "parts": [[1,100],[200,300]]}
         """
         return self._parse_location_node(location_str.strip())
 
     _LOCATION_OPERATOR_RE = re.compile(r"^(complement|join|order)\((.*)\)$", re.S)
-    _LOCATION_RANGE_RE = re.compile(r"^[<>]?(\d+)(?:(?:\.\.|\^)[<>]?(\d+))?$")
+    _LOCATION_RANGE_RE = re.compile(r"^(<?)(\d+)(?:(?:\.\.|\^)(>?)(\d+))?$")
 
     @classmethod
     def _parse_location_node(cls, text: str) -> dict:
@@ -296,19 +299,26 @@ class GenBank(datasets.ArrowBasedBuilder):
             parts = [cls._parse_location_node(part) for part in cls._split_top_level(inner)]
             strands = {part["strand"] for part in parts}
             location = {"strand": strands.pop() if len(strands) == 1 else None, "operator": operator}
-            spans = [[part["start"], part["end"]] for part in parts if "start" in part]
-            if spans:
-                location["parts"] = spans
-                location["start"] = spans[0][0]
-                location["end"] = spans[-1][1]
+            located = [part for part in parts if "start" in part]
+            if located:
+                location["parts"] = [[part["start"], part["end"]] for part in located]
+                location["start"] = located[0]["start"]
+                location["end"] = located[-1]["end"]
+                location["start_partial"] = located[0]["start_partial"]
+                location["end_partial"] = located[-1]["end_partial"]
             return location
 
         location = {"strand": 1}
         # A remote reference (ACCESSION.VERSION:range) keeps only the range here.
         range_match = cls._LOCATION_RANGE_RE.match(text.rsplit(":", 1)[-1].strip())
         if range_match:
-            location["start"] = int(range_match.group(1))
-            location["end"] = int(range_match.group(2) or range_match.group(1))
+            before, start, after, end = range_match.groups()
+            location["start"] = int(start)
+            location["end"] = int(end or start)
+            # "<" and ">" mark a boundary that lies beyond the given coordinate
+            # (Biopython's BeforePosition / AfterPosition).
+            location["start_partial"] = before == "<"
+            location["end_partial"] = after == ">"
         return location
 
     @staticmethod
@@ -355,6 +365,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             if line.startswith("//"):
                 features.finalize_feature()
                 record["features"] = features.features
+                record["contig"] = "".join(record["contig"].split())
                 yield record
                 state = ParserState.HEADER
                 record = self._new_record()
@@ -365,7 +376,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             if state == ParserState.HEADER:
                 state = self._handle_header_line(line, record, header) or state
             elif state == ParserState.FEATURES:
-                state = self._handle_features_line(line, features) or state
+                state = self._handle_features_line(line, features, record, header) or state
             elif state == ParserState.ORIGIN:
                 self._handle_origin_line(line, record)
 
@@ -402,8 +413,13 @@ class GenBank(datasets.ArrowBasedBuilder):
             record["definition"] = value
             header.active_field = "definition"
         elif line.startswith("ACCESSION"):
-            record["accession"] = value.split()[0] if value else ""
-            header.active_field = None
+            accessions = value.split()
+            record["accession"] = accessions[0] if accessions else ""
+            record["secondary_accessions"] = accessions[1:]
+            header.active_field = "secondary_accessions"
+        elif line.startswith("CONTIG"):
+            record["contig"] = value
+            header.active_field = "contig"
         elif line.startswith("VERSION"):
             record["version"] = value
             header.active_field = None
@@ -430,19 +446,31 @@ class GenBank(datasets.ArrowBasedBuilder):
         No delimiter is inserted: a wrapped value already carries its own punctuation,
         so a taxonomy listing that ends a line with ``;`` keeps exactly that one ``;``.
         """
-        record[field] = f"{record[field]} {text}".strip() if record[field] else text
+        if isinstance(record[field], list):
+            record[field].extend(text.split())
+        elif field == "contig":
+            record[field] += text  # a location expression; whitespace is not part of it
+        else:
+            record[field] = f"{record[field]} {text}".strip() if record[field] else text
 
-    def _handle_features_line(self, line: str, features: "_FeatureAccumulator") -> Optional[str]:
+    def _handle_features_line(
+        self, line: str, features: "_FeatureAccumulator", record: dict, header: "_HeaderState"
+    ) -> Optional[str]:
         """Parse one FEATURES line into ``features``.
 
-        Returns ``ParserState.ORIGIN`` when the ORIGIN section starts, otherwise
+        Returns the next parser state when a keyword ends the section (ORIGIN, or a
+        header keyword such as CONTIG that follows the feature table), otherwise
         ``None`` to stay in the FEATURES state.
         """
         # A line that starts at column 0 is a keyword (ORIGIN, BASE COUNT, CONTIG, ...),
         # never a feature: it ends the open feature and only ORIGIN changes state.
         if line[:1].strip():
             features.finalize_feature()
-            return ParserState.ORIGIN if line.startswith("ORIGIN") else None
+            if line.startswith("ORIGIN"):
+                return ParserState.ORIGIN
+            if line.startswith("CONTIG"):
+                return self._handle_header_line(line, record, header) or ParserState.HEADER
+            return None
 
         # A feature starts with its type at column 5, e.g. "     gene   1..100".
         if len(line) > 5 and line[5] != " ":
@@ -462,7 +490,7 @@ class GenBank(datasets.ArrowBasedBuilder):
                 key, value = qualifier_line.split("=", 1)
                 features.begin_qualifier(key[1:], value)  # key[1:] drops the leading '/'
             else:
-                features.begin_qualifier(qualifier_line[1:], "true")  # boolean qualifier, e.g. /pseudo
+                features.begin_qualifier(qualifier_line[1:], "")  # valueless qualifier, e.g. /pseudo
 
         # An unbalanced location wraps onto the next line before any qualifier appears.
         elif len(line) > 21 and line[21] != "/" and features.has_open_location:
@@ -499,6 +527,8 @@ class GenBank(datasets.ArrowBasedBuilder):
             "features": [],
             "length": 0,
             "molecule_type": "",
+            "secondary_accessions": [],
+            "contig": "",
         }
 
     _MOLECULE_TYPE_RE = re.compile(r"^(?:[sdm]s-)?(?:[a-z]*[DR]NA|NA)$")
@@ -542,7 +572,17 @@ class GenBank(datasets.ArrowBasedBuilder):
                 record["molecule_type"] = "protein"
 
     def _get_columns(self) -> list[str]:
-        """Get the list of columns to include in output."""
+        """Get the list of columns to include in output.
+
+        ``columns`` wins when given; otherwise a user-supplied ``features`` schema
+        selects its own columns, so a schema naming a subset stays valid when the
+        default schema grows.
+        """
+        if self.config.columns is None and self.config.features is not None:
+            unknown = [col for col in self.config.features if col not in self.ALL_COLUMNS]
+            if unknown:
+                raise ValueError(f"Invalid feature column(s) {unknown}. Valid columns are: {self.ALL_COLUMNS}")
+            return list(self.config.features)
         if self.config.columns is not None:
             # Validate columns
             for col in self.config.columns:
@@ -567,6 +607,8 @@ class GenBank(datasets.ArrowBasedBuilder):
             elif col == "sequence":
                 # Use large_string for potentially very long sequence data.
                 fields.append(pa.field(col, pa.large_string()))
+            elif col == "secondary_accessions":
+                fields.append(pa.field(col, pa.list_(pa.string())))
             elif col == "length":
                 fields.append(pa.field(col, pa.int64()))
             else:
@@ -626,7 +668,7 @@ class GenBank(datasets.ArrowBasedBuilder):
 
                     # Add record to batch
                     for col in columns:
-                        batch[col].append(record.get(col, "" if col != "length" else 0))
+                        batch[col].append(record.get(col, self._new_record()[col]))
                     batch_bytes += record_bytes
 
                     # Yield batch when it reaches batch_size (record count limit)

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -241,7 +241,7 @@ class GenBank(datasets.ArrowBasedBuilder):
         Examples:
             "100..200" -> {"start": 100, "end": 200, "strand": 1}
             "complement(100..200)" -> {"start": 100, "end": 200, "strand": -1}
-            "join(1..100,200..300)" -> {"start": 1, "end": 300, "strand": 1, "parts": [[1,100],[200,300]]}
+            "join(1..100,200..300)" -> {"start": 1, "end": 300, "strand": 1, "operator": "join", "parts": [[1,100],[200,300]]}
         """
         location = {"strand": 1}
 
@@ -250,9 +250,14 @@ class GenBank(datasets.ArrowBasedBuilder):
             location["strand"] = -1
             location_str = location_str[11:-1]  # Remove "complement(" and ")"
 
-        # Check for join
-        if location_str.startswith("join("):
-            location_str = location_str[5:-1]  # Remove "join(" and ")"
+        # join(...) and order(...) share a shape; order() carries no contiguity claim,
+        # so the operator is kept rather than collapsed into join.
+        for operator in ("join", "order"):
+            if location_str.startswith(operator + "("):
+                location["operator"] = operator
+                location_str = location_str[len(operator) + 1 : -1]
+                break
+        if "operator" in location:
             parts = []
             for part in location_str.split(","):
                 part = part.strip()

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -47,6 +47,10 @@ class _FeatureAccumulator:
     boundaries so the parser loop doesn't have to repeat that bookkeeping.
     """
 
+    # Biopython's rule (Bio.GenBank.Scanner): wrapped qualifier lines join with a space,
+    # except /translation whose wrapped lines concatenate directly.
+    SPACELESS_QUALIFIERS = frozenset({"translation"})
+
     def __init__(self, location_parser: Callable[[str], dict]) -> None:
         self.features: list[dict] = []
         self._location_parser = location_parser
@@ -55,6 +59,7 @@ class _FeatureAccumulator:
         self._qualifier_seen = False
         self._qualifier_key: Optional[str] = None
         self._qualifier_value: list[str] = []
+        self._quote_open = False
 
     @property
     def has_open_qualifier(self) -> bool:
@@ -83,9 +88,11 @@ class _FeatureAccumulator:
         """
         if self._feature is not None and self._qualifier_key is not None:
             values = self._feature["qualifiers"].setdefault(self._qualifier_key, [])
-            values.append("".join(self._qualifier_value))
+            spacer = "" if self._qualifier_key in self.SPACELESS_QUALIFIERS else " "
+            values.append(spacer.join(self._qualifier_value))
         self._qualifier_key = None
         self._qualifier_value = []
+        self._quote_open = False
 
     def finalize_feature(self) -> None:
         """Flush the pending qualifier and append the current feature, if any."""
@@ -112,15 +119,32 @@ class _FeatureAccumulator:
         self._location_text.append(text)
 
     def begin_qualifier(self, key: str, value: str) -> None:
-        """Commit the previous qualifier and start buffering a new one."""
+        """Commit the previous qualifier and start buffering a new one.
+
+        ``value`` is the raw text after ``=``. A value that opens with ``"`` and does
+        not close it on the same line stays open, and every following line belongs
+        to it even when that line starts with ``/``.
+        """
         self._commit_qualifier()
         self._qualifier_seen = True
         self._qualifier_key = key
+        if value.startswith('"'):
+            value = value[1:]
+            self._quote_open = not value.endswith('"')
+            value = value[:-1] if not self._quote_open else value
         self._qualifier_value = [value]
 
     def add_continuation(self, text: str) -> None:
         """Append a continuation line to the qualifier currently being read."""
+        if self._quote_open and text.endswith('"'):
+            text = text[:-1]
+            self._quote_open = False
         self._qualifier_value.append(text)
+
+    @property
+    def has_open_quote(self) -> bool:
+        """Whether the current qualifier's quoted value has not been closed yet."""
+        return self._quote_open
 
 
 @dataclass
@@ -198,6 +222,11 @@ class GenBank(datasets.ArrowBasedBuilder):
     def _info(self):
         if self.config.features is not None:
             features = self.config.features
+            if self.config.columns is not None:
+                missing = [col for col in self.config.columns if col not in features]
+                if missing:
+                    raise ValueError(f"columns {missing} are not in features {list(features)}")
+                features = datasets.Features({col: features[col] for col in self.config.columns})
         else:
             features = datasets.Features({col: self.DEFAULT_FEATURES[col] for col in self._get_columns()})
         return datasets.DatasetInfo(features=features)
@@ -243,46 +272,58 @@ class GenBank(datasets.ArrowBasedBuilder):
             "complement(100..200)" -> {"start": 100, "end": 200, "strand": -1}
             "join(1..100,200..300)" -> {"start": 1, "end": 300, "strand": 1, "operator": "join", "parts": [[1,100],[200,300]]}
         """
-        location = {"strand": 1}
+        return self._parse_location_node(location_str.strip())
 
-        # Check for complement
-        if location_str.startswith("complement("):
-            location["strand"] = -1
-            location_str = location_str[11:-1]  # Remove "complement(" and ")"
+    _LOCATION_OPERATOR_RE = re.compile(r"^(complement|join|order)\((.*)\)$", re.S)
+    _LOCATION_RANGE_RE = re.compile(r"^[<>]?(\d+)(?:(?:\.\.|\^)[<>]?(\d+))?$")
 
-        # join(...) and order(...) share a shape; order() carries no contiguity claim,
-        # so the operator is kept rather than collapsed into join.
-        for operator in ("join", "order"):
-            if location_str.startswith(operator + "("):
-                location["operator"] = operator
-                location_str = location_str[len(operator) + 1 : -1]
-                break
-        if "operator" in location:
-            parts = []
-            for part in location_str.split(","):
-                part = part.strip()
-                if ".." in part:
-                    start, end = part.split("..")
-                    # Handle < and > symbols for partial sequences
-                    start = int(start.lstrip("<>"))
-                    end = int(end.lstrip("<>"))
-                    parts.append([start, end])
-            if parts:
-                location["parts"] = parts
-                location["start"] = parts[0][0]
-                location["end"] = parts[-1][1]
+    @classmethod
+    def _parse_location_node(cls, text: str) -> dict:
+        """Parse one location expression; operators nest, so this recurses.
+
+        ``complement(x)`` flips the strand of whatever ``x`` yields. ``join``/``order``
+        parse each comma-separated part on its own (commas inside nested parentheses
+        do not split). A join whose parts sit on different strands has no single
+        strand and reports ``None``, as Biopython's CompoundLocation does.
+        """
+        operator_match = cls._LOCATION_OPERATOR_RE.match(text)
+        if operator_match:
+            operator, inner = operator_match.groups()
+            if operator == "complement":
+                location = cls._parse_location_node(inner)
+                location["strand"] = -location["strand"] if location["strand"] is not None else None
+                return location
+            parts = [cls._parse_location_node(part) for part in cls._split_top_level(inner)]
+            strands = {part["strand"] for part in parts}
+            location = {"strand": strands.pop() if len(strands) == 1 else None, "operator": operator}
+            spans = [[part["start"], part["end"]] for part in parts if "start" in part]
+            if spans:
+                location["parts"] = spans
+                location["start"] = spans[0][0]
+                location["end"] = spans[-1][1]
             return location
 
-        # Simple location
-        if ".." in location_str:
-            start, end = location_str.split("..")
-            location["start"] = int(start.lstrip("<>"))
-            location["end"] = int(end.lstrip("<>"))
-        elif location_str.isdigit():
-            location["start"] = int(location_str)
-            location["end"] = int(location_str)
-
+        location = {"strand": 1}
+        # A remote reference (ACCESSION.VERSION:range) keeps only the range here.
+        range_match = cls._LOCATION_RANGE_RE.match(text.rsplit(":", 1)[-1].strip())
+        if range_match:
+            location["start"] = int(range_match.group(1))
+            location["end"] = int(range_match.group(2) or range_match.group(1))
         return location
+
+    @staticmethod
+    def _split_top_level(text: str) -> list[str]:
+        """Split on commas that are not nested inside parentheses."""
+        parts, depth, current = [], 0, []
+        for char in text:
+            if char == "," and depth == 0:
+                parts.append("".join(current).strip())
+                current = []
+                continue
+            depth += (char == "(") - (char == ")")
+            current.append(char)
+        parts.append("".join(current).strip())
+        return [part for part in parts if part]
 
     def _parse_genbank(self, fp):
         """State machine parser for GenBank format.
@@ -397,24 +438,29 @@ class GenBank(datasets.ArrowBasedBuilder):
         Returns ``ParserState.ORIGIN`` when the ORIGIN section starts, otherwise
         ``None`` to stay in the FEATURES state.
         """
-        if line.startswith("ORIGIN"):
+        # A line that starts at column 0 is a keyword (ORIGIN, BASE COUNT, CONTIG, ...),
+        # never a feature: it ends the open feature and only ORIGIN changes state.
+        if line[:1].strip():
             features.finalize_feature()
-            return ParserState.ORIGIN
+            return ParserState.ORIGIN if line.startswith("ORIGIN") else None
 
         # A feature starts with its type at column 5, e.g. "     gene   1..100".
-        if len(line) > 5 and line[5] != " " and not line.startswith("FEATURES"):
+        if len(line) > 5 and line[5] != " ":
             parts = line[5:].split(None, 1)
             if len(parts) >= 2:
                 features.begin_feature(parts[0], parts[1].strip())
             else:
                 features.finalize_feature()
 
+        # Inside an unclosed quoted value every line is a continuation, '/' included.
+        elif len(line) > 21 and features.has_open_quote:
+            features.add_continuation(line[21:].strip())
         # A qualifier starts with "/key=value" at column 21.
         elif len(line) > 21 and line[21] == "/":
             qualifier_line = line[21:].strip()
             if "=" in qualifier_line:
                 key, value = qualifier_line.split("=", 1)
-                features.begin_qualifier(key[1:], value.strip('"'))  # key[1:] drops the leading '/'
+                features.begin_qualifier(key[1:], value)  # key[1:] drops the leading '/'
             else:
                 features.begin_qualifier(qualifier_line[1:], "true")  # boolean qualifier, e.g. /pseudo
 
@@ -424,7 +470,7 @@ class GenBank(datasets.ArrowBasedBuilder):
 
         # Anything else at column 21+ is a continuation of the current qualifier's value.
         elif len(line) > 21 and line[21] != "/" and features.has_open_qualifier:
-            features.add_continuation(line[21:].strip().strip('"'))
+            features.add_continuation(line[21:].strip())
 
         return None
 
@@ -432,6 +478,8 @@ class GenBank(datasets.ArrowBasedBuilder):
         """Accumulate sequence characters from one ORIGIN line into ``record``."""
         if line.startswith("//"):
             return  # Handled by the terminator at the top of the parse loop.
+        if line[:1].strip():
+            return  # A keyword line (CONTIG, BASE COUNT) carries no sequence characters.
         # ORIGIN lines look like "   123 atcgatcg atcgatcg ..."; keep only the bases.
         seq_chars = re.sub(r"[\s\d]", "", line)
         if seq_chars:
@@ -452,6 +500,8 @@ class GenBank(datasets.ArrowBasedBuilder):
             "length": 0,
             "molecule_type": "",
         }
+
+    _MOLECULE_TYPE_RE = re.compile(r"^(?:[sdm]s-)?(?:[a-z]*[DR]NA|NA)$")
 
     def _parse_locus_line(self, line: str, record: dict) -> None:
         """Parse the LOCUS line which contains key metadata.
@@ -481,9 +531,10 @@ class GenBank(datasets.ArrowBasedBuilder):
                 break
 
         # Nucleotide records name their molecule type explicitly.
-        molecule_types = {"DNA", "RNA", "mRNA", "rRNA", "tRNA", "protein"}
+        # Molecule types are DNA/RNA (with a lowercase class prefix such as m, r, t, sn)
+        # or the generic NA, optionally prefixed by strandedness ss-/ds-/ms-.
         for part in parts:
-            if part in molecule_types:
+            if self._MOLECULE_TYPE_RE.match(part):
                 record["molecule_type"] = part
                 break
         else:

--- a/src/datasets/packaged_modules/genbank/genbank.py
+++ b/src/datasets/packaged_modules/genbank/genbank.py
@@ -12,6 +12,7 @@ import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from io import TextIOWrapper
 from typing import Optional
 
 import pyarrow as pa
@@ -178,7 +179,7 @@ class GenBankConfig(datasets.BuilderConfig):
             to disable byte-based batching.
         columns: Subset of columns to include. Options: ["locus_name", "accession",
             "version", "definition", "organism", "taxonomy", "keywords", "sequence",
-            "features", "length", "molecule_type"].
+            "features", "length", "molecule_type", "secondary_accessions", "contig", "record"].
     """
 
     features: Optional[datasets.Features] = None
@@ -215,22 +216,29 @@ class GenBank(datasets.ArrowBasedBuilder):
             "molecule_type": datasets.Value("string"),
             "secondary_accessions": datasets.List(datasets.Value("string")),
             "contig": datasets.Value("string"),
+            "record": datasets.BioSequence(format="genbank"),
         }
     )
 
     # All available columns (the canonical feature order).
     ALL_COLUMNS: list[str] = list(DEFAULT_FEATURES)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # DatasetBuilder applies features= after _info(); project the effective
+        # schema again, preserving features supplied through info= as well.
+        self.info.features = self._info().features
+
     def _info(self):
-        if self.config.features is not None:
-            features = self.config.features
-            if self.config.columns is not None:
-                missing = [col for col in self.config.columns if col not in features]
-                if missing:
-                    raise ValueError(f"columns {missing} are not in features {list(features)}")
-                features = datasets.Features({col: features[col] for col in self.config.columns})
-        else:
-            features = datasets.Features({col: self.DEFAULT_FEATURES[col] for col in self._get_columns()})
+        features = self.info.features if hasattr(self, "info") else self.config.features
+        columns = self._get_columns()
+        if features is None:
+            features = datasets.Features({col: self.DEFAULT_FEATURES[col] for col in columns})
+        if self.config.columns is not None:
+            missing = [col for col in self.config.columns if col not in features]
+            if missing:
+                raise ValueError(f"columns {missing} are not in features {list(features)}")
+            features = datasets.Features({col: features[col] for col in self.config.columns})
         return datasets.DatasetInfo(features=features)
 
     def _split_generators(self, dl_manager):
@@ -257,11 +265,11 @@ class GenBank(datasets.ArrowBasedBuilder):
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
         """Cast the raw Arrow table to the resolved features schema.
 
-        The resolved features are ``config.features`` if the user provided them,
-        otherwise the canonical ``DEFAULT_FEATURES`` projected to the selected columns.
+        DatasetInfo holds the effective schema from ``features=``, ``info=``, or
+        the canonical ``DEFAULT_FEATURES``, projected to the selected columns.
         This is what turns the JSON-encoded ``features`` column into the ``Json()`` type.
         """
-        features = self._info().features
+        features = self.info.features
         if all(not require_storage_cast(feature) for feature in features.values()):
             return pa_table.cast(features.arrow_schema)
         return table_cast(pa_table, features.arrow_schema)
@@ -359,18 +367,28 @@ class GenBank(datasets.ArrowBasedBuilder):
         record = self._new_record()
         header = _HeaderState()
         features = _FeatureAccumulator(self._parse_feature_location)
+        capture_record = "record" in self._get_columns()
+        raw_lines = []
 
         for line in fp:
+            # Keep the original text, including ignored fields and whitespace, from
+            # LOCUS through // without buffering it when the column is dropped.
+            if capture_record and (raw_lines or line.startswith("LOCUS")):
+                raw_lines.append(line)
+
             # Record terminator: finalize the pending feature and emit the record.
             if line.startswith("//"):
                 features.finalize_feature()
                 record["features"] = features.features
                 record["contig"] = "".join(record["contig"].split())
+                if raw_lines:
+                    record["record"] = {"bytes": "".join(raw_lines).encode("utf-8"), "path": None}
                 yield record
                 state = ParserState.HEADER
                 record = self._new_record()
                 header = _HeaderState()
                 features = _FeatureAccumulator(self._parse_feature_location)
+                raw_lines = []
                 continue
 
             if state == ParserState.HEADER:
@@ -529,6 +547,7 @@ class GenBank(datasets.ArrowBasedBuilder):
             "molecule_type": "",
             "secondary_accessions": [],
             "contig": "",
+            "record": None,
         }
 
     _MOLECULE_TYPE_RE = re.compile(r"^(?:[sdm]s-)?(?:[a-z]*[DR]NA|NA)$")
@@ -578,16 +597,21 @@ class GenBank(datasets.ArrowBasedBuilder):
         selects its own columns, so a schema naming a subset stays valid when the
         default schema grows.
         """
-        if self.config.columns is None and self.config.features is not None:
-            unknown = [col for col in self.config.features if col not in self.ALL_COLUMNS]
+        features = self.info.features if hasattr(self, "info") else self.config.features
+        if self.config.columns is None and features is not None:
+            unknown = [col for col in features if col not in self.ALL_COLUMNS]
             if unknown:
                 raise ValueError(f"Invalid feature column(s) {unknown}. Valid columns are: {self.ALL_COLUMNS}")
-            return list(self.config.features)
+            return list(features)
         if self.config.columns is not None:
             # Validate columns
+            seen = set()
             for col in self.config.columns:
                 if col not in self.ALL_COLUMNS:
                     raise ValueError(f"Invalid column '{col}'. Valid columns are: {self.ALL_COLUMNS}")
+                if col in seen:
+                    raise ValueError(f"Duplicate column '{col}' in columns.")
+                seen.add(col)
             return self.config.columns
         return self.ALL_COLUMNS
 
@@ -611,6 +635,8 @@ class GenBank(datasets.ArrowBasedBuilder):
                 fields.append(pa.field(col, pa.list_(pa.string())))
             elif col == "length":
                 fields.append(pa.field(col, pa.int64()))
+            elif col == "record":
+                fields.append(pa.field(col, datasets.BioSequence().pa_type))
             else:
                 fields.append(pa.field(col, pa.string()))
         return pa.schema(fields)
@@ -637,7 +663,9 @@ class GenBank(datasets.ArrowBasedBuilder):
             batch = {col: [] for col in columns}
             batch_bytes = 0
 
-            with open(file, encoding="utf-8") as fp:
+            # Wrap the binary stream ourselves so compressed inputs also preserve
+            # the original line endings in the BioSequence bytes.
+            with open(file, "rb") as binary_fp, TextIOWrapper(binary_fp, encoding="utf-8", newline="") as fp:
                 for record in self._parse_genbank(fp):
                     # Update length from actual sequence if not set
                     if record["length"] == 0 and record["sequence"]:
@@ -650,8 +678,10 @@ class GenBank(datasets.ArrowBasedBuilder):
 
                     # Calculate record size (approximate UTF-8 byte size)
                     record_bytes = (
-                        sum(len(str(record.get(col, ""))) for col in columns if col != "length") + 8
+                        sum(len(str(record.get(col, ""))) for col in columns if col not in ("length", "record")) + 8
                     )  # 8 bytes for int64 length
+                    if "record" in columns and record["record"] is not None:
+                        record_bytes += len(record["record"]["bytes"])
 
                     # Check if adding this record would exceed byte limit
                     # Flush current batch first if needed (but only if batch is non-empty)

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -1,0 +1,697 @@
+"""Tests for GenBank file loader."""
+
+import bz2
+import gzip
+import json
+import lzma
+import textwrap
+
+import pyarrow as pa
+import pytest
+
+from datasets import Features, Value
+from datasets.builder import InvalidConfigName
+from datasets.data_files import DataFilesList
+from datasets.packaged_modules.genbank.genbank import GenBank, GenBankConfig
+
+
+@pytest.fixture
+def genbank_file(tmp_path):
+    """Create a simple GenBank file with a single record."""
+    filename = tmp_path / "sequence.gb"
+    data = textwrap.dedent(
+        """\
+        LOCUS       SCU49845     5028 bp    DNA             PLN       21-JUN-1999
+        DEFINITION  Saccharomyces cerevisiae TCP1-beta gene, partial cds.
+        ACCESSION   U49845
+        VERSION     U49845.1
+        KEYWORDS    .
+        SOURCE      Saccharomyces cerevisiae (baker's yeast)
+          ORGANISM  Saccharomyces cerevisiae
+                    Eukaryota; Fungi; Dikarya; Ascomycota; Saccharomycotina;
+                    Saccharomycetes.
+        FEATURES             Location/Qualifiers
+             source          1..5028
+                             /organism="Saccharomyces cerevisiae"
+                             /mol_type="genomic DNA"
+             CDS             687..3158
+                             /gene="TCP1-beta"
+                             /product="TCP1-beta"
+                             /protein_id="AAA98665.1"
+        ORIGIN
+                1 gatcgatcga tcgatcgatc gatcgatcga tcgatcgatc gatcgatcga tcgatcgatc
+               61 gatcgatcga tcgatcgatc
+        //
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def genbank_file_multi_record(tmp_path):
+    """Create a GenBank file with multiple records."""
+    filename = tmp_path / "multi_sequence.gb"
+    data = textwrap.dedent(
+        """\
+        LOCUS       SEQ001       100 bp    DNA             BCT       01-JAN-2024
+        DEFINITION  Test sequence 1.
+        ACCESSION   SEQ001
+        VERSION     SEQ001.1
+        KEYWORDS    test.
+        SOURCE      Escherichia coli
+          ORGANISM  Escherichia coli
+                    Bacteria; Proteobacteria; Gammaproteobacteria.
+        FEATURES             Location/Qualifiers
+             source          1..100
+                             /organism="Escherichia coli"
+             gene            10..90
+                             /gene="testA"
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+               61 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+        //
+        LOCUS       SEQ002       50 bp    RNA             VRL       01-JAN-2024
+        DEFINITION  Test sequence 2.
+        ACCESSION   SEQ002
+        VERSION     SEQ002.1
+        KEYWORDS    .
+        SOURCE      Test virus
+          ORGANISM  Test virus
+                    Viruses; RNA viruses.
+        FEATURES             Location/Qualifiers
+             source          1..50
+                             /organism="Test virus"
+        ORIGIN
+                1 augcaugcau gcaugcaugc augcaugcau gcaugcaugc augcaugcau
+        //
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def genbank_file_gzipped(tmp_path):
+    """Create a gzipped GenBank file."""
+    filename = tmp_path / "sequence.gb.gz"
+    data = textwrap.dedent(
+        """\
+        LOCUS       GZSEQ        80 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  Gzipped test sequence.
+        ACCESSION   GZSEQ
+        VERSION     GZSEQ.1
+        KEYWORDS    gzip; test.
+        SOURCE      Test organism
+          ORGANISM  Test organism
+                    Eukaryota; Testaceae.
+        FEATURES             Location/Qualifiers
+             source          1..80
+                             /organism="Test organism"
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+               61 atcgatcgat cgatcgatcg
+        //
+        """
+    )
+    with gzip.open(filename, "wt", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def genbank_file_bz2(tmp_path):
+    """Create a bzip2 compressed GenBank file."""
+    filename = tmp_path / "sequence.gb.bz2"
+    data = textwrap.dedent(
+        """\
+        LOCUS       BZ2SEQ       60 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  Bzip2 test sequence.
+        ACCESSION   BZ2SEQ
+        VERSION     BZ2SEQ.1
+        KEYWORDS    bzip2.
+        SOURCE      Test organism
+          ORGANISM  Test organism
+                    Eukaryota; Testaceae.
+        FEATURES             Location/Qualifiers
+             source          1..60
+                             /organism="Test organism"
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+        //
+        """
+    )
+    with bz2.open(filename, "wt", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def genbank_file_xz(tmp_path):
+    """Create an xz/lzma compressed GenBank file."""
+    filename = tmp_path / "sequence.gb.xz"
+    data = textwrap.dedent(
+        """\
+        LOCUS       XZSEQ        40 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  XZ test sequence.
+        ACCESSION   XZSEQ
+        VERSION     XZSEQ.1
+        KEYWORDS    .
+        SOURCE      Test organism
+          ORGANISM  Test organism
+                    Eukaryota; Testaceae.
+        FEATURES             Location/Qualifiers
+             source          1..40
+                             /organism="Test organism"
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+        //
+        """
+    )
+    with lzma.open(filename, "wt", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def genbank_file_complex_features(tmp_path):
+    """Create a GenBank file with complex feature locations."""
+    filename = tmp_path / "complex_features.gb"
+    data = textwrap.dedent(
+        """\
+        LOCUS       COMPLEX      300 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  Sequence with complex feature locations.
+        ACCESSION   COMPLEX
+        VERSION     COMPLEX.1
+        KEYWORDS    complex; features.
+        SOURCE      Test organism
+          ORGANISM  Test organism
+                    Eukaryota; Testaceae.
+        FEATURES             Location/Qualifiers
+             source          1..300
+                             /organism="Test organism"
+             gene            complement(10..100)
+                             /gene="revGene"
+             CDS             join(1..50,100..150,200..250)
+                             /gene="splitGene"
+                             /product="split protein"
+             misc_feature    <1..>300
+                             /note="partial feature"
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+               61 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+              121 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+              181 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+              241 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+        //
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def genbank_file_large_sequences(tmp_path):
+    """Create a GenBank file with large sequences to test batching."""
+    filename = tmp_path / "large_sequences.gb"
+    records = []
+    for i in range(5):
+        seq_len = 1000 * (i + 1)  # 1K, 2K, 3K, 4K, 5K bases
+        seq = "ACGT" * (seq_len // 4)
+        # Format sequence with GenBank-style line breaks
+        formatted_seq = ""
+        for j in range(0, len(seq), 60):
+            line_num = j + 1
+            line_seq = seq[j : j + 60]
+            # Add spaces every 10 bases
+            spaced = " ".join(line_seq[k : k + 10] for k in range(0, len(line_seq), 10))
+            formatted_seq += f"{line_num:>9} {spaced}\n"
+
+        record = f"""LOCUS       LARGE{i:03d}    {seq_len} bp    DNA             PLN       01-JAN-2024
+DEFINITION  Large sequence {i}.
+ACCESSION   LARGE{i:03d}
+VERSION     LARGE{i:03d}.1
+KEYWORDS    large.
+SOURCE      Test organism
+  ORGANISM  Test organism
+            Eukaryota; Testaceae.
+FEATURES             Location/Qualifiers
+     source          1..{seq_len}
+                     /organism="Test organism"
+ORIGIN
+{formatted_seq}//
+"""
+        records.append(record)
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("\n".join(records))
+    return str(filename)
+
+
+def test_config_raises_when_invalid_name() -> None:
+    with pytest.raises(InvalidConfigName, match="Bad characters"):
+        _ = GenBankConfig(name="name-with-*-invalid-character")
+
+
+@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+def test_config_raises_when_invalid_data_files(data_files) -> None:
+    with pytest.raises(ValueError, match="Expected a DataFilesDict"):
+        _ = GenBankConfig(name="name", data_files=data_files)
+
+
+def test_genbank_basic_loading(genbank_file):
+    """Test basic GenBank file loading."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["locus_name"]) == 1
+    assert result["locus_name"][0] == "SCU49845"
+    assert result["accession"][0] == "U49845"
+    assert result["version"][0] == "U49845.1"
+    assert "Saccharomyces cerevisiae TCP1-beta gene" in result["definition"][0]
+    assert result["organism"][0] == "Saccharomyces cerevisiae"
+    assert "Eukaryota" in result["taxonomy"][0]
+    assert result["length"][0] == 5028
+    assert result["molecule_type"][0] == "DNA"
+
+
+def test_genbank_multi_record(genbank_file_multi_record):
+    """Test loading GenBank file with multiple records."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file_multi_record]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["locus_name"]) == 2
+    assert result["locus_name"] == ["SEQ001", "SEQ002"]
+    assert result["accession"] == ["SEQ001", "SEQ002"]
+    assert result["molecule_type"] == ["DNA", "RNA"]
+    assert result["organism"] == ["Escherichia coli", "Test virus"]
+
+
+def test_genbank_gzipped(genbank_file_gzipped):
+    """Test loading gzipped GenBank files."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file_gzipped]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["locus_name"]) == 1
+    assert result["locus_name"][0] == "GZSEQ"
+    assert result["keywords"][0] == "gzip; test."
+
+
+def test_genbank_bz2(genbank_file_bz2):
+    """Test loading bzip2 compressed GenBank files."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file_bz2]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["locus_name"]) == 1
+    assert result["locus_name"][0] == "BZ2SEQ"
+    assert result["keywords"][0] == "bzip2."
+
+
+def test_genbank_xz(genbank_file_xz):
+    """Test loading xz/lzma compressed GenBank files."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file_xz]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["locus_name"]) == 1
+    assert result["locus_name"][0] == "XZSEQ"
+
+
+def test_genbank_feature_parsing(genbank_file_complex_features):
+    """Test parsing of complex feature locations."""
+    genbank = GenBank(parse_features=True)
+    generator = genbank._generate_tables([[genbank_file_complex_features]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+    features = json.loads(result["features"][0])
+
+    assert len(features) >= 3
+
+    # Find the complement feature
+    rev_gene = next((f for f in features if f.get("qualifiers", {}).get("gene") == "revGene"), None)
+    assert rev_gene is not None
+    assert rev_gene["location"]["strand"] == -1
+
+    # Find the join feature
+    split_gene = next((f for f in features if f.get("qualifiers", {}).get("gene") == "splitGene"), None)
+    assert split_gene is not None
+    assert "parts" in split_gene["location"]
+    assert len(split_gene["location"]["parts"]) == 3
+
+
+def test_genbank_feature_parsing_disabled(genbank_file):
+    """Test that feature parsing can be disabled."""
+    genbank = GenBank(parse_features=False)
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    # Features should be empty string when parsing is disabled
+    assert result["features"][0] == ""
+
+
+def test_genbank_column_filtering(genbank_file):
+    """Test loading with column subset."""
+    genbank = GenBank(columns=["locus_name", "sequence", "length"])
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert list(result.keys()) == ["locus_name", "sequence", "length"]
+    assert len(result["locus_name"]) == 1
+
+
+def test_genbank_column_filtering_single(genbank_file):
+    """Test loading with single column."""
+    genbank = GenBank(columns=["sequence"])
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert list(result.keys()) == ["sequence"]
+
+
+def test_genbank_invalid_column():
+    """Test that invalid column names raise an error."""
+    genbank = GenBank(columns=["sequence", "invalid_column"])
+    with pytest.raises(ValueError, match="Invalid column 'invalid_column'"):
+        list(genbank._generate_tables([[]]))
+
+
+def test_genbank_batch_size(genbank_file_multi_record):
+    """Test batch size configuration."""
+    genbank = GenBank(batch_size=1)
+    generator = genbank._generate_tables([[genbank_file_multi_record]])
+    tables = [table for _, table in generator]
+
+    # Should have 2 batches (one per record)
+    assert len(tables) == 2
+
+    for table in tables:
+        assert table.num_rows == 1
+
+
+def test_genbank_max_batch_bytes(genbank_file_large_sequences):
+    """Test byte-based batching with max_batch_bytes."""
+    genbank = GenBank(batch_size=1000, max_batch_bytes=5000)
+    generator = genbank._generate_tables([[genbank_file_large_sequences]])
+    tables = [table for _, table in generator]
+
+    # Should create multiple batches due to byte limit
+    assert len(tables) > 1
+
+
+def test_genbank_no_byte_limit(genbank_file_large_sequences):
+    """Test disabling byte-based batching."""
+    genbank = GenBank(batch_size=1000, max_batch_bytes=None)
+    generator = genbank._generate_tables([[genbank_file_large_sequences]])
+    tables = [table for _, table in generator]
+
+    # Should create single batch since batch_size is high
+    assert len(tables) == 1
+    assert tables[0].num_rows == 5
+
+
+def test_genbank_schema_types(genbank_file):
+    """Test that schema uses correct Arrow types."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    schema = pa_table.schema
+
+    # Regular string columns
+    assert schema.field("locus_name").type == pa.string()
+    assert schema.field("accession").type == pa.string()
+    assert schema.field("version").type == pa.string()
+    assert schema.field("definition").type == pa.string()
+    assert schema.field("organism").type == pa.string()
+    assert schema.field("taxonomy").type == pa.string()
+    assert schema.field("keywords").type == pa.string()
+    assert schema.field("molecule_type").type == pa.string()
+
+    # Large string for sequence and features
+    assert schema.field("sequence").type == pa.large_string()
+    assert schema.field("features").type == pa.large_string()
+
+    # Integer for length
+    assert schema.field("length").type == pa.int64()
+
+
+def test_genbank_feature_casting(genbank_file):
+    """Test feature casting to custom schema."""
+    features = Features(
+        {
+            "locus_name": Value("string"),
+            "accession": Value("string"),
+            "version": Value("string"),
+            "definition": Value("string"),
+            "organism": Value("string"),
+            "taxonomy": Value("string"),
+            "keywords": Value("string"),
+            "sequence": Value("large_string"),
+            "features": Value("large_string"),
+            "length": Value("int64"),
+            "molecule_type": Value("string"),
+        }
+    )
+    genbank = GenBank(features=features)
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    assert pa_table.schema.field("locus_name").type == pa.string()
+    assert pa_table.schema.field("sequence").type == pa.large_string()
+    assert pa_table.schema.field("length").type == pa.int64()
+
+
+def test_genbank_empty_file(tmp_path):
+    """Test handling of empty GenBank file."""
+    filename = tmp_path / "empty.gb"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("")
+
+    genbank = GenBank()
+    generator = genbank._generate_tables([[str(filename)]])
+    tables = list(generator)
+
+    # Empty file should produce no tables
+    assert len(tables) == 0
+
+
+def test_genbank_sequence_parsing(genbank_file):
+    """Test that sequence is parsed correctly."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    # Sequence should be uppercase with no whitespace or numbers
+    sequence = result["sequence"][0]
+    assert sequence.isupper()
+    assert " " not in sequence
+    assert all(c in "ACGT" for c in sequence)
+
+
+def test_genbank_multiple_files(tmp_path):
+    """Test loading multiple GenBank files."""
+    file1 = tmp_path / "seq1.gb"
+    file2 = tmp_path / "seq2.gb"
+
+    data1 = textwrap.dedent(
+        """\
+        LOCUS       FILE1SEQ     20 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  File 1 sequence.
+        ACCESSION   FILE1
+        VERSION     FILE1.1
+        KEYWORDS    .
+        SOURCE      Test organism
+          ORGANISM  Test organism
+                    Eukaryota.
+        FEATURES             Location/Qualifiers
+             source          1..20
+                             /organism="Test organism"
+        ORIGIN
+                1 atcgatcgat cgatcgatcg
+        //
+        """
+    )
+
+    data2 = textwrap.dedent(
+        """\
+        LOCUS       FILE2SEQ     20 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  File 2 sequence.
+        ACCESSION   FILE2
+        VERSION     FILE2.1
+        KEYWORDS    .
+        SOURCE      Test organism
+          ORGANISM  Test organism
+                    Eukaryota.
+        FEATURES             Location/Qualifiers
+             source          1..20
+                             /organism="Test organism"
+        ORIGIN
+                1 gctagctagc tagctagcta
+        //
+        """
+    )
+
+    with open(file1, "w", encoding="utf-8") as f:
+        f.write(data1)
+    with open(file2, "w", encoding="utf-8") as f:
+        f.write(data2)
+
+    genbank = GenBank()
+    generator = genbank._generate_tables([[str(file1)], [str(file2)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert len(result["accession"]) == 2
+    assert "FILE1" in result["accession"]
+    assert "FILE2" in result["accession"]
+
+
+def test_genbank_extensions():
+    """Test that correct extensions are defined."""
+    assert ".gb" in GenBank.EXTENSIONS
+    assert ".gbk" in GenBank.EXTENSIONS
+    assert ".genbank" in GenBank.EXTENSIONS
+
+
+def test_genbank_all_columns():
+    """Test that all expected columns are defined."""
+    expected_columns = [
+        "locus_name",
+        "accession",
+        "version",
+        "definition",
+        "organism",
+        "taxonomy",
+        "keywords",
+        "sequence",
+        "features",
+        "length",
+        "molecule_type",
+    ]
+    assert GenBank.ALL_COLUMNS == expected_columns
+
+
+def test_genbank_locus_parsing_variations(tmp_path):
+    """Test parsing different LOCUS line formats."""
+    filename = tmp_path / "locus_variations.gb"
+    # Minimal LOCUS line
+    data = textwrap.dedent(
+        """\
+        LOCUS       MINSEQ          100 bp    mRNA            01-JAN-2024
+        DEFINITION  Minimal sequence.
+        ACCESSION   MINSEQ
+        VERSION     MINSEQ.1
+        KEYWORDS    .
+        SOURCE      Test
+          ORGANISM  Test
+                    Test.
+        FEATURES             Location/Qualifiers
+             source          1..100
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+               61 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg
+        //
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+
+    genbank = GenBank()
+    generator = genbank._generate_tables([[str(filename)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    assert result["locus_name"][0] == "MINSEQ"
+    assert result["length"][0] == 100
+    assert result["molecule_type"][0] == "mRNA"
+
+
+def test_genbank_keywords_empty(genbank_file):
+    """Test that '.' keywords are handled correctly."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    # The fixture has KEYWORDS    . which should result in empty keywords
+    assert result["keywords"][0] == ""
+
+
+def test_genbank_taxonomy_continuation(genbank_file):
+    """Test multi-line taxonomy parsing."""
+    genbank = GenBank()
+    generator = genbank._generate_tables([[genbank_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+
+    # Taxonomy should include continuation lines
+    taxonomy = result["taxonomy"][0]
+    assert "Eukaryota" in taxonomy
+    assert "Fungi" in taxonomy
+
+
+def test_genbank_feature_boolean_qualifier(tmp_path):
+    """Test parsing of boolean qualifiers like /pseudo."""
+    filename = tmp_path / "boolean_qual.gb"
+    data = textwrap.dedent(
+        """\
+        LOCUS       BOOLSEQ      50 bp    DNA             PLN       01-JAN-2024
+        DEFINITION  Sequence with boolean qualifier.
+        ACCESSION   BOOLSEQ
+        VERSION     BOOLSEQ.1
+        KEYWORDS    .
+        SOURCE      Test
+          ORGANISM  Test
+                    Test.
+        FEATURES             Location/Qualifiers
+             gene            1..50
+                             /gene="testGene"
+                             /pseudo
+        ORIGIN
+                1 atcgatcgat cgatcgatcg atcgatcgat cgatcgatcg atcgatcgat
+        //
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+
+    genbank = GenBank(parse_features=True)
+    generator = genbank._generate_tables([[str(filename)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+
+    result = pa_table.to_pydict()
+    features = json.loads(result["features"][0])
+
+    gene_feature = next((f for f in features if f["type"] == "gene"), None)
+    assert gene_feature is not None
+    assert gene_feature["qualifiers"].get("pseudo") == "true"

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -4,6 +4,7 @@ import bz2
 import gzip
 import json
 import lzma
+import os
 import textwrap
 
 import pyarrow as pa
@@ -12,7 +13,22 @@ import pytest
 from datasets import Features, Value
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
+from datasets.download.streaming_download_manager import _get_extraction_protocol
 from datasets.packaged_modules.genbank.genbank import GenBank, GenBankConfig
+
+
+def _compression_uri(path):
+    """Build the chained fsspec URI datasets uses to read a single compressed file.
+
+    The builder opens files with the streaming-patched ``open()`` (``xopen``), which
+    handles compression via ``<protocol>://<inner>::<outer>`` URIs rather than by
+    sniffing magic bytes. The protocol is derived from datasets' own extraction logic
+    so the test tracks the loader's real behavior. ``inner`` is the decompressed name.
+    """
+    path = str(path)
+    protocol = _get_extraction_protocol(path)
+    inner = os.path.basename(path).rsplit(".", 1)[0]
+    return f"{protocol}://{inner}::{path}"
 
 
 @pytest.fixture
@@ -118,7 +134,7 @@ def genbank_file_gzipped(tmp_path):
     )
     with gzip.open(filename, "wt", encoding="utf-8") as f:
         f.write(data)
-    return str(filename)
+    return _compression_uri(filename)
 
 
 @pytest.fixture
@@ -145,7 +161,7 @@ def genbank_file_bz2(tmp_path):
     )
     with bz2.open(filename, "wt", encoding="utf-8") as f:
         f.write(data)
-    return str(filename)
+    return _compression_uri(filename)
 
 
 @pytest.fixture
@@ -172,7 +188,7 @@ def genbank_file_xz(tmp_path):
     )
     with lzma.open(filename, "wt", encoding="utf-8") as f:
         f.write(data)
-    return str(filename)
+    return _compression_uri(filename)
 
 
 @pytest.fixture

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -336,7 +336,7 @@ def test_genbank_xz(genbank_file_xz):
 
 def test_genbank_feature_parsing(genbank_file_complex_features):
     """Test parsing of complex feature locations."""
-    genbank = GenBank(parse_features=True)
+    genbank = GenBank()
     generator = genbank._generate_tables([[genbank_file_complex_features]])
     pa_table = pa.concat_tables([table for _, table in generator])
 
@@ -355,18 +355,6 @@ def test_genbank_feature_parsing(genbank_file_complex_features):
     assert split_gene is not None
     assert "parts" in split_gene["location"]
     assert len(split_gene["location"]["parts"]) == 3
-
-
-def test_genbank_feature_parsing_disabled(genbank_file):
-    """Test that feature parsing can be disabled."""
-    genbank = GenBank(parse_features=False)
-    generator = genbank._generate_tables([[genbank_file]])
-    pa_table = pa.concat_tables([table for _, table in generator])
-
-    result = pa_table.to_pydict()
-
-    # Features should be empty string when parsing is disabled
-    assert result["features"][0] == ""
 
 
 def test_genbank_column_filtering(genbank_file):
@@ -393,10 +381,13 @@ def test_genbank_column_filtering_single(genbank_file):
 
 
 def test_genbank_invalid_column():
-    """Test that invalid column names raise an error."""
-    genbank = GenBank(columns=["sequence", "invalid_column"])
+    """Test that invalid column names raise an error.
+
+    Validation happens at builder construction time (via _info -> _get_columns),
+    so the error surfaces as soon as the invalid columns are configured.
+    """
     with pytest.raises(ValueError, match="Invalid column 'invalid_column'"):
-        list(genbank._generate_tables([[]]))
+        GenBank(columns=["sequence", "invalid_column"])
 
 
 def test_genbank_batch_size(genbank_file_multi_record):
@@ -451,9 +442,11 @@ def test_genbank_schema_types(genbank_file):
     assert schema.field("keywords").type == pa.string()
     assert schema.field("molecule_type").type == pa.string()
 
-    # Large string for sequence and features
+    # Large string for sequence
     assert schema.field("sequence").type == pa.large_string()
-    assert schema.field("features").type == pa.large_string()
+
+    # JSON extension type for features (parsed into objects on read)
+    assert schema.field("features").type == pa.json_()
 
     # Integer for length
     assert schema.field("length").type == pa.int64()
@@ -685,7 +678,7 @@ def test_genbank_feature_boolean_qualifier(tmp_path):
     with open(filename, "w", encoding="utf-8") as f:
         f.write(data)
 
-    genbank = GenBank(parse_features=True)
+    genbank = GenBank()
     generator = genbank._generate_tables([[str(filename)]])
     pa_table = pa.concat_tables([table for _, table in generator])
 

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -815,3 +815,91 @@ def test_genbank_protein_locus_lowercase_aa(tmp_path):
     )
     assert result["length"][0] == 50
     assert result["molecule_type"][0] == "protein"
+
+
+_HDR = _LOCUS_DNA + "FEATURES             Location/Qualifiers\n"
+
+
+def test_genbank_join_of_complements_parses_recursively(tmp_path):
+    """complement() may appear inside join()/order(); each part is parsed on its own."""
+    _, features = _parse_one(
+        tmp_path, _HDR + "     CDS             join(complement(6..10),complement(1..5))\n" + _ORIGIN
+    )
+    location = features[0]["location"]
+    assert location["operator"] == "join"
+    assert location["parts"] == [[6, 10], [1, 5]]
+    assert location["strand"] == -1
+
+
+def test_genbank_mixed_strand_join_has_no_single_strand(tmp_path):
+    """A trans-spliced join mixes strands; Biopython reports strand None for that case."""
+    _, features = _parse_one(tmp_path, _HDR + "     CDS             join(1..5,complement(8..10))\n" + _ORIGIN)
+    assert features[0]["location"]["strand"] is None
+    assert features[0]["location"]["parts"] == [[1, 5], [8, 10]]
+
+
+def test_genbank_remote_reference_in_join(tmp_path):
+    """A part may name another record (ACCESSION.VERSION:range); the range still parses."""
+    _, features = _parse_one(tmp_path, _HDR + "     CDS             join(AB000001.1:1..10,20..30)\n" + _ORIGIN)
+    assert features[0]["location"]["parts"] == [[1, 10], [20, 30]]
+
+
+def test_genbank_wrapped_free_text_qualifier_keeps_word_boundary(tmp_path):
+    """Wrapped free-text values join with a space (Biopython: q_value.replace("\\n", " "))."""
+    text = (
+        _HDR
+        + '     gene            1..10\n                     /note="alpha beta\n                     gamma"\n'
+        + _ORIGIN
+    )
+    _, features = _parse_one(tmp_path, text)
+    assert features[0]["qualifiers"]["note"] == ["alpha beta gamma"]
+
+
+def test_genbank_wrapped_translation_joins_without_space(tmp_path):
+    """/translation is the one qualifier whose wrapped lines concatenate directly."""
+    text = (
+        _HDR
+        + '     CDS             1..10\n                     /translation="MRLL\n                     ELKA"\n'
+        + _ORIGIN
+    )
+    _, features = _parse_one(tmp_path, text)
+    assert features[0]["qualifiers"]["translation"] == ["MRLLELKA"]
+
+
+def test_genbank_slash_inside_open_quoted_value_is_not_a_new_qualifier(tmp_path):
+    """A continuation line starting with '/' belongs to the still-open quoted value."""
+    text = (
+        _HDR + '     gene            1..10\n                     /note="see\n                     /docs"\n' + _ORIGIN
+    )
+    _, features = _parse_one(tmp_path, text)
+    assert features[0]["qualifiers"] == {"note": ["see /docs"]}
+
+
+def test_genbank_base_count_line_is_not_a_feature(tmp_path):
+    """Legacy BASE COUNT sits between FEATURES and ORIGIN and is a keyword, not a feature."""
+    text = _HDR + "     source          1..4\nBASE COUNT       1 a 1 c 1 g 1 t\n" + _ORIGIN
+    _, features = _parse_one(tmp_path, text)
+    assert [f["type"] for f in features] == ["source"]
+
+
+def test_genbank_contig_line_is_not_sequence(tmp_path):
+    """A CONTIG keyword line must not be folded into the sequence text."""
+    result, _ = _parse_one(tmp_path, _LOCUS_DNA + "ORIGIN\nCONTIG      join(AB000001.1:1..10,AB000002.1:1..10)\n//\n")
+    assert result["sequence"] == [""]
+
+
+def test_genbank_locus_strandedness_prefixed_molecule_type(tmp_path):
+    """LOCUS may carry ss-/ds-/ms- prefixed molecule types such as ds-DNA."""
+    result, _ = _parse_one(tmp_path, "LOCUS       T             10 bp ds-DNA     linear   PLN 01-JAN-2024\n" + _ORIGIN)
+    assert result["molecule_type"] == ["ds-DNA"]
+
+
+def test_genbank_columns_project_custom_features(tmp_path):
+    """columns= applies to a user-supplied features schema too."""
+    filename = tmp_path / "proj.gb"
+    filename.write_text(_LOCUS_DNA + _ORIGIN, encoding="utf-8")
+    builder = GenBank(columns=["sequence"], features=GenBank.DEFAULT_FEATURES)
+    table = next(iter(builder._generate_tables([[str(filename)]])))[1]
+    assert table.column_names == ["sequence"]
+    with pytest.raises(ValueError, match="not in features"):
+        GenBank(columns=["sequence"], features=Features({"locus_name": Value("string")}))._info()

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -362,12 +362,12 @@ def test_genbank_feature_parsing(genbank_file_complex_features):
     assert len(features) >= 3
 
     # Find the complement feature
-    rev_gene = next((f for f in features if f.get("qualifiers", {}).get("gene") == "revGene"), None)
+    rev_gene = next((f for f in features if f.get("qualifiers", {}).get("gene") == ["revGene"]), None)
     assert rev_gene is not None
     assert rev_gene["location"]["strand"] == -1
 
     # Find the join feature
-    split_gene = next((f for f in features if f.get("qualifiers", {}).get("gene") == "splitGene"), None)
+    split_gene = next((f for f in features if f.get("qualifiers", {}).get("gene") == ["splitGene"]), None)
     assert split_gene is not None
     assert "parts" in split_gene["location"]
     assert len(split_gene["location"]["parts"]) == 3
@@ -703,4 +703,100 @@ def test_genbank_feature_boolean_qualifier(tmp_path):
 
     gene_feature = next((f for f in features if f["type"] == "gene"), None)
     assert gene_feature is not None
-    assert gene_feature["qualifiers"].get("pseudo") == "true"
+    assert gene_feature["qualifiers"].get("pseudo") == ["true"]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for parser defects found in review. Each one reproduces a
+# case that valid GenBank files hit routinely: repeated qualifiers, locations
+# and header fields wrapped across lines, and protein LOCUS records.
+# ---------------------------------------------------------------------------
+
+_LOCUS_DNA = "LOCUS       T           100 bp    DNA     linear   PLN 01-JAN-2024\n"
+_ORIGIN = "ORIGIN\n        1 atcgatcgat\n//\n"
+
+
+def _parse_one(tmp_path, text, name="reg.gb"):
+    """Load a single inline GenBank record and return (record, decoded features)."""
+    filename = tmp_path / name
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(text)
+    tables = [table for _, table in GenBank()._generate_tables([[str(filename)]])]
+    result = pa.concat_tables(tables).to_pydict()
+    features = json.loads(result["features"][0]) if result["features"][0] else []
+    return result, features
+
+
+def test_genbank_repeated_qualifiers_are_all_kept(tmp_path):
+    """A feature with two /db_xref entries must keep both, not just the last."""
+    _, features = _parse_one(
+        tmp_path,
+        _LOCUS_DNA
+        + "FEATURES             Location/Qualifiers\n"
+        + "     gene            1..100\n"
+        + '                     /gene="g1"\n'
+        + '                     /db_xref="TAX:1"\n'
+        + '                     /db_xref="TAX:2"\n'
+        + _ORIGIN,
+    )
+    qualifiers = features[0]["qualifiers"]
+    assert qualifiers["db_xref"] == ["TAX:1", "TAX:2"]
+    assert qualifiers["gene"] == ["g1"]
+
+
+def test_genbank_wrapped_join_location(tmp_path):
+    """A join(...) location wrapped onto a second line must parse completely."""
+    _, features = _parse_one(
+        tmp_path,
+        _LOCUS_DNA
+        + "FEATURES             Location/Qualifiers\n"
+        + "     CDS             join(1..10,20..30,\n"
+        + "                     40..50)\n"
+        + '                     /gene="split"\n'
+        + _ORIGIN,
+    )
+    location = features[0]["location"]
+    assert location["parts"] == [[1, 10], [20, 30], [40, 50]]
+    assert location["start"] == 1
+    assert location["end"] == 50
+
+
+def test_genbank_wrapped_definition_is_complete(tmp_path):
+    """A DEFINITION wrapped onto a second line must not be truncated."""
+    result, _ = _parse_one(
+        tmp_path,
+        "LOCUS       T           100 bp    DNA     linear   PLN 01-JAN-2024\n"
+        "DEFINITION  First line of a long definition that\n"
+        "            continues on a second line.\n"
+        "ACCESSION   T\n" + _ORIGIN,
+    )
+    assert result["definition"][0] == "First line of a long definition that continues on a second line."
+
+
+def test_genbank_taxonomy_separators_and_no_reference_bleed(tmp_path):
+    """Taxonomy keeps the file's own delimiters and ignores later header blocks."""
+    result, _ = _parse_one(
+        tmp_path,
+        "LOCUS       T           100 bp    DNA     linear   PLN 01-JAN-2024\n"
+        "SOURCE      Test organism\n"
+        "  ORGANISM  Test organism\n"
+        "            Eukaryota; Fungi;\n"
+        "            Ascomycota.\n"
+        "REFERENCE   1  (bases 1 to 100)\n"
+        "  AUTHORS   Someone,A.\n"
+        "            Wrapped author line here\n" + _ORIGIN,
+    )
+    taxonomy = result["taxonomy"][0]
+    assert taxonomy == "Eukaryota; Fungi; Ascomycota."
+    assert ";;" not in taxonomy
+    assert "author" not in taxonomy.lower()
+
+
+def test_genbank_protein_locus_lowercase_aa(tmp_path):
+    """A protein LOCUS line using the lowercase `aa` unit is a protein record."""
+    result, _ = _parse_one(
+        tmp_path,
+        "LOCUS       P            50 aa            linear   PLN 01-JAN-2024\nORIGIN\n        1 mkwvtfisll\n//\n",
+    )
+    assert result["length"][0] == 50
+    assert result["molecule_type"][0] == "protein"

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -744,6 +744,21 @@ def test_genbank_repeated_qualifiers_are_all_kept(tmp_path):
     assert qualifiers["gene"] == ["g1"]
 
 
+def test_genbank_order_location_parses(tmp_path):
+    """order(...) is a valid location operator and must not crash the loader."""
+    _, features = _parse_one(
+        tmp_path,
+        _LOCUS_DNA
+        + "FEATURES             Location/Qualifiers\n"
+        + "     gene            order(1..5,8..10)\n"
+        + _ORIGIN,
+    )
+    location = features[0]["location"]
+    assert location["operator"] == "order"
+    assert location["parts"] == [[1, 5], [8, 10]]
+    assert (location["start"], location["end"]) == (1, 10)
+
+
 def test_genbank_wrapped_join_location(tmp_path):
     """A join(...) location wrapped onto a second line must parse completely."""
     _, features = _parse_one(

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -603,6 +603,8 @@ def test_genbank_all_columns():
         "features",
         "length",
         "molecule_type",
+        "secondary_accessions",
+        "contig",
     ]
     assert GenBank.ALL_COLUMNS == expected_columns
 
@@ -703,7 +705,7 @@ def test_genbank_feature_boolean_qualifier(tmp_path):
 
     gene_feature = next((f for f in features if f["type"] == "gene"), None)
     assert gene_feature is not None
-    assert gene_feature["qualifiers"].get("pseudo") == ["true"]
+    assert gene_feature["qualifiers"].get("pseudo") == [""]  # valueless, as Biopython stores it
 
 
 # ---------------------------------------------------------------------------
@@ -903,3 +905,44 @@ def test_genbank_columns_project_custom_features(tmp_path):
     assert table.column_names == ["sequence"]
     with pytest.raises(ValueError, match="not in features"):
         GenBank(columns=["sequence"], features=Features({"locus_name": Value("string")}))._info()
+
+
+def test_genbank_partial_location_markers_are_kept(tmp_path):
+    """'<' and '>' mark boundaries beyond the coordinate (Biopython Before/AfterPosition)."""
+    _, features = _parse_one(
+        tmp_path,
+        _HDR
+        + "     gene            <1..>10\n     CDS             3..8\n     mRNA            join(<1..5,8..>10)\n"
+        + _ORIGIN,
+    )
+    fuzzy, exact, compound = (f["location"] for f in features)
+    assert (fuzzy["start_partial"], fuzzy["end_partial"]) == (True, True)
+    assert (exact["start_partial"], exact["end_partial"]) == (False, False)
+    assert (compound["start_partial"], compound["end_partial"]) == (True, True)
+    assert (fuzzy["start"], fuzzy["end"]) == (1, 10)
+
+
+def test_genbank_secondary_accessions_including_continuation_lines(tmp_path):
+    result, _ = _parse_one(tmp_path, _LOCUS_DNA + "ACCESSION   M55673 M25818\n            M27095\n" + _ORIGIN)
+    assert result["accession"] == ["M55673"]
+    assert result["secondary_accessions"] == [["M25818", "M27095"]]
+
+
+def test_genbank_contig_expression_is_stored(tmp_path):
+    """CONTIG follows the feature table and may wrap; it is kept whole and is not sequence."""
+    text = _HDR + "     source          1..20\nCONTIG      join(AB000001.1:1..10,\n            AB000002.1:1..10)\n//\n"
+    result, features = _parse_one(tmp_path, text)
+    assert result["contig"] == ["join(AB000001.1:1..10,AB000002.1:1..10)"]
+    assert result["sequence"] == [""]
+    assert [f["type"] for f in features] == ["source"]
+    result, _ = _parse_one(tmp_path, _LOCUS_DNA + "CONTIG      join(X.1:1..5)\n" + _ORIGIN)
+    assert result["contig"] == ["join(X.1:1..5)"]
+
+
+def test_genbank_features_subset_selects_columns(tmp_path):
+    """A features schema naming a subset of columns yields exactly those columns."""
+    filename = tmp_path / "sub.gb"
+    filename.write_text(_LOCUS_DNA + _ORIGIN, encoding="utf-8")
+    features = Features({"locus_name": Value("string"), "sequence": Value("large_string")})
+    table = next(iter(GenBank(features=features)._generate_tables([[str(filename)]])))[1]
+    assert table.column_names == ["locus_name", "sequence"]

--- a/tests/packaged_modules/test_genbank.py
+++ b/tests/packaged_modules/test_genbank.py
@@ -6,15 +6,21 @@ import json
 import lzma
 import os
 import textwrap
+from pathlib import Path
 
 import pyarrow as pa
 import pytest
 
-from datasets import Features, Value
+from datasets import BioSequence, Dataset, DatasetInfo, Features, Value
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.download.streaming_download_manager import _get_extraction_protocol
 from datasets.packaged_modules.genbank.genbank import GenBank, GenBankConfig
+
+
+require_biopython = pytest.mark.skipif(
+    not __import__("datasets").config.BIOPYTHON_AVAILABLE, reason="biopython is not installed"
+)
 
 
 def _compression_uri(path):
@@ -60,7 +66,7 @@ def genbank_file(tmp_path):
         //
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
     return str(filename)
 
@@ -104,7 +110,7 @@ def genbank_file_multi_record(tmp_path):
         //
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
     return str(filename)
 
@@ -132,7 +138,7 @@ def genbank_file_gzipped(tmp_path):
         //
         """
     )
-    with gzip.open(filename, "wt", encoding="utf-8") as f:
+    with gzip.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(data)
     return _compression_uri(filename)
 
@@ -159,7 +165,7 @@ def genbank_file_bz2(tmp_path):
         //
         """
     )
-    with bz2.open(filename, "wt", encoding="utf-8") as f:
+    with bz2.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(data)
     return _compression_uri(filename)
 
@@ -186,7 +192,7 @@ def genbank_file_xz(tmp_path):
         //
         """
     )
-    with lzma.open(filename, "wt", encoding="utf-8") as f:
+    with lzma.open(filename, "wt", encoding="utf-8", newline="") as f:
         f.write(data)
     return _compression_uri(filename)
 
@@ -224,7 +230,7 @@ def genbank_file_complex_features(tmp_path):
         //
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
     return str(filename)
 
@@ -262,7 +268,7 @@ ORIGIN
 """
         records.append(record)
 
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write("\n".join(records))
     return str(filename)
 
@@ -310,6 +316,126 @@ def test_genbank_multi_record(genbank_file_multi_record):
     assert result["accession"] == ["SEQ001", "SEQ002"]
     assert result["molecule_type"] == ["DNA", "RNA"]
     assert result["organism"] == ["Escherichia coli", "Test virus"]
+
+
+def test_genbank_record_feature(genbank_file_multi_record):
+    builder = GenBank()
+    table = pa.concat_tables([table for _, table in builder._generate_tables([[genbank_file_multi_record]])])
+
+    assert builder.DEFAULT_FEATURES["record"] == BioSequence(format="genbank")
+    assert builder.info.features["record"] == BioSequence(format="genbank")
+    assert table.schema.field("record").type == BioSequence().pa_type
+    assert Dataset(table).features["record"] == BioSequence(format="genbank")
+
+
+@require_biopython
+def test_genbank_record_decodes_to_seqrecord(genbank_file_multi_record):
+    from Bio.SeqRecord import SeqRecord
+
+    builder = GenBank(batch_size=1)
+    table = pa.concat_tables([table for _, table in builder._generate_tables([[genbank_file_multi_record]])])
+    dataset = Dataset(table, info=builder.info)
+
+    assert len(dataset) == 2
+    for row in dataset:
+        record = row["record"]
+        assert isinstance(record, SeqRecord)
+        assert record.id == row["version"]
+        assert record.id.rsplit(".", 1)[0] == row["accession"]
+        assert record.name == row["locus_name"]
+        assert str(record.seq) == row["sequence"]
+
+
+def test_genbank_columns_drop_record_without_biopython(genbank_file_multi_record, monkeypatch):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    builder = GenBank(columns=["accession", "sequence"])
+    table = pa.concat_tables([table for _, table in builder._generate_tables([[genbank_file_multi_record]])])
+    dataset = Dataset(table, info=builder.info)
+
+    assert dataset.column_names == ["accession", "sequence"]
+    assert "record" not in dataset.features
+    assert [row["accession"] for row in dataset] == ["SEQ001", "SEQ002"]
+
+
+@pytest.mark.parametrize("columns", [None, ["record"], ["sequence", "record"]])
+def test_genbank_record_decode_false(genbank_file_multi_record, monkeypatch, columns):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    features = Features({**GenBank.DEFAULT_FEATURES, "record": BioSequence(format="genbank", decode=False)})
+    builder = GenBank(features=features, columns=columns)
+    table = pa.concat_tables([table for _, table in builder._generate_tables([[genbank_file_multi_record]])])
+    dataset = Dataset(table, info=builder.info)
+
+    assert dataset.features["record"] == BioSequence(format="genbank", decode=False)
+    if columns is not None:
+        assert dataset.column_names == columns
+    records = [row["record"] for row in dataset]
+    raw = Path(genbank_file_multi_record).read_bytes()
+    expected = [record + b"//\n" for record in raw.split(b"//\n")[:-1]]
+    assert records == [{"bytes": record, "path": None} for record in expected]
+    assert b"".join(record["bytes"] for record in records) == raw
+
+
+@pytest.mark.parametrize(
+    "suffix,opener", [(".gb", open), (".gb.gz", gzip.open), (".gb.bz2", bz2.open), (".gb.xz", lzma.open)]
+)
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n"])
+def test_genbank_record_preserves_bytes(genbank_file_multi_record, tmp_path, suffix, opener, newline):
+    records = [
+        (record + b"//\n").replace(b"\n", newline)
+        for record in Path(genbank_file_multi_record).read_bytes().split(b"//\n")[:-1]
+    ]
+    filename = tmp_path / ("raw" + suffix)
+    with opener(filename, "wb") as fp:
+        fp.write(b"File preamble\n\n" + b"\n".join(records) + b"\nFile trailer\n")
+    file = str(filename) if suffix == ".gb" else _compression_uri(filename)
+    builder = GenBank(columns=["record"], batch_size=1)
+    table = pa.concat_tables([table for _, table in builder._generate_tables([[file]])])
+    dataset = Dataset(table, info=builder.info).cast_column("record", BioSequence(format="genbank", decode=False))
+
+    assert [row["record"] for row in dataset] == [{"bytes": record, "path": None} for record in records]
+
+
+@pytest.fixture
+def genbank_file_missing_final_newline(genbank_file_multi_record, tmp_path):
+    raw = Path(genbank_file_multi_record).read_bytes().removesuffix(b"\n")
+    filename = tmp_path / "no_final_newline.gb"
+    filename.write_bytes(raw)
+    return filename
+
+
+def test_genbank_record_preserves_missing_final_newline(genbank_file_missing_final_newline, monkeypatch):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    raw = genbank_file_missing_final_newline.read_bytes()
+    builder = GenBank(columns=["record"])
+    table = pa.concat_tables(
+        [table for _, table in builder._generate_tables([[str(genbank_file_missing_final_newline)]])]
+    )
+
+    assert raw.endswith(b"//")
+    assert table["record"].to_pylist()[-1] == {"bytes": raw.rsplit(b"//\n", 1)[-1], "path": None}
+    assert b"".join(record["bytes"] for record in table["record"].to_pylist()) == raw
+
+
+@require_biopython
+def test_genbank_record_decodes_missing_final_newline(genbank_file_missing_final_newline):
+    from Bio.SeqRecord import SeqRecord
+
+    builder = GenBank(columns=["record"])
+    table = pa.concat_tables(
+        [table for _, table in builder._generate_tables([[str(genbank_file_missing_final_newline)]])]
+    )
+    record = Dataset(table, info=builder.info)[-1]["record"]
+    assert isinstance(record, SeqRecord)
+    assert record.id == "SEQ002.1"
+    assert str(record.seq) == "AUGC" * 12 + "AU"
+
+
+def test_genbank_record_capture_accepts_single_pass_iterator(genbank_file_multi_record):
+    raw = Path(genbank_file_multi_record).read_bytes()
+    records = list(GenBank()._parse_genbank(iter(raw.decode("utf-8").splitlines(keepends=True))))
+
+    assert len(records) == 2
+    assert b"".join(record["record"]["bytes"] for record in records) == raw
 
 
 def test_genbank_gzipped(genbank_file_gzipped):
@@ -406,6 +532,12 @@ def test_genbank_invalid_column():
         GenBank(columns=["sequence", "invalid_column"])
 
 
+@pytest.mark.parametrize("features", [None, Features({"sequence": Value("string")})])
+def test_genbank_duplicate_columns_is_rejected(features):
+    with pytest.raises(ValueError, match=r"^Duplicate column 'sequence' in columns\.$"):
+        GenBank(columns=["sequence", "sequence"], features=features)
+
+
 def test_genbank_batch_size(genbank_file_multi_record):
     """Test batch size configuration."""
     genbank = GenBank(batch_size=1)
@@ -497,7 +629,7 @@ def test_genbank_feature_casting(genbank_file):
 def test_genbank_empty_file(tmp_path):
     """Test handling of empty GenBank file."""
     filename = tmp_path / "empty.gb"
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write("")
 
     genbank = GenBank()
@@ -566,9 +698,9 @@ def test_genbank_multiple_files(tmp_path):
         """
     )
 
-    with open(file1, "w", encoding="utf-8") as f:
+    with open(file1, "w", encoding="utf-8", newline="") as f:
         f.write(data1)
-    with open(file2, "w", encoding="utf-8") as f:
+    with open(file2, "w", encoding="utf-8", newline="") as f:
         f.write(data2)
 
     genbank = GenBank()
@@ -605,6 +737,7 @@ def test_genbank_all_columns():
         "molecule_type",
         "secondary_accessions",
         "contig",
+        "record",
     ]
     assert GenBank.ALL_COLUMNS == expected_columns
 
@@ -631,7 +764,7 @@ def test_genbank_locus_parsing_variations(tmp_path):
         //
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
 
     genbank = GenBank()
@@ -693,7 +826,7 @@ def test_genbank_feature_boolean_qualifier(tmp_path):
         //
         """
     )
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(data)
 
     genbank = GenBank()
@@ -721,7 +854,7 @@ _ORIGIN = "ORIGIN\n        1 atcgatcgat\n//\n"
 def _parse_one(tmp_path, text, name="reg.gb"):
     """Load a single inline GenBank record and return (record, decoded features)."""
     filename = tmp_path / name
-    with open(filename, "w", encoding="utf-8") as f:
+    with open(filename, "w", encoding="utf-8", newline="") as f:
         f.write(text)
     tables = [table for _, table in GenBank()._generate_tables([[str(filename)]])]
     result = pa.concat_tables(tables).to_pydict()
@@ -899,12 +1032,31 @@ def test_genbank_locus_strandedness_prefixed_molecule_type(tmp_path):
 def test_genbank_columns_project_custom_features(tmp_path):
     """columns= applies to a user-supplied features schema too."""
     filename = tmp_path / "proj.gb"
-    filename.write_text(_LOCUS_DNA + _ORIGIN, encoding="utf-8")
+    filename.write_bytes((_LOCUS_DNA + _ORIGIN).encode("utf-8"))
     builder = GenBank(columns=["sequence"], features=GenBank.DEFAULT_FEATURES)
+    assert builder.info.features == Features({"sequence": Value("large_string")})
     table = next(iter(builder._generate_tables([[str(filename)]])))[1]
     assert table.column_names == ["sequence"]
+    assert Features.from_arrow_schema(table.schema) == builder.info.features
     with pytest.raises(ValueError, match="not in features"):
         GenBank(columns=["sequence"], features=Features({"locus_name": Value("string")}))._info()
+
+
+@pytest.mark.parametrize("columns", [None, ["record"]])
+@pytest.mark.parametrize("subset", [False, True])
+def test_genbank_preserves_supplied_info_features(genbank_file_multi_record, monkeypatch, columns, subset):
+    monkeypatch.setattr("datasets.config.BIOPYTHON_AVAILABLE", False)
+    features = Features({**GenBank.DEFAULT_FEATURES, "record": BioSequence(format="genbank", decode=False)})
+    if subset:
+        features = Features({"record": features["record"]})
+    builder = GenBank(info=DatasetInfo(features=features, description="custom info"), columns=columns)
+    expected = features if columns is None else Features({"record": features["record"]})
+    assert builder.info.features == expected
+    assert builder.info.description == "custom info"
+    _, table = next(builder._generate_tables([[genbank_file_multi_record]]))
+    assert Features.from_arrow_schema(table.schema) == expected
+    dataset = Dataset(table, info=builder.info)
+    assert b"".join(row["record"]["bytes"] for row in dataset) == Path(genbank_file_multi_record).read_bytes()
 
 
 def test_genbank_partial_location_markers_are_kept(tmp_path):
@@ -942,7 +1094,7 @@ def test_genbank_contig_expression_is_stored(tmp_path):
 def test_genbank_features_subset_selects_columns(tmp_path):
     """A features schema naming a subset of columns yields exactly those columns."""
     filename = tmp_path / "sub.gb"
-    filename.write_text(_LOCUS_DNA + _ORIGIN, encoding="utf-8")
+    filename.write_bytes((_LOCUS_DNA + _ORIGIN).encode("utf-8"))
     features = Features({"locus_name": Value("string"), "sequence": Value("large_string")})
     table = next(iter(GenBank(features=features)._generate_tables([[str(filename)]])))[1]
     assert table.column_names == ["locus_name", "sequence"]


### PR DESCRIPTION
## Summary
Add native support for loading GenBank (.gb, .gbk, .genbank) files, a standard format for biological sequence data with annotations maintained by NCBI.

## Changes
- Add `genbank` packaged module with pure Python state machine parser
- Register GenBank extensions in `_PACKAGED_DATASETS_MODULES` and `_EXTENSION_TO_MODULE`
- Add comprehensive test suite (28 tests)

## Features
- **Metadata parsing**: LOCUS, DEFINITION, ACCESSION, VERSION, KEYWORDS, ORGANISM, taxonomy
- **Feature parsing**: Structured JSON output with location parsing (complement, join)
- **Sequence parsing**: ORIGIN section with automatic length calculation
- **Compression support**: gzip, bz2, xz via magic bytes detection
- **Memory efficiency**: Dual-threshold batching (batch_size + max_batch_bytes)
- **Large sequences**: Uses `large_string` Arrow type for sequences/features

## Usage
```python
from datasets import load_dataset

# Load GenBank files
ds = load_dataset("genbank", data_files="sequences.gb")

# With options
ds = load_dataset("genbank", data_files="*.gbk", 
                  columns=["sequence", "organism", "features"],
                  parse_features=True)
```

## Test plan
- [x] All 28 unit tests pass
- [x] Tests cover: basic loading, multi-record, compression, feature parsing, column filtering, batching, schema types