### PR TITLE
Add reshard support for JSON Lines and CSV file formats

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -620,7 +620,7 @@ class RebatchedArrowExamplesIterable(_BaseExamplesIterable):
             self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             self.batch_size,
             self.drop_last_batch,
-            self.force_convert_to_arrow
+            self.force_convert_to_arrow,
         )
 
     @property

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -224,11 +224,15 @@ class _BaseExamplesIterable:
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         raise NotImplementedError(f"{type(self)} doesn't implement shard_data_sources yet")
 
-    def reshard_data_sources(self) -> "_BaseExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "_BaseExamplesIterable":
         """
         Either reshard the shards/sources of the dataset, i.e. further split the current shards into more shards,
         or propagate the resharding to the underlying iterable.
         If the examples iterable can't be further resharded, then this method returns self.
+
+        Args:
+            num_shards (`int`, *optional*):
+                Target number of shards. If not specified, reshard to maximum possible number.
         """
         raise NotImplementedError(f"{type(self)} doesn't implement reshard_data_sources yet")
 
@@ -313,18 +317,39 @@ class ExamplesIterable(_BaseExamplesIterable):
         requested_gen_kwargs = _merge_gen_kwargs([gen_kwargs_list[i] for i in shard_indices])
         return ExamplesIterable(self.generate_examples_fn, requested_gen_kwargs, self.generate_more_kwargs_fn)
 
-    def reshard_data_sources(self) -> "ExamplesIterable":
-        """Split shars into more shards if possible."""
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "ExamplesIterable":
+        """Split shars into more shards if possible.
+
+        Args:
+            num_shards (`int`, *optional*):
+                Target number of shards. If not specified, reshard to maximum possible number.
+        """
         if not self.generate_more_kwargs_fn:
             return ExamplesIterable(self.generate_examples_fn, self.kwargs, self.generate_more_kwargs_fn)
         gen_kwargs_list = _split_gen_kwargs(self.kwargs, max_num_jobs=self.num_shards)
-        new_gen_kwargs = _merge_gen_kwargs(
-            [
-                new_gen_kwargs
-                for gen_kwargs in gen_kwargs_list
-                for new_gen_kwargs in self.generate_more_kwargs_fn(**gen_kwargs)
-            ]
-        )
+        all_new_gen_kwargs = []
+        for gen_kwargs in gen_kwargs_list:
+            for new_gen_kwargs in self.generate_more_kwargs_fn(**gen_kwargs, num_shards=num_shards):
+                all_new_gen_kwargs.append(new_gen_kwargs)
+
+        # If num_shards is specified, limit the number of shards
+        if num_shards is not None and len(all_new_gen_kwargs) > num_shards:
+            # Calculate how many original shards to include per target shard
+            shards_per_target = len(all_new_gen_kwargs) // num_shards
+            remainder = len(all_new_gen_kwargs) % num_shards
+
+            selected_gen_kwargs = []
+            current_idx = 0
+            for i in range(num_shards):
+                # Distribute remainder across first few shards
+                num_to_take = shards_per_target + (1 if i < remainder else 0)
+                selected_gen_kwargs.extend(all_new_gen_kwargs[current_idx : current_idx + num_to_take])
+                current_idx += num_to_take
+
+            new_gen_kwargs = _merge_gen_kwargs(selected_gen_kwargs)
+        else:
+            new_gen_kwargs = _merge_gen_kwargs(all_new_gen_kwargs)
+
         return ExamplesIterable(self.generate_examples_fn, new_gen_kwargs, self.generate_more_kwargs_fn)
 
     @property
@@ -404,18 +429,39 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
         requested_gen_kwargs = _merge_gen_kwargs([gen_kwargs_list[i] for i in shard_indices])
         return ArrowExamplesIterable(self.generate_tables_fn, requested_gen_kwargs)
 
-    def reshard_data_sources(self) -> "ArrowExamplesIterable":
-        """Split shars into more shards if possible."""
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "ArrowExamplesIterable":
+        """Split shars into more shards if possible.
+
+        Args:
+            num_shards (`int`, *optional*):
+                Target number of shards. If not specified, reshard to maximum possible number.
+        """
         if not self.generate_more_kwargs_fn:
             return ArrowExamplesIterable(self.generate_tables_fn, self.kwargs, self.generate_more_kwargs_fn)
         gen_kwargs_list = _split_gen_kwargs(self.kwargs, max_num_jobs=self.num_shards)
-        new_gen_kwargs = _merge_gen_kwargs(
-            [
-                new_gen_kwargs
-                for gen_kwargs in gen_kwargs_list
-                for new_gen_kwargs in self.generate_more_kwargs_fn(**gen_kwargs)
-            ]
-        )
+        all_new_gen_kwargs = []
+        for gen_kwargs in gen_kwargs_list:
+            for new_gen_kwargs in self.generate_more_kwargs_fn(**gen_kwargs, num_shards=num_shards):
+                all_new_gen_kwargs.append(new_gen_kwargs)
+
+        # If num_shards is specified, limit the number of shards
+        if num_shards is not None and len(all_new_gen_kwargs) > num_shards:
+            # Calculate how many original shards to include per target shard
+            shards_per_target = len(all_new_gen_kwargs) // num_shards
+            remainder = len(all_new_gen_kwargs) % num_shards
+
+            selected_gen_kwargs = []
+            current_idx = 0
+            for i in range(num_shards):
+                # Distribute remainder across first few shards
+                num_to_take = shards_per_target + (1 if i < remainder else 0)
+                selected_gen_kwargs.extend(all_new_gen_kwargs[current_idx : current_idx + num_to_take])
+                current_idx += num_to_take
+
+            new_gen_kwargs = _merge_gen_kwargs(selected_gen_kwargs)
+        else:
+            new_gen_kwargs = _merge_gen_kwargs(all_new_gen_kwargs)
+
         return ArrowExamplesIterable(self.generate_tables_fn, new_gen_kwargs, self.generate_more_kwargs_fn)
 
     @property
@@ -569,9 +615,12 @@ class RebatchedArrowExamplesIterable(_BaseExamplesIterable):
             self.force_convert_to_arrow,
         )
 
-    def reshard_data_sources(self) -> "RebatchedArrowExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "RebatchedArrowExamplesIterable":
         return RebatchedArrowExamplesIterable(
-            self.ex_iterable.reshard_data_sources(), self.batch_size, self.drop_last_batch, self.force_convert_to_arrow
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
+            self.batch_size,
+            self.drop_last_batch,
+            self.force_convert_to_arrow
         )
 
     @property
@@ -619,8 +668,8 @@ class SelectColumnsIterable(_BaseExamplesIterable):
             self.ex_iterable.shard_data_sources(num_shards, index, contiguous=contiguous), self.column_names
         )
 
-    def reshard_data_sources(self) -> "SelectColumnsIterable":
-        return SelectColumnsIterable(self.ex_iterable.reshard_data_sources(), self.column_names)
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "SelectColumnsIterable":
+        return SelectColumnsIterable(self.ex_iterable.reshard_data_sources(num_shards=num_shards), self.column_names)
 
     @property
     def num_shards(self) -> int:
@@ -686,9 +735,9 @@ class StepExamplesIterable(_BaseExamplesIterable):
             offset=self.offset,
         )
 
-    def reshard_data_sources(self) -> "StepExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "StepExamplesIterable":
         return StepExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             step=self.step,
             offset=self.offset,
         )
@@ -874,9 +923,9 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
                 stopping_strategy=self.stopping_strategy,
             )
 
-    def reshard_data_sources(self) -> "CyclingMultiSourcesExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "CyclingMultiSourcesExamplesIterable":
         return CyclingMultiSourcesExamplesIterable(
-            [iterable.reshard_data_sources() for iterable in self.ex_iterables],
+            [iterable.reshard_data_sources(num_shards=num_shards) for iterable in self.ex_iterables],
             stopping_strategy=self.stopping_strategy,
         )
 
@@ -964,9 +1013,11 @@ class VerticallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable):
             [single_shard_ex_iterables[i] for i in shard_indices]
         )
 
-    def reshard_data_sources(self) -> "VerticallyConcatenatedMultiSourcesExamplesIterable":
+    def reshard_data_sources(
+        self, num_shards: Optional[int] = None
+    ) -> "VerticallyConcatenatedMultiSourcesExamplesIterable":
         return VerticallyConcatenatedMultiSourcesExamplesIterable(
-            [iterable.reshard_data_sources() for iterable in self.ex_iterables]
+            [iterable.reshard_data_sources(num_shards=num_shards) for iterable in self.ex_iterables]
         )
 
 
