### PR TITLE
feat: add return_file_name support to Parquet packaged builder

### DIFF
--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
 
@@ -82,6 +83,8 @@ class ParquetConfig(datasets.BuilderConfig):
     filters: Optional[Union[ds.Expression, list[tuple], list[list[tuple]]]] = None
     fragment_scan_options: Optional[ds.ParquetFragmentScanOptions] = None
     on_bad_files: Literal["error", "warn", "skip"] = "error"
+    return_file_name: bool = False
+    """If True, add a ``file_name`` column with the source file basename for each batch."""
 
     def __post_init__(self):
         super().__post_init__()
@@ -206,6 +209,12 @@ class Parquet(datasets.ArrowBasedBuilder):
                             # Uncomment for debugging (will print the Arrow table size and elements)
                             # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
                             # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
+                            if self.config.return_file_name:
+                                file_name = os.path.basename(file)
+                                pa_table = pa_table.append_column(
+                                    "file_name",
+                                    pa.array([file_name] * len(pa_table), type=pa.string()),
+                                )
                             yield Key(file_idx, batch_idx), self._cast_table(pa_table)
             except (pa.ArrowInvalid, ValueError) as e:
                 if self.config.on_bad_files == "error":

--- a/tests/packaged_modules/test_parquet.py
+++ b/tests/packaged_modules/test_parquet.py
@@ -1,8 +1,12 @@
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
-from datasets.packaged_modules.parquet.parquet import ParquetConfig
+from datasets.packaged_modules.parquet.parquet import Parquet, ParquetConfig
 
 
 def test_config_raises_when_invalid_name() -> None:
@@ -14,3 +18,37 @@ def test_config_raises_when_invalid_name() -> None:
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = ParquetConfig(name="name", data_files=data_files)
+
+
+@pytest.fixture
+def parquet_file(tmp_path):
+    filename = tmp_path / "file.parquet"
+    table = pa.table({"col_1": [1, 2, 3], "col_2": ["a", "b", "c"]})
+    pq.write_table(table, filename)
+    return str(filename)
+
+
+def test_parquet_no_file_name_by_default(parquet_file):
+    """Ensure backward compatibility: file_name column is absent when return_file_name is not set."""
+    parquet = Parquet()
+    generator = parquet._generate_tables(files=[parquet_file], row_groups_list=[None])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert "file_name" not in pa_table.column_names
+
+
+def test_parquet_return_file_name_enabled(parquet_file):
+    """When return_file_name=True, the file_name column should be present."""
+    parquet = Parquet(return_file_name=True)
+    generator = parquet._generate_tables(files=[parquet_file], row_groups_list=[None])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert "file_name" in pa_table.column_names
+
+
+def test_parquet_file_name_values(parquet_file):
+    """The file_name column should contain the basename of the source file for every row."""
+    parquet = Parquet(return_file_name=True)
+    generator = parquet._generate_tables(files=[parquet_file], row_groups_list=[None])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    data = pa_table.to_pydict()
+    expected_name = os.path.basename(parquet_file)
+    assert all(name == expected_name for name in data["file_name"])


### PR DESCRIPTION
Part of #5806. Extends the `return_file_name` feature (implemented for JSON in #7948 and CSV in #8019) to the Parquet packaged builder. When `return_file_name=True`, a `file_name` column containing the source file basename is appended to each batch.