### PR TITLE
#5354: replace list with Sequence in from_parquet type hints

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -138,9 +138,6 @@ from .utils.stratify import stratified_shuffle_split_generate_indices
 from .utils.tf_utils import dataset_to_tf, minimal_tf_collate_fn, multiprocess_dataset_to_tf
 from .utils.typing import ListLike, PathLike
 
-
-
-
 if TYPE_CHECKING:
     import sqlite3
 


### PR DESCRIPTION
\This PR replaces `list` type hints with `Sequence` in `from_parquet` to improve type checking.

Note: Local pytest errors on Python 3.13 due to removal of `distutils` are unrelated to this change.
