### PR TITLE
fix(image): guard exif_transpose against corrupted EXIF rational tags

### DIFF
--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -192,7 +192,17 @@ class Image:
             image = PIL.Image.open(BytesIO(bytes_))
         image.load()  # to avoid "Too many open files" errors
         if image.getexif().get(PIL.Image.ExifTags.Base.Orientation) is not None:
-            image = PIL.ImageOps.exif_transpose(image)
+            try:
+                image = PIL.ImageOps.exif_transpose(image)
+            except Exception:
+                # Malformed EXIF data (e.g. rational tag with denominator=0) must not
+                # kill the streaming iterator.  Return the image without orientation fix.
+                warnings.warn(
+                    f"Could not apply EXIF orientation to image {value.get('path')!r}: "
+                    "corrupted EXIF data; returning image without orientation correction.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         if self.mode and self.mode != image.mode:
             image = image.convert(self.mode)
         return image

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -113,6 +113,36 @@ def test_image_decode_example_with_exif_orientation_tag(shared_datadir):
 
 
 @require_pil
+def test_image_decode_example_with_corrupted_exif_orientation_tag(shared_datadir):
+    """Corrupted EXIF data (e.g. rational tag with denominator=0) must not raise;
+    the image should be returned without orientation correction."""
+    import warnings
+
+    import PIL.Image
+
+    image_path = str(shared_datadir / "test_image_rgb.jpg")
+    buffer = BytesIO()
+    exif = PIL.Image.Exif()
+    exif[PIL.Image.ExifTags.Base.Orientation] = 8  # rotate tag present…
+    PIL.Image.open(image_path).save(buffer, format="JPEG", exif=exif.tobytes())
+
+    image = Image()
+
+    from unittest.mock import patch
+
+    with warnings.catch_warnings(record=True) as caught, patch(
+        "PIL.ImageOps.exif_transpose", side_effect=ZeroDivisionError("denominator is zero")
+    ):
+        warnings.simplefilter("always")
+        decoded_example = image.decode_example({"path": None, "bytes": buffer.getvalue()})
+
+    assert isinstance(decoded_example, PIL.Image.Image)
+    assert decoded_example.size == (640, 480)  # NOT rotated – orientation fix was skipped
+    assert decoded_example.mode == "RGB"
+    assert any(issubclass(w.category, UserWarning) and "EXIF" in str(w.message) for w in caught)
+
+
+@require_pil
 def test_image_change_mode(shared_datadir):
     import PIL.Image
 


### PR DESCRIPTION
## Summary

When an `IterableDataset` contains images with corrupted EXIF metadata (e.g. a TIFF rational tag whose denominator is zero), `PIL.ImageOps.exif_transpose` raises `ZeroDivisionError` inside `Image.decode_example`. Because this exception escapes the internal generator frame, the streaming iterator dies immediately — calling `next()` again raises `StopIteration` rather than advancing to the next sample. This silently drops an unknown number of training examples and makes the data pipeline non-resumable without a full restart from sample 0, causing silent data repetition.

The fix wraps `PIL.ImageOps.exif_transpose` in a `try/except Exception` block. When PIL raises (for any malformed-EXIF reason), `decode_example` emits a `UserWarning` naming the affected file and returns the image without orientation correction. The exception is no longer allowed to escape `decode_example`, so the streaming iterator remains alive and iteration continues normally from the next sample.

A new test (`test_image_decode_example_with_corrupted_exif_orientation_tag`) mocks `PIL.ImageOps.exif_transpose` to raise `ZeroDivisionError` and asserts that (a) the returned image is the correct size/mode without orientation rotation and (b) a `UserWarning` containing "EXIF" is emitted.

## Issue

Fixes #8165

## Local verification

```
$ cd /tmp/datasets
$ ruff check src/datasets/features/image.py tests/features/test_image.py
All checks passed!
ruff exit: 0

$ python -m pytest tests/features/test_image.py::test_image_decode_example \
    tests/features/test_image.py::test_image_decode_example_with_exif_orientation_tag \
    tests/features/test_image.py::test_image_decode_example_with_corrupted_exif_orientation_tag \
    -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
plugins: datadir-1.8.0, anyio-4.13.0
collected 3 items

tests/features/test_image.py::test_image_decode_example PASSED
tests/features/test_image.py::test_image_decode_example_with_exif_orientation_tag PASSED
tests/features/test_image.py::test_image_decode_example_with_corrupted_exif_orientation_tag PASSED

============================== 3 passed in 0.12s ==============================
=== LOCAL_TEST_PASSED ===
```

## Risk

The `except Exception` catch is intentionally broad to cover any PIL internal error from `exif_transpose` (not just `ZeroDivisionError`), since future Pillow versions may raise different exceptions for similarly malformed data. The worst-case regression is that a genuine PIL bug in `exif_transpose` would now be silently swallowed — but this is mitigated by the `UserWarning`, which lets users notice and investigate affected samples. The happy path (well-formed EXIF) is unchanged and remains outside the try/except.
