### PR TITLE
docs: fix broken WebDataset documentation link in audio/video/image dataset pages (#7699)

### DIFF
--- a/docs/source/audio_dataset.mdx
+++ b/docs/source/audio_dataset.mdx
@@ -189,4 +189,4 @@ f18b91585c4d3f3e.json
 ...
 ```
 
-For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
+For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://github.com/webdataset/webdataset).

--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -207,7 +207,7 @@ f18b91585c4d3f3e.json
 ...
 ```
 
-For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
+For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://github.com/webdataset/webdataset).
 
 ## Lance
 

--- a/docs/source/video_dataset.mdx
+++ b/docs/source/video_dataset.mdx
@@ -159,7 +159,7 @@ ed600d57fcee4f94.json
 
 You can put your videos labels/captions/features using JSON or text files for example.
 
-For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
+For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://github.com/webdataset/webdataset).
 
 Load your WebDataset and it will create on column per file suffix (here "mp4" and "json"):
 


### PR DESCRIPTION
Fixes #7699.

## Summary

The link to the WebDataset documentation in the audio, video and image dataset docs pages points to `https://webdataset.github.io/webdataset`, which returns **HTTP 404**.

The WebDataset library now lives at `https://github.com/webdataset/webdataset`, which is the canonical documentation entry point (its README links to the getting-started guide and the API docs).

Three identical occurrences of the broken link are updated:
- `docs/source/audio_dataset.mdx`
- `docs/source/video_dataset.mdx`
- `docs/source/image_dataset.mdx`

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main ---
curl -sI https://webdataset.github.io/webdataset | head -1
# Expected: HTTP/2 404

# --- AFTER: this branch (no code to run, but the new link resolves) ---
curl -sI https://github.com/webdataset/webdataset | head -1
# Expected: HTTP/2 200
```

The hosted docs at https://huggingface.co/docs/datasets/main/en/video_dataset#webdataset will pick up the new URL after the next docs build.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed by me.