### PR TITLE
Validate split name before starting download

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -59,7 +59,7 @@ from .fingerprint import Hasher
 from .info import DatasetInfo
 from .iterable_dataset import ArrowExamplesIterable, ExamplesIterable, IterableDataset
 from .naming import INVALID_WINDOWS_CHARACTERS_IN_PATH, camelcase_to_snakecase
-from .splits import Split, SplitDict, SplitGenerator, SplitInfo
+from .splits import Split, SplitDict, SplitGenerator, SplitInfo, _check_split_names
 from .streaming import extend_dataset_builder_for_streaming
 from .table import CastError
 from .utils import logging
@@ -1023,6 +1023,10 @@ class DatasetBuilder:
         # By default, return all splits
         if split is None:
             split = {s: s for s in self.info.splits}
+
+        # Validate before doing any work so the error is clear rather than
+        # something cryptic bubbling up from inside arrow_reader.
+        _check_split_names(split, self.info.splits)
 
         # Create a dataset for each of the given splits
         datasets = map_nested(

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -75,7 +75,7 @@ from .packaged_modules import (
     _PACKAGED_DATASETS_MODULES,
 )
 from .packaged_modules.folder_based_builder.folder_based_builder import FolderBasedBuilder
-from .splits import Split
+from .splits import Split, _check_split_names
 from .utils import _dataset_viewer
 from .utils.file_utils import (
     _raise_if_offline_mode_is_enabled,
@@ -1699,6 +1699,12 @@ def load_dataset(
         storage_options=storage_options,
         **config_kwargs,
     )
+
+    # If split info is already known (from Hub YAML metadata or a previously cached
+    # dataset_info.json) we can catch a bad split name right here, before starting
+    # what could be a very large download.
+    if split is not None and builder_instance.info.splits:
+        _check_split_names(split, builder_instance.info.splits)
 
     # Return iterable dataset in case of streaming
     if streaming:

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -610,6 +610,41 @@ class SplitDict(dict[str, SplitInfo]):
         return cls.from_split_dict(yaml_data)
 
 
+def _check_split_names(split, known_splits):
+    """Raise ValueError if any requested split name isn't in the dataset's known splits.
+
+    Handles composite specs like ``"train+test"`` and sliced specs like
+    ``"train[:1000]"`` by extracting the base split name before checking.
+
+    Args:
+        split: The split argument passed by the user – a string, :class:`Split`,
+            list, or dict (as accepted by ``load_dataset``).
+        known_splits: Mapping of available split names, e.g. ``builder.info.splits``.
+    """
+    if not known_splits:
+        return
+
+    if isinstance(split, dict):
+        specs = list(split.values())
+    elif isinstance(split, (list, tuple)):
+        specs = list(split)
+    else:
+        specs = [split]
+
+    available = sorted(known_splits)
+    for spec in specs:
+        if spec is None:
+            continue
+        spec = str(spec).strip().strip("()")
+        if not spec or spec == "all":
+            continue
+        # "train+test[:50%]" → check "train" and "test" separately
+        for part in spec.split("+"):
+            name = part.strip().split("[")[0].strip()
+            if name and name not in known_splits:
+                raise ValueError(f'Unknown split "{name}". Should be one of {available}.')
+
+
 @dataclass
 class SplitGenerator:
     """Defines the split information for the generator.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -552,6 +552,30 @@ def test_builder_as_dataset(split, expected_dataset_class, expected_dataset_leng
         dataset.column_names == ["text"]
 
 
+def test_builder_as_dataset_unknown_split_raises(tmp_path):
+    builder = DummyBuilder(cache_dir=str(tmp_path))
+    os.makedirs(builder.cache_dir)
+
+    builder.info.splits = SplitDict()
+    builder.info.splits.add(SplitInfo("train", num_examples=10))
+    builder.info.splits.add(SplitInfo("test", num_examples=10))
+
+    for split_name in builder.info.splits:
+        with ArrowWriter(
+            path=os.path.join(builder.cache_dir, f"{builder.dataset_name}-{split_name}.arrow"),
+            features=Features({"text": Value("string")}),
+        ) as writer:
+            writer.write_batch({"text": ["foo"] * 10})
+            writer.finalize()
+
+    with pytest.raises(ValueError, match='Unknown split "validation"'):
+        builder.as_dataset(split="validation")
+
+    # compound spec – one part is valid, one isn't
+    with pytest.raises(ValueError, match='Unknown split "oops"'):
+        builder.as_dataset(split="train+oops")
+
+
 @pytest.mark.parametrize("in_memory", [False, True])
 def test_generator_based_builder_as_dataset(in_memory, tmp_path):
     cache_dir = tmp_path / "data"

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from datasets.splits import Split, SplitDict, SplitInfo
+from datasets.splits import Split, SplitDict, SplitInfo, _check_split_names
 from datasets.utils.py_utils import asdict
 
 
@@ -41,3 +41,55 @@ def test_split_dict_asdict_has_dataset_name(split_info):
 def test_named_split_inequality():
     # Used while building the docs, when set as a default parameter value in a function signature
     assert Split.TRAIN != inspect.Parameter.empty
+
+
+# ---------------------------------------------------------------------------
+# _check_split_names
+# ---------------------------------------------------------------------------
+
+_SPLITS = SplitDict(
+    {
+        "train": SplitInfo(name="train", num_examples=100),
+        "test": SplitInfo(name="test", num_examples=50),
+    }
+)
+
+
+@pytest.mark.parametrize(
+    "split",
+    [
+        "train",
+        "test",
+        "train[:50%]",
+        "train[10:20]",
+        "train+test",
+        "train[:50%]+test",
+        ["train", "test"],
+        {"my_train": "train", "my_test": "test"},
+        None,
+        "all",
+    ],
+)
+def test_check_split_names_valid(split):
+    # should not raise
+    _check_split_names(split, _SPLITS)
+
+
+@pytest.mark.parametrize(
+    "split, bad_name",
+    [
+        ("blabla", "blabla"),
+        ("train+blabla", "blabla"),
+        ("blabla[:50%]", "blabla"),
+        (["train", "blabla"], "blabla"),
+        ({"a": "train", "b": "blabla"}, "blabla"),
+    ],
+)
+def test_check_split_names_invalid(split, bad_name):
+    with pytest.raises(ValueError, match=f'Unknown split "{bad_name}"'):
+        _check_split_names(split, _SPLITS)
+
+
+def test_check_split_names_empty_known_splits():
+    # can't validate anything without known splits – should be a no-op
+    _check_split_names("whatever", SplitDict())


### PR DESCRIPTION
## What this fixes

Closes #5523.

When you pass an invalid split name to `load_dataset()`, the error only surfaces after the entire dataset has already been downloaded. For large datasets that can mean waiting many minutes before seeing a one-liner like:

```python
from datasets import load_dataset
load_dataset("mozilla-foundation/common_voice_11_0", "en", split="blabla")
# ... full download happens first ...
# ValueError: Unknown split "blabla". Should be one of [...]
```

The expected behaviour is to raise immediately.

## How it works

**`splits.py`** — new `_check_split_names(split, known_splits)` helper.  It normalises all the split spec shapes the library accepts (plain name, `"train[:50%]"`, `"train+test"`, list, dict) and raises a `ValueError` with the list of available splits if any base name is not recognised.

**`load.py`** — calls `_check_split_names` right after `load_dataset_builder()` returns, before `download_and_prepare()` is ever reached.  This fires whenever split info is already available – i.e. when the builder was initialised from Hub YAML metadata or from a cached `dataset_info.json`.

**`builder.py`** — calls `_check_split_names` at the top of `as_dataset()`, before `map_nested()`.  This is the safety-net for the cases where the early check wasn't possible (first download with no Hub YAML split info): instead of an opaque error from `arrow_reader`, the user gets a clean `ValueError` with the list of available splits.

## Tests

- **`test_splits.py`**: 14 parametrised cases covering valid names, slices, compound specs, lists, dicts, `None`, `"all"`, and empty `known_splits`.
- **`test_builder.py`**: `test_builder_as_dataset_unknown_split_raises` – verifies the guard in `as_dataset()` for both a plain bad name and a compound spec with one bad part.