### PR TITLE
fix(arrow_dataset): initialise writer on first non-None map result, not on i==0

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3733,7 +3733,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     _time = time.time()
                     for i, example in iter_outputs(shard_iterable):
                         if update_data:
-                            if i == 0:
+                            if writer is None:
                                 buf_writer, writer, tmp_file = init_buffer_and_writer()
                                 stack.enter_context(writer)
                             if isinstance(example, pa.Table):
@@ -3759,7 +3759,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     for i, batch in iter_outputs(shard_iterable):
                         num_examples_in_batch = len(i)
                         if update_data:
-                            if i and i[0] == 0:
+                            if writer is None:
                                 buf_writer, writer, tmp_file = init_buffer_and_writer()
                                 stack.enter_context(writer)
                             if isinstance(batch, pa.Table):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1889,6 +1889,30 @@ class BaseDatasetTest(TestCase):
                 dset.map(ex_cnt)
                 self.assertEqual(ex_cnt.cnt, len(dset))
 
+    def test_map_writer_initialized_when_first_examples_return_none(self, in_memory):
+        """Dataset.map must not crash when early examples return None.
+
+        The writer was previously only initialized when i == 0.  If the map
+        function returns None for the first N examples, update_data stays False
+        and the writer is never created.  When a later example returns a dict,
+        update_data flips to True but writer is still None, causing:
+            AttributeError: 'NoneType' object has no attribute 'write'
+        (issue #7990)
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                def fn(example, idx):
+                    if idx < 2:
+                        return None
+                    return {"filename": example["filename"] + "_transformed"}
+
+                result = dset.map(fn, with_indices=True)
+                # First two rows are skipped (return None → no update)
+                # Remaining rows are transformed
+                self.assertEqual(len(result), len(dset))
+                for i in range(2, len(dset)):
+                    self.assertTrue(result[i]["filename"].endswith("_transformed"))
+
     @require_not_windows
     def test_map_crash_subprocess(self, in_memory):
         # be sure that a crash in one of the subprocess will not


### PR DESCRIPTION
## Summary

`Dataset.map` crashes with `AttributeError: 'NoneType' object has no attribute 'write'` when the map function returns `None` for the first N examples and a dict for later ones (issue #7990).

## Root Cause

The `ArrowWriter` was initialised with a guard tied to the example index:

```python
# Non-batched path (line ~3736)
if i == 0:
    buf_writer, writer, tmp_file = init_buffer_and_writer()

# Batched path (line ~3762)
if i and i[0] == 0:
    buf_writer, writer, tmp_file = init_buffer_and_writer()
```

`update_data` is set lazily via `prepare_outputs()`: when the first example returns `None`, `update_data = False` and no writer is created. When example `i=2` returns a dict, `update_data` flips to `True`, but since `i != 0` the writer initialisation is skipped. The subsequent `writer.write(example)` call then crashes because `writer is None`.

## Fix

Replace the index-based guards with `if writer is None`:

```python
# Non-batched path
if writer is None:
    buf_writer, writer, tmp_file = init_buffer_and_writer()

# Batched path
if writer is None:
    buf_writer, writer, tmp_file = init_buffer_and_writer()
```

The writer is now created on the first example/batch that actually produces output, regardless of its position.

## Tests

Added `test_map_writer_initialized_when_first_examples_return_none` to `tests/test_arrow_dataset.py`: applies a map function that returns `None` for indices 0–1 and a transformed dict for the rest, verifying the call completes without error and produces correct output.

Fixes #7990