@@ -1213,10 +1264,10 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
                 self.stopping_strategy,
             )
 
-    def reshard_data_sources(self) -> "RandomlyCyclingMultiSourcesExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "RandomlyCyclingMultiSourcesExamplesIterable":
         """Either keep only the requested shard, or propagate the request to the underlying iterable."""
         return RandomlyCyclingMultiSourcesExamplesIterable(
-            [iterable.reshard_data_sources() for iterable in self.ex_iterables],
+            [iterable.reshard_data_sources(num_shards=num_shards) for iterable in self.ex_iterables],
             self.generator,
             self.probabilities,
             self.stopping_strategy,
@@ -1621,9 +1672,9 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             max_num_running_async_map_functions_in_parallel=self.max_num_running_async_map_functions_in_parallel,
         )
 
-    def reshard_data_sources(self) -> "MappedExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "MappedExamplesIterable":
         return MappedExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             function=self.function,
             with_indices=self.with_indices,
             input_columns=self.input_columns,
@@ -1739,9 +1790,9 @@ class FilteredExamplesIterable(MappedExamplesIterable):
             formatting=self.formatting,
         )
 
-    def reshard_data_sources(self) -> "FilteredExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "FilteredExamplesIterable":
         return FilteredExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             function=self.mask_function,
             with_indices=self.with_indices,
             input_columns=self.input_columns,
@@ -1851,9 +1902,9 @@ class BufferShuffledExamplesIterable(_BaseExamplesIterable):
             generator=self.generator,
         )
 
-    def reshard_data_sources(self) -> "BufferShuffledExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "BufferShuffledExamplesIterable":
         return BufferShuffledExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             buffer_size=self.buffer_size,
             generator=self.generator,
         )
@@ -1958,9 +2009,9 @@ class SkipExamplesIterable(_BaseExamplesIterable):
         else:
             return self
 
-    def reshard_data_sources(self) -> "SkipExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "SkipExamplesIterable":
         return SkipExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             n=self.n,
             block_sources_order_when_shuffling=self.block_sources_order_when_shuffling,
             split_when_sharding=self.split_when_sharding,
@@ -2015,9 +2066,9 @@ class RepeatExamplesIterable(_BaseExamplesIterable):
             num_times=self.num_times,
         )
 
-    def reshard_data_sources(self) -> "RepeatExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "RepeatExamplesIterable":
         return RepeatExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             num_times=self.num_times,
         )
 
@@ -2132,9 +2183,9 @@ class TakeExamplesIterable(_BaseExamplesIterable):
                 split_when_sharding=self.split_when_sharding,
             )
 
-    def reshard_data_sources(self) -> "TakeExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "TakeExamplesIterable":
         return TakeExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             n=self.n,
             block_sources_order_when_shuffling=self.block_sources_order_when_shuffling,
             split_when_sharding=self.split_when_sharding,
@@ -2280,9 +2331,9 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
             force_convert_to_python=self.force_convert_to_python,
         )
 
-    def reshard_data_sources(self) -> "FormattedExamplesIterable":
+    def reshard_data_sources(self, num_shards: Optional[int] = None) -> "FormattedExamplesIterable":
         return FormattedExamplesIterable(
-            self.ex_iterable.reshard_data_sources(),
+            self.ex_iterable.reshard_data_sources(num_shards=num_shards),
             features=self.features,
             token_per_repo_id=self.token_per_repo_id,
             formatting=self.formatting,
@@ -3798,7 +3849,7 @@ class IterableDataset(DatasetInfoMixin):
             token_per_repo_id=self._token_per_repo_id,
         )
 
-    def reshard(self) -> "IterableDataset":
+    def reshard(self, num_shards: Optional[int] = None) -> "IterableDataset":
         """Reshard the dataset if possible, i.e. split the current shards further into more shards.
         This increases the number of shards and the resulting dataset has num_shards >= previous_num_shards.
         Equality may happen if no shard can be split further.
@@ -3806,7 +3857,22 @@ class IterableDataset(DatasetInfoMixin):
         The resharding mechanism depends on the dataset file format:
 
         * Parquet: shard per row group instead of per file
+        * JSON Lines: shard by line boundaries (only when `num_shards` is specified)
+        * CSV: shard by line boundaries (only when `num_shards` is specified)
         * Other: not implemented yet (contributions are welcome !)
+
+        Args:
+            num_shards (`int`, *optional*):
+                Target number of shards. If not specified, the dataset is resharded to the maximum
+                possible number of shards (e.g., for Parquet, it's the number of row groups).
+                For JSON Lines and CSV, resharding only takes effect when `num_shards` is specified.
+
+                <Added version="3.0.0"/>
+                <Note>
+                If the dataset has fewer data items than `num_shards`, the actual number of shards after resharding
+                may be less than `num_shards`. For example, if a JSON Lines file has only 5 lines and you call
+                `reshard(num_shards=10)`, the resulting dataset will have at most 5 shards (one per line).
+                </Note>
 
         Be sure to reshard/shard before using any randomizing operator (such as `shuffle`).
         It is best if the shard operator is used early in the dataset pipeline.
@@ -3826,9 +3892,14 @@ class IterableDataset(DatasetInfoMixin):
             features: ['label', 'title', 'content'],
             num_shards: 3600
         })
+        >>> ds.reshard(num_shards=100)
+        IterableDataset({
+            features: ['label', 'title', 'content'],
+            num_shards: 100
+        })
         ```
         """
