### PR TITLE
replace AutoFeatureExtractor with AutoImageProcessor in docs

### DIFF
--- a/docs/source/use_dataset.mdx
+++ b/docs/source/use_dataset.mdx
@@ -154,10 +154,10 @@ The most common preprocessing you'll do with image datasets is _data augmentatio
 **1**. Start by loading the [Beans](https://huggingface.co/datasets/AI-Lab-Makerere/beans) dataset, the `Image` feature, and the feature extractor corresponding to a pretrained [ViT](https://huggingface.co/google/vit-base-patch16-224-in21k) model:
 
 ```py
->>> from transformers import AutoFeatureExtractor
+>>> from transformers import AutoImageProcessor
 >>> from datasets import load_dataset, Image
 
->>> feature_extractor = AutoFeatureExtractor.from_pretrained("google/vit-base-patch16-224-in21k")
+>>> image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224-in21k")
 >>> dataset = load_dataset("AI-Lab-Makerere/beans", split="train")
 ```
 


### PR DESCRIPTION
Closes #8199

## What does this PR do?

Replaces `AutoFeatureExtractor` with `AutoImageProcessor` in the image augmentation example in `docs/source/use_dataset.mdx`. For vision models, `AutoImageProcessor` is the recommended API and better reflects current `transformers` conventions.

This is consistent with the direction taken in the `transformers` library itself — see [PR #20111](https://github.com/huggingface/transformers/pull/20111) and [PR #20501](https://github.com/huggingface/transformers/pull/20501), where vision feature extractor references were systematically replaced with image processors across the `transformers` codebase and documentation. The `datasets` docs were not in scope for that PR, making this a natural follow-up.