### PR TITLE
fix docs: use AutoImageProcessor for vision model examples

### DIFF
--- a/docs/source/use_dataset.mdx
+++ b/docs/source/use_dataset.mdx
@@ -154,10 +154,10 @@ The most common preprocessing you'll do with image datasets is _data augmentatio
 **1**. Start by loading the [Beans](https://huggingface.co/datasets/AI-Lab-Makerere/beans) dataset, the `Image` feature, and the feature extractor corresponding to a pretrained [ViT](https://huggingface.co/google/vit-base-patch16-224-in21k) model:
 
 ```py
->>> from transformers import AutoFeatureExtractor
+>>> from transformers import AutoImageProcessor
 >>> from datasets import load_dataset, Image
 
->>> feature_extractor = AutoFeatureExtractor.from_pretrained("google/vit-base-patch16-224-in21k")
+>>> image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224-in21k")
 >>> dataset = load_dataset("AI-Lab-Makerere/beans", split="train")
 ```
 


### PR DESCRIPTION
swaps AutoFeatureExtractor for AutoImageProcessor in the image preprocessing section of use_dataset.mdx — aligns with the transformers library direction where vision feature extractor references were already replaced in their own docs (see PRs #20111 and #20501). audio section is untouched since AutoFeatureExtractor is still correct there.
