### PR TITLE
fix parquet reshard

### DIFF
--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -161,7 +161,7 @@ class Parquet(datasets.ArrowBasedBuilder):
                 }
 
     def _generate_more_gen_kwargs(self, files, row_groups_list):
-        if not row_groups_list:
+        if not row_groups_list or any(row_group is None for row_group in row_groups_list):
             parquet_file_format = ds.ParquetFileFormat(default_fragment_scan_options=self.config.fragment_scan_options)
             for file in files:
                 with open(file, "rb") as f:
@@ -195,7 +195,7 @@ class Parquet(datasets.ArrowBasedBuilder):
                     fragment_is_closed = False
                     try:
                         if row_groups is not None:
-                            parquet_fragment.subset(row_group_ids=row_groups)
+                            parquet_fragment = parquet_fragment.subset(row_group_ids=row_groups)
                         if parquet_fragment.row_groups:
                             batch_size = self.config.batch_size or parquet_fragment.row_groups[0].num_rows
                             for batch_idx, record_batch in enumerate(

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -348,6 +348,26 @@ def parquet_path(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def multi_row_groups_parquet_path(tmp_path_factory):
+    num_row_groups = 4
+    path = str(tmp_path_factory.mktemp("data") / "multi_row_groups_dataset.parquet")
+    schema = pa.schema(
+        {
+            "col_1": pa.string(),
+            "col_2": pa.int64(),
+            "col_3": pa.float64(),
+        }
+    )
+    with open(path, "wb") as f:
+        writer = pq.ParquetWriter(f, schema=schema)
+        pa_table = pa.Table.from_pydict({k: [DATA[i][k] for i in range(len(DATA))] for k in DATA[0]}, schema=schema)
+        for _ in range(num_row_groups):
+            writer.write_table(pa_table)
+        writer.close()
+    return path
+
+
+@pytest.fixture(scope="session")
 def geoparquet_path(tmp_path_factory):
     df = pd.read_parquet(path="https://github.com/opengeospatial/geoparquet/raw/v1.0.0/examples/example.parquet")
     path = str(tmp_path_factory.mktemp("data") / "dataset.geoparquet")

--- a/tests/packaged_modules/test_parquet.py
+++ b/tests/packaged_modules/test_parquet.py
@@ -1,5 +1,6 @@
 import pytest
 
+from datasets import load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.packaged_modules.parquet.parquet import ParquetConfig
@@ -14,3 +15,12 @@ def test_config_raises_when_invalid_name() -> None:
 def test_config_raises_when_invalid_data_files(data_files) -> None:
     with pytest.raises(ValueError, match="Expected a DataFilesDict"):
         _ = ParquetConfig(name="name", data_files=data_files)
+
+
+def test_parquet_reshard(multi_row_groups_parquet_path):
+    ds = load_dataset("parquet", data_files=multi_row_groups_parquet_path, split="train", streaming=True)
+    assert ds.num_shards == 1
+    expected = list(ds)
+    resharded_ds = ds.reshard()
+    assert resharded_ds.num_shards == 4
+    assert list(resharded_ds) == expected


### PR DESCRIPTION
.reshard() would not do anything and return the same iterable dataset for parquet, now it returns the resharded iterable dataset - sharded per row group instead of per file