### PR TITLE
Support composed splits in streaming datasets

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -57,7 +57,12 @@ from .filesystems import (
 )
 from .fingerprint import Hasher
 from .info import DatasetInfo
-from .iterable_dataset import ArrowExamplesIterable, ExamplesIterable, IterableDataset
+from .iterable_dataset import (
+    ArrowExamplesIterable,
+    ExamplesIterable,
+    IterableDataset,
+    _concatenate_iterable_datasets,
+)
 from .naming import INVALID_WINDOWS_CHARACTERS_IN_PATH, camelcase_to_snakecase
 from .splits import Split, SplitDict, SplitGenerator, SplitInfo
 from .streaming import extend_dataset_builder_for_streaming
@@ -1114,8 +1119,37 @@ class DatasetBuilder:
         # By default, return all splits
         if split is None:
             splits_generator = splits_generators
-        elif split in splits_generators:
-            splits_generator = splits_generators[split]
+        elif str(split) in splits_generators:
+            splits_generator = splits_generators[str(split)]
+        elif hasattr(split, "get_read_instruction"):
+            split_dict = SplitDict({name: sg.split_info for name, sg in splits_generators.items()})
+            split_instruction = split.get_read_instruction(split_dict)
+            split_infos = split_instruction.get_list_sliced_split_info()
+            if any(split_info.slice_value is not None for split_info in split_infos):
+                raise ValueError(f"Bad split: {split}. Available splits: {list(splits_generators)}")
+            return _concatenate_iterable_datasets(
+                [
+                    self._as_streaming_dataset_single(splits_generators[split_info.split_info.name])
+                    for split_info in split_infos
+                ],
+                info=self.info,
+                split=split,
+            )
+        elif str(split) == str(Split.ALL):
+            return _concatenate_iterable_datasets(
+                [self._as_streaming_dataset_single(sg) for sg in splits_generators.values()],
+                info=self.info,
+                split=split,
+            )
+        elif "+" in str(split) and "[" not in str(split) and "]" not in str(split):
+            split_names = [split_name.strip() for split_name in str(split).split("+")]
+            if not all(split_name in splits_generators for split_name in split_names):
+                raise ValueError(f"Bad split: {split}. Available splits: {list(splits_generators)}")
+            return _concatenate_iterable_datasets(
+                [self._as_streaming_dataset_single(splits_generators[split_name]) for split_name in split_names],
+                info=self.info,
+                split=split,
+            )
         else:
             raise ValueError(f"Bad split: {split}. Available splits: {list(splits_generators)}")
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -70,6 +70,21 @@ class DummyGeneratorBasedBuilder(GeneratorBasedBuilder):
             yield (0, i), {"text": "foo"}
 
 
+class DummyGeneratorBasedBuilderWithTwoSplits(GeneratorBasedBuilder):
+    def _info(self):
+        return DatasetInfo(features=Features({"text": Value("string")}))
+
+    def _split_generators(self, dl_manager):
+        return [
+            SplitGenerator(name=Split.TRAIN, gen_kwargs={"text": "train"}),
+            SplitGenerator(name=Split.TEST, gen_kwargs={"text": "test"}),
+        ]
+
+    def _generate_examples(self, text):
+        for i in range(10):
+            yield i, {"text": text}
+
+
 class DummyArrowBasedBuilder(ArrowBasedBuilder):
     def _info(self):
         return DatasetInfo(features=Features({"text": Value("string")}))
@@ -588,6 +603,29 @@ def test_builder_as_streaming_dataset(tmp_path):
     dset = dummy_builder.as_streaming_dataset(split="train")
     assert isinstance(dset, IterableDataset)
     assert len(list(dset)) == 100
+
+
+@pytest.mark.parametrize("split", ["train+test", Split.TRAIN + Split.TEST])
+def test_builder_as_streaming_dataset_with_split_composition(split, tmp_path):
+    dummy_builder = DummyGeneratorBasedBuilderWithTwoSplits(cache_dir=str(tmp_path))
+    check_streaming(dummy_builder)
+    dset = dummy_builder.as_streaming_dataset(split=split)
+    assert isinstance(dset, IterableDataset)
+    if isinstance(split, str):
+        assert dset.split == split
+    else:
+        assert dset.split is split
+    assert [example["text"] for example in dset] == ["train"] * 10 + ["test"] * 10
+
+
+@pytest.mark.parametrize("split", ["all", Split.ALL])
+def test_builder_as_streaming_dataset_with_all_split(split, tmp_path):
+    dummy_builder = DummyGeneratorBasedBuilderWithTwoSplits(cache_dir=str(tmp_path))
+    check_streaming(dummy_builder)
+    dset = dummy_builder.as_streaming_dataset(split=split)
+    assert isinstance(dset, IterableDataset)
+    assert dset.split == split
+    assert [example["text"] for example in dset] == ["train"] * 10 + ["test"] * 10
 
 
 def _run_test_builder_streaming_works_in_subprocesses(builder):


### PR DESCRIPTION
Fixes #2699
Fixes #4804

This PR adds support for unsliced split composition when loading datasets in streaming mode, e.g. `split="train+validation"`.

Previously, `DatasetBuilder.as_streaming_dataset()` only accepted a single split name or returned all splits as an `IterableDatasetDict`, so composed split strings raised `ValueError: Bad split`.

The change resolves composed split instructions by building each requested streaming split and concatenating the resulting `IterableDataset`s. It also supports the `all` split sentinel in streaming mode.

This intentionally does not add support for sliced streaming expressions such as `train[:10%]`, which require separate handling.

Tests added for:
- string split composition: `"train+test"`
- object split composition: `Split.TRAIN + Split.TEST`
- `"all"`
- `Split.ALL`

Validation:
- `python -m pytest tests/test_builder.py -q`