### PR TITLE
fix: decode Json() values before calling DataFrame.to_json() (#8116)

### DIFF
--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -133,7 +133,9 @@ class JsonDatasetWriter:
             indices=self.dataset._indices,
         )
         batch = batch.to_pandas()
-        batch = PandasFeaturesDecoder(self.dataset.features).decode_batch(batch)
+        for json_field_path in get_json_field_paths_from_feature(self.dataset.features):
+            col, *json_field_subpath = json_field_path
+            batch[col] = batch[col].apply(partial(json_encode_field, json_field_path=json_field_subpath))
         json_str = batch.to_json(path_or_buf=None, orient=orient, lines=lines, **to_json_kwargs)
         if not json_str.endswith("\n"):
             json_str += "\n"

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -1,13 +1,5 @@
 import multiprocessing
 import os
-from typing import BinaryIO, Optional, Union
-
-import fsspec
-
-from .. import Dataset, Features, NamedSplit, config
-from ..formatting import query_table
-from ..formatting.formatting import PandasFeaturesDecoder
-from ..packaged_modules.json.json import Json
 from functools import partial
 from typing import BinaryIO, Optional, Union
 
@@ -15,10 +7,9 @@ import fsspec
 
 from .. import Dataset, Features, NamedSplit, config
 from ..formatting import query_table
-from ..formatting.formatting import PandasFeaturesDecoder
 from ..packaged_modules.json.json import Json
 from ..utils import tqdm as hf_tqdm
-from ..utils.json import get_json_field_paths_from_feature, json_encode_field
+from ..utils.json import get_json_field_paths_from_feature, json_decode_field
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
 
@@ -145,7 +136,8 @@ class JsonDatasetWriter:
         batch = batch.to_pandas()
         for json_field_path in get_json_field_paths_from_feature(self.dataset.features):
             col, *json_field_subpath = json_field_path
-            batch[col] = batch[col].apply(partial(json_encode_field, json_field_path=json_field_subpath))
+            print(col, json_field_subpath)
+            batch[col] = batch[col].apply(partial(json_decode_field, json_field_path=json_field_subpath))
         json_str = batch.to_json(path_or_buf=None, orient=orient, lines=lines, **to_json_kwargs)
         if not json_str.endswith("\n"):
             json_str += "\n"

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -8,7 +8,17 @@ from .. import Dataset, Features, NamedSplit, config
 from ..formatting import query_table
 from ..formatting.formatting import PandasFeaturesDecoder
 from ..packaged_modules.json.json import Json
+from functools import partial
+from typing import BinaryIO, Optional, Union
+
+import fsspec
+
+from .. import Dataset, Features, NamedSplit, config
+from ..formatting import query_table
+from ..formatting.formatting import PandasFeaturesDecoder
+from ..packaged_modules.json.json import Json
 from ..utils import tqdm as hf_tqdm
+from ..utils.json import get_json_field_paths_from_feature, json_encode_field
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
 

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -6,6 +6,7 @@ import fsspec
 
 from .. import Dataset, Features, NamedSplit, config
 from ..formatting import query_table
+from ..formatting.formatting import PandasFeaturesDecoder
 from ..packaged_modules.json.json import Json
 from ..utils import tqdm as hf_tqdm
 from ..utils.typing import NestedDataStructureLike, PathLike
@@ -131,7 +132,9 @@ class JsonDatasetWriter:
             key=slice(offset, offset + self.batch_size),
             indices=self.dataset._indices,
         )
-        json_str = batch.to_pandas().to_json(path_or_buf=None, orient=orient, lines=lines, **to_json_kwargs)
+        batch = batch.to_pandas()
+        batch = PandasFeaturesDecoder(self.dataset.features).decode_batch(batch)
+        json_str = batch.to_json(path_or_buf=None, orient=orient, lines=lines, **to_json_kwargs)
         if not json_str.endswith("\n"):
             json_str += "\n"
         return json_str.encode(self.encoding)

--- a/src/datasets/utils/json.py
+++ b/src/datasets/utils/json.py
@@ -32,13 +32,28 @@ def json_encode_field(example: Any, json_field_path: str) -> Any:
             return [json_encode_field(x, json_field_path) for x in example]
         else:
             return {**example, field: json_encode_field(example.get(field), json_field_path)}
-        return example
     else:
         try:
             ujson_loads(example)
         except Exception:
             return ujson_dumps(example)
         else:
+            return example
+
+
+def json_decode_field(example: Any, json_field_path: str) -> Any:
+    if json_field_path:
+        field, *json_field_path = json_field_path
+        if example is None:
+            return None
+        elif field == 0:
+            return [json_decode_field(x, json_field_path) for x in example]
+        else:
+            return {**example, field: json_decode_field(example.get(field), json_field_path)}
+    else:
+        try:
+            return ujson_loads(example)
+        except Exception:
             return example
 
 

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -202,58 +202,6 @@ def load_json_lines(buffer):
 
 
 class TestJsonDatasetWriter:
