### PR TITLE
Keep None as a real null in Json() columns instead of the string "null"

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1226,6 +1226,8 @@ class Json:
         return self.pa_type
 
     def encode_example(self, example_data):
+        if example_data is None:
+            return None
         if not isinstance(example_data, str):
             example_data = ujson_dumps(example_data)
         else:
@@ -1238,6 +1240,8 @@ class Json:
     def decode_example(self, example_data, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None):
         if not self.decode:
             raise RuntimeError("Decoding is disabled for this feature. Please use Json(decode=True) instead.")
+        if example_data is None:
+            return None
         return ujson_loads(example_data)
 
     def cast_storage(self, storage: Union[pa.Array]) -> pa.JsonArray:
@@ -1256,11 +1260,14 @@ class Json:
             items = storage[:5].to_pylist()
             try:
                 for item in items:
-                    ujson_loads(item)
+                    if item is not None:
+                        ujson_loads(item)
             except Exception:
-                storage = pa.array([ujson_dumps(x) for x in storage.to_pylist()], pa.json_())
+                storage = pa.array(
+                    [ujson_dumps(x) if x is not None else None for x in storage.to_pylist()], pa.json_()
+                )
         else:
-            storage = pa.array([ujson_dumps(x) for x in storage.to_pylist()], pa.json_())
+            storage = pa.array([ujson_dumps(x) if x is not None else None for x in storage.to_pylist()], pa.json_())
         return array_cast(storage, self.pa_type)
 
 

--- a/src/datasets/utils/json.py
+++ b/src/datasets/utils/json.py
@@ -32,6 +32,9 @@ def json_encode_field(example: Any, json_field_path: list[str]) -> Any:
             return [json_encode_field(x, json_field_path) for x in example]
         else:
             return {**example, field: json_encode_field(example.get(field), json_field_path)}
+    elif example is None:
+        # keep missing values as real nulls instead of the JSON string "null"
+        return None
     else:
         try:
             ujson_loads(example)
@@ -50,6 +53,8 @@ def json_decode_field(example: Any, json_field_path: str) -> Any:
             return [json_decode_field(x, json_field_path) for x in example]
         else:
             return {**example, field: json_decode_field(example.get(field), json_field_path)}
+    elif example is None:
+        return None
     else:
         try:
             return ujson_loads(example)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3522,6 +3522,30 @@ class MiscellaneousDatasetTest(TestCase):
         assert isinstance(result_dict["col"][0], dict), f"expected dict, got {type(result_dict[0]['col'])}"
         assert result_dict == {"col": [{"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}]}
 
+    def test_json_feature_keeps_none_as_null(self):
+        # Regression test for the JSON type: a missing value (None) must be stored as a real
+        # Arrow null, not as the JSON string "null". Otherwise null_count is wrong and a missing
+        # value becomes indistinguishable from the literal JSON value null.
+        data = {"col": [{"a": 1}, None, {"b": 2}]}
+        test_dataset = Dataset.from_dict(data, features=Features({"col": Json()}))
+
+        storage = test_dataset.data["col"].combine_chunks()
+        assert storage.null_count == 1
+        assert storage.is_null().to_pylist() == [False, True, False]
+        # the None must not be re-encoded as the string "null"
+        assert storage.to_pylist() == ['{"a":1}', None, '{"b":2}']
+
+        # decoded access preserves the None
+        assert test_dataset[:] == {"col": [{"a": 1}, None, {"b": 2}]}
+        assert test_dataset.to_list() == [{"col": {"a": 1}}, {"col": None}, {"col": {"b": 2}}]
+
+    def test_json_feature_all_none(self):
+        # An all-None JSON column should be all real Arrow nulls.
+        test_dataset = Dataset.from_dict({"col": [None, None]}, features=Features({"col": Json()}))
+        storage = test_dataset.data["col"].combine_chunks()
+        assert storage.null_count == 2
+        assert test_dataset[:] == {"col": [None, None]}
+
     def test_concatenate_mixed_memory_and_disk(self):
         data1, data2, data3 = {"id": [0, 1, 2]}, {"id": [3, 4, 5]}, {"id": [6, 7]}
         info1 = DatasetInfo(description="Dataset1")


### PR DESCRIPTION
## What this fixes

A missing value (`None`) in a `Json()` column is currently stored as the JSON string `"null"` instead of a real Arrow null. This has two visible consequences:

1. The column reports `null_count == 0` even when values are missing, and `is_null()` returns all `False`. Anything that relies on Arrow null semantics (filtering on nulls, counting nulls, null-aware Parquet writes) sees no nulls at all.
2. A genuine missing value becomes indistinguishable from a column that holds the literal JSON value `null`. Both end up as the same `"null"` string in storage.

Reproducer on current `main`:

```python
from datasets import Dataset, Features, Json

ds = Dataset.from_dict({"col": [{"a": 1}, None, {"b": 2}]}, features=Features({"col": Json()}))
arr = ds.data["col"].combine_chunks()
print(arr.null_count)        # 0, expected 1
print(arr.to_pylist())       # ['{"a":1}', 'null', '{"b":2}'], expected the middle to be a real null
```

## Root cause

The `from_dict` path and the `on_mixed_types="use_json"` path encode each value through `json_encode_field` in `src/datasets/utils/json.py`. Its leaf branch ran `ujson_loads(example)` on the value. For `None` that raises, so it fell into the `except` and returned `ujson_dumps(None)`, which is the string `"null"`. The same gap existed in `Json.encode_example`. On the read side `Json.decode_example(None)` crashed because it passed `None` straight to `ujson_loads`, and `Json.cast_storage` re-serialized `None` entries to `"null"` when it had to rebuild the array.

## The fix

`None` is now preserved as a real Arrow null across all of these entry points:

- `json_encode_field` and `json_decode_field` return `None` unchanged at the leaf.
- `Json.encode_example(None)` returns `None`.
- `Json.decode_example(None)` returns `None` instead of crashing.
- `Json.cast_storage` keeps `None` entries as nulls when it rebuilds the storage array, and the validation sampling skips `None` so a sampled null does not force a needless re-encode.

Decoded access through `ds[:]`, `to_list` and `to_dict` is unchanged, so this does not change observed values for existing users. It only fixes the underlying storage so nulls behave like nulls.

## Verification

Added two regression tests in `tests/test_arrow_dataset.py` (`test_json_feature_keeps_none_as_null` and `test_json_feature_all_none`). Both fail before the change and pass after.

Ran on CPU:

```
python -m pytest tests/test_arrow_dataset.py -k "json or Json or mixed" -q   # 25 passed
python -m pytest tests/features/test_features.py -k "json or round_trip or yaml" -q   # 58 passed
python -m pytest tests/io/test_json.py tests/packaged_modules/test_json.py -q   # 79 passed
python -m pytest tests/io/test_parquet.py -q   # passed
python -m pytest tests/test_arrow_writer.py -q   # 86 passed
```

Also confirmed by hand that the mixed-None column now reports `null_count == 1`, that an all-None column is all nulls, that the `on_mixed_types="use_json"` path keeps nulls, and that a Parquet roundtrip preserves the null. `ruff check` and `ruff format --check` are clean on the changed files.
