### PR TITLE
Fix all exhausted without replacement

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6638,65 +6638,63 @@ def _interleave_map_style_datasets(
     # if stopping_strategy is "first_exhausted", it is an undersampling situation whereas it is an oversampling situation if it is "all_exhausted"
     oversampling = stopping_strategy == "all_exhausted"
 
-    if probabilities is None and not oversampling:
-        # Undersampling situation with cycling between each sources
-        # Example:: If lengths of the datasets are [3, 4, 5]
-        # Then the resulting indices should be [0, 3, 7, 1, 4, 8, 2, 6, 9]
-        # Note that we only have 3 examples per dataset since the first dataset ran out of examples
-
-        # Reasoning behind the following operation: keeping the min_length first indices of each dataset
-        # while offsetting in order to correspond to the right indices of the concatenated dataset
-        # and flattening to effectively interleave the datasets
+    if probabilities is None and stopping_strategy == "first_exhausted":
+        # Undersampling situation with cycling between each source
         indices = (offsets.reshape(1, -1) + np.arange(min(lengths)).reshape(-1, 1)).flatten().tolist()
-    elif probabilities is None:
-        # Oversampling situation with cycling between each sources
-        # Then the resulting indices should be [0, 3, 7, 1, 4, 8, 2, 5, 9, 0, 6, 10, 1, 3, 11]
-        # Note that we have 5 examples per dataset with a rolling window since the longest dataset has 5 samples
-
-        # Reasoning behind the following operation: for each dataset indices (i.e column) repeat the indices to have max_length indices per dataset
-        # For example, if the max_length is 5 and the i-th dataset has 3 samples, the i-th column will be [0,1,2,0,1]
+    elif probabilities is None and stopping_strategy == "all_exhausted":
+        # Oversampling situation with cycling between each source
         indices = np.mod(np.arange(max(lengths)).reshape(-1, 1), np.array(lengths).reshape(1, -1))
-
-        # We have to keep the indices to their respective dataset offsets and to flatten to effectively interleave the datasets
         indices = (indices + offsets).flatten().tolist()
-
+    elif probabilities is None and stopping_strategy == "all_exhausted_without_replacement":
+        # Deterministic round-robin without replacement: emit every sample exactly once
+        current_index = [0] * len(datasets)
+        indices = []
+        total_samples = sum(lengths)
+        while len(indices) < total_samples:
+            for source_idx in range(len(datasets)):
+                if current_index[source_idx] >= lengths[source_idx]:
+                    continue
+                indices.append(current_index[source_idx] + offsets[source_idx])
+                current_index[source_idx] += 1
+                if len(indices) == total_samples:
+                    break
     else:
-        # boolean array indicating if at index i if the dataset_i has been fully exhausted
+        # Random sampling branch (with or without replacement depending on strategy)
         is_exhausted = np.full(len(lengths), False)
-
-        # if undersampling ("first_exhausted"), we stop as soon as one dataset is exhausted
-        # if oversampling ("all_exhausted"), we stop as soons as every dataset is exhausted, i.e as soon as every samples of every dataset has been visited at least once
-        bool_strategy_func = (
-            np.all if oversampling else np.any
-        )
+        bool_strategy_func = np.all if (oversampling or stopping_strategy == "all_exhausted_without_replacement") else np.any
 
         def iter_random_indices():
-            """Get an infinite iterator that randomly samples the index of the source to pick examples from."""
             rng = np.random.default_rng(seed)
             while True:
                 yield from (int(i) for i in rng.choice(len(datasets), size=1000, p=probabilities))
 
         current_index = [0] * len(datasets)
         indices = []
+        total_samples = sum(lengths)
+        emitted = 0
+
         for source_idx in iter_random_indices():
-            # If no oversampling, we stop as soon as a dataset has ran out of examples (np.any)
-            # Otherwise, we stop as soon as every dataset has ran out of examples (np.all)
-            if bool_strategy_func(is_exhausted):
-                # the stopping condition was reached, let's stop
-                break
+            if stopping_strategy == "all_exhausted_without_replacement" and is_exhausted[source_idx]:
+                continue
 
-            # let's add the example at the current index of the `source_idx`-th dataset
-            # For without replacement sampling we additionally need to make sure the current source is not exhausted to not oversample.
-            if not is_exhausted[source_idx]:
-                indices.append(current_index[source_idx] + offsets[source_idx])
-                current_index[source_idx] += 1
+            indices.append(current_index[source_idx] + offsets[source_idx])
+            current_index[source_idx] += 1
 
-            # we've ran out of examples for the current dataset, let's update our boolean array and bring the current_index back to 0
-            if current_index[source_idx] >= lengths[source_idx]:
-                is_exhausted[source_idx] = True
-                # We don't want to reset the iterator when stopping strategy is without replacement.
-                if stopping_strategy != "all_exhausted_without_replacement":
-                    current_index[source_idx] = 0
+            if stopping_strategy == "all_exhausted_without_replacement":
+                emitted += 1
+                if current_index[source_idx] >= lengths[source_idx]:
+                    is_exhausted[source_idx] = True
+                if emitted == total_samples:
+                    break
+            else:
+                if current_index[source_idx] >= lengths[source_idx]:
+                    is_exhausted[source_idx] = True
+                if bool_strategy_func(is_exhausted):
+                    break
+
+            if stopping_strategy != "all_exhausted_without_replacement" and current_index[source_idx] >= lengths[source_idx]:
+                current_index[source_idx] = 0
+
 
     return concatenated_datasets.select(indices, **kwargs)
 

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,0 +1,13 @@
+def test_interleave_all_exhausted_without_replacement_keeps_last_elements():
+    from datasets import Dataset, interleave_datasets
+
+    d1 = Dataset.from_dict({"a": [0, 1, 2]})
+    d2 = Dataset.from_dict({"a": [10, 11, 12, 13]})
+    d3 = Dataset.from_dict({"a": [20, 21, 22]})
+
+    dataset = interleave_datasets(
+        [d1, d2, d3],
+        stopping_strategy="all_exhausted_without_replacement",
+    )
+
+    assert dataset["a"] == [0, 10, 20, 1, 11, 21, 2, 12, 22, 13]


### PR DESCRIPTION
Fix interleave_datasets "all_exhausted_without_replacement" stopping strategy

- Corrected logic to ensure each sample is picked exactly once when using 
  stopping_strategy="all_exhausted_without_replacement".
- Adjusted boolean stopping condition to properly track dataset exhaustion.
- Added test to verify the last element is included as expected.
