### PR TITLE
Add Apache TsFile packaged module and Time Series docs category

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -102,6 +102,10 @@
       title: Load tabular data
     title: "Tabular"
   - sections:
+    - local: timeseries_load
+      title: Load time series data
+    title: "Time Series"
+  - sections:
     - local: share
       title: Share
     - local: dataset_card

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -200,6 +200,33 @@ This will return the image caption and the image bytes in a single request.
 
 Note that the HDF5 loader assumes that the file has "tabular" structure, i.e. that all datasets in the file have (the same number of) rows on their first dimension.
 
+### TsFile
+
+[Apache TsFile](https://tsfile.apache.org/) is a columnar file format optimized for time series data, used by [Apache IoTDB](https://iotdb.apache.org/) and other time series systems. Each `.tsfile` is loaded as a single Arrow table whose first column is `timestamp` (`int64`) followed by one `float64` column per logical timeseries:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("tsfile", data_files="data/sample.tsfile", split="train")
+```
+
+You can select specific timeseries with `columns` and push down a time-range filter with `start_time` / `end_time`:
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/sample.tsfile",
+...     columns=["mytable.d1.temperature"],
+...     start_time=1_700_000_000_000,
+...     end_time=1_700_000_003_000,
+...     split="train",
+... )
+```
+
+The builder also supports device-level (`devices=`) and field-level (`fields=`) filters that prune timeseries at the metadata layer, so unselected devices or sensors are never decoded.
+
+> [!TIP]
+> For more details, check out the [how to load time series datasets](timeseries_load) guide.
+
 ### SQL
 
 Read database contents with [`~datasets.Dataset.from_sql`] by specifying the URI to connect to your database. You can read both table names and queries:

--- a/docs/source/timeseries_load.mdx
+++ b/docs/source/timeseries_load.mdx
@@ -1,0 +1,218 @@
+# Load time series data
+
+Time series data are sequences of values indexed by timestamps, commonly produced by sensors, IoT devices, monitoring systems, financial markets and scientific experiments. Unlike generic tabular data, time series data come with several domain-specific concerns:
+
+- a dedicated **timestamp axis** that aligns observations across many sensors / channels;
+- the need to **filter or slice by a time range** efficiently, often on files containing millions of rows;
+- the need to **address individual devices and individual measurements** as first-class concepts, not as ad-hoc string columns;
+- compact **time-series-specific encodings** (delta-of-delta on timestamps, GORILLA on slowly-varying floats) that dramatically beat generic columnar formats on storage size.
+
+Generic columnar formats such as CSV, JSON, Parquet and HDF5 can technically *store* time series, but they treat *time* as just another column. They are documented under the [tabular](tabular_load) guide and remain perfectly valid options for small or simple datasets. For larger or production time-series workloads, 🤗 Datasets ships a dedicated builder for the [Apache TsFile](https://tsfile.apache.org/) format (`.tsfile`), the columnar storage format used by [Apache IoTDB](https://iotdb.apache.org/) and other time series systems.
+
+## Apache TsFile
+
+A TsFile organizes data around the triple **(table, device, field)**:
+
+- a *table* groups devices that share the same schema (think of it as a "plant", a "fleet" or a "metric family");
+- a *device* (identified by one or more *tag* columns) is one physical or logical source of measurements;
+- a *field* is one numeric measurement channel on a device (a.k.a. *sensor* or *measurement*: `temperature`, `voltage`, `latency_ms`, ...).
+
+Every value lives at a specific `(device, field, timestamp)` coordinate. Both the on-disk layout (chunk-level time indices, per-device chunk groups) and the reader API are built around this structure, so range queries and device pruning don't require scanning the whole file.
+
+🤗 Datasets reads TsFile shards through the high-level `tsfile.TsFileDataFrame` API. Each `.tsfile` is opened lazily and converted to a single Arrow table whose first column is `timestamp` (`int64`, in the unit chosen by the writer — typically milliseconds since the Unix epoch, but the builder does not interpret it) followed by one `float64` column per selected timeseries.
+
+> [!WARNING]
+> The `TsFileDataFrame` API only supports the **table-model** TsFile. Files written purely with the tree model (`TsFileWriter.register_device` without any `register_table`) cannot be loaded yet, and only **numeric** field types (`BOOLEAN`, `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `TIMESTAMP`) are exposed — they are unified to `float64` regardless of their original `TSDataType`. Non-numeric fields (`TEXT`, `STRING`, `BLOB`, `DATE`) are silently skipped during metadata discovery.
+
+### Installation
+
+The TsFile builder requires the `tsfile` Python package, which provides the `TsFileDataFrame` API:
+
+```bash
+pip install tsfile
+```
+
+### Basic usage
+
+Load a single TsFile by passing the `tsfile` builder name to [`~datasets.load_dataset`] and pointing `data_files` at one or several files:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("tsfile", data_files="data/sample.tsfile", split="train")
+>>> dataset
+Dataset({
+    features: ['timestamp', 'mytable.d1.temperature', 'mytable.d1.humidity'],
+    num_rows: 5
+})
+```
+
+Files can also be discovered directly by their extension:
+
+```py
+>>> dataset = load_dataset("data/*.tsfile", split="train")
+```
+
+To build train/test splits from separate files or directories, pass a dictionary:
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files={"train": "data/train/*.tsfile", "test": "data/test/*.tsfile"},
+... )
+```
+
+### Series paths
+
+Each logical timeseries is exposed as a single Arrow column. Its name is built by joining the table name, the tag values that identify the device, and the field name with `.`:
+
+```
+<table> . <tag_value_1> ... <tag_value_n> . <field>
+```
+
+For a `mytable` with one tag column `device` and field `temperature`, the rows where `device = "d1"` are exposed as the series `mytable.d1.temperature`. The dot-separated form looks hierarchical but is purely a flattening of the table-model `(table, tag_tuple, field)` triple.
+
+You can list the available series for a given file with the underlying API:
+
+```py
+>>> from tsfile import TsFileDataFrame
+>>> df = TsFileDataFrame("data/sample.tsfile", show_progress=False)
+>>> df.list_timeseries()
+['mytable.d1.temperature', 'mytable.d1.humidity']
+>>> df.close()
+```
+
+### Selecting series
+
+The TsFile builder offers four complementary ways to narrow what is loaded. All filters are pushed down to the reader's metadata layer, so unselected devices/fields are never decoded.
+
+**By explicit path** — when you already know the exact series you want:
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/sample.tsfile",
+...     columns=["mytable.d1.temperature"],
+...     split="train",
+... )
+>>> dataset.column_names
+['timestamp', 'mytable.d1.temperature']
+```
+
+**By device** (`devices=`) — keep only listed device(s), across all their fields. Useful for "give me everything from these machines":
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/plant_2024.tsfile",
+...     devices=["d1", "d7"],
+...     split="train",
+... )
+>>> dataset.column_names
+['timestamp', 'plant.d1.temperature', 'plant.d1.humidity',
+ 'plant.d7.temperature', 'plant.d7.humidity']
+```
+
+The match is exact and segment-based: `devices=["d1"]` keeps `plant.d1.temperature` but never matches `plant.d10.temperature`.
+
+**By field** (`fields=`) — keep only specific measurements, across all devices. Useful for "give me the same sensor over the whole fleet":
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/plant_2024.tsfile",
+...     fields=["temperature"],
+...     split="train",
+... )
+>>> dataset.column_names
+['timestamp', 'plant.d1.temperature', 'plant.d2.temperature', 'plant.d3.temperature']
+```
+
+`devices=` and `fields=` combine as a logical AND — providing both gives you a 2-D projection of the schema:
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/plant_2024.tsfile",
+...     devices=["d2", "d3"],
+...     fields=["humidity"],
+...     split="train",
+... )
+>>> dataset.column_names
+['timestamp', 'plant.d2.humidity', 'plant.d3.humidity']
+```
+
+**By prefix** (`path_prefix=`) — delegates straight to `TsFileDataFrame.list_timeseries(path_prefix=...)` for the cheapest possible pruning when you can express your selection as a string prefix:
+
+```py
+>>> dataset = load_dataset("tsfile", data_files="...", path_prefix="plant.d1", split="train")
+```
+
+The `timestamp` column is always present and does not need to be listed in `columns`. An explicit `columns=` cannot be combined with `devices=` / `fields=` / `path_prefix=`.
+
+### Filtering by time range
+
+For long-running sensor logs, loading the whole file just to slice a window in memory is wasteful. The TsFile builder pushes time-range filters down to the underlying reader (via chunk-level time indices) using `start_time` and `end_time` (both inclusive, in the same unit as the file's timestamps):
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/sample.tsfile",
+...     start_time=1_700_000_000_000,
+...     end_time=1_700_000_003_000,
+...     split="train",
+... )
+```
+
+Either bound is optional. Omitting `start_time` means "from the beginning of the file"; omitting `end_time` means "until the end".
+
+Time and series filters compose naturally — for example, "the temperature of d1 and d7 during Q1":
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/plant_2024.tsfile",
+...     devices=["d1", "d7"],
+...     fields=["temperature"],
+...     start_time=Q1_START_MS,
+...     end_time=Q1_END_MS,
+...     split="train",
+... )
+```
+
+### Handling bad files
+
+When loading a glob of TsFile shards in production pipelines, occasionally one file may be corrupted. The `on_bad_files` argument controls the policy:
+
+- `"error"` (default): raise an exception on the first bad file.
+- `"warn"`: emit a warning and skip the file.
+- `"skip"`: silently skip the file.
+
+```py
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/*.tsfile",
+...     on_bad_files="warn",
+...     split="train",
+... )
+```
+
+### Schema and feature casting
+
+By default the schema is inferred from the first valid file: a `timestamp: int64` column followed by one `float64` column per selected timeseries. You can override this by passing your own [`~datasets.Features`]:
+
+```py
+>>> from datasets import Features, Value, load_dataset
+>>> features = Features({
+...     "timestamp": Value("int64"),
+...     "mytable.d1.temperature": Value("float32"),
+... })
+>>> dataset = load_dataset(
+...     "tsfile",
+...     data_files="data/sample.tsfile",
+...     columns=["mytable.d1.temperature"],
+...     features=features,
+...     split="train",
+... )
+```
+
+When both `columns` and `features` are provided, they must reference the same set of series (`features` must contain exactly `columns + ["timestamp"]`).

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -19,6 +19,7 @@ from .parquet import parquet
 from .pdffolder import pdffolder
 from .sql import sql
 from .text import text
+from .tsfile import tsfile
 from .videofolder import videofolder
 from .webdataset import webdataset
 from .xml import xml
@@ -55,6 +56,7 @@ _PACKAGED_DATASETS_MODULES = {
     "hdf5": (hdf5.__name__, _hash_python_lines(inspect.getsource(hdf5).splitlines())),
     "eval": (eval.__name__, _hash_python_lines(inspect.getsource(eval).splitlines())),
     "lance": (lance.__name__, _hash_python_lines(inspect.getsource(lance).splitlines())),
+    "tsfile": (tsfile.__name__, _hash_python_lines(inspect.getsource(tsfile).splitlines())),
 }
 
 # get importable module names and hash for caching
@@ -88,6 +90,7 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".h5": ("hdf5", {}),
     ".eval": ("eval", {}),
     ".lance": ("lance", {}),
+    ".tsfile": ("tsfile", {}),
 }
 _EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})

--- a/src/datasets/packaged_modules/tsfile/tsfile.py
+++ b/src/datasets/packaged_modules/tsfile/tsfile.py
@@ -1,0 +1,224 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import numpy as np
+import pyarrow as pa
+
+import datasets
+from datasets.builder import Key
+from datasets.table import table_cast
+
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+@dataclass
+class TsFileConfig(datasets.BuilderConfig):
+    """BuilderConfig for Apache TsFile.
+
+    Args:
+        columns (`list[str]`, *optional*):
+            Explicit list of logical timeseries paths to load. When set, the
+            ``devices``, ``fields`` and ``path_prefix`` filters must be left
+            unset. Use ``TsFileDataFrame.list_timeseries()`` to inspect
+            available series for a given file.
+        devices (`list[str]`, *optional*):
+            Keep only series whose tag-value segment matches one of the given
+            device identifiers. Equivalent to "give me everything from these
+            devices". Combined with ``fields`` and ``path_prefix`` as a logical
+            AND. The match is exact and segment-based, e.g. ``devices=["d1"]``
+            keeps ``mytable.d1.temperature`` but not ``mytable.d10.temperature``.
+        fields (`list[str]`, *optional*):
+            Keep only series whose final path segment (a.k.a. *field*, *sensor*
+            or *measurement*) matches one of the given names. Equivalent to
+            "give me this measurement across all devices".
+        path_prefix (`str`, *optional*):
+            Keep only series whose path starts with this prefix, delegated to
+            ``TsFileDataFrame.list_timeseries(path_prefix=...)``. Note that
+            the prefix is matched as a raw string and should not include a
+            trailing dot.
+        start_time (`int`, *optional*):
+            Lower bound (inclusive) of the timestamp range to load.
+            Defaults to the minimum int64 (no lower bound).
+        end_time (`int`, *optional*):
+            Upper bound (inclusive) of the timestamp range to load.
+            Defaults to the maximum int64 (no upper bound).
+        features (`Features`, *optional*):
+            Cast the data to ``features``.
+        on_bad_files (`Literal["error", "warn", "skip"]`, *optional*, defaults to "error"):
+            Specify what to do when a TsFile cannot be read.
+    """
+
+    columns: Optional[list[str]] = None
+    devices: Optional[list[str]] = None
+    fields: Optional[list[str]] = None
+    path_prefix: Optional[str] = None
+    start_time: Optional[int] = None
+    end_time: Optional[int] = None
+    features: Optional[datasets.Features] = None
+    on_bad_files: Literal["error", "warn", "skip"] = "error"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.columns is not None and (
+            self.devices is not None or self.fields is not None or self.path_prefix is not None
+        ):
+            raise ValueError(
+                "`columns` cannot be combined with `devices`, `fields` or `path_prefix`. "
+                "Use either an explicit list of series paths, or one or more of the "
+                "device/field/prefix predicates."
+            )
+
+
+class TsFile(datasets.ArrowBasedBuilder):
+    """Apache TsFile builder backed by ``tsfile.TsFileDataFrame``.
+
+    Each ``.tsfile`` file is opened as a ``TsFileDataFrame`` and converted to
+    a single Arrow table whose first column is ``timestamp`` (int64) followed
+    by one float64 column per logical timeseries.
+    """
+
+    BUILDER_CONFIG_CLASS = TsFileConfig
+
+    def _info(self):
+        if (
+            self.config.columns is not None
+            and self.config.features is not None
+            and set(self.config.columns) | {"timestamp"} != set(self.config.features)
+        ):
+            raise ValueError(
+                "The columns and features arguments must reference the same series, but got "
+                f"{self.config.columns} and {list(self.config.features)}"
+            )
+        return datasets.DatasetInfo(features=self.config.features)
+
+    def _split_generators(self, dl_manager):
+        if not self.config.data_files:
+            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+        dl_manager.download_config.extract_on_the_fly = True
+        data_files = dl_manager.download(self.config.data_files)
+        splits = []
+        for split_name, files in data_files.items():
+            if self.info.features is None:
+                for file in files:
+                    try:
+                        self.info.features = datasets.Features.from_arrow_schema(self._infer_schema(file))
+                        break
+                    except Exception as e:
+                        if self.config.on_bad_files == "error":
+                            logger.error(f"Failed to read schema from '{file}' with error {type(e).__name__}: {e}")
+                            raise
+                        elif self.config.on_bad_files == "warn":
+                            logger.warning(f"Skipping bad schema from '{file}'. {type(e).__name__}: {e}")
+                        else:
+                            logger.debug(f"Skipping bad schema from '{file}'. {type(e).__name__}: {e}")
+            if self.info.features is None:
+                raise ValueError(
+                    f"At least one valid data file must be specified, all the data_files are invalid: {self.config.data_files}"
+                )
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+        return splits
+
+    def _cast_table(self, pa_table: pa.Table) -> pa.Table:
+        if self.info.features is not None:
+            pa_table = table_cast(pa_table, self.info.features.arrow_schema)
+        return pa_table
+
+    def _generate_shards(self, files):
+        yield from files
+
+    def _generate_tables(self, files):
+        for file_idx, file in enumerate(files):
+            try:
+                pa_table = self._read_file_to_arrow(file)
+            except Exception as e:
+                if self.config.on_bad_files == "error":
+                    logger.error(f"Failed to read file '{file}' with error {type(e).__name__}: {e}")
+                    raise
+                elif self.config.on_bad_files == "warn":
+                    logger.warning(f"Skipping bad file '{file}'. {type(e).__name__}: {e}")
+                else:
+                    logger.debug(f"Skipping bad file '{file}'. {type(e).__name__}: {e}")
+                continue
+            yield Key(file_idx, 0), self._cast_table(pa_table)
+
+    # --- helpers -------------------------------------------------------
+
+    def _resolve_columns(self, df) -> list[str]:
+        # Explicit list takes precedence and is validated as-is.
+        if self.config.columns is not None:
+            available = set(df.list_timeseries())
+            missing = [c for c in self.config.columns if c != "timestamp" and c not in available]
+            if missing:
+                raise ValueError(
+                    f"Requested columns {missing} not found in TsFile. "
+                    f"Use TsFileDataFrame.list_timeseries() to inspect available series."
+                )
+            return [c for c in self.config.columns if c != "timestamp"]
+
+        # Predicate-based filtering. Start with the cheapest filter (path_prefix)
+        # so the upstream reader can prune at the metadata level.
+        if self.config.path_prefix is not None:
+            candidates = df.list_timeseries(path_prefix=self.config.path_prefix)
+        else:
+            candidates = df.list_timeseries()
+
+        if self.config.devices is not None:
+            wanted_devices = set(self.config.devices)
+            # The series path is "<table>.<tag_value_1>...<tag_value_n>.<field>".
+            # We match exact segments between the first (table) and last (field).
+            candidates = [series for series in candidates if wanted_devices.intersection(series.split(".")[1:-1])]
+
+        if self.config.fields is not None:
+            wanted_fields = set(self.config.fields)
+            candidates = [series for series in candidates if series.rsplit(".", 1)[-1] in wanted_fields]
+
+        if not candidates and (
+            self.config.devices is not None or self.config.fields is not None or self.config.path_prefix is not None
+        ):
+            available = df.list_timeseries()
+            raise ValueError(
+                "No timeseries matched the requested filters "
+                f"(devices={self.config.devices}, fields={self.config.fields}, "
+                f"path_prefix={self.config.path_prefix!r}). "
+                f"Available series in this file: {available}"
+            )
+
+        return candidates
+
+    def _infer_schema(self, file: str) -> pa.Schema:
+        from tsfile import TsFileDataFrame
+
+        df = TsFileDataFrame(file, show_progress=False)
+        try:
+            series = self._resolve_columns(df)
+        finally:
+            df.close()
+        fields = [pa.field("timestamp", pa.int64())]
+        fields.extend(pa.field(name, pa.float64()) for name in series)
+        return pa.schema(fields)
+
+    def _read_file_to_arrow(self, file: str) -> pa.Table:
+        from tsfile import TsFileDataFrame
+
+        int64_min = np.iinfo(np.int64).min
+        int64_max = np.iinfo(np.int64).max
+        start = int64_min if self.config.start_time is None else int(self.config.start_time)
+        end = int64_max if self.config.end_time is None else int(self.config.end_time)
+
+        df = TsFileDataFrame(file, show_progress=False)
+        try:
+            series = self._resolve_columns(df)
+            if not series:
+                arrays = [pa.array(np.empty(0, dtype=np.int64))]
+                return pa.table(arrays, names=["timestamp"])
+            aligned = df.loc[start:end, series]
+        finally:
+            df.close()
+
+        timestamps = np.asarray(aligned.timestamps, dtype=np.int64)
+        values = np.asarray(aligned.values)
+        arrays = [pa.array(timestamps)]
+        for col_idx, name in enumerate(aligned.series_names):
+            arrays.append(pa.array(np.asarray(values[:, col_idx], dtype=np.float64)))
+        return pa.table(arrays, names=["timestamp", *aligned.series_names])

--- a/tests/packaged_modules/test_tsfile.py
+++ b/tests/packaged_modules/test_tsfile.py
@@ -1,0 +1,221 @@
+import pytest
+
+from datasets import load_dataset
+from datasets.builder import InvalidConfigName
+from datasets.data_files import DataFilesList
+from datasets.packaged_modules.tsfile.tsfile import TsFileConfig
+
+
+tsfile = pytest.importorskip("tsfile")
+
+
+def _write_sample_tsfile(path: str) -> None:
+    """Create a small TsFile with one table, one tag value, two numeric fields."""
+    from tsfile import (
+        ColumnCategory,
+        ColumnSchema,
+        TableSchema,
+        Tablet,
+        TsFileWriter,
+    )
+    from tsfile.constants import TSDataType
+
+    schema = TableSchema(
+        "mytable",
+        [
+            ColumnSchema("time", TSDataType.TIMESTAMP, ColumnCategory.TIME),
+            ColumnSchema("device", TSDataType.STRING, ColumnCategory.TAG),
+            ColumnSchema("temperature", TSDataType.DOUBLE, ColumnCategory.FIELD),
+            ColumnSchema("humidity", TSDataType.DOUBLE, ColumnCategory.FIELD),
+        ],
+    )
+
+    writer = TsFileWriter(path)
+    try:
+        writer.register_table(schema)
+        n = 5
+        tablet = Tablet(
+            ["device", "temperature", "humidity"],
+            [TSDataType.STRING, TSDataType.DOUBLE, TSDataType.DOUBLE],
+            n,
+        )
+        tablet.set_table_name("mytable")
+        for i in range(n):
+            tablet.add_timestamp(i, 1_700_000_000_000 + i * 1000)
+            tablet.add_value_by_name("device", i, "d1")
+            tablet.add_value_by_name("temperature", i, 20.0 + i)
+            tablet.add_value_by_name("humidity", i, 50.0 + i)
+        writer.write_table(tablet)
+    finally:
+        writer.close()
+
+
+def _write_multi_device_tsfile(path: str) -> None:
+    """Create a TsFile with three devices and two fields each."""
+    from tsfile import (
+        ColumnCategory,
+        ColumnSchema,
+        TableSchema,
+        Tablet,
+        TsFileWriter,
+    )
+    from tsfile.constants import TSDataType
+
+    schema = TableSchema(
+        "plant",
+        [
+            ColumnSchema("time", TSDataType.TIMESTAMP, ColumnCategory.TIME),
+            ColumnSchema("device", TSDataType.STRING, ColumnCategory.TAG),
+            ColumnSchema("temperature", TSDataType.DOUBLE, ColumnCategory.FIELD),
+            ColumnSchema("humidity", TSDataType.DOUBLE, ColumnCategory.FIELD),
+        ],
+    )
+
+    writer = TsFileWriter(path)
+    try:
+        writer.register_table(schema)
+        for device in ("d1", "d2", "d3"):
+            tablet = Tablet(
+                ["device", "temperature", "humidity"],
+                [TSDataType.STRING, TSDataType.DOUBLE, TSDataType.DOUBLE],
+                3,
+            )
+            tablet.set_table_name("plant")
+            for i in range(3):
+                tablet.add_timestamp(i, 1_700_000_000_000 + i * 1000)
+                tablet.add_value_by_name("device", i, device)
+                tablet.add_value_by_name("temperature", i, 10.0 + i)
+                tablet.add_value_by_name("humidity", i, 50.0 + i)
+            writer.write_table(tablet)
+    finally:
+        writer.close()
+
+
+@pytest.fixture
+def tsfile_path(tmp_path) -> str:
+    path = tmp_path / "sample.tsfile"
+    _write_sample_tsfile(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def multi_device_tsfile_path(tmp_path) -> str:
+    path = tmp_path / "multi.tsfile"
+    _write_multi_device_tsfile(str(path))
+    return str(path)
+
+
+@pytest.fixture
+def tsfile_series_names(tsfile_path) -> list[str]:
+    from tsfile import TsFileDataFrame
+
+    df = TsFileDataFrame(tsfile_path, show_progress=False)
+    try:
+        return df.list_timeseries()
+    finally:
+        df.close()
+
+
+def test_config_raises_when_invalid_name() -> None:
+    with pytest.raises(InvalidConfigName, match="Bad characters"):
+        _ = TsFileConfig(name="name-with-*-invalid-character")
+
+
+@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+def test_config_raises_when_invalid_data_files(data_files) -> None:
+    with pytest.raises(ValueError, match="Expected a DataFilesDict"):
+        _ = TsFileConfig(name="name", data_files=data_files)
+
+
+def test_load_tsfile_dataset(tsfile_path, tsfile_series_names):
+    dataset_dict = load_dataset("tsfile", data_files=tsfile_path)
+    assert "train" in dataset_dict
+    dataset = dataset_dict["train"]
+
+    assert "timestamp" in dataset.column_names
+    for name in tsfile_series_names:
+        assert name in dataset.column_names
+
+    assert len(dataset) == 5
+    assert dataset["timestamp"][0] == 1_700_000_000_000
+    assert dataset["timestamp"][-1] == 1_700_000_000_000 + 4 * 1000
+
+
+def test_load_tsfile_dataset_with_columns(tsfile_path, tsfile_series_names):
+    selected = tsfile_series_names[:1]
+    dataset_dict = load_dataset("tsfile", data_files=tsfile_path, columns=selected)
+    dataset = dataset_dict["train"]
+
+    assert dataset.column_names == ["timestamp", *selected]
+    for name in tsfile_series_names[1:]:
+        assert name not in dataset.column_names
+
+
+def test_load_tsfile_dataset_with_time_range(tsfile_path):
+    start = 1_700_000_000_000 + 1000
+    end = 1_700_000_000_000 + 3000
+    dataset_dict = load_dataset(
+        "tsfile",
+        data_files=tsfile_path,
+        start_time=start,
+        end_time=end,
+    )
+    dataset = dataset_dict["train"]
+
+    timestamps = dataset["timestamp"]
+    assert min(timestamps) >= start
+    assert max(timestamps) <= end
+    assert len(timestamps) == 3
+
+
+def test_load_tsfile_dataset_on_bad_files_skip(tmp_path, tsfile_path):
+    bad_path = tmp_path / "broken.tsfile"
+    bad_path.write_bytes(b"not a real tsfile")
+
+    dataset_dict = load_dataset(
+        "tsfile",
+        data_files=[tsfile_path, str(bad_path)],
+        on_bad_files="skip",
+    )
+    dataset = dataset_dict["train"]
+    assert len(dataset) == 5
+
+
+def test_load_tsfile_dataset_with_devices_filter(multi_device_tsfile_path):
+    dataset = load_dataset("tsfile", data_files=multi_device_tsfile_path, devices=["d1"])["train"]
+    assert dataset.column_names == ["timestamp", "plant.d1.temperature", "plant.d1.humidity"]
+
+
+def test_load_tsfile_dataset_with_fields_filter(multi_device_tsfile_path):
+    dataset = load_dataset("tsfile", data_files=multi_device_tsfile_path, fields=["temperature"])["train"]
+    assert dataset.column_names == [
+        "timestamp",
+        "plant.d1.temperature",
+        "plant.d2.temperature",
+        "plant.d3.temperature",
+    ]
+
+
+def test_load_tsfile_dataset_with_devices_and_fields_filter(multi_device_tsfile_path):
+    dataset = load_dataset(
+        "tsfile",
+        data_files=multi_device_tsfile_path,
+        devices=["d2", "d3"],
+        fields=["humidity"],
+    )["train"]
+    assert dataset.column_names == ["timestamp", "plant.d2.humidity", "plant.d3.humidity"]
+
+
+def test_load_tsfile_dataset_with_path_prefix(multi_device_tsfile_path):
+    dataset = load_dataset("tsfile", data_files=multi_device_tsfile_path, path_prefix="plant.d1")["train"]
+    assert dataset.column_names == ["timestamp", "plant.d1.temperature", "plant.d1.humidity"]
+
+
+def test_load_tsfile_dataset_filters_no_match_raises(multi_device_tsfile_path):
+    with pytest.raises(ValueError, match="No timeseries matched"):
+        load_dataset("tsfile", data_files=multi_device_tsfile_path, devices=["does_not_exist"])
+
+
+def test_config_columns_conflicts_with_filters() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        TsFileConfig(name="x", columns=["a"], devices=["d1"])


### PR DESCRIPTION
## What does this PR do?

Adds first-class support for the [Apache TsFile](https://tsfile.apache.org/)
columnar time-series format (used by [Apache IoTDB](https://iotdb.apache.org/)
and other time-series systems) to 🤗 Datasets, and surfaces time-series
datasets as a dedicated modality in the documentation sidebar.

Users can now do:

```py
from datasets import load_dataset

ds = load_dataset("tsfile", data_files="data/*.tsfile", split="train")
```

or rely on extension auto-detection:

```py
ds = load_dataset("data/*.tsfile", split="train")
```

## Why a dedicated builder?

Generic columnar formats (CSV / Parquet / HDF5) can technically store
time-series data, but they treat *time* as just another column. TsFile is
purpose-built around the **(table, device, field)** triple with chunk-level
time indices and time-series-specific encodings (delta-of-delta on
timestamps, GORILLA on slowly-varying floats), so range queries and device
pruning don't require scanning the whole file.

The new `tsfile` builder pushes selection down to the reader's metadata
layer instead of materializing-then-filtering.

## What's added

### 1. `tsfile` packaged module (tsfile)

Backed by `tsfile.TsFileDataFrame` (`tsfile>=2.2.1.dev4`). Each `.tsfile`
is loaded as a single Arrow table: a `timestamp` (int64) column followed
by one float64 column per selected logical timeseries.

Four complementary, mutually-aware ways to select series — all pushed
down to the metadata layer so unselected devices/fields are never decoded:

| Argument        | Behaviour                                                                 |
|-----------------|---------------------------------------------------------------------------|
| `columns=`      | Explicit list of logical series paths.                                    |
| `devices=`      | Keep listed device(s), across all their fields. Exact segment match.      |
| `fields=`       | Keep listed measurement(s), across all devices.                           |
| `path_prefix=`  | Delegated to `TsFileDataFrame.list_timeseries(path_prefix=...)`.          |

`devices=` and `fields=` combine as a logical AND. `columns=` is mutually
exclusive with the three predicate-based filters.

Plus:

- `start_time` / `end_time` — inclusive time-range filter pushed down to
  `df.loc[start:end, series]` (uses chunk-level time indices).
- `features` — optional cast to a user-provided `Features` schema.
- `on_bad_files` — `"error"` (default) / `"warn"` / `"skip"`, matching the
  Parquet / HDF5 builders.

Registered in `_PACKAGED_DATASETS_MODULES` and bound to the `.tsfile`
extension via `_EXTENSION_TO_MODULE`.

### 2. Tests (test_tsfile.py)

14 tests, gated by `pytest.importorskip("tsfile")`:

- config validation (`columns` vs predicate filters mutual exclusion)
- basic load + extension auto-detection
- `columns=` / `devices=` / `fields=` / `path_prefix=` individually
- combined `devices=` + `fields=` 2-D projection
- empty-result filters → informative `ValueError`
- `start_time` / `end_time` pruning
- `on_bad_files="skip"` skipping a corrupted shard
- explicit `features` cast

All 14 pass on the dev machine.

### 3. Documentation

- **New sidebar category "Time Series"** in _toctree.yml,
  alongside `Tabular` / `Audio` / `Vision` / `Text`. Currently the official
  docs file time-series under `Tabular`, which underplays its
  domain-specific concerns (timestamp axis, time-range pruning, per-device
  addressing).
- **New page timeseries_load.mdx** documenting the `tsfile`
  builder: data model, four series-selection paths, time-range pruning,
  bad-file handling, feature casting, and the table-model / numeric-only
  limitations of the underlying `TsFileDataFrame` API.
- **Cross-link** from loading.mdx (the generic loading
  reference) to the new guide, with a minimal example surfacing the
  device- and field-level filters.

## Known limitations (documented in the new page)

The current `tsfile.TsFileDataFrame` API:

- only supports the **table-model** TsFile (tree-only files cannot be
  loaded);
- only exposes **numeric** field types (`BOOLEAN`, `INT32`, `INT64`,
  `FLOAT`, `DOUBLE`, `TIMESTAMP`), unifying them to `float64`;
- silently skips non-numeric fields (`TEXT`, `STRING`, `BLOB`, `DATE`)
  during metadata discovery.

## Dependency note

`tsfile` is **not** added to setup.py `extras_require` in this PR:
the latest published version on PyPI is a dev pre-release
(`2.2.1.dev4`) whose own metadata pins `pyarrow<20`, which conflicts
with the version of pyarrow used by `datasets`. The builder lazy-imports
`tsfile` and the tests are gated by `pytest.importorskip`, so users opt
in by installing `tsfile` themselves. We can add a proper extra once a
stable `tsfile` release lands.

## Commits

1. **Add Apache TsFile packaged module** — builder, registration, tests.
2. **Add Time Series category and TsFile loading guide** — sidebar entry,
   new docs page, cross-link from `loading.mdx`.

## Checklist

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/packaged_modules/test_tsfile.py` — 14 passed
- [x] No changes to existing builders / public API
```