### PR TITLE
fix: pass token_per_repo_id to embed_table_storage when pushing shards

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5893,7 +5893,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 format = shard.format
                 shard = shard.with_format("arrow")
                 shard = shard.map(
-                    embed_table_storage,
+                    partial(embed_table_storage, token_per_repo_id=token_per_repo_id),
                     batched=True,
                     batch_size=writer_batch_size,
                     keep_in_memory=True,


### PR DESCRIPTION
## Summary

- Fixes #6348
- When `push_to_hub` is called with a `token`, the per-repo token map (`token_per_repo_id`) is built correctly earlier in the function — but it was never forwarded to `embed_table_storage` during the shard-map step.
- This caused a one-line fix: wrap `embed_table_storage` with `functools.partial` so `token_per_repo_id` is passed through.

## Root cause

In `Dataset.push_to_hub` (around line 5896 of `src/datasets/arrow_dataset.py`), the shard is mapped with:

```python
# Before
shard.map(embed_table_storage, ...)

# After
shard.map(partial(embed_table_storage, token_per_repo_id=token_per_repo_id), ...)
```

Without this, any dataset with embedded storage (e.g. `Image`, `Audio`) pushed to a private/gated repo would fail to authenticate when reading the referenced files.

## Test plan

- [ ] Existing unit tests pass (`pytest tests/test_arrow_dataset.py -x -q`)
- [ ] Manual smoke-test: push a dataset with `Image` column to a private Hub repo using a token