### PR TITLE
Remove pre-release workaround in CI for `transformers v5` and `huggingface_hub v1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,7 @@ jobs:
       - name: Install uv
         run: pip install --upgrade uv
       - name: Install dependencies
-        run: |
-          uv pip install --system "datasets[tests_numpy2] @ ."
-          # TODO: remove once transformers v5 / huggingface_hub v1 are released officially
-          uv pip uninstall --system transformers huggingface_hub
-          uv pip install --system --prerelease=allow git+https://github.com/huggingface/transformers.git
+        run: uv pip install --system "datasets[tests_numpy2] @ ."
       - name: Print dependencies
         run: pip list
 


### PR DESCRIPTION
This PR removes workaround for pre-release `transformers v5.*` / `huggingface_hub v1.*` in `test_py314_future` job since they are now officially released.

cc @Wauplin just for viz since you introduced this in https://github.com/huggingface/datasets/pull/7783.