### PR TITLE
Use multiple input shards for shuffle buffer

### DIFF
--- a/docs/source/about_mapstyle_vs_iterable.mdx
+++ b/docs/source/about_mapstyle_vs_iterable.mdx
@@ -134,7 +134,7 @@ for example in my_iterable_dataset:
     break
 ```
 
-But using a shuffle buffer is not enough to provide a satisfactory shuffling for machine learning model training. So [`IterableDataset.shuffle`] also shuffles the dataset shards if your dataset is made of multiple files or sources:
+But using a shuffle buffer is not enough to provide a satisfactory shuffling for machine learning model training. So [`IterableDataset.shuffle`] also shuffles the dataset shards if your dataset is made of multiple files or sources. Additionally, it fills the buffer using up to `max_buffer_input_shards` shards at a time (default is 10), which greatly improves the quality of the shuffling:
 
 ```python
 # Stream from the internet
@@ -156,6 +156,10 @@ gen_kwargs = {"n": 10, "sources": [f"path/to/data_{i}" for i in range(1024)]}
 my_iterable_dataset = IterableDataset.from_generator(my_generator, gen_kwargs=gen_kwargs)
 my_iterable_dataset.num_shards  # 1024
 ```
+
+> [!TIP]
+>
+> If your dataset has few files, you can improve shuffling quality by calling [`~IterableDataset.reshard`] before shuffling. For example, for Parquet datasets this reshards using row groups instead of having one file per shard, giving you many more shards to shuffle from.
 
 ## Speed differences
 

--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -115,7 +115,11 @@ The `buffer_size` argument controls the size of the buffer to randomly sample ex
 
 > [!TIP]
 > 
-> [`IterableDataset.shuffle`] will also shuffle the order of the shards if the dataset is sharded into multiple files.
+> [`IterableDataset.shuffle`] fills the buffer using up to `max_buffer_input_shards` shards at a time (default is 10), which greatly improves the quality of the shuffling. It also shuffles the order of the shards if the dataset is sharded into multiple files.
+
+> [!TIP]
+>
+> If you're streaming a Parquet dataset with only one or few files, use [`~IterableDataset.reshard`] before shuffling. This is useful to shard the dataset by row group instead of by file, improving shuffling quality.
 
 ## Reshuffle
 

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -297,6 +297,9 @@ class DatasetBuilder:
     # None means that the ArrowWriter will use its default value
     DEFAULT_WRITER_BATCH_SIZE = None
 
+    # Useful to make sure PyArrow threads in c++ have time to shut down before gargabe collection
+    SLEEP_ON_THREADS_SHUTDOWNS = False
+
     def __init__(
         self,
         cache_dir: Optional[str] = None,
@@ -1850,6 +1853,7 @@ class ArrowBasedBuilder(DatasetBuilder):
             self._generate_tables,
             kwargs=split_generator.gen_kwargs,
             generate_more_kwargs_fn=getattr(self, "_generate_more_gen_kwargs", None),
+            sleep_on_threads_shutdown=self.SLEEP_ON_THREADS_SHUTDOWNS,
         )
 
 

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -270,3 +270,6 @@ UPLOADS_MAX_NUMBER_PER_COMMIT = 50
 
 # Backward compatibility
 MAX_TABLE_NBYTES_FOR_PICKLING = 4 << 30
+
+# Time to let PyArrow close threads gracefully
+SLEEP_TIME_ON_THREADS_SHUTDOWN = 5

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3602,7 +3602,7 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def shuffle(
-        self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000
+        self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000, max_buffer_input_shards: int = 10,
     ) -> "IterableDataset":
         """
         Randomly shuffles the elements of this dataset.
@@ -3616,9 +3616,11 @@ class IterableDataset(DatasetInfoMixin):
         selected, its space in the buffer is replaced by the next (i.e. 1,001-st) element,
         maintaining the 1000 element buffer.
 
-        If the dataset is made of several shards, it also does shuffle the order of the shards.
-        However if the order has been fixed by using [`~datasets.IterableDataset.skip`] or [`~datasets.IterableDataset.take`]
-        then the order of the shards is kept unchanged.
+        If the dataset is made of several shards, it fills the buffer using up to `max_buffer_input_shards` shards
+        at a time and also does shuffle the order of the shards. This greatly improves the quality of the shuffling.
+
+        However if the order has been fixed by using [`~datasets.IterableDataset.skip`]
+        or [`~datasets.IterableDataset.take`] then the order of the shards is kept unchanged.
 
         Args:
             seed (`int`, *optional*, defaults to `None`):
@@ -3629,6 +3631,8 @@ class IterableDataset(DatasetInfoMixin):
                 If `generator=None` (default), uses `np.random.default_rng` (the default BitGenerator (PCG64) of NumPy).
             buffer_size (`int`, defaults to `1000`):
                 Size of the buffer.
+            max_buffer_input_shards (`int`, defaults to `101000`):
+                Maximum number of shards to use to feed the buffer at a time.
 
         Example:
 
@@ -3636,33 +3640,46 @@ class IterableDataset(DatasetInfoMixin):
         >>> from datasets import load_dataset
         >>> ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train", streaming=True)
         >>> list(ds.take(3))
-        [{'label': 1,
-         'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'},
-         {'label': 1,
-         'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .'},
-         {'label': 1, 'text': 'effective but too-tepid biopic'}]
+        [{'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .',
+         'label': 1},
+         {'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .',
+         'label': 1},
+         {'text': 'effective but too-tepid biopic', 'label': 1}]
         >>> shuffled_ds = ds.shuffle(seed=42)
         >>> list(shuffled_ds.take(3))
-        [{'label': 1,
-         'text': "a sports movie with action that's exciting on the field and a story you care about off it ."},
-         {'label': 1,
-         'text': 'at its best , the good girl is a refreshingly adult take on adultery . . .'},
-         {'label': 1,
-         'text': "sam jones became a very lucky filmmaker the day wilco got dropped from their record label , proving that one man's ruin may be another's fortune ."}]
+        [{'text': "a sports movie with action that's exciting on the field and a story you care about off it .",
+         'label': 1},
+         {'text': 'at its best , the good girl is a refreshingly adult take on adultery . . .',
+         'label': 1},
+         {'text': "sam jones became a very lucky filmmaker the day wilco got dropped from their record label , proving that one man's ruin may be another's fortune .",
+         'label': 1}]
+        >>> resharded_ds = ds.reshard()  # useful to shard Parquet datasets by row group instead of by file, improving shuffling quality on dataset with one or few files.
+        >>> shuffled_resharded_ds = resharded_ds.shuffle(seed=42)
+        >>> list(shuffled_resharded_ds.take(3))
+        [{'text': 'this mistaken-identity picture is so film-culture referential that the final product is a ghost .',
+         'label': 0},
+         {'text': 'woody allen used to ridicule movies like hollywood ending . now he makes them .',
+         'label': 0},
+         {'text': "not only is undercover brother as funny , if not more so , than both austin powers films , but it's also one of the smarter , savvier spoofs to come along in some time .",
+         'label': 1}]
         ```
         """
         if generator is None:
             generator = np.random.default_rng(seed)
         else:
             generator = deepcopy(generator)
+        ex_iterable = self._ex_iterable.shuffle_data_sources(generator)
+        if ex_iterable.iter_arrow:
+            ex_iterable = RebatchedArrowExamplesIterable(ex_iterable, batch_size=1)
+        if max_buffer_input_shards > 1:
+            num_shards_to_interleave = min(ex_iterable.num_shards, max_buffer_input_shards)
+            ex_iterable = CyclingMultiSourcesExamplesIterable(
+                [ex_iterable.shard_data_sources(num_shards=num_shards_to_interleave, index=index) for index in range(num_shards_to_interleave)],
+                stopping_strategy="all_exhausted_without_replacement",
+            )
+        ex_iterable = BufferShuffledExamplesIterable(ex_iterable, buffer_size=buffer_size, generator=generator)
         return IterableDataset(
-            BufferShuffledExamplesIterable(
-                RebatchedArrowExamplesIterable(self._ex_iterable.shuffle_data_sources(generator), batch_size=1)
-                if self._ex_iterable.iter_arrow
-                else self._ex_iterable.shuffle_data_sources(generator),
-                buffer_size=buffer_size,
-                generator=generator,
-            ),
+            ex_iterable,
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -7,6 +7,7 @@ import multiprocessing.pool
 import re
 import sys
 import tempfile
+import time
 from collections import Counter
 from collections.abc import Iterable, Iterator
 from copy import copy, deepcopy
@@ -102,29 +103,6 @@ Key = Union[int, str, tuple[int, int], "BuilderKey"]
 
 def identity_func(x):
     return x
-
-
-def _copy_state_dict(state_dict: dict) -> dict:
-    return deepcopy(state_dict)
-
-    def _copy_item(item):
-        if isinstance(item, dict):
-            # no need to copy the current state since we use the previous one anyways
-            uses_previous_state_only = (
-                item.get("previous_states") is not None or item.get("previous_state") is not None
-            )
-            return {
-                k: ([None] * len(v) if isinstance(v, list) else None)
-                if uses_previous_state_only and k == "ex_iterable" or k == "ex_iterabkes"
-                else _copy_item(v)
-                for k, v in item.items()
-            }
-        if isinstance(item, list):
-            return [_copy_item(x) for x in item]
-        else:
-            return item
-
-    return _copy_item(state_dict)
 
 
 def _rename_columns_fn(example: dict, column_mapping: dict[str, str]):
@@ -296,8 +274,16 @@ class _BaseExamplesIterable:
 
     def state_dict(self) -> dict:
         if self._state_dict:
-            return _copy_state_dict(self._state_dict)
+            return deepcopy(self._state_dict)
         raise RuntimeError("State dict is not initialized, please call ex_iterable._init_state_dict() first.")
+
+    @property
+    def sleep_on_threads_shutdown(self):
+        if hasattr(self, "_sleep_on_threads_shutdown"):
+            return self._sleep_on_threads_shutdown
+        else:
+            ex_iterables = [self.ex_iterable] if hasattr(self, "ex_iterable") else self.ex_iterables
+            return any(ex_iterable.sleep_on_threads_shutdown for ex_iterable in ex_iterables)
 
 
 class ExamplesIterable(_BaseExamplesIterable):
@@ -306,6 +292,7 @@ class ExamplesIterable(_BaseExamplesIterable):
         generate_examples_fn: Callable[..., Iterator[tuple[Key, dict]]],
         kwargs: dict,
         generate_more_kwargs_fn: Optional[Callable[..., Iterator[dict]]] = None,
+        sleep_on_threads_shutdown: bool = False,
     ):
         super().__init__()
         self.generate_examples_fn = generate_examples_fn
@@ -313,6 +300,9 @@ class ExamplesIterable(_BaseExamplesIterable):
 
         # for resharding
         self.generate_more_kwargs_fn = generate_more_kwargs_fn
+
+        # for threads shutdowns
+        self._sleep_on_threads_shutdown = sleep_on_threads_shutdown
 
     def _init_state_dict(self) -> dict:
         self._state_dict = {"shard_idx": 0, "shard_example_idx": 0, "type": self.__class__.__name__}
@@ -335,6 +325,7 @@ class ExamplesIterable(_BaseExamplesIterable):
             self.generate_examples_fn,
             _shuffle_gen_kwargs(deepcopy(generator), self.kwargs),
             self.generate_more_kwargs_fn,
+            self.sleep_on_threads_shutdown,
         )
 
     def shard_data_sources(self, num_shards: int, index: int, contiguous=True) -> "ExamplesIterable":
@@ -342,12 +333,19 @@ class ExamplesIterable(_BaseExamplesIterable):
         gen_kwargs_list = _split_gen_kwargs(self.kwargs, max_num_jobs=self.num_shards)
         shard_indices = self.split_shard_indices_by_worker(num_shards, index, contiguous=contiguous)
         requested_gen_kwargs = _merge_gen_kwargs([gen_kwargs_list[i] for i in shard_indices])
-        return ExamplesIterable(self.generate_examples_fn, requested_gen_kwargs, self.generate_more_kwargs_fn)
+        return ExamplesIterable(
+            self.generate_examples_fn,
+            requested_gen_kwargs,
+            self.generate_more_kwargs_fn,
+            self.sleep_on_threads_shutdown,
+        )
 
     def reshard_data_sources(self) -> "ExamplesIterable":
         """Split shars into more shards if possible."""
         if not self.generate_more_kwargs_fn:
-            return ExamplesIterable(self.generate_examples_fn, self.kwargs, self.generate_more_kwargs_fn)
+            return ExamplesIterable(
+                self.generate_examples_fn, self.kwargs, self.generate_more_kwargs_fn, self.sleep_on_threads_shutdown
+            )
         gen_kwargs_list = _split_gen_kwargs(self.kwargs, max_num_jobs=self.num_shards)
         new_gen_kwargs = _merge_gen_kwargs(
             [
@@ -356,7 +354,9 @@ class ExamplesIterable(_BaseExamplesIterable):
                 for new_gen_kwargs in self.generate_more_kwargs_fn(**gen_kwargs)
             ]
         )
-        return ExamplesIterable(self.generate_examples_fn, new_gen_kwargs, self.generate_more_kwargs_fn)
+        return ExamplesIterable(
+            self.generate_examples_fn, new_gen_kwargs, self.generate_more_kwargs_fn, self.sleep_on_threads_shutdown
+        )
 
     @property
     def num_shards(self) -> int:
@@ -369,6 +369,7 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
         generate_tables_fn: Callable[..., Iterator[tuple[Key, pa.Table]]],
         kwargs: dict,
         generate_more_kwargs_fn: Optional[Callable[..., Iterator[dict]]] = None,
+        sleep_on_threads_shutdown: bool = False,
     ):
         super().__init__()
         self.generate_tables_fn = generate_tables_fn
@@ -376,6 +377,9 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
 
         # for resharding
         self.generate_more_kwargs_fn = generate_more_kwargs_fn
+
+        # for threads shutdowns
+        self._sleep_on_threads_shutdown = sleep_on_threads_shutdown
 
     @property
     def iter_arrow(self):
@@ -425,7 +429,10 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "ArrowExamplesIterable":
         return ArrowExamplesIterable(
-            self.generate_tables_fn, _shuffle_gen_kwargs(deepcopy(generator), self.kwargs), generator
+            self.generate_tables_fn,
+            _shuffle_gen_kwargs(deepcopy(generator), self.kwargs),
+            self.generate_more_kwargs_fn,
+            self.sleep_on_threads_shutdown,
         )
 
     def shard_data_sources(self, num_shards: int, index: int, contiguous=True) -> "ArrowExamplesIterable":
@@ -433,7 +440,9 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
         gen_kwargs_list = _split_gen_kwargs(self.kwargs, max_num_jobs=self.num_shards)
         shard_indices = self.split_shard_indices_by_worker(num_shards, index, contiguous=contiguous)
         requested_gen_kwargs = _merge_gen_kwargs([gen_kwargs_list[i] for i in shard_indices])
-        return ArrowExamplesIterable(self.generate_tables_fn, requested_gen_kwargs)
+        return ArrowExamplesIterable(
+            self.generate_tables_fn, requested_gen_kwargs, self.generate_more_kwargs_fn, self.sleep_on_threads_shutdown
+        )
 
     def reshard_data_sources(self) -> "ArrowExamplesIterable":
         """Split shars into more shards if possible."""
@@ -447,7 +456,9 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
                 for new_gen_kwargs in self.generate_more_kwargs_fn(**gen_kwargs)
             ]
         )
-        return ArrowExamplesIterable(self.generate_tables_fn, new_gen_kwargs, self.generate_more_kwargs_fn)
+        return ArrowExamplesIterable(
+            self.generate_tables_fn, new_gen_kwargs, self.generate_more_kwargs_fn, self.sleep_on_threads_shutdown
+        )
 
     @property
     def num_shards(self) -> int:
@@ -853,7 +864,8 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
             while iterators:
                 iterator = iterators.pop()
                 del iterator
-            executor.shutdown(wait=True)
+            if any(ex_iterable.sleep_on_threads_shutdown for ex_iterable in self.ex_iterables):
+                time.sleep(config.SLEEP_TIME_ON_THREADS_SHUTDOWN)
 
     def __iter__(self):
         # we use this to buffer one example of each iterator to know if an iterator is exhausted
@@ -928,6 +940,8 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
                 iterator = iterators.pop()
                 del iterator
             executor.shutdown(wait=True)
+            if any(ex_iterable.sleep_on_threads_shutdown for ex_iterable in self.ex_iterables):
+                time.sleep(config.SLEEP_TIME_ON_THREADS_SHUTDOWN)
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "CyclingMultiSourcesExamplesIterable":
         """Shuffle each underlying examples iterable."""
@@ -2573,7 +2587,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> dataloader.load_state_dict(state_dict)  # uses ds.load_state_dict() under the hood
         ```
         """
