### PR TITLE
Fix tilde expansion for local data_files paths

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -346,6 +346,8 @@ def resolve_pattern(
     Returns:
         List[str]: List of paths or URLs to the local or remote files that match the patterns.
     """
+    if is_local_path(pattern):
+        pattern = os.path.expanduser(pattern)
     if is_relative_path(pattern):
         pattern = xjoin(base_path, pattern)
     elif is_local_path(pattern):

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -207,6 +207,28 @@ def test_resolve_pattern_locally_with_absolute_path(tmp_path, complex_data_dir):
     assert len(resolved_data_files) == 1
 
 
+def test_resolve_pattern_locally_with_tilde(tmp_path):
+    home_dir = tmp_path / "home"
+    data_dir = home_dir / "data"
+    data_dir.mkdir(parents=True)
+    data_file = data_dir / "train.txt"
+    data_file.write_text("foo\n" * 10)
+
+    with patch.dict(
+        os.environ,
+        {
+            "HOME": home_dir.as_posix(),
+            "USERPROFILE": home_dir.as_posix(),
+            "HOMEDRIVE": home_dir.drive,
+            "HOMEPATH": home_dir.as_posix()[len(home_dir.drive) :],
+        },
+        clear=False,
+    ):
+        resolved_data_files = resolve_pattern(os.path.join("~", "data", "train.txt"), str(tmp_path / "blabla"))
+
+    assert resolved_data_files == [data_file.as_posix()]
+
+
 def test_resolve_pattern_locally_with_double_dots(tmp_path, complex_data_dir):
     path_with_double_dots = os.path.join(complex_data_dir, "data", "subdir", "..", "train.txt")
     resolved_data_files = resolve_pattern(path_with_double_dots, str(tmp_path / "blabla"))


### PR DESCRIPTION
Summary
- expand `~` before classifying local `data_files` patterns
- add a regression test covering `resolve_pattern(os.path.join("~", ...), ...)`

Impact
- `load_dataset(..., data_files="~/path/to/file.parquet")` currently treats `~` as a literal relative directory under the working tree instead of the user's home directory
- this brings `data_files` in line with the existing `data_dir` handling and fixes issue #6212

Testing
- `python -m pytest tests/test_data_files.py`
- `make quality`
- manual repro: `load_dataset("parquet", data_files="~/.codex-tmp-datasets-tilde-repro/sample.parquet")`

Fixes #6212