### PR TITLE
fix(map): fix progress bar exceeding total when load_from_cache_file=False

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3591,7 +3591,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 )
 
             pbar_total = len(self)
-            pbar_initial = len(existing_cache_files) * pbar_total // num_shards
+            num_shards_done = num_shards - len(unprocessed_kwargs_per_job)
+            pbar_initial = num_shards_done * pbar_total // num_shards
             if batched and drop_last_batch:
                 batch_size = batch_size or 1
                 pbar_initial = pbar_initial // num_shards // batch_size * num_shards * batch_size

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3500,8 +3500,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
             num_shards = min(existing_cache_file_map, key=select_existing_cache_files)
 
-        existing_cache_files = existing_cache_file_map[num_shards]
-
         def format_cache_file_name(
             cache_file_name: Optional[str],
             rank: Union[int, Literal["*"]],  # noqa: F722

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1510,6 +1510,21 @@ class BaseDatasetTest(TestCase):
             finally:
                 datasets.enable_caching()
 
+    def test_map_load_from_cache_file_false_progress_bar_starts_at_zero(self, in_memory):
+        # regression test for https://github.com/huggingface/datasets/issues/8167
+        # when load_from_cache_file=False and cache files exist on disk, pbar_initial must be 0
+        if not in_memory:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                    cache_file = os.path.join(tmp_dir, "mapped.arrow")
+                    with dset.map(lambda x: {"foo": "bar"}, cache_file_name=cache_file):
+                        pass
+                    with patch("datasets.arrow_dataset.hf_tqdm") as mock_tqdm:
+                        with dset.map(lambda x: {"foo": "bar"}, cache_file_name=cache_file, load_from_cache_file=False):
+                            pass
+                        mock_tqdm.assert_called_once()
+                        self.assertEqual(mock_tqdm.call_args.kwargs.get("initial", 0), 0)
+
     def test_suffix_template_format(self, in_memory):
         with (
             tempfile.TemporaryDirectory() as tmp_dir,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1520,7 +1520,9 @@ class BaseDatasetTest(TestCase):
                     with dset.map(lambda x: {"foo": "bar"}, cache_file_name=cache_file):
                         pass
                     with patch("datasets.arrow_dataset.hf_tqdm") as mock_tqdm:
-                        with dset.map(lambda x: {"foo": "bar"}, cache_file_name=cache_file, load_from_cache_file=False):
+                        with dset.map(
+                            lambda x: {"foo": "bar"}, cache_file_name=cache_file, load_from_cache_file=False
+                        ):
                             pass
                         mock_tqdm.assert_called_once()
                         self.assertEqual(mock_tqdm.call_args.kwargs.get("initial", 0), 0)


### PR DESCRIPTION
## Summary

When `load_from_cache_file=False`, the progress bar in `Dataset.map()` displayed a count that exceeded the dataset size (e.g. "800 examples" for a 400-row dataset). 

The bug: `pbar_initial` was computed using `len(existing_cache_files)`, which counts cache files on disk regardless of whether they would be used. With `load_from_cache_file=False`, those files exist but are ignored, yet the bar was initialized to the full dataset size as if all work was already done. The actual processing then added on top of that, pushing the counter past the total and causing tqdm to drop the percentage display entirely.

Fix: use `num_shards - len(unprocessed_kwargs_per_job)` instead, which is 0 when `load_from_cache_file=False`, so the bar starts and counts correctly.

## Issue

Fixes #8167

## Local verification

`py -3.14 -m pytest tests/test_arrow_dataset.py -k "test_map_load_from_cache_file_false_progress_bar_starts_at_zero" -v`

2 passed


## Risk

Low risk, a one-line change to how `pbar_initial` is computed. No behaviour changes outside of the progress bar display.


