### PR TITLE
add agent trace prompt, sent_at, count fields

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -165,7 +165,7 @@ class Json(datasets.ArrowBasedBuilder):
                 elif is_agent_traces:
                     with open(file, "r", encoding="utf-8") as f:
                         traces = f.readlines()
-                    harness, session_id = parse_traces_info(traces)
+                    harness, session_id, prompt, sent_at, num_user_messages, num_tool_calls = parse_traces_info(traces)
                     file_path = original_files[shard_idx]
                     if file_path.startswith(self.base_path):
                         file_path = os.path.relpath(file_path, self.base_path)
@@ -173,6 +173,10 @@ class Json(datasets.ArrowBasedBuilder):
                         {
                             "harness": [harness],
                             "session_id": [session_id],
+                            "prompt": [prompt],
+                            "sent_at": [sent_at],
+                            "num_user_messages": [num_user_messages],
+                            "num_tool_calls": [num_tool_calls],
                             "traces": [traces],
                             "file_path": [file_path],
                         }
@@ -333,6 +337,10 @@ AGENT_TRACES_FEATURES = datasets.Features(
     {
         "harness": datasets.Value("string"),
         "session_id": datasets.Value("string"),
+        "prompt": datasets.Value("string"),
+        "sent_at": datasets.Value("string"),
+        "num_user_messages": datasets.Value("int64"),
+        "num_tool_calls": datasets.Value("int64"),
         "traces": datasets.List(datasets.Json()),
         "file_path": datasets.Value("string"),
     }
@@ -346,38 +354,136 @@ def has_agent_traces_markers(features: datasets.Features) -> bool:
     return False
 
 
-def parse_traces_info(traces: list[str]) -> tuple[Optional[str], Optional[str]]:
-    harness, session_id = None, None
+def parse_traces_info(
+    traces: list[str],
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str], int, int]:
+    harness, session_id, prompt, sent_at = None, None, None, None
+    # Codex response_item user messages can include context files (for example AGENTS.md) before the real prompt.
+    # Prefer event_msg user messages, and use response_item user messages only as a fallback.
+    codex_response_prompt, codex_response_sent_at = None, None
+    num_user_messages = 0
+    num_codex_response_user_messages = 0
+    num_tool_calls = 0
     for trace in traces:
         decoded_trace = ujson_loads(trace)
         if harness is None:
             if "type" in decoded_trace and isinstance(decoded_trace["type"], str):
                 harness = AGENT_TRACES_TYPE_TO_HARNESS.get(decoded_trace["type"])
         if session_id is None:
