### PR TITLE
DOC: document missing save_infos and max_depth parameters

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2322,6 +2322,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             new_fingerprint (`str`, *optional*):
                 The new fingerprint of the dataset after transform.
                 If `None`, the new fingerprint is computed using a hash of the previous fingerprint, and the transform arguments.
+            max_depth (`int`, defaults to `16`):
+                Maximum number of nesting levels to flatten. Flattening stops when either
+                all struct columns have been resolved or `max_depth` iterations have been completed.
 
         Returns:
             [`Dataset`]: A copy of the dataset with flattened columns.

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1568,6 +1568,10 @@ def load_dataset(
             Whether to copy the dataset in-memory. If `None`, the dataset
             will not be copied in-memory unless explicitly enabled by setting `datasets.config.IN_MEMORY_MAX_SIZE` to
             nonzero. See more details in the [improve performance](../cache#improve-performance) section.
+        save_infos (`bool`, defaults to `False`):
+            Save the dataset builders' infos (checksums/size/splits/...) by forcing full
+            verification. If `True`, overrides `verification_mode` and sets it to
+            [`VerificationMode.ALL_CHECKS`].
         revision ([`Version`] or `str`, *optional*):
             Version of the dataset to load.
             As datasets have their own git repository on the Datasets Hub, the default version "main" corresponds to their "main" branch.


### PR DESCRIPTION
## What this fixes

Two public API functions were missing parameters from their docstrings:

### 1. `load_dataset()` — missing `save_infos`

The `save_infos` parameter has been in the function signature but was absent from the `Args` section of the docstring. When `save_infos=True`, it overrides `verification_mode` and forces it to `VerificationMode.ALL_CHECKS`, running full checksums/size/splits verification.

### 2. `Dataset.flatten()` — missing `max_depth`

The `max_depth` parameter (default `16`) controls how many nesting levels are flattened, but was not documented in the `Args` section.

## Files changed

- `src/datasets/load.py` — added `save_infos` to `load_dataset` docstring
- `src/datasets/arrow_dataset.py` — added `max_depth` to `Dataset.flatten` docstring
