### PR TITLE
Read cached dataset_info.json to populate config_names offline

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -823,10 +823,23 @@ class CachedDatasetModuleFactory(_DatasetModuleFactory):
             if config.HF_HUB_OFFLINE:
                 warning_msg += " (offline mode is enabled)."
             logger.warning(warning_msg)
+            config_names = set()
+            for cached_directory_path in cached_directory_paths:
+                dataset_info_path = Path(cached_directory_path) / "dataset_info.json"
+                if not dataset_info_path.is_file():
+                    continue
+                try:
+                    config_name = json.loads(dataset_info_path.read_text(encoding="utf-8")).get("config_name")
+                except (OSError, ValueError):
+                    continue
+                if config_name:
+                    config_names.add(config_name)
+            builder_configs = [BuilderConfig(name=config_name) for config_name in sorted(config_names)]
             return DatasetModule(
                 "datasets.packaged_modules.cache.cache",
                 "auto",
                 {**builder_kwargs, "version": "auto"},
+                builder_configs_parameters=BuilderConfigsParameters(builder_configs=builder_configs or None),
             )
         raise FileNotFoundError(f"Dataset {self.name} is not cached in {self.cache_dir}")
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import os
 import pickle
 import shutil
@@ -684,6 +685,27 @@ class ModuleFactoryTest(TestCase):
                 )
                 module_factory_result = factory.get_module()
                 assert importlib.import_module(module_factory_result.module_path) is not None
+
+
+def test_CachedDatasetModuleFactory_offline_populates_config_names(tmp_path):
+    # Build a fake cache directory with multiple cached configs for the same dataset
+    # (mirrors the layout produced by `Cache` in `datasets.packaged_modules.cache.cache`):
+    #   <cache_dir>/<namespace>___<dataset>/<config_name>/<version>/<hash>/dataset_info.json
+    repo_id = "fake-namespace/fake-dataset"
+    cached_relative_path = "fake-namespace___fake-dataset"
+    cached_configs = ["abstract_algebra", "all", "anatomy"]
+    for config_name in cached_configs:
+        cached_directory_path = tmp_path / cached_relative_path / config_name / "0.0.0" / "abcdef"
+        cached_directory_path.mkdir(parents=True)
+        (cached_directory_path / "dataset_info.json").write_text(
+            json.dumps({"config_name": config_name}), encoding="utf-8"
+        )
+    factory = CachedDatasetModuleFactory(repo_id, cache_dir=str(tmp_path))
+    with patch("datasets.config.HF_HUB_OFFLINE", True):
+        module = factory.get_module()
+    builder_configs = module.builder_configs_parameters.builder_configs
+    assert builder_configs is not None
+    assert sorted(bc.name for bc in builder_configs) == sorted(cached_configs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`get_dataset_config_names` with `HF_DATASETS_OFFLINE=1` returns `['default']` even when the cache contains multiple config subdirectories for the dataset. For example, after caching `cais/mmlu`:

```
$ HF_DATASETS_OFFLINE=1 python -c "import datasets; print(datasets.get_dataset_config_names('cais/mmlu'))"
Using the latest cached version of the dataset since cais/mmlu couldn't be found on the Hugging Face Hub (offline mode is enabled).
['default']
```

This is because `CachedDatasetModuleFactory.get_module` returns a `DatasetModule` without `builder_configs_parameters`, so `get_dataset_config_names` falls back to `default`.

## Fix

Walk the cached repo subdirectories, parse each `dataset_info.json`, and populate `builder_configs_parameters` with the discovered config names. Malformed or unreadable `dataset_info.json` files are skipped silently so a single bad cache entry does not break the lookup.

With this change:

```
$ HF_DATASETS_OFFLINE=1 python -c "import datasets; print(datasets.get_dataset_config_names('cais/mmlu'))"
Using the latest cached version of the dataset since cais/mmlu couldn't be found on the Hugging Face Hub (offline mode is enabled).
['abstract_algebra', 'all', 'anatomy', ...]
```

## Test

Adds `test_CachedDatasetModuleFactory_offline_populates_config_names` in `tests/test_load.py` that builds a fake cache layout with three configs, calls the factory with `HF_HUB_OFFLINE` patched to `True`, and asserts every cached config name is returned. No network access required.

Fixes #7947. Supersedes the abandoned #7977.