### PR TITLE
fix: tolerate chmod PermissionError on flat-permission filesystems

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4046,7 +4046,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             shutil.move(tmp_file.name, cache_file_name)
             umask = os.umask(0o666)
             os.umask(umask)
-            os.chmod(cache_file_name, 0o666 & ~umask)
+            try:
+                os.chmod(cache_file_name, 0o666 & ~umask)
+            except OSError as e:
+                # Flat-permission filesystems (e.g. GCS FUSE, S3 FUSE mounts)
+                # reject chmod. The cache file is already written, so treat
+                # the permission update as best-effort rather than fatal.
+                logger.debug("Could not chmod %s: %s", cache_file_name, e)
 
         if update_data:
             # Create new Dataset from buffer or file
@@ -4591,7 +4597,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             shutil.move(tmp_file.name, indices_cache_file_name)
             umask = os.umask(0o666)
             os.umask(umask)
-            os.chmod(indices_cache_file_name, 0o666 & ~umask)
+            try:
+                os.chmod(indices_cache_file_name, 0o666 & ~umask)
+            except OSError as e:
+                # See note on the matching chmod in _map_single — best-effort
+                # so writes succeed on flat-permission filesystems.
+                logger.debug("Could not chmod %s: %s", indices_cache_file_name, e)
 
         # Return new Dataset object
         if buf_writer is None:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4930,3 +4930,37 @@ def test_process_large_few_examples(tmp_path):
     # make sure this is split into 2 shards
     ds.save_to_disk(dataset_path, max_shard_size="1KB")
     assert (dataset_path / "data-00000-of-00001.arrow").exists()
+
+
+def test_map_survives_chmod_permission_error(tmp_path):
+    """
+    Regression test for https://github.com/huggingface/datasets/issues/8125.
+
+    Flat-permission filesystems (GCS FUSE, S3 FUSE mounts) reject os.chmod
+    with PermissionError. The cache file is already written at that point,
+    so the chmod is best-effort — map() must not abort on it.
+    """
+    from datasets import Dataset
+
+    real_chmod = os.chmod
+    chmod_calls = []
+
+    def chmod_raising_permission_error(path, mode):
+        # Only fail for paths inside the cache dir. Let pytest's tmp-path
+        # housekeeping and unrelated chmod calls still work.
+        if str(path).startswith(str(tmp_path)):
+            chmod_calls.append(path)
+            raise PermissionError(f"[Errno 1] Operation not permitted: {path!r}")
+        return real_chmod(path, mode)
+
+    ds = Dataset.from_dict({"a": [1, 2, 3]})
+    cache_file = str(tmp_path / "mapped.arrow")
+
+    with patch("datasets.arrow_dataset.os.chmod", side_effect=chmod_raising_permission_error):
+        mapped = ds.map(lambda x: {"b": x["a"] * 2}, cache_file_name=cache_file)
+
+    # Map completed despite chmod failing — output is correct and file exists.
+    assert mapped["b"][:] == [2, 4, 6]
+    assert os.path.exists(cache_file)
+    # And the chmod was actually attempted (so the guard isn't a no-op).
+    assert len(chmod_calls) >= 1


### PR DESCRIPTION
## Summary

Fixes #8125.

`Dataset.map()` (and the indices writer in `Dataset.flatten_indices` / `Dataset.select` path) calls `os.chmod(cache_file, 0o666 & ~umask)` on the freshly moved cache file. On flat-permission filesystems — GCS FUSE, S3 FUSE mounts, and similar object-storage-backed mounts — `chmod` raises `PermissionError` (a subclass of `OSError`). The cache file itself is already written successfully at that point, but the unguarded chmod takes down the whole `.map()` call with a traceback like:

```
  File "src/datasets/arrow_dataset.py", line 3747, in _map_single
    os.chmod(cache_file_name, 0o666 & ~umask)
PermissionError: [Errno 1] Operation not permitted: '/mnt/data/cache_55b1844ebd9dffff_00000_of_00001.arrow'
```

## Fix

Wrap each of the two `os.chmod` call sites in `src/datasets/arrow_dataset.py` with `try/except OSError`, logging the failure at debug level. The permission update stays best-effort: sane `0o666 & ~umask` permissions on POSIX filesystems that support it, silent graceful degradation on flat-permission mounts where there's nothing to set.

No new API surface, no env-var toggle — the issue body suggested an opt-out env var, but catching `OSError` is narrower and doesn't require users to know about a new knob. If a future caller actually needs to detect the degraded mode, they can observe the debug log.

## Tests

New regression test `test_map_survives_chmod_permission_error` in `tests/test_arrow_dataset.py`:

- Patches `datasets.arrow_dataset.os.chmod` to raise `PermissionError` for paths inside the pytest `tmp_path` (so pytest's own housekeeping is unaffected)
- Runs `Dataset.from_dict({\"a\": [1, 2, 3]}).map(lambda x: {\"b\": x[\"a\"] * 2}, cache_file_name=...)`
- Asserts the mapped values are correct (`[2, 4, 6]`), the cache file exists on disk, and the chmod guard was actually exercised

Verified the test fails on `main` without the fix (propagates `PermissionError`) and passes with it.

## Scope notes

- Two chmod sites changed in `arrow_dataset.py` — both follow the identical `shutil.move → umask → chmod` pattern
- No behavior change on POSIX filesystems that accept chmod
- Issue author asked about an env-var opt-out; this goes narrower (catch-the-error) because the chmod is genuinely best-effort and failure is recoverable

## Checklist

- [x] Added a regression test in `tests/`
- [x] `ruff check` and `ruff format --check` clean on touched files
- [x] Related `test_map_caching*` tests still pass
- [x] Scope isolated to one bug