-            # claude
-            if "sessionId" in decoded_trace and isinstance(decoded_trace["sessionId"], str):
-                session_id = decoded_trace["sessionId"]
-            # claude (not sure but this format does exist online)
-            elif "session_id" in decoded_trace and isinstance(decoded_trace["session_id"], str):
-                session_id = decoded_trace["session_id"]
-            # codex
-            elif (
-                "payload" in decoded_trace
-                and isinstance(decoded_trace["payload"], dict)
-                and "id" in decoded_trace["payload"]
-                and isinstance(decoded_trace["payload"]["id"], str)
+            session_id = get_session_id(decoded_trace)
+            if (
+                session_id is not None
+                and decoded_trace.get("type") == "session"
+                and isinstance(decoded_trace.get("cwd"), str)
+                and "/.openclaw/" in decoded_trace["cwd"]
             ):
-                session_id = decoded_trace["payload"]["id"]
-            # pi / openclaw (openclaw embeds pi-agent; distinguish via cwd)
-            elif (
-                "type" in decoded_trace
-                and decoded_trace["type"] == "session"
-                and "id" in decoded_trace
-                and isinstance(decoded_trace["id"], str)
-            ):
-                session_id = decoded_trace["id"]
-                if isinstance(decoded_trace.get("cwd"), str) and "/.openclaw/" in decoded_trace["cwd"]:
-                    harness = "openclaw"
-        if harness and session_id:
-            break
-    return harness, session_id
+                harness = "openclaw"
+        user_prompt = get_user_prompt(decoded_trace)
+        if user_prompt is not None:
+            num_user_messages += 1
+            if prompt is None:
+                prompt = user_prompt
+                sent_at = get_trace_timestamp(decoded_trace)
+        codex_response_user_prompt = get_codex_response_user_prompt(decoded_trace)
+        if codex_response_user_prompt is not None:
+            num_codex_response_user_messages += 1
+            if codex_response_prompt is None:
+                codex_response_prompt = codex_response_user_prompt
+                codex_response_sent_at = get_trace_timestamp(decoded_trace)
+        num_tool_calls += get_tool_call_count(decoded_trace)
+    if prompt is None:
+        prompt = codex_response_prompt
+        sent_at = codex_response_sent_at
+        num_user_messages = num_codex_response_user_messages
+    return harness, session_id, prompt, sent_at, num_user_messages, num_tool_calls
+
+
+def get_session_id(trace: dict) -> Optional[str]:
+    # claude
+    if isinstance(trace.get("sessionId"), str):
+        return trace["sessionId"]
+    # claude (not sure but this format does exist online)
+    if isinstance(trace.get("session_id"), str):
+        return trace["session_id"]
+    # codex
+    if isinstance(trace.get("payload"), dict) and isinstance(trace["payload"].get("id"), str):
+        return trace["payload"]["id"]
+    # pi / openclaw (openclaw embeds pi-agent; distinguish via cwd)
+    if trace.get("type") == "session" and isinstance(trace.get("id"), str):
+        return trace["id"]
+    return None
+
+
+def get_user_prompt(trace: dict) -> Optional[str]:
+    if trace.get("type") == "user" and isinstance(trace.get("message"), dict):
+        message = trace["message"]
+        if message.get("role") == "user":
+            return get_content_text(message.get("content"))
+
+    if trace.get("type") == "message":
+        if isinstance(trace.get("message"), dict):
+            message = trace["message"]
+            if message.get("role") == "user":
+                return get_content_text(message.get("content"))
+        if trace.get("role") == "user":
+            return get_content_text(trace.get("content"))
+
+    if trace.get("type") == "event_msg" and isinstance(trace.get("payload"), dict):
+        payload = trace["payload"]
+        if payload.get("type") == "user_message":
+            return get_content_text(payload.get("message"))
+
+    return None
+
+
+def get_codex_response_user_prompt(trace: dict) -> Optional[str]:
+    if trace.get("type") != "response_item" or not isinstance(trace.get("payload"), dict):
+        return None
+    payload = trace["payload"]
+    if payload.get("type") == "message" and payload.get("role") == "user":
+        return get_content_text(payload.get("content"))
+    return None
+
+
+def get_tool_call_count(trace: dict) -> int:
+    if trace.get("type") == "response_item" and isinstance(trace.get("payload"), dict):
+        if trace["payload"].get("type") == "function_call":
+            return 1
+
+    if not isinstance(trace.get("message"), dict):
+        return 0
+    message = trace["message"]
+    if message.get("role") != "assistant":
+        return 0
+    content = message.get("content")
+    if not isinstance(content, list):
+        return 0
+    return sum(
+        1
+        for content_part in content
+        if isinstance(content_part, dict) and content_part.get("type") in {"tool_use", "toolCall"}
+    )
+
+
+def get_trace_timestamp(trace: dict) -> Optional[str]:
+    timestamp = trace.get("timestamp")
+    if isinstance(timestamp, str):
+        return timestamp
+    return None
+
+
+def get_content_text(content) -> Optional[str]:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        content_parts = []
+        for content_part in content:
+            if isinstance(content_part, str):
+                content_parts.append(content_part)
+            elif isinstance(content_part, dict):
+                text = content_part.get("text")
+                if isinstance(text, str):
+                    content_parts.append(text)
+        if content_parts:
+            return "\n".join(content_parts)
+    return None

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -167,7 +167,7 @@ class Json(datasets.ArrowBasedBuilder):
                         traces = f.readlines()
                     harness, session_id, prompt, sent_at, num_user_messages, num_tool_calls = parse_traces_info(traces)
                     file_path = original_files[shard_idx]
-                    if file_path.startswith(self.base_path):
+                    if self.base_path is not None and file_path.startswith(self.base_path):
                         file_path = os.path.relpath(file_path, self.base_path)
                     pa_table = pa.Table.from_pydict(
                         {
@@ -358,11 +358,10 @@ def parse_traces_info(
     traces: list[str],
 ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str], int, int]:
     harness, session_id, prompt, sent_at = None, None, None, None
-    # Codex response_item user messages can include context files (for example AGENTS.md) before the real prompt.
-    # Prefer event_msg user messages, and use response_item user messages only as a fallback.
-    codex_response_prompt, codex_response_sent_at = None, None
+    # prompt/sent_at describe the first user message; the counters summarize the whole trace file.
+    # Codex response_item user messages can include context files (for example AGENTS.md), so only event_msg
+    # user_message records are treated as Codex user messages.
     num_user_messages = 0
-    num_codex_response_user_messages = 0
     num_tool_calls = 0
     for trace in traces:
         decoded_trace = ujson_loads(trace)
@@ -384,17 +383,7 @@ def parse_traces_info(
             if prompt is None:
                 prompt = user_prompt
                 sent_at = get_trace_timestamp(decoded_trace)
-        codex_response_user_prompt = get_codex_response_user_prompt(decoded_trace)
-        if codex_response_user_prompt is not None:
-            num_codex_response_user_messages += 1
-            if codex_response_prompt is None:
-                codex_response_prompt = codex_response_user_prompt
-                codex_response_sent_at = get_trace_timestamp(decoded_trace)
         num_tool_calls += get_tool_call_count(decoded_trace)
-    if prompt is None:
-        prompt = codex_response_prompt
-        sent_at = codex_response_sent_at
-        num_user_messages = num_codex_response_user_messages
     return harness, session_id, prompt, sent_at, num_user_messages, num_tool_calls
 
 
@@ -436,21 +425,15 @@ def get_user_prompt(trace: dict) -> Optional[str]:
     return None
 
 
-def get_codex_response_user_prompt(trace: dict) -> Optional[str]:
-    if trace.get("type") != "response_item" or not isinstance(trace.get("payload"), dict):
-        return None
-    payload = trace["payload"]
-    if payload.get("type") == "message" and payload.get("role") == "user":
-        return get_content_text(payload.get("content"))
-    return None
-
-
 def get_tool_call_count(trace: dict) -> int:
-    if trace.get("type") == "response_item" and isinstance(trace.get("payload"), dict):
-        if trace["payload"].get("type") == "function_call":
+    trace_type = trace.get("type")
+    if trace_type == "response_item":
+        payload = trace.get("payload")
+        if isinstance(payload, dict) and payload.get("type") == "function_call":
             return 1
+        return 0
 
-    if not isinstance(trace.get("message"), dict):
+    if trace_type not in {"assistant", "message"} or not isinstance(trace.get("message"), dict):
         return 0
     message = trace["message"]
     if message.get("role") != "assistant":

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -4,7 +4,7 @@ import textwrap
 import pyarrow as pa
 import pytest
 
-from datasets import Features, Value
+from datasets import Features, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES, Json, JsonConfig
@@ -312,6 +312,46 @@ def generate_agent_traces_output(trace_file):
     return Features.from_arrow_schema(pa_table.schema).decode_batch(pa_table.to_pydict())
 
 
+def assert_agent_traces_output(tmp_path, filename, rows, expected):
+    trace_file = write_jsonl(tmp_path / filename, rows)
+    out = generate_agent_traces_output(trace_file)
+    for key, value in zip(AGENT_TRACE_FIELD_NAMES, expected):
+        assert out[key] == [value]
+    assert out["file_path"] == [trace_file]
+    return trace_file, out
+
+
+AGENT_TRACE_FIELD_NAMES = ("harness", "session_id", "prompt", "sent_at", "num_user_messages", "num_tool_calls")
+CODEX_AGENT_TRACE_ROWS = [
+    {"type": "session_meta", "payload": {"id": "codex-session"}},
+    {
+        "type": "response_item",
+        "payload": {"type": "message", "role": "user", "content": [{"text": "context-wrapped codex prompt"}]},
+    },
+    {
+        "timestamp": "2026-04-01T10:01:00.000Z",
+        "type": "event_msg",
+        "payload": {"type": "user_message", "message": "actual codex prompt"},
+    },
+    {
+        "type": "response_item",
+        "payload": {"type": "function_call", "name": "exec_command", "call_id": "call_1"},
+    },
+    {
+        "type": "response_item",
+        "payload": {"type": "function_call_output", "call_id": "call_1", "output": "done"},
+    },
+]
+CODEX_EXPECTED_AGENT_TRACE_FIELDS = (
+    "codex",
+    "codex-session",
+    "actual codex prompt",
+    "2026-04-01T10:01:00.000Z",
+    1,
+    1,
+)
+
+
 def test_config_raises_when_invalid_name() -> None:
     with pytest.raises(InvalidConfigName, match="Bad characters"):
         _ = JsonConfig(name="name-with-*-invalid-character")
@@ -407,257 +447,135 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
     assert pa_table.column_names == ["ID", "Language", "Topic"]
 
 
-def test_json_generate_tables_with_codex_agent_trace_metadata(tmp_path):
-    trace_file = write_jsonl(
-        tmp_path / "codex.jsonl",
-        [
-            {
-                "timestamp": "2026-04-01T10:00:00.000Z",
-                "type": "session_meta",
-                "payload": {"id": "codex-session"},
-            },
-            {
-                "timestamp": "2026-04-01T10:00:30.000Z",
-                "type": "response_item",
-                "payload": {
+@pytest.mark.parametrize(
+    "filename, rows, expected",
+    [
+        pytest.param("codex.jsonl", CODEX_AGENT_TRACE_ROWS, CODEX_EXPECTED_AGENT_TRACE_FIELDS, id="codex"),
+        pytest.param(
+            "codex_response_item_only.jsonl",
+            [
+                {"type": "session_meta", "payload": {"id": "codex-session"}},
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"text": "codex response item prompt"}],
+                    },
+                },
+                {
+                    "type": "response_item",
+                    "payload": {"type": "function_call", "name": "exec_command", "call_id": "call_1"},
+                },
+            ],
+            ("codex", "codex-session", None, None, 0, 1),
+            id="codex-response-item-only",
+        ),
+        pytest.param(
+            "claude.jsonl",
+            [
+                {
+                    "timestamp": "2026-04-02T10:00:00.000Z",
+                    "type": "user",
+                    "sessionId": "claude-session",
+                    "message": {"role": "user", "content": "claude prompt"},
+                },
+                {
+                    "type": "assistant",
+                    "sessionId": "claude-session",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use", "id": "toolu_1"}, {"type": "tool_use", "id": "toolu_2"}],
+                    },
+                },
+                {
+                    "type": "user",
+                    "sessionId": "claude-session",
+                    "message": {"role": "user", "content": [{"type": "tool_result", "content": "done"}]},
+                },
+            ],
+            ("claude_code", "claude-session", "claude prompt", "2026-04-02T10:00:00.000Z", 1, 2),
+            id="claude",
+        ),
+        pytest.param(
+            "pi.jsonl",
+            [
+                {"type": "session", "id": "pi-session"},
+                {
+                    "timestamp": "2026-04-03T10:01:00.000Z",
                     "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "context-wrapped codex prompt"}],
+                    "message": {"role": "user", "content": "pi prompt"},
                 },
-            },
-            {
-                "timestamp": "2026-04-01T10:01:00.000Z",
-                "type": "response_item",
-                "payload": {
+                {
                     "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "actual codex prompt"}],
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "toolCall", "id": "call_1"}, {"type": "toolCall", "id": "call_2"}],
+                    },
                 },
-            },
-            {
-                "timestamp": "2026-04-01T10:01:00.000Z",
-                "type": "event_msg",
-                "payload": {"type": "user_message", "message": "actual codex prompt"},
-            },
-            {
-                "timestamp": "2026-04-01T10:02:00.000Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "function_call",
-                    "name": "exec_command",
-                    "call_id": "call_1",
+                {
+                    "type": "message",
+                    "message": {"role": "toolResult", "content": [{"type": "text", "text": "done"}]},
                 },
-            },
-            {
-                "timestamp": "2026-04-01T10:03:00.000Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "function_call_output",
-                    "call_id": "call_1",
-                    "output": "done",
+                {
+                    "type": "message",
+                    "message": {"role": "user", "content": [{"type": "text", "text": "second pi prompt"}]},
                 },
-            },
-        ],
-    )
-
-    out = generate_agent_traces_output(trace_file)
-
-    assert out["harness"] == ["codex"]
-    assert out["session_id"] == ["codex-session"]
-    assert out["prompt"] == ["actual codex prompt"]
-    assert out["sent_at"] == ["2026-04-01T10:01:00.000Z"]
-    assert out["num_user_messages"] == [1]
-    assert out["num_tool_calls"] == [1]
-    assert out["file_path"] == [trace_file]
+            ],
+            ("pi", "pi-session", "pi prompt", "2026-04-03T10:01:00.000Z", 2, 2),
+            id="pi",
+        ),
+        pytest.param(
+            "openclaw.jsonl",
+            [
+                {
+                    "type": "session",
+                    "id": "openclaw-session",
+                    "cwd": "/Users/test/.openclaw/agents/main",
+                },
+                {
+                    "timestamp": "2026-04-03T10:01:00.000Z",
+                    "type": "message",
+                    "message": {"role": "user", "content": "openclaw prompt"},
+                },
+            ],
+            ("openclaw", "openclaw-session", "openclaw prompt", "2026-04-03T10:01:00.000Z", 1, 0),
+            id="openclaw",
+        ),
+        pytest.param(
+            "missing_prompt.jsonl",
+            [
+                {"type": "session_meta", "payload": {"id": "codex-session"}},
+                {
+                    "type": "response_item",
+                    "payload": {"type": "message", "role": "assistant", "content": [{"text": "assistant response"}]},
+                },
+            ],
+            ("codex", "codex-session", None, None, 0, 0),
+            id="missing-prompt",
+        ),
+    ],
+)
+def test_json_generate_tables_with_agent_trace_metadata(tmp_path, filename, rows, expected):
+    _, out = assert_agent_traces_output(tmp_path, filename, rows, expected)
     assert "models" not in out
 
 
