### PR TITLE
Docs: add Dataset.from_dict example

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-detectable=false

--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -100,6 +100,15 @@ The base class [`Dataset`] implements a Dataset backed by an Apache Arrow table.
     - from_sql
     - align_labels_with_mapping
 
+### Example: create a Dataset from a Python dict
+
+```py
+from datasets import Dataset
+
+data = {"text": ["hello", "world"], "label": [0, 1]}
+ds = Dataset.from_dict(data)
+```
+
 [[autodoc]] datasets.concatenate_datasets
 
 [[autodoc]] datasets.interleave_datasets


### PR DESCRIPTION
Docs: add a minimal `Dataset.from_dict` example.

This helps new users discover the most direct way to build a small dataset from in-memory Python data.

Docs-only change.