-        return _copy_state_dict(self._state_dict)
+        return deepcopy(self._state_dict)
 
     def load_state_dict(self, state_dict: dict) -> None:
         """Load the state_dict of the dataset.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3602,7 +3602,11 @@ class IterableDataset(DatasetInfoMixin):
         )
 
     def shuffle(
-        self, seed=None, generator: Optional[np.random.Generator] = None, buffer_size: int = 1000, max_buffer_input_shards: int = 10,
+        self,
+        seed=None,
+        generator: Optional[np.random.Generator] = None,
+        buffer_size: int = 1000,
+        max_buffer_input_shards: int = 10,
     ) -> "IterableDataset":
         """
         Randomly shuffles the elements of this dataset.
@@ -3674,7 +3678,10 @@ class IterableDataset(DatasetInfoMixin):
         if max_buffer_input_shards > 1:
             num_shards_to_interleave = min(ex_iterable.num_shards, max_buffer_input_shards)
             ex_iterable = CyclingMultiSourcesExamplesIterable(
-                [ex_iterable.shard_data_sources(num_shards=num_shards_to_interleave, index=index) for index in range(num_shards_to_interleave)],
+                [
+                    ex_iterable.shard_data_sources(num_shards=num_shards_to_interleave, index=index)
+                    for index in range(num_shards_to_interleave)
+                ],
                 stopping_strategy="all_exhausted_without_replacement",
             )
         ex_iterable = BufferShuffledExamplesIterable(ex_iterable, buffer_size=buffer_size, generator=generator)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1,6 +1,6 @@
 import asyncio