-        ex_iterable = self._ex_iterable.reshard_data_sources()
+        ex_iterable = self._ex_iterable.reshard_data_sources(num_shards=num_shards)
         return IterableDataset(
             ex_iterable=ex_iterable,
             info=self._info.copy(),

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -279,7 +279,7 @@ class Csv(datasets.ArrowBasedBuilder):
                     file, start_byte, end_byte = file_item
                 else:
                     file, start_byte, end_byte = file_item, 0, None
-
+                file_path = file
                 with open(file, "rb") as f:
                     header_line = f.readline()
                     header_end_pos = f.tell()
@@ -320,5 +320,5 @@ class Csv(datasets.ArrowBasedBuilder):
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
                         yield Key(shard_idx, batch_idx), self._cast_table(pa_table)
                 except ValueError as e:
-                    logger.error(f"Failed to read file '{file}' with error {type(e)}: {e}")
+                    logger.error(f"Failed to read file '{file_path}' with error {type(e)}: {e}")
                     raise

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,3 +1,4 @@
+import io
 import os
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
@@ -181,16 +182,8 @@ class Csv(datasets.ArrowBasedBuilder):
     def _generate_shards(self, base_files, files_iterables):
         yield from base_files
 
-    def _estimate_line_count(self, file, max_bytes=20 << 20):
-        """Estimate the number of lines in a file by reading the first max_bytes (default 20MB).
-        
-        Args:
-            file: Path to the file
-            max_bytes: Maximum bytes to read (default 20MB)
-            
-        Returns:
-            Estimated line count
-        """
+    def _estimate_byte_size_per_line(self, file, max_bytes=20 << 20):
+        """Estimate the byte size per line by reading the first max_bytes (default 20MB)."""
         try:
             with open(
                 file,
@@ -200,83 +193,75 @@ class Csv(datasets.ArrowBasedBuilder):
             ) as f:
                 line_count = 0
                 bytes_read = 0
-                
+
                 while bytes_read < max_bytes:
                     line = f.readline()
                     if not line:
                         break
                     line_count += 1
                     bytes_read += len(line.encode())
-                
-                # If we hit the byte limit, estimate the total based on file size
-                if bytes_read >= max_bytes:
-                    try:
-                        file_size = os.path.getsize(file)
-                        if bytes_read > 0:
-                            estimated_line_count = int((file_size / bytes_read) * line_count)
-                        else:
-                            estimated_line_count = line_count
-                    except OSError:
-                        estimated_line_count = line_count
+                if line_count > 0:
+                    return bytes_read // line_count
                 else:
-                    estimated_line_count = line_count
-                return estimated_line_count
+                    return 0
         except Exception:
             return 0
 
     def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
         """Generate more gen_kwargs for resharding.
-        
         When num_shards is specified, create that many shards.
         When num_shards is None, maximize sharding by aiming for self.config.chunksize lines per shard.
         """
         for base_file, files_iterable in zip(base_files, files_iterables):
             files_list = list(files_iterable)
-            
+
             if not files_list:
                 continue
-            
+
             # Estimate total line count from the first file only (assuming similar structure)
-            total_line_count = 0
+            line_size = 0
             for file in files_list:
-                line_count = self._estimate_line_count(file)
-                if line_count > 0:
-                    # If we got a good estimate from the first file, use it for all files
-                    # This avoids expensive line counting on every file
-                    total_line_count = line_count
-                    break
-            
-            # Determine target number of shards
-            if num_shards is None:
-                # Maximum sharding: aim for self.config.chunksize lines per shard
-                target_num_shards = max(1, (total_line_count + self.config.chunksize - 1) // self.config.chunksize)
-            else:
-                target_num_shards = num_shards if total_line_count == 0 else min(num_shards, total_line_count)
-            
-            # If only one shard, return the original gen_kwargs
-            if target_num_shards <= 1:
-                for file in files_list:
+                file_size = os.path.getsize(file)
+                if line_size == 0:
+                    line_size = self._estimate_byte_size_per_line(file)
+                    if line_size == 0:
+                        yield {"base_files": [base_file], "files_iterables": [[(file, 0, file_size)]]}
+                        continue
+
+                # Calculate shard size and number of shards
+                # If num_shards is specified, use that number of shards
+                # If num_shards is None, aim use self.config.chunksize lines per shard
+                if num_shards is None:
+                    target_num_shards = max(1, file_size // (self.config.chunksize * line_size))
+                else:
+                    target_num_shards = max(1, num_shards)
+                shard_size = max(1, file_size // target_num_shards)
+
+                if target_num_shards <= 1:
                     yield {
                         "base_files": [base_file],
-                        "files_iterables": [[(file, 0, None)]],
+                        "files_iterables": [[(file, 0, file_size)]],
                     }
-                continue
-            
-            # Calculate lines per shard
-            lines_per_shard = (total_line_count + target_num_shards - 1) // target_num_shards
-            
-            # Generate gen_kwargs for each shard
-            for shard_idx in range(target_num_shards):
-                shard_start = shard_idx * lines_per_shard
-                shard_end = (shard_idx + 1) * lines_per_shard
-                
-                # Distribute files across shards, keeping shard info with files
-                yield {
-                    "base_files": [base_file],
-                    "files_iterables": [[(file, shard_start, shard_end) for file in files_list]],
-                }
+                    continue
 
-    def _generate_tables(self, base_files, files_iterables, shard_start_line=0, shard_end_line=None):
+                for i in range(target_num_shards):
+                    start = i * shard_size
+                    if start >= file_size:
+                        break
+
+                    end = (i + 1) * shard_size if i < target_num_shards - 1 else file_size
+
+                    if end > file_size:
+                        end = file_size
+
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[(file, start, end)]],
+                    }
+                    if end >= file_size:
+                        break
+
+    def _generate_tables(self, base_files, files_iterables):
         schema = self.config.features.arrow_schema if self.config.features else None
         # dtype allows reading an int column as str
         dtype = (
@@ -288,29 +273,44 @@ class Csv(datasets.ArrowBasedBuilder):
             else None
         )
 
-        # Handle list parameters (from resharding) - kept for backward compatibility
-        if isinstance(shard_start_line, list):
-            shard_start_line = shard_start_line[0]
-        if isinstance(shard_end_line, list):
-            shard_end_line = shard_end_line[0]
-
         for shard_idx, files_iterable in enumerate(files_iterables):
             for file_item in files_iterable:
-                # Handle both tuple format (file, shard_start, shard_end) and plain file format
                 if isinstance(file_item, tuple):
-                    file, shard_start, shard_end = file_item
+                    file, start_byte, end_byte = file_item
                 else:
-                    file = file_item
-                    shard_start = shard_start_line
-                    shard_end = shard_end_line
-                
-                # Handle shard_start_line and shard_end_line
-                read_csv_kwargs = self.config.pd_read_csv_kwargs.copy()
-                if shard_start > 0:
-                    read_csv_kwargs["skiprows"] = shard_start
-                if shard_end is not None:
-                    read_csv_kwargs["nrows"] = shard_end - shard_start
+                    file, start_byte, end_byte = file_item, 0, None
 
+                with open(file, "rb") as f:
+                    header_line = f.readline()
+                    header_end_pos = f.tell()
+                    if start_byte > 0:
+                        # If start_byte is before the header, skip the header
+                        if start_byte < header_end_pos:
+                            f.seek(header_end_pos)
+                        else:
+                            f.seek(start_byte)
+                        f.readline()
+
+                    current_pos = f.tell()
+
+                    if end_byte is not None and current_pos >= end_byte:
+                        if not (start_byte < header_end_pos and current_pos == header_end_pos):
+                            continue
+
+                    if end_byte is not None:
+                        bytes_to_read = max(0, end_byte - current_pos)
+                        content = f.read(bytes_to_read)
+                        if f.tell() < os.path.getsize(file):
+                            content += f.readline()
+                    else:
+                        content = f.read()
+
+                    if not content or not content.strip(b"\r\n "):
+                        continue
+                    shard_data = header_line + content
+                    file = io.BytesIO(shard_data)
+
+                read_csv_kwargs = self.config.pd_read_csv_kwargs.copy()
                 csv_file_reader = pd.read_csv(file, iterator=True, dtype=dtype, **read_csv_kwargs)
                 try:
                     for batch_idx, df in enumerate(csv_file_reader):

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
@@ -180,58 +181,100 @@ class Csv(datasets.ArrowBasedBuilder):
     def _generate_shards(self, base_files, files_iterables):
         yield from base_files
 
+    def _estimate_line_count(self, file, max_bytes=20 << 20):
+        """Estimate the number of lines in a file by reading the first max_bytes (default 20MB).
+        
+        Args:
+            file: Path to the file
+            max_bytes: Maximum bytes to read (default 20MB)
+            
+        Returns:
+            Estimated line count
+        """
+        try:
+            with open(
+                file,
+                "r",
+                encoding=self.config.encoding or "utf-8",
+                errors=self.config.encoding_errors or "strict",
+            ) as f:
+                line_count = 0
+                bytes_read = 0
+                
+                while bytes_read < max_bytes:
+                    line = f.readline()
+                    if not line:
+                        break
+                    line_count += 1
+                    bytes_read += len(line.encode())
+                
+                # If we hit the byte limit, estimate the total based on file size
+                if bytes_read >= max_bytes:
+                    try:
+                        file_size = os.path.getsize(file)
+                        if bytes_read > 0:
+                            estimated_line_count = int((file_size / bytes_read) * line_count)
+                        else:
+                            estimated_line_count = line_count
+                    except OSError:
+                        estimated_line_count = line_count
+                else:
+                    estimated_line_count = line_count
+                return estimated_line_count
+        except Exception:
+            return 0
+
     def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
-        """Generate more gen_kwargs for resharding"""
-        # Only reshard if num_shards is specified
-        if num_shards is None:
-            # No resharding - return the original gen_kwargs
-            for base_file, files_iterable in zip(base_files, files_iterables):
-                for file in files_iterable:
-                    yield {
-                        "base_files": [base_file],
-                        "files_iterables": [[file]],
-                        "shard_start_line": [0],
-                        "shard_end_line": [None],
-                    }
-            return
-
+        """Generate more gen_kwargs for resharding.
+        
+        When num_shards is specified, create that many shards.
+        When num_shards is None, maximize sharding by aiming for self.config.chunksize lines per shard.
+        """
         for base_file, files_iterable in zip(base_files, files_iterables):
-            for file in files_iterable:
-                # Split the file into multiple shards based on line boundaries
-                try:
-                    with open(
-                        file,
-                        "r",
-                        encoding=self.config.encoding or "utf-8",
-                        errors=self.config.encoding_errors or "strict",
-                    ) as f:
-                        # Read the file to count lines
-                        line_count = 0
-                        while f.readline():
-                            line_count += 1
-
-                    # Use the specified number of shards
-                    # But limit to the number of lines to avoid empty shards
-                    target_num_shards = min(num_shards, line_count)
-
-                    lines_per_shard = (line_count + target_num_shards - 1) // target_num_shards
-
-                    # Generate gen_kwargs for each shard
-                    for shard_idx in range(target_num_shards):
-                        yield {
-                            "base_files": [base_file],
-                            "files_iterables": [[file]],
-                            "shard_start_line": [shard_idx * lines_per_shard],
-                            "shard_end_line": [(shard_idx + 1) * lines_per_shard],
-                        }
-                except Exception:
-                    # If we can't split the file, just use the whole file as one shard
+            files_list = list(files_iterable)
+            
+            if not files_list:
+                continue
+            
+            # Estimate total line count from the first file only (assuming similar structure)
+            total_line_count = 0
+            for file in files_list:
+                line_count = self._estimate_line_count(file)
+                if line_count > 0:
+                    # If we got a good estimate from the first file, use it for all files
+                    # This avoids expensive line counting on every file
+                    total_line_count = line_count
+                    break
+            
+            # Determine target number of shards
+            if num_shards is None:
+                # Maximum sharding: aim for self.config.chunksize lines per shard
+                target_num_shards = max(1, (total_line_count + self.config.chunksize - 1) // self.config.chunksize)
+            else:
+                target_num_shards = num_shards if total_line_count == 0 else min(num_shards, total_line_count)
+            
+            # If only one shard, return the original gen_kwargs
+            if target_num_shards <= 1:
+                for file in files_list:
                     yield {
                         "base_files": [base_file],
-                        "files_iterables": [[file]],
-                        "shard_start_line": [0],
-                        "shard_end_line": [None],
+                        "files_iterables": [[(file, 0, None)]],
                     }
+                continue
+            
+            # Calculate lines per shard
+            lines_per_shard = (total_line_count + target_num_shards - 1) // target_num_shards
+            
+            # Generate gen_kwargs for each shard
+            for shard_idx in range(target_num_shards):
+                shard_start = shard_idx * lines_per_shard
+                shard_end = (shard_idx + 1) * lines_per_shard
+                
+                # Distribute files across shards, keeping shard info with files
+                yield {
+                    "base_files": [base_file],
+                    "files_iterables": [[(file, shard_start, shard_end) for file in files_list]],
+                }
 
     def _generate_tables(self, base_files, files_iterables, shard_start_line=0, shard_end_line=None):
         schema = self.config.features.arrow_schema if self.config.features else None
@@ -245,20 +288,28 @@ class Csv(datasets.ArrowBasedBuilder):
             else None
         )
 
-        # Handle list parameters (from resharding)
+        # Handle list parameters (from resharding) - kept for backward compatibility
         if isinstance(shard_start_line, list):
             shard_start_line = shard_start_line[0]
         if isinstance(shard_end_line, list):
             shard_end_line = shard_end_line[0]
 
         for shard_idx, files_iterable in enumerate(files_iterables):
-            for file in files_iterable:
+            for file_item in files_iterable:
+                # Handle both tuple format (file, shard_start, shard_end) and plain file format
+                if isinstance(file_item, tuple):
+                    file, shard_start, shard_end = file_item
+                else:
+                    file = file_item
+                    shard_start = shard_start_line
+                    shard_end = shard_end_line
+                
                 # Handle shard_start_line and shard_end_line
                 read_csv_kwargs = self.config.pd_read_csv_kwargs.copy()
-                if shard_start_line > 0:
-                    read_csv_kwargs["skiprows"] = shard_start_line
-                if shard_end_line is not None:
-                    read_csv_kwargs["nrows"] = shard_end_line - shard_start_line
+                if shard_start > 0:
+                    read_csv_kwargs["skiprows"] = shard_start
+                if shard_end is not None:
+                    read_csv_kwargs["nrows"] = shard_end - shard_start
 
                 csv_file_reader = pd.read_csv(file, iterator=True, dtype=dtype, **read_csv_kwargs)
                 try:

--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -180,7 +180,60 @@ class Csv(datasets.ArrowBasedBuilder):
     def _generate_shards(self, base_files, files_iterables):
         yield from base_files
 
-    def _generate_tables(self, base_files, files_iterables):
+    def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
+        """Generate more gen_kwargs for resharding"""
+        # Only reshard if num_shards is specified
+        if num_shards is None:
+            # No resharding - return the original gen_kwargs
+            for base_file, files_iterable in zip(base_files, files_iterables):
+                for file in files_iterable:
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[file]],
+                        "shard_start_line": [0],
+                        "shard_end_line": [None],
+                    }
+            return
+
+        for base_file, files_iterable in zip(base_files, files_iterables):
+            for file in files_iterable:
+                # Split the file into multiple shards based on line boundaries
+                try:
+                    with open(
+                        file,
+                        "r",
+                        encoding=self.config.encoding or "utf-8",
+                        errors=self.config.encoding_errors or "strict",
+                    ) as f:
+                        # Read the file to count lines
+                        line_count = 0
+                        while f.readline():
+                            line_count += 1
+
+                    # Use the specified number of shards
+                    # But limit to the number of lines to avoid empty shards
+                    target_num_shards = min(num_shards, line_count)
+
+                    lines_per_shard = (line_count + target_num_shards - 1) // target_num_shards
+
+                    # Generate gen_kwargs for each shard
+                    for shard_idx in range(target_num_shards):
+                        yield {
+                            "base_files": [base_file],
+                            "files_iterables": [[file]],
+                            "shard_start_line": [shard_idx * lines_per_shard],
+                            "shard_end_line": [(shard_idx + 1) * lines_per_shard],
+                        }
+                except Exception:
+                    # If we can't split the file, just use the whole file as one shard
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[file]],
+                        "shard_start_line": [0],
+                        "shard_end_line": [None],
+                    }
+
+    def _generate_tables(self, base_files, files_iterables, shard_start_line=0, shard_end_line=None):
         schema = self.config.features.arrow_schema if self.config.features else None
         # dtype allows reading an int column as str
         dtype = (
@@ -191,13 +244,27 @@ class Csv(datasets.ArrowBasedBuilder):
             if schema is not None
             else None
         )
