### PR TITLE
add sample_by="document" support for jsonl files

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -50,6 +50,7 @@ class JsonConfig(datasets.BuilderConfig):
     chunksize: int = 10 << 20  # 10MB
     newlines_in_values: Optional[bool] = None
     on_mixed_types: Optional[Literal["use_json"]] = "use_json"
+    sample_by: Literal["line", "document"] = "line"
 
     def __post_init__(self):
         super().__post_init__()
@@ -135,6 +136,17 @@ class Json(datasets.ArrowBasedBuilder):
 
         for shard_idx, files_iterable in enumerate(files_iterables):
             for file in files_iterable:
+                # If sample_by="document", yield one row per file with the raw content as a string
+                if self.config.sample_by == "document":
+                    encoding_errors = (
+                        self.config.encoding_errors if self.config.encoding_errors is not None else "strict"
+                    )
+                    with open(file, encoding=self.config.encoding, errors=encoding_errors) as f:
+                        content = f.read()
+                    pa_table = pa.table({"text": [content]})
+                    yield Key(shard_idx, 0), self._cast_table(pa_table)
+                    continue
+
                 # If the file is one json object and if we need to look at the items in one specific field
                 if self.config.field is not None:
                     if not allow_full_read:

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -377,3 +377,12 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
     generator = json._generate_tables(base_files=base_files, files_iterables=files_iterables)
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa_table.column_names == ["ID", "Language", "Topic"]
+
+
+def test_json_sample_by_document(jsonl_file):
+    with open(jsonl_file, encoding="utf-8") as f:
+        expected_content = f.read()
+    json = Json(sample_by="document")
+    generator = json._generate_tables(base_files=[jsonl_file], files_iterables=[[jsonl_file]])
+    generated_content = pa.concat_tables([table for _, table in generator]).to_pydict()["text"]
+    assert generated_content == [expected_content]


### PR DESCRIPTION
With more agentic traces (_ie Claude Code / Codex / Pi etc_) being published to the Hub as JSONL files, it would be nice to easily support loading / viewing them in Dataset Viewer. 

Datasets like https://huggingface.co/datasets/cfahlgren1/agent-sessions contain one JSONL file per session. Without sample_by, each line becomes a separate row, losing the file-level grouping. With sample_by="document", each file is preserved as a single row:

```python
  ds = load_dataset("cfahlgren1/agent-sessions", sample_by="document")
  # Each row is one session file
```

  Also configurable via YAML metadata:

```yaml
  ---
  configs:
    - config_name: default
      data_files: "*.jsonl"
      sample_by: "document"
  ---
```
