### PR TITLE
don't embed remote files in download_and_prepare to parquet

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -759,7 +759,7 @@ class ArrowWriter:
         pa_table = pa_table.combine_chunks()
         pa_table = table_cast(pa_table, self._schema)
         if self.embed_local_files:
-            pa_table = embed_table_storage(pa_table)
+            pa_table = embed_table_storage(pa_table, local_files=True, remote_files=False)
         self._num_bytes += pa_table.nbytes
         self._num_examples += pa_table.num_rows
         self.pa_writer.write_table(pa_table, writer_batch_size)

--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
-from ..utils.file_utils import is_local_path, xopen
+from ..utils.file_utils import is_local_path, is_remote_url, xopen
 from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
 
 
@@ -277,12 +277,25 @@ class Audio:
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
         """Embed audio files into the Arrow array.
 
         Args:
             storage (`pa.StructArray`):
                 PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`)
+                Whether to embed local files data in the array
+
+                <Added version="4.8.5"/>
+            remote_files (`bool`, defaults to `True`)
+                Whether to embed remote files data in the array.
+                E.g. files with paths that start with hf:// or https://
+
+                <Added version="4.8.5"/>
 
         Returns:
             `pa.StructArray`: Array in the Audio arrow storage type, that is
@@ -305,13 +318,29 @@ class Audio:
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    path_to_bytes(x["path"])
+                    if x["bytes"] is None
+                    and ((local_files and is_local_path(x["path"])) or (remote_files and is_remote_url(x["path"])))
+                    else x["bytes"]
+                )
+                if x is not None
+                else None
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                (
+                    os.path.basename(path)
+                    if (local_files and is_local_path(path)) or (remote_files and is_remote_url(path))
+                    else path
+                )
+                if path is not None
+                else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -12,7 +12,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
-from ..utils.file_utils import is_local_path, xopen
+from ..utils.file_utils import is_local_path, is_remote_url, xopen
 from ..utils.py_utils import first_non_null_value, no_op_if_value_is_null, string_to_dict
 
 
@@ -272,12 +272,25 @@ class Image:
             )
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
         """Embed image files into the Arrow array.
 
         Args:
             storage (`pa.StructArray`):
                 PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`)
+                Whether to embed local files data in the array
+
+                <Added version="4.8.5"/>
+            remote_files (`bool`, defaults to `True`)
+                Whether to embed remote files data in the array.
+                E.g. files with paths that start with hf:// or https://
+
+                <Added version="4.8.5"/>
 
         Returns:
             `pa.StructArray`: Array in the Image arrow storage type, that is
@@ -300,13 +313,29 @@ class Image:
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    path_to_bytes(x["path"])
+                    if x["bytes"] is None
+                    and ((local_files and is_local_path(x["path"])) or (remote_files and is_remote_url(x["path"])))
+                    else x["bytes"]
+                )
+                if x is not None
+                else None
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                (
+                    os.path.basename(path)
+                    if (local_files and is_local_path(path)) or (remote_files and is_remote_url(path))
+                    else path
+                )
+                if path is not None
+                else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())

--- a/src/datasets/features/nifti.py
+++ b/src/datasets/features/nifti.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
-from ..utils.file_utils import is_local_path, xopen
+from ..utils.file_utils import is_local_path, is_remote_url, xopen
 from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
 
 
@@ -210,12 +210,25 @@ class Nifti:
 
         return Nifti1ImageWrapper(nifti)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
         """Embed NifTI files into the Arrow array.
 
         Args:
             storage (`pa.StructArray`):
                 PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`)
+                Whether to embed local files data in the array
+
+                <Added version="4.8.5"/>
+            remote_files (`bool`, defaults to `True`)
+                Whether to embed remote files data in the array.
+                E.g. files with paths that start with hf:// or https://
+
+                <Added version="4.8.5"/>
 
         Returns:
             `pa.StructArray`: Array in the NifTI arrow storage type, that is
@@ -238,13 +251,29 @@ class Nifti:
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    path_to_bytes(x["path"])
+                    if x["bytes"] is None
+                    and ((local_files and is_local_path(x["path"])) or (remote_files and is_remote_url(x["path"])))
+                    else x["bytes"]
+                )
+                if x is not None
+                else None
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                (
+                    os.path.basename(path)
+                    if (local_files and is_local_path(path)) or (remote_files and is_remote_url(path))
+                    else path
+                )
+                if path is not None
+                else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())

--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
-from ..utils.file_utils import is_local_path, xopen
+from ..utils.file_utils import is_local_path, is_remote_url, xopen
 from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
 
 