+import concurrent.futures
 import contextlib
-import copy
 import inspect
 import itertools
 import multiprocessing.pool
@@ -9,7 +9,7 @@ import sys
 import tempfile
 from collections import Counter
 from collections.abc import Iterable, Iterator
-from copy import deepcopy
+from copy import copy, deepcopy
 from dataclasses import dataclass
 from functools import partial
 from itertools import cycle, islice
@@ -102,6 +102,29 @@ Key = Union[int, str, tuple[int, int], "BuilderKey"]
 
 def identity_func(x):
     return x
+
+
+def _copy_state_dict(state_dict: dict) -> dict:
+    return deepcopy(state_dict)
+
+    def _copy_item(item):
+        if isinstance(item, dict):
+            # no need to copy the current state since we use the previous one anyways
+            uses_previous_state_only = (
+                item.get("previous_states") is not None or item.get("previous_state") is not None
+            )
+            return {
+                k: ([None] * len(v) if isinstance(v, list) else None)
+                if uses_previous_state_only and k == "ex_iterable" or k == "ex_iterabkes"
+                else _copy_item(v)
+                for k, v in item.items()
+            }
+        if isinstance(item, list):
+            return [_copy_item(x) for x in item]
+        else:
+            return item
+
+    return _copy_item(state_dict)
 
 
 def _rename_columns_fn(example: dict, column_mapping: dict[str, str]):