-def test_json_generate_tables_ignores_codex_response_item_user_without_event_msg(tmp_path):
-    trace_file = write_jsonl(
-        tmp_path / "codex_response_item_only.jsonl",
-        [
-            {
-                "timestamp": "2026-04-01T10:00:00.000Z",
-                "type": "session_meta",
-                "payload": {"id": "codex-session"},
-            },
-            {
-                "timestamp": "2026-04-01T10:02:00.000Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "codex response item prompt"}],
-                },
-            },
-            {
-                "timestamp": "2026-04-01T10:03:00.000Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "function_call",
-                    "name": "exec_command",
-                    "call_id": "call_1",
-                },
-            },
-        ],
-    )
+def test_json_load_dataset_with_agent_trace_metadata(tmp_path):
+    trace_file = write_jsonl(tmp_path / "codex.jsonl", CODEX_AGENT_TRACE_ROWS)
 
-    out = generate_agent_traces_output(trace_file)
+    dataset = load_dataset("json", data_files=trace_file, split="train", cache_dir=str(tmp_path / "cache"))
+    row = dataset[0]
 
-    assert out["harness"] == ["codex"]
-    assert out["session_id"] == ["codex-session"]
-    assert out["prompt"] == [None]
-    assert out["sent_at"] == [None]
-    assert out["num_user_messages"] == [0]
-    assert out["num_tool_calls"] == [1]
-
-
-def test_json_generate_tables_with_claude_agent_trace_metadata(tmp_path):
-    trace_file = write_jsonl(
-        tmp_path / "claude.jsonl",
-        [
-            {
-                "timestamp": "2026-04-02T10:00:00.000Z",
-                "type": "user",
-                "sessionId": "claude-session",
-                "message": {"role": "user", "content": "claude prompt"},
-            },
-            {
-                "timestamp": "2026-04-02T10:01:00.000Z",
-                "type": "assistant",
-                "sessionId": "claude-session",
-                "message": {
-                    "role": "assistant",
-                    "content": [
-                        {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {}},
-                        {"type": "tool_use", "id": "toolu_2", "name": "Read", "input": {}},
-                    ],
-                },
-            },
-            {
-                "timestamp": "2026-04-02T10:02:00.000Z",
-                "type": "user",
-                "sessionId": "claude-session",
-                "message": {
-                    "role": "user",
-                    "content": [{"type": "tool_result", "tool_use_id": "toolu_1", "content": "done"}],
-                },
-            },
-        ],
-    )
-
-    out = generate_agent_traces_output(trace_file)
-
-    assert out["harness"] == ["claude_code"]
-    assert out["session_id"] == ["claude-session"]
-    assert out["prompt"] == ["claude prompt"]
-    assert out["sent_at"] == ["2026-04-02T10:00:00.000Z"]
-    assert out["num_user_messages"] == [1]
-    assert out["num_tool_calls"] == [2]
-
-
-def test_json_generate_tables_with_pi_agent_trace_metadata(tmp_path):
-    trace_file = write_jsonl(
-        tmp_path / "pi.jsonl",
-        [
-            {
-                "timestamp": "2026-04-03T10:00:00.000Z",
-                "type": "session",
-                "id": "pi-session",
-            },
-            {
-                "timestamp": "2026-04-03T10:01:00.000Z",
-                "type": "message",
-                "message": {"role": "user", "content": "pi prompt"},
-            },
-            {
-                "timestamp": "2026-04-03T10:02:00.000Z",
-                "type": "message",
-                "message": {
-                    "role": "assistant",
-                    "content": [
-                        {"type": "toolCall", "id": "call_1", "name": "read"},
-                        {"type": "toolCall", "id": "call_2", "name": "bash"},
-                    ],
-                },
-            },
-            {
-                "timestamp": "2026-04-03T10:03:00.000Z",
-                "type": "message",
-                "message": {"role": "toolResult", "content": [{"type": "text", "text": "done"}]},
-            },
-            {
-                "timestamp": "2026-04-03T10:04:00.000Z",
-                "type": "message",
-                "message": {"role": "user", "content": [{"type": "text", "text": "second pi prompt"}]},
-            },
-        ],
-    )
-
-    out = generate_agent_traces_output(trace_file)
-
-    assert out["harness"] == ["pi"]
-    assert out["session_id"] == ["pi-session"]
-    assert out["prompt"] == ["pi prompt"]
-    assert out["sent_at"] == ["2026-04-03T10:01:00.000Z"]
-    assert out["num_user_messages"] == [2]
-    assert out["num_tool_calls"] == [2]
-
-
-def test_json_generate_tables_with_openclaw_agent_trace_metadata(tmp_path):
-    trace_file = write_jsonl(
-        tmp_path / "openclaw.jsonl",
-        [
-            {
-                "timestamp": "2026-04-03T10:00:00.000Z",
-                "type": "session",
-                "id": "openclaw-session",
-                "cwd": "/Users/test/.openclaw/agents/main",
-            },
-            {
-                "timestamp": "2026-04-03T10:01:00.000Z",
-                "type": "message",
-                "message": {"role": "user", "content": "openclaw prompt"},
-            },
-        ],
-    )
-
-    out = generate_agent_traces_output(trace_file)
-
-    assert out["harness"] == ["openclaw"]
-    assert out["session_id"] == ["openclaw-session"]
-    assert out["prompt"] == ["openclaw prompt"]
-    assert out["sent_at"] == ["2026-04-03T10:01:00.000Z"]
-    assert out["num_user_messages"] == [1]
-    assert out["num_tool_calls"] == [0]
-
-
-def test_json_generate_tables_with_missing_agent_trace_prompt(tmp_path):
-    trace_file = write_jsonl(
-        tmp_path / "missing_prompt.jsonl",
-        [
-            {
-                "timestamp": "2026-04-04T10:00:00.000Z",
-                "type": "session_meta",
-                "payload": {"id": "codex-session"},
-            },
-            {
-                "timestamp": "2026-04-04T10:01:00.000Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": "assistant response"}],
-                },
-            },
-        ],
-    )
-
-    out = generate_agent_traces_output(trace_file)
-
-    assert out["harness"] == ["codex"]
-    assert out["session_id"] == ["codex-session"]
-    assert out["prompt"] == [None]
-    assert out["sent_at"] == [None]
-    assert out["num_user_messages"] == [0]
-    assert out["num_tool_calls"] == [0]
+    assert dataset.column_names == [
+        "harness",
+        "session_id",
+        "prompt",
+        "sent_at",
+        "num_user_messages",
+        "num_tool_calls",
+        "traces",
+        "file_path",
+    ]
+    for key, value in zip(AGENT_TRACE_FIELD_NAMES, CODEX_EXPECTED_AGENT_TRACE_FIELDS):
+        assert row[key] == value

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -301,7 +301,7 @@ def write_jsonl(path, rows):
 
 
 def generate_agent_traces_output(trace_file):
