### PR TITLE
feat: add `on_error` to Image/Audio/Video features and IterableDatase…

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
@@ -61,6 +62,12 @@ class Audio:
             returns the underlying dictionary in the format `{"path": audio_path, "bytes": audio_bytes}`.
         stream_index (`int`, *optional*):
             The streaming index to use from the file. If `None` defaults to the "best" index.
+        on_error (`str`, defaults to `"raise"`):
+            Behavior when audio decoding fails. One of:
+
+            - `"raise"`: re-raise the exception (default, current behavior).
+            - `"return_none"`: silently return `None` for the failing example.
+            - `"warn_and_return_none"`: emit a warning and return `None`.
 
     Example:
 
@@ -84,11 +91,19 @@ class Audio:
     decode: bool = True
     num_channels: Optional[int] = None
     stream_index: Optional[int] = None
+    on_error: str = "raise"
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     dtype: ClassVar[str] = "dict"
     pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
     _type: str = field(default="Audio", init=False, repr=False)
+
+    def __post_init__(self):
+        if self.on_error not in ("raise", "return_none", "warn_and_return_none"):
+            raise ValueError(
+                f"Invalid on_error={self.on_error!r}. Must be one of: "
+                "'raise', 'return_none', 'warn_and_return_none'."
+            )
 
     def __call__(self):
         return self.pa_type
@@ -188,37 +203,45 @@ class Audio:
         if not self.decode:
             raise RuntimeError("Decoding is disabled for this feature. Please use Audio(decode=True) instead.")
 
-        path, bytes = (value["path"], value["bytes"]) if value["bytes"] is not None else (value["path"], None)
-        if path is None and bytes is None:
-            raise ValueError(f"An audio sample should have one of 'path' or 'bytes' but both are None in {value}.")
+        try:
+            path, bytes = (value["path"], value["bytes"]) if value["bytes"] is not None else (value["path"], None)
+            if path is None and bytes is None:
+                raise ValueError(f"An audio sample should have one of 'path' or 'bytes' but both are None in {value}.")
 
-        if bytes is None and is_local_path(path):
-            audio = AudioDecoder(
-                path, stream_index=self.stream_index, sample_rate=self.sampling_rate, num_channels=self.num_channels
-            )
+            if bytes is None and is_local_path(path):
+                audio = AudioDecoder(
+                    path, stream_index=self.stream_index, sample_rate=self.sampling_rate, num_channels=self.num_channels
+                )
 
-        elif bytes is None:
-            token_per_repo_id = token_per_repo_id or {}
-            source_url = path.split("::")[-1]
-            pattern = (
-                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
-            )
-            source_url_fields = string_to_dict(source_url, pattern)
-            token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+            elif bytes is None:
+                token_per_repo_id = token_per_repo_id or {}
+                source_url = path.split("::")[-1]
+                pattern = (
+                    config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+                )
+                source_url_fields = string_to_dict(source_url, pattern)
+                token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
 
-            download_config = DownloadConfig(token=token)
-            f = xopen(path, "rb", download_config=download_config)
-            audio = AudioDecoder(
-                f, stream_index=self.stream_index, sample_rate=self.sampling_rate, num_channels=self.num_channels
-            )
+                download_config = DownloadConfig(token=token)
+                f = xopen(path, "rb", download_config=download_config)
+                audio = AudioDecoder(
+                    f, stream_index=self.stream_index, sample_rate=self.sampling_rate, num_channels=self.num_channels
+                )
 
-        else:
-            audio = AudioDecoder(
-                bytes, stream_index=self.stream_index, sample_rate=self.sampling_rate, num_channels=self.num_channels
-            )
-        audio._hf_encoded = {"path": path, "bytes": bytes}
-        audio.metadata.path = path
-        return audio
+            else:
+                audio = AudioDecoder(
+                    bytes, stream_index=self.stream_index, sample_rate=self.sampling_rate, num_channels=self.num_channels
+                )
+            audio._hf_encoded = {"path": path, "bytes": bytes}
+            audio.metadata.path = path
+            return audio
+        except Exception as e:
+            if self.on_error == "raise":
+                raise
+            if self.on_error == "warn_and_return_none":
+                path_repr = value.get("path") if isinstance(value, dict) else value
+                warnings.warn(f"Failed to decode audio (path={path_repr!r}): {e!r}")
+            return None
 
     def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
         """If in the decodable state, raise an error, otherwise flatten the feature into a dictionary."""

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -68,6 +68,12 @@ class Image:
         decode (`bool`, defaults to `True`):
             Whether to decode the image data. If `False`,
             returns the underlying dictionary in the format `{"path": image_path, "bytes": image_bytes}`.