@@ -266,13 +289,14 @@ class _BaseExamplesIterable:
                 for i in range(len(state)):
                     state[i] = _inner_load_state_dict(state[i], new_state[i])
                 return state
-            return new_state
+            return deepcopy(new_state)
 
+        self._init_state_dict()
         return _inner_load_state_dict(self._state_dict, state_dict)
 
     def state_dict(self) -> dict:
         if self._state_dict:
-            return copy.deepcopy(self._state_dict)
+            return _copy_state_dict(self._state_dict)
         raise RuntimeError("State dict is not initialized, please call ex_iterable._init_state_dict() first.")
 
 
@@ -309,7 +333,7 @@ class ExamplesIterable(_BaseExamplesIterable):
     def shuffle_data_sources(self, generator: np.random.Generator) -> "ExamplesIterable":
         return ExamplesIterable(
             self.generate_examples_fn,
-            _shuffle_gen_kwargs(copy.deepcopy(generator), self.kwargs),
+            _shuffle_gen_kwargs(deepcopy(generator), self.kwargs),
             self.generate_more_kwargs_fn,
         )
 
@@ -401,7 +425,7 @@ class ArrowExamplesIterable(_BaseExamplesIterable):
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "ArrowExamplesIterable":
         return ArrowExamplesIterable(
-            self.generate_tables_fn, _shuffle_gen_kwargs(copy.deepcopy(generator), self.kwargs), generator
+            self.generate_tables_fn, _shuffle_gen_kwargs(deepcopy(generator), self.kwargs), generator
         )
 
     def shard_data_sources(self, num_shards: int, index: int, contiguous=True) -> "ArrowExamplesIterable":
@@ -747,9 +771,10 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
             ex_iterable_idx = next_ex_iterable_idx
 
     def _init_state_dict(self) -> dict:
+        for ex_iterable in self.ex_iterables:
+            ex_iterable._init_state_dict()
         self._state_dict = {
             "ex_iterable_idx": 0,
-            "ex_iterables": [ex_iterable._init_state_dict() for ex_iterable in self.ex_iterables],
             "previous_states": [None] * len(self.ex_iterables),
             "is_exhausted": [False] * len(self.ex_iterables),
             "type": self.__class__.__name__,
@@ -764,43 +789,71 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
             for i in range(len(self.ex_iterables)):
                 if self._state_dict["previous_states"][i] is not None:
                     self.ex_iterables[i].load_state_dict(self._state_dict["previous_states"][i])
+            previous_states = [ex_iterable.state_dict() for ex_iterable in self.ex_iterables]
         iterators = [ex_iterable.iter_arrow() for ex_iterable in self.ex_iterables]
+
+        # Pre-populate futures for next samples from each iterator using threads for prefetching
+        def fetch_next_sample(iterator):
+            return next(iterator, False)
+
+        # Use ThreadPoolExecutor to fetch next samples in parallel
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(self.ex_iterables))
+        futures = [executor.submit(fetch_next_sample, iterator) for iterator in iterators]
 
         indices_iterator = self._get_indices_iterator()
 
         is_exhausted = (
             np.array(self._state_dict["is_exhausted"]) if self._state_dict else np.full(len(self.ex_iterables), False)
         )
