### PR TITLE
Bump fsspec upper bound to 2026.2.0 (fixes #7994)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ REQUIRED_PKGS = [
     "multiprocess<0.70.19",  # to align with dill<0.3.9 (see above)
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0,<=2025.10.0",
+    "fsspec[http]>=2023.1.0,<=2026.2.0",
     # To get datasets from the Datasets Hub on huggingface.co
     "huggingface-hub>=0.25.0,<2.0",
     # Utilities from PyPA to e.g., compare versions


### PR DESCRIPTION
Fixes #7994 and e.g. “Bumps fsspec upper bound so the latest version can be used; CI will validate compatibility.”