### PR TITLE
follow `cache_dir` in download option when loading datasets

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -192,6 +192,7 @@ def cached_path(
                     filename=resolved_path.path_in_repo,
                     force_download=download_config.force_download,
                     proxies=download_config.proxies,
+                    cache_dir=download_config.cache_dir,
                 )
             except (
                 huggingface_hub.utils.RepositoryNotFoundError,


### PR DESCRIPTION
fixes #8029