### PR TITLE
Fix batching for table-formatted datasets

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -113,6 +113,7 @@ from .table import (
     InMemoryTable,
     MemoryMappedTable,
     Table,
+    _batch_arrow_table,
     _memory_mapped_record_batch_reader_from_file,
     cast_array_to_feature,
     concat_tables,
@@ -4098,6 +4099,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         def batch_fn(example):
             return {k: [v] for k, v in example.items()}
+
+        if self._format_type in ("arrow", "pandas", "polars"):
+            return self.with_format("arrow").map(
+                _batch_arrow_table,
+                batched=True,
+                batch_size=batch_size,
+                drop_last_batch=drop_last_batch,
+                num_proc=num_proc,
+                new_fingerprint=new_fingerprint,
+                desc="Batching examples",
+            )
 
         return self.map(
             batch_fn,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -58,7 +58,7 @@ from .formatting import (
 from .info import DatasetInfo
 from .naming import _split_re
 from .splits import NamedSplit, Split, SplitInfo
-from .table import cast_table_to_features, embed_table_storage, read_schema_from_file, table_cast
+from .table import _batch_arrow_table, cast_table_to_features, embed_table_storage, read_schema_from_file, table_cast
 from .utils import tqdm as hf_tqdm
 from .utils.logging import get_logger
 from .utils.py_utils import (
@@ -4223,6 +4223,18 @@ class IterableDataset(DatasetInfoMixin):
             features = Features({col: List(feature) for col, feature in self.features.items()})
         else:
             features = None
+        if self._formatting and self._formatting.is_table:
+            return (
+                self.with_format("arrow")
+                .map(
+                    _batch_arrow_table,
+                    batched=True,
+                    batch_size=batch_size,
+                    drop_last_batch=drop_last_batch,
+                    features=features,
+                )
+                .with_format(self._formatting.format_type)
+            )
         return self.map(
             _batch_fn, batched=True, batch_size=batch_size, drop_last_batch=drop_last_batch, features=features
         )

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -59,6 +59,15 @@ def read_schema_from_file(filename: str) -> pa.Schema:
     return schema
 
 
+def _batch_arrow_table(table: pa.Table) -> pa.Table:
+    batched_columns = []
+    for column_name in table.column_names:
+        column = table[column_name].combine_chunks()
+        offsets = pa.array([0, len(column)], type=pa.int32())
+        batched_columns.append(pa.ListArray.from_arrays(offsets, column))
+    return pa.Table.from_arrays(batched_columns, names=table.column_names)
+
+
 def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
     opened_stream = _memory_mapped_record_batch_reader_from_file(filename)
     pa_table = opened_stream.read_all()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -80,6 +80,28 @@ class Unpicklable:
         raise pickle.PicklingError()
 
 
+def _normalize_batched_output(batch):
+    def to_python(value):
+        if isinstance(value, np.ndarray):
+            return [to_python(item) for item in value.tolist()]
+        if isinstance(value, list):
+            return [to_python(item) for item in value]
+        if isinstance(value, tuple):
+            return [to_python(item) for item in value]
+        return value
+
+    if isinstance(batch, pa.Table):
+        return {column: to_python(values) for column, values in batch.to_pydict().items()}
+    if isinstance(batch, pd.DataFrame):
+        return {column: to_python(batch[column].tolist()) for column in batch.columns}
+    if datasets.config.POLARS_AVAILABLE and "polars" in sys.modules:
+        import polars as pl
+
+        if isinstance(batch, pl.DataFrame):
+            return {column: to_python(values) for column, values in batch.to_dict(as_series=False).items()}
+    return to_python(batch)
+
+
 def picklable_map_function(x):
     return {"id": int(x["filename"].split("_")[-1])}
 
@@ -4778,6 +4800,33 @@ def test_dataset_batch():
     assert len(batches[2]["text"]) == 2
     assert batches[2]["id"] == [8, 9]
     assert batches[2]["text"] == ["Text 8", "Text 9"]
+
+
+@pytest.mark.parametrize("format_type", ["pyarrow", "pandas"])
+def test_dataset_batch_with_table_format(format_type):
+    ds = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    left = list(ds.with_format(format_type).batch(2))
+    right = list(ds.batch(2).with_format(format_type))
+
+    assert len(left) == len(right) == 2
+    assert all(type(lhs) is type(rhs) for lhs, rhs in zip(left, right))
+    assert [_normalize_batched_output(batch) for batch in left] == [
+        _normalize_batched_output(batch) for batch in right
+    ]
+
+
+@require_polars
+def test_dataset_batch_with_polars_format():
+    ds = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    left = list(ds.with_format("polars").batch(2))
+    right = list(ds.batch(2).with_format("polars"))
+
+    assert len(left) == len(right) == 2
+    assert [_normalize_batched_output(batch) for batch in left] == [
+        _normalize_batched_output(batch) for batch in right
+    ]
 
 
 def test_dataset_from_dict_with_large_list():

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1,5 +1,6 @@
 import asyncio
 import pickle
+import sys
 import time
 from copy import deepcopy
 from dataclasses import dataclass
@@ -80,6 +81,28 @@ SAMPLE_DATASET_IDENTIFIER = "hf-internal-testing/dataset_with_data_files"
 DEFAULT_N_EXAMPLES = 20
 DEFAULT_BATCH_SIZE = 4
 DEFAULT_FILEPATH = "file.txt"
+
+
+def _normalize_batched_output(batch):
+    def to_python(value):
+        if isinstance(value, np.ndarray):
+            return [to_python(item) for item in value.tolist()]
+        if isinstance(value, list):
+            return [to_python(item) for item in value]
+        if isinstance(value, tuple):
+            return [to_python(item) for item in value]
+        return value
+
+    if isinstance(batch, pa.Table):
+        return {column: to_python(values) for column, values in batch.to_pydict().items()}
+    if isinstance(batch, pd.DataFrame):
+        return {column: to_python(batch[column].tolist()) for column in batch.columns}
+    if config.POLARS_AVAILABLE and "polars" in sys.modules:
+        import polars as pl
+
+        if isinstance(batch, pl.DataFrame):
+            return {column: to_python(values) for column, values in batch.to_dict(as_series=False).items()}
+    return to_python(batch)
 
 
 def generate_examples_fn(**kwargs):
@@ -2828,6 +2851,33 @@ def test_iterable_dataset_batch():
         assert len(batch["text"]) == 3
         assert batch["id"] == [3 * i, 3 * i + 1, 3 * i + 2]
         assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
+
+
+@pytest.mark.parametrize("format_type", ["pyarrow", "pandas"])
+def test_iterable_dataset_batch_with_table_format(format_type):
+    ds = IterableDataset.from_dict({"a": [1, 2, 3, 4]})
+
+    left = list(ds.with_format(format_type).batch(2))
+    right = list(ds.batch(2).with_format(format_type))
+
+    assert len(left) == len(right) == 2
+    assert all(type(lhs) is type(rhs) for lhs, rhs in zip(left, right))
+    assert [_normalize_batched_output(batch) for batch in left] == [
+        _normalize_batched_output(batch) for batch in right
+    ]
+
+
+@require_polars
+def test_iterable_dataset_batch_with_polars_format():
+    ds = IterableDataset.from_dict({"a": [1, 2, 3, 4]})
+
+    left = list(ds.with_format("polars").batch(2))
+    right = list(ds.batch(2).with_format("polars"))
+
+    assert len(left) == len(right) == 2
+    assert [_normalize_batched_output(batch) for batch in left] == [
+        _normalize_batched_output(batch) for batch in right
+    ]
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Fix #8075

Fix `.batch()` on table-formatted `Dataset` and `IterableDataset`.

Before this change, calling `.batch()` on datasets formatted as `pyarrow`, `pandas`, or `polars` could fail because the batching path assumed dict-like inputs. This updates batching to use an Arrow-based path for table-style formats, so batching works regardless of whether the table format is applied before or after `.batch()`. These two forms now behave equivalently:

```python
dataset.with_format(format_type).batch(n)
```

and

```python
dataset.batch(n).with_format(format_type)
```

for `pyarrow`, `pandas`, and `polars`.

## What changed

- added a shared `_batch_arrow_table` helper to build batched Arrow tables
- updated `Dataset.batch()` to route table-formatted batching through an Arrow `.map(...)` path
- updated `IterableDataset.batch()` to do the same and then restore the original table format
- added regression tests for `pyarrow`, `pandas`, and `polars` on both `Dataset` and `IterableDataset`

## Tests

- `python -m pytest tests/test_arrow_dataset.py -k "test_dataset_batch or test_dataset_batch_with_table_format or test_dataset_batch_with_polars_format" -q`
- `python -m pytest tests/test_iterable_dataset.py -k "test_iterable_dataset_batch or test_iterable_dataset_batch_with_table_format or test_iterable_dataset_batch_with_polars_format" -q`
- `python -m ruff check src/datasets/arrow_dataset.py src/datasets/iterable_dataset.py src/datasets/table.py tests/test_arrow_dataset.py tests/test_iterable_dataset.py`