### PR TITLE
Reject `num_shards > len(dataset)` in `Dataset.shard` (#7443)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5306,6 +5306,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         if not 0 <= index < num_shards:
             raise ValueError("index should be in [0, num_shards-1]")
+        if len(self) > 0 and num_shards > len(self):
+            # Without this guard, shard indices >= len(self) silently produce empty
+            # shards (contiguous=True) or trigger an `IndexError` deep in `.select`
+            # (contiguous=False). Fail fast so callers like `push_to_hub` /
+            # `save_to_disk` surface the misuse upfront — see issue #7443.
+            # (Empty datasets are exempt: pipeline code may legitimately call
+            # `shard(1, 0)` on an empty result and expect the empty dataset back.)
+            raise ValueError(
+                f"num_shards ({num_shards}) must be smaller than or equal to the number of rows "
+                f"in the dataset ({len(self)}). Reduce num_shards or, when used through "
+                f"`push_to_hub` / `save_to_disk`, increase max_shard_size so num_shards <= len(dataset)."
+            )
         if contiguous:
             div = len(self) // num_shards
             mod = len(self) % num_shards

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2868,6 +2868,28 @@ class BaseDatasetTest(TestCase):
                 with dset.shard(num_shards=3, index=0) as dset_sharded_formatted:
                     self.assertEqual(dset_sharded_formatted.format["type"], "numpy")
 
+    def test_shard_rejects_num_shards_greater_than_len(self, in_memory):
+        # Regression for https://github.com/huggingface/datasets/issues/7443:
+        # `num_shards > len(dataset)` previously silently produced empty shards
+        # (contiguous=True) or crashed with `IndexError` deep in `.select`
+        # (contiguous=False) — and bubbled up unhelpfully through `push_to_hub`
+        # / `save_to_disk`. Fail fast with an informative ValueError.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with Dataset.from_dict({"x": [1, 2, 3]}) as dset:
+                with self._to(in_memory, tmp_dir, dset) as dset:
+                    with self.assertRaisesRegex(ValueError, r"num_shards \(10\) must be smaller"):
+                        dset.shard(num_shards=10, index=0)
+                    with self.assertRaisesRegex(ValueError, r"num_shards \(10\) must be smaller"):
+                        dset.shard(num_shards=10, index=5)
+                    with self.assertRaisesRegex(ValueError, r"num_shards \(4\) must be smaller"):
+                        dset.shard(num_shards=4, index=0, contiguous=False)
+                    # Boundary case: num_shards == len works.
+                    self.assertEqual(len(dset.shard(num_shards=3, index=0)), 1)
+                    # Empty datasets are exempt: pipeline code may legitimately call
+                    # `shard(1, 0)` on an empty result and expect the empty dataset back.
+                    with Dataset.from_dict({"x": []}) as empty:
+                        self.assertEqual(len(empty.shard(num_shards=1, index=0)), 0)
+
     def test_flatten_indices(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:


### PR DESCRIPTION
Fixes #7443.

## Summary

`Dataset.shard(num_shards=N, index=i)` with `N > len(dataset)`:
- silently produced empty shards (`contiguous=True`)
- crashed with `IndexError: Index ... out of range for dataset of size ...` deep in `.select` (`contiguous=False`)

`push_to_hub` / `save_to_disk` then surfaced this confusing IndexError after partial work was already done.

Raise an informative `ValueError` upfront. Empty datasets are exempt so pipeline code that legitimately calls `shard(1, 0)` on an empty result still works.

## Reproduce BEFORE/AFTER

```bash
# --- BEFORE: origin/main, IndexError ---
git fetch origin main && git checkout origin/main
python - <<'PY'
from datasets import Dataset
ds = Dataset.from_dict({"x": [1, 2, 3]})
ds.shard(num_shards=10, index=5)
PY

# --- AFTER: this branch, clear ValueError ---
# ValueError: num_shards (10) must be smaller than or equal to the number of rows in the dataset (3). ...
```

## What I ran

```
pytest tests/test_arrow_dataset.py -k test_shard
# 4 passed
```

The new `test_shard_rejects_num_shards_greater_than_len` covers `contiguous=True`/`False`, the boundary `num_shards == len`, and the empty-dataset exemption. Fails on `origin/main`, passes on this branch.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), tested locally.