@@ -218,12 +218,25 @@ class Pdf:
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
         """Embed PDF files into the Arrow array.
 
         Args:
             storage (`pa.StructArray`):
                 PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`)
+                Whether to embed local files data in the array
+
+                <Added version="4.8.5"/>
+            remote_files (`bool`, defaults to `True`)
+                Whether to embed remote files data in the array.
+                E.g. files with paths that start with hf:// or https://
+
+                <Added version="4.8.5"/>
 
         Returns:
             `pa.StructArray`: Array in the PDF arrow storage type, that is
@@ -246,13 +259,29 @@ class Pdf:
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    path_to_bytes(x["path"])
+                    if x["bytes"] is None
+                    and ((local_files and is_local_path(x["path"])) or (remote_files and is_remote_url(x["path"])))
+                    else x["bytes"]
+                )
+                if x is not None
+                else None
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                (
+                    os.path.basename(path)
+                    if (local_files and is_local_path(path)) or (remote_files and is_remote_url(path))
+                    else path
+                )
+                if path is not None
+                else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
-from ..utils.file_utils import is_local_path, xopen
+from ..utils.file_utils import is_local_path, is_remote_url, xopen
 from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
 
 
@@ -288,12 +288,25 @@ class Video:
             )
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
         """Embed image files into the Arrow array.
 
         Args:
             storage (`pa.StructArray`):
                 PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`)
+                Whether to embed local files data in the array
+
+                <Added version="4.8.5"/>
+            remote_files (`bool`, defaults to `True`)
+                Whether to embed remote files data in the array.
+                E.g. files with paths that start with hf:// or https://
+
+                <Added version="4.8.5"/>
 
         Returns:
             `pa.StructArray`: Array in the Video arrow storage type, that is
@@ -316,13 +329,29 @@ class Video:
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    path_to_bytes(x["path"])
+                    if x["bytes"] is None
+                    and ((local_files and is_local_path(x["path"])) or (remote_files and is_remote_url(x["path"])))
+                    else x["bytes"]
+                )
+                if x is not None
+                else None
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                (
+                    os.path.basename(path)
+                    if (local_files and is_local_path(path)) or (remote_files and is_remote_url(path))
+                    else path
+                )
+                if path is not None
+                else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -2102,7 +2102,13 @@ def cast_array_to_feature(
 
 
 @_wrap_for_chunked_arrays
-def embed_array_storage(array: pa.Array, feature: "FeatureType", token_per_repo_id=None):
+def embed_array_storage(
+    array: pa.Array,
+    feature: "FeatureType",
+    token_per_repo_id=None,
+    local_files: bool = True,
+    remote_files: bool = True,
+):
     """Embed data into an arrays's storage.
     For custom features like Audio or Image, it takes into account the "embed_storage" methods
     they define to embed external data (e.g. an image file) into an array.
@@ -2114,6 +2120,15 @@ def embed_array_storage(array: pa.Array, feature: "FeatureType", token_per_repo_
             The PyArrow array in which to embed data.
         feature (`datasets.features.FeatureType`):
             Array features.
+        local_files (`bool`, defaults to `True`)
+            Whether to embed local files data in the array
+
+            <Added version="4.8.5"/>
+        remote_files (`bool`, defaults to `True`)
+            Whether to embed remote files data in the array.
+            E.g. files with paths that start with hf:// or https://
+
+            <Added version="4.8.5"/>
 
     Raises:
         `TypeError`: if the target type is not supported according, e.g.
@@ -2123,14 +2138,21 @@ def embed_array_storage(array: pa.Array, feature: "FeatureType", token_per_repo_
     Returns:
          array (`pyarrow.Array`): the casted array
     """
+    if not local_files and not remote_files:
+        return array
+
     from .features import LargeList, List
 
-    _e = partial(embed_array_storage, token_per_repo_id=token_per_repo_id)
+    _e = partial(
+        embed_array_storage, token_per_repo_id=token_per_repo_id, local_files=local_files, remote_files=remote_files
+    )
 
     if isinstance(array, pa.ExtensionArray):
         array = array.storage
     if hasattr(feature, "embed_storage"):
-        return feature.embed_storage(array, token_per_repo_id=token_per_repo_id)
+        return feature.embed_storage(
+            array, token_per_repo_id=token_per_repo_id, local_files=local_files, remote_files=remote_files
+        )
     elif pa.types.is_struct(array.type):
         # feature must be a dict
         if isinstance(feature, dict):
@@ -2239,7 +2261,7 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
     return pa.Table.from_arrays(arrays, schema=schema)
 
 
-def embed_table_storage(table: pa.Table, token_per_repo_id=None):
+def embed_table_storage(table: pa.Table, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True):
     """Embed external data into a table's storage.
 
     <Added version="2.4.0"/>
@@ -2247,15 +2269,33 @@ def embed_table_storage(table: pa.Table, token_per_repo_id=None):
     Args:
         table (`pyarrow.Table`):
             PyArrow table in which to embed data.
+        local_files (`bool`, defaults to `True`)
+            Whether to embed local files data in the table
+
+            <Added version="4.8.5"/>
+        remote_files (`bool`, defaults to `True`)
+            Whether to embed remote files data in the table.
+            E.g. files with paths that start with hf:// or https://
+
+            <Added version="4.8.5"/>
 
     Returns:
         table (`pyarrow.Table`): the table with embedded data
     """
+    if not local_files and not remote_files:
+        return table
+
     from .features.features import Features, require_storage_embed
 
     features = Features.from_arrow_schema(table.schema)
     arrays = [
-        embed_array_storage(table[name], feature, token_per_repo_id=token_per_repo_id)
+        embed_array_storage(
+            table[name],
+            feature,
+            token_per_repo_id=token_per_repo_id,
+            local_files=local_files,
+            remote_files=remote_files,
+        )
         if require_storage_embed(feature)
         else table[name]
         for name, feature in features.items()


### PR DESCRIPTION
fix the viewer at https://huggingface.co/datasets/raivn/vn-test/discussions/1

kinda related: https://github.com/huggingface/datasets/issues/5717