### PR TITLE
Fix docstring of Json.cast_storage

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1239,7 +1239,7 @@ class Json:
             raise RuntimeError("Decoding is disabled for this feature. Please use Json(decode=True) instead.")
         return ujson_loads(example_data)
 
-    def cast_storage(self, storage: Union[pa.Array]) -> pa.Int64Array:
+    def cast_storage(self, storage: Union[pa.Array]) -> pa.JsonArray:
         """Cast an Arrow array to the `Json` arrow storage type.
 
         Args:
@@ -1247,7 +1247,7 @@ class Json:
                 PyArrow array to cast.
 
         Returns:
-            `pa.Int64Array`: Array in the `ClassLabel` arrow storage type.
+            `pa.JsonArray`: Array in the `Json` arrow storage type.
         """
         if isinstance(storage, pa.JsonArray):
             return storage


### PR DESCRIPTION
Fix docstring of `Json.cast_storage`.

This PR makes a minor change to the `cast_storage` method in the `Json` feature, updating its return type and documentation to better reflect its intended functionality.

* Updated the `cast_storage` method to return a `pa.JsonArray` instead of a `pa.Int64Array`, and revised the docstring to accurately describe the return type.