### PR TITLE
Don't infer labels from split-named directories in folder-based builders (#7880)

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -148,6 +148,14 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                         if self.config.drop_labels is None
                         else not self.config.drop_labels
                     )
+                    # If the only "labels" we inferred are the split-name directories themselves
+                    # (e.g. data is laid out as `train/file.mp3`, `test/file.mp3` with no class
+                    # subdirectories), don't promote the split names to a `label` column —
+                    # see issue #7880. Only do this when the user hasn't explicitly opted in
+                    # via drop_labels=False, since they may legitimately want labels named
+                    # after the split-level directories.
+                    if add_labels and self.config.drop_labels is None and labels.issubset(set(data_files)):
+                        add_labels = False
 
                 if add_labels:
                     logger.info("Adding the labels inferred from data directories to the dataset's features...")

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -272,6 +272,45 @@ def test_inferring_labels_from_data_dirs(data_files_with_labels_no_metadata, cac
     assert all(example["label"] in {"class0", "class1"} for _, example in generator)
 
 
+@pytest.fixture
+def data_files_with_split_dirs_no_metadata(tmp_path, auto_text_file):
+    # Files are placed directly under split-named directories (no class subdirs).
+    data_dir = tmp_path / "data_files_with_split_dirs"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    train_dir = data_dir / "train"
+    train_dir.mkdir(parents=True, exist_ok=True)
+    test_dir = data_dir / "test"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(auto_text_file, train_dir / "file0.txt")
+    shutil.copyfile(auto_text_file, test_dir / "file1.txt")
+    return DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+
+
+def test_no_label_inferred_when_directories_match_split_names(data_files_with_split_dirs_no_metadata, cache_dir):
+    # Regression for https://github.com/huggingface/datasets/issues/7880:
+    # when files are laid out under directories that match split names (no class
+    # subdirectories), `audiofolder`/`imagefolder` previously created a spurious
+    # `label` column with the split names as classes. With drop_labels=None (default),
+    # we now skip label inference in that case.
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_split_dirs_no_metadata, cache_dir=cache_dir, drop_labels=None
+    )
+    autofolder._split_generators(StreamingDownloadManager())
+    assert "label" not in autofolder.info.features
+
+
+def test_explicit_drop_labels_false_still_uses_split_dirs_as_labels(data_files_with_split_dirs_no_metadata, cache_dir):
+    # Inverse of the above: an explicit `drop_labels=False` is the user opting in
+    # to whatever directory-based labels happen to be present, so the spurious
+    # `label` column should still appear (matching the prior behavior). This
+    # guards the issue #7880 fix from over-reaching.
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_split_dirs_no_metadata, cache_dir=cache_dir, drop_labels=False
+    )
+    autofolder._split_generators(StreamingDownloadManager())
+    assert "label" in autofolder.info.features
+
+
 def test_default_folder_builder_not_usable(data_files_with_labels_no_metadata, cache_dir):
     # builder would try to access non-existing attributes of a default `BuilderConfig` class
     # as a custom one is not provided


### PR DESCRIPTION
Fixes #7880.

## Summary

When an `audiofolder`/`imagefolder`/`videofolder` dataset is laid out as

```
folder/train/file0.mp3
folder/test/file1.mp3
```

with no class subdirectories, label inference accumulates the parent directory of each file across **all splits**, ends up with `labels = {\"train\", \"test\"}`, sees `len(labels) > 1`, and adds a spurious `label` column with `ClassLabel(names=[\"test\", \"train\"])` — i.e. it treats the split names themselves as class labels.

The example dataset called out in the issue (`datasets-examples/doc-audio-4`) reproduces this directly.

## Fix

When `drop_labels=None` (the default) and the only candidate label values are exactly the split names, skip label inference. The user can still opt in to the old behavior with explicit `drop_labels=False`, which is kept by a separate regression test.

```python
if (
    add_labels
    and self.config.drop_labels is None
    and labels.issubset(set(data_files))
):
    add_labels = False
```

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main ---
git fetch origin main && git checkout origin/main
python - <<'PY'
import os, tempfile, shutil
import PIL.Image
from datasets import load_dataset
tmp = tempfile.mkdtemp()
os.makedirs(tmp + "/train"); os.makedirs(tmp + "/test")
PIL.Image.new("RGB", (4, 4), "red").save(tmp + "/train/a.png")
PIL.Image.new("RGB", (4, 4), "blue").save(tmp + "/test/b.png")
shutil.rmtree(os.path.expanduser('~/.cache/huggingface/datasets'), ignore_errors=True)
ds = load_dataset("imagefolder", data_dir=tmp)
print(ds["train"].features)  # Expected: {'image': Image(...), 'label': ClassLabel(names=['test','train'])} ❌
PY

# --- AFTER: this branch ---
git fetch origin pull/<PR>/head:fix && git checkout fix
python - <<'PY'
import os, tempfile, shutil
import PIL.Image
from datasets import load_dataset
tmp = tempfile.mkdtemp()
os.makedirs(tmp + "/train"); os.makedirs(tmp + "/test")
PIL.Image.new("RGB", (4, 4), "red").save(tmp + "/train/a.png")
PIL.Image.new("RGB", (4, 4), "blue").save(tmp + "/test/b.png")
shutil.rmtree(os.path.expanduser('~/.cache/huggingface/datasets'), ignore_errors=True)
ds = load_dataset("imagefolder", data_dir=tmp)
print(ds["train"].features)  # Expected: {'image': Image(...)}  ✓ (no spurious 'label')
PY
```

## What I ran locally

```
pytest tests/packaged_modules/test_folder_based_builder.py
# 48 passed
```

The new `test_no_label_inferred_when_directories_match_split_names` fails on `origin/main` with the spurious `ClassLabel(names=['test','train'])` and passes on this branch. The companion `test_explicit_drop_labels_false_still_uses_split_dirs_as_labels` keeps the opt-in path covered.

## Edge cases covered

| Layout | `drop_labels` | Pre-fix | Post-fix |
|---|---|---|---|
| `train/file.mp3`, `test/file.mp3` (no class dirs) | `None` (default) | spurious `label` ❌ | no `label` ✓ |
| Same layout | `False` (explicit opt-in) | `label` from split names | unchanged (still `label`) |
| `train/cat/a.png`, `train/dog/b.png` (real classes) | `None` | `label=ClassLabel(['cat','dog'])` | unchanged ✓ |

Verified end-to-end with `imagefolder` (locally constructed PNGs) for the no-class case and the cat/dog case.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed and tested by me.