### PR TITLE
Add space between sentences 'operation.To debug'

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -617,7 +617,7 @@ def iflatmap_unordered(
                     pool_changed = True
                     # One of the subprocesses has died. We should not wait forever.
                     raise RuntimeError(
-                        "One of the subprocesses has abruptly died during map operation."
+                        "One of the subprocesses has abruptly died during map operation. "
                         "To debug the error, disable multiprocessing."
                     )
         finally:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1905,7 +1905,7 @@ class BaseDatasetTest(TestCase):
                 with pytest.raises(RuntimeError) as excinfo:
                     dset.map(do_crash, num_proc=2)
                 assert str(excinfo.value) == (
-                    "One of the subprocesses has abruptly died during map operation."
+                    "One of the subprocesses has abruptly died during map operation. "
                     "To debug the error, disable multiprocessing."
                 )
 


### PR DESCRIPTION
Previously the exception message would read "...abruptly died during map _operation.To_ debug the error...".

The `operation.To` part would actually render as a hyperlink when printed to Slack.