-        for i in indices_iterator:
-            # if the stopping criteria is met, break the main for loop
-            if self.bool_strategy_func(is_exhausted):
-                break
-            # Skip exhausted iterators if we sample without replacement
-            if is_exhausted[i] and self.stopping_strategy in ["all_exhausted_without_replacement"]:
-                continue
-            # let's pick one example from the iterator at index i
-            if nexts[i] is None:
-                nexts[i] = next(iterators[i], False)
-            result = nexts[i]
-            if self._state_dict:
-                self._state_dict["previous_states"][i] = deepcopy(self._state_dict["ex_iterables"][i])
-            nexts[i] = next(iterators[i], False)
-
-            # the iterator is exhausted
-            if nexts[i] is False:
-                is_exhausted[i] = True
-                if self._state_dict:
-                    self._state_dict["is_exhausted"][i] = True
-                # we reset it in case the stopping crtieria isn't met yet and we sample with replacement
-                if self.stopping_strategy not in ["all_exhausted_without_replacement"]:
-                    nexts[i] = None
+        try:
+            for i in indices_iterator:
+                # if the stopping criteria is met, break the main for loop
+                if self.bool_strategy_func(is_exhausted):
+                    break
+                # Skip exhausted iterators if we sample without replacement
+                if is_exhausted[i] and self.stopping_strategy in ["all_exhausted_without_replacement"]:
+                    continue
+                # let's pick one example from the iterator at index i
+                # Resolve the future to get the current sample
+                if nexts[i] is None:
+                    nexts[i] = futures[i].result()
                     if self._state_dict:
-                        self._state_dict["ex_iterables"][i] = self.ex_iterables[i]._init_state_dict()
-                        self._state_dict["previous_states"][i] = None
-                    iterators[i] = self.ex_iterables[i]._iter_arrow()
+                        self._state_dict["previous_states"][i] = previous_states[i]
+                        previous_states[i] = self.ex_iterables[i].state_dict()
+                    futures[i] = executor.submit(fetch_next_sample, iterators[i])
+                result = nexts[i]
+                # Fetch the next sample for this iterator (prefetching)
+                nexts[i] = futures[i].result()
+                if self._state_dict:
+                    self._state_dict["previous_states"][i] = previous_states[i]
+                    previous_states[i] = self.ex_iterables[i].state_dict()
 
-            if result is not False:
-                yield result
+                if nexts[i] is not False:
+                    futures[i] = executor.submit(fetch_next_sample, iterators[i])
+                else:
+                    # the iterator is exhausted
+                    is_exhausted[i] = True
+                    if self._state_dict:
+                        self._state_dict["is_exhausted"][i] = True
+                    # we reset it in case the stopping criteria isn't met yet
+                    if self.stopping_strategy not in ["all_exhausted_without_replacement"]:
+                        if self._state_dict:
+                            self.ex_iterables[i]._init_state_dict()
+                            previous_states[i] = self.ex_iterables[i].state_dict()
+                            self._state_dict["previous_states"][i] = None
+                        iterators[i] = self.ex_iterables[i].iter_arrow()
+                        nexts[i] = None
+                        futures[i] = executor.submit(fetch_next_sample, iterators[i])
+                if result is not False:
+                    yield result
+        finally:
+            # Related to https://github.com/apache/arrow/issues/45214
+            for future in futures:
+                future.result()
+            while iterators:
+                iterator = iterators.pop()
+                del iterator
+            executor.shutdown(wait=True)
 
     def __iter__(self):
         # we use this to buffer one example of each iterator to know if an iterator is exhausted
@@ -810,41 +863,71 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
             for i in range(len(self.ex_iterables)):
                 if self._state_dict["previous_states"][i] is not None:
                     self.ex_iterables[i].load_state_dict(self._state_dict["previous_states"][i])
+            previous_states = [ex_iterable.state_dict() for ex_iterable in self.ex_iterables]
         iterators = [iter(ex_iterable) for ex_iterable in self.ex_iterables]
+
+        # Pre-populate futures for next samples from each iterator using threads for prefetching
+        def fetch_next_sample(iterator):
+            return next(iterator, False)
+
+        # Use ThreadPoolExecutor to fetch next samples in parallel
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(self.ex_iterables))
+        futures = [executor.submit(fetch_next_sample, iterator) for iterator in iterators]
 
         indices_iterator = self._get_indices_iterator()
 
         is_exhausted = (
             np.array(self._state_dict["is_exhausted"]) if self._state_dict else np.full(len(self.ex_iterables), False)
         )
-        for i in indices_iterator:
-            # if the stopping criteria is met, break the main for loop
-            if self.bool_strategy_func(is_exhausted):
-                break
-            # let's pick one example from the iterator at index i
-            if is_exhausted[i] and self.stopping_strategy in ["all_exhausted_without_replacement"]:
-                continue
-            if nexts[i] is None:
-                nexts[i] = next(iterators[i], False)
-            result = nexts[i]
-            if self._state_dict:
-                self._state_dict["previous_states"][i] = deepcopy(self._state_dict["ex_iterables"][i])
-            nexts[i] = next(iterators[i], False)
-
-            # the iterator is exhausted
-            if nexts[i] is False:
-                is_exhausted[i] = True
-                if self._state_dict:
-                    self._state_dict["is_exhausted"][i] = True
-                # we reset it in case the stopping crtieria isn't met yet
-                if self.stopping_strategy not in ["all_exhausted_without_replacement"]:
-                    nexts[i] = None
+        try:
+            for i in indices_iterator:
+                # if the stopping criteria is met, break the main for loop
+                if self.bool_strategy_func(is_exhausted):
+                    break
+                # Skip exhausted iterators if we sample without replacement
+                if is_exhausted[i] and self.stopping_strategy in ["all_exhausted_without_replacement"]:
+                    continue
+                # let's pick one example from the iterator at index i
+                # Resolve the future to get the current sample
+                if nexts[i] is None:
+                    nexts[i] = futures[i].result()
                     if self._state_dict:
