### PR TITLE
Preserve `info.features` across `IterableDataset.map(remove_columns=...)` (#7568)

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3446,6 +3446,10 @@ class IterableDataset(DatasetInfoMixin):
             input_columns = [input_columns]
         if isinstance(remove_columns, str):
             remove_columns = [remove_columns]
+        # Track whether the caller asked for the identity map (no `function` passed)
+        # so we can carry over the original `info.features` minus `remove_columns`
+        # below — see #7568.
+        function_was_none = function is None
         if function is None:
             function = identity_func
         if fn_kwargs is None:
@@ -3507,6 +3511,16 @@ class IterableDataset(DatasetInfoMixin):
         )
         info = self.info.copy()
         info.features = features
+        # When the caller passes only `remove_columns` (no `features`, no `function`
+        # that would add columns), we can carry over the existing schema minus the
+        # dropped columns rather than blowing it away to `None` — otherwise
+        # `column_names` silently becomes `None` after `.map(remove_columns=...)`
+        # (#7568). For arbitrary-`function` calls the resulting schema is unknown
+        # ahead of iteration, so we keep the prior conservative behavior of
+        # `info.features = None` to avoid lying about the columns.
+        if features is None and function_was_none and remove_columns is not None and self.info.features is not None:
+            removed = {remove_columns} if isinstance(remove_columns, str) else set(remove_columns)
+            info.features = Features({k: v for k, v in self.info.features.items() if k not in removed})
         return IterableDataset(
             ex_iterable=ex_iterable,
             info=info,

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2335,6 +2335,31 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableD
     assert all(c not in new_dataset.column_names for c in ["id", "filepath"])
 
 
+def test_iterable_dataset_map_remove_columns_preserves_features():
+    # Regression for https://github.com/huggingface/datasets/issues/7568:
+    # `IterableDataset.map(remove_columns=[...])` (no `function`, no explicit
+    # `features`) used to overwrite `info.features` with `None`, so
+    # `column_names` silently became `None` after a column-removal map. Now
+    # we carry over the existing schema minus the dropped columns.
+    from datasets import Features, IterableDataset, Value
+
+    ds = IterableDataset.from_generator(
+        lambda: ({"text": f"hi {i}", "foo": i} for i in range(3)),
+        features=Features({"text": Value("string"), "foo": Value("int64")}),
+    )
+    out = ds.map(remove_columns=["foo"])
+    assert out.features == Features({"text": Value("string")})
+    assert out.column_names == ["text"]
+    # `remove_columns` accepts a single string too.
+    out = ds.map(remove_columns="foo")
+    assert out.column_names == ["text"]
+    # When a `function` is also passed, the resulting schema is unknown ahead
+    # of iteration, so we keep the prior conservative behavior of dropping the
+    # schema (matches existing assumptions in test_map_async etc.).
+    out = ds.map(lambda x: x, remove_columns=["foo"])
+    assert out.features is None
+
+
 def test_iterable_dataset_select_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.select_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
Fixes #7568.

## Summary

`IterableDataset.map(remove_columns=[...])` (without an explicit `features=` and without a user-provided `function`) overwrites `info.features` with `None`, so `IterableDataset.column_names` (which reads `info.features.keys()`) silently becomes `None`. The same regression bubbles up through `IterableDatasetDict.map`.

## Fix

When the caller didn't pass `function` (the identity map case), carry over the existing schema minus the dropped columns. For arbitrary-`function` calls the resulting schema is unknown ahead of iteration, so we preserve the prior conservative `info.features = None` behavior to avoid lying about the columns (this is what `test_map_async` and friends rely on).

```python
function_was_none = function is None
if function is None:
    function = identity_func
...
info.features = features
if features is None and function_was_none and remove_columns is not None and self.info.features is not None:
    removed = {remove_columns} if isinstance(remove_columns, str) else set(remove_columns)
    info.features = Features({k: v for k, v in self.info.features.items() if k not in removed})
```

## Reproduce BEFORE/AFTER

```bash
# --- BEFORE: origin/main, column_names becomes None ---
git fetch origin main && git checkout origin/main
python - <<'PY'
from datasets import IterableDataset, IterableDatasetDict, Features, Value
ds = IterableDataset.from_generator(
    lambda: ({"text": f"hi {i}", "foo": i} for i in range(3)),
    features=Features({"text": Value("string"), "foo": Value("int64")}),
)
dd = IterableDatasetDict({"train": ds})
print(dd.map(remove_columns=["foo"])["train"].column_names)  # Expected: None
PY

# --- AFTER: this branch ---
# Expected: ['text']
```

## What I ran

```
pytest tests/test_iterable_dataset.py -k "map"
# 78 passed
```

The new `test_iterable_dataset_map_remove_columns_preserves_features` covers identity-map + `remove_columns`, the `remove_columns="foo"` (single string) variant, and the explicit-function case (which still gets `features=None`). Fails on `origin/main`, passes on this branch.

## Notes

- Doesn't address the broader case where the user passes a function that doesn't change the schema — that requires runtime inference which the iterable code already avoids by design.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), tested locally.