### PR TITLE
fix: preserve features in IterableDataset.add_column (fixes #5752)

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3848,7 +3848,13 @@ class IterableDataset(DatasetInfoMixin):
         Returns:
             `IterableDataset`
         """
-        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
+        # Preserve existing features and extend them with the new column's inferred type.
+        # Without this, map() would set info.features=None (its default), losing all schema info.
+        new_features = None
+        if self._info.features is not None:
+            column_features = _infer_features_from_batch({name: list(column)})
+            new_features = Features({**self._info.features, **column_features})
+        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True, features=new_features)
 
     def rename_column(self, original_column_name: str, new_column_name: str) -> "IterableDataset":
         """


### PR DESCRIPTION
## Summary

Fixes #5752.

`IterableDataset.add_column()` lost the dataset's feature schema on every call because it delegated to `map()` without passing the `features` argument. `map()` unconditionally writes `info.features = features`, so the default `None` silently overwrote the existing schema.

**Root cause** (`iterable_dataset.py:3459`):
```python
info = self.info.copy()
info.features = features  # None when add_column() doesn't pass features
```

**Fix**: infer the new column's Arrow type via the existing `_infer_features_from_batch` helper, merge it with the existing features, and pass the result to `map()`.

```python
new_features = None
if self._info.features is not None:
    column_features = _infer_features_from_batch({name: list(column)})
    new_features = Features({**self._info.features, **column_features})
return self.map(..., features=new_features)
```

If the dataset had no features to begin with (`_info.features is None`), behaviour is unchanged — `map()` receives `None` as before.

## Test plan

- [ ] Reproduce the original issue: create a streaming dataset with known features, call `.add_column()`, assert `.features` is not None and contains the new column
- [ ] Verify existing `test_iterable_dataset.py` tests still pass
- [ ] Smoke-test with numpy array column input (not just list)