### PR TITLE
Add batch(by_column=...)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4085,8 +4085,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 The column used to batch examples together.
                 Successive examples with the same value for that column are in grouped the same batch.
                 This can also be a list of columns if you want to batch by multiple columns.
-                If batching by column, the batch_size is only used to control the size of internal batches
-                during acculumation.
+                If batching by column, the batch_size is only used to control the size of the batches
+                to group together or slice during acculumation.
 
                 <Added version="4.9.0"/>
             drop_last_batch (`bool`, defaults to `False`):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -113,6 +113,7 @@ from .table import (
     InMemoryTable,
     MemoryMappedTable,
     Table,
+    _batch_accumulate_arrow_table_by_columns,
     _batch_arrow_table,
     _memory_mapped_record_batch_reader_from_file,
     cast_array_to_feature,
@@ -4063,7 +4064,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @fingerprint_transform(inplace=False)
     def batch(
         self,
-        batch_size: int,
+        batch_size: Optional[int] = None,
+        by_column: Optional[Union[str, list[str]]] = None,
         drop_last_batch: bool = False,
         num_proc: Optional[int] = None,
         new_fingerprint: Optional[str] = None,
@@ -4071,9 +4073,22 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         Group samples from the dataset into batches.
 
+        Specify either `batch_size` to make batches of `batch_size` examples.
+
+        Or use `by_column=column_name` to make batches of successive examples that share
+        the same value in column `column_name`.
+
         Args:
-            batch_size (`int`):
+            batch_size (`int`, optional):
                 The number of samples in each batch.
+            by_column (`Union[str, list[str]`, optional):
+                The column used to batch examples together.
+                Successive examples with the same value for that column are in grouped the same batch.
+                This can also be a list of columns if you want to batch by multiple columns.
+                If batching by column, the batch_size is only used to control the size of internal batches
+                during acculumation.
+
+                <Added version="4.9.0"/>
             drop_last_batch (`bool`, defaults to `False`):
                 Whether to drop the last incomplete batch.
             num_proc (`int`, *optional*, defaults to `None`):
@@ -4096,29 +4111,30 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         'label': [1, 1, 1, 1]}
         ```
         """
-
-        def batch_fn(example):
-            return {k: [v] for k, v in example.items()}
-
-        if self._format_type in ("arrow", "pandas", "polars"):
-            return self.with_format("arrow").map(
-                _batch_arrow_table,
-                batched=True,
-                batch_size=batch_size,
-                drop_last_batch=drop_last_batch,
-                num_proc=num_proc,
-                new_fingerprint=new_fingerprint,
-                desc="Batching examples",
+        if batch_size is None and by_column is None:
+            raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+        if by_column is not None:
+            if num_proc:
+                raise NotImplementedError("Multiprocessed batching by column is not implemented yet")
+            columns = [by_column] if isinstance(by_column, str) else by_column
+            _batch_fn = partial(
+                _batch_accumulate_arrow_table_by_columns, columns=columns, tables_accumulator=[], length=len(self)
             )
+            with_indices = True
+        else:
+            _batch_fn = _batch_arrow_table
+            with_indices = False
 
-        return self.map(
-            batch_fn,
+        return self.with_format("arrow").map(
+            _batch_fn,
+            with_indices=with_indices,
             batched=True,
             batch_size=batch_size,
             drop_last_batch=drop_last_batch,
             num_proc=num_proc,
             new_fingerprint=new_fingerprint,
             desc="Batching examples",
+            features=Features({col: List(feature) for col, feature in self.features.items()}),
         )
 
     @transmit_format

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -58,7 +58,14 @@ from .formatting import (
 from .info import DatasetInfo
 from .naming import _split_re
 from .splits import NamedSplit, Split, SplitInfo
-from .table import _batch_arrow_table, cast_table_to_features, embed_table_storage, read_schema_from_file, table_cast
+from .table import (
+    _batch_accumulate_arrow_table_by_columns,
+    _batch_arrow_table,
+    cast_table_to_features,
+    embed_table_storage,
+    read_schema_from_file,
+    table_cast,
+)
 from .utils import tqdm as hf_tqdm
 from .utils.logging import get_logger
 from .utils.py_utils import (
@@ -1251,6 +1258,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         formatting: Optional["FormattingConfig"] = None,
         features: Optional[Features] = None,
         max_num_running_async_map_functions_in_parallel: Optional[int] = None,
+        is_batch_accumulate_arrow_table_function: bool = False,
     ):
         super().__init__()
         self.ex_iterable = ex_iterable
@@ -1267,6 +1275,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         self.max_num_running_async_map_functions_in_parallel = (
             max_num_running_async_map_functions_in_parallel or config.MAX_NUM_RUNNING_ASYNC_MAP_FUNCTIONS_IN_PARALLEL
         )
+        self.is_batch_accumulate_arrow_table_function = is_batch_accumulate_arrow_table_function
         # sanity checks
         if formatting and formatting.is_table:
             # batch_size should match for iter_arrow
@@ -1534,6 +1543,8 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             self._state_dict["previous_state"] = self.ex_iterable.state_dict()
             self._state_dict["num_examples_since_previous_state"] = 0
         current_idx = self._state_dict["previous_state_example_idx"] if self._state_dict else 0
+        tables_accumulator: list[pa.Table] = []
+        length: Optional[int] = None
         for key, pa_table in iterator:
             if (
                 self.batched
@@ -1554,7 +1565,9 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 else:
                     function_args.append(current_idx)
             # then apply the transform
-            output = self.function(*function_args, **self.fn_kwargs)
+            output = self.function(
+                *function_args, **self.fn_kwargs, tables_accumulator=tables_accumulator, length=length
+            )
             output_table = _table_output_to_arrow(output)
             if not isinstance(output_table, pa.Table):
                 raise TypeError(
@@ -1582,10 +1595,25 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         num_examples_to_skip -= 1
                         continue
                     yield f"{key}_{i}", pa_subtable
-                if self._state_dict:
+            if self._state_dict:
+                if self.is_batch_accumulate_arrow_table_function:
+                    output_batch_size = len(output_table)
+                    if output_batch_size > 0:  # skip checkpoint if function is accumulating
+                        self._state_dict["previous_state"] = self.ex_iterable.state_dict()
+                        self._state_dict["num_examples_since_previous_state"] = 0
+                        self._state_dict["previous_state_example_idx"] = current_idx
+                else:
                     self._state_dict["previous_state"] = self.ex_iterable.state_dict()
                     self._state_dict["num_examples_since_previous_state"] = 0
                     self._state_dict["previous_state_example_idx"] += len(pa_table)
+        if tables_accumulator:
+            pa_table = tables_accumulator.pop(-1)
+            indices = [current_idx + i for i in range(len(pa_table))]
+            function_args = (pa_table, indices)
+            output_table = self.function(
+                *function_args, **self.fn_kwargs, tables_accumulator=tables_accumulator, length=indices[-1] + 1
+            )
+            yield "last_batch_from_tables_accumulator", output_table
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "MappedExamplesIterable":
         """Shuffle the wrapped examples iterable."""
@@ -3394,6 +3422,31 @@ class IterableDataset(DatasetInfoMixin):
          {'label': 1, 'text': 'Review: effective but too-tepid biopic'}]
         ```
         """
+        return self._map(
+            function=function,
+            with_indices=with_indices,
+            input_columns=input_columns,
+            batched=batched,
+            batch_size=batch_size,
+            drop_last_batch=drop_last_batch,
+            remove_columns=remove_columns,
+            features=features,
+            fn_kwargs=fn_kwargs,
+        )
+
+    def _map(
+        self,
+        function: Optional[Callable] = None,
+        with_indices: bool = False,
+        input_columns: Optional[Union[str, list[str]]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        remove_columns: Optional[Union[str, list[str]]] = None,
+        features: Optional[Features] = None,
+        fn_kwargs: Optional[dict] = None,
+        is_batch_accumulate_arrow_table_function: bool = False,
+    ) -> "IterableDataset":
         if isinstance(input_columns, str):
             input_columns = [input_columns]
         if isinstance(remove_columns, str):
@@ -3455,6 +3508,7 @@ class IterableDataset(DatasetInfoMixin):
             fn_kwargs=fn_kwargs,
             formatting=self._formatting,
             features=features,
+            is_batch_accumulate_arrow_table_function=is_batch_accumulate_arrow_table_function,
         )
         info = self.info.copy()
         info.features = features
@@ -4205,13 +4259,28 @@ class IterableDataset(DatasetInfoMixin):
             token_per_repo_id=self._token_per_repo_id,
         )
 
-    def batch(self, batch_size: int, drop_last_batch: bool = False) -> "IterableDataset":
+    def batch(
+        self,
+        batch_size: Optional[int] = None,
+        by_column: Optional[Union[str, list[str]]] = None,
+        drop_last_batch: bool = False,
+    ) -> "IterableDataset":
         """
         Group samples from the dataset into batches.
 
         Args:
-            batch_size (`int`): The number of samples in each batch.
-            drop_last_batch (`bool`, defaults to `False`): Whether to drop the last incomplete batch.
+            batch_size (`int`, optional):
+                The number of samples in each batch.
+            by_column (`Union[str, list[str]`, optional):
+                The column used to batch examples together.
+                Successive examples with the same value for that column are in grouped the same batch.
+                This can also be a list of columns if you want to batch by multiple columns.
+                If batching by column, the batch_size is only used to control the size of internal batches
+                during acculumation.
+
+                <Added version="4.9.0"/>
+            drop_last_batch (`bool`, defaults to `False`):
+                Whether to drop the last incomplete batch.
 
         Example:
         ```py
@@ -4219,11 +4288,28 @@ class IterableDataset(DatasetInfoMixin):
         >>> batched_ds = ds.batch(batch_size=32)
         ```
         """
-
+        if batch_size is None and by_column is None:
+            raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
         if self.features:
             features = Features({col: List(feature) for col, feature in self.features.items()})
         else:
             features = None
+        if by_column is not None:
+            columns = [by_column] if isinstance(by_column, str) else by_column
+            ds = (
+                self.with_format("arrow")
+                ._map(
+                    partial(_batch_accumulate_arrow_table_by_columns, columns=columns),
+                    with_indices=True,
+                    batched=True,
+                    batch_size=batch_size,
+                    drop_last_batch=drop_last_batch,
+                    features=features,
+                    is_batch_accumulate_arrow_table_function=True,
+                )
+                .with_format(self._formatting.format_type if self._formatting else None)
+            )
+            return ds
         if self._formatting and self._formatting.is_table:
             return (
                 self.with_format("arrow")

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1597,11 +1597,11 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         num_examples_to_skip -= 1
                         continue
                     yield f"{key}_{i}", pa_subtable
-            if self._state_dict:
-                self._state_dict["previous_state"] = self.ex_iterable.state_dict()
-                self._state_dict["num_examples_since_previous_state"] = 0
-                self._state_dict["previous_state_example_idx"] = current_idx
-        if tables_accumulator:
+                if self._state_dict:
+                    self._state_dict["previous_state"] = self.ex_iterable.state_dict()
+                    self._state_dict["num_examples_since_previous_state"] = 0
+                    self._state_dict["previous_state_example_idx"] = current_idx
+        if self.is_batch_accumulate_arrow_table_function and tables_accumulator:
             pa_table = tables_accumulator.pop(-1)
             indices = [current_idx + i for i in range(len(pa_table))]
             function_args = (pa_table, indices)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1543,8 +1543,12 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             self._state_dict["previous_state"] = self.ex_iterable.state_dict()
             self._state_dict["num_examples_since_previous_state"] = 0
         current_idx = self._state_dict["previous_state_example_idx"] if self._state_dict else 0
-        tables_accumulator: list[pa.Table] = []
-        length: Optional[int] = None
+        fn_kwargs = self.fn_kwargs.copy()
+        if self.is_batch_accumulate_arrow_table_function:
+            tables_accumulator: list[pa.Table] = []
+            length: Optional[int] = None
+            fn_kwargs["tables_accumulator"] = tables_accumulator
+            fn_kwargs["length"] = length
         for key, pa_table in iterator:
             if (
                 self.batched
@@ -1565,9 +1569,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 else:
                     function_args.append(current_idx)
             # then apply the transform
-            output = self.function(
-                *function_args, **self.fn_kwargs, tables_accumulator=tables_accumulator, length=length
-            )
+            output = self.function(*function_args, **fn_kwargs)
             output_table = _table_output_to_arrow(output)
             if not isinstance(output_table, pa.Table):
                 raise TypeError(
@@ -1596,16 +1598,9 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                         continue
                     yield f"{key}_{i}", pa_subtable
             if self._state_dict:
-                if self.is_batch_accumulate_arrow_table_function:
-                    output_batch_size = len(output_table)
-                    if output_batch_size > 0:  # skip checkpoint if function is accumulating
-                        self._state_dict["previous_state"] = self.ex_iterable.state_dict()
-                        self._state_dict["num_examples_since_previous_state"] = 0
-                        self._state_dict["previous_state_example_idx"] = current_idx
-                else:
-                    self._state_dict["previous_state"] = self.ex_iterable.state_dict()
-                    self._state_dict["num_examples_since_previous_state"] = 0
-                    self._state_dict["previous_state_example_idx"] += len(pa_table)
+                self._state_dict["previous_state"] = self.ex_iterable.state_dict()
+                self._state_dict["num_examples_since_previous_state"] = 0
+                self._state_dict["previous_state_example_idx"] = current_idx
         if tables_accumulator:
             pa_table = tables_accumulator.pop(-1)
             indices = [current_idx + i for i in range(len(pa_table))]
@@ -4275,8 +4270,8 @@ class IterableDataset(DatasetInfoMixin):
                 The column used to batch examples together.
                 Successive examples with the same value for that column are in grouped the same batch.
                 This can also be a list of columns if you want to batch by multiple columns.
-                If batching by column, the batch_size is only used to control the size of internal batches
-                during acculumation.
+                If batching by column, the batch_size is only used to control the size of the batches
+                to group together or slice during acculumation.
 
                 <Added version="4.9.0"/>
             drop_last_batch (`bool`, defaults to `False`):

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -78,6 +78,7 @@ def _batch_accumulate_arrow_table_by_columns(
             if any(pc.not_equal(table[column], tables_accumulator[0][column][0]).to_pylist()):
                 break
         else:
+            tables_accumulator.append(table)
             empty_batched_table = pa.Table.from_arrays(
                 [
                     pa.ListArray.from_arrays(pa.array([0], type=pa.int32()), table[column].chunk(0))

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -68,6 +68,53 @@ def _batch_arrow_table(table: pa.Table) -> pa.Table:
     return pa.Table.from_arrays(batched_columns, names=table.column_names)
 
 
+def _batch_accumulate_arrow_table_by_columns(
+    table: pa.Table, indices: list[int], columns: tuple[str], tables_accumulator: list[pa.Table], length: Optional[int]
+) -> pa.Table:
+    accumulate_last_batch = length is None or indices[-1] + 1 < length
+    # keep accumulating if key is the same, otherwise include the accumulated tables
+    if tables_accumulator and accumulate_last_batch:
+        for column in columns:
+            if any(pc.not_equal(table[column], tables_accumulator[0][column][0]).to_pylist()):
+                break
+        else:
+            empty_batched_table = pa.Table.from_arrays(
+                [
+                    pa.ListArray.from_arrays(pa.array([0], type=pa.int32()), table[column].chunk(0))
+                    for column in table.column_names
+                ],
+                names=table.column_names,
+            )
+            return empty_batched_table
+    table = pa.concat_tables(tables_accumulator + [table])
+    tables_accumulator[:] = []
+    if len(table) == 0:
+        return table
+    # cut the table per key, i.e. when the columns change value
+    if len(table) > 1:
+        cut_array = pc.not_equal(table[columns[0]][1:], table[columns[0]][:-1])
+        for column in columns[1:]:
+            cut_array = pc.or_(cut_array, pc.not_equal(table[column][1:], table[column][:-1]))
+    else:
+        cut_array = pa.array([], type=pa.uint64())
+    offsets = pc.indices_nonzero(cut_array)
+    # make the batched table
+    offsets = pc.add(1, offsets)
+    offsets = pa.concat_arrays([pa.array([0], type=pa.int32()), offsets.cast(pa.int32())])
+    if not accumulate_last_batch:
+        offsets = pa.concat_arrays([offsets, pa.array([len(table)], type=pa.int32())])
+    batched_columns = []
+    for column_name in table.column_names:
+        column = table[column_name].combine_chunks()
+        batched_columns.append(pa.ListArray.from_arrays(offsets, column))
+    batched_table = pa.Table.from_arrays(batched_columns, names=table.column_names)
+    # add the last batch to the accumulator since it might not be full yet
+    if accumulate_last_batch:
+        last_offset = offsets[-1].as_py()
+        tables_accumulator.append(table.slice(last_offset, len(table) - last_offset))
+    return batched_table
+
+
 def _memory_mapped_arrow_table_from_file(filename: str) -> pa.Table:
     opened_stream = _memory_mapped_record_batch_reader_from_file(filename)
     pa_table = opened_stream.read_all()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4832,6 +4832,116 @@ def test_dataset_batch():
     assert batches[2]["text"] == ["Text 8", "Text 9"]
 
 
+def test_dataset_batch_by_column():
+    # Create a Dataset with a column to group by
+    data = {
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "category": ["A", "A", "B", "B", "B", "C", "B", "B", "B", "B"],
+        "value": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+    }
+    ds = Dataset.from_dict(data)
+
+    # Test batching by a single column
+    batched_ds = ds.batch(by_column="category")
+    batches = list(batched_ds)
+
+    # Should have 4 batches (one for each series of the same category)
+    assert len(batches) == 4
+
+    # Check first batch (category A)
+    assert batches[0]["id"] == [1, 2]
+    assert batches[0]["category"] == ["A", "A"]
+    assert batches[0]["value"] == [10, 20]
+
+    # Check second batch (category B)
+    assert batches[1]["id"] == [3, 4, 5]
+    assert batches[1]["category"] == ["B", "B", "B"]
+    assert batches[1]["value"] == [30, 40, 50]
+
+    # Check third batch (category C)
+    assert batches[2]["id"] == [6]
+    assert batches[2]["category"] == ["C"]
+    assert batches[2]["value"] == [60]
+
+    # Check fourth batch (category B again)
+    assert batches[3]["id"] == [7, 8, 9, 10]
+    assert batches[3]["category"] == ["B", "B", "B", "B"]
+    assert batches[3]["value"] == [70, 80, 90, 100]
+
+    # Test batching by multiple columns
+    data_multi = {
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "category": ["A", "A", "B", "B", "B", "C", "B", "B", "B", "B"],
+        "subcategory": ["X", "X", "Y", "Y", "Z", "X", "Y", "Y", "Y", "Y"],
+        "value": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+    }
+    ds_multi = Dataset.from_dict(data_multi)
+
+    # Batch by both category and subcategory
+    batched_ds_multi = ds_multi.batch(by_column=["category", "subcategory"])
+    batches_multi = list(batched_ds_multi)
+
+    # Should have 4 batches (A-X, B-Y, B-Z, C-X, B-Y again)
+    assert len(batches_multi) == 5
+
+    # Check first batch (category A, subcategory X)
+    assert batches_multi[0]["id"] == [1, 2]
+    assert batches_multi[0]["category"] == ["A", "A"]
+    assert batches_multi[0]["subcategory"] == ["X", "X"]
+    assert batches_multi[0]["value"] == [10, 20]
+
+    # Check second batch (category B, subcategory Y)
+    assert batches_multi[1]["id"] == [3, 4]
+    assert batches_multi[1]["category"] == ["B", "B"]
+    assert batches_multi[1]["subcategory"] == ["Y", "Y"]
+    assert batches_multi[1]["value"] == [30, 40]
+
+    # Check third batch (category B, subcategory Z)
+    assert batches_multi[2]["id"] == [5]
+    assert batches_multi[2]["category"] == ["B"]
+    assert batches_multi[2]["subcategory"] == ["Z"]
+    assert batches_multi[2]["value"] == [50]
+
+    # Check fourth batch (category C, subcategory X)
+    assert batches_multi[3]["id"] == [6]
+    assert batches_multi[3]["category"] == ["C"]
+    assert batches_multi[3]["subcategory"] == ["X"]
+    assert batches_multi[3]["value"] == [60]
+
+    # Check fifth batch (category B, subcategory Y again)
+    assert batches_multi[4]["id"] == [7, 8, 9, 10]
+    assert batches_multi[4]["category"] == ["B", "B", "B", "B"]
+    assert batches_multi[4]["subcategory"] == ["Y", "Y", "Y", "Y"]
+    assert batches_multi[4]["value"] == [70, 80, 90, 100]
+
+    # Test batching by column with batch_size parameter
+    # Create a dataset where one category has more elements than batch_size
+    data_with_large_category = {
+        "id": list(range(1, 11)),  # 10 items
+        "category": ["A"] * 7 + ["B"] * 3,  # 7 items in category A, 3 in category B
+        "value": list(range(10, 20)),
+    }
+    ds_large_category = Dataset.from_dict(data_with_large_category)
+
+    # Batch by category with a small batch_size
+    # The batch_size should only be used for buffering, not for limiting the final batch sizes
+    batched_ds_with_buffer = ds_large_category.batch(by_column="category", batch_size=3)
+    batches_with_buffer = list(batched_ds_with_buffer)
+
+    # Should still have 2 batches (one for each category), regardless of batch_size
+    assert len(batches_with_buffer) == 2
+
+    # Check first batch (category A) - should contain all 7 items despite batch_size=3
+    assert batches_with_buffer[0]["id"] == list(range(1, 8))
+    assert batches_with_buffer[0]["category"] == ["A"] * 7
+    assert batches_with_buffer[0]["value"] == list(range(10, 17))
+
+    # Check second batch (category B) - should contain all 3 items
+    assert batches_with_buffer[1]["id"] == list(range(8, 11))
+    assert batches_with_buffer[1]["category"] == ["B"] * 3
+    assert batches_with_buffer[1]["value"] == list(range(17, 20))
+
+
 @pytest.mark.parametrize("format_type", ["pyarrow", "pandas"])
 def test_dataset_batch_with_table_format(format_type):
     ds = Dataset.from_dict({"a": [1, 2, 3, 4]})

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2790,10 +2790,11 @@ def test_resume_dataloader(dataset: IterableDataset):
     assert remaining == list(dl)
 
 
-def test_iterable_dataset_batch():
+@pytest.mark.parametrize("num_shards", [1, 2, 3, 7])
+def test_iterable_dataset_batch(num_shards: int):
     # Create a simple IterableDataset
-    data = [{"id": i, "text": f"Text {i}"} for i in range(10)]
-    ds = IterableDataset.from_generator(lambda: (x for x in data))
+    data = {"id": list(range(10)), "text": [f"Text {i}" for i in range(10)]}
+    ds = IterableDataset.from_dict(data, num_shards=num_shards)
 
     # Test with batch_size=3, drop_last_batch=False
     batched_ds = ds.batch(batch_size=3, drop_last_batch=False)
@@ -2851,6 +2852,129 @@ def test_iterable_dataset_batch():
         assert len(batch["text"]) == 3
         assert batch["id"] == [3 * i, 3 * i + 1, 3 * i + 2]
         assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
+
+
+@pytest.mark.parametrize("num_shards", [1, 2, 3, 7, 10])
+def test_iterable_dataset_batch_by_column(num_shards: int):
+    # Create a Dataset with a column to group by
+    data = {
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "category": ["A", "A", "B", "B", "B", "C", "B", "B", "B", "B"],
+        "value": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+    }
+    ds = IterableDataset.from_dict(data, num_shards=num_shards)
+
+    # Test batching by a single column
+    batched_ds = ds.batch(by_column="category")
+    batches = list(batched_ds)
+
+    # Should have 4 batches (one for each series of the same category)
+    assert len(batches) == 4
+
+    # Check first batch (category A)
+    assert batches[0]["id"] == [1, 2]
+    assert batches[0]["category"] == ["A", "A"]
+    assert batches[0]["value"] == [10, 20]
+
+    # Check second batch (category B)
+    assert batches[1]["id"] == [3, 4, 5]
+    assert batches[1]["category"] == ["B", "B", "B"]
+    assert batches[1]["value"] == [30, 40, 50]
+
+    # Check third batch (category C)
+    assert batches[2]["id"] == [6]
+    assert batches[2]["category"] == ["C"]
+    assert batches[2]["value"] == [60]
+
+    # Check fourth batch (category B again)
+    assert batches[3]["id"] == [7, 8, 9, 10]
+    assert batches[3]["category"] == ["B", "B", "B", "B"]
+    assert batches[3]["value"] == [70, 80, 90, 100]
+
+    # Test batching by multiple columns
+    data_multi = {
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "category": ["A", "A", "B", "B", "B", "C", "B", "B", "B", "B"],
+        "subcategory": ["X", "X", "Y", "Y", "Z", "X", "Y", "Y", "Y", "Y"],
+        "value": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+    }
+    ds_multi = IterableDataset.from_dict(data_multi, num_shards=num_shards)
+
+    # Batch by both category and subcategory
+    batched_ds_multi = ds_multi.batch(by_column=["category", "subcategory"])
+    batches_multi = list(batched_ds_multi)
+
+    # Should have 4 batches (A-X, B-Y, B-Z, C-X, B-Y again)
+    assert len(batches_multi) == 5
+
+    # Check first batch (category A, subcategory X)
+    assert batches_multi[0]["id"] == [1, 2]
+    assert batches_multi[0]["category"] == ["A", "A"]
+    assert batches_multi[0]["subcategory"] == ["X", "X"]
+    assert batches_multi[0]["value"] == [10, 20]
+
+    # Check second batch (category B, subcategory Y)
+    assert batches_multi[1]["id"] == [3, 4]
+    assert batches_multi[1]["category"] == ["B", "B"]
+    assert batches_multi[1]["subcategory"] == ["Y", "Y"]
+    assert batches_multi[1]["value"] == [30, 40]
+
+    # Check third batch (category B, subcategory Z)
+    assert batches_multi[2]["id"] == [5]
+    assert batches_multi[2]["category"] == ["B"]
+    assert batches_multi[2]["subcategory"] == ["Z"]
+    assert batches_multi[2]["value"] == [50]
+
+    # Check fourth batch (category C, subcategory X)
+    assert batches_multi[3]["id"] == [6]
+    assert batches_multi[3]["category"] == ["C"]
+    assert batches_multi[3]["subcategory"] == ["X"]
+    assert batches_multi[3]["value"] == [60]
+
+    # Check fifth batch (category B, subcategory Y again)
+    assert batches_multi[4]["id"] == [7, 8, 9, 10]
+    assert batches_multi[4]["category"] == ["B", "B", "B", "B"]
+    assert batches_multi[4]["subcategory"] == ["Y", "Y", "Y", "Y"]
+    assert batches_multi[4]["value"] == [70, 80, 90, 100]
+
+    # Test batching by column with batch_size parameter
+    # Create a dataset where one category has more elements than batch_size
+    data_with_large_category = {
+        "id": list(range(1, 11)),  # 10 items
+        "category": ["A"] * 7 + ["B"] * 3,  # 7 items in category A, 3 in category B
+        "value": list(range(10, 20)),
+    }
+    ds_large_category = IterableDataset.from_dict(data_with_large_category, num_shards=num_shards)
+
+    # Batch by category with a small batch_size
+    # The batch_size should only be used for buffering, not for limiting the final batch sizes
+    batched_ds_with_buffer = ds_large_category.batch(by_column="category", batch_size=3)
+    batches_with_buffer = list(batched_ds_with_buffer)
+
+    # Should still have 2 batches (one for each category), regardless of batch_size
+    assert len(batches_with_buffer) == 2
+
+    # Check first batch (category A) - should contain all 7 items despite batch_size=3
+    assert batches_with_buffer[0]["id"] == list(range(1, 8))
+    assert batches_with_buffer[0]["category"] == ["A"] * 7
+    assert batches_with_buffer[0]["value"] == list(range(10, 17))
+
+    # Check second batch (category B) - should contain all 3 items
+    assert batches_with_buffer[1]["id"] == list(range(8, 11))
+    assert batches_with_buffer[1]["category"] == ["B"] * 3
+    assert batches_with_buffer[1]["value"] == list(range(17, 20))
+
+    # Check that state_dict() / load_state_dict() works
+    for batch_size in [1, 2, 3, 7, 10, 20]:
+        assert_load_state_dict_resumes_arrow_iteration(
+            batched_ds._prepare_ex_iterable_for_iteration(batch_size=batch_size)
+        )
+        assert_load_state_dict_resumes_arrow_iteration(
+            batched_ds_multi._prepare_ex_iterable_for_iteration(batch_size=batch_size)
+        )
+        assert_load_state_dict_resumes_arrow_iteration(
+            batched_ds_with_buffer._prepare_ex_iterable_for_iteration(batch_size=batch_size)
+        )
 
 
 @pytest.mark.parametrize("format_type", ["pyarrow", "pandas"])


### PR DESCRIPTION
Will be useful for robotics dataset to batch samples by episode cc @pkooij 

example of usage:

```python
from datasets import Dataset

ds = Dataset.from_dict({"episode": [0] * 10 + [1] * 10, "frame": list(range(10)) * 2})
# ds = ds.to_iterable_dataset()
ds = ds.batch(by_column="episode")
for x in ds:
    print(x)
# {'episode': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 'frame': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
# {'episode': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 'frame': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
```

It's implemented using efficient Arrow functions for substantial speed up for Dataset and for Parquet IterableDataset.
It also supports lossless state_dict() / load_state_dict().

It works by accumulating Arrow data and grouping the batches together using `pyarrow.ListArray` in an arrow map() function.

Multiprocessing is not supported because it could split batches in two or more when distributing shards to processes (batches can overlap multiple shards). This is fine IMO since multiprocessing is only for Dataset.batch() and since the operation is unlikely to be CPU bound thanks to Arrow functions. Though this could be useful for very large datasets and clusters.

Another note when streaming: this assumes the examples of each batch should be in the same shard ! Otherwise the IterableDataset may yield multiple cuts of the same batch (one per shard containing examples of the same batch)