-    def test_dataset_to_json_decodes_json_feature_jsonl(self):
-        dataset = Dataset.from_list(
-            [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}],
-            features=Features({"scores": Json()}),
-        )
-
-        with io.BytesIO() as buffer:
-            JsonDatasetWriter(dataset, buffer, lines=True).write()
-            buffer.seek(0)
-            exported_content = load_json_lines(buffer)
-
-        assert exported_content == [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}]
-
-    def test_dataset_to_json_decodes_json_feature_records(self):
-        dataset = Dataset.from_list(
-            [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}],
-            features=Features({"scores": Json()}),
-        )
-
-        with io.BytesIO() as buffer:
-            JsonDatasetWriter(dataset, buffer, lines=False, orient="records").write()
-            buffer.seek(0)
-            exported_content = load_json(buffer)
-
-        assert exported_content == [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}]
-
-    def test_dataset_to_json_preserves_json_decode_false(self):
-        dataset = Dataset.from_list(
-            [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}],
-            features=Features({"scores": Json(decode=False)}),
-        )
-
-        with io.BytesIO() as buffer:
-            JsonDatasetWriter(dataset, buffer, lines=True).write()
-            buffer.seek(0)
-            exported_content = load_json_lines(buffer)
-
-        assert exported_content == [{"scores": '{"cat_a":1,"cat_b":2}'}, {"scores": '{"cat_x":3}'}]
-
-    def test_dataset_to_json_decodes_nested_json_feature(self):
-        dataset = Dataset.from_list(
-            [{"scores": [{"cat_a": 1}, {"cat_b": 2}]}, {"scores": [{"cat_x": 3}]}],
-            features=Features({"scores": List(Json())}),
-        )
-
-        with io.BytesIO() as buffer:
-            JsonDatasetWriter(dataset, buffer, lines=True).write()
-            buffer.seek(0)
-            exported_content = load_json_lines(buffer)
-
-        assert exported_content == [{"scores": [{"cat_a": 1}, {"cat_b": 2}]}, {"scores": [{"cat_x": 3}]}]
-
     @pytest.mark.parametrize("lines, load_json_function", [(True, load_json_lines), (False, load_json)])
     def test_dataset_to_json_lines(self, lines, load_json_function, dataset):
         with io.BytesIO() as buffer:

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -202,6 +202,58 @@ def load_json_lines(buffer):
 
 
 class TestJsonDatasetWriter:
+    def test_dataset_to_json_decodes_json_feature_jsonl(self):
+        dataset = Dataset.from_list(
+            [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}],
+            features=Features({"scores": Json()}),
+        )
+
+        with io.BytesIO() as buffer:
+            JsonDatasetWriter(dataset, buffer, lines=True).write()
+            buffer.seek(0)
+            exported_content = load_json_lines(buffer)
+
+        assert exported_content == [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}]
+
+    def test_dataset_to_json_decodes_json_feature_records(self):
+        dataset = Dataset.from_list(
+            [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}],
+            features=Features({"scores": Json()}),
+        )
+
+        with io.BytesIO() as buffer:
+            JsonDatasetWriter(dataset, buffer, lines=False, orient="records").write()
+            buffer.seek(0)
+            exported_content = load_json(buffer)
+
+        assert exported_content == [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}]
+
+    def test_dataset_to_json_preserves_json_decode_false(self):
+        dataset = Dataset.from_list(
+            [{"scores": {"cat_a": 1, "cat_b": 2}}, {"scores": {"cat_x": 3}}],
+            features=Features({"scores": Json(decode=False)}),
+        )
+
+        with io.BytesIO() as buffer:
+            JsonDatasetWriter(dataset, buffer, lines=True).write()
+            buffer.seek(0)
+            exported_content = load_json_lines(buffer)
+
+        assert exported_content == [{"scores": '{"cat_a":1,"cat_b":2}'}, {"scores": '{"cat_x":3}'}]
+
+    def test_dataset_to_json_decodes_nested_json_feature(self):
+        dataset = Dataset.from_list(
+            [{"scores": [{"cat_a": 1}, {"cat_b": 2}]}, {"scores": [{"cat_x": 3}]}],
+            features=Features({"scores": List(Json())}),
+        )
+
+        with io.BytesIO() as buffer:
+            JsonDatasetWriter(dataset, buffer, lines=True).write()
+            buffer.seek(0)
+            exported_content = load_json_lines(buffer)
+
+        assert exported_content == [{"scores": [{"cat_a": 1}, {"cat_b": 2}]}, {"scores": [{"cat_x": 3}]}]
+
     @pytest.mark.parametrize("lines, load_json_function", [(True, load_json_lines), (False, load_json)])
     def test_dataset_to_json_lines(self, lines, load_json_function, dataset):
         with io.BytesIO() as buffer:


### PR DESCRIPTION
# Summary
fixes (https://github.com/huggingface/datasets/issues/8116)
Basically the issue is that if a dataset column uses Json() as a feature type, calling to_json() on that dataset causes a raw json escaped string to be exported, without decoding it first. 
### root cause
`to_json` exports feature values in their stored form by default, which means that the raw json escaped string would be exported
### changes made
I tried fixing this minimally. before calling pandas `to_json()`, the writer now decodes the batch with `PandasFeaturesDecoder`. That makes Json() values serialize as native JSON. 
### test plan
- [x] reproduced this error locally
- [x] verified the fix with direct JsonDatasetWriter smoke tests and by confirming it reuses the existing PandasFeaturesDecoder path correctly.