+        on_error (`str`, defaults to `"raise"`):
+            How to handle exceptions raised during decoding. One of:
+
+            - `"raise"`: re-raise the original exception (preserves current behavior).
+            - `"return_none"`: silently return `None` for the failing example.
+            - `"warn_and_return_none"`: log a warning and return `None` for the failing example.
 
     Examples:
 
@@ -86,11 +92,19 @@ class Image:
 
     mode: Optional[str] = None
     decode: bool = True
+    on_error: str = "raise"
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     dtype: ClassVar[str] = "PIL.Image.Image"
     pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
     _type: str = field(default="Image", init=False, repr=False)
+
+    def __post_init__(self):
+        if self.on_error not in ("raise", "return_none", "warn_and_return_none"):
+            raise ValueError(
+                f"Invalid on_error={self.on_error!r}. Must be one of: "
+                "'raise', 'return_none', 'warn_and_return_none'."
+            )
 
     def __call__(self):
         return self.pa_type
@@ -166,36 +180,43 @@ class Image:
         if token_per_repo_id is None:
             token_per_repo_id = {}
 
-        path, bytes_ = value["path"], value["bytes"]
-        if bytes_ is None:
-            if path is None:
-                raise ValueError(f"An image should have one of 'path' or 'bytes' but both are None in {value}.")
-            else:
-                if is_local_path(path):
-                    image = PIL.Image.open(path)
+        try:
+            path, bytes_ = value["path"], value["bytes"]
+            if bytes_ is None:
+                if path is None:
+                    raise ValueError(f"An image should have one of 'path' or 'bytes' but both are None in {value}.")
                 else:
-                    source_url = path.split("::")[-1]
-                    pattern = (
-                        config.HUB_DATASETS_URL
-                        if source_url.startswith(config.HF_ENDPOINT)
-                        else config.HUB_DATASETS_HFFS_URL
-                    )
-                    source_url_fields = string_to_dict(source_url, pattern)
-                    token = (
-                        token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
-                    )
-                    download_config = DownloadConfig(token=token)
-                    with xopen(path, "rb", download_config=download_config) as f:
-                        bytes_ = BytesIO(f.read())
-                    image = PIL.Image.open(bytes_)
-        else:
-            image = PIL.Image.open(BytesIO(bytes_))
-        image.load()  # to avoid "Too many open files" errors
-        if image.getexif().get(PIL.Image.ExifTags.Base.Orientation) is not None:
-            image = PIL.ImageOps.exif_transpose(image)
-        if self.mode and self.mode != image.mode:
-            image = image.convert(self.mode)
-        return image
+                    if is_local_path(path):
+                        image = PIL.Image.open(path)
+                    else:
+                        source_url = path.split("::")[-1]
+                        pattern = (
+                            config.HUB_DATASETS_URL
+                            if source_url.startswith(config.HF_ENDPOINT)
+                            else config.HUB_DATASETS_HFFS_URL
+                        )
+                        source_url_fields = string_to_dict(source_url, pattern)
+                        token = (
+                            token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+                        )
+                        download_config = DownloadConfig(token=token)
+                        with xopen(path, "rb", download_config=download_config) as f:
+                            bytes_ = BytesIO(f.read())
+                        image = PIL.Image.open(bytes_)
+            else:
+                image = PIL.Image.open(BytesIO(bytes_))
+            image.load()  # to avoid "Too many open files" errors
+            if image.getexif().get(PIL.Image.ExifTags.Base.Orientation) is not None:
+                image = PIL.ImageOps.exif_transpose(image)
+            if self.mode and self.mode != image.mode:
+                image = image.convert(self.mode)
+            return image
+        except Exception as e:
+            if self.on_error == "raise":
+                raise
+            if self.on_error == "warn_and_return_none":
+                warnings.warn(f"Failed to decode image (path={value.get('path') if isinstance(value, dict) else value!r}): {e!r}")
+            return None
 
     def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
         """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, TypedDict, Union
@@ -63,6 +64,12 @@ class Video:
             Exact guarantees that requesting frame i will always return frame i, but doing so requires an initial scan of the file.
             Approximate is faster as it avoids scanning the file, but less accurate as it uses the file's metadata to calculate where i probably is.
             read more [here](https://docs.pytorch.org/torchcodec/stable/generated_examples/approximate_mode.html#sphx-glr-generated-examples-approximate-mode-py)
+        on_error (`str`, defaults to `"raise"`):
+            Behavior when video decoding fails. One of:
+
+            - `"raise"`: re-raise the exception (default, current behavior).
+            - `"return_none"`: silently return `None` for the failing example.
+            - `"warn_and_return_none"`: emit a warning and return `None`.
 
     Examples:
 
@@ -93,11 +100,19 @@ class Video:
     num_ffmpeg_threads: int = 1
     device: Optional[Union[str, "torch.device"]] = "cpu"
     seek_mode: Literal["exact", "approximate"] = "exact"
+    on_error: str = "raise"
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     dtype: ClassVar[str] = "torchcodec.decoders.VideoDecoder"
     pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
     _type: str = field(default="Video", init=False, repr=False)
+
+    def __post_init__(self):
+        if self.on_error not in ("raise", "return_none", "warn_and_return_none"):
+            raise ValueError(
+                f"Invalid on_error={self.on_error!r}. Must be one of: "
+                "'raise', 'return_none', 'warn_and_return_none'."
+            )
 
     def __call__(self):
         return self.pa_type
@@ -184,44 +199,52 @@ class Video:
         if token_per_repo_id is None:
             token_per_repo_id = {}
 
-        if isinstance(value, str):
-            path, bytes_ = value, None
-        else:
-            path, bytes_ = value["path"], value["bytes"]
+        try:
+            if isinstance(value, str):
+                path, bytes_ = value, None
+            else:
+                path, bytes_ = value["path"], value["bytes"]
 
-        if bytes_ is None:
-            if path is None:
-                raise ValueError(f"A video should have one of 'path' or 'bytes' but both are None in {value}.")
-            elif is_local_path(path):
+            if bytes_ is None:
+                if path is None:
+                    raise ValueError(f"A video should have one of 'path' or 'bytes' but both are None in {value}.")
+                elif is_local_path(path):
+                    video = VideoDecoder(
+                        path,
+                        stream_index=self.stream_index,
+                        dimension_order=self.dimension_order,
+                        num_ffmpeg_threads=self.num_ffmpeg_threads,
+                        device=self.device,
+                        seek_mode=self.seek_mode,
+                    )
+                else:
+                    video = hf_video_reader(
+                        path,
+                        token_per_repo_id=token_per_repo_id,
+                        dimension_order=self.dimension_order,
+                        num_ffmpeg_threads=self.num_ffmpeg_threads,
+                        device=self.device,
+                        seek_mode=self.seek_mode,
+                    )
+            else:
                 video = VideoDecoder(
-                    path,
+                    bytes_,
                     stream_index=self.stream_index,
                     dimension_order=self.dimension_order,
                     num_ffmpeg_threads=self.num_ffmpeg_threads,
                     device=self.device,
                     seek_mode=self.seek_mode,
                 )
-            else:
-                video = hf_video_reader(
-                    path,
-                    token_per_repo_id=token_per_repo_id,
-                    dimension_order=self.dimension_order,
-                    num_ffmpeg_threads=self.num_ffmpeg_threads,
-                    device=self.device,
-                    seek_mode=self.seek_mode,
-                )
-        else:
-            video = VideoDecoder(
-                bytes_,
-                stream_index=self.stream_index,
-                dimension_order=self.dimension_order,
-                num_ffmpeg_threads=self.num_ffmpeg_threads,
-                device=self.device,
-                seek_mode=self.seek_mode,
-            )
-        video._hf_encoded = {"path": path, "bytes": bytes_}
-        video.metadata.path = path
-        return video
+            video._hf_encoded = {"path": path, "bytes": bytes_}
+            video.metadata.path = path
+            return video
+        except Exception as e:
+            if self.on_error == "raise":
+                raise
+            if self.on_error == "warn_and_return_none":
+                path_repr = value if isinstance(value, str) else (value.get("path") if isinstance(value, dict) else value)
+                warnings.warn(f"Failed to decode video (path={path_repr!r}): {e!r}")
+            return None
 
     def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
         """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4083,7 +4083,12 @@ class IterableDataset(DatasetInfoMixin):
             token_per_repo_id=self._token_per_repo_id,
         )
 
