### PR TITLE
fix(iterable_dataset): preserve features when chaining filter() on typed IterableDataset

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3404,7 +3404,7 @@ class IterableDataset(DatasetInfoMixin):
             ex_iterable = FormattedExamplesIterable(
                 ex_iterable,
                 formatting=self._formatting,
-                features=None if ex_iterable.is_typed else self._info.features,
+                features=ex_iterable.features if ex_iterable.is_typed else self._info.features,
                 token_per_repo_id=self._token_per_repo_id,
             )
 

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1754,6 +1754,34 @@ def test_iterable_dataset_filter(dataset: IterableDataset) -> None:
     assert next(iter(filtered_dataset)) == {"id": 1}
 
 
+def test_iterable_dataset_filter_chaining_does_not_raise() -> None:
+    """Chaining two .filter() calls must not raise TypeError.
+
+    After the first .filter() the internal ex_iterable becomes typed
+    (is_typed=True) because FilteredExamplesIterable adds a mask column.
+    The second .filter() then wraps it in FormattedExamplesIterable.
+    Previously, features=None was passed when is_typed=True, causing
+    FilteredExamplesIterable.__init__ to crash with:
+      TypeError: 'NoneType' object is not a mapping
+    (issue #8037)
+    """
+    from datasets import IterableDataset
+    from datasets.features import Features, Value
+
+    features = Features({"id": Value("int32"), "text": Value("string")})
+
+    def gen():
+        for i in range(5):
+            yield {"id": i, "text": f"item-{i}"}
+
+    ds = IterableDataset.from_generator(gen, features=features)
+    ds = ds.filter(lambda x: x["id"] >= 1)
+    # Second filter must not raise TypeError
+    ds = ds.filter(lambda x: x["id"] <= 3)
+    result = list(ds)
+    assert [row["id"] for row in result] == [1, 2, 3]
+
+
 @pytest.mark.parametrize("seed", [42, 1337, 101010, 123456])
 @pytest.mark.parametrize("epoch", [None, 0, 1])
 def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):


### PR DESCRIPTION
## Summary

Chaining two `.filter()` calls on an `IterableDataset` with explicit features raises:

```
TypeError: 'NoneType' object is not a mapping
```

on the second `.filter()` call (issue #8037).

## Root Cause

After the first `.filter()`, the internal `ex_iterable` becomes _typed_ (`is_typed=True`) because `FilteredExamplesIterable` appends a boolean mask column. In `IterableDataset.filter()`, the `FormattedExamplesIterable` wrapper was constructed with:

```python
# Before (buggy)
features=None if ex_iterable.is_typed else self._info.features,
```

This set `FormattedExamplesIterable._features = None`. Then in the second `.filter()`, `FilteredExamplesIterable.__init__` tried to do:

```python
Features({**ex_iterable.features, self.mask_column_name: Value("bool")})
# ex_iterable.features == None  →  TypeError
```

## Fix

Forward the existing features when the iterable is already typed:

```python
# After (fixed)
features=ex_iterable.features if ex_iterable.is_typed else self._info.features,
```

One line change in `src/datasets/iterable_dataset.py`.

## Tests

Added `test_iterable_dataset_filter_chaining_does_not_raise` to `tests/test_iterable_dataset.py`: creates a typed `IterableDataset`, applies two chained `.filter()` calls, and asserts the result is correct without error.

Fixes #8037
