### PR TITLE
Preserve float columns when JSON loader uses `field=`

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -36,6 +36,48 @@ def pandas_read_json(path_or_buf, **kwargs):
     if datasets.config.PANDAS_VERSION.major >= 2:
         kwargs["dtype_backend"] = "pyarrow"
     return pd.read_json(path_or_buf, **kwargs)
+
+
+def _arrow_table_from_field(
+    dataset: Any, features: Optional["datasets.Features"] = None, field: Optional[str] = None
+) -> pa.Table:
+    # Build directly from the parsed Python object instead of routing through
+    # pandas.read_json. Pandas with the pyarrow dtype_backend coerces columns
+    # like [0.0, 1.0, 2.0] to int64, dropping the float semantics (#6937,
+    # pandas-dev/pandas#58866). PyArrow's own inference preserves float64,
+    # and CPython dict key iteration order already gives us the
+    # column-insertion-order invariant from #6914.
+    if isinstance(dataset, list):
+        if not dataset:
+            if features is not None:
+                return pa.Table.from_pydict({name: [] for name in features})
+            return pa.Table.from_pydict({})
+        if not isinstance(dataset[0], dict):
+            # List of scalars; mirror the prior `df.columns == [0]` rename.
+            if features is None:
+                return pa.Table.from_pydict({"text": dataset})
+            # A scalar list is a single column, so an over-specified `features`
+            # cannot be satisfied. Pandas used to catch this when the rename
+            # assigned to `df.columns`; keep it an error rather than returning
+            # the extra columns as all-null.
+            if len(features) != 1:
+                raise ValueError(
+                    f"Field {field!r} is a list of scalars, which maps to a single column, "
+                    f"but `features` declares {len(features)}: {list(features)}"
+                )
+            return pa.Table.from_pydict({next(iter(features)): dataset})
+        keys: dict[str, None] = {}
+        for row in dataset:
+            for key in row.keys():
+                keys.setdefault(key, None)
+        column_order = list(keys)
+        mapping = {col: [row.get(col) for row in dataset] for col in column_order}
+        return pa.Table.from_pydict(mapping)
+    if isinstance(dataset, dict):
+        return pa.Table.from_pydict(dataset)
+    raise ValueError(
+        f"Cannot build a table from the JSON field at type {type(dataset).__name__}"
+    )
 
 
 class FullReadDisallowed(Exception):
@@ -162,10 +204,9 @@ class Json(datasets.ArrowBasedBuilder):
                         dataset = ujson_loads(f.read())
                     # We keep only the field we are interested in
                     dataset = dataset[self.config.field]
-                    df = pandas_read_json(io.StringIO(ujson_dumps(dataset)))
-                    if df.columns.tolist() == [0]:
-                        df.columns = list(self.config.features) if self.config.features else ["text"]
-                    pa_table = pa.Table.from_pandas(df, preserve_index=False)
+                    pa_table = _arrow_table_from_field(
+                        dataset, self.config.features, self.config.field
+                    )
                     yield Key(shard_idx, 0), self._cast_table(pa_table)
 
                 # If the files are agent traces (one row = one file except for hermes which can have multiple sessions per file)

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -807,3 +807,184 @@ def test_json_load_dataset_without_droid_marker_stays_ordinary_json(tmp_path):
 
     assert dataset.column_names == ["type", "id", "version", "timestamp", "message"]
     assert dataset[0]["type"] == "session_start"
