### PR TITLE
docs: surface `repository_structure` earlier in the Get Started flow

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -17,6 +17,8 @@
     title: Preprocess
   - local: create_dataset
     title: Create a dataset
+  - local: repository_structure
+    title: Structure your repository
   - local: upload_dataset
     title: Share a dataset to the Hub
   title: "Tutorials"
@@ -106,8 +108,6 @@
       title: Share
     - local: dataset_card
       title: Create a dataset card
-    - local: repository_structure
-      title: Structure your repository
     title: "Dataset repository"
   title: "How-to guides"
 - sections:


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

Closes #5971

## What

The `repository_structure` doc page describes the simplest path to
creating a dataset (no dataset script required) but is currently
buried in the side navigation, so newcomers don't find it. This PR
repositions the entry in `docs/source/_toctree.yml` to surface it
earlier in the "Get started" / "Create a dataset" sequence.

## Why

The reporter on #5971 observed that the easiest onboarding flow is
not visible until users dig several layers into the docs.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by
a Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal
token-burn initiative before my Cursor billing cycle ends. Opened as
**draft** for review. Happy to iterate (in particular if maintainers
prefer a different placement or a cross-link instead).

Made with [Cursor](https://cursor.com)
