### PR TITLE
docs: fix duplicate "to" in IterableDataset push-to-hub example

### DIFF
--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -581,7 +581,7 @@ This can be used with the `StatefulDataLoader` from `torchdata`:
 
 Once your iterable dataset is ready, you can save it as a Hugging Face Dataset in Parquet format and reuse it later with [`load_dataset`].
 
-Save your dataset by providing the name of the dataset repository on Hugging Face you wish to save it to to [`~Dataset.push_to_hub`]. This iterates over the dataset and progressively uploads the data to Hugging Face:
+Save your dataset by providing the name of the dataset repository on Hugging Face you wish to save it to as an argument to [`~Dataset.push_to_hub`]. This iterates over the dataset and progressively uploads the data to Hugging Face:
 
 ```python
 dataset.push_to_hub("username/my_dataset")


### PR DESCRIPTION
## What does this PR do?

The save-to-hub paragraph in `docs/source/stream.mdx` (line 584) currently reads:

> "you wish to save it **to to** [`~Dataset.push_to_hub`]"

The first `to` closes the relative clause ("the repo you wish to save it to"), and the second `to` introduces the function argument. The collision reads as a typo. Rephrase as:

> "...you wish to save it to **as an argument to** [`~Dataset.push_to_hub`]"

…which keeps both meanings explicit without the adjacent duplicate.

Single-line, doc-only change. The same file is touched by #8109 but at different lines (60, 97, 276); line 584 is not in that PR's diff.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/datasets/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a typo in the docs.
- [ ] Did you make sure to update the documentation with your changes? _(This PR is the documentation change.)_
- [ ] Did you write any new necessary tests? _(N/A, docs-only.)_