### PR TITLE
fix save_to_disk/load_from_disk with pathlib.Path input

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1566,6 +1566,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             # if we have only a few large samples, we should only create as many shards as samples
             num_shards = min(len(self.data), num_shards)
 
+        dataset_path = os.fspath(dataset_path)
+
         fs: fsspec.AbstractFileSystem
         fs, _ = url_to_fs(dataset_path, **(storage_options or {}))
 
@@ -1737,6 +1739,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds = load_from_disk("path/to/dataset/directory")
         ```
         """
+        dataset_path = os.fspath(dataset_path)
+
         fs: fsspec.AbstractFileSystem
         fs, dataset_path = url_to_fs(dataset_path, **(storage_options or {}))
 

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -4,6 +4,7 @@ import fnmatch
 import itertools
 import json
 import math
+import os
 import posixpath
 import random
 import re
@@ -1338,6 +1339,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         >>> dataset_dict.save_to_disk("path/to/dataset/directory", num_shards={"train": 1024, "test": 8})
         ```
         """
+        dataset_dict_path = os.fspath(dataset_dict_path)
+
         fs: fsspec.AbstractFileSystem
         fs, _ = url_to_fs(dataset_dict_path, **(storage_options or {}))
 
@@ -1397,6 +1400,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         >>> ds = load_from_disk('path/to/dataset/directory')
         ```
         """
+        dataset_dict_path = os.fspath(dataset_dict_path)
+
         fs: fsspec.AbstractFileSystem
         fs, dataset_dict_path = url_to_fs(dataset_dict_path, **(storage_options or {}))
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1553,6 +1553,8 @@ def load_from_disk(
     >>> ds = load_from_disk('path/to/dataset/directory')
     ```
     """
+    dataset_path = os.fspath(dataset_path)
+
     fs: fsspec.AbstractFileSystem
     fs, *_ = url_to_fs(dataset_path, **(storage_options or {}))
     if not fs.exists(dataset_path):


### PR DESCRIPTION
Since #6704, `save_to_disk` and `load_from_disk` use `fsspec.core.url_to_fs` which expects a `str`, but both methods accept `PathLike` (which includes `pathlib.Path`). Passing a `Path` object raises a `TypeError` because `url_to_fs` can't handle it.

Fixed by converting the path argument with `os.fspath()` before handing it off to `url_to_fs`. This affects all five call sites across `Dataset`, `DatasetDict`, and the standalone `load_from_disk` function.

Fixes #6829