-                        self._state_dict["ex_iterables"][i] = self.ex_iterables[i]._init_state_dict()
-                        self._state_dict["previous_states"][i] = None
-                    iterators[i] = iter(self.ex_iterables[i])
-            if result is not False:
-                yield result
+                        self._state_dict["previous_states"][i] = previous_states[i]
+                        previous_states[i] = self.ex_iterables[i].state_dict()
+                    futures[i] = executor.submit(fetch_next_sample, iterators[i])
+                result = nexts[i]
+                # Fetch the next sample for this iterator (prefetching)
+                nexts[i] = futures[i].result()
+                if self._state_dict:
+                    self._state_dict["previous_states"][i] = previous_states[i]
+                    previous_states[i] = self.ex_iterables[i].state_dict()
+
+                if nexts[i] is not False:
+                    futures[i] = executor.submit(fetch_next_sample, iterators[i])
+                else:
+                    # the iterator is exhausted
+                    is_exhausted[i] = True
+                    if self._state_dict:
+                        self._state_dict["is_exhausted"][i] = True
+                    # we reset it in case the stopping criteria isn't met yet
+                    if self.stopping_strategy not in ["all_exhausted_without_replacement"]:
+                        if self._state_dict:
+                            self.ex_iterables[i]._init_state_dict()
+                            previous_states[i] = self.ex_iterables[i].state_dict()
+                            self._state_dict["previous_states"][i] = None
+                        iterators[i] = iter(self.ex_iterables[i])
+                        nexts[i] = None
+                        futures[i] = executor.submit(fetch_next_sample, iterators[i])
+                if result is not False:
+                    yield result
+        finally:
+            # Related to https://github.com/apache/arrow/issues/45214
+            for future in futures:
+                future.result()
+            while iterators:
+                iterator = iterators.pop()
+                del iterator
+            executor.shutdown(wait=True)
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "CyclingMultiSourcesExamplesIterable":
         """Shuffle each underlying examples iterable."""
@@ -1168,10 +1251,11 @@ class RandomlyCyclingMultiSourcesExamplesIterable(CyclingMultiSourcesExamplesIte
                     yield int(i)
 
     def _init_state_dict(self) -> dict:
+        for ex_iterable in self.ex_iterables:
+            ex_iterable._init_state_dict()
         self._state_dict = {
             "bit_generator_state": self.generator.bit_generator.state,
             "bit_generator_index_offset": 0,
-            "ex_iterables": [ex_iterable._init_state_dict() for ex_iterable in self.ex_iterables],
             "previous_states": [None] * len(self.ex_iterables),
             "is_exhausted": [False] * len(self.ex_iterables),
             "type": self.__class__.__name__,
@@ -2275,9 +2359,9 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
         if not self.features:
             yield from self.ex_iterable._iter_arrow()
             return
+        schema = self.features.arrow_schema
         for key, pa_table in self.ex_iterable._iter_arrow():
             columns = set(pa_table.column_names)
-            schema = self.features.arrow_schema
             # add missing columns
             for column_name in self.features:
                 if column_name not in columns:
@@ -2396,7 +2480,7 @@ class IterableDataset(DatasetInfoMixin):
         info = info.copy() if info is not None else DatasetInfo()
         DatasetInfoMixin.__init__(self, info=info, split=split)
 
-        self._ex_iterable = copy.copy(ex_iterable)
+        self._ex_iterable = copy(ex_iterable)
         self._formatting = formatting
         self._distributed = distributed
         self._token_per_repo_id: dict[str, Union[str, bool, None]] = token_per_repo_id or {}
@@ -2489,7 +2573,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> dataloader.load_state_dict(state_dict)  # uses ds.load_state_dict() under the hood
         ```
         """
-        return copy.deepcopy(self._state_dict)
+        return _copy_state_dict(self._state_dict)
 
     def load_state_dict(self, state_dict: dict) -> None:
         """Load the state_dict of the dataset.
@@ -3334,7 +3418,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=FormattingConfig(format_type=type),
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3469,7 +3553,7 @@ class IterableDataset(DatasetInfoMixin):
             # apply formatting before iter_arrow to keep map examples iterable happy
             ex_iterable = FormattedExamplesIterable(
                 ex_iterable,
-                formatting=copy.deepcopy(self._formatting),
+                formatting=deepcopy(self._formatting),
                 features=input_features,
                 token_per_repo_id=self._token_per_repo_id,
             )
@@ -3489,7 +3573,7 @@ class IterableDataset(DatasetInfoMixin):
                 # apply formatting after iter_arrow to avoid re-encoding the examples
                 ex_iterable = FormattedExamplesIterable(
                     ex_iterable,
-                    formatting=copy.deepcopy(self._formatting),
+                    formatting=deepcopy(self._formatting),
                     features=input_features,
                     token_per_repo_id=self._token_per_repo_id,
                     force_convert_to_python=True,
@@ -3516,7 +3600,7 @@ class IterableDataset(DatasetInfoMixin):
             info=info,
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3601,7 +3685,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info,
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3699,7 +3783,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3744,7 +3828,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3786,7 +3870,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info,
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3821,7 +3905,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3877,7 +3961,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -3917,7 +4001,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -4052,7 +4136,7 @@ class IterableDataset(DatasetInfoMixin):
             column_names = [column_names]
 
         if self._info:
-            info = copy.deepcopy(self._info)
+            info = deepcopy(self._info)
             if self._info.features is not None:
                 missing_columns = set(column_names) - set(self._info.features.keys())
                 if missing_columns:
@@ -4115,7 +4199,7 @@ class IterableDataset(DatasetInfoMixin):
             info=info,
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -4161,7 +4245,7 @@ class IterableDataset(DatasetInfoMixin):
             info=info,
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -4265,7 +4349,7 @@ class IterableDataset(DatasetInfoMixin):
             info=self._info.copy(),
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -4283,7 +4367,7 @@ class IterableDataset(DatasetInfoMixin):
             info=info,
             split=self._split,
             formatting=self._formatting,
-            distributed=copy.deepcopy(self._distributed),
+            distributed=deepcopy(self._distributed),
             token_per_repo_id=self._token_per_repo_id,
         )
 
@@ -5124,7 +5208,7 @@ def _concatenate_iterable_datasets(
         {k: v for features in _align_features([dset.features for dset in dsets]) for k, v in features.items()}
     )
 
-    ex_iterables = [copy.deepcopy(d._ex_iterable) for d in dsets]
+    ex_iterables = [deepcopy(d._ex_iterable) for d in dsets]
     if axis == 0:
         ex_iterable = VerticallyConcatenatedMultiSourcesExamplesIterable(ex_iterables)
     else:
@@ -5205,7 +5289,7 @@ def _interleave_iterable_datasets(
         {k: v for features in _align_features([dset.features for dset in datasets]) for k, v in features.items()}
     )
 
-    ex_iterables = [copy.deepcopy(d._ex_iterable) for d in datasets]
+    ex_iterables = [deepcopy(d._ex_iterable) for d in datasets]
     if all(ex_iterable.iter_arrow for ex_iterable in ex_iterables):
         ex_iterables = [RebatchedArrowExamplesIterable(ex_iterable, batch_size=1) for ex_iterable in ex_iterables]
     # Use cycling or random cycling of sources

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1886,6 +1886,10 @@ class BufferShuffledExamplesIterable(_BaseExamplesIterable):
         return self.ex_iterable.num_shards
 
 
+class DataSourcesShufflingDisallowed(Exception):
+    """skip() or take() freeze the order of data sources shards"""
+
+
 class SkipExamplesIterable(_BaseExamplesIterable):
     def __init__(
         self,
@@ -1960,7 +1964,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
     def shuffle_data_sources(self, generator: np.random.Generator) -> "SkipExamplesIterable":
         """May not shuffle the wrapped examples iterable since it would skip examples from other shards instead."""
         if self.block_sources_order_when_shuffling:
-            return self
+            raise DataSourcesShufflingDisallowed()
         else:
             return SkipExamplesIterable(
                 self.ex_iterable.shuffle_data_sources(generator),
@@ -2129,7 +2133,7 @@ class TakeExamplesIterable(_BaseExamplesIterable):
     def shuffle_data_sources(self, generator: np.random.Generator) -> "TakeExamplesIterable":
         """May not shuffle the wrapped examples iterable since it would take examples from other shards instead."""
         if self.block_sources_order_when_shuffling:
-            return self
+            raise DataSourcesShufflingDisallowed()
         else:
             return TakeExamplesIterable(
                 self.ex_iterable.shuffle_data_sources(generator),
@@ -3624,7 +3628,8 @@ class IterableDataset(DatasetInfoMixin):
         at a time and also does shuffle the order of the shards. This greatly improves the quality of the shuffling.
 
         However if the order has been fixed by using [`~datasets.IterableDataset.skip`]
-        or [`~datasets.IterableDataset.take`] then the order of the shards is kept unchanged.
+        or [`~datasets.IterableDataset.take`] then the order of the shards is kept unchanged and only one shard at
+        a time is used to fill the buffer.
 
         Args:
             seed (`int`, *optional*, defaults to `None`):
@@ -3672,7 +3677,11 @@ class IterableDataset(DatasetInfoMixin):
             generator = np.random.default_rng(seed)
         else:
             generator = deepcopy(generator)
-        ex_iterable = self._ex_iterable.shuffle_data_sources(generator)
+        ex_iterable = self._ex_iterable
+        try:
+            ex_iterable = ex_iterable.shuffle_data_sources(generator)
+        except DataSourcesShufflingDisallowed:
+            max_buffer_input_shards = 1
         if ex_iterable.iter_arrow:
             ex_iterable = RebatchedArrowExamplesIterable(ex_iterable, batch_size=1)
         if max_buffer_input_shards > 1:

--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -92,6 +92,7 @@ class ParquetConfig(datasets.BuilderConfig):
 
 class Parquet(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = ParquetConfig
+    SLEEP_ON_THREADS_SHUTDOWNS = True  # Related to https://github.com/apache/arrow/issues/45214
 
     def _info(self):
         if (

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1844,6 +1844,22 @@ def test_iterable_dataset_shuffle_with_multiple_workers_different_rng():
         assert len(set(values)) != 1, "Make sure not all values are identical"
 
 
+def test_iterable_dataset_shuffle_buffer_uses_multiple_input_shards():
+    ds = IterableDataset.from_dict({"i": range(100)}, num_shards=10)
+
+    shuffled_ds = ds.shuffle(buffer_size=10, seed=1234)
+    shard_indices_of_first_ten_examples = {i // 10 for i in shuffled_ds.take(10)["i"]}
+    assert len(shard_indices_of_first_ten_examples) == 7
+
+    shuffled_ds = ds.shuffle(buffer_size=10, seed=1234, max_buffer_input_shards=1)
+    shard_indices_of_first_ten_examples = {i // 10 for i in shuffled_ds.take(10)["i"]}
+    assert len(shard_indices_of_first_ten_examples) == 2
+
+    shuffled_ds = ds.shuffle(buffer_size=10, seed=1234, max_buffer_input_shards=4)
+    shard_indices_of_first_ten_examples = {i // 10 for i in shuffled_ds.take(10)["i"]}
+    assert len(shard_indices_of_first_ten_examples) == 4
+
+
 def gen_with_value(shard, value):
     for i in range(100):
         yield {"value": value}
@@ -2060,7 +2076,7 @@ def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):
     buffer_size = 3
     dataset = deepcopy(dataset)
     dataset._ex_iterable.kwargs["filepaths"] = ["0.txt", "1.txt"]
-    dataset = dataset.shuffle(seed, buffer_size=buffer_size)
+    dataset = dataset.shuffle(seed, buffer_size=buffer_size, max_buffer_input_shards=1)
     # Effective seed is mix of seed and epoch
     if epoch is None or epoch == 0:
         effective_seed = seed

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -394,6 +394,33 @@ def test_cycling_multi_sources_examples_iterable():
     assert_load_state_dict_resumes_iteration(ex_iterable)
 
 
+def test_sharded_cycling_multi_sources_examples_iterable():
+    ex_iterable1 = ExamplesIterable(
+        generate_examples_fn, {"text": "foo", "filepaths": [f"{i}.txt" for i in range(3)], "n": 2}
+    )
+    ex_iterable2 = ExamplesIterable(
+        generate_examples_fn, {"text": "bar", "filepaths": [f"{i}.txt" for i in range(2)], "n": 2}
+    )
+    ex_iterable = CyclingMultiSourcesExamplesIterable([ex_iterable1, ex_iterable2])
+    expected = [
+        x
+        for i in range(2)
+        for x in chain(
+            *zip(
+                generate_examples_fn(text="foo", filepaths=[f"{i}.txt"], n=2),
+                generate_examples_fn(text="bar", filepaths=[f"{i}.txt"], n=2),
+            )
+        )
+    ]
+
+    # The cycling stops as soon as one iterable is out of examples (here ex_iterable2 since it has 2 shards and ex_iterable1 has 3)
+
+    assert next(iter(ex_iterable)) == expected[0]
+    assert list(ex_iterable) == expected
+    assert all(x["text"] == "bar" if i % 2 else "foo" for i, (_, x) in enumerate(ex_iterable))
+    assert_load_state_dict_resumes_iteration(ex_iterable)
+
+
 @pytest.mark.parametrize("probabilities", [None, (0.5, 0.5), (0.9, 0.1)])
 def test_randomly_cycling_multi_sources_examples_iterable(probabilities):
     seed = 42

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -31,6 +31,7 @@ from datasets.iterable_dataset import (
     ArrowExamplesIterable,
     BufferShuffledExamplesIterable,
     CyclingMultiSourcesExamplesIterable,
+    DataSourcesShufflingDisallowed,
     ExamplesIterable,
     FilteredExamplesIterable,
     FormattedExamplesIterable,
@@ -1249,9 +1250,8 @@ def test_skip_examples_iterable():
     skip_ex_iterable = SkipExamplesIterable(base_ex_iterable, n=count)
     expected = list(generate_examples_fn(n=total))[count:]
     assert list(skip_ex_iterable) == expected
-    assert skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable, (
-        "skip examples makes the shards order fixed"
-    )
+    with pytest.raises(DataSourcesShufflingDisallowed):
+        skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
     assert_load_state_dict_resumes_iteration(skip_ex_iterable)
 
 
@@ -1261,9 +1261,8 @@ def test_take_examples_iterable():
     take_ex_iterable = TakeExamplesIterable(base_ex_iterable, n=count)
     expected = list(generate_examples_fn(n=total))[:count]
     assert list(take_ex_iterable) == expected
-    assert take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable, (
-        "skip examples makes the shards order fixed"
-    )
+    with pytest.raises(DataSourcesShufflingDisallowed):
+        take_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
     assert_load_state_dict_resumes_iteration(take_ex_iterable)
 
 
@@ -1282,9 +1281,8 @@ def test_skip_arrow_examples_iterable():
     skip_ex_iterable = SkipExamplesIterable(base_ex_iterable, n=count)
     expected = [x for _, pa_table in generate_tables_fn(n=total) for x in pa_table.to_pylist()][count:]
     assert [example for _, example in skip_ex_iterable] == expected
-    assert skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is skip_ex_iterable, (
-        "skip examples makes the shards order fixed"
-    )
+    with pytest.raises(DataSourcesShufflingDisallowed):
+        skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
     assert_load_state_dict_resumes_iteration(skip_ex_iterable)
 
 
@@ -1294,9 +1292,8 @@ def test_take_arrow_examples_iterable():
     take_ex_iterable = TakeExamplesIterable(base_ex_iterable, n=count)
     expected = [x for _, pa_table in generate_tables_fn(n=total) for x in pa_table.to_pylist()][:count]
     assert [example for _, example in take_ex_iterable] == expected
-    assert take_ex_iterable.shuffle_data_sources(np.random.default_rng(42)) is take_ex_iterable, (
-        "skip examples makes the shards order fixed"
-    )
+    with pytest.raises(DataSourcesShufflingDisallowed):
+        take_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
     assert_load_state_dict_resumes_iteration(take_ex_iterable)
 
 


### PR DESCRIPTION
```python
ds = load_dataset(..., streaming=True)
ds = ds.shuffle(seed=42)
# or configure local buffer shuffling manually, default is:
ds = ds.shuffle(seed=42, buffer_size=1000, max_buffer_input_shards=10)
```

before👎:
<img width="1061" height="529" alt="image" src="https://github.com/user-attachments/assets/dd85a11b-72fc-474c-8faa-33eda779a4fb" />

after✨:
<img width="1057" height="523" alt="image" src="https://github.com/user-attachments/assets/77acc8d3-61d4-4e57-bc87-43fcd3c2e8f3" />

toy example comparison

```python
from datasets import IterableDataset

ds = IterableDataset.from_dict({"i": range(123_456_789)}, num_shards=1024)
ds = ds.shuffle(seed=42)

print("Cold start ids:")
print(list(ds.take(10)["i"]))
print("Nominal regime ids:")
print(list(ds.skip(10_000).take(10)["i"]))
```

before👎:

```
Cold start ids:
[6148853, 6149537, 6149418, 6149202, 6149197, 6149622, 6148849, 6149461, 6148965, 6148858]
Nominal regime ids:
[6149537, 6149418, 6149202, 6149197, 6149622, 6148849, 6149461, 6148965, 6148858, 6149290]
```

after✨:

```
Cold start ids:
[7836668, 9283505, 95847927, 482299, 9283471, 482341, 112003312, 59920157, 43764666, 95847871]
Nominal regime ids:
[9283505, 95847927, 482299, 9283471, 482341, 112003312, 59920157, 43764666, 95847871, 16758448]
```


related to https://github.com/huggingface/datasets/issues/8015

Note: `ds.state_dict()` and `ds.load_state_dict()` are still supported for this improved shuffling :) enabling dataset checkpointing

Note 2: it uses threads to fetch the first examples in parallel from the input shards