-    json_builder = Json(features=AGENT_TRACES_FEATURES, base_path="/not/a/prefix")
+    json_builder = Json(features=AGENT_TRACES_FEATURES)
     base_files = [trace_file]
     files_iterables = [[trace_file]]
     original_files = list(base_files)
@@ -472,7 +472,7 @@ def test_json_generate_tables_with_codex_agent_trace_metadata(tmp_path):
     assert "models" not in out
 
 
-def test_json_generate_tables_with_codex_response_item_prompt_fallback(tmp_path):
+def test_json_generate_tables_ignores_codex_response_item_user_without_event_msg(tmp_path):
     trace_file = write_jsonl(
         tmp_path / "codex_response_item_only.jsonl",
         [
@@ -506,9 +506,9 @@ def test_json_generate_tables_with_codex_response_item_prompt_fallback(tmp_path)
 
     assert out["harness"] == ["codex"]
     assert out["session_id"] == ["codex-session"]
-    assert out["prompt"] == ["codex response item prompt"]
-    assert out["sent_at"] == ["2026-04-01T10:02:00.000Z"]
-    assert out["num_user_messages"] == [1]
+    assert out["prompt"] == [None]
+    assert out["sent_at"] == [None]
+    assert out["num_user_messages"] == [0]
     assert out["num_tool_calls"] == [1]
 
 

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -7,7 +7,7 @@ import pytest
 from datasets import Features, Value
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
-from datasets.packaged_modules.json.json import Json, JsonConfig
+from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES, Json, JsonConfig
 
 
 @pytest.fixture
@@ -293,6 +293,25 @@ def jsonl_file_with_messages(tmp_path):
     return str(filename)
 
 
+def write_jsonl(path, rows):
+    with open(path, "w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    return str(path)
+
+
+def generate_agent_traces_output(trace_file):
+    json_builder = Json(features=AGENT_TRACES_FEATURES, base_path="/not/a/prefix")
+    base_files = [trace_file]
+    files_iterables = [[trace_file]]
+    original_files = list(base_files)
+    generator = json_builder._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    return Features.from_arrow_schema(pa_table.schema).decode_batch(pa_table.to_pydict())
+
+
 def test_config_raises_when_invalid_name() -> None:
     with pytest.raises(InvalidConfigName, match="Bad characters"):
         _ = JsonConfig(name="name-with-*-invalid-character")
@@ -386,3 +405,259 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
     )
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa_table.column_names == ["ID", "Language", "Topic"]
+
+
+def test_json_generate_tables_with_codex_agent_trace_metadata(tmp_path):
+    trace_file = write_jsonl(
+        tmp_path / "codex.jsonl",
+        [
+            {
+                "timestamp": "2026-04-01T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "codex-session"},
+            },
+            {
+                "timestamp": "2026-04-01T10:00:30.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "context-wrapped codex prompt"}],
+                },
+            },
+            {
+                "timestamp": "2026-04-01T10:01:00.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "actual codex prompt"}],
+                },
+            },
+            {
+                "timestamp": "2026-04-01T10:01:00.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "actual codex prompt"},
+            },
+            {
+                "timestamp": "2026-04-01T10:02:00.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": "call_1",
+                },
+            },
+            {
+                "timestamp": "2026-04-01T10:03:00.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "done",
+                },
+            },
+        ],
+    )
+
+    out = generate_agent_traces_output(trace_file)
+
+    assert out["harness"] == ["codex"]
+    assert out["session_id"] == ["codex-session"]
+    assert out["prompt"] == ["actual codex prompt"]
+    assert out["sent_at"] == ["2026-04-01T10:01:00.000Z"]
+    assert out["num_user_messages"] == [1]
+    assert out["num_tool_calls"] == [1]
+    assert out["file_path"] == [trace_file]
+    assert "models" not in out
+
+
+def test_json_generate_tables_with_codex_response_item_prompt_fallback(tmp_path):
+    trace_file = write_jsonl(
+        tmp_path / "codex_response_item_only.jsonl",
+        [
+            {
+                "timestamp": "2026-04-01T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "codex-session"},
+            },
+            {
+                "timestamp": "2026-04-01T10:02:00.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "codex response item prompt"}],
+                },
+            },
+            {
+                "timestamp": "2026-04-01T10:03:00.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": "call_1",
+                },
+            },
+        ],
+    )
+
+    out = generate_agent_traces_output(trace_file)
+
+    assert out["harness"] == ["codex"]
+    assert out["session_id"] == ["codex-session"]
+    assert out["prompt"] == ["codex response item prompt"]
+    assert out["sent_at"] == ["2026-04-01T10:02:00.000Z"]
+    assert out["num_user_messages"] == [1]
+    assert out["num_tool_calls"] == [1]
+
+
+def test_json_generate_tables_with_claude_agent_trace_metadata(tmp_path):
+    trace_file = write_jsonl(
+        tmp_path / "claude.jsonl",
+        [
+            {
+                "timestamp": "2026-04-02T10:00:00.000Z",
+                "type": "user",
+                "sessionId": "claude-session",
+                "message": {"role": "user", "content": "claude prompt"},
+            },
+            {
+                "timestamp": "2026-04-02T10:01:00.000Z",
+                "type": "assistant",
+                "sessionId": "claude-session",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {}},
+                        {"type": "tool_use", "id": "toolu_2", "name": "Read", "input": {}},
+                    ],
+                },
+            },
+            {
+                "timestamp": "2026-04-02T10:02:00.000Z",
+                "type": "user",
+                "sessionId": "claude-session",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "toolu_1", "content": "done"}],
+                },
+            },
+        ],
+    )
+
+    out = generate_agent_traces_output(trace_file)
+
+    assert out["harness"] == ["claude_code"]
+    assert out["session_id"] == ["claude-session"]
+    assert out["prompt"] == ["claude prompt"]
+    assert out["sent_at"] == ["2026-04-02T10:00:00.000Z"]
+    assert out["num_user_messages"] == [1]
+    assert out["num_tool_calls"] == [2]
+
+
+def test_json_generate_tables_with_pi_agent_trace_metadata(tmp_path):
+    trace_file = write_jsonl(
+        tmp_path / "pi.jsonl",
+        [
+            {
+                "timestamp": "2026-04-03T10:00:00.000Z",
+                "type": "session",
+                "id": "pi-session",
+            },
+            {
+                "timestamp": "2026-04-03T10:01:00.000Z",
+                "type": "message",
+                "message": {"role": "user", "content": "pi prompt"},
+            },
+            {
+                "timestamp": "2026-04-03T10:02:00.000Z",
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "toolCall", "id": "call_1", "name": "read"},
+                        {"type": "toolCall", "id": "call_2", "name": "bash"},
+                    ],
+                },
+            },
+            {
+                "timestamp": "2026-04-03T10:03:00.000Z",
+                "type": "message",
+                "message": {"role": "toolResult", "content": [{"type": "text", "text": "done"}]},
+            },
+            {
+                "timestamp": "2026-04-03T10:04:00.000Z",
+                "type": "message",
+                "message": {"role": "user", "content": [{"type": "text", "text": "second pi prompt"}]},
+            },
+        ],
+    )
+
+    out = generate_agent_traces_output(trace_file)
+
+    assert out["harness"] == ["pi"]
+    assert out["session_id"] == ["pi-session"]
+    assert out["prompt"] == ["pi prompt"]
+    assert out["sent_at"] == ["2026-04-03T10:01:00.000Z"]
+    assert out["num_user_messages"] == [2]
+    assert out["num_tool_calls"] == [2]
+
+
+def test_json_generate_tables_with_openclaw_agent_trace_metadata(tmp_path):
+    trace_file = write_jsonl(
+        tmp_path / "openclaw.jsonl",
+        [
+            {
+                "timestamp": "2026-04-03T10:00:00.000Z",
+                "type": "session",
+                "id": "openclaw-session",
+                "cwd": "/Users/test/.openclaw/agents/main",
+            },
+            {
+                "timestamp": "2026-04-03T10:01:00.000Z",
+                "type": "message",
+                "message": {"role": "user", "content": "openclaw prompt"},
+            },
+        ],
+    )
+
+    out = generate_agent_traces_output(trace_file)
+
+    assert out["harness"] == ["openclaw"]
+    assert out["session_id"] == ["openclaw-session"]
+    assert out["prompt"] == ["openclaw prompt"]
+    assert out["sent_at"] == ["2026-04-03T10:01:00.000Z"]
+    assert out["num_user_messages"] == [1]
+    assert out["num_tool_calls"] == [0]
+
+
+def test_json_generate_tables_with_missing_agent_trace_prompt(tmp_path):
+    trace_file = write_jsonl(
+        tmp_path / "missing_prompt.jsonl",
+        [
+            {
+                "timestamp": "2026-04-04T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "codex-session"},
+            },
+            {
+                "timestamp": "2026-04-04T10:01:00.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "assistant response"}],
+                },
+            },
+        ],
+    )
+
+    out = generate_agent_traces_output(trace_file)
+
+    assert out["harness"] == ["codex"]
+    assert out["session_id"] == ["codex-session"]
+    assert out["prompt"] == [None]
+    assert out["sent_at"] == [None]
+    assert out["num_user_messages"] == [0]
+    assert out["num_tool_calls"] == [0]


### PR DESCRIPTION
- add agent trace metadata columns: `prompt`, `sent_at`, `num_user_messages`, and `num_tool_calls`.
- extract `prompt` / `sent_at` from the first real user message for Claude Code, Pi/OpenClaw, and Codex traces.

