### PR TITLE
Fix #5354: replace list with Sequence in from_parquet type hints

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1265,7 +1265,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, Sequence[PathLike]],
+        path_or_paths: Union[PathLike, Sequence_[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,


### PR DESCRIPTION
This PR replaces `list` type hints with `Sequence` in `from_parquet` to improve type checking.

Note: Local pytest errors on Python 3.13 due to removal of `distutils` are unrelated to this change.