+
+        # Handle list parameters (from resharding)
+        if isinstance(shard_start_line, list):
+            shard_start_line = shard_start_line[0]
+        if isinstance(shard_end_line, list):
+            shard_end_line = shard_end_line[0]
+
         for shard_idx, files_iterable in enumerate(files_iterables):
             for file in files_iterable:
-                csv_file_reader = pd.read_csv(file, iterator=True, dtype=dtype, **self.config.pd_read_csv_kwargs)
+                # Handle shard_start_line and shard_end_line
+                read_csv_kwargs = self.config.pd_read_csv_kwargs.copy()
+                if shard_start_line > 0:
+                    read_csv_kwargs["skiprows"] = shard_start_line
+                if shard_end_line is not None:
+                    read_csv_kwargs["nrows"] = shard_end_line - shard_start_line
+
+                csv_file_reader = pd.read_csv(file, iterator=True, dtype=dtype, **read_csv_kwargs)
                 try:
                     for batch_idx, df in enumerate(csv_file_reader):
                         pa_table = pa.Table.from_pandas(df)
-                        # Uncomment for debugging (will print the Arrow table size and elements)
+                        # Uncomment for debugging (will print Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")
                         # logger.warning('\n'.join(str(pa_table.slice(i, 1).to_pydict()) for i in range(pa_table.num_rows)))
                         yield Key(shard_idx, batch_idx), self._cast_table(pa_table)

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -1,4 +1,5 @@
 import io
+import os
 from dataclasses import dataclass
 from typing import Literal, Optional
 
@@ -127,63 +128,106 @@ class Json(datasets.ArrowBasedBuilder):
     def _generate_shards(self, base_files, files_iterables):
         yield from base_files
 
-    def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
-        """Generate more gen_kwargs for resharding"""
-        # Only reshard if num_shards is specified
-        if num_shards is None:
-            # No resharding - return the original gen_kwargs
-            for base_file, files_iterable in zip(base_files, files_iterables):
-                for file in files_iterable:
-                    yield {
-                        "base_files": [base_file],
-                        "files_iterables": [[file]],
-                        "shard_start_line": [0],
-                        "shard_end_line": [None],
-                    }
-            return
-
-        for base_file, files_iterable in zip(base_files, files_iterables):
-            for file in files_iterable:
-                # Check if the file is a JSON Lines file (one JSON object per line)
-                if self.config.field is None:
-                    # Split the file into multiple shards based on line boundaries
+    def _estimate_line_count(self, file, max_bytes=20 << 20):
+        """Estimate the number of lines in a JSON Lines file by reading the first max_bytes (default 20MB).
+        
+        Args:
+            file: Path to the file
+            max_bytes: Maximum bytes to read (default 20MB)
+            
+        Returns:
+            Estimated line count
+        """
+        try:
+            with open(file, "rb") as f:
+                line_count = 0
+                bytes_read = 0
+                
+                while bytes_read < max_bytes:
+                    line = f.readline()
+                    if not line:
+                        break
+                    line_count += 1
+                    bytes_read += len(line)
+                
+                # If we hit the byte limit, estimate the total based on file size
+                if bytes_read >= max_bytes:
                     try:
