### PR TITLE
Catch RecursionError when decoding deeply nested mesh files (#8246)

### DIFF
--- a/src/datasets/features/mesh.py
+++ b/src/datasets/features/mesh.py
@@ -108,9 +108,7 @@ class Mesh:
         if not self.decode:
             raise RuntimeError("Decoding is disabled for this feature. Please use Mesh(decode=True) instead.")
 
-        if config.TRIMESH_AVAILABLE:
-            import trimesh
-        else:
+        if not config.TRIMESH_AVAILABLE:
             raise ImportError("To support decoding meshes, please install 'trimesh'.")
 
         if token_per_repo_id is None:
@@ -124,7 +122,7 @@ class Mesh:
                 file_type = _infer_mesh_file_type(path)
                 if file_type is None:
                     raise ValueError("A mesh path should have a .glb, .ply, or .stl extension.")
-                return trimesh.load(path, file_type=file_type)
+                return _load_mesh(path, file_type)
             source_url = path.split("::")[-1]
             pattern = (
                 config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
@@ -141,7 +139,7 @@ class Mesh:
                 "Decoding mesh bytes requires a 'path' value with a .glb, .ply, or .stl extension "
                 "to infer the mesh file type."
             )
-        return trimesh.load(BytesIO(bytes_), file_type=file_type)
+        return _load_mesh(BytesIO(bytes_), file_type)
 
     def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
         """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""
@@ -273,6 +271,21 @@ class Mesh:
         )
         storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         return array_cast(storage, self.pa_type)
+
+
+def _load_mesh(source: Union[str, BytesIO], file_type: str) -> Union["trimesh.Trimesh", "trimesh.Scene"]:
+    import trimesh
+
+    try:
+        return trimesh.load(source, file_type=file_type)
+    except RecursionError as e:
+        # A GLB whose glTF JSON chunk is deeply nested (malformed or malicious) can
+        # exceed Python's recursion limit while trimesh parses it, crashing the whole
+        # load. Surface a clear error instead. See #8246.
+        raise ValueError(
+            f"Could not decode mesh (file_type={file_type!r}): the data is too deeply nested "
+            "and may be malformed or malicious."
+        ) from e
 
 
 def _infer_mesh_file_type(path: Optional[str]) -> Optional[str]:

--- a/tests/features/test_mesh.py
+++ b/tests/features/test_mesh.py
@@ -70,6 +70,29 @@ def test_mesh_decode_example(shared_datadir):
 
 
 @require_trimesh
+def test_mesh_decode_example_raises_on_deeply_nested_glb():
+    # Regression test for #8246: a GLB whose glTF JSON chunk is deeply nested can
+    # exceed Python's recursion limit while trimesh parses it. decode_example should
+    # raise a clean ValueError instead of crashing with a RecursionError.
+    import struct
+
+    depth = 100_000
+    json_chunk = (b"[" * depth) + (b"]" * depth)
+    json_chunk += b" " * (-len(json_chunk) % 4)  # pad to a 4-byte boundary
+    glb_bytes = (
+        # GLB header: magic "glTF", version 2, total length.
+        struct.pack("<III", 0x46546C67, 2, 12 + 8 + len(json_chunk))
+        # JSON chunk header: chunk length, chunk type "JSON".
+        + struct.pack("<II", len(json_chunk), 0x4E4F534A)
+        + json_chunk
+    )
+
+    mesh = Mesh()
+    with pytest.raises(ValueError):
+        mesh.decode_example({"path": "deeply_nested.glb", "bytes": glb_bytes})
+
+
+@require_trimesh
 def test_dataset_with_mesh_feature(shared_datadir):
     import trimesh
 


### PR DESCRIPTION
Fixes #8246.

A GLB whose glTF JSON chunk is deeply nested (malformed or malicious) makes `trimesh.load` exceed Python's recursion limit while parsing it (`RecursionError: maximum recursion depth exceeded while decoding a JSON array`), crashing `Mesh.decode_example` with an uncaught error.

This routes both `trimesh.load` call sites through a small `_load_mesh` helper that catches `RecursionError` and re-raises it as a clear `ValueError`, so a malformed/adversarial mesh produces an actionable error instead of crashing the whole load. `htmlTreeAsString`-style decoding for valid meshes is unchanged.

Added a regression test that builds a GLB with a deeply-nested JSON chunk and asserts `decode_example` raises `ValueError` (it fails with the uncaught `RecursionError` without the fix).

Verified locally: `ruff check` / `ruff format` clean, and the new test passes.
