### PR TITLE
fix(Dataset.map): initialize writer on first non-None output instead of first index

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3972,7 +3972,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     _time = time.time()
                     for i, example in iter_outputs(shard_iterable):
                         if update_data:
-                            if i == 0:
+                            if writer is None:
                                 buf_writer, writer, tmp_file = init_buffer_and_writer()
                                 stack.enter_context(writer)
                             if isinstance(example, pa.Table):
@@ -3998,7 +3998,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     for i, batch in iter_outputs(shard_iterable):
                         num_examples_in_batch = len(i)
                         if update_data:
-                            if i and i[0] == 0:
+                            if writer is None:
                                 buf_writer, writer, tmp_file = init_buffer_and_writer()
                                 stack.enter_context(writer)
                             if isinstance(batch, pa.Table):


### PR DESCRIPTION
## What does this PR do?

Fixes #7990

## The Bug

When a map function returns `None` for the first examples and a dict for
later ones, `Dataset.map()` crashes with:

    AttributeError: 'NoneType' object has no attribute 'write'

This happens because the ArrowWriter was initialized only when processing
index 0. If index 0 returns `None`, `update_data` is False at that point,
so the writer is never created. When a later example returns a dict,
`update_data` becomes True but the writer is still None.

## The Fix

Replace index-based checks with `writer is None`:

**Before:**
if i == 0:          # non-batched
if i and i[0] == 0: # batched
    buf_writer, writer, tmp_file = init_buffer_and_writer()

**After:**
if writer is None:  # both cases
    buf_writer, writer, tmp_file = init_buffer_and_writer()

## Reproduction

```python
from datasets import Dataset

ds = Dataset.from_dict({"x": [1, 2, 3]})

def fn(example, idx):
    if idx < 2:
        return None
    return {"x": [example["x"] * 10]}

list(ds.map(fn, with_indices=True))  # Previously crashed, now works

Tests
Non-batched: first examples return None ✅
Batched: first batch returns None ✅
All examples return None → dataset unchanged ✅
Normal map with no None returns ✅