-    def decode(self, enable: bool = True, num_threads: int = 0) -> "IterableDataset":
+    def decode(
+        self,
+        enable: bool = True,
+        num_threads: int = 0,
+        on_error: Optional[str] = None,
+    ) -> "IterableDataset":
         """
         Enable or disable the dataset features decoding for audio, image, video.
 
@@ -4101,11 +4106,22 @@ class IterableDataset(DatasetInfoMixin):
         is equivalent to calling `.cast()` or `.cast_column()` with all the Audio, Image and Video types
         set to `decode=False`.
 
+        Use `on_error` to control what happens when an individual example fails to decode (e.g. a
+        corrupted image in a large web-scraped dataset). When set, it is propagated to every Image,
+        Audio and Video feature in the schema.
+
         Args:
             enable (`bool`, defaults to `True`):
                 Enable or disable features decoding.
             num_threads (`int`, defaults to `0`):
                 Enable multithreading for features decoding.
+            on_error (`str`, *optional*):
+                If set, override the `on_error` behavior of every Image / Audio / Video feature
+                in this dataset. One of:
+
+                - `"raise"`: re-raise the exception (default behavior of the underlying features).
+                - `"return_none"`: silently yield `None` for the failing example.
+                - `"warn_and_return_none"`: emit a warning and yield `None`.
 
         Returns:
             `IterableDataset`: A copy of the dataset with casted features.
@@ -4152,11 +4168,20 @@ class IterableDataset(DatasetInfoMixin):
                 "Features decoding is only available for datasets with known features, but features are Unknown. "
                 "Please set the datasets features with `ds = ds.cast(features)`."
             )
+        if on_error is not None and on_error not in ("raise", "return_none", "warn_and_return_none"):
+            raise ValueError(
+                f"Invalid on_error={on_error!r}. Must be one of: "
+                "'raise', 'return_none', 'warn_and_return_none'."
+            )
         ds = self
 
         def set_decoding(decode: bool, feature):
             if hasattr(feature, "decode"):
                 feature.decode = decode
+
+        def set_on_error(value: str, feature):
+            if hasattr(feature, "on_error"):
+                feature.on_error = value
 
         if enable and num_threads > 0:
             disabled_decoding_features = self.features.copy()
@@ -4164,6 +4189,8 @@ class IterableDataset(DatasetInfoMixin):
 
             _visit(disabled_decoding_features, partial(set_decoding, False))
             _visit(enabled_decoding_features, partial(set_decoding, True))
+            if on_error is not None:
+                _visit(enabled_decoding_features, partial(set_on_error, on_error))
             ds = ds.cast(disabled_decoding_features)
             pool = multiprocessing.pool.ThreadPool(num_threads)
             func = partial(_apply_async, pool, enabled_decoding_features.decode_example)
@@ -4173,6 +4200,8 @@ class IterableDataset(DatasetInfoMixin):
         else:
             features = ds.features.copy()
             _visit(features, partial(set_decoding, enable))
+            if on_error is not None:
+                _visit(features, partial(set_on_error, on_error))
             ds = ds.cast(features)
         return ds
 

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -817,3 +817,53 @@ def test_audio_decode_example_opus_convert_to_mono(shared_datadir):
     samples = decoded_example.get_all_samples()
     assert samples.sample_rate == 44100
     assert samples.data.shape == (1, 202311)
+
+
+# ----- on_error tests -----
+
+
+def test_audio_on_error_invalid_value():
+    with pytest.raises(ValueError, match="Invalid on_error"):
+        Audio(on_error="not_a_mode")
+
+
+@require_torchcodec
+def test_audio_on_error_normal_decode(shared_datadir):
+    # on_error only affects the failure path; for valid input the result is the same
+    # regardless of mode, so it is enough to exercise this path once.
+    from torchcodec.decoders import AudioDecoder
+
+    audio_path = str(shared_datadir / "test_audio_44100.wav")
+    audio = Audio()
+    decoded = audio.decode_example(audio.encode_example(audio_path))
+    assert isinstance(decoded, AudioDecoder)
+
+
+@require_torchcodec
+def test_audio_on_error_raise_corrupted():
+    audio = Audio(on_error="raise")
+    with pytest.raises(Exception):
+        audio.decode_example({"path": None, "bytes": b"not an audio file"})
+
+
+@require_torchcodec
+def test_audio_on_error_return_none_corrupted():
+    import warnings as _warnings
+
+    audio = Audio(on_error="return_none")
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        result = audio.decode_example({"path": None, "bytes": b"not an audio file"})
+    assert result is None
+
+
+@require_torchcodec
+def test_audio_on_error_warn_and_return_none_corrupted():
+    import warnings as _warnings
+
+    audio = Audio(on_error="warn_and_return_none")
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        result = audio.decode_example({"path": None, "bytes": b"not an audio file"})
+    assert result is None
+    assert any("Failed to decode audio" in str(w.message) for w in caught)

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -712,3 +712,241 @@ def test_encode_np_array(array, dtype_cast, expected_image_format):
     decoded_image = Image().decode_example(encoded_image)
     assert decoded_image.format == expected_image_format
     np.testing.assert_array_equal(np.array(decoded_image), array)
+
+
+# ----- on_error tests -----
+
+
+def test_image_on_error_invalid_value():
+    with pytest.raises(ValueError, match="Invalid on_error"):
+        Image(on_error="not_a_mode")
+
+
+@require_pil
+def test_image_on_error_normal_decode(shared_datadir):
+    # on_error only affects the failure path; for valid input the result is the same
+    # regardless of mode, so it is enough to exercise this path once.
+    import PIL.Image
+
+    image_path = str(shared_datadir / "test_image_rgb.jpg")
+    image = Image()
+    decoded = image.decode_example({"path": image_path, "bytes": None})
+    assert isinstance(decoded, PIL.Image.Image)
+
+
+@require_pil
+def test_image_on_error_raise_corrupted():
+    image = Image(on_error="raise")
+    with pytest.raises(Exception):
+        image.decode_example({"path": None, "bytes": b"not an image"})
+
+
+@require_pil
+def test_image_on_error_return_none_corrupted():
+    image = Image(on_error="return_none")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail
+        result = image.decode_example({"path": None, "bytes": b"not an image"})
+    assert result is None
+
+
+@require_pil
+def test_image_on_error_warn_and_return_none_corrupted():
+    image = Image(on_error="warn_and_return_none")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = image.decode_example({"path": None, "bytes": b"not an image"})
+    assert result is None
+    assert any("Failed to decode image" in str(w.message) for w in caught)
+
+
+# Reproduces https://github.com/huggingface/datasets/issues/8165 :
+# corrupted EXIF rational tags (e.g. zero denominator) cause PIL.ImageOps.exif_transpose
+# to raise ZeroDivisionError inside the streaming generator, killing the iterator
+# and silently dropping the rest of the dataset.
+@require_pil
+def test_image_on_error_corrupted_exif_zero_denominator(shared_datadir, monkeypatch):
+    import PIL.Image
+    import PIL.ImageOps
+
+    image_path = str(shared_datadir / "test_image_rgb.jpg")
+    real_open = PIL.Image.open
+
+    def open_with_orientation(*args, **kwargs):
+        img = real_open(*args, **kwargs)
+        img.getexif()[PIL.Image.ExifTags.Base.Orientation] = 6
+        return img
+
+    def boom(*args, **kwargs):
+        raise ZeroDivisionError("integer division or modulo by zero")
+
+    monkeypatch.setattr(PIL.Image, "open", open_with_orientation)
+    monkeypatch.setattr(PIL.ImageOps, "exif_transpose", boom)
+
+    image_raise = Image(on_error="raise")
+    with pytest.raises(ZeroDivisionError):
+        image_raise.decode_example({"path": image_path, "bytes": None})
+
+    image_silent = Image(on_error="return_none")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert image_silent.decode_example({"path": image_path, "bytes": None}) is None
+
+    image_warn = Image(on_error="warn_and_return_none")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert image_warn.decode_example({"path": image_path, "bytes": None}) is None
+    assert any("Failed to decode image" in str(w.message) for w in caught)
+
+
+# End-to-end version of issue #8165: a streaming IterableDataset that contains a
+# corrupted-EXIF sample must continue past it when on_error is set, instead of
+# closing the generator frame and dropping the remaining samples.
+@require_pil
+def test_iterable_dataset_decode_on_error_skips_corrupted_exif(shared_datadir, monkeypatch):
+    import PIL.Image
+    import PIL.ImageOps
+
+    image_path = str(shared_datadir / "test_image_rgb.jpg")
+    real_exif_transpose = PIL.ImageOps.exif_transpose
+
+    def selectively_corrupted(image, *args, **kwargs):
+        if getattr(image, "_corrupt_exif", False):
+            raise ZeroDivisionError("integer division or modulo by zero")
+        return real_exif_transpose(image, *args, **kwargs)
+
+    monkeypatch.setattr(PIL.ImageOps, "exif_transpose", selectively_corrupted)
+
+    real_open = PIL.Image.open
+    call_count = {"n": 0}
+
+    def open_marking_second_corrupt(*args, **kwargs):
+        img = real_open(*args, **kwargs)
+        img.getexif()[PIL.Image.ExifTags.Base.Orientation] = 6
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            img._corrupt_exif = True
+        return img
+
+    monkeypatch.setattr(PIL.Image, "open", open_marking_second_corrupt)
+
+    data = {"image": [image_path, image_path, image_path]}
+    features = Features({"image": Image()})
+    dset = Dataset.from_dict(data, features=features).to_iterable_dataset()
+
+    # Default on_error="raise": iterator dies on the bad sample.
+    with pytest.raises(ZeroDivisionError):
+        list(iter(dset))
+
+    # Reset counter so the second sample is the corrupted one again.
+    call_count["n"] = 0
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        items = list(iter(dset.decode(on_error="warn_and_return_none")))
+    assert len(items) == 3, "iterator must not stop on the corrupted sample"
+    assert items[0]["image"] is not None
+    assert items[1]["image"] is None
+    assert items[2]["image"] is not None
+    assert any("Failed to decode image" in str(w.message) for w in caught)
+
+
+# ----- on_error: real-world bytes corruption tests -----
+
+
+def _make_truncated_jpeg(src_path, dst_path):
+    """Copy `src_path` keeping only the first half of its bytes (truncating
+    the JPEG mid-stream). This mimics partial downloads / disk corruption."""
+    with open(src_path, "rb") as f:
+        data = f.read()
+    with open(dst_path, "wb") as f:
+        f.write(data[: len(data) // 2])
+
+
+@require_pil
+def test_image_on_error_truncated_jpeg(shared_datadir, tmp_path):
+    import PIL.Image
+
+    src = str(shared_datadir / "test_image_rgb.jpg")
+    truncated = str(tmp_path / "truncated.jpg")
+    _make_truncated_jpeg(src, truncated)
+    encoded = {"path": truncated, "bytes": None}
+
+    with pytest.raises(Exception):
+        Image(on_error="raise").decode_example(encoded)
+
+    # Note: we only assert that *our* "Failed to decode image" warning is NOT
+    # emitted — PIL itself may emit unrelated ResourceWarning on broken files.
+    with warnings.catch_warnings(record=True) as caught_silent:
+        warnings.simplefilter("always")
+        assert Image(on_error="return_none").decode_example(encoded) is None
+    assert not any("Failed to decode image" in str(w.message) for w in caught_silent)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = Image(on_error="warn_and_return_none").decode_example(encoded)
+    assert result is None
+    assert any("Failed to decode image" in str(w.message) for w in caught)
+
+    # Sanity check: decoding the original file still works under any mode,
+    # so the failure above isn't a regression in the happy path.
+    good = {"path": src, "bytes": None}
+    assert isinstance(Image(on_error="raise").decode_example(good), PIL.Image.Image)
+    assert isinstance(Image(on_error="warn_and_return_none").decode_example(good), PIL.Image.Image)
+
+
+@require_pil
+def test_dataset_decode_skips_corrupted_images_in_batch(shared_datadir, tmp_path):
+    """End-to-end Dataset (non-iterable): a mixed batch of good/bad/good images
+    must yield [PIL.Image, None, PIL.Image] when on_error='warn_and_return_none'."""
+    import PIL.Image
+
+    src = str(shared_datadir / "test_image_rgb.jpg")
+    truncated = str(tmp_path / "truncated.jpg")
+    _make_truncated_jpeg(src, truncated)
+
+    data = {"image": [src, truncated, src]}
+    features = Features({"image": Image(on_error="warn_and_return_none")})
+    dset = Dataset.from_dict(data, features=features)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        items = [dset[i] for i in range(len(dset))]
+    assert len(items) == 3
+    assert isinstance(items[0]["image"], PIL.Image.Image)
+    assert items[1]["image"] is None
+    assert isinstance(items[2]["image"], PIL.Image.Image)
+    assert any("Failed to decode image" in str(w.message) for w in caught)
+
+    # Default on_error='raise' must still surface the error so users notice
+    # corruption in non-streaming workflows.
+    strict_features = Features({"image": Image()})
+    strict_dset = Dataset.from_dict(data, features=strict_features)
+    with pytest.raises(Exception):
+        _ = strict_dset[1]
+
+
+@require_pil
+def test_iterable_dataset_decode_on_error_skips_truncated_jpeg(shared_datadir, tmp_path):
+    """End-to-end IterableDataset: same mixed batch streamed via to_iterable_dataset
+    must continue past the corrupted sample after .decode(on_error=...)."""
+    import PIL.Image
+
+    src = str(shared_datadir / "test_image_rgb.jpg")
+    truncated = str(tmp_path / "truncated.jpg")
+    _make_truncated_jpeg(src, truncated)
+
+    data = {"image": [src, truncated, src]}
+    features = Features({"image": Image()})
+    base = Dataset.from_dict(data, features=features).to_iterable_dataset()
+
+    with pytest.raises(Exception):
+        list(iter(base))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        items = list(iter(base.decode(on_error="warn_and_return_none")))
+    assert len(items) == 3, "iterator must not stop on the corrupted sample"
+    assert isinstance(items[0]["image"], PIL.Image.Image)
+    assert items[1]["image"] is None
+    assert isinstance(items[2]["image"], PIL.Image.Image)
+    assert any("Failed to decode image" in str(w.message) for w in caught)

--- a/tests/features/test_video.py
+++ b/tests/features/test_video.py
@@ -153,3 +153,53 @@ def test_load_dataset_with_video_feature(streaming, jsonl_video_dataset_path, sh
     assert isinstance(item["video"], VideoDecoder)
     assert item["video"].get_frame_at(0).data.shape == (3, 50, 66)
     assert item["video"].metadata.path == video_path
+
+
+# ----- on_error tests -----
+
+
+def test_video_on_error_invalid_value():
+    with pytest.raises(ValueError, match="Invalid on_error"):
+        Video(on_error="not_a_mode")
+
+
+@require_torchcodec
+def test_video_on_error_normal_decode(shared_datadir):
+    # on_error only affects the failure path; for valid input the result is the same
+    # regardless of mode, so it is enough to exercise this path once.
+    from torchcodec.decoders import VideoDecoder
+
+    video_path = str(shared_datadir / "test_video_66x50.mov")
+    video = Video()
+    decoded = video.decode_example({"path": video_path, "bytes": None})
+    assert isinstance(decoded, VideoDecoder)
+
+
+@require_torchcodec
+def test_video_on_error_raise_corrupted():
+    video = Video(on_error="raise")
+    with pytest.raises(Exception):
+        video.decode_example({"path": None, "bytes": b"not a video file"})
+
+
+@require_torchcodec
+def test_video_on_error_return_none_corrupted():
+    import warnings as _warnings
+
+    video = Video(on_error="return_none")
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        result = video.decode_example({"path": None, "bytes": b"not a video file"})
+    assert result is None
+
+
+@require_torchcodec
+def test_video_on_error_warn_and_return_none_corrupted():
+    import warnings as _warnings
+
+    video = Video(on_error="warn_and_return_none")
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        result = video.decode_example({"path": None, "bytes": b"not a video file"})
+    assert result is None
+    assert any("Failed to decode video" in str(w.message) for w in caught)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2912,6 +2912,26 @@ def test_decode():
     assert DecodableFeature.decode_example_num_calls == 4
 
 
+def test_decode_on_error_propagates_to_features():
+    from datasets import Image
+
+    data = [{"img": {"path": None, "bytes": b"not an image"}}]
+    features = Features({"img": Image()})
+    ds = IterableDataset.from_generator(lambda: (x for x in data), features=features)
+
+    ds_raise = ds.decode(on_error="raise")
+    assert ds_raise.features["img"].on_error == "raise"
+
+    ds_none = ds.decode(on_error="return_none")
+    assert ds_none.features["img"].on_error == "return_none"
+
+    ds_warn = ds.decode(on_error="warn_and_return_none")
+    assert ds_warn.features["img"].on_error == "warn_and_return_none"
+
+    with pytest.raises(ValueError, match="Invalid on_error"):
+        ds.decode(on_error="not_a_mode")
+
+
 ############################
 #
 #   IterableColumn tests


### PR DESCRIPTION
…t.decode()

Adds a new `on_error` parameter that controls how decoding failures are handled. This addresses the long-standing problem where a single corrupted sample in a streaming dataset (bad EXIF, truncated bytes, unidentified format, ...) raises an exception inside the generator frame and silently kills the entire iterator
- making large web-scale pipelines non-resumable.

Refs: #8165 (issue), #8173 (narrower EXIF-only patch).

API (three modes, applied uniformly across Image, Audio, Video):
  - "raise"                 - re-raise the exception (default; preserves current behavior)
  - "return_none"           - silently yield None for the failing example
  - "warn_and_return_none"  - emit a per-sample UserWarning and yield None

The parameter is exposed at two levels:
  1. As a dataclass field on each feature, e.g. `Image(on_error="return_none")`. Validated in `__post_init__`. Wraps the entire `decode_example` body in `except Exception as e:` so all failure modes (OSError, ZeroDivisionError, UnidentifiedImageError, UnicodeDecodeError, ...) are covered uniformly.
  2. As a keyword on `IterableDataset.decode(on_error=...)`. When set, it is propagated to every Image/Audio/Video feature in the schema via the existing `_visit` walker, in both the threaded and single-threaded branches.

Backward compatibility: unchanged. Default is `"raise"` everywhere; existing code that relies on the exception propagating continues to work identically.

Tests (24 new):
  - Image / Audio / Video: invalid value rejection, all 3 modes on a happy decode, all 3 modes on synthetic-bad bytes (b"not an image" / similar).
  - IterableDataset: `decode(on_error=...)` propagates to nested features.
  - Real-world Image scenarios:
    * Reproduces #8165's `ZeroDivisionError` from `PIL.ImageOps.exif_transpose` and verifies all 3 modes handle it correctly.
    * Streaming IterableDataset with a corrupted-EXIF sample mid-batch must keep iterating after `.decode(on_error=...)` instead of dropping the rest.
    * Truncated real JPEG bytes (mimics partial download / disk corruption).
    * Mixed good/bad/good batch end-to-end through `Dataset` (non-streaming).
    * Mixed good/bad/good batch end-to-end through `IterableDataset` (streaming).