### PR TITLE
fix: embed_external_files=True for mesh support

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -84,6 +84,10 @@
       title: Load video data
     - local: video_dataset
       title: Create a video dataset
+    - local: mesh_load
+      title: Load mesh data
+    - local: mesh_dataset
+      title: Create a mesh dataset
     - local: document_load
       title: Load document data
     - local: document_dataset

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -84,10 +84,6 @@
       title: Load video data
     - local: video_dataset
       title: Create a video dataset
-    - local: mesh_load
-      title: Load mesh data
-    - local: mesh_dataset
-      title: Create a mesh dataset
     - local: document_load
       title: Load document data
     - local: document_dataset
@@ -95,6 +91,12 @@
     - local: nifti_dataset
       title: Create a medical imaging dataset
     title: "Vision"
+  - sections:
+    - local: mesh_load
+      title: Load mesh data
+    - local: mesh_dataset
+      title: Create a mesh dataset
+    title: "3D"
   - sections:
     - local: nlp_load
       title: Load text data

--- a/docs/source/about_dataset_features.mdx
+++ b/docs/source/about_dataset_features.mdx
@@ -136,30 +136,33 @@ For gray-scale images you can use the integer or float precision you want as lon
 
 ## Mesh feature
 
-Mesh datasets have a column with type [`Mesh`], which loads 3D mesh files with `trimesh`.
+Mesh datasets have a column with type [`Mesh`], which loads 3D mesh files as `trimesh` objects.
 
 When you load a mesh dataset and call the mesh column, the [`Mesh`] feature automatically decodes the mesh file:
 
 ```py
->>> from datasets import Dataset, Features, Mesh
+>>> from datasets import load_dataset, Mesh
 
->>> dataset = Dataset.from_dict({"mesh": ["path/to/model.glb"]}, features=Features({"mesh": Mesh()}))
+>>> dataset = load_dataset("VINAY-UMRETHE/My-Mesh-Dataset", split="train")
 >>> dataset[0]["mesh"]
-<trimesh.scene.scene.Scene object at 0x125506CF8>
+<trimesh.Scene(len(geometry)=33)>
 ```
 
-Depending on the file content, `trimesh` may return a `trimesh.Trimesh` object or a `trimesh.Scene` object. GLB files commonly decode to scenes, while STL and PLY files commonly decode to meshes.
+Depending on the file content, `trimesh` may return a `trimesh.Trimesh` object or a `trimesh.Scene` object.
+
+> [!WARNING]
+> Index into a mesh dataset using the row index first and then the `mesh` column - `dataset[0]["mesh"]` - to avoid decoding all the mesh files in the dataset. Otherwise, this can be a slow and time-consuming process if you have a large dataset.
 
 With `decode=False`, the [`Mesh`] type gives you the path or bytes of the mesh file without decoding it with `trimesh`:
 
 ```py
->>> dataset = dataset.cast_column("mesh", Mesh(decode=False))
+>>> dataset = load_dataset("VINAY-UMRETHE/My-Mesh-Dataset", split="train").cast_column("mesh", Mesh(decode=False))
 >>> dataset[0]["mesh"]
-{'bytes': None,
- 'path': 'path/to/model.glb'}
+{'bytes': b'...',
+ 'path': '00001.glb'}
 ```
 
-For embedded bytes, the stored `path` is used to infer the mesh file type.
+The [`Mesh`] feature supports `.glb`, `.ply`, and `.stl` files. For embedded bytes, the stored `path` is used to infer the mesh file type.
 
 ## Json feature
 