+
+
+# Regression tests for #6937 (float-to-int coercion in the field= JSON loader).
+
+
+@pytest.fixture
+def json_file_with_integer_valued_floats_field(tmp_path):
+    path = tmp_path / "file_with_int_valued_floats_field.json"
+    data = textwrap.dedent(
+        """\
+        {
+            "data": [
+                {"col": 0.0},
+                {"col": 1.0},
+                {"col": 2.0}
+            ]
+        }
+        """
+    )
+    with open(path, "w") as f:
+        f.write(data)
+    return str(path)
+
+
+@pytest.fixture
+def json_file_with_integer_valued_floats_list(tmp_path):
+    path = tmp_path / "file_with_int_valued_floats_list.json"
+    data = textwrap.dedent(
+        """\
+        {
+            "data": [
+                {"col_int": 0, "col_float": 0.0, "col_mixed": 0.5},
+                {"col_int": 1, "col_float": 1.0, "col_mixed": 1.0},
+                {"col_int": 2, "col_float": 2.0, "col_mixed": 2.0}
+            ]
+        }
+        """
+    )
+    with open(path, "w") as f:
+        f.write(data)
+    return str(path)
+
+
+@pytest.fixture
+def json_file_with_integer_valued_floats_dict_of_lists_field(tmp_path):
+    path = tmp_path / "file_with_int_valued_floats_dict_of_lists.json"
+    data = textwrap.dedent(
+        """\
+        {
+            "data": {
+                "col_float": [0.0, 1.0, 2.0],
+                "col_int": [0, 1, 2]
+            }
+        }
+        """
+    )
+    with open(path, "w") as f:
+        f.write(data)
+    return str(path)
+
+
+def test_json_field_path_preserves_float_columns(
+    json_file_with_integer_valued_floats_field,
+):
+    # #6937 repro: col was getting silently coerced to int64.
+    json = Json(field="data")
+    base_files = [json_file_with_integer_valued_floats_field]
+    files_iterables = [list(base_files)]
+    original_files = list(base_files)
+    generator = json._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.schema.field("col").type == pa.float64()
+    assert pa_table.column("col").to_pylist() == [0.0, 1.0, 2.0]
+
+
+def test_json_field_path_preserves_float_columns_alongside_ints(
+    json_file_with_integer_valued_floats_list,
+):
+    json = Json(field="data")
+    base_files = [json_file_with_integer_valued_floats_list]
+    files_iterables = [list(base_files)]
+    original_files = list(base_files)
+    generator = json._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.schema.field("col_int").type == pa.int64()
+    assert pa_table.schema.field("col_float").type == pa.float64()
+    assert pa_table.schema.field("col_mixed").type == pa.float64()
+
+
+def test_json_field_path_preserves_float_columns_with_dict_of_lists(
+    json_file_with_integer_valued_floats_dict_of_lists_field,
+):
+    json = Json(field="data")
+    base_files = [json_file_with_integer_valued_floats_dict_of_lists_field]
+    files_iterables = [list(base_files)]
+    original_files = list(base_files)
+    generator = json._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.schema.field("col_float").type == pa.float64()
+    assert pa_table.schema.field("col_int").type == pa.int64()
+
+
+def test_json_field_path_preserves_float_columns_with_nulls(tmp_path):
+    # A float column whose only non-null values are integer-valued was also
+    # coerced to int64 by the pandas path.
+    path = tmp_path / "float_with_nulls_field.json"
+    with open(path, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                {
+                    "data": [
+                        {"col": 1.0},
+                        {"col": null}
+                    ]
+                }
+                """
+            )
+        )
+    json = Json(field="data")
+    base_files = [str(path)]
+    files_iterables = [list(base_files)]
+    original_files = list(base_files)
+    generator = json._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.schema.field("col").type == pa.float64()
+    assert pa_table.to_pydict()["col"] == [1.0, None]
+
+
+def test_json_field_path_scalar_list_rejects_over_specified_features(tmp_path):
+    # A scalar list is one column, so `features` declaring more cannot be
+    # satisfied. This used to raise from the pandas `df.columns = ...` rename;
+    # it must not silently return the extra columns as all-null.
+    path = tmp_path / "scalar_list_field.json"
+    with open(path, "w") as f:
+        f.write('{"data": [1, 2, 3]}\n')
+    features = Features({"num": Value("int64"), "extra": Value("string")})
+    json = Json(field="data", features=features)
+    base_files = [str(path)]
+    files_iterables = [list(base_files)]
+    original_files = list(base_files)
+    generator = json._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    with pytest.raises(ValueError, match="list of scalars"):
+        pa.concat_tables([table for _, table in generator])
+
+
+def test_json_field_path_preserves_column_order_with_list_of_dicts(tmp_path):
+    # #6913 invariant: keys appear in insertion order, not sorted order.
+    path = tmp_path / "preserve_order_field.json"
+    with open(path, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                {
+                    "data": [
+                        {"z": 1, "a": 2, "m": 3},
+                        {"z": 4, "a": 5, "m": 6}
+                    ]
+                }
+                """
+            )
+        )
+    json = Json(field="data")
+    base_files = [str(path)]
+    files_iterables = [list(base_files)]
+    original_files = list(base_files)
+    generator = json._generate_tables(
+        base_files=base_files, files_iterables=files_iterables, original_files=original_files
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.schema.names == ["z", "a", "m"]


### PR DESCRIPTION
Closes #6937.

When `load_dataset("json", data_files=..., field="data", ...)` is used, columns whose values are all integer-valued floats (`[0.0, 1.0, 2.0]`) get silently coerced to `int64`. Repro:

```python
import tempfile, json
from datasets import load_dataset

with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
    json.dump({"data": [{"col": v} for v in [0.0, 1.0, 2.0]]}, f)

ds = load_dataset("json", data_files=f.name, field="data", split="train")
print(ds.features)  # before: {'col': Value('int64')}
                    # after:  {'col': Value('float64')}
```

The underlying cause is `pd.read_json(..., dtype_backend="pyarrow")` (tracked upstream at pandas-dev/pandas#58866). The path that hits it is the one introduced in #6914 to preserve column insertion order. The dataset-viewer statistics regression in the issue is a direct consequence.

This PR replaces the `pandas.read_json` -> `pa.Table.from_pandas` path in the `field=` branch with a small `_arrow_table_from_field` helper that builds the Arrow table directly from the already-parsed Python object. PyArrow's own JSON inference preserves `float64`, and CPython dict iteration order gives us the `#6914` column-insertion-order invariant for free (no pandas roundtrip needed).

The helper handles:

- list of dicts (the common case): collect keys in insertion order, build a column-major dict
- list of scalars: wrap in a single-column table named after the configured feature, falling back to "text" (matches the prior `df.columns == [0]` rename)
- dict of lists (column-major payload): pass through to `pa.Table.from_pydict`
- empty list with features supplied: emit empty columns matching the configured feature names so downstream `_cast_table` aligns

The other JSON loading path (raw JSON Lines via `paj.read_json`) does not have this bug and is unchanged.

There is an older dormant PR for this issue (#7635 from June 2025, no reviews). I went a different direction because that PR scans the resulting DataFrame and re-casts float-looking int columns back to float after the fact. By that point pandas has already converted the values to Python ints, so the `isinstance(x, float)` check there does not actually detect them, and the scan adds an O(rows) Python pass to a hot path. Sidestepping pandas entirely is simpler and faster.

Tests in `tests/packaged_modules/test_json.py`:

- `test_json_field_path_preserves_float_columns`: the exact #6937 repro, asserts `col` stays float64
- `test_json_field_path_preserves_float_columns_alongside_ints`: list-of-dicts payload with mixed int / float / int-valued-float columns, each type preserved
- `test_json_field_path_preserves_float_columns_with_dict_of_lists`: dict-of-lists field payload
- `test_json_field_path_preserves_column_order_with_list_of_dicts`: column insertion order check (sanity vs the #6914 invariant)

`pytest tests/packaged_modules/test_json.py` shows 33 passed, 0 failed (29 pre-existing + 4 new).
