### PR TITLE
Better error for sliced splits in streaming mode (`train[:10%]`, `train[:N]`) (#7721)

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1114,6 +1114,18 @@ class DatasetBuilder:
         elif split in splits_generators:
             splits_generator = splits_generators[split]
         else:
+            # Streaming requires a known dataset size to translate percentages or row
+            # indices into a slice, which we don't have until iteration. Surface that
+            # explicitly instead of the generic "Bad split" message — see issue #7721.
+            if isinstance(split, str) and "[" in split and "]" in split:
+                base_split = split[: split.index("[")]
+                if base_split in splits_generators:
+                    raise ValueError(
+                        f"Sliced splits like {split!r} (e.g. 'train[:10%]', 'train[:90000]') are not supported "
+                        f"with streaming=True because the dataset size is not known ahead of iteration. "
+                        f"Use streaming=True with split={base_split!r} and apply .skip(...) / .take(...) "
+                        f"on the resulting IterableDataset instead, or load with streaming=False."
+                    )
             raise ValueError(f"Bad split: {split}. Available splits: {list(splits_generators)}")
 
         # Create a dataset for each of the given splits

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -590,6 +590,32 @@ def test_builder_as_streaming_dataset(tmp_path):
     assert len(list(dset)) == 100
 
 
+@pytest.mark.parametrize(
+    "split",
+    ["train[0%:10%]", "train[:90000]", "train[10%]", "train[10:20]"],
+)
+def test_builder_as_streaming_dataset_rejects_slices_with_helpful_message(tmp_path, split):
+    # Regression for https://github.com/huggingface/datasets/issues/7721:
+    # `as_streaming_dataset` previously raised a generic "Bad split" message for any
+    # split string it didn't recognize (including the legitimate slice/percentage
+    # syntax that works for the non-streaming path), leaving users to guess that
+    # streaming has different semantics. Surface that explicitly with a message
+    # that points at .skip()/.take() as the streaming-friendly alternative.
+    dummy_builder = DummyGeneratorBasedBuilder(cache_dir=str(tmp_path))
+    check_streaming(dummy_builder)
+    with pytest.raises(ValueError, match=r"Sliced splits like .* are not supported with streaming=True"):
+        dummy_builder.as_streaming_dataset(split=split)
+
+
+def test_builder_as_streaming_dataset_unknown_split_keeps_generic_message(tmp_path):
+    # Splits that aren't of the form "<name>[...]" still fall through to the
+    # generic "Bad split" error.
+    dummy_builder = DummyGeneratorBasedBuilder(cache_dir=str(tmp_path))
+    check_streaming(dummy_builder)
+    with pytest.raises(ValueError, match=r"Bad split: nope\. Available splits"):
+        dummy_builder.as_streaming_dataset(split="nope")
+
+
 def _run_test_builder_streaming_works_in_subprocesses(builder):
     check_streaming(builder)
     dset = builder.as_streaming_dataset(split="train")


### PR DESCRIPTION
Fixes #7721.

## Summary

```python
load_dataset("user/dataset", split="train[0%:10%]", streaming=True)
```

raised the generic

```
ValueError: Bad split: train[0%:10%]. Available splits: ['train']
```

which makes it look like the slice syntax is malformed. The actual reason is that streaming mode doesn't know the dataset size until iteration, so percentages (`[:10%]`) and row indices (`[:90000]`) can't be translated to a slice ahead of time.

## Fix

When the split string is of the form `<known-split>[<slice>]`, raise a specific message that points at `.skip(...)` / `.take(...)` on the resulting `IterableDataset` (or `streaming=False`) as the streaming-friendly alternative. Other unrecognized splits still get the original message.

```
ValueError: Sliced splits like 'train[0%:10%]' (e.g. 'train[:10%]', 'train[:90000]') are not supported
with streaming=True because the dataset size is not known ahead of iteration.
Use streaming=True with split='train' and apply .skip(...) / .take(...) on the resulting IterableDataset
instead, or load with streaming=False.
```

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main, generic error ---
git fetch origin main && git checkout origin/main
python - <<'PY'
import json, tempfile
from datasets import load_dataset
d = tempfile.mkdtemp()
with open(d + "/data.json", "w") as f: json.dump([{"x": i} for i in range(100)], f)
try:
    load_dataset("json", data_files=[d + "/data.json"], split="train[:10%]", streaming=True)
except ValueError as e:
    print(f"BEFORE: {e}")  # Expected: "Bad split: train[:10%]. Available splits: ['train']"
PY

# --- AFTER: this branch, specific guidance ---
git fetch origin pull/<PR>/head:fix && git checkout fix
python - <<'PY'
import json, tempfile
from datasets import load_dataset
d = tempfile.mkdtemp()
with open(d + "/data.json", "w") as f: json.dump([{"x": i} for i in range(100)], f)
try:
    load_dataset("json", data_files=[d + "/data.json"], split="train[:10%]", streaming=True)
except ValueError as e:
    print(f"AFTER: {e}")  # Expected: "Sliced splits like 'train[:10%]' ... use .skip(...)/.take(...) ..."
PY
```

## What I ran locally

```
pytest tests/test_builder.py -k test_builder_as_streaming_dataset
# 6 passed
```

The four new parametrized regression cases (`train[0%:10%]`, `train[:90000]`, `train[10%]`, `train[10:20]`) fail on `origin/main` and pass on this branch. The unknown-split case (`split="nope"`) still produces the original error message — verified by a separate test.

## Notes

- This is a **diagnostic** change. The actual support for slice/percentage syntax in streaming would require knowing the dataset size, which is a bigger feature; the issue specifically asks for a clearer error.
- No public API change.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed and tested by me.