--- a/docs/source/create_dataset.mdx
+++ b/docs/source/create_dataset.mdx
@@ -72,7 +72,7 @@ charmander.png, It has a preference for hot things.
 squirtle.png, When it retracts its long neck into its shell, it squirts out water with vigorous force.
 ```
 
-To learn more about each of these folder-based builders, check out the and <a href="https://huggingface.co/docs/datasets/image_dataset#imagefolder"><span class="underline decoration-yellow-400 decoration-2 font-semibold">ImageFolder</span></a> or <a href="https://huggingface.co/docs/datasets/audio_dataset#audiofolder"><span class="underline decoration-pink-400 decoration-2 font-semibold">AudioFolder</span></a> guides.
+To learn more about each of these folder-based builders, check out the <a href="https://huggingface.co/docs/datasets/image_dataset#imagefolder"><span class="underline decoration-yellow-400 decoration-2 font-semibold">ImageFolder</span></a>, <a href="https://huggingface.co/docs/datasets/audio_dataset#audiofolder"><span class="underline decoration-pink-400 decoration-2 font-semibold">AudioFolder</span></a>, or <a href="https://huggingface.co/docs/datasets/mesh_dataset#meshfolder"><span class="underline decoration-purple-400 decoration-2 font-semibold">MeshFolder</span></a> guides.
 
 ## From Python dictionaries
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -70,6 +70,14 @@ To work with image datasets, you need to install the [`Image`] feature as an ext
 pip install datasets[vision]
 ```
 
+## Mesh
+
+To work with mesh datasets, you need to install the [`Mesh`] feature as an extra dependency:
+
+```bash
+pip install datasets[mesh]
+```
+
 ## source
 
 Building 🤗 Datasets from source lets you make changes to the code base. To install from the source, clone the repository and install with the following commands:

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -10,7 +10,7 @@ This guide will show you how to load a dataset from:
 - Offline
 - A specific slice of a split
 
-For more details specific to loading other dataset modalities, take a look at the <a class="underline decoration-pink-400 decoration-2 font-semibold" href="./audio_load">load audio dataset guide</a>, the <a class="underline decoration-yellow-400 decoration-2 font-semibold" href="./image_load">load image dataset guide</a>, the <a class="underline decoration-blue-400 decoration-2 font-semibold" href="./video_load">load video dataset guide</a>, or the <a class="underline decoration-green-400 decoration-2 font-semibold" href="./nlp_load">load text dataset guide</a>.
+For more details specific to loading other dataset modalities, take a look at the <a class="underline decoration-pink-400 decoration-2 font-semibold" href="./audio_load">load audio dataset guide</a>, the <a class="underline decoration-yellow-400 decoration-2 font-semibold" href="./image_load">load image dataset guide</a>, the <a class="underline decoration-blue-400 decoration-2 font-semibold" href="./video_load">load video dataset guide</a>, the <a class="underline decoration-purple-400 decoration-2 font-semibold" href="./mesh_load">load mesh dataset guide</a>, or the <a class="underline decoration-green-400 decoration-2 font-semibold" href="./nlp_load">load text dataset guide</a>.
 
 <a id='load-from-the-hub'></a>
 