-                        with open(file, "rb") as f:
-                            # Read the file to count lines
-                            line_count = 0
-                            while f.readline():
-                                line_count += 1
-
-                        # Use the specified number of shards
-                        # But limit to the number of lines to avoid empty shards
-                        target_num_shards = min(num_shards, line_count)
-
-                        lines_per_shard = (line_count + target_num_shards - 1) // target_num_shards
-
-                        # Generate gen_kwargs for each shard
-                        for shard_idx in range(target_num_shards):
-                            yield {
-                                "base_files": [base_file],
-                                "files_iterables": [[file]],
-                                "shard_start_line": [shard_idx * lines_per_shard],
-                                "shard_end_line": [(shard_idx + 1) * lines_per_shard],
-                            }
-                    except Exception:
-                        # If we can't split the file, just use the whole file as one shard
-                        yield {
-                            "base_files": [base_file],
-                            "files_iterables": [[file]],
-                            "shard_start_line": [0],
-                            "shard_end_line": [None],
-                        }
+                        file_size = os.path.getsize(file)
+                        if bytes_read > 0:
+                            estimated_line_count = int((file_size / bytes_read) * line_count)
+                        else:
+                            estimated_line_count = line_count
+                    except OSError:
+                        estimated_line_count = line_count
                 else:
-                    # For single JSON object files, we can't split them further
+                    estimated_line_count = line_count
+                return estimated_line_count
+        except Exception:
+            return 0
+
+    def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
+        """Generate more gen_kwargs for resharding.
+        
+        When num_shards is specified, create that many shards.
+        When num_shards is None, maximize sharding by aiming for self.config.chunksize bytes per shard.
+        """
+        for base_file, files_iterable in zip(base_files, files_iterables):
+            files_list = list(files_iterable)
+            
+            if not files_list:
+                continue
+            
+            # Check if the file is a JSON Lines file (one JSON object per line)
+            # For single JSON object files, we can't split them further
+            if self.config.field is not None:
+                for file in files_list:
                     yield {
                         "base_files": [base_file],
-                        "files_iterables": [[file]],
-                        "shard_start_line": [0],
-                        "shard_end_line": [None],
+                        "files_iterables": [[(file, 0, None)]],
                     }
+                continue
+            
+            # Estimate total line count from the first file only (assuming similar structure)
+            total_line_count = 0
+            for file in files_list:
+                line_count = self._estimate_line_count(file)
+                if line_count > 0:
+                    # If we got a good estimate from the first file, use it for all files
+                    # This avoids expensive line counting on every file
+                    total_line_count = line_count
+                    break
+            
+            # Determine target number of shards
+            if num_shards is None:
+                # Maximum sharding: aim for self.config.chunksize bytes per shard (10MB by default)
+                # We use line count as a proxy: assume average line size and target for chunksize bytes
+                target_num_shards = max(1, (total_line_count + (self.config.chunksize // 100) - 1) // (self.config.chunksize // 100))
+            else:
+                target_num_shards = num_shards if total_line_count == 0 else min(num_shards, total_line_count)
+            
+            # If only one shard, return the original gen_kwargs
+            if target_num_shards <= 1:
+                for file in files_list:
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[(file, 0, None)]],
+                    }
+                continue
+            
+            # Calculate lines per shard
+            lines_per_shard = (total_line_count + target_num_shards - 1) // target_num_shards
+            
+            # Generate gen_kwargs for each shard
+            for shard_idx in range(target_num_shards):
+                shard_start = shard_idx * lines_per_shard
+                shard_end = (shard_idx + 1) * lines_per_shard
+                
+                # Distribute files across shards, keeping shard info with files
+                yield {
+                    "base_files": [base_file],
+                    "files_iterables": [[(file, shard_start, shard_end) for file in files_list]],
+                }
 
     def _generate_tables(
         self, base_files, files_iterables, allow_full_read=True, shard_start_line=0, shard_end_line=None
@@ -193,14 +237,22 @@ class Json(datasets.ArrowBasedBuilder):
         if self.info.features is not None:
             json_field_paths = get_json_field_paths_from_feature(self.info.features)
 
-        # Handle list parameters (from resharding)
+        # Handle list parameters (from resharding) - kept for backward compatibility
         if isinstance(shard_start_line, list):
             shard_start_line = shard_start_line[0]
         if isinstance(shard_end_line, list):
             shard_end_line = shard_end_line[0]
 
         for shard_idx, files_iterable in enumerate(files_iterables):
-            for file in files_iterable:
+            for file_item in files_iterable:
+                # Handle both tuple format (file, shard_start, shard_end) and plain file format
+                if isinstance(file_item, tuple):
+                    file, shard_start, shard_end = file_item
+                else:
+                    file = file_item
+                    shard_start = shard_start_line
+                    shard_end = shard_end_line
+                
                 # If the file is one json object and if we need to look at the items in one specific field
                 if self.config.field is not None:
                     if not allow_full_read:

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -127,11 +127,77 @@ class Json(datasets.ArrowBasedBuilder):
     def _generate_shards(self, base_files, files_iterables):
         yield from base_files
 
-    def _generate_tables(self, base_files, files_iterables, allow_full_read=True):
+    def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
+        """Generate more gen_kwargs for resharding"""
+        # Only reshard if num_shards is specified
+        if num_shards is None:
+            # No resharding - return the original gen_kwargs
+            for base_file, files_iterable in zip(base_files, files_iterables):
+                for file in files_iterable:
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[file]],
+                        "shard_start_line": [0],
+                        "shard_end_line": [None],
+                    }
+            return
+
+        for base_file, files_iterable in zip(base_files, files_iterables):
+            for file in files_iterable:
+                # Check if the file is a JSON Lines file (one JSON object per line)
+                if self.config.field is None:
+                    # Split the file into multiple shards based on line boundaries
+                    try:
+                        with open(file, "rb") as f:
+                            # Read the file to count lines
+                            line_count = 0
+                            while f.readline():
+                                line_count += 1
+
+                        # Use the specified number of shards
+                        # But limit to the number of lines to avoid empty shards
+                        target_num_shards = min(num_shards, line_count)
+
+                        lines_per_shard = (line_count + target_num_shards - 1) // target_num_shards
+
+                        # Generate gen_kwargs for each shard
+                        for shard_idx in range(target_num_shards):
+                            yield {
+                                "base_files": [base_file],
+                                "files_iterables": [[file]],
+                                "shard_start_line": [shard_idx * lines_per_shard],
+                                "shard_end_line": [(shard_idx + 1) * lines_per_shard],
+                            }
+                    except Exception:
+                        # If we can't split the file, just use the whole file as one shard
+                        yield {
+                            "base_files": [base_file],
+                            "files_iterables": [[file]],
+                            "shard_start_line": [0],
+                            "shard_end_line": [None],
+                        }
+                else:
+                    # For single JSON object files, we can't split them further
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[file]],
+                        "shard_start_line": [0],
+                        "shard_end_line": [None],
+                    }
+
+    def _generate_tables(
+        self, base_files, files_iterables, allow_full_read=True, shard_start_line=0, shard_end_line=None
+    ):
         json_field_paths = []
 
         if self.info.features is not None:
             json_field_paths = get_json_field_paths_from_feature(self.info.features)
+
+        # Handle list parameters (from resharding)
+        if isinstance(shard_start_line, list):
+            shard_start_line = shard_start_line[0]
+        if isinstance(shard_end_line, list):
+            shard_end_line = shard_end_line[0]
 
         for shard_idx, files_iterable in enumerate(files_iterables):
             for file in files_iterable:
@@ -159,6 +225,16 @@ class Json(datasets.ArrowBasedBuilder):
                         encoding_errors = (
                             self.config.encoding_errors if self.config.encoding_errors is not None else "strict"
                         )
+
+                        # Skip lines until shard_start_line
+                        current_line = 0
+                        if shard_start_line > 0:
+                            while current_line < shard_start_line:
+                                line = f.readline()
+                                if not line:
+                                    break
+                                current_line += 1
+
                         while True:
                             batch = f.read(self.config.chunksize)
                             if not batch:
