### PR TITLE
Pass library_name/version to HfApi in dataset push and delete paths

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -75,7 +75,7 @@ from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, Repository
 from packaging import version
 from tqdm.contrib.concurrent import thread_map
 
-from . import config
+from . import __version__, config
 from .arrow_reader import ArrowReader
 from .arrow_writer import ArrowWriter, OptimizedTypedSequence
 from .data_files import sanitize_patterns
@@ -5861,7 +5861,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             (start + i, self.shard(num_shards=end - start, index=i, contiguous=True)) for i in range(end - start)
         )
 
-        api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+        api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
 
         additions: list[CommitOperationAdd] = []
         new_parquet_paths: list[str] = []
@@ -6159,7 +6159,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if not data_dir:
             data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
-        api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+        api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
             if BucketNotFoundError is None:
                 raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
@@ -6628,7 +6628,7 @@ def _push_to_repo(
     embed_external_files: bool = True,
     num_proc: Optional[int] = None,
 ) -> CommitInfo:
-    api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+    api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
     resolved_output_path = HfFileSystemResolvedRepositoryPath(
         repo_id=repo_id, repo_type="dataset", revision=revision or "main", path_in_repo=""
     )
@@ -6791,7 +6791,7 @@ def _push_to_bucket(
     embed_external_files: bool = True,
     num_proc: Optional[int] = None,
 ) -> None:
-    api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+    api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
     resolved_output_path = HfFileSystemResolvedBucketPath(bucket_id=bucket_id, path=path)
     hf_path = resolved_output_path.unresolve()
     hffs = HfFileSystem(endpoint=config.HF_ENDPOINT, token=token)

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -26,7 +26,7 @@ from huggingface_hub import (
 from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, RepositoryNotFoundError
 from packaging import version
 
-from . import config
+from . import __version__, config
 from .arrow_dataset import (
     Dataset,
     _get_updated_dataset_card,
@@ -1762,7 +1762,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         if not data_dir:
             data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
-        api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+        api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
             if BucketNotFoundError is None:
                 raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
@@ -2461,7 +2461,7 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         if not data_dir:
             data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
-        api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+        api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
             if BucketNotFoundError is None:
                 raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
@@ -2534,7 +2534,7 @@ def _push_to_repo(
     embed_external_files: bool = True,
     num_proc: Optional[int] = None,
 ) -> CommitInfo:
-    api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+    api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
     resolved_output_path = HfFileSystemResolvedRepositoryPath(
         repo_id=repo_id, repo_type="dataset", revision=revision or "main", path_in_repo=""
     )
@@ -2706,7 +2706,7 @@ def _push_to_bucket(
     embed_external_files: bool = True,
     num_proc: Optional[int] = None,
 ) -> None:
-    api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+    api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
     resolved_output_path = HfFileSystemResolvedBucketPath(bucket_id=bucket_id, path=path)
     hf_path = resolved_output_path.unresolve()
     hffs = HfFileSystem(endpoint=config.HF_ENDPOINT, token=token)

--- a/src/datasets/hub.py
+++ b/src/datasets/hub.py
@@ -12,6 +12,7 @@ from huggingface_hub import (
 )
 
 import datasets.config
+from datasets import __version__
 from datasets.info import DatasetInfosDict
 from datasets.load import load_dataset_builder
 from datasets.utils.metadata import MetadataConfigs
@@ -74,7 +75,12 @@ def delete_from_hub(
     operations.append(
         CommitOperationAdd(path_in_repo=datasets.config.REPOCARD_FILENAME, path_or_fileobj=str(dataset_card).encode())
     )
-    api = HfApi(endpoint=datasets.config.HF_ENDPOINT, token=token)
+    api = HfApi(
+        endpoint=datasets.config.HF_ENDPOINT,
+        token=token,
+        library_name="datasets",
+        library_version=__version__,
+    )
     commit_info = api.create_commit(
         repo_id,
         operations=operations,
@@ -90,7 +96,12 @@ def delete_from_hub(
 
 
 def _delete_files(dataset_id, revision=None, token=None):
-    hf_api = HfApi(endpoint=datasets.config.HF_ENDPOINT, token=token)
+    hf_api = HfApi(
+        endpoint=datasets.config.HF_ENDPOINT,
+        token=token,
+        library_name="datasets",
+        library_version=__version__,
+    )
     repo_files = hf_api.list_repo_files(
         dataset_id,
         repo_type="dataset",

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -33,7 +33,7 @@ from huggingface_hub import (
 from huggingface_hub.utils import RepositoryNotFoundError
 from packaging import version
 
-from . import config
+from . import __version__, config
 from .arrow_dataset import Dataset, DatasetInfoMixin, _push_to_bucket, _push_to_repo
 from .features import Features
 from .features.features import (
@@ -4574,7 +4574,7 @@ class IterableDataset(DatasetInfoMixin):
             (start + i, self.shard(num_shards=end - start, index=i, contiguous=True)) for i in range(end - start)
         )
 
-        api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+        api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
 
         dataset_nbytes = 0
         num_examples = 0
@@ -4890,7 +4890,7 @@ class IterableDataset(DatasetInfoMixin):
         if not data_dir:
             data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
-        api = HfApi(endpoint=config.HF_ENDPOINT, token=token)
+        api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
             if BucketNotFoundError is None:
                 raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")


### PR DESCRIPTION
Adds `library_name="datasets"` and `library_version=__version__` to 12 bare `HfApi(endpoint=..., token=...)` instantiations across `hub.py`, `arrow_dataset.py`, `iterable_dataset.py`, and `dataset_dict.py`. Commits made via `push_to_hub` / `delete_from_hub` currently report a User-Agent of `unknown/None; hf_hub/X.Y.Z; ...`; with this change they report as `datasets/X.Y.Z; ...`.

This completes a convention the repo already follows in `load.py` and `utils/file_utils.py`. Motivated by some recent UA-attribution work on the Hub side (happy to share more context on Slack).

Opened as draft to let CI verify nothing breaks before requesting review.

## Test plan
- [ ] CI green
- [ ] Optional manual smoke: `Dataset.from_dict({"x": [1]}).push_to_hub(...)` against a staging repo, confirm commit UA reports `datasets/<version>`.

cc @Wauplin to check this makes sense in your opinion! 