### PR TITLE
Fix schema enforcement in streaming _convert_to_arrow

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -144,6 +144,7 @@ def _convert_to_arrow(
     iterable: Iterable[tuple[Key, dict]],
     batch_size: int,
     drop_last_batch: bool = False,
+    features: Optional[Features] = None,
 ) -> Iterator[tuple[Key, pa.Table]]:
     """Convert and group examples in Arrow tables of size `batch_size`.
 
@@ -154,12 +155,18 @@ def _convert_to_arrow(
             Size of each sub-table to yield. If None or <= 0, yields the full table.
         drop_last_batch (`bool`, defaults to `False`):
             Drop the last batch if it is smaller than `batch_size`.
+        features (`Optional[Features]`, defaults to `None`):
+            If provided, cast each produced Arrow table to the given features schema.
+            This prevents schema mismatches when Arrow infers inconsistent types across batches
+            (e.g. `null` vs `struct` when early batches contain None values).
     """
     if batch_size is None or batch_size <= 0:
-        yield (
-            "all",
-            pa.Table.from_pylist(cast_to_python_objects([example for _, example in iterable], only_1d_for_numpy=True)),
+        pa_table = pa.Table.from_pylist(
+            cast_to_python_objects([example for _, example in iterable], only_1d_for_numpy=True)
         )
+        if features is not None:
+            pa_table = cast_table_to_features(pa_table, features)
+        yield "all", pa_table
         return
     iterator = iter(iterable)
     for key, example in iterator:
@@ -169,7 +176,10 @@ def _convert_to_arrow(
             return
         keys, examples = zip(*key_examples_list)
         new_key = "_".join(str(key) for key in keys)
-        yield new_key, pa.Table.from_pylist(cast_to_python_objects(examples, only_1d_for_numpy=True))
+        pa_table = pa.Table.from_pylist(cast_to_python_objects(examples, only_1d_for_numpy=True))
+        if features is not None:
+            pa_table = cast_table_to_features(pa_table, features)
+        yield new_key, pa_table
 
 
 def shift_ex_examples_rngs(ex_iterable: "_BaseExamplesIterable", value: int) -> "_BaseExamplesIterable":
@@ -459,7 +469,7 @@ class RebatchedArrowExamplesIterable(_BaseExamplesIterable):
         if self.ex_iterable.iter_arrow:
             iterator = self.ex_iterable.iter_arrow()
         else:
-            iterator = _convert_to_arrow(self.ex_iterable, batch_size=1)
+            iterator = _convert_to_arrow(self.ex_iterable, batch_size=1, features=self.ex_iterable.features)
         if self.batch_size is None or self.batch_size <= 0:
             if self._state_dict and self._state_dict["batch_idx"] > 0:
                 return
@@ -1444,6 +1454,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 self.ex_iterable,
                 batch_size=self.batch_size if self.batched else 1,
                 drop_last_batch=self.drop_last_batch,
+                features=self._features,
             )
         if self._state_dict and self._state_dict["previous_state"]:
             self.ex_iterable.load_state_dict(self._state_dict["previous_state"])
@@ -2461,7 +2472,7 @@ class IterableDataset(DatasetInfoMixin):
                 if ex_iterable.iter_arrow:
                     iterator = ex_iterable.iter_arrow()
                 else:
-                    iterator = _convert_to_arrow(ex_iterable, batch_size=1)
+                    iterator = _convert_to_arrow(ex_iterable, batch_size=1, features=self.features)
                 for key, pa_table in iterator:
                     yield formatter.format_row(pa_table)
                 return
@@ -2559,7 +2570,7 @@ class IterableDataset(DatasetInfoMixin):
             if ex_iterable.iter_arrow:
                 iterator = ex_iterable.iter_arrow()
             else:
-                iterator = _convert_to_arrow(ex_iterable, batch_size=1)
+                iterator = _convert_to_arrow(ex_iterable, batch_size=1, features=self.features)
             for key, pa_table in iterator:
                 yield formatter.format_row(pa_table)
             return
@@ -2588,7 +2599,9 @@ class IterableDataset(DatasetInfoMixin):
             if ex_iterable.iter_arrow:
                 iterator = ex_iterable.iter_arrow()
             else:
-                iterator = _convert_to_arrow(ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch)
+                iterator = _convert_to_arrow(
+                    ex_iterable, batch_size=batch_size, drop_last_batch=drop_last_batch, features=self.features
+                )
             for key, pa_table in iterator:
                 yield formatter.format_batch(pa_table)
             return

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -186,6 +186,100 @@ def test_convert_to_arrow(batch_size, drop_last_batch):
         assert full_table.slice(0, num_rows).to_pydict() == reloaded.to_pydict()
 
 
+def test_convert_to_arrow_schema_mismatch_with_nulls():
+    """When early batches have None values, Arrow infers null type which conflicts with later batches.
+
+    This reproduces the bug where _convert_to_arrow produces tables with inconsistent schemas
+    because pa.Table.from_pylist infers types per-batch without schema enforcement.
+    """
+    # First batch: nested field is None → Arrow infers null type
+    # Second batch: nested field has real data → Arrow infers struct type
+    examples = [
+        {"id": 0, "nested": None},
+        {"id": 1, "nested": None},
+        {"id": 2, "nested": {"value": 1.0, "label": "a"}},
+        {"id": 3, "nested": {"value": 2.0, "label": "b"}},
+    ]
+    # batch_size=2 ensures first batch is all-null, second batch has structs
+    subtables = list(
+        _convert_to_arrow(
+            list(enumerate(examples)),
+            batch_size=2,
+        )
+    )
+    # Without fix: first table has schema {id: int64, nested: null}
+    #              second table has schema {id: int64, nested: struct<value: double, label: string>}
+    # pa.concat_tables will fail with ArrowInvalid
+    with pytest.raises(pa.lib.ArrowInvalid):
+        pa.concat_tables([subtable for _, subtable in subtables])
+
+
+def test_convert_to_arrow_schema_mismatch_with_empty_lists():
+    """When early batches have empty lists, Arrow infers list<null> which conflicts with later batches."""
+    examples = [
+        {"id": 0, "values": []},
+        {"id": 1, "values": []},
+        {"id": 2, "values": [1.0, 2.0]},
+        {"id": 3, "values": [3.0, 4.0]},
+    ]
+    subtables = list(
+        _convert_to_arrow(
+            list(enumerate(examples)),
+            batch_size=2,
+        )
+    )
+    with pytest.raises(pa.lib.ArrowInvalid):
+        pa.concat_tables([subtable for _, subtable in subtables])
+
+
+def test_convert_to_arrow_with_features_enforces_schema():
+    """When features are provided, _convert_to_arrow should cast tables to the declared schema."""
+    features = Features(
+        {
+            "id": Value("int64"),
+            "nested": {"value": Value("float64"), "label": Value("string")},
+        }
+    )
+    examples = [
+        {"id": 0, "nested": None},
+        {"id": 1, "nested": None},
+        {"id": 2, "nested": {"value": 1.0, "label": "a"}},
+        {"id": 3, "nested": {"value": 2.0, "label": "b"}},
+    ]
+    subtables = list(
+        _convert_to_arrow(
+            list(enumerate(examples)),
+            batch_size=2,
+            features=features,
+        )
+    )
+    # With features, all tables should have consistent schema and concat should work
+    result = pa.concat_tables([subtable for _, subtable in subtables])
+    assert len(result) == 4
+    assert result.schema == features.arrow_schema
+
+
+def test_convert_to_arrow_with_features_enforces_schema_empty_lists():
+    """When features are provided, empty lists should be cast to the correct list type."""
+    features = Features({"id": Value("int64"), "values": List(Value("float64"))})
+    examples = [
+        {"id": 0, "values": []},
+        {"id": 1, "values": []},
+        {"id": 2, "values": [1.0, 2.0]},
+        {"id": 3, "values": [3.0, 4.0]},
+    ]
+    subtables = list(
+        _convert_to_arrow(
+            list(enumerate(examples)),
+            batch_size=2,
+            features=features,
+        )
+    )
+    result = pa.concat_tables([subtable for _, subtable in subtables])
+    assert len(result) == 4
+    assert result.schema == features.arrow_schema
+
+
 ################################
 #
 #   _BaseExampleIterable tests


### PR DESCRIPTION
When the iter_arrow chain is broken (e.g. after .map() without with_format("arrow")), _convert_to_arrow falls back to pa.Table.from_pylist() which infers types from values. If early batches contain None or empty lists, Arrow infers null/list<null> types that conflict with later batches containing real data, causing ArrowInvalid schema mismatch errors.

Add an optional features parameter to _convert_to_arrow that applies cast_table_to_features to each produced table, mirroring what ArrowWriter.write_table does in the map-style path.