### PR TITLE
Include all test files in sdist via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+graft tests
+global-exclude __pycache__
+global-exclude *.py[cod]


### PR DESCRIPTION
Fixes #8159.

## What's wrong

The sdist on PyPI for `datasets==4.8.5` only ships **37 of the 95** files under `tests/`. Without an explicit `MANIFEST.in`, setuptools' default sdist behavior includes only top-level `tests/test_*.py` files and drops everything else.

Files missing from the current sdist:

- `tests/conftest.py`
- `tests/_test_patching.py`
- everything under `tests/commands/`, `tests/features/`, `tests/fixtures/`, `tests/io/`, `tests/packaged_modules/`, `tests/distributed_scripts/`
- the audio / image / PDF / JSON test-data files under `tests/features/data/` and `tests/io/data/`

Anyone installing from sdist (distros, mirrors, air-gapped builds) cannot run the test suite — `pytest` fails to even collect because `tests/conftest.py` is missing the `pytest_plugins` configuration that pulls in `tests.fixtures.*`.

## Fix

Add a minimal `MANIFEST.in` that grafts the whole `tests/` directory and excludes bytecode.

```
graft tests
global-exclude __pycache__
global-exclude *.py[cod]
```

## Verification

Built the sdist locally on `main` before/after the change and compared:

```
$ python -m build --sdist
```

| | Before | After |
|---|---|---|
| Files under `tests/` in sdist | 37 | 95 |
| `tests/conftest.py` | missing | included |
| `tests/_test_patching.py` | missing | included |
| `tests/fixtures/fsspec.py` | missing | included |
| `tests/features/test_audio.py` | missing | included |
| `tests/io/test_csv.py` | missing | included |
| `tests/packaged_modules/test_arrow.py` | missing | included |
| `tests/features/data/test_audio_16000.mp3` | missing | included |
| `__pycache__` files | 0 | 0 |

All 95 files under `tests/` in the working tree are now in the sdist; nothing else is added.