### PR TITLE
docs: make `Dataset.map` batched example self-contained (#7703)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -248,7 +248,7 @@ The syntax for Example docstrings can look as follows:
         'Review: rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .']
 
     # process a batch of examples
-    >>> ds = ds.map(lambda example: tokenizer(example["text"]), batched=True)
+    >>> ds = ds.map(lambda batch: {"text": [t.upper() for t in batch["text"]]}, batched=True)
     # set number of processors
     >>> ds = ds.map(add_prefix, num_proc=4)
     ```

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3347,7 +3347,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
          'Review: rodriguez does a splendid job of racial profiling hollywood style--casting excellent latin actors of all ages--a trend long overdue .']
 
         # process a batch of examples
-        >>> ds = ds.map(lambda example: tokenizer(example["text"]), batched=True)
+        >>> ds = ds.map(lambda batch: {"text": [t.upper() for t in batch["text"]]}, batched=True)
         # set number of processors
         >>> ds = ds.map(add_prefix, num_proc=4)
         ```

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -952,7 +952,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
          'Review: effective but too-tepid biopic']
 
         # process a batch of examples
-        >>> ds = ds.map(lambda example: tokenizer(example["text"]), batched=True)
+        >>> ds = ds.map(lambda batch: {"text": [t.upper() for t in batch["text"]]}, batched=True)
         # set number of processors
         >>> ds = ds.map(add_prefix, num_proc=4)
         ```


### PR DESCRIPTION
Fixes #7703.

## Summary

The batched-map example in `Dataset.map`, `DatasetDict.map` and `docs/README.md` referenced `tokenizer` without defining or importing it:

```python
>>> ds = ds.map(lambda example: tokenizer(example["text"]), batched=True)
```

Users copy-pasting the snippet hit `NameError: name 'tokenizer' is not defined`, contradicting the project's documentation principle that examples should "work as expected" when copied directly (`docs/README.md` itself states this on the next paragraph).

## Fix

Replace with a self-contained lambda that demonstrates `batched=True` without dragging in a `transformers` dependency:

```python
>>> ds = ds.map(lambda batch: {"text": [t.upper() for t in batch["text"]]}, batched=True)
```

Three files updated, all in sync (the same line was duplicated):
- `src/datasets/arrow_dataset.py` (`Dataset.map` docstring)
- `src/datasets/dataset_dict.py` (`DatasetDict.map` docstring)
- `docs/README.md` (the meta-example used in the contributor guide)

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main, expect NameError ---
git fetch origin main && git checkout origin/main
python - <<'PY'
from datasets import load_dataset
ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", split="validation")
def add_prefix(example):
    example["text"] = "Review: " + example["text"]
    return example
ds = ds.map(add_prefix)
# Copy-pasted from the docstring:
ds = ds.map(lambda example: tokenizer(example["text"]), batched=True)  # NameError
PY

# --- AFTER: this branch ---
git fetch origin pull/<PR>/head:fix && git checkout fix
python - <<'PY'
from datasets import load_dataset
ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", split="validation")
def add_prefix(example):
    example["text"] = "Review: " + example["text"]
    return example
ds = ds.map(add_prefix)
ds = ds.map(lambda batch: {"text": [t.upper() for t in batch["text"]]}, batched=True)
print(ds[0]["text"])  # REVIEW: COMPASSIONATELY ...
PY
```

## What I ran locally

The new lambda was executed against a small `Dataset.from_dict` to confirm it works end-to-end. `ruff check` and `ruff format --check` are green on the changed files.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed and tested by me.