### PR TITLE
feat: add return_file_name support to CSV packaged builder

### DIFF
--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
+import os
+
 import pandas as pd
 import pyarrow as pa
 
@@ -66,6 +68,8 @@ class CsvConfig(datasets.BuilderConfig):
     encoding_errors: Optional[str] = "strict"
     on_bad_lines: Literal["error", "warn", "skip"] = "error"
     date_format: Optional[str] = None
+    return_file_name: bool = False
+    """If True, add a ``file_name`` column with the source file basename for each row."""
 
     def __post_init__(self):
         super().__post_init__()
@@ -200,6 +204,12 @@ class Csv(datasets.ArrowBasedBuilder):
                         # Uncomment for debugging (will print the Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
+                        if self.config.return_file_name:
+                            file_name = os.path.basename(file)
+                            pa_table = pa_table.append_column(
+                                "file_name",
+                                pa.array([file_name] * len(pa_table), type=pa.string()),
+                            )
                         yield Key(shard_idx, batch_idx), self._cast_table(pa_table)
                 except ValueError as e:
                     logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")

--- a/tests/packaged_modules/test_csv.py
+++ b/tests/packaged_modules/test_csv.py
@@ -151,3 +151,35 @@ def test_csv_convert_int_list(csv_file_with_int_list):
     assert pa.types.is_list(pa_table.schema.field("int_list").type)
     generated_content = pa_table.to_pydict()["int_list"]
     assert generated_content == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+
+def test_csv_no_file_name_by_default(csv_file):
+    """Ensure backward compatibility: file_name column is absent when return_file_name is not set."""
+    csv = Csv()
+    base_files = [csv_file]
+    files_iterables = [[file] for file in base_files]
+    generator = csv._generate_tables(base_files=base_files, files_iterables=files_iterables)
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert "file_name" not in pa_table.column_names
+
+
+def test_csv_return_file_name_enabled(csv_file):
+    """When return_file_name=True, the file_name column should be present."""
+    csv = Csv(return_file_name=True)
+    base_files = [csv_file]
+    files_iterables = [[file] for file in base_files]
+    generator = csv._generate_tables(base_files=base_files, files_iterables=files_iterables)
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert "file_name" in pa_table.column_names
+
+
+def test_csv_file_name_values(csv_file):
+    """The file_name column should contain the basename of the source file for every row."""
+    csv = Csv(return_file_name=True)
+    base_files = [csv_file]
+    files_iterables = [[csv_file]]
+    generator = csv._generate_tables(base_files=base_files, files_iterables=files_iterables)
+    pa_table = pa.concat_tables([table for _, table in generator])
+    data = pa_table.to_pydict()
+    expected_name = os.path.basename(csv_file)
+    assert all(name == expected_name for name in data["file_name"])


### PR DESCRIPTION
## Summary

- Adds an optional `return_file_name: bool = False` parameter to `CsvConfig`
- When `return_file_name=True`, a `file_name` column is appended to every batch in `_generate_tables`, containing the basename of the source CSV file for each row
- Default is `False`, preserving full backward compatibility

## Motivation

Part of #5806. Extends the `file_name` feature (already implemented for the JSON packaged builder in #7948) to the CSV packaged builder. This enables use cases such as resuming training from checkpoints by identifying which data shards have already been consumed.

## Changes

- `src/datasets/packaged_modules/csv/csv.py`: Add `return_file_name: bool = False` field to `CsvConfig`; in `_generate_tables`, append a `file_name` column when the flag is `True`
- `tests/packaged_modules/test_csv.py`: Add three tests covering default behavior (no column), enabled behavior (column present), and correct column values

## Test plan

- [ ] `test_csv_no_file_name_by_default` — verifies `file_name` column is absent by default
- [ ] `test_csv_return_file_name_enabled` — verifies `file_name` column is present when `return_file_name=True`
- [ ] `test_csv_file_name_values` — verifies each row's `file_name` value equals the source file basename

All three tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)