### PR TITLE
Add dtype="list" to List / Sequence / LargeList features (#8002)

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1315,6 +1315,9 @@ class List(Sequence):
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     pa_type: ClassVar[Any] = None
+    # Mirror the other feature types (Image, Audio, ...) which expose a descriptive
+    # `dtype` so downstream code can branch on `feature.dtype == "list"` — issue #8002.
+    dtype: ClassVar[str] = "list"
     _type: str = field(default="List", init=False, repr=False)
 
     def __repr__(self):
@@ -1339,6 +1342,8 @@ class LargeList:
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     pa_type: ClassVar[Any] = None
+    # See issue #8002: expose a descriptive `dtype` like the other feature types.
+    dtype: ClassVar[str] = "list"
     _type: str = field(default="LargeList", init=False, repr=False)
 
     def __repr__(self):

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -294,6 +294,21 @@ class FeaturesTest(TestCase):
         assert_features_dicts_are_synced(features)
 
 
+def test_list_sequence_largelist_dtype():
+    # Regression test for https://github.com/huggingface/datasets/issues/8002:
+    # `List`, `Sequence` (when not given a dict) and `LargeList` should expose a
+    # descriptive `dtype` like the other feature types (e.g. `Image.dtype == "PIL.Image.Image"`),
+    # so that downstream code (e.g. transformers' `run_classification.py`) can branch
+    # on `feature.dtype == "list"`.
+    assert List(Value("int64")).dtype == "list"
+    assert LargeList(Value("int64")).dtype == "list"
+    # Sequence(non_dict) returns a List under the hood, so the same check applies.
+    assert Sequence(ClassLabel(names=["No", "Yes"])).dtype == "list"
+    # Sequence(dict) intentionally returns a regular dict — not a feature class —
+    # so it has no `dtype`. Make sure we didn't accidentally change that.
+    assert isinstance(Sequence({"a": Value("int64")}), dict)
+
+
 def test_classlabel_init(tmp_path_factory):
     names = ["negative", "positive"]
     names_file = str(tmp_path_factory.mktemp("features") / "labels.txt")


### PR DESCRIPTION
Fixes #8002.

## Summary

Most feature types expose a descriptive `dtype` string:

- `Value("int64").dtype == "int64"`
- `ClassLabel(...).dtype == "int64"`
- `Array2D(...).dtype == "<element-dtype>"`
- `Image().dtype == "PIL.Image.Image"`
- `Audio().dtype == "dict"`

But `List`, `LargeList` and `Sequence(non-dict)` (which actually constructs a `List` under the hood) had no `dtype` attribute. Downstream code that branches on `feature.dtype` therefore crashes — e.g. transformers' `run_classification.py:442`:

```python
if raw_datasets["train"].features["label"].dtype == "list":
    ...
```

raises `AttributeError: 'List' object has no attribute 'dtype'`.

This PR adds `dtype: ClassVar[str] = "list"` to `List` and `LargeList`. `Sequence(dict)` intentionally returns a regular `dict` (TFDS-compat layer), so it stays unchanged.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main, expect AttributeError ---
git fetch origin main && git checkout origin/main
python - <<'PY'
from datasets import ClassLabel, Sequence, Value
features = {"text": Value("string"), "label": Sequence(ClassLabel(names=["No", "Yes"]))}
try:
    print(features["label"].dtype)
    print("NO ERROR (unexpected)")
except AttributeError as e:
    print(f"REPRO: {e}")  # Expected: 'List' object has no attribute 'dtype'
PY

# --- AFTER: this branch ---
git fetch origin pull/<PR>/head:fix && git checkout fix
python - <<'PY'
from datasets import ClassLabel, Sequence, List, Value
from datasets.features.features import LargeList
print(Sequence(ClassLabel(names=["No", "Yes"])).dtype)  # Expected: list
print(List(Value("int64")).dtype)                       # Expected: list
print(LargeList(Value("int64")).dtype)                  # Expected: list
PY
```

## What I ran locally

```
pytest tests/features/test_features.py -k "feature or List or Sequence"
# 307 passed, 142 skipped, 1 failed (pre-existing PIL import error in test_dataset_cast_to_image_features_polars, unrelated)
```

The new regression test `test_list_sequence_largelist_dtype` fails on `origin/main` with the exact `AttributeError` from the issue, and passes on this branch.

## Edge cases covered

| Input | `.dtype` |
|---|---|
| `List(Value("int64"))` | `"list"` |
| `LargeList(Value("int64"))` | `"list"` |
| `Sequence(ClassLabel(...))` | `"list"` (actually a `List` instance) |
| `Sequence({"a": Value("int64")})` | unchanged — still a regular `dict`, no `dtype` (this is the TFDS-compat path and would be a bigger semantic change) |

## Notes

- Implemented as `ClassVar[str] = "list"` so the dataclass machinery doesn't treat it as an init field.
- No public API change beyond gaining the new attribute.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed and tested by me. The reproducer was run on `origin/main` (fails) and this branch (passes); the regression test was run both ways to confirm it gates the bug.