### PR TITLE
fix: condition for file_name feature check

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -216,7 +216,8 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                     out = type(feature)()
                     for key in feature:
                         if (key == "file_name" or key.endswith("_file_name")) and (
-                            feature[key] == datasets.Value("string") or feature[key] == datasets.Value("large_string")
+                            feature[key] == datasets.Value("string")
+                            or feature[key] == datasets.Value("large_string")
                         ):
                             key = key[: -len("_file_name")] or self.BASE_COLUMN_NAME
                             out[key] = self.BASE_FEATURE()


### PR DESCRIPTION
## Description
Accept `Value("large_string")` in addition to `Value("string")` for the `file_name` (or `*_file_name`) metadata key in folder-based builders (e.g. `audiofolder`).

## Problem
When loading a dataset with `load_dataset("audiofolder", data_dir=...)` and a `metadata.csv` file, the metadata schema is inferred via pandas to Arrow. For string columns, Arrow often uses the `large_string` type, so `Features.from_arrow_schema()` yields `Value("large_string")` for the `file_name` column. The builder only checks for `Value("string")`, so validation fails with:

`ValueError: file_name or *_file_name must be present as dictionary key (with type string) in metadata files`

Users then have to convert metadata to JSONL (which produces Arrow `string`) or work around the loader.

## Solution
Treat `Value("large_string")` as valid for the `file_name` / `*_file_name` key, since it is still a string type and behaves the same for resolution of audio/image paths. This matches the fact that when metadata is loaded from CSV (via pandas and then converted to Arrow), string columns are often inferred as Arrow `large_string`, so accepting it keeps CSV metadata working without format changes.