### PR TITLE
docs(map): clarify that fn_kwargs yields a stable cache fingerprint vs closures

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3303,6 +3303,26 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 Disallow null values in the table.
             fn_kwargs (`Dict`, *optional*, defaults to `None`):
                 Keyword arguments to be passed to `function`.
+
+                Tip: prefer passing extra parameters via `fn_kwargs` over defining a
+                closure that captures them from the surrounding scope. When `function` is a
+                closure, the caching fingerprint is computed from the serialized function
+                object, which includes **all** captured variables. If any captured variable
+                has non-deterministic state across Python sessions (e.g. a UUID, a random
+                seed, or a mutable attribute of a class instance), the fingerprint will
+                differ between runs and the cache will never be reused. Passing the same
+                values through `fn_kwargs` instead keeps the fingerprint stable:
+
+                ```python
+                # Unstable fingerprint: closure captures `self`, including any
+                # non-deterministic attributes like UUIDs or random seeds.
+                ds.map(lambda x: my_fn(x, param=self.param))
+
+                # Stable fingerprint: only the explicit value is hashed.
+                ds.map(my_fn, fn_kwargs={"param": self.param})
+                ```
+
+                `functools.partial` can also be used as a stable alternative to closures.
             num_proc (`int`, *optional*, defaults to `None`):
                  The number of processes to use for multiprocessing.
                 - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
@@ -4187,7 +4207,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 This value is a good trade-off between memory usage during the processing, and processing speed.
                 Higher value makes the processing do fewer lookups, lower value consume less temporary memory while running `map`.
             fn_kwargs (`dict`, *optional*):
-                Keyword arguments to be passed to `function`.
+                Keyword arguments to be passed to `function`. Prefer this over closures
+                when the extra parameters are extracted from objects with non-deterministic
+                state, as it produces a stable cache fingerprint. See
+                [`~datasets.Dataset.map`] for a detailed explanation.
             num_proc (`int`, *optional*, defaults to `None`):
                  The number of processes to use for multiprocessing.
                 - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -573,3 +573,41 @@ def test_dependency_on_dill():
     # AttributeError: module 'dill._dill' has no attribute 'stack'
     hasher = Hasher()
     hasher.update(lambda x: x)
+
+
+def test_fn_kwargs_produces_stable_fingerprint_vs_closure():
+    """Closures that capture objects with non-deterministic state (e.g. UUIDs)
+    yield a different fingerprint on every instantiation, defeating caching.
+    Passing the same values through fn_kwargs instead keeps the fingerprint
+    stable because only the deterministic value—not the surrounding object—is
+    hashed.  See https://github.com/huggingface/datasets/issues/7986.
+    """
+    import uuid
+
+    class Config:
+        def __init__(self, multiplier):
+            self.multiplier = multiplier
+            # Simulates non-deterministic state (e.g. a logger id, a UUID, etc.)
+            self._internal_id = uuid.uuid4()
+
+    def apply_multiplier(batch, multiplier):
+        return {"x": [v * multiplier for v in batch["x"]]}
+
+    cfg1 = Config(multiplier=3)
+    cfg2 = Config(multiplier=3)  # same multiplier, different _internal_id
+
+    # Closures: the entire cfg object (including _internal_id) is serialized.
+    closure1 = lambda batch: {"x": [v * cfg1.multiplier for v in batch["x"]]}  # noqa: E731
+    closure2 = lambda batch: {"x": [v * cfg2.multiplier for v in batch["x"]]}  # noqa: E731
+    assert Hasher.hash(closure1) != Hasher.hash(closure2), (
+        "Closures capturing different Config instances should hash differently "
+        "even when the logic-relevant field (multiplier) is the same."
+    )
+
+    # fn_kwargs: only the deterministic value is hashed, not the Config object.
+    hash_kwargs1 = Hasher.hash({"multiplier": cfg1.multiplier})
+    hash_kwargs2 = Hasher.hash({"multiplier": cfg2.multiplier})
+    assert hash_kwargs1 == hash_kwargs2, (
+        "fn_kwargs dicts with the same deterministic values should always hash "
+        "identically, regardless of the surrounding object's state."
+    )


### PR DESCRIPTION
## Summary

When `Dataset.map()` or `Dataset.filter()` receives a closure that closes over an object containing non-deterministic state — for example a UUID, a random seed, or any mutable attribute of a class instance — `dill` serialises the **entire** captured object into the fingerprint.  Two calls that are logically identical but use different object instances therefore produce different fingerprints, and the computed cache is never reused.  This happens silently: no warning is emitted and the re-computation cost can be severe for large datasets.

Passing the same values through `fn_kwargs` (or `functools.partial`) avoids the problem because only the explicit, deterministic values are hashed — not the surrounding object.  The fix is already available to users today; what was missing was documentation explaining *why* the behaviour occurs and *how* to avoid it.

This PR adds a focused **Tip** block to the `fn_kwargs` parameter in `Dataset.map()` with side-by-side code examples (unstable closure vs stable `fn_kwargs`) and a back-reference in `Dataset.filter()`.  It also adds a new test (`test_fn_kwargs_produces_stable_fingerprint_vs_closure`) that pins the described behaviour and acts as a regression guard.

## Issue

Fixes #7986

## Local verification

```bash
# Linter
ruff check src/datasets/arrow_dataset.py tests/test_fingerprint.py
# All checks passed!

# New test
pytest tests/test_fingerprint.py::test_fn_kwargs_produces_stable_fingerprint_vs_closure -xvs
```

```
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
collecting ... collected 1 item

tests/test_fingerprint.py::test_fn_kwargs_produces_stable_fingerprint_vs_closure PASSED

============================== 1 passed in 0.06s ===============================
```

```bash
# Full fingerprint test suite
pytest tests/test_fingerprint.py -x -q
# 23 passed, 9 skipped in 3.14s
```

=== LOCAL_TEST_PASSED ===

## Risk

Changes are documentation-only in the library source (`arrow_dataset.py` docstrings) and a new test in `test_fingerprint.py`.  No behaviour is modified; the test asserts facts that have always been true about the `Hasher` API.  The only risk is that the Tip wording turns out to be misleading or incomplete — happy to revise based on reviewer feedback.