### PR TITLE
docs: clarify `num_proc` semantics in `Dataset.batch` / `Dataset.filter` (#7700)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4092,7 +4092,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             drop_last_batch (`bool`, defaults to `False`):
                 Whether to drop the last incomplete batch.
             num_proc (`int`, *optional*, defaults to `None`):
-                Max number of processes when generating cache. Already cached shards are loaded sequentially.
+                The number of processes to use for multiprocessing.
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.
+                Already cached shards are loaded sequentially.
             new_fingerprint (`str`, *optional*, defaults to `None`):
                 The new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments.
@@ -4314,11 +4317,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 instead of the automatically generated one.
             disable_nullable (`bool`, defaults to `False`):
                 Allow null values in the table.
-            num_proc (`int`, optional, default `None`):
-                Max number of processes when generating cache. Already cached shards are loaded sequentially
+            num_proc (`int`, *optional*, defaults to `None`):
+                The number of processes to use for multiprocessing.
+                - If `None` or `0`, no multiprocessing is used and the operation runs in the main process.
+                - If greater than `1`, one or multiple worker processes are used to process data in parallel.
+                Already cached shards are loaded sequentially.
             new_fingerprint (`str`, *optional*, defaults to `None`):
                 The new fingerprint of the dataset after transform.
-                If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments
+                If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments.
         """
 
         return self.map(


### PR DESCRIPTION
Fixes #7700.

## Summary

`Dataset.batch.num_proc` and `Dataset.filter.num_proc` had a one-liner docstring (\"Max number of processes when generating cache. Already cached shards are loaded sequentially.\") that left readers wondering whether `None` means "no multiprocessing" or "pick a number".

Both methods simply delegate to `Dataset.map`, which already has the precise semantics:

- `None` or `0` → no multiprocessing, run in the main process
- `> 1` → one or multiple worker processes process data in parallel

This PR mirrors that wording on `batch` and `filter` so the three sibling docstrings agree, matching the actual code path (`map` already normalizes `num_proc == 0` to `None` before dispatching, and `batch`/`filter` go through `map`).

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git fetch origin pull/<PR>/head:fix
diff <(git show origin/main:src/datasets/arrow_dataset.py | sed -n '/def batch/,/def map/p' | grep -A4 num_proc | head -8) \
     <(git show fix:src/datasets/arrow_dataset.py | sed -n '/def batch/,/def map/p' | grep -A4 num_proc | head -8)
```

## What I ran locally

- `ruff check` and `ruff format --check` are green on the changed file.
- No code change, so no behavior tests.

## Notes

- No code change, only docstring text on `Dataset.batch` and `Dataset.filter`.
- The actual `num_proc == 0` → `None` normalization is already done inside `Dataset.map`; the docstring just makes that visible to readers.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed by me.