### PR TITLE
Include version in DatasetInfo YAML so push_to_hub preserves it

### DIFF
--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -162,6 +162,7 @@ class DatasetInfo:
         "dataset_size",
         "features",
         "splits",
+        "version",
     ]
 
     def __post_init__(self):

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -92,6 +92,14 @@ def test_dataset_info_to_yaml_dict_empty():
     assert dataset_info_yaml_dict == {}
 
 
+def test_dataset_info_to_yaml_dict_preserves_version():
+    dataset_info = DatasetInfo(config_name="config", version="1.2.3")
+    dataset_info_yaml_dict = dataset_info._to_yaml_dict()
+    assert dataset_info_yaml_dict.get("version") == "1.2.3"
+    reloaded = DatasetInfo._from_yaml_dict(dataset_info_yaml_dict)
+    assert str(reloaded.version) == "1.2.3"
+
+
 @pytest.mark.parametrize(
     "dataset_infos_dict",
     [


### PR DESCRIPTION
DatasetInfo._INCLUDED_INFO_IN_YAML controls which fields land in the README.md dataset_info block written by push_to_hub, and it currently omits version. Setting version on a Dataset (e.g. via load_dataset(..., version=...)) and pushing it to the Hub silently drops the version from the rendered front matter, so reloading the dataset returns version=None unless the user edits the README by hand. Closes #7378.

The reload side already handles a version string in DatasetInfo.__post_init__ via the Version dataclass, so adding "version" to the included keys is enough to round-trip the value through YAML without any extra coercion. The empty case is preserved because _to_yaml_dict only emits keys whose values are set on the instance.

Added test_dataset_info_to_yaml_dict_preserves_version in tests/test_info.py that asserts the string survives _to_yaml_dict and _from_yaml_dict. tests/test_info.py and tests/test_hub.py pass locally.