### PR TITLE
Fix partial extraction when concurrent processes share a cache (#4661)

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -49,8 +49,13 @@ class ExtractManager:
         if not extractor_format:
             return input_path
         output_path = self._get_output_path(input_path)
-        if self._do_extract(output_path, force_extract):
-            self.extractor.extract(input_path, output_path, extractor_format)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        # Take the lock *before* the "is it already extracted?" check. Otherwise a second
+        # process can see a half-written output dir (a peer is mid-extraction), decide it's
+        # already done, and return a partial path. See #4661.
+        with FileLock(output_path + ".lock"):
+            if self._do_extract(output_path, force_extract):
+                self.extractor.extract(input_path, output_path, extractor_format)
         return output_path
 
 
@@ -436,9 +441,8 @@ class Extractor:
         extractor_format: str,
     ) -> None:
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        # Prevent parallel extractions
-        lock_path = str(Path(output_path).with_suffix(".lock"))
-        with FileLock(lock_path):
-            shutil.rmtree(output_path, ignore_errors=True)
-            extractor = cls.extractors[extractor_format]
-            return extractor.extract(input_path, output_path)
+        # Serialization across processes is handled by ExtractManager.extract, which holds the
+        # lock around the "already extracted?" check and this call (see #4661).
+        shutil.rmtree(output_path, ignore_errors=True)
+        extractor = cls.extractors[extractor_format]
+        return extractor.extract(input_path, output_path)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,9 +1,13 @@
+import multiprocessing
 import os
+import time
+import zipfile
 
 import pytest
 
 from datasets.utils.extract import (
     Bzip2Extractor,
+    ExtractManager,
     Extractor,
     GzipExtractor,
     Lz4Extractor,
@@ -200,3 +204,44 @@ def test_is_zipfile_false_positive(tmpdir):
         f.write(data)
     # zipfile.is_zipfile(str(not_a_zip_file)) could be a false positive for `zipfile`
     assert not ZipExtractor.is_extractable(not_a_zip_file)  # but we're right
+
+
+def _extract_in_subprocess(zip_path, cache_dir, start_delay, result_queue):
+    # Slow down the leaf extractor so a half-written output dir is observable while a peer extracts.
+    def _slow_zip_extract(input_path, output_path):
+        os.makedirs(output_path, exist_ok=True)
+        with zipfile.ZipFile(input_path) as zf:
+            names = zf.namelist()
+            with open(os.path.join(output_path, names[0]), "w") as f:
+                f.write("partial")
+            time.sleep(0.5)
+            zf.extractall(output_path)
+
+    ZipExtractor.extract = staticmethod(_slow_zip_extract)
+    time.sleep(start_delay)
+    output_path = ExtractManager(cache_dir=cache_dir).extract(zip_path)
+    result_queue.put(len(os.listdir(output_path)) if os.path.isdir(output_path) else -1)
+
+
+def test_extract_manager_concurrent_does_not_return_partial(tmp_path):
+    # Regression test for https://github.com/huggingface/datasets/issues/4661: two jobs sharing a
+    # cache must not observe a partially extracted archive. The second process should wait for the
+    # first instead of seeing a half-written directory and skipping extraction.
+    n_files = 5
+    zip_path = str(tmp_path / "data.zip")
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for i in range(n_files):
+            zf.writestr(f"f{i}.txt", f"content {i}")
+    cache_dir = str(tmp_path / "cache")
+
+    ctx = multiprocessing.get_context("fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn")
+    queue = ctx.Queue()
+    p1 = ctx.Process(target=_extract_in_subprocess, args=(zip_path, cache_dir, 0.0, queue))
+    p2 = ctx.Process(target=_extract_in_subprocess, args=(zip_path, cache_dir, 0.2, queue))
+    p1.start()
+    p2.start()
+    p1.join(30)
+    p2.join(30)
+
+    observed = sorted(queue.get() for _ in range(2))
+    assert observed == [n_files, n_files], f"a process observed a partial extraction: {observed}"


### PR DESCRIPTION
Fixes #4661.

`ExtractManager.extract` runs the `_do_extract` "already extracted?" check outside any lock; the lock sits one level down in `Extractor.extract`. When two jobs share a cache, the second can catch a half-written output directory mid-extraction, assume it's done, and return a partial path.

This moves the lock up into `ExtractManager.extract` so the check and the extraction are atomic, the same way `get_from_cache` handles the download side. The now-redundant lock inside `Extractor.extract` is removed — keeping both would deadlock on the same lock file.

The added test forks two processes against a shared cache with a slowed extractor: it fails on `main` (a process observes a partial directory) and passes with the fix. The existing `test_extract.py` is unchanged and still passes.

One case left out of scope: if a process is killed mid-extraction, the next one can still see the partial directory. Fully addressing that would mean extracting to a temporary path and renaming it into place (the `.incomplete` approach used in `get_from_cache`). I can include that here or leave it as a follow-up.
