### PR TITLE
Fix iterable skip over full Arrow blocks

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2041,6 +2041,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
                 skipped += len(pa_table)
                 if self._state_dict:
                     self._state_dict["skipped"] = skipped
+                continue
             if skipped + 1 <= self.n:
                 offset = self.n - skipped
                 skipped = self.n

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2041,8 +2041,7 @@ class SkipExamplesIterable(_BaseExamplesIterable):
                 skipped += len(pa_table)
                 if self._state_dict:
                     self._state_dict["skipped"] = skipped
-                continue
-            if skipped + 1 <= self.n:
+            elif skipped + 1 <= self.n:
                 offset = self.n - skipped
                 skipped = self.n
                 if self._state_dict:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1302,15 +1302,18 @@ def test_step_examples_iterable():
     assert_load_state_dict_resumes_iteration(step_ex_iterable)
 
 
-def test_skip_arrow_examples_iterable():
-    total, count = 10, 2
+@pytest.mark.parametrize("count", [2, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_SIZE + 2, DEFAULT_BATCH_SIZE * 3])
+def test_skip_arrow_examples_iterable(count):
+    total = 10
     base_ex_iterable = ArrowExamplesIterable(generate_tables_fn, {"n": total})
     skip_ex_iterable = SkipExamplesIterable(base_ex_iterable, n=count)
     expected = [x for _, pa_table in generate_tables_fn(n=total) for x in pa_table.to_pylist()][count:]
     assert [example for _, example in skip_ex_iterable] == expected
+    assert [example for _, pa_table in skip_ex_iterable.iter_arrow() for example in pa_table.to_pylist()] == expected
     with pytest.raises(DataSourcesShufflingDisallowed):
         skip_ex_iterable.shuffle_data_sources(np.random.default_rng(42))
     assert_load_state_dict_resumes_iteration(skip_ex_iterable)
+    assert_load_state_dict_resumes_arrow_iteration(skip_ex_iterable)
 
 
 def test_take_arrow_examples_iterable():


### PR DESCRIPTION
## What does this PR do?

Fixes `IterableDataset.skip(n)` for streaming datasets when the underlying iterable uses Arrow batches and `n` skips one or more complete Arrow blocks.

Previously, after a full Arrow block was counted as skipped, `_iter_arrow()` continued into the partial-slice branch and yielded rows from a block that should have been fully skipped.

## What was the issue?

`SkipExamplesIterable._iter_arrow()` handles skipping in two cases:

1. the current Arrow table is fully skipped
2. only the beginning of the current Arrow table is skipped, and the rest is yielded

The bug was that case 1 did not stop after marking the table as skipped. So the same table then fell through into case 2.

In other words, a table could first be counted as "already skipped", but then still be sliced and yielded.

For example, if Arrow tables have 4 rows each and we call `skip(6)`:

- table 1 has rows `[0, 1, 2, 3]` and should be fully skipped
- table 2 has rows `[4, 5, 6, 7]`, so only `[4, 5]` should be skipped and `[6, 7]` should be yielded

Before this PR, after table 1 was counted as skipped, the code kept processing table 1 and yielded part of it. This is why skipped rows could appear in the output.

This PR adds `continue` after a table is fully skipped, so the code moves directly to the next Arrow table.

## Tests

- `PYTHONPATH=src pytest tests/test_iterable_dataset.py::test_skip_arrow_examples_iterable -q`

The regression test covers skipping within a block, exactly one block, across blocks, and beyond the dataset length.