### PR TITLE
Fix: Add validation to prevent duplicate kwargs in load_dataset_builder

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1303,6 +1303,13 @@ def load_dataset_builder(
      'text': Value('string')}
     ```
     """
+    args = {"name", "data_dir", "data_files", "cache_dir", "features", "download_config", "download_mode", "revision", "token", "storage_options"}
+    conf = set(config_kwargs.keys())
+    dupes = args & conf
+    
+    if dupes:
+        err = f"Duplicate keys found: {dupes}"
+        raise ValueError(err)
     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
     if token is not None:
         download_config = download_config.copy() if download_config else DownloadConfig()


### PR DESCRIPTION
This PR adds a set intersection check in `load_dataset_builder` to catch overlapping keys between the standard build arguments and `config_kwargs`. 

Previously, passing identical keys caused a confusing Python `TypeError` during unpacking. This fix intercepts the duplicates early and raises a clear `ValueError` specifying exactly which keys are overlapping.

Fixes #4910