### PR TITLE
fix: avoid duplicate kwargs collisions in load_dataset_builder

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1145,6 +1145,10 @@ def load_dataset_builder(
     )
     dataset_name = builder_kwargs.pop("dataset_name", None)
     info = dataset_module.dataset_infos.get(config_name) if dataset_module.dataset_infos else None
+    # Some kwargs (e.g. base_path) can be present in both builder_kwargs and config_kwargs.
+    # Remove duplicates to avoid "multiple values for keyword argument" when instantiating builders.
+    for key in config_kwargs:
+        builder_kwargs.pop(key, None)
 
     if (
         path in _PACKAGED_DATASETS_MODULES

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -858,6 +858,11 @@ def test_load_dataset_builder_for_relative_data_dir(complex_data_dir):
         assert len(builder.config.data_files["test"]) > 0
 
 
+def test_load_dataset_builder_config_kwargs_can_override_builder_kwargs(complex_data_dir):
+    builder = datasets.load_dataset_builder(complex_data_dir, base_path=complex_data_dir)
+    assert isinstance(builder, DatasetBuilder)
+
+
 @pytest.mark.integration
 def test_load_dataset_builder_for_community_dataset():
     builder = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER2)


### PR DESCRIPTION
## Summary
- avoid duplicate keyword collisions when `config_kwargs` overlap with module-provided `builder_kwargs` in `load_dataset_builder`
- this fixes cases like passing `base_path=...` where `base_path` is already present in `builder_kwargs`
- add a regression test using a local dataset directory to ensure overriding kwargs no longer raises

## Reproduction
Before this change:
```python
from datasets import load_dataset_builder
load_dataset_builder("/path/to/local/data", base_path="/path/to/local/data")
# TypeError: ... got multiple values for keyword argument 'base_path'
```

## Validation
- `uv run --python 3.11 --with-editable . --with pytest --with setuptools -m pytest tests/test_load.py::test_load_dataset_builder_config_kwargs_can_override_builder_kwargs tests/test_load.py::test_load_dataset_builder_for_absolute_data_dir -q`
- `uv run --python 3.11 --with ruff --with setuptools ruff check src/datasets/load.py tests/test_load.py`

Fixes #4910
