### PR TITLE
Skip origin metadata fetch when streaming=True

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -581,10 +581,16 @@ class DataFilesList(list[str]):
         base_path: Optional[str] = None,
         allowed_extensions: Optional[list[str]] = None,
         download_config: Optional[DownloadConfig] = None,
+        *,
+        skip_origin_metadata: bool = False,
     ) -> "DataFilesList":
         base_path = f"hf://datasets/{dataset_info.id}@{dataset_info.sha}/{base_path or ''}".rstrip("/")
         return cls.from_patterns(
-            patterns, base_path=base_path, allowed_extensions=allowed_extensions, download_config=download_config
+            patterns,
+            base_path=base_path,
+            allowed_extensions=allowed_extensions,
+            download_config=download_config,
+            skip_origin_metadata=skip_origin_metadata,
         )
 
     @classmethod
@@ -594,10 +600,16 @@ class DataFilesList(list[str]):
         base_path: Optional[str] = None,
         allowed_extensions: Optional[list[str]] = None,
         download_config: Optional[DownloadConfig] = None,
+        *,
+        skip_origin_metadata: bool = False,
     ) -> "DataFilesList":
         base_path = base_path if base_path is not None else Path().resolve().as_posix()
         return cls.from_patterns(
-            patterns, base_path=base_path, allowed_extensions=allowed_extensions, download_config=download_config
+            patterns,
+            base_path=base_path,
+            allowed_extensions=allowed_extensions,
+            download_config=download_config,
+            skip_origin_metadata=skip_origin_metadata,
         )
 
     @classmethod
@@ -607,6 +619,8 @@ class DataFilesList(list[str]):
         base_path: Optional[str] = None,
         allowed_extensions: Optional[list[str]] = None,
         download_config: Optional[DownloadConfig] = None,
+        *,
+        skip_origin_metadata: bool = False,
     ) -> "DataFilesList":
         base_path = base_path if base_path is not None else Path().resolve().as_posix()
         data_files = []
@@ -623,7 +637,11 @@ class DataFilesList(list[str]):
             except FileNotFoundError:
                 if not has_magic(pattern):
                     raise
-        origin_metadata = _get_origin_metadata(data_files, download_config=download_config)
+        origin_metadata = (
+            [()] * len(data_files)
+            if skip_origin_metadata
+            else _get_origin_metadata(data_files, download_config=download_config)
+        )
         return cls(data_files, origin_metadata)
 
     def filter(
@@ -668,6 +686,8 @@ class DataFilesDict(dict[str, DataFilesList]):
         base_path: Optional[str] = None,
         allowed_extensions: Optional[list[str]] = None,
         download_config: Optional[DownloadConfig] = None,
+        *,
+        skip_origin_metadata: bool = False,
     ) -> "DataFilesDict":
         out = cls()
         for key, patterns_for_key in patterns.items():
@@ -679,6 +699,7 @@ class DataFilesDict(dict[str, DataFilesList]):
                     base_path=base_path,
                     allowed_extensions=allowed_extensions,
                     download_config=download_config,
+                    skip_origin_metadata=skip_origin_metadata,
                 )
             )
         return out
@@ -691,6 +712,8 @@ class DataFilesDict(dict[str, DataFilesList]):
         base_path: Optional[str] = None,
         allowed_extensions: Optional[list[str]] = None,
         download_config: Optional[DownloadConfig] = None,
+        *,
+        skip_origin_metadata: bool = False,
     ) -> "DataFilesDict":
         out = cls()
         for key, patterns_for_key in patterns.items():
@@ -703,6 +726,7 @@ class DataFilesDict(dict[str, DataFilesList]):
                     base_path=base_path,
                     allowed_extensions=allowed_extensions,
                     download_config=download_config,
+                    skip_origin_metadata=skip_origin_metadata,
                 )
             )
         return out
@@ -714,6 +738,8 @@ class DataFilesDict(dict[str, DataFilesList]):
         base_path: Optional[str] = None,
         allowed_extensions: Optional[list[str]] = None,
         download_config: Optional[DownloadConfig] = None,
+        *,
+        skip_origin_metadata: bool = False,
     ) -> "DataFilesDict":
         out = cls()
         for key, patterns_for_key in patterns.items():
@@ -725,6 +751,7 @@ class DataFilesDict(dict[str, DataFilesList]):
                     base_path=base_path,
                     allowed_extensions=allowed_extensions,
                     download_config=download_config,
+                    skip_origin_metadata=skip_origin_metadata,
                 )
             )
         return out

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1231,6 +1231,8 @@ def load_dataset_builder(
     revision: Optional[Union[str, Version]] = None,
     token: Optional[Union[bool, str]] = None,
     storage_options: Optional[dict] = None,
+    *,
+    streaming: bool = False,
     **config_kwargs,
 ) -> DatasetBuilder:
     """Load a dataset builder which can be used to:
@@ -1357,6 +1359,19 @@ def load_dataset_builder(
     # When users pass config kwargs, they should override module-provided defaults
     # instead of colliding at constructor call time.
     builder_kwargs = {key: value for key, value in builder_kwargs.items() if key not in config_kwargs}
+
+    if streaming and data_files is not None and not isinstance(data_files, DataFilesDict):
+        download_config_for_data_files = download_config.copy() if download_config else DownloadConfig()
+        if token is not None:
+            download_config_for_data_files.token = token
+        if storage_options is not None:
+            download_config_for_data_files.storage_options.update(storage_options)
+        data_files = DataFilesDict.from_patterns(
+            sanitize_patterns(data_files),
+            base_path=builder_kwargs.get("base_path"),
+            download_config=download_config_for_data_files,
+            skip_origin_metadata=True,
+        )
 
     builder_cls = get_dataset_builder_class(dataset_module, dataset_name=dataset_name)
     # Instantiate the dataset builder
@@ -1707,6 +1722,7 @@ def load_dataset(
         revision=revision,
         token=token,
         storage_options=storage_options,
+        streaming=streaming,
         **config_kwargs,
     )
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -949,6 +949,20 @@ def test_load_dataset_streaming_gz_json(jsonl_gz_path):
     assert ds_item == {"col_1": "0", "col_2": 0, "col_3": 0.0}
 
 
+def test_load_dataset_streaming_skips_origin_metadata(monkeypatch, jsonl_path):
+    import datasets.data_files
+
+    monkeypatch.setattr(
+        datasets.data_files,
+        "_get_origin_metadata",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("_get_origin_metadata called")),
+    )
+
+    ds = load_dataset("json", split="train", data_files=jsonl_path, streaming=True)
+    assert isinstance(ds, IterableDataset)
+    assert next(iter(ds)) == {"col_1": "0", "col_2": 0, "col_3": 0.0}
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "path",


### PR DESCRIPTION
Fixes #8197

When using `load_dataset(..., streaming=True, data_files=...)`, `DataFilesList.from_patterns` currently fetches origin metadata (ETag/mtime) for each resolved file even though the streaming pipeline doesn't use the local cache/fingerprint path.

This PR adds an opt-out (`skip_origin_metadata`) for data-file resolution and uses it in `load_dataset_builder(..., streaming=True)` so we skip the origin metadata fetch in streaming mode, reducing init latency and avoiding unnecessary network calls.

Includes a unit test that asserts `_get_origin_metadata` is not called for streaming.
