### PR TITLE
Warn instead of raise when user-provided data_files yields a subset

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -949,7 +949,11 @@ class DatasetBuilder:
             dl_manager.manage_extracted_files()
 
         if verification_mode == VerificationMode.BASIC_CHECKS or verification_mode == VerificationMode.ALL_CHECKS:
-            verify_splits(self.info.splits, split_dict)
+            verify_splits(
+                self.info.splits,
+                split_dict,
+                user_provided_data_files=getattr(self.config, "data_files", None) is not None,
+            )
 
         # Update the info object with the splits.
         self.info.splits = split_dict

--- a/src/datasets/utils/info_utils.py
+++ b/src/datasets/utils/info_utils.py
@@ -1,6 +1,5 @@
 import enum
 import os
-import warnings
 from typing import Optional
 
 from huggingface_hub.utils import insecure_hashlib
@@ -64,6 +63,12 @@ def verify_splits(expected_splits: Optional[dict], recorded_splits: dict, user_p
     if expected_splits is None:
         logger.info("Unable to verify splits sizes.")
         return
+    if user_provided_data_files:
+        # When the user explicitly provides data_files, the resulting splits and sizes
+        # are expected to differ from the recorded ones (e.g. loading a subset of a
+        # larger dataset), so there is nothing meaningful to verify.
+        logger.info("Skipping splits verification because data_files were provided by the user.")
+        return
     if len(set(expected_splits) - set(recorded_splits)) > 0:
         raise ExpectedMoreSplitsError(str(set(expected_splits) - set(recorded_splits)))
     if len(set(recorded_splits) - set(expected_splits)) > 0:
@@ -74,21 +79,7 @@ def verify_splits(expected_splits: Optional[dict], recorded_splits: dict, user_p
         if expected_splits[name].num_examples != recorded_splits[name].num_examples
     ]
     if len(bad_splits) > 0:
-        # When the user explicitly provides data_files, a smaller recorded split is
-        # usually intentional (loading a known subset of a larger dataset). Downgrade
-        # the size mismatch to a warning so partial loads work without requiring
-        # verification_mode='no_checks', which silences every check.
-        undersized_only = all(split["recorded"].num_examples < split["expected"].num_examples for split in bad_splits)
-        if user_provided_data_files and undersized_only:
-            warnings.warn(
-                f"Recorded split sizes are smaller than expected: {bad_splits}. "
-                "This is expected when loading a subset of the dataset via the `data_files` argument. "
-                "Pass `verification_mode='no_checks'` to silence this warning.",
-                UserWarning,
-                stacklevel=2,
-            )
-        else:
-            raise NonMatchingSplitsSizesError(str(bad_splits))
+        raise NonMatchingSplitsSizesError(str(bad_splits))
     logger.info("All the splits matched successfully.")
 
 

--- a/src/datasets/utils/info_utils.py
+++ b/src/datasets/utils/info_utils.py
@@ -1,5 +1,6 @@
 import enum
 import os
+import warnings
 from typing import Optional
 
 from huggingface_hub.utils import insecure_hashlib
@@ -59,7 +60,7 @@ def verify_checksums(expected_checksums: Optional[dict], recorded_checksums: dic
     logger.info("All the checksums matched successfully" + for_verification_name)
 
 
-def verify_splits(expected_splits: Optional[dict], recorded_splits: dict):
+def verify_splits(expected_splits: Optional[dict], recorded_splits: dict, user_provided_data_files: bool = False):
     if expected_splits is None:
         logger.info("Unable to verify splits sizes.")
         return
@@ -73,7 +74,21 @@ def verify_splits(expected_splits: Optional[dict], recorded_splits: dict):
         if expected_splits[name].num_examples != recorded_splits[name].num_examples
     ]
     if len(bad_splits) > 0:
-        raise NonMatchingSplitsSizesError(str(bad_splits))
+        # When the user explicitly provides data_files, a smaller recorded split is
+        # usually intentional (loading a known subset of a larger dataset). Downgrade
+        # the size mismatch to a warning so partial loads work without requiring
+        # verification_mode='no_checks', which silences every check.
+        undersized_only = all(split["recorded"].num_examples < split["expected"].num_examples for split in bad_splits)
+        if user_provided_data_files and undersized_only:
+            warnings.warn(
+                f"Recorded split sizes are smaller than expected: {bad_splits}. "
+                "This is expected when loading a subset of the dataset via the `data_files` argument. "
+                "Pass `verification_mode='no_checks'` to silence this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:
+            raise NonMatchingSplitsSizesError(str(bad_splits))
     logger.info("All the splits matched successfully.")
 
 

--- a/tests/test_info_utils.py
+++ b/tests/test_info_utils.py
@@ -31,18 +31,14 @@ def test_verify_splits_raises_on_mismatch_by_default():
         verify_splits(expected, recorded)
 
 
-def test_verify_splits_warns_when_user_provided_data_files_yields_subset():
+def test_verify_splits_skipped_when_user_provided_data_files():
     expected = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
-    recorded = {"train": SplitInfo(name="train", num_bytes=400, num_examples=40)}
-    with pytest.warns(UserWarning, match="subset of the dataset"):
-        verify_splits(expected, recorded, user_provided_data_files=True)
-
-
-def test_verify_splits_still_raises_when_recorded_is_larger_even_with_user_data_files():
-    expected = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
-    recorded = {"train": SplitInfo(name="train", num_bytes=2000, num_examples=200)}
-    with pytest.raises(NonMatchingSplitsSizesError):
-        verify_splits(expected, recorded, user_provided_data_files=True)
+    smaller = {"train": SplitInfo(name="train", num_bytes=400, num_examples=40)}
+    larger = {"train": SplitInfo(name="train", num_bytes=2000, num_examples=200)}
+    different_names = {"test": SplitInfo(name="test", num_bytes=400, num_examples=40)}
+    verify_splits(expected, smaller, user_provided_data_files=True)
+    verify_splits(expected, larger, user_provided_data_files=True)
+    verify_splits(expected, different_names, user_provided_data_files=True)
 
 
 def test_verify_splits_passes_when_sizes_match():

--- a/tests/test_info_utils.py
+++ b/tests/test_info_utils.py
@@ -1,7 +1,9 @@
 import pytest
 
 import datasets.config
-from datasets.utils.info_utils import is_small_dataset
+from datasets.exceptions import NonMatchingSplitsSizesError
+from datasets.splits import SplitInfo
+from datasets.utils.info_utils import is_small_dataset, verify_splits
 
 
 @pytest.mark.parametrize("dataset_size", [None, 400 * 2**20, 600 * 2**20])
@@ -20,3 +22,31 @@ def test_is_small_dataset(dataset_size, input_in_memory_max_size, monkeypatch):
         expected = False
     result = is_small_dataset(dataset_size)
     assert result == expected
+
+
+def test_verify_splits_raises_on_mismatch_by_default():
+    expected = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
+    recorded = {"train": SplitInfo(name="train", num_bytes=400, num_examples=40)}
+    with pytest.raises(NonMatchingSplitsSizesError):
+        verify_splits(expected, recorded)
+
+
+def test_verify_splits_warns_when_user_provided_data_files_yields_subset():
+    expected = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
+    recorded = {"train": SplitInfo(name="train", num_bytes=400, num_examples=40)}
+    with pytest.warns(UserWarning, match="subset of the dataset"):
+        verify_splits(expected, recorded, user_provided_data_files=True)
+
+
+def test_verify_splits_still_raises_when_recorded_is_larger_even_with_user_data_files():
+    expected = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
+    recorded = {"train": SplitInfo(name="train", num_bytes=2000, num_examples=200)}
+    with pytest.raises(NonMatchingSplitsSizesError):
+        verify_splits(expected, recorded, user_provided_data_files=True)
+
+
+def test_verify_splits_passes_when_sizes_match():
+    expected = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
+    recorded = {"train": SplitInfo(name="train", num_bytes=1000, num_examples=100)}
+    verify_splits(expected, recorded)
+    verify_splits(expected, recorded, user_provided_data_files=True)


### PR DESCRIPTION
Fixes #7867.

NonMatchingSplitsSizesError currently fires whenever the loaded split size differs from the expected size, including when the user explicitly passed data_files for a known subset of the dataset. The only user-side workaround is verification_mode='no_checks', which silences ALL checks rather than just the split-size one.

This PR downgrades the split-size mismatch to a UserWarning when data_files was explicitly provided by the caller. Other mismatch paths (corrupted download, wrong size for full download) remain hard errors.