### PR TITLE
Clarify dataset creation vs loading workflows in create_dataset tutorial

### DIFF
--- a/docs/source/create_dataset.mdx
+++ b/docs/source/create_dataset.mdx
@@ -2,10 +2,16 @@
 
 Sometimes, you may need to create a dataset if you're working with your own data. Creating a dataset with 🤗 Datasets confers all the advantages of the library to your dataset: fast loading and processing, [stream enormous datasets](stream), [memory-mapping](https://huggingface.co/course/chapter5/4?fw=pt#the-magic-of-memory-mapping), and more. You can easily and rapidly create a dataset with 🤗 Datasets low-code approaches, reducing the time it takes to start training a model. In many cases, it is as easy as [dragging and dropping](upload_dataset#upload-with-the-hub-ui) your data files into a dataset repository on the Hub.
 
-In this tutorial, you'll learn how to use 🤗 Datasets low-code methods for creating all types of datasets:
+In this tutorial, you'll learn how to use 🤗 Datasets low-code methods for creating datasets from your own data.
+
+> **Note**
+>
+> If you want to learn how to load existing datasets, or how to load local and remote files (CSV, JSON, Parquet, etc.), see the [Load guide](./loading).
+
+This tutorial covers:
 
 - Folder-based builders for quickly creating an image or audio dataset
-- `from_` methods for creating datasets from local files
+- `from_` methods for creating datasets from local Python objects
 
 ## File-based builders
 

--- a/docs/source/create_dataset.mdx
+++ b/docs/source/create_dataset.mdx
@@ -6,7 +6,7 @@ In this tutorial, you'll learn how to use 🤗 Datasets low-code methods for cre
 
 > **Note**
 >
-> If you want to learn how to load existing datasets, or how to load local and remote files (CSV, JSON, Parquet, etc.), see the [Load guide](./loading).
+> If you want to learn how to load existing datasets, or how to load local and remote files (CSV, JSON, Parquet, etc.), see the [Load guide](https://huggingface.co/docs/datasets/loading).
 
 This tutorial covers:
 


### PR DESCRIPTION
This PR clarifies the distinction between dataset creation and dataset loading workflows in the create_dataset tutorial.

Changes:
- Added a note directing users to the loading guide.
- Clarified that `from_` methods create datasets from local Python objects rather than local files.

Addresses #5805.