@@ -180,6 +256,18 @@ class Json(datasets.ArrowBasedBuilder):
                                 batch += f.readline()
                             except (AttributeError, io.UnsupportedOperation):
                                 batch += readline(f)
+
+                            # Count lines in batch and respect shard_end_line
+                            lines = batch.splitlines()
+                            if shard_end_line is not None:
+                                remaining_lines = shard_end_line - current_line
+                                if remaining_lines <= 0:
+                                    break
+                                if len(lines) > remaining_lines:
+                                    lines = lines[:remaining_lines]
+                                    batch = b"\n".join(lines) + b"\n"
+                            current_line += len(lines)
+
                             # PyArrow only accepts utf-8 encoded bytes
                             if self.config.encoding != "utf-8":
                                 batch = batch.decode(self.config.encoding, errors=encoding_errors).encode("utf-8")
@@ -238,7 +326,22 @@ class Json(datasets.ArrowBasedBuilder):
                                     with open(
                                         file, encoding=self.config.encoding, errors=self.config.encoding_errors
                                     ) as f:
-                                        df = pandas_read_json(f)
+                                        # Skip lines until shard_start_line
+                                        if shard_start_line > 0:
+                                            for _ in range(shard_start_line):
+                                                f.readline()
+                                        # Read until shard_end_line
+                                        lines = []
+                                        current_line = shard_start_line
+                                        while True:
+                                            line = f.readline()
+                                            if not line:
+                                                break
+                                            if shard_end_line is not None and current_line >= shard_end_line:
+                                                break
+                                            lines.append(line)
+                                            current_line += 1
+                                        df = pandas_read_json(io.StringIO("".join(lines)))
                                 except ValueError:
                                     logger.error(f"Failed to load JSON from file '{file}' with error {type(e)}: {e}")
                                     raise e
@@ -260,3 +363,7 @@ class Json(datasets.ArrowBasedBuilder):
                                 self._cast_table(pa_table, json_field_paths=json_field_paths),
                             )
                             batch_idx += 1
+
+                            # Stop if we've reached shard_end_line
+                            if shard_end_line is not None and current_line >= shard_end_line:
+                                break

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -128,131 +128,70 @@ class Json(datasets.ArrowBasedBuilder):
     def _generate_shards(self, base_files, files_iterables):
         yield from base_files
 
-    def _estimate_line_count(self, file, max_bytes=20 << 20):
-        """Estimate the number of lines in a JSON Lines file by reading the first max_bytes (default 20MB).
-        
-        Args:
-            file: Path to the file
-            max_bytes: Maximum bytes to read (default 20MB)
-            
-        Returns:
-            Estimated line count
-        """
-        try:
-            with open(file, "rb") as f:
-                line_count = 0
-                bytes_read = 0
-                
-                while bytes_read < max_bytes:
-                    line = f.readline()
-                    if not line:
-                        break
-                    line_count += 1
-                    bytes_read += len(line)
-                
-                # If we hit the byte limit, estimate the total based on file size
-                if bytes_read >= max_bytes:
-                    try:
-                        file_size = os.path.getsize(file)
-                        if bytes_read > 0:
-                            estimated_line_count = int((file_size / bytes_read) * line_count)
-                        else:
-                            estimated_line_count = line_count
-                    except OSError:
-                        estimated_line_count = line_count
-                else:
-                    estimated_line_count = line_count
-                return estimated_line_count
-        except Exception:
-            return 0
-
     def _generate_more_gen_kwargs(self, base_files, files_iterables, num_shards=None):
         """Generate more gen_kwargs for resharding.
-        
         When num_shards is specified, create that many shards.
         When num_shards is None, maximize sharding by aiming for self.config.chunksize bytes per shard.
         """
         for base_file, files_iterable in zip(base_files, files_iterables):
             files_list = list(files_iterable)
-            
             if not files_list:
                 continue
-            
+
             # Check if the file is a JSON Lines file (one JSON object per line)
             # For single JSON object files, we can't split them further
             if self.config.field is not None:
                 for file in files_list:
-                    yield {
-                        "base_files": [base_file],
-                        "files_iterables": [[(file, 0, None)]],
-                    }
+                    yield {"base_files": [base_file], "files_iterables": [[(file, 0, None)]]}
                 continue
