### PR TITLE
Fix: decode JSON type before to_list or to_dict is called

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5384,11 +5384,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds.to_dict()
         ```
         """
-        return query_table(
+        result = query_table(
             table=self._data,
             key=slice(0, len(self)),
             indices=self._indices,
         ).to_pydict()
+        from .utils.json import get_json_field_paths_from_feature, json_decode_field
+
+        for json_field_path in get_json_field_paths_from_feature(self.features):
+            col, *json_field_subpath = json_field_path
+            result[col] = [json_decode_field(row, json_field_subpath) for row in result[col]]
+        return result
 
     def to_list(self) -> list:
         """Returns the dataset as a Python list.
@@ -5402,11 +5408,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds.to_list()
         ```
         """
-        return query_table(
+        result = query_table(
             table=self._data,
             key=slice(0, len(self)),
             indices=self._indices,
         ).to_pylist()
+        from .utils.json import get_json_field_paths_from_feature, json_decode_field
+
+        for json_field_path in get_json_field_paths_from_feature(self.features):
+            col, *json_field_subpath = json_field_path
+            for row in result:
+                row[col] = json_decode_field(row[col], json_field_subpath)
+        return result
 
     def to_json(
         self,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -37,7 +37,6 @@ from datasets.features import (
     Json,
     LargeList,
     List,
-    Sequence,
     Translation,
     TranslationVariableLanguages,
     Value,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -37,6 +37,7 @@ from datasets.features import (
     Json,
     LargeList,
     List,
+    Sequence,
     Translation,
     TranslationVariableLanguages,
     Value,
@@ -3465,6 +3466,36 @@ class MiscellaneousDatasetTest(TestCase):
         with Dataset.from_dict(data, on_mixed_types="use_json") as dset:
             self.assertEqual(dset[:], data)
             self.assertEqual(dset.features["empty_struct"], Json())
+
+    def test_to_list_and_to_dict_decode_json(self):
+        # Regression test for the addition of JSON type. to_list() and to_dict() should not return raw JSON strings for Json() columns.
+        data = {"col": [{"a": 1}, {"b": 2}]}
+        test_dataset = Dataset.from_dict(data, features=Features({"col": Json()}))
+
+        # access through list
+        result_list = test_dataset.to_list()
+        assert isinstance(result_list[0]["col"], dict), f"expected dict, got {type(result_list[0]['col'])}"
+        assert result_list == [{"col": {"a": 1}}, {"col": {"b": 2}}]
+
+        # access through dict
+        result_dict = test_dataset.to_dict()
+        assert isinstance(result_dict["col"][0], dict), f"expected dict, got {type(result_dict[0]['col'])}"
+        assert result_dict == {"col": [{"a": 1}, {"b": 2}]}
+
+    def test_to_list_and_to_dict_decode_nested_json(self):
+        # Regression test for the addition of JSON type. to_list() and to_dict() should not return raw JSON strings for Json() columns.
+        data = {"col": [{"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}]}
+        test_dataset = Dataset.from_dict(data, features=Features({"col": Json()}))
+
+        # access through list
+        result_list = test_dataset.to_list()
+        assert isinstance(result_list[0]["col"], dict), f"expected dict, got {type(result_list[0]['col'])}"
+        assert result_list == [{"col": {"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}}]
+
+        # access through dict
+        result_dict = test_dataset.to_dict()
+        assert isinstance(result_dict["col"][0], dict), f"expected dict, got {type(result_dict[0]['col'])}"
+        assert result_dict == {"col": [{"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}]}
 
     def test_concatenate_mixed_memory_and_disk(self):
         data1, data2, data3 = {"id": [0, 1, 2]}, {"id": [3, 4, 5]}, {"id": [6, 7]}


### PR DESCRIPTION
**Motivation**:
There is a change in the approach to decoding JSON types, added in https://github.com/huggingface/datasets/commit/d560b58e1f1ec96591a95a1780ee118f5eea6c74. Since 4.7.0, to_list() returns raw JSON strings for columns stored as Json(), while direct access via getitem returns dicts.

In versions prior to 4.7.0, to_list() returned dicts.

**Added context**:
- Closes https://github.com/huggingface/datasets/issues/8131
- On it, the maintainer suggested taking a similar approach to https://github.com/huggingface/datasets/pull/8122

This PR contains:
- An update to the to_list and to_dict functions for the arrow dataset inspired by a (and using the utils developed for) [similar fix](https://github.com/huggingface/datasets/pull/8122) to another problem caused by the addition of the JSON type.
- Unit tests specifying the intended outcome (which was how dictionaries were processed or handled prior to v4.7.0).

**Additional questions/considerations**:
- This PR restore behaviour prior to the breaking change introduced by the addition of the JSON datatype in v4.7.0. However, does mean we now decode one data type (JSON) and not others. We could decide to decode elements of the list in the same way _get_item does but this would be a big change (i.e memory concerns with images and audio etc etc)
- I implemented the PR with a lazy import - just checking that's in line with the repo's design/ vibe?