### PR TITLE
Fix parquet columns arg

### DIFF
--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -106,9 +106,7 @@ class Parquet(datasets.ArrowBasedBuilder):
                     f"{self.config.columns} and {self.config.features}",
                 )
             else:
-                features = datasets.Features(
-                    {col: self.config.features[col] for col in self.config.columns}
-                )
+                features = datasets.Features({col: self.config.features[col] for col in self.config.columns})
         else:
             features = self.config.features
         return datasets.DatasetInfo(features=features)

--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -100,11 +100,18 @@ class Parquet(datasets.ArrowBasedBuilder):
             and self.config.features is not None
             and set(self.config.columns) != set(self.config.features)
         ):
-            raise ValueError(
-                "The columns and features argument must contain the same columns, but got ",
-                f"{self.config.columns} and {self.config.features}",
-            )
-        return datasets.DatasetInfo(features=self.config.features)
+            if any(col not in self.config.features for col in self.config.columns):
+                raise ValueError(
+                    "The columns and features argument must match, but got ",
+                    f"{self.config.columns} and {self.config.features}",
+                )
+            else:
+                features = datasets.Features(
+                    {col: self.config.features[col] for col in self.config.columns}
+                )
+        else:
+            features = self.config.features
+        return datasets.DatasetInfo(features=features)
 
     def _split_generators(self, dl_manager):
         """We handle string, list and dicts in datafiles"""

--- a/tests/packaged_modules/test_parquet.py
+++ b/tests/packaged_modules/test_parquet.py
@@ -24,3 +24,18 @@ def test_parquet_reshard(multi_row_groups_parquet_path):
     resharded_ds = ds.reshard()
     assert resharded_ds.num_shards == 4
     assert list(resharded_ds) == expected
+
+
+def test_parquet_columns(parquet_path):
+    ds = load_dataset("parquet", data_files=parquet_path, split="train", streaming=True)
+    full_features = ds.features
+    assert len(ds.features) == 3
+    assert len(next(iter(ds))) == 3
+    ds = load_dataset("parquet", data_files=parquet_path, split="train", streaming=True, columns=["col_1"])
+    assert len(ds.features) == 1
+    assert len(next(iter(ds))) == 1
+    ds = load_dataset(
+        "parquet", data_files=parquet_path, split="train", streaming=True, columns=["col_1"], features=full_features
+    )
+    assert len(ds.features) == 1
+    assert len(next(iter(ds))) == 1


### PR DESCRIPTION
Fix the error message "The columns and features argument must contain the same columns, but got.." when passing `columns=` to load_dataset on a streaming parquet dataset (with features declared in the README.md)

useful e.g. for https://huggingface.co/datasets/jasperai/monet to load the thumbnails without the embeddings