### PR TITLE
Add `.conll` / `.conllu` dataset format loader (CoNLL-2003 / 2000 / U)

### DIFF
--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -7,6 +7,7 @@ from huggingface_hub.utils import insecure_hashlib
 from .arrow import arrow
 from .audiofolder import audiofolder
 from .cache import cache
+from .conll import conll
 from .csv import csv
 from .eval import eval
 from .hdf5 import hdf5
@@ -45,6 +46,7 @@ _PACKAGED_DATASETS_MODULES = {
     "parquet": (parquet.__name__, _hash_python_lines(inspect.getsource(parquet).splitlines())),
     "arrow": (arrow.__name__, _hash_python_lines(inspect.getsource(arrow).splitlines())),
     "text": (text.__name__, _hash_python_lines(inspect.getsource(text).splitlines())),
+    "conll": (conll.__name__, _hash_python_lines(inspect.getsource(conll).splitlines())),
     "imagefolder": (imagefolder.__name__, _hash_python_lines(inspect.getsource(imagefolder).splitlines())),
     "audiofolder": (audiofolder.__name__, _hash_python_lines(inspect.getsource(audiofolder).splitlines())),
     "videofolder": (videofolder.__name__, _hash_python_lines(inspect.getsource(videofolder).splitlines())),
@@ -82,6 +84,8 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".gpq": ("parquet", {}),
     ".arrow": ("arrow", {}),
     ".txt": ("text", {}),
+    ".conll": ("conll", {}),
+    ".conllu": ("conll", {"comment_prefix": "#"}),
     ".tar": ("webdataset", {}),
     ".xml": ("xml", {}),
     ".hdf5": ("hdf5", {}),

--- a/src/datasets/packaged_modules/conll/conll.py
+++ b/src/datasets/packaged_modules/conll/conll.py
@@ -1,0 +1,155 @@
+"""CoNLL format dataset builder.
+
+Reads CoNLL-style files where each line carries one token plus its tag columns,
+columns are whitespace-separated, and empty lines mark sentence boundaries.
+Each example is one sentence, with each configured column produced as a list
+aligned with the tokens list.
+
+Supports CoNLL-2000 (chunking), CoNLL-2003 (NER), CoNLL-U (Universal
+Dependencies), and any custom column schema by overriding ``column_names``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pyarrow as pa
+
+import datasets
+from datasets.builder import Key
+from datasets.features.features import require_storage_cast
+from datasets.table import table_cast
+
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+
+DEFAULT_COLUMN_NAMES = ["tokens"]
+
+
+@dataclass
+class ConllConfig(datasets.BuilderConfig):
+    """BuilderConfig for CoNLL-style files.
+
+    Args:
+        features: (`Features`, *optional*):
+            Cast the data to `features`.
+        column_names: (`list[str]`, defaults to `["tokens"]`):
+            Names for each whitespace-separated column. The first name is the
+            token column; subsequent names cover the tag columns. Common
+            schemas:
+
+            - CoNLL-2003 NER: `["tokens", "pos_tags", "chunk_tags", "ner_tags"]`
+            - CoNLL-2000 chunking: `["tokens", "pos_tags", "chunk_tags"]`
+            - CoNLL-U: `["id", "form", "lemma", "upos", "xpos", "feats",
+              "head", "deprel", "deps", "misc"]`
+        delimiter: (`str`, *optional*):
+            Column delimiter inside each line. If `None` (default), any
+            whitespace is used, matching the standard CoNLL convention.
+        encoding: (`str`, defaults to `"utf-8"`):
+            Encoding to decode the file.
+        encoding_errors: (`str`, *optional*):
+            Argument to define what to do in case of encoding error. Same as
+            the `errors` argument in `open()`.
+        skip_docstart: (`bool`, defaults to `True`):
+            Skip CoNLL-2003 `-DOCSTART-` document-boundary marker lines.
+        comment_prefix: (`str`, *optional*):
+            If set, lines starting with this prefix are skipped. CoNLL-U
+            comments start with `#`.
+    """
+
+    features: Optional[datasets.Features] = None
+    column_names: list[str] = field(default_factory=lambda: list(DEFAULT_COLUMN_NAMES))
+    delimiter: Optional[str] = None
+    encoding: str = "utf-8"
+    encoding_errors: Optional[str] = None
+    skip_docstart: bool = True
+    comment_prefix: Optional[str] = None
+
+
+class Conll(datasets.ArrowBasedBuilder):
+    BUILDER_CONFIG_CLASS = ConllConfig
+
+    def _info(self):
+        return datasets.DatasetInfo(features=self.config.features)
+
+    def _split_generators(self, dl_manager):
+        """The `data_files` kwarg in load_dataset() can be a str, List[str],
+        Dict[str,str], or Dict[str,List[str]].
+
+        If str or List[str], then the dataset returns only the 'train' split.
+        If dict, then keys should be from the `datasets.Split` enum.
+        """
+        if not self.config.data_files:
+            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+        dl_manager.download_config.extract_on_the_fly = True
+        base_data_files = dl_manager.download(self.config.data_files)
+        extracted_data_files = dl_manager.extract(base_data_files)
+        splits = []
+        for split_name, files in extracted_data_files.items():
+            files_iterables = [dl_manager.iter_files(file) for file in files]
+            splits.append(
+                datasets.SplitGenerator(
+                    name=split_name,
+                    gen_kwargs={
+                        "files_iterables": files_iterables,
+                        "base_files": base_data_files[split_name],
+                    },
+                )
+            )
+        return splits
+
+    def _cast_table(self, pa_table: pa.Table) -> pa.Table:
+        if self.config.features is not None:
+            schema = self.config.features.arrow_schema
+            if all(not require_storage_cast(feature) for feature in self.config.features.values()):
+                pa_table = pa_table.cast(schema)
+            else:
+                pa_table = table_cast(pa_table, schema)
+        return pa_table
+
+    def _generate_shards(self, base_files, files_iterables):
+        yield from base_files
+
+    def _generate_tables(self, base_files, files_iterables):
+        column_names = list(self.config.column_names)
+        if not column_names:
+            raise ValueError("ConllConfig.column_names must be a non-empty list")
+        num_cols = len(column_names)
+        delimiter = self.config.delimiter
+        skip_docstart = self.config.skip_docstart
+        comment_prefix = self.config.comment_prefix
+
+        for shard_idx, files_iterable in enumerate(files_iterables):
+            for file in files_iterable:
+                sentences: list[list[list[str]]] = []
+                current: list[list[str]] = [[] for _ in range(num_cols)]
+                with open(file, encoding=self.config.encoding, errors=self.config.encoding_errors) as f:
+                    for raw_line in f:
+                        # Strip the trailing newline only — preserve embedded whitespace
+                        line = raw_line.rstrip("\r\n")
+                        if not line.strip():
+                            # Sentence boundary
+                            if current[0]:
+                                sentences.append(current)
+                                current = [[] for _ in range(num_cols)]
+                            continue
+                        if skip_docstart and line.startswith("-DOCSTART-"):
+                            continue
+                        if comment_prefix is not None and line.startswith(comment_prefix):
+                            continue
+                        parts = line.split(delimiter) if delimiter is not None else line.split()
+                        # Pad or truncate to num_cols so column alignment is preserved
+                        if len(parts) < num_cols:
+                            parts = parts + [""] * (num_cols - len(parts))
+                        elif len(parts) > num_cols:
+                            parts = parts[:num_cols]
+                        for i, val in enumerate(parts):
+                            current[i].append(val)
+                    # Tail sentence with no trailing blank line
+                    if current[0]:
+                        sentences.append(current)
+
+                if sentences:
+                    arrays = [pa.array([sentence[col_idx] for sentence in sentences]) for col_idx in range(num_cols)]
+                    pa_table = pa.Table.from_arrays(arrays, names=column_names)
+                    yield Key(shard_idx, 0), self._cast_table(pa_table)

--- a/tests/packaged_modules/test_conll.py
+++ b/tests/packaged_modules/test_conll.py
@@ -1,0 +1,213 @@
+import textwrap
+
+import pyarrow as pa
+import pytest
+
+from datasets.builder import InvalidConfigName
+from datasets.data_files import DataFilesList
+from datasets.packaged_modules.conll.conll import Conll, ConllConfig
+
+
+@pytest.fixture
+def conll2003_file(tmp_path):
+    """Minimal CoNLL-2003-style NER file: token POS chunk NER."""
+    filename = tmp_path / "sample.conll"
+    data = textwrap.dedent(
+        """\
+        -DOCSTART- -X- -X- O
+
+        EU NNP B-NP B-ORG
+        rejects VBZ B-VP O
+        German JJ B-NP B-MISC
+        call NN I-NP O
+        . . O O
+
+        Peter NNP B-NP B-PER
+        Blackburn NNP I-NP I-PER
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def conll_no_trailing_blank_file(tmp_path):
+    """Sentence with no trailing blank line — should still flush."""
+    filename = tmp_path / "no_trailing.conll"
+    data = "Hello NN\nworld NN\n. ."
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def conll_tab_delimited_file(tmp_path):
+    """Tab-delimited CoNLL — fields can contain spaces."""
+    filename = tmp_path / "tab.conll"
+    data = "tok1\tNN\nphrase with spaces\tNNP\n\ntok2\tVB\n"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def conllu_file(tmp_path):
+    """CoNLL-U with # comment lines."""
+    filename = tmp_path / "sample.conllu"
+    data = textwrap.dedent(
+        """\
+        # sent_id = test-1
+        # text = The cat sat.
+        1\tThe\tthe\tDET
+        2\tcat\tcat\tNOUN
+        3\tsat\tsit\tVERB
+        4\t.\t.\tPUNCT
+
+        # sent_id = test-2
+        1\tHello\thello\tINTJ
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+def test_config_raises_when_invalid_name() -> None:
+    with pytest.raises(InvalidConfigName, match="Bad characters"):
+        _ = ConllConfig(name="name-with-*-invalid-character")
+
+
+@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+def test_config_raises_when_invalid_data_files(data_files) -> None:
+    with pytest.raises(ValueError, match="Expected a DataFilesDict"):
+        _ = ConllConfig(name="name", data_files=data_files)
+
+
+def test_config_default_column_names():
+    c = ConllConfig(name="test")
+    assert c.column_names == ["tokens"]
+
+
+def test_generate_tables_conll2003_with_full_schema(conll2003_file):
+    builder = Conll(
+        column_names=["tokens", "pos_tags", "chunk_tags", "ner_tags"],
+    )
+    generator = builder._generate_tables(base_files=[conll2003_file], files_iterables=[[conll2003_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    data = pa_table.to_pydict()
+
+    assert data["tokens"] == [
+        ["EU", "rejects", "German", "call", "."],
+        ["Peter", "Blackburn"],
+    ]
+    assert data["pos_tags"] == [
+        ["NNP", "VBZ", "JJ", "NN", "."],
+        ["NNP", "NNP"],
+    ]
+    assert data["chunk_tags"] == [
+        ["B-NP", "B-VP", "B-NP", "I-NP", "O"],
+        ["B-NP", "I-NP"],
+    ]
+    assert data["ner_tags"] == [
+        ["B-ORG", "O", "B-MISC", "O", "O"],
+        ["B-PER", "I-PER"],
+    ]
+
+
+def test_generate_tables_skips_docstart_by_default(conll2003_file):
+    builder = Conll(column_names=["tokens", "pos_tags", "chunk_tags", "ner_tags"])
+    generator = builder._generate_tables(base_files=[conll2003_file], files_iterables=[[conll2003_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    # DOCSTART line should not appear as a token
+    all_tokens = sum(pa_table.to_pydict()["tokens"], [])
+    assert "-DOCSTART-" not in all_tokens
+
+
+def test_generate_tables_keeps_docstart_when_disabled(conll2003_file):
+    builder = Conll(
+        column_names=["tokens", "pos_tags", "chunk_tags", "ner_tags"],
+        skip_docstart=False,
+    )
+    generator = builder._generate_tables(base_files=[conll2003_file], files_iterables=[[conll2003_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    all_tokens = sum(pa_table.to_pydict()["tokens"], [])
+    assert "-DOCSTART-" in all_tokens
+
+
+def test_generate_tables_flushes_tail_sentence_without_trailing_blank(
+    conll_no_trailing_blank_file,
+):
+    builder = Conll(column_names=["tokens", "pos_tags"])
+    generator = builder._generate_tables(
+        base_files=[conll_no_trailing_blank_file],
+        files_iterables=[[conll_no_trailing_blank_file]],
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.to_pydict()["tokens"] == [["Hello", "world", "."]]
+    assert pa_table.to_pydict()["pos_tags"] == [["NN", "NN", "."]]
+
+
+def test_generate_tables_with_tab_delimiter(conll_tab_delimited_file):
+    builder = Conll(column_names=["tokens", "pos_tags"], delimiter="\t")
+    generator = builder._generate_tables(
+        base_files=[conll_tab_delimited_file],
+        files_iterables=[[conll_tab_delimited_file]],
+    )
+    pa_table = pa.concat_tables([table for _, table in generator])
+    # 'phrase with spaces' must stay a single token under tab delimiter
+    assert pa_table.to_pydict()["tokens"] == [["tok1", "phrase with spaces"], ["tok2"]]
+
+
+def test_generate_tables_conllu_with_comment_prefix(conllu_file):
+    builder = Conll(
+        column_names=["id", "form", "lemma", "upos"],
+        delimiter="\t",
+        comment_prefix="#",
+    )
+    generator = builder._generate_tables(base_files=[conllu_file], files_iterables=[[conllu_file]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    data = pa_table.to_pydict()
+    # 2 sentences, comments stripped, # never appears in any column
+    assert data["form"] == [["The", "cat", "sat", "."], ["Hello"]]
+    assert data["upos"] == [["DET", "NOUN", "VERB", "PUNCT"], ["INTJ"]]
+    for col in data.values():
+        for sentence in col:
+            for cell in sentence:
+                assert not cell.startswith("#")
+
+
+def test_generate_tables_pads_rows_with_fewer_columns(tmp_path):
+    """A row with fewer columns than column_names should pad with empty strings."""
+    filename = tmp_path / "padded.conll"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("only_token\nfull token POS\n")
+    builder = Conll(column_names=["tokens", "pos_tags"])
+    generator = builder._generate_tables(base_files=[str(filename)], files_iterables=[[str(filename)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.to_pydict()["tokens"] == [["only_token", "full"]]
+    # First row has empty POS (padded), second has "token" because line had 3 parts but column_names has 2 -> truncated
+    assert pa_table.to_pydict()["pos_tags"] == [["", "token"]]
+
+
+def test_generate_tables_truncates_rows_with_extra_columns(tmp_path):
+    """A row with more columns than column_names should truncate."""
+    filename = tmp_path / "extra.conll"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("tok POS chunk ner extra_col\n")
+    builder = Conll(column_names=["tokens", "pos_tags"])
+    generator = builder._generate_tables(base_files=[str(filename)], files_iterables=[[str(filename)]])
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.to_pydict()["tokens"] == [["tok"]]
+    assert pa_table.to_pydict()["pos_tags"] == [["POS"]]
+
+
+def test_generate_tables_empty_column_names_raises(tmp_path):
+    """Empty column_names should raise a clear ValueError."""
+    filename = tmp_path / "x.conll"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("a b\n")
+    builder = Conll(column_names=[])
+    generator = builder._generate_tables(base_files=[str(filename)], files_iterables=[[str(filename)]])
+    with pytest.raises(ValueError, match="column_names must be a non-empty list"):
+        list(generator)


### PR DESCRIPTION
Closes #7757.

## Summary

Adds a `packaged_modules/conll/` builder so `.conll` and `.conllu` files load directly via `load_dataset(...)` without manual parsing scripts. Each row of the loaded dataset corresponds to one sentence, with each configured column produced as a list aligned with the token list.

Builder shape mirrors the `text` packaged module (line-based reading) — as suggested by @namesarnav in the issue thread.

```python
from datasets import load_dataset

ds = load_dataset(
    "conll",
    data_files="train.conll",
    column_names=["tokens", "pos_tags", "chunk_tags", "ner_tags"],
)
# Each example: {"tokens": [...], "pos_tags": [...], "chunk_tags": [...], "ner_tags": [...]}