-            
-            # Estimate total line count from the first file only (assuming similar structure)
-            total_line_count = 0
-            for file in files_list:
-                line_count = self._estimate_line_count(file)
-                if line_count > 0:
-                    # If we got a good estimate from the first file, use it for all files
-                    # This avoids expensive line counting on every file
-                    total_line_count = line_count
-                    break
-            
-            # Determine target number of shards
-            if num_shards is None:
-                # Maximum sharding: aim for self.config.chunksize bytes per shard (10MB by default)
-                # We use line count as a proxy: assume average line size and target for chunksize bytes
-                target_num_shards = max(1, (total_line_count + (self.config.chunksize // 100) - 1) // (self.config.chunksize // 100))
-            else:
-                target_num_shards = num_shards if total_line_count == 0 else min(num_shards, total_line_count)
-            
-            # If only one shard, return the original gen_kwargs
-            if target_num_shards <= 1:
-                for file in files_list:
-                    yield {
-                        "base_files": [base_file],
-                        "files_iterables": [[(file, 0, None)]],
-                    }
-                continue
-            
-            # Calculate lines per shard
-            lines_per_shard = (total_line_count + target_num_shards - 1) // target_num_shards
-            
-            # Generate gen_kwargs for each shard
-            for shard_idx in range(target_num_shards):
-                shard_start = shard_idx * lines_per_shard
-                shard_end = (shard_idx + 1) * lines_per_shard
-                
-                # Distribute files across shards, keeping shard info with files
-                yield {
-                    "base_files": [base_file],
-                    "files_iterables": [[(file, shard_start, shard_end) for file in files_list]],
-                }
 
-    def _generate_tables(
-        self, base_files, files_iterables, allow_full_read=True, shard_start_line=0, shard_end_line=None
-    ):
+            for file in files_list:
+                try:
+                    file_size = os.path.getsize(file)
+                except OSError:
+                    yield {"base_files": [base_file], "files_iterables": [[(file, 0, None)]]}
+                    continue
+
+                # Calculate shard size and number of shards
+                # If num_shards is specified, use that number of shards
+                # If num_shards is None, aim use self.config.chunksize bytes per shard
+                if num_shards is not None:
+                    shard_size = max(1, file_size // num_shards)
+                    target_num_shards = num_shards
+                else:
+                    shard_size = self.config.chunksize
+                    target_num_shards = max(1, file_size // shard_size)
+
+                for i in range(target_num_shards):
+                    start = i * shard_size
+                    if start >= file_size:
+                        break
+
+                    end = (i + 1) * shard_size if i < target_num_shards - 1 else file_size
+
+                    if end > file_size:
+                        end = file_size
+
+                    yield {
+                        "base_files": [base_file],
+                        "files_iterables": [[(file, start, end)]],
+                    }
+                    if end >= file_size:
+                        break
+
+    def _generate_tables(self, base_files, files_iterables, allow_full_read=True):
         json_field_paths = []
 
         if self.info.features is not None:
             json_field_paths = get_json_field_paths_from_feature(self.info.features)
 
-        # Handle list parameters (from resharding) - kept for backward compatibility
-        if isinstance(shard_start_line, list):
-            shard_start_line = shard_start_line[0]
-        if isinstance(shard_end_line, list):
-            shard_end_line = shard_end_line[0]
-
         for shard_idx, files_iterable in enumerate(files_iterables):
             for file_item in files_iterable:
-                # Handle both tuple format (file, shard_start, shard_end) and plain file format
                 if isinstance(file_item, tuple):
-                    file, shard_start, shard_end = file_item
+                    file, start_byte, end_byte = file_item
                 else:
-                    file = file_item
-                    shard_start = shard_start_line
-                    shard_end = shard_end_line
-                
+                    file, start_byte, end_byte = file_item, 0, None
+
                 # If the file is one json object and if we need to look at the items in one specific field
                 if self.config.field is not None:
                     if not allow_full_read:
@@ -277,18 +216,29 @@ class Json(datasets.ArrowBasedBuilder):
                         encoding_errors = (
                             self.config.encoding_errors if self.config.encoding_errors is not None else "strict"
                         )
-
-                        # Skip lines until shard_start_line
-                        current_line = 0
-                        if shard_start_line > 0:
-                            while current_line < shard_start_line:
-                                line = f.readline()
-                                if not line:
-                                    break
-                                current_line += 1
+                        # Seek to the start of the shard
+                        if start_byte > 0:
+                            f.seek(start_byte - 1)
+                            last_char = f.read(1)
+                            # If the last character is a newline, we are already at the start of the shard
+                            # Otherwise, we need to read until the next newline
+                            # This is to ensure that we start reading from the beginning of a JSON object
+                            if last_char == b"\n":
+                                f.seek(start_byte)
+                            else:
+                                f.readline()
 
                         while True:
-                            batch = f.read(self.config.chunksize)
+                            # Only read up to end_byte if it is set
+                            curr = f.tell()
+                            if end_byte is not None and curr >= end_byte:
+                                break
+                            to_read = (
+                                self.config.chunksize
+                                if end_byte is None
+                                else min(self.config.chunksize, end_byte - curr)
+                            )
+                            batch = f.read(to_read)
                             if not batch:
                                 break
                             if batch.startswith(b"["):
@@ -308,17 +258,6 @@ class Json(datasets.ArrowBasedBuilder):
                                 batch += f.readline()
                             except (AttributeError, io.UnsupportedOperation):
                                 batch += readline(f)
-
-                            # Count lines in batch and respect shard_end_line
-                            lines = batch.splitlines()
-                            if shard_end_line is not None:
-                                remaining_lines = shard_end_line - current_line
-                                if remaining_lines <= 0:
-                                    break
-                                if len(lines) > remaining_lines:
-                                    lines = lines[:remaining_lines]
-                                    batch = b"\n".join(lines) + b"\n"
-                            current_line += len(lines)
 
                             # PyArrow only accepts utf-8 encoded bytes
                             if self.config.encoding != "utf-8":
@@ -378,22 +317,7 @@ class Json(datasets.ArrowBasedBuilder):
                                     with open(
                                         file, encoding=self.config.encoding, errors=self.config.encoding_errors
                                     ) as f:
-                                        # Skip lines until shard_start_line
-                                        if shard_start_line > 0:
-                                            for _ in range(shard_start_line):
-                                                f.readline()
-                                        # Read until shard_end_line
-                                        lines = []
-                                        current_line = shard_start_line
-                                        while True:
-                                            line = f.readline()
-                                            if not line:
-                                                break
-                                            if shard_end_line is not None and current_line >= shard_end_line:
-                                                break
-                                            lines.append(line)
-                                            current_line += 1
-                                        df = pandas_read_json(io.StringIO("".join(lines)))
+                                        df = pandas_read_json(io.BytesIO(batch), lines=True)
                                 except ValueError:
                                     logger.error(f"Failed to load JSON from file '{file}' with error {type(e)}: {e}")
                                     raise e
@@ -416,6 +340,5 @@ class Json(datasets.ArrowBasedBuilder):
                             )
                             batch_idx += 1
 
-                            # Stop if we've reached shard_end_line
-                            if shard_end_line is not None and current_line >= shard_end_line:
+                            if end_byte is not None and f.tell() >= end_byte:
                                 break

--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -157,18 +157,36 @@ class Parquet(datasets.ArrowBasedBuilder):
                     "fragment_row_groups": row_groups,
                 }
 
-    def _generate_more_gen_kwargs(self, files, row_groups_list):
+    def _generate_more_gen_kwargs(self, files, row_groups_list, num_shards=None):
+        """Generate more gen_kwargs for resharding"""
         if not row_groups_list:
             parquet_file_format = ds.ParquetFileFormat(default_fragment_scan_options=self.config.fragment_scan_options)
             for file in files:
                 with open(file, "rb") as f:
                     parquet_fragment = parquet_file_format.make_fragment(f)
-                    yield {
-                        "files": [file] * parquet_fragment.num_row_groups,
-                        "row_groups_list": [
-                            (row_group_id,) for row_group_id in range(parquet_fragment.num_row_groups)
-                        ],
-                    }
+                    if num_shards is not None and parquet_fragment.num_row_groups > num_shards:
+                        # If num_shards is specified and we have more row groups than requested shards,
+                        # distribute row groups evenly across shards
+                        row_groups_per_shard = parquet_fragment.num_row_groups // num_shards
+                        remainder = parquet_fragment.num_row_groups % num_shards
+
+                        current_row_group = 0
+                        for shard_idx in range(num_shards):
+                            num_row_groups = row_groups_per_shard + (1 if shard_idx < remainder else 0)
+                            row_group_ids = tuple(range(current_row_group, current_row_group + num_row_groups))
+                            current_row_group += num_row_groups
+                            yield {
+                                "files": [file],
+                                "row_groups_list": [row_group_ids],
+                            }
+                    else:
+                        # Split by row groups
+                        yield {
+                            "files": [file] * parquet_fragment.num_row_groups,
+                            "row_groups_list": [
+                                (row_group_id,) for row_group_id in range(parquet_fragment.num_row_groups)
+                            ],
+                        }
         else:
             for file, row_groups in zip(files, row_groups_list):
                 yield {"files": [file], "row_groups_list": [row_groups]}

--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -159,7 +159,8 @@ class Parquet(datasets.ArrowBasedBuilder):
 
     def _generate_more_gen_kwargs(self, files, row_groups_list, num_shards=None):
         """Generate more gen_kwargs for resharding"""
-        if not row_groups_list:
+        # Check if row_groups_list is empty or contains only None values (meaning no specific row groups are specified)
+        if not row_groups_list or all(rg is None for rg in row_groups_list):
             parquet_file_format = ds.ParquetFileFormat(default_fragment_scan_options=self.config.fragment_scan_options)
             for file in files:
                 with open(file, "rb") as f:
@@ -208,7 +209,7 @@ class Parquet(datasets.ArrowBasedBuilder):
                 with open(file, "rb") as f:
                     parquet_fragment = parquet_file_format.make_fragment(f)
                     if row_groups is not None:
-                        parquet_fragment.subset(row_group_ids=row_groups)
+                        parquet_fragment = parquet_fragment.subset(row_group_ids=row_groups)
                     if parquet_fragment.row_groups:
                         batch_size = self.config.batch_size or parquet_fragment.row_groups[0].num_rows
                         for batch_idx, record_batch in enumerate(

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2190,6 +2190,63 @@ def test_iterable_dataset_shard():
     ) == list(dataset)
 
 
+def test_iterable_dataset_reshard():
+    num_examples = 100
+    num_shards = 5
+    dataset = Dataset.from_dict({"a": range(num_examples)}).to_iterable_dataset(num_shards=num_shards)
+    # without generate_more_kwargs_fn, reshard returns the same dataset
+    resharded_dataset = dataset.reshard()
+    assert resharded_dataset.num_shards == dataset.num_shards
+    assert list(resharded_dataset) == list(dataset)
+    resharded_dataset = dataset.reshard(num_shards=10)
+    assert resharded_dataset.num_shards == dataset.num_shards
+    assert list(resharded_dataset) == list(dataset)
+
+
+def test_iterable_dataset_reshard_with_more_kwargs_fn():
+    def generate_examples_fn(files, shard_start_line=None, shard_end_line=None):
+        for file_idx, file in enumerate(files):
+            start = shard_start_line[file_idx] if shard_start_line else 0
+            end = shard_end_line[file_idx] if shard_end_line else 10
+            for line_idx in range(start, min(end, 10)):
+                yield f"{file}_{line_idx}", {"file": file, "line": line_idx}
+
+    def generate_more_kwargs_fn(files, num_shards=None):
+        total_lines = 10
+        if num_shards is not None:
+            lines_per_shard = (total_lines + num_shards - 1) // num_shards
+            for shard_idx in range(num_shards):
+                start = shard_idx * lines_per_shard
+                end = min((shard_idx + 1) * lines_per_shard, total_lines)
+                yield {
+                    "files": files,
+                    "shard_start_line": [start],
+                    "shard_end_line": [end],
+                }
+        else:
+            yield {
+                "files": files,
+                "shard_start_line": [0],
+                "shard_end_line": [total_lines],
+            }
+
+    files = ["data.txt"]
+    ex_iterable = ExamplesIterable(
+        generate_examples_fn, {"files": files}, generate_more_kwargs_fn=generate_more_kwargs_fn
+    )
+    dataset = IterableDataset(ex_iterable)
+    assert dataset.num_shards == 1
+    original_data = list(dataset)
+    assert len(original_data) == 10
+
+    # reshard with num_shards
+    resharded_dataset = dataset.reshard(num_shards=4)
+    assert resharded_dataset.num_shards == 4
+    resharded_data = list(resharded_dataset)
+    assert len(resharded_data) == len(original_data)
+    assert sorted(resharded_data, key=lambda x: x["line"]) == sorted(original_data, key=lambda x: x["line"])
+
+
 @pytest.mark.parametrize("method", ["skip", "take"])
 @pytest.mark.parametrize("after_shuffle", [False, True])
 @pytest.mark.parametrize("count", [2, 5, 11])

--- a/tests/test_reshard.py
+++ b/tests/test_reshard.py
@@ -1,0 +1,177 @@
+import csv
+import json
+
+import pytest
+
+from datasets import load_dataset
+
+
+@pytest.fixture(scope="session")
+def csv_path_big(tmp_path_factory):
+    """Create a CSV file with multiple lines for resharding testing"""
+    path = str(tmp_path_factory.mktemp("data") / "dataset_reshard.csv")
+    data = [{"id": i, "text": f"text {i}", "label": i % 2} for i in range(100)]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "text", "label"])
+        writer.writeheader()
+        for item in data:
+            writer.writerow(item)
+    return path
+
+
+@pytest.fixture(scope="session")
+def csv_path_small(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "dataset_small.csv")
+    data = [{"id": i, "text": f"text {i}"} for i in range(5)]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "text"])
+        writer.writeheader()
+        for item in data:
+            writer.writerow(item)
+    return path
+
+
+@pytest.fixture(scope="session")
+def jsonl_path_big(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "dataset_reshard.jsonl")
+    data = [{"id": i, "text": f"text {i}", "label": i % 2} for i in range(100)]
+    with open(path, "w") as f:
+        for item in data:
+            f.write(json.dumps(item) + "\n")
+    return path
+
+
+@pytest.fixture(scope="session")
+def jsonl_path_small(tmp_path_factory):
+    path = str(tmp_path_factory.mktemp("data") / "dataset_small.jsonl")
+    data = [{"id": i, "text": f"text {i}"} for i in range(5)]
+    with open(path, "w") as f:
+        for item in data:
+            f.write(json.dumps(item) + "\n")
+    return path
+
+
+@pytest.fixture(scope="session")
+def parquet_path_multiple_rowgroups(tmp_path_factory):
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    path = str(tmp_path_factory.mktemp("data") / "dataset_reshard.parquet")
+    schema = pa.schema(
+        {
+            "id": pa.int64(),
+            "text": pa.string(),
+            "label": pa.int64(),
+        }
+    )
+
+    data = {
+        "id": list(range(100)),
+        "text": [f"text {i}" for i in range(100)],
+        "label": [i % 2 for i in range(100)],
+    }
+
+    with open(path, "wb") as f:
+        writer = pq.ParquetWriter(f, schema=schema)
+        # Write in multiple row groups to test resharding
+        for i in range(0, 100, 10):
+            table = pa.Table.from_pydict({k: v[i : i + 10] for k, v in data.items()}, schema=schema)
+            writer.write_table(table)
+        writer.close()
+    return path
+
+
+def test_reshard_jsonl_basic(jsonl_path_big):
+    ds = load_dataset("json", data_files=jsonl_path_big, streaming=True)
+    original_num_shards = ds["train"].num_shards
+    print(f"Original num of shards: {original_num_shards}")
+    # Reshard to maximum possible shards
+    resharded_ds = ds["train"].reshard()
+    assert resharded_ds.num_shards >= original_num_shards
+
+    # Reshard to a specific number of shards
+    target_shards = 10
+    resharded_ds_specific = ds["train"].reshard(num_shards=target_shards)
+    assert resharded_ds_specific.num_shards == target_shards
+
+    origin_ids = [item["id"] for item in ds["train"]]
+    resharded_ids = [item["id"] for item in resharded_ds]
+    resharded_specific_ids = [item["id"] for item in resharded_ds_specific]
+    assert origin_ids == resharded_ids
+    assert resharded_ids == resharded_specific_ids
+
+
+def test_reshard_parquet_basic(parquet_path_multiple_rowgroups):
+    ds = load_dataset("parquet", data_files=parquet_path_multiple_rowgroups, streaming=True)
+    original_num_shards = ds["train"].num_shards
+
+    # Reshard to maximum possible shards (should split by row groups)
+    resharded_ds = ds["train"].reshard()
+    assert resharded_ds.num_shards >= original_num_shards
+
+    # Reshard to a specific number of shards
+    target_shards = 5
+    resharded_ds_specific = ds["train"].reshard(num_shards=target_shards)
+    assert resharded_ds_specific.num_shards == target_shards
+
+    origin_ids = [item["id"] for item in ds["train"]]
+    resharded_ids = [item["id"] for item in resharded_ds]
+    resharded_specific_ids = [item["id"] for item in resharded_ds_specific]
+    assert origin_ids == resharded_ids
+    assert resharded_ids == resharded_specific_ids
+
+
+def test_reshard_csv_basic(csv_path_big):
+    ds = load_dataset("csv", data_files=csv_path_big, streaming=True)
+    original_num_shards = ds["train"].num_shards
+
+    # Reshard to maximum possible shards
+    resharded_ds = ds["train"].reshard()
+    assert resharded_ds.num_shards >= original_num_shards
+
+    # Reshard to a specific number of shards
+    target_shards = 10
+    resharded_ds_specific = ds["train"].reshard(num_shards=target_shards)
+    assert resharded_ds_specific.num_shards == target_shards
+
+    origin_ids = [item["id"] for item in ds["train"]]
+    resharded_ids = [item["id"] for item in resharded_ds]
+    resharded_specific_ids = [item["id"] for item in resharded_ds_specific]
+    assert origin_ids == resharded_ids
+    assert resharded_ids == resharded_specific_ids
+
+
+def test_reshard_csv_boundary_case(csv_path_small):
+    """Test reshard with CSV dataset smaller than num_shards"""
+    # Load the small dataset
+    ds = load_dataset("csv", data_files=csv_path_small, streaming=True)
+    # Try to reshard to more shards than data items
+    target_shards = 10
+    resharded_ds = ds["train"].reshard(num_shards=target_shards)
+    origin_ids = [item["id"] for item in ds["train"]]
+    resharded_ids = [item["id"] for item in resharded_ds]
+    assert origin_ids == resharded_ids
+    assert resharded_ds.num_shards == target_shards
+
+
+def test_reshard_jsonl_boundary_case(jsonl_path_small):
+    ds = load_dataset("json", data_files=jsonl_path_small, streaming=True)
+    target_shards = 10
+    resharded_ds = ds["train"].reshard(num_shards=target_shards)
+    assert resharded_ds.num_shards == 10
+    origin_ids = [item["id"] for item in ds["train"]]
+    resharded_ids = [item["id"] for item in resharded_ds]
+    assert origin_ids == resharded_ids
+    assert resharded_ds.num_shards == target_shards
+
+
+def test_reshard_pipeline(jsonl_path_big):
+    ds = load_dataset("json", data_files=jsonl_path_big, streaming=True)
+    resharded_ds = ds["train"].reshard(num_shards=10)
+    filtered_ds = resharded_ds.filter(lambda x: x["label"] == 1)
+    batched_ds = filtered_ds.batch(32)
+    # Verify the dataset is still iterable
+    batch = next(iter(batched_ds))
+    assert "id" in batch
+    assert "text" in batch
+    assert "label" in batch


### PR DESCRIPTION
This PR extends the IterableDataset.reshard() functionality to support JSON Lines and CSV file formats, building on the foundation laid in #7992.

### Summary
- JSON Lines : Resharding splits files by line boundaries (only when num_shards is specified)
- CSV : Resharding splits files by line boundaries (only when num_shards is specified)
- Parquet : Already supported via row groups (enhanced to support num_shards parameter)


### Usage
```python
from datasets import load_dataset

# JSON Lines
ds = load_dataset("json", data_files=["data.jsonl"], streaming=True)
resharded_ds = ds['train'].reshard(num_shards=100)

# CSV
ds = load_dataset("csv", data_files=["data.csv"], streaming=True)
resharded_ds = ds['train'].reshard(num_shards=100)

# Parquet
ds = load_dataset("parquet", data_files=["data.parquet"], streaming=True)
resharded_ds = ds['train'].reshard(num_shards=100)
```