### PR TITLE
Fix imagefolder metadata with split-named files

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -1,6 +1,6 @@
 import os
 import re
-from functools import partial
+from functools import lru_cache, partial
 from glob import has_magic
 from pathlib import Path, PurePath
 from typing import Callable, Optional, Union
@@ -45,6 +45,7 @@ SPLIT_KEYWORDS = {
     Split.VALIDATION: ["validation", "valid", "dev", "val"],
     Split.TEST: ["test", "testing", "eval", "evaluation"],
 }
+SPLIT_KEYWORDS_VALUES = {keyword for keywords in SPLIT_KEYWORDS.values() for keyword in keywords}
 NON_WORDS_CHARS = "-._ 0-9"
 if config.FSSPEC_VERSION < version.parse("2023.9.0"):
     KEYWORDS_IN_FILENAME_BASE_PATTERNS = ["**[{sep}/]{keyword}[{sep}]*", "{keyword}[{sep}]*"]
@@ -112,6 +113,21 @@ FILES_TO_IGNORE = [
     "dummy_data.zip",
     "dataset_dict.json",
 ]
+
+
+@lru_cache(maxsize=1)
+def _get_media_extensions() -> set[str]:
+    from .packaged_modules.audiofolder.audiofolder import AudioFolder
+    from .packaged_modules.imagefolder.imagefolder import ImageFolder
+    from .packaged_modules.videofolder.videofolder import VideoFolder
+
+    return set(ImageFolder.EXTENSIONS + AudioFolder.EXTENSIONS + VideoFolder.EXTENSIONS)
+
+
+def _is_split_named_media_file(data_file: str) -> bool:
+    file_name = xbasename(data_file.split("::")[0]).lower()
+    stem, extension = os.path.splitext(file_name)
+    return extension in _get_media_extensions() and stem in SPLIT_KEYWORDS_VALUES
 
 
 def contains_wildcards(pattern: str) -> bool:
@@ -290,6 +306,8 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], list[str]]) -> di
                     data_files = pattern_resolver(pattern)
                 except FileNotFoundError:
                     continue
+                if patterns_dict is DEFAULT_PATTERNS_SPLIT_IN_FILENAME:
+                    data_files = [data_file for data_file in data_files if not _is_split_named_media_file(data_file)]
                 if len(data_files) > 0:
                     non_empty_splits.append(split)
                     break

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -1,10 +1,11 @@
 import shutil
+import tempfile
 import textwrap
 
 import numpy as np
 import pytest
 
-from datasets import ClassLabel, Features, Image
+from datasets import ClassLabel, Features, Image, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesDict, DataFilesList, get_data_patterns
 from datasets.download.streaming_download_manager import StreamingDownloadManager
@@ -332,6 +333,49 @@ def test_data_files_with_metadata_and_single_split(streaming, cache_dir, data_fi
         assert len({example["image"].filename for example in dataset}) == expected_num_of_images
         assert len({example["caption"] for example in dataset}) == expected_num_of_images
         assert all(example["caption"] is not None for example in dataset)
+
+
+@require_pil
+def test_load_dataset_with_metadata_and_split_named_image_file(tmp_path, image_file):
+    from PIL import Image as PILImage
+
+    data_dir = tmp_path / "imagefolder_data_dir_with_split_named_image"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    for image_name in ["train.png", "pika.png", "pika_pika.png"]:
+        PILImage.open(image_file).save(data_dir / image_name)
+    image_metadata_filename = data_dir / "metadata.csv"
+    image_metadata = textwrap.dedent(
+        """\
+        file_name,text
+        train.png,A train
+        pika.png,Pika
+        pika_pika.png,Pika Pika!
+        """
+    )
+    with open(image_metadata_filename, "w", encoding="utf-8") as f:
+        f.write(image_metadata)
+
+    with tempfile.TemporaryDirectory() as cache_dir:
+        dataset = load_dataset("imagefolder", data_dir=data_dir.as_posix(), cache_dir=cache_dir)["train"]
+
+        assert dataset.num_rows == 3
+        assert sorted(dataset["text"]) == ["A train", "Pika", "Pika Pika!"]
+
+    with tempfile.TemporaryDirectory() as cache_dir:
+        dataset = load_dataset(data_dir.as_posix(), cache_dir=cache_dir)["train"]
+
+        assert dataset.num_rows == 3
+        assert sorted(dataset["text"]) == ["A train", "Pika", "Pika Pika!"]
+
+    with tempfile.TemporaryDirectory() as cache_dir:
+        dataset = load_dataset(
+            "imagefolder",
+            data_files=(data_dir / "train.png").as_posix(),
+            cache_dir=cache_dir,
+        )["train"]
+
+        assert dataset.num_rows == 1
+        assert "text" not in dataset.column_names
 
 
 @require_pil

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -682,6 +682,18 @@ def test_get_data_files_patterns(base_path, data_file_per_split):
         assert matched == expected
 
 
+@pytest.mark.parametrize("split_named_media_file", ["train.png", "valid.mp3", "test.mp4"])
+def test_get_data_files_patterns_ignores_split_named_media_files(split_named_media_file):
+    file_paths = [split_named_media_file, "metadata.csv", "sample.png"]
+    DummyTestFS = mock_fs(file_paths)
+    fs = DummyTestFS()
+
+    def resolver(pattern):
+        return [file_path.lstrip("/") for file_path in fs.glob(pattern) if fs.isfile(file_path)]
+
+    assert _get_data_files_patterns(resolver) == {"train": ["**"]}
+
+
 def test_get_data_patterns_from_directory_with_the_word_data_twice(tmp_path):
     repo_dir = tmp_path / "directory-name-ending-with-the-word-data"  # parent directory contains the word "data/"
     data_dir = repo_dir / "data"


### PR DESCRIPTION
## Summary
- Preserve folder-builder metadata when auto-inferred split filename patterns match only a file such as `train.png`
- Re-resolve default `**` patterns only for auto-inferred folder datasets when sidecar metadata would otherwise be dropped
- Add regression coverage for explicit `imagefolder`, local auto-detection, and explicit single-file `data_files`

Fixes #7201

## Tests
- `python -m pytest tests/packaged_modules/test_imagefolder.py::test_load_dataset_with_metadata_and_split_named_image_file -q`
- `python -m pytest tests/packaged_modules/test_imagefolder.py -q --basetemp=C:\tmp\hfds-imagefolder-tests`
- `python -m pytest tests/test_data_files.py::test_get_data_files_patterns tests/test_data_files.py::test_get_data_patterns_from_directory_with_the_word_data_twice -q`
- `ruff format --check src/datasets/load.py tests/packaged_modules/test_imagefolder.py`
- `ruff check src/datasets/load.py tests/packaged_modules/test_imagefolder.py`
- `git diff --check`