### PR TITLE
fix: mutable default argument in `_visit_with_path`

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1721,7 +1721,7 @@ _VisitPath = list[Union[str, Literal[0]]]
 
 
 def _visit_with_path(
-    feature: FeatureType, func: Callable[[FeatureType, _VisitPath], Optional[FeatureType]], visit_path: _VisitPath = []
+    feature: FeatureType, func: Callable[[FeatureType, _VisitPath], Optional[FeatureType]], visit_path: Optional[_VisitPath] = None
 ) -> FeatureType:
     """Visit a (possibly nested) feature with its path in the Feature object.
 
@@ -1739,6 +1739,8 @@ def _visit_with_path(
     Returns:
         `FeatureType`: the visited feature.
     """
+    if visit_path is None:
+        visit_path = []
     if isinstance(feature, Features):
         out = func(Features({k: _visit_with_path(f, func, visit_path + [k]) for k, f in feature.items()}), visit_path)
     elif isinstance(feature, dict):


### PR DESCRIPTION
Replace `visit_path: _VisitPath = []` with `Optional[_VisitPath] = None` to avoid the mutable default argument anti-pattern ([B006](https://docs.astral.sh/ruff/rules/mutable-argument-default/)).

While the current callers always use `visit_path + [k]` (creating new lists), the shared default list is a latent bug that would surface if any future code path mutates `visit_path` in place (e.g. via `.append()`).

The fix initializes `visit_path = []` inside the function body when `None` is passed.