### PR TITLE
Fix IterableDataset features being set to None on chained filter (Fixes #8037)

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3404,7 +3404,7 @@ class IterableDataset(DatasetInfoMixin):
             ex_iterable = FormattedExamplesIterable(
                 ex_iterable,
                 formatting=self._formatting,
-                features=None if ex_iterable.is_typed else self._info.features,
+                features=ex_iterable.features if ex_iterable.is_typed else self._info.features,
                 token_per_repo_id=self._token_per_repo_id,
             )
 


### PR DESCRIPTION
This PR implements the solution suggested in #8037.

It updates the features argument in IterableDataset.filter() to preserve existing features when ex_iterable.is_typed is True. This prevents the TypeError: 'NoneType' object is not a mapping from being raised when chaining multiple .filter() calls.