--- a/docs/source/mesh_dataset.mdx
+++ b/docs/source/mesh_dataset.mdx
@@ -1,0 +1,164 @@
+# Create a mesh dataset
+
+There are two methods for creating and sharing a mesh dataset. This guide will show you how to:
+
+* Create a mesh dataset from local files in python with [`Dataset.push_to_hub`]. This is an easy way that requires only a few steps in python.
+
+* Create a mesh dataset with `MeshFolder` and some metadata. This is a no-code solution for quickly creating a mesh dataset with several thousand 3D files.
+
+> [!TIP]
+> You can control access to your dataset by requiring users to share their contact information first. Check out the [Gated datasets](https://huggingface.co/docs/hub/datasets-gated) guide for more information about how to enable this feature on the Hub.
+
+## Local files
+
+You can load your own dataset using the paths to your mesh files. Use the [`~Dataset.cast_column`] function to take a column of mesh file paths, and cast it to the [`Mesh`] feature:
+
+```py
+>>> from datasets import Dataset, Mesh
+
+>>> mesh_dataset = Dataset.from_dict({"mesh": ["path/to/model_1.glb", "path/to/model_2.ply", "path/to/model_3.stl"]}).cast_column("mesh", Mesh())
+>>> mesh_dataset[0]["mesh"]
+<trimesh.Scene(len(geometry)=33)>
+```
+
+Then upload the dataset to the Hugging Face Hub using [`Dataset.push_to_hub`]:
+
+```py
+mesh_dataset.push_to_hub("<username>/my_dataset")
+```
+
+This will create a dataset repository containing your mesh dataset:
+
+```text
+my_dataset/README.md
+my_dataset/data/train-00000-of-00001.parquet
+```
+
+## MeshFolder
+
+The `MeshFolder` is a dataset builder designed to quickly load a mesh dataset with several thousand mesh files without requiring you to write any code.
+
+> [!TIP]
+> Take a look at the [Split pattern hierarchy](repository_structure#split-pattern-hierarchy) to learn more about how `MeshFolder` creates dataset splits based on your dataset repository structure.
+
+`MeshFolder` automatically infers the class labels of your dataset based on the directory name. Store your dataset in a directory structure like:
+
+```text
+folder/train/diya/brass_diya.glb
+folder/train/diya/clay_diya.ply
+folder/train/diya/festival_diya.stl
+
+folder/train/kalash/copper_kalash.glb
+folder/train/kalash/pooja_kalash.ply
+folder/train/kalash/temple_kalash.stl
+```
+
+If the dataset follows the `MeshFolder` structure, then you can load it directly with [`load_dataset`]:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("path/to/folder")
+```
+
+This is equivalent to passing `meshfolder` manually in [`load_dataset`] and the directory in `data_dir`:
+
+```py
+>>> dataset = load_dataset("meshfolder", data_dir="/path/to/folder")
+```
+
+You can also use `meshfolder` to load datasets involving multiple splits. To do so, your dataset directory should have the following structure:
+
+```text
+folder/train/diya/brass_diya.glb
+folder/train/kalash/copper_kalash.glb
+folder/test/diya/clay_diya.ply
+folder/test/kalash/temple_kalash.stl
+```
+
+> [!WARNING]
+> If all mesh files are contained in a single directory or if they are not on the same level of directory structure, `label` column won't be added automatically. If you need it, set `drop_labels=False` explicitly.
+
+If there is additional information you'd like to include about your dataset, like text captions or 3D asset metadata, add it as a `metadata.csv` file in your folder. You can also use a JSONL file `metadata.jsonl` or a Parquet file `metadata.parquet`.
+
+```text
+folder/train/metadata.csv
+folder/train/0001.glb
+folder/train/0002.ply
+folder/train/0003.stl
+```
+
+You can also zip your mesh files, and in this case each zip should contain both the mesh files and the metadata.
+
+```text
+folder/train.zip
+folder/test.zip
+folder/validation.zip
+```
+
+Your `metadata.csv` file must have a `file_name` or `*_file_name` field which links mesh files with their metadata:
+
+```csv
+file_name,caption
+0001.glb,A brass diya with a small bowl and raised wick holder
+0002.ply,A copper kalash with a rounded body and narrow neck
+0003.stl,A carved jharokha window with an arched frame
+```
+
+or using `metadata.jsonl`:
+
+```jsonl
+{"file_name": "0001.glb", "caption": "A brass diya with a small bowl and raised wick holder"}
+{"file_name": "0002.ply", "caption": "A copper kalash with a rounded body and narrow neck"}
+{"file_name": "0003.stl", "caption": "A carved jharokha window with an arched frame"}
+```
+
+Here the `file_name` must be the name of the mesh file next to the metadata file. More generally, it must be the relative path from the directory containing the metadata to the mesh file.
+
+It's possible to point to more than one mesh in each row in your dataset, for example if both your input and output are mesh files:
+
+```jsonl
+{"input_file_name": "0001.glb", "output_file_name": "0001_output.glb"}
+{"input_file_name": "0002.ply", "output_file_name": "0002_output.ply"}
+{"input_file_name": "0003.stl", "output_file_name": "0003_output.stl"}
+```
+
+You can also define lists of meshes. In that case you need to name the field `file_names` or `*_file_names`. Here is an example:
+
+```jsonl
+{"parts_file_names": ["0001_bowl.glb", "0001_wick_holder.glb"], "label": "diya"}
+{"parts_file_names": ["0002_body.ply", "0002_neck.ply"], "label": "kalash"}
+{"parts_file_names": ["0003_frame.stl", "0003_arch.stl"], "label": "jharokha"}
+```
+
+### Mesh captioning
+
+Mesh captioning datasets have text describing a 3D mesh. An example `metadata.csv` may look like:
+
+```csv
+file_name,text
+0001.glb,A brass diya with a small bowl and raised wick holder
+0002.ply,A copper kalash with a rounded body and narrow neck
+0003.stl,A carved jharokha window with an arched frame
+```
+
+Load the dataset with `MeshFolder`, and it will create a `text` column for the mesh captions:
+
+```py
+>>> dataset = load_dataset("meshfolder", data_dir="/path/to/folder", split="train")
+>>> dataset[0]["text"]
+"A brass diya with a small bowl and raised wick holder"
+```
+
+### Upload dataset to the Hub
+
+Once you've created a dataset, you can share it to the Hub with the [`~datasets.DatasetDict.push_to_hub`] method. Make sure you have the [huggingface_hub](https://huggingface.co/docs/huggingface_hub/index) library installed and you're logged in to your Hugging Face account (see the [Upload with Python tutorial](upload_dataset#upload-with-python) for more details).
+
+Upload your dataset with [`~datasets.DatasetDict.push_to_hub`]:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("meshfolder", data_dir="/path/to/folder", split="train")
+>>> dataset.push_to_hub("username/my-mesh-captioning-dataset")
+```

--- a/docs/source/mesh_load.mdx
+++ b/docs/source/mesh_load.mdx
@@ -1,0 +1,123 @@
+# Load mesh data
+
+Mesh datasets have [`Mesh`] type columns, which contain `trimesh.Trimesh` or `trimesh.Scene` objects.
+
+> [!TIP]
+> To work with mesh datasets, you need to have the `mesh` dependency installed. Check out the [installation](./installation#mesh) guide to learn how to install it.
+
+When you load a mesh dataset and call the mesh column, the meshes are decoded with `trimesh`:
+
+```py
+>>> from datasets import load_dataset, Mesh
+
+>>> dataset = load_dataset("VINAY-UMRETHE/My-Mesh-Dataset", split="train")
+>>> dataset[0]["mesh"]
+<trimesh.Scene(len(geometry)=33)>
+```
+
+Depending on the file content, `trimesh` may return a `trimesh.Trimesh` object or a `trimesh.Scene` object.
+
+> [!WARNING]
+> Index into a mesh dataset using the row index first and then the `mesh` column - `dataset[0]["mesh"]` - to avoid decoding all the mesh files in the dataset. Otherwise, this can be a slow and time-consuming process if you have a large dataset.
+
+For a guide on how to load any type of dataset, take a look at the <a class="underline decoration-sky-400 decoration-2 font-semibold" href="./loading">general loading guide</a>.
+
+## Local files
+
+You can load a dataset from mesh paths. Use the [`~Dataset.cast_column`] function to accept a column of mesh file paths, and decode it into a `trimesh` object with the [`Mesh`] feature:
+
+```py
+>>> from datasets import Dataset, Mesh
+
+>>> dataset = Dataset.from_dict({"mesh": ["path/to/model_1.glb", "path/to/model_2.ply", "path/to/model_3.stl"]}).cast_column("mesh", Mesh())
+>>> dataset[0]["mesh"]
+<trimesh.Scene(len(geometry)=33)>
+```
+
+If you only want to load the underlying path or bytes of the mesh dataset without decoding the mesh object, set `decode=False` in the [`Mesh`] feature:
+
+```py
+>>> dataset = load_dataset("VINAY-UMRETHE/My-Mesh-Dataset", split="train").cast_column("mesh", Mesh(decode=False))
+>>> dataset[0]["mesh"]
+{'bytes': b'...',
+ 'path': '00001.glb'}
+```
+
+The [`Mesh`] feature supports `.glb`, `.ply`, and `.stl` files. Depending on the file content, `trimesh` may return a `trimesh.Trimesh` object or a `trimesh.Scene` object.
+
+## MeshFolder
+
+You can also load a dataset with a `MeshFolder` dataset builder which does not require writing a custom dataloader. This makes `MeshFolder` useful for quickly creating and loading mesh datasets with several thousand 3D files. Your mesh dataset structure should look like this:
+
+```text
+folder/train/diya/brass_diya.glb
+folder/train/diya/clay_diya.ply
+folder/train/diya/festival_diya.stl
+
+folder/train/kalash/copper_kalash.glb
+folder/train/kalash/pooja_kalash.ply
+folder/train/kalash/temple_kalash.stl
+```
+
+If the dataset follows the `MeshFolder` structure, then you can load it directly with [`load_dataset`]:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("username/dataset_name")
+>>> # OR locally:
+>>> dataset = load_dataset("/path/to/folder")
+```
+
+For local datasets, this is equivalent to passing `meshfolder` manually in [`load_dataset`] and the directory in `data_dir`:
+
+```py
+>>> dataset = load_dataset("meshfolder", data_dir="/path/to/folder")
+```
+
+Then you can access the meshes as `trimesh` objects:
+
+```py
+>>> dataset["train"][0]
+{"mesh": <trimesh.Scene(len(geometry)=33)>, "label": 0}
+```
+
+To ignore the information in the metadata file, set `drop_metadata=True` in [`load_dataset`]:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("username/dataset_with_metadata", drop_metadata=True)
+```
+
+If you don't have a metadata file, `MeshFolder` automatically infers the label name from the directory name.
+If you want to drop automatically created labels, set `drop_labels=True`.
+In this case, your dataset will only contain a mesh column:
+
+```py
+>>> from datasets import load_dataset
+
+>>> dataset = load_dataset("username/dataset_without_metadata", drop_labels=True)
+```
+
+Finally the `filters` argument lets you load only a subset of the dataset, based on a condition on the label or the metadata. This is especially useful if the metadata is in Parquet format, since this format enables fast filtering. It is also recommended to use this argument with `streaming=True`, because by default the dataset is fully downloaded before filtering.
+
+```python
+>>> filters = [("label", "=", 0)]
+>>> dataset = load_dataset("username/dataset_name", streaming=True, filters=filters)
+```
+
+> [!TIP]
+> For more information about creating your own `MeshFolder` dataset, take a look at the [Create a mesh dataset](./mesh_dataset) guide.
+
+## Mesh decoding
+
+By default, meshes are decoded sequentially as `trimesh.Trimesh` or `trimesh.Scene` objects when you iterate on a dataset.
+
+If you are not interested in the meshes decoded as `trimesh` objects and would like to access the path or bytes instead, you can disable decoding:
+
+```python
+>>> dataset = dataset.decode(False)
+```
+
+Note: [`IterableDataset.decode`] is only available for streaming datasets at the moment.

--- a/src/datasets/features/mesh.py
+++ b/src/datasets/features/mesh.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..table import array_cast
-from ..utils.file_utils import is_local_path, xopen
+from ..utils.file_utils import is_local_path, is_remote_url, xopen
 from ..utils.py_utils import string_to_dict
 
 
@@ -209,12 +209,20 @@ class Mesh:
 
         return array_cast(storage, self.pa_type)
 
-    def embed_storage(self, storage: pa.StructArray, token_per_repo_id=None) -> pa.StructArray:
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
         """Embed mesh files into the Arrow array.
 
         Args:
             storage (`pa.StructArray`):
                 PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`):
+                Whether to embed local files data in the array.
+            remote_files (`bool`, defaults to `True`):
+                Whether to embed remote files data in the array.
 
         Returns:
             `pa.StructArray`: Array in the Mesh arrow storage type, that is
@@ -238,16 +246,32 @@ class Mesh:
 
         bytes_array = pa.array(
             [
-                (path_to_bytes(x["path"]) if x["bytes"] is None else x["bytes"]) if x is not None else None
+                (
+                    path_to_bytes(x["path"])
+                    if x["bytes"] is None
+                    and ((local_files and is_local_path(x["path"])) or (remote_files and is_remote_url(x["path"])))
+                    else x["bytes"]
+                )
+                if x is not None
+                else None
                 for x in storage.to_pylist()
             ],
             type=pa.binary(),
         )
         path_array = pa.array(
-            [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+            [
+                (
+                    os.path.basename(path)
+                    if (local_files and is_local_path(path)) or (remote_files and is_remote_url(path))
+                    else path
+                )
+                if path is not None
+                else None
+                for path in storage.field("path").to_pylist()
+            ],
             type=pa.string(),
         )
-        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
+        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
 
 

--- a/tests/features/test_mesh.py
+++ b/tests/features/test_mesh.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pyarrow as pa
@@ -39,40 +38,43 @@ def test_mesh_feature_type_to_arrow():
         lambda mesh_path: {"bytes": open(mesh_path, "rb").read()},
     ],
 )
-def test_mesh_feature_encode_example(mesh_file, build_example):
+def test_mesh_feature_encode_example(shared_datadir, build_example):
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
     mesh = Mesh()
-    encoded_example = mesh.encode_example(build_example(mesh_file))
+    encoded_example = mesh.encode_example(build_example(mesh_path))
     assert isinstance(encoded_example, dict)
     assert encoded_example.keys() == {"bytes", "path"}
     assert encoded_example["bytes"] is not None or encoded_example["path"] is not None
 
 
 @require_trimesh
-def test_mesh_decode_example(mesh_file):
+def test_mesh_decode_example(shared_datadir):
     import trimesh
 
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
     mesh = Mesh()
-    with open(mesh_file, "rb") as f:
+    with open(mesh_path, "rb") as f:
         mesh_bytes = f.read()
 
-    decoded_example = mesh.decode_example({"path": mesh_file, "bytes": None})
+    decoded_example = mesh.decode_example({"path": mesh_path, "bytes": None})
     assert isinstance(decoded_example, (trimesh.Trimesh, trimesh.Scene))
 
-    decoded_example = mesh.decode_example({"path": mesh_file, "bytes": mesh_bytes})
+    decoded_example = mesh.decode_example({"path": mesh_path, "bytes": mesh_bytes})
     assert isinstance(decoded_example, (trimesh.Trimesh, trimesh.Scene))
 
     with pytest.raises(ValueError, match="requires a 'path' value"):
         mesh.decode_example({"path": None, "bytes": mesh_bytes})
 
     with pytest.raises(RuntimeError):
-        Mesh(decode=False).decode_example({"path": mesh_file, "bytes": None})
+        Mesh(decode=False).decode_example({"path": mesh_path, "bytes": None})
 
 
 @require_trimesh
-def test_dataset_with_mesh_feature(mesh_file):
+def test_dataset_with_mesh_feature(shared_datadir):
     import trimesh
 
-    data = {"mesh": [mesh_file]}
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
+    data = {"mesh": [mesh_path]}
     features = Features({"mesh": Mesh()})
     dset = Dataset.from_dict(data, features=features)
     item = dset[0]
@@ -91,31 +93,34 @@ def test_dataset_with_mesh_feature(mesh_file):
     assert isinstance(column[0], (trimesh.Trimesh, trimesh.Scene))
 
 
-def test_dataset_with_mesh_feature_decode_false(mesh_file):
-    data = {"mesh": [mesh_file]}
+def test_dataset_with_mesh_feature_decode_false(shared_datadir):
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
+    data = {"mesh": [mesh_path]}
     features = Features({"mesh": Mesh(decode=False)})
     dset = Dataset.from_dict(data, features=features)
     item = dset[0]
     assert item.keys() == {"mesh"}
     assert isinstance(item["mesh"], dict)
-    assert item["mesh"]["path"] == mesh_file
+    assert item["mesh"]["path"] == mesh_path
 
 
 @require_trimesh
-def test_dataset_cast_to_mesh_features(mesh_file):
+def test_dataset_cast_to_mesh_features(shared_datadir):
     import trimesh
 
-    data = {"mesh": [mesh_file]}
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
+    data = {"mesh": [mesh_path]}
     dset = Dataset.from_dict(data)
     dset = dset.cast(Features({"mesh": Mesh()}))
     item = dset[0]
     assert isinstance(item["mesh"], (trimesh.Trimesh, trimesh.Scene))
 
 
-def test_dataset_concatenate_mesh_features(mesh_file):
-    data1 = {"mesh": [mesh_file]}
+def test_dataset_concatenate_mesh_features(shared_datadir):
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
+    data1 = {"mesh": [mesh_path]}
     dset1 = Dataset.from_dict(data1, features=Features({"mesh": Mesh(decode=False)}))
-    with open(mesh_file, "rb") as f:
+    with open(mesh_path, "rb") as f:
         data2 = {"mesh": [{"bytes": f.read()}]}
     dset2 = Dataset.from_dict(data2, features=Features({"mesh": Mesh(decode=False)}))
     concatenated_dataset = concatenate_datasets([dset1, dset2])
@@ -141,15 +146,14 @@ def test_require_decoding():
     assert require_decoding(Mesh())
 
 
-def test_mesh_embed_storage(mesh_file):
-    features = Features({"mesh": Mesh()})
+def test_mesh_embed_storage(shared_datadir):
+    mesh_path = str(shared_datadir / "test_mesh_glb.glb")
+    example = {"bytes": None, "path": mesh_path}
+    storage = pa.array([example], type=pa.struct({"bytes": pa.binary(), "path": pa.string()}))
+    embedded_storage = Mesh().embed_storage(storage)
+    embedded_example = embedded_storage.to_pylist()[0]
+    assert embedded_example == {"bytes": open(mesh_path, "rb").read(), "path": "test_mesh_glb.glb"}
 
-    with open(mesh_file, "rb") as f:
-        content = f.read()
-
-    # Test bytes are embedded
-    storage = features["mesh"].embed_storage(pa.array([{"path": mesh_file, "bytes": None}]))
-    assert storage.to_pylist() == [{"path": os.path.basename(mesh_file), "bytes": content}]
-
-    storage = features["mesh"].embed_storage(pa.array([{"path": mesh_file, "bytes": None}]), local_files=False)
-    assert storage.to_pylist() == [{"path": mesh_file, "bytes": None}]
+    non_embedded_storage = Mesh().embed_storage(storage, local_files=False)
+    non_embedded_example = non_embedded_storage.to_pylist()[0]
+    assert non_embedded_example == {"bytes": None, "path": mesh_path}

--- a/tests/features/test_mesh.py
+++ b/tests/features/test_mesh.py
@@ -150,3 +150,6 @@ def test_mesh_embed_storage(mesh_file):
     # Test bytes are embedded
     storage = features["mesh"].embed_storage(pa.array([{"path": mesh_file, "bytes": None}]))
     assert storage.to_pylist() == [{"path": os.path.basename(mesh_file), "bytes": content}]
+
+    storage = features["mesh"].embed_storage(pa.array([{"path": mesh_file, "bytes": None}]), local_files=False)
+    assert storage.to_pylist() == [{"path": mesh_file, "bytes": None}]


### PR DESCRIPTION
## Fix for #8055 

This is follow-up PR for fixing a specific issue related to `dataset.push_to_hub(repo_id, embed_external_files=True)`

### Test Conducted

```python
from datasets import Features, Image, Mesh, Value, load_dataset


repo_id = "VINAY-UMRETHE/My-Mesh-Dataset"

dataset = load_dataset("json", data_files="TEST_DATA/records.jsonl", split="train")
dataset = dataset.map(
    lambda example: {
        "image": "TEST_DATA/" + example["image_path"],
        "mesh": "TEST_DATA/" + example["mesh_path"],
    }
)
dataset = dataset.cast(
    Features(
        {
            "id": Value("string"),
            "text": Value("string"),
            "image_path": Value("string"),
            "mesh_path": Value("string"),
            "image": Image(),
            "mesh": Mesh(),
        }
    )
)

dataset.push_to_hub(repo_id, embed_external_files=True)
```

Demo: [VINAY-UMRETHE/My-Mesh-Dataset](https://huggingface.co/datasets/VINAY-UMRETHE/My-Mesh-Dataset)