### PR TITLE
Fix JSON loader schema inference for files starting with a UTF-8 BOM (#8241)

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -1,3 +1,4 @@
+import codecs
 import io
 import os
 from dataclasses import dataclass
@@ -208,6 +209,13 @@ class Json(datasets.ArrowBasedBuilder):
                             batch = f.read(self.config.chunksize)
                             if not batch:
                                 break
+                            # A leading UTF-8 BOM makes the ujson pre-scan below raise
+                            # ValueError, silently skipping mixed-struct detection, while
+                            # PyArrow tolerates the BOM -- so the inferred schema differed
+                            # depending on whether the file started with a BOM. Strip it so
+                            # both see the same bytes (a BOM only appears at the start of the file).
+                            if shard_idx == 0 and batch_idx == 0 and batch.startswith(codecs.BOM_UTF8):
+                                batch = batch[len(codecs.BOM_UTF8) :]
                             if batch.startswith(b"["):
                                 if not allow_full_read:
                                     raise FullReadDisallowed()

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -252,6 +252,22 @@ def jsonl_file_with_lists_of_dicts_of_varying_keys(tmp_path):
     return str(filename)
 
 
+@pytest.fixture
+def jsonl_file_with_lists_of_dicts_of_varying_keys_and_bom(tmp_path):
+    # Same content as jsonl_file_with_lists_of_dicts_of_varying_keys, but the file
+    # starts with a UTF-8 BOM (written via the utf-8-sig codec).
+    filename = tmp_path / "file_with_bom.jsonl"
+    data = textwrap.dedent(
+        """\
+        {"col_1": [{"a": 0}, {"b": 0}]}
+        {"col_1": [{"c": 0}, {"d": 0}]}
+        """
+    )
+    with open(filename, "w", encoding="utf-8-sig") as f:
+        f.write(data)
+    return str(filename)
+
+
 _messages = [
     {"role": "user", "content": "Turn on the living room lights and play my electronic music playlist."},
     {
@@ -408,6 +424,11 @@ def test_config_raises_when_invalid_data_files(data_files) -> None:
         ("jsonl_file_with_mix_of_str_and_int", {}, EXPECTED_MIX),
         ("jsonl_file_with_dicts_of_varying_keys", {}, EXPECTED_DICTS_WITH_VARYING_KEYS),
         ("jsonl_file_with_lists_of_dicts_of_varying_keys", {}, EXPECTED_LISTS_OF_DICTS_WITH_VARYING_KEYS),
+        (
+            "jsonl_file_with_lists_of_dicts_of_varying_keys_and_bom",
+            {},
+            EXPECTED_LISTS_OF_DICTS_WITH_VARYING_KEYS,
+        ),
         ("jsonl_file_with_messages", {}, EXPECTED_MESSAGES),
     ],
 )


### PR DESCRIPTION
Fixes #8241.

## What's the bug

When a JSONL file starts with a UTF-8 BOM (`\xef\xbb\xbf`), `load_dataset("json", ...)` infers a different schema than the same file without the BOM.

The JSON builder's first-batch "mixed-struct-types" pre-scan parses each line with `ujson` to decide whether to preserve heterogeneous nested dicts as a `Json` type:

```python
try:
    examples = [ujson_loads(line) for line in batch.splitlines()]
except ValueError:
    pass
else:
    json_field_paths += find_mixed_struct_types_field_paths(examples)
```

`ujson` rejects the leading BOM with `ValueError`, the broad `except ValueError` swallows it, and `find_mixed_struct_types_field_paths` is never called. PyArrow's `read_json` tolerates the BOM and instead unifies the schema, materializing spurious `null`s for fields absent from individual records. So the user-visible content silently changes depending on whether the file happens to start with a BOM.

## Fix

Strip a leading UTF-8 BOM from the first batch (guarded to the start of the file) so the pre-scan and PyArrow operate on the same bytes.

## Test

Added a regression test: a BOM-prefixed variant of the existing `jsonl_file_with_lists_of_dicts_of_varying_keys` fixture, asserting it produces the same schema (`EXPECTED_LISTS_OF_DICTS_WITH_VARYING_KEYS`) as the non-BOM file. It fails on `main` and passes with this change.

`ruff check`, `ruff format`, and `pytest tests/packaged_modules/test_json.py::test_json_generate_tables` all pass locally.
