### PR TITLE
tag openclaw sessions via cwd in pi agent traces

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -362,7 +362,7 @@ def parse_traces_info(traces: list[str]) -> tuple[Optional[str], Optional[str]]:
                 and isinstance(decoded_trace["payload"]["id"], str)
             ):
                 session_id = decoded_trace["payload"]["id"]
-            # pi
+            # pi / openclaw (openclaw embeds pi-agent; distinguish via cwd)
             elif (
                 "type" in decoded_trace
                 and decoded_trace["type"] == "session"
@@ -370,6 +370,8 @@ def parse_traces_info(traces: list[str]) -> tuple[Optional[str], Optional[str]]:
                 and isinstance(decoded_trace["id"], str)
             ):
                 session_id = decoded_trace["id"]
+                if isinstance(decoded_trace.get("cwd"), str) and "/.openclaw/" in decoded_trace["cwd"]:
+                    harness = "openclaw"
         if harness and session_id:
             break
     return harness, session_id


### PR DESCRIPTION
Tag OpenClaw datasets from Pi agent sessions. Will add a PR to add icon for it in moon too

cc: @merveenoyan 