### PR TITLE
fix pathlib.Path support in save_to_disk and load_from_disk

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1848,7 +1848,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             num_shards = min(len(self.data), num_shards)
 
         fs: fsspec.AbstractFileSystem
-        fs, _ = url_to_fs(dataset_path, **(storage_options or {}))
+        fs, _ = url_to_fs(str(dataset_path), **(storage_options or {}))
 
         if not is_remote_filesystem(fs):
             parent_cache_files_paths = {
@@ -2019,7 +2019,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         """
         fs: fsspec.AbstractFileSystem
-        fs, dataset_path = url_to_fs(dataset_path, **(storage_options or {}))
+        fs, dataset_path = url_to_fs(str(dataset_path), **(storage_options or {}))
 
         dest_dataset_path = dataset_path
         dataset_dict_json_path = posixpath.join(dest_dataset_path, config.DATASETDICT_JSON_FILENAME)

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1356,7 +1356,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         fs: fsspec.AbstractFileSystem
-        fs, _ = url_to_fs(dataset_dict_path, **(storage_options or {}))
+        fs, _ = url_to_fs(str(dataset_dict_path), **(storage_options or {}))
 
         if num_shards is None:
             num_shards = dict.fromkeys(self)
@@ -1415,7 +1415,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         fs: fsspec.AbstractFileSystem
-        fs, dataset_dict_path = url_to_fs(dataset_dict_path, **(storage_options or {}))
+        fs, dataset_dict_path = url_to_fs(str(dataset_dict_path), **(storage_options or {}))
 
         dataset_dict_json_path = posixpath.join(dataset_dict_path, config.DATASETDICT_JSON_FILENAME)
         dataset_state_json_path = posixpath.join(dataset_dict_path, config.DATASET_STATE_JSON_FILENAME)

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1757,7 +1757,7 @@ def load_from_disk(
     ```
     """
     fs: fsspec.AbstractFileSystem
-    fs, *_ = url_to_fs(dataset_path, **(storage_options or {}))
+    fs, *_ = url_to_fs(str(dataset_path), **(storage_options or {}))
     if not fs.exists(dataset_path):
         raise FileNotFoundError(f"Directory {dataset_path} not found")
     if fs.isfile(posixpath.join(dataset_path, config.DATASET_INFO_FILENAME)) and fs.isfile(

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1757,7 +1757,8 @@ def load_from_disk(
     ```
     """
     fs: fsspec.AbstractFileSystem
-    fs, *_ = url_to_fs(str(dataset_path), **(storage_options or {}))
+    dataset_path = str(dataset_path)
+    fs, *_ = url_to_fs(dataset_path, **(storage_options or {}))
     if not fs.exists(dataset_path):
         raise FileNotFoundError(f"Directory {dataset_path} not found")
     if fs.isfile(posixpath.join(dataset_path, config.DATASET_INFO_FILENAME)) and fs.isfile(


### PR DESCRIPTION
`url_to_fs` from fsspec only accepts strings, but `save_to_disk` and `load_from_disk` in `arrow_dataset.py`, `dataset_dict.py`, and `load.py` pass the user-supplied path directly without converting it, causing a crash when a `pathlib.Path` is provided. Added `str()` conversion at each `url_to_fs` call site so all path-like objects are handled correctly. To verify, call `dataset.save_to_disk(Path("my_dir"))` and `Dataset.load_from_disk(Path("my_dir"))` with a `pathlib.Path`.

Fixes #6829