### PR TITLE
Fix storage_options lookup for streaming Lance datasets

### DIFF
--- a/src/datasets/packaged_modules/lance/lance.py
+++ b/src/datasets/packaged_modules/lance/lance.py
@@ -118,7 +118,7 @@ class Lance(datasets.ArrowBasedBuilder, datasets.builder._CountableBuilderMixin)
 
         splits: list[datasets.SplitGenerator] = []
         for split_name, files in data_files.items():
-            storage_options = dl_manager.download_config.storage_options.get(files[0].split("://", 0)[0] + "://")
+            storage_options = dl_manager.download_config.storage_options.get(files[0].split("://", 1)[0])
 
             lance_dataset_uris = resolve_dataset_uris(files)
             if lance_dataset_uris:


### PR DESCRIPTION
In `Lance._split_generators`, the `storage_options` lookup used `files[0].split("://", 0)[0] + "://"`, which has two bugs that compound: `split("://", 0)` does not split at all (maxsplit=0), and the `storage_options` dict is keyed by the bare scheme (`"hf"`), not `"hf://"`. The lookup therefore always returned `None`, dropping the HF token before it reached `lance.dataset` and causing 401s for streaming reads of private Lance repos (and the dataset-viewer worker path via `get_dataset_split_names`).

Use `split("://", 1)[0]` to extract the scheme, matching the key written in `DownloadConfig` and the pattern used by `sql.py:60`.

Fixes #8164.