### PR TITLE
Fix spurious label column when folder builders see split-named directories

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -142,9 +142,12 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                     # if `all_metadata_files` are not found, don't add metadata
                     add_metadata = False
                     # if `all_metadata_files` are not found and `drop_labels` is None (default) -
-                    # add labels if files are on the same level in directory hierarchy and there is more than one label
+                    # add labels if files are on the same level in directory hierarchy and there is more than one label.
+                    # Skip inference when the inferred labels are just split-name directories
+                    # (e.g. `train/*.png`, `test/*.png`), which are splits, not classes.
+                    inferred_labels_are_split_dirs = bool(labels) and labels.issubset(set(data_files))
                     add_labels = (
-                        (len(labels) > 1 and len(path_depths) == 1)
+                        (len(labels) > 1 and len(path_depths) == 1 and not inferred_labels_are_split_dirs)
                         if self.config.drop_labels is None
                         else not self.config.drop_labels
                     )

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -102,6 +102,23 @@ def data_files_with_one_label_no_metadata(tmp_path, auto_text_file):
 
 
 @pytest.fixture
+def data_files_with_split_dirs_no_metadata(tmp_path, auto_text_file):
+    # directory names match split names: `train/`, `test/`. These are splits, not class labels.
+    data_dir = tmp_path / "data_files_with_split_dirs"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    subdir_train = data_dir / "train"
+    subdir_train.mkdir(parents=True, exist_ok=True)
+    subdir_test = data_dir / "test"
+    subdir_test.mkdir(parents=True, exist_ok=True)
+
+    shutil.copyfile(auto_text_file, subdir_train / "file0.txt")
+    shutil.copyfile(auto_text_file, subdir_train / "file1.txt")
+    shutil.copyfile(auto_text_file, subdir_test / "file2.txt")
+
+    return DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+
+
+@pytest.fixture
 def files_with_labels_and_duplicated_label_key_in_metadata(tmp_path, auto_text_file):
     data_dir = tmp_path / "files_with_labels_and_label_key_in_metadata"
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -389,6 +406,30 @@ def test_data_files_with_one_label_no_metadata(data_files_with_one_label_no_meta
         assert "label" in autofolder.info.features
         assert isinstance(autofolder.info.features["label"], ClassLabel)
         assert all(example.keys() == {"base", "label"} for _, example in generator)
+
+
+@pytest.mark.parametrize("drop_labels", [None, True, False])
+def test_data_files_with_split_dirs_no_metadata(data_files_with_split_dirs_no_metadata, drop_labels, cache_dir):
+    # When directory names match split names (e.g. `train/`, `test/`), the directories
+    # are splits, not class labels: no `label` column should be inferred under the default
+    # `drop_labels=None`. Passing `drop_labels=False` still force-adds labels.
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_split_dirs_no_metadata,
+        cache_dir=cache_dir,
+        drop_labels=drop_labels,
+    )
+    split_generators = autofolder._split_generators(StreamingDownloadManager())
+    if drop_labels is False:
+        # explicit opt-in to labels: split-name dirs are surfaced as ClassLabel
+        assert "label" in autofolder.info.features
+        assert isinstance(autofolder.info.features["label"], ClassLabel)
+        assert set(autofolder.info.features["label"].names) == {"train", "test"}
+    else:
+        # default (None) and explicit drop: no spurious `label` column
+        assert "label" not in autofolder.info.features
+        for split_generator in split_generators:
+            generator = autofolder._generate_examples(**split_generator.gen_kwargs)
+            assert all(example.keys() == {"base"} for _, example in generator)
 
 
 @pytest.mark.parametrize("streaming", [False, True])


### PR DESCRIPTION
Closes #7880.

## What

`folder_based_builder._split_generators` allocates a single `labels: set[str]` outside the per-split loop and `analyze(...)` mutates it across every split. When the user passes:

```python
load_dataset("audiofolder", data_files={"train": "train/**", "test": "test/**"})
```

and the actual files live directly under `train/` and `test/` (no per-class subdirs), the parent-dir-name accumulator ends up with `labels = {"train", "test"}`. The `add_labels = len(labels) > 1 and len(path_depths) == 1` heuristic then flips True and the loader silently adds a `ClassLabel(names=['test', 'train'])` column. Worse, `add_labels` is recomputed per split inside the loop while features get set once after, so the first split's examples are emitted with `label=None`, which downstream `int2str(None)` then trips over.

The fix adds a single check: if the inferred label set is a subset of the user-declared split names, treat it as splits-not-classes and skip label inference. `drop_labels=False` (the explicit opt-in to label inference) is preserved.

## How is this tested?

New fixture `data_files_with_split_dirs_no_metadata` builds `train/` + `test/` dirs without class subdirs. Parametrized test:

- default: no `label` column
- `drop_labels=True`: no `label` column
- `drop_labels=False`: ClassLabel still produced with `names=['test', 'train']` (opt-in preserved)

The test fails on `main` with both the spurious column and the `int2str(None)` crash on `drop_labels=False` (mis-emitted label=None). It passes with this PR.

`tests/packaged_modules/test_folder_based_builder.py`, `test_imagefolder.py`, `test_videofolder.py`, and `test_data_files.py` all pass. `make quality` and `make style` are clean.

`test_audiofolder.py` has 11 pre-existing `torchcodec`/`libavutil` failures on `main` that are unrelated to this change.
