### PR TITLE
Prefer torchvision to decode images instead of PIL

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1474,7 +1474,7 @@ def decode_nested_example(
     Args:
         decoder_overrides: optional dict mapping feature types to custom decode functions.
             When the python type of a leaf feature matches a key, the override function is called
-            as ``override_fn(obj, schema)`` instead of ``schema.decode_example(obj, ...)``.
+            as ``override_fn(obj, schema, token_per_repo_id=...)`` instead of ``schema.decode_example(obj, ...)``.
     """
     _kwargs = {"token_per_repo_id": token_per_repo_id, "decoder_overrides": decoder_overrides}
     # Nested structures: we allow dict, list/tuples, sequences
@@ -1519,7 +1519,7 @@ def decode_nested_example(
             return None
         if decoder_overrides:
             if override_fn := decoder_overrides.get(type(schema)):
-                return override_fn(obj, schema)
+                return override_fn(obj, schema, token_per_repo_id=token_per_repo_id)
         # we pass the token to read and decode files from private repositories in streaming mode
         return schema.decode_example(obj, token_per_repo_id=token_per_repo_id)
     return obj

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1462,17 +1462,28 @@ def encode_nested_example(schema, obj, level=0):
     return obj
 
 
-def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None):
+def decode_nested_example(
+    schema, obj, token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None, decoder_overrides=None
+):
     """Decode a nested example.
     This is used since some features (in particular Audio and Image) have some logic during decoding.
 
     To avoid iterating over possibly long lists, it first checks (recursively) if the first element that is not None or empty (if it is a sequence) has to be decoded.
     If the first element needs to be decoded, then all the elements of the list will be decoded, otherwise they'll stay the same.
+
+    Args:
+        decoder_overrides: optional dict mapping feature types to custom decode functions.
+            When a leaf feature matches a key (via isinstance), the override function is called
+            as ``override_fn(obj, schema)`` instead of ``schema.decode_example(obj, ...)``.
     """
+    _kwargs = {"token_per_repo_id": token_per_repo_id, "decoder_overrides": decoder_overrides}
     # Nested structures: we allow dict, list/tuples, sequences
     if isinstance(schema, dict):
         return (
-            {k: decode_nested_example(sub_schema, sub_obj) for k, (sub_schema, sub_obj) in zip_dict(schema, obj)}
+            {
+                k: decode_nested_example(sub_schema, sub_obj, **_kwargs)
+                for k, (sub_schema, sub_obj) in zip_dict(schema, obj)
+            }
             if obj is not None
             else None
         )
@@ -1485,8 +1496,8 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Uni
                 for first_elmt in obj:
                     if _check_non_null_non_empty_recursive(first_elmt, sub_schema):
                         break
-                if decode_nested_example(sub_schema, first_elmt) != first_elmt:
-                    return [decode_nested_example(sub_schema, o) for o in obj]
+                if decode_nested_example(sub_schema, first_elmt, **_kwargs) != first_elmt:
+                    return [decode_nested_example(sub_schema, o, **_kwargs) for o in obj]
             return list(obj)
     elif isinstance(schema, (LargeList, List)):
         if obj is None:
@@ -1494,18 +1505,24 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Uni
         else:
             sub_schema = schema.feature
             if isinstance(sub_schema, dict):
-                return [decode_nested_example(sub_schema, o) for o in obj]
+                return [decode_nested_example(sub_schema, o, **_kwargs) for o in obj]
             if len(obj) > 0:
                 for first_elmt in obj:
                     if _check_non_null_non_empty_recursive(first_elmt, sub_schema):
                         break
-                if decode_nested_example(sub_schema, first_elmt) != first_elmt:
-                    return [decode_nested_example(sub_schema, o) for o in obj]
+                if decode_nested_example(sub_schema, first_elmt, **_kwargs) != first_elmt:
+                    return [decode_nested_example(sub_schema, o, **_kwargs) for o in obj]
             return list(obj)
     # Object with special decoding:
     elif hasattr(schema, "decode_example") and getattr(schema, "decode", True):
+        if obj is None:
+            return None
+        if decoder_overrides:
+            for type_, override_fn in decoder_overrides.items():
+                if isinstance(schema, type_):
+                    return override_fn(obj, schema)
         # we pass the token to read and decode files from private repositories in streaming mode
-        return schema.decode_example(obj, token_per_repo_id=token_per_repo_id) if obj is not None else None
+        return schema.decode_example(obj, token_per_repo_id=token_per_repo_id)
     return obj
 
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1473,7 +1473,7 @@ def decode_nested_example(
 
     Args:
         decoder_overrides: optional dict mapping feature types to custom decode functions.
-            When a leaf feature matches a key (via isinstance), the override function is called
+            When the python type of a leaf feature matches a key, the override function is called
             as ``override_fn(obj, schema)`` instead of ``schema.decode_example(obj, ...)``.
     """
     _kwargs = {"token_per_repo_id": token_per_repo_id, "decoder_overrides": decoder_overrides}
@@ -1518,9 +1518,8 @@ def decode_nested_example(
         if obj is None:
             return None
         if decoder_overrides:
-            for type_, override_fn in decoder_overrides.items():
-                if isinstance(schema, type_):
-                    return override_fn(obj, schema)
+            if override_fn := decoder_overrides.get(type(schema)):
+                return override_fn(obj, schema)
         # we pass the token to read and decode files from private repositories in streaming mode
         return schema.decode_example(obj, token_per_repo_id=token_per_repo_id)
     return obj

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -43,6 +43,28 @@ _VALID_IMAGE_ARRAY_DTPYES = [
 ]
 
 
+def _read_remote_image_bytes(path: str, token_per_repo_id: Optional[dict] = None) -> bytes:
+    """Read the raw bytes of a remote image file (e.g. a Hub URL), handling auth tokens.
+
+    Args:
+        path (`str`): A remote (non-local) path to the image file.
+        token_per_repo_id (`dict`, *optional*): Mapping repo_id (`str`) -> token (`bool` or `str`)
+            used to access files from private repositories on the Hub.
+
+    Returns:
+        `bytes`: The raw encoded bytes of the image file.
+    """
+    if token_per_repo_id is None:
+        token_per_repo_id = {}
+    source_url = path.split("::")[-1]
+    pattern = config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+    source_url_fields = string_to_dict(source_url, pattern)
+    token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+    download_config = DownloadConfig(token=token)
+    with xopen(path, "rb", download_config=download_config) as f:
+        return f.read()
+
+
 @dataclass
 class Image:
     """Image [`Feature`] to read image data from an image file.
@@ -174,19 +196,7 @@ class Image:
                 if is_local_path(path):
                     image = PIL.Image.open(path)
                 else:
-                    source_url = path.split("::")[-1]
-                    pattern = (
-                        config.HUB_DATASETS_URL
-                        if source_url.startswith(config.HF_ENDPOINT)
-                        else config.HUB_DATASETS_HFFS_URL
-                    )
-                    source_url_fields = string_to_dict(source_url, pattern)
-                    token = (
-                        token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
-                    )
-                    download_config = DownloadConfig(token=token)
-                    with xopen(path, "rb", download_config=download_config) as f:
-                        bytes_ = BytesIO(f.read())
+                    bytes_ = BytesIO(_read_remote_image_bytes(path, token_per_repo_id=token_per_repo_id))
                     image = PIL.Image.open(bytes_)
         else:
             image = PIL.Image.open(BytesIO(bytes_))

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -42,7 +42,7 @@ _PIL_MODE_TO_TORCHVISION_MODE = {
 }
 
 
-def _decode_image_for_torch(value: dict, image_feature: "Image") -> "torch.Tensor":
+def _decode_image_for_torch(value: dict, image_feature: "Image", token_per_repo_id=None) -> "torch.Tensor":
     """Decode an image dict {"bytes": ..., "path": ...} to a CHW torch.Tensor using torchvision.
 
     Uses torchvision.io.decode_image for efficient decoding. Falls back to PIL
@@ -52,6 +52,7 @@ def _decode_image_for_torch(value: dict, image_feature: "Image") -> "torch.Tenso
     Args:
         value: dict with "bytes" and "path" keys from Arrow extraction
         image_feature: the Image feature instance (carries mode/decode info)
+        token_per_repo_id: mapping repo_id -> token to access remote private repositories
 
     Returns:
         torch.Tensor in CHW format
@@ -59,15 +60,19 @@ def _decode_image_for_torch(value: dict, image_feature: "Image") -> "torch.Tenso
     import torch
     from torchvision.io import decode_image
 
+    from ..features.image import _read_remote_image_bytes
+
     path, bytes_ = value["path"], value["bytes"]
 
     tv_mode = _PIL_MODE_TO_TORCHVISION_MODE.get(image_feature.mode) if image_feature.mode else None
 
     try:
+        if bytes_ is None and path is not None and not is_local_path(path):
+            bytes_ = _read_remote_image_bytes(path, token_per_repo_id=token_per_repo_id)
         if bytes_ is not None:
             input_tensor = torch.frombuffer(bytearray(bytes_), dtype=torch.uint8)
             return decode_image(input_tensor, mode=tv_mode or "UNCHANGED", apply_exif_orientation=True)
-        elif path is not None and is_local_path(path):
+        elif path is not None:
             return decode_image(path, mode=tv_mode or "UNCHANGED", apply_exif_orientation=True)
     except Exception:
         pass
@@ -75,7 +80,7 @@ def _decode_image_for_torch(value: dict, image_feature: "Image") -> "torch.Tenso
     # Fallback: PIL decode + pil_to_tensor
     from torchvision.transforms.v2.functional import pil_to_tensor
 
-    pil_image = image_feature.decode_example(value)
+    pil_image = image_feature.decode_example(value, token_per_repo_id=token_per_repo_id)
     return pil_to_tensor(pil_image)
 
 

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -82,8 +82,9 @@ def _decode_image_for_torch(value: dict, image_feature: "Image") -> "torch.Tenso
 class TorchFeaturesDecoder:
     """Features decoder that uses torchvision for Image columns when available.
 
-    For Image columns, decodes directly to torch.Tensor via torchvision.io.decode_image,
-    bypassing PIL entirely. For all other decodable features (Audio, Video, nested Images, etc.),
+    For Image features, decodes directly to torch.Tensor via torchvision.io.decode_image,
+    bypassing PIL entirely. This works for both top-level and nested Image features
+    (e.g. List(Image())). For all other decodable features (Audio, Video, etc.),
     delegates to the standard decode_nested_example path.
     """
 
@@ -95,51 +96,50 @@ class TorchFeaturesDecoder:
         self.features = features
         self.token_per_repo_id = token_per_repo_id
 
-        # Pre-compute which columns should use the torchvision fast path.
-        # Only top-level Image columns with decode=True when torchvision is available.
-        self._torchvision_columns: set[str] = set()
+        self._decoder_overrides = None
         if self.features and config.TORCHVISION_AVAILABLE:
             from ..features.image import Image
 
-            for column_name, feature in self.features.items():
-                if isinstance(feature, Image) and feature.decode:
-                    self._torchvision_columns.add(column_name)
+            self._decoder_overrides = {Image: _decode_image_for_torch}
 
     def decode_row(self, row: dict) -> dict:
         if not self.features:
             return row
-        return {column_name: self._decode_value(column_name, value) for column_name, value in row.items()}
+        return {
+            column_name: (
+                decode_nested_example(
+                    self.features[column_name],
+                    value,
+                    token_per_repo_id=self.token_per_repo_id,
+                    decoder_overrides=self._decoder_overrides,
+                )
+                if self.features._column_requires_decoding[column_name]
+                else value
+            )
+            for column_name, value in row.items()
+        }
 
     def decode_column(self, column: list, column_name: str) -> list:
         if not self.features:
             return column
-        if column_name in self._torchvision_columns:
-            image_feature = self.features[column_name]
-            return [_decode_image_for_torch(value, image_feature) if value is not None else None for value in column]
-        if self.features._column_requires_decoding[column_name]:
-            return [
-                decode_nested_example(self.features[column_name], value, token_per_repo_id=self.token_per_repo_id)
-                if value is not None
-                else None
-                for value in column
-            ]
-        return column
+        if not self.features._column_requires_decoding[column_name]:
+            return column
+        return [
+            decode_nested_example(
+                self.features[column_name],
+                value,
+                token_per_repo_id=self.token_per_repo_id,
+                decoder_overrides=self._decoder_overrides,
+            )
+            if value is not None
+            else None
+            for value in column
+        ]
 
     def decode_batch(self, batch: dict) -> dict:
         if not self.features:
             return batch
         return {column_name: self.decode_column(column, column_name) for column_name, column in batch.items()}
-
-    def _decode_value(self, column_name: str, value):
-        if column_name in self._torchvision_columns:
-            return _decode_image_for_torch(value, self.features[column_name]) if value is not None else None
-        if self.features._column_requires_decoding[column_name]:
-            return (
-                decode_nested_example(self.features[column_name], value, token_per_repo_id=self.token_per_repo_id)
-                if value is not None
-                else None
-            )
-        return value
 
 
 class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -15,12 +15,15 @@
 # Lint as: python3
 import sys
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pyarrow as pa
 
 from .. import config
+from ..features import Features
+from ..features.features import decode_nested_example
+from ..utils.file_utils import is_local_path
 from ..utils.py_utils import map_nested
 from .formatting import TensorFormatter
 
@@ -28,11 +31,122 @@ from .formatting import TensorFormatter
 if TYPE_CHECKING:
     import torch
 
+    from ..features.image import Image
+
+
+_PIL_MODE_TO_TORCHVISION_MODE = {
+    "L": "GRAY",
+    "LA": "GRAY_ALPHA",
+    "RGB": "RGB",
+    "RGBA": "RGB_ALPHA",
+}
+
+
+def _decode_image_for_torch(value: dict, image_feature: "Image") -> "torch.Tensor":
+    """Decode an image dict {"bytes": ..., "path": ...} to a CHW torch.Tensor using torchvision.
+
+    Uses torchvision.io.decode_image for efficient decoding. Falls back to PIL
+    decoding + torchvision.transforms.v2.functional.pil_to_tensor on failure
+    (e.g. unsupported format).
+
+    Args:
+        value: dict with "bytes" and "path" keys from Arrow extraction
+        image_feature: the Image feature instance (carries mode/decode info)
+
+    Returns:
+        torch.Tensor in CHW format
+    """
+    import torch
+    from torchvision.io import decode_image
+
+    path, bytes_ = value["path"], value["bytes"]
+
+    tv_mode = _PIL_MODE_TO_TORCHVISION_MODE.get(image_feature.mode) if image_feature.mode else None
+
+    try:
+        if bytes_ is not None:
+            input_tensor = torch.frombuffer(bytearray(bytes_), dtype=torch.uint8)
+            return decode_image(input_tensor, mode=tv_mode or "UNCHANGED", apply_exif_orientation=True)
+        elif path is not None and is_local_path(path):
+            return decode_image(path, mode=tv_mode or "UNCHANGED", apply_exif_orientation=True)
+    except Exception:
+        pass
+
+    # Fallback: PIL decode + pil_to_tensor
+    from torchvision.transforms.v2.functional import pil_to_tensor
+
+    pil_image = image_feature.decode_example(value)
+    return pil_to_tensor(pil_image)
+
+
+class TorchFeaturesDecoder:
+    """Features decoder that uses torchvision for Image columns when available.
+
+    For Image columns, decodes directly to torch.Tensor via torchvision.io.decode_image,
+    bypassing PIL entirely. For all other decodable features (Audio, Video, nested Images, etc.),
+    delegates to the standard decode_nested_example path.
+    """
+
+    def __init__(
+        self,
+        features: Optional[Features],
+        token_per_repo_id: Optional[dict[str, Union[str, bool, None]]] = None,
+    ):
+        self.features = features
+        self.token_per_repo_id = token_per_repo_id
+
+        # Pre-compute which columns should use the torchvision fast path.
+        # Only top-level Image columns with decode=True when torchvision is available.
+        self._torchvision_columns: set[str] = set()
+        if self.features and config.TORCHVISION_AVAILABLE:
+            from ..features.image import Image
+
+            for column_name, feature in self.features.items():
+                if isinstance(feature, Image) and feature.decode:
+                    self._torchvision_columns.add(column_name)
+
+    def decode_row(self, row: dict) -> dict:
+        if not self.features:
+            return row
+        return {column_name: self._decode_value(column_name, value) for column_name, value in row.items()}
+
+    def decode_column(self, column: list, column_name: str) -> list:
+        if not self.features:
+            return column
+        if column_name in self._torchvision_columns:
+            image_feature = self.features[column_name]
+            return [_decode_image_for_torch(value, image_feature) if value is not None else None for value in column]
+        if self.features._column_requires_decoding[column_name]:
+            return [
+                decode_nested_example(self.features[column_name], value, token_per_repo_id=self.token_per_repo_id)
+                if value is not None
+                else None
+                for value in column
+            ]
+        return column
+
+    def decode_batch(self, batch: dict) -> dict:
+        if not self.features:
+            return batch
+        return {column_name: self.decode_column(column, column_name) for column_name, column in batch.items()}
+
+    def _decode_value(self, column_name: str, value):
+        if column_name in self._torchvision_columns:
+            return _decode_image_for_torch(value, self.features[column_name]) if value is not None else None
+        if self.features._column_requires_decoding[column_name]:
+            return (
+                decode_nested_example(self.features[column_name], value, token_per_repo_id=self.token_per_repo_id)
+                if value is not None
+                else None
+            )
+        return value
+
 
 class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
     def __init__(self, features=None, token_per_repo_id=None, **torch_tensor_kwargs):
         super().__init__(features=features, token_per_repo_id=token_per_repo_id)
         self.torch_tensor_kwargs = torch_tensor_kwargs
+        self.torch_features_decoder = TorchFeaturesDecoder(self.features, self.token_per_repo_id)
         import torch  # noqa import torch at initialization
 
     def _consolidate(self, column):
@@ -48,6 +162,9 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
 
     def _tensorize(self, value):
         import torch
+
+        if isinstance(value, torch.Tensor):
+            return value
 
         if isinstance(value, (str, bytes, type(None))):
             return value
@@ -111,19 +228,19 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
 
     def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
-        row = self.python_features_decoder.decode_row(row)
+        row = self.torch_features_decoder.decode_row(row)
         return self.recursive_tensorize(row)
 
     def format_column(self, pa_table: pa.Table) -> "torch.Tensor":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
-        column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
+        column = self.torch_features_decoder.decode_column(column, pa_table.column_names[0])
         column = self.recursive_tensorize(column)
         column = self._consolidate(column)
         return column
 
     def format_batch(self, pa_table: pa.Table) -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
-        batch = self.python_features_decoder.decode_batch(batch)
+        batch = self.torch_features_decoder.decode_batch(batch)
         batch = self.recursive_tensorize(batch)
         for column_name in batch:
             batch[column_name] = self._consolidate(batch[column_name])

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from datasets import Audio, Features, Image, IterableDataset
+from datasets import Audio, Features, Image, IterableDataset, Sequence
 from datasets.formatting import NumpyFormatter, PandasFormatter, PythonFormatter, query_table
 from datasets.formatting.formatting import (
     LazyBatch,
@@ -507,6 +507,31 @@ class FormatterTest(TestCase):
         row = formatter.format_row(pa_table)
         self.assertEqual(row["image"].dtype, torch.uint8)
         self.assertEqual(row["image"].shape, (1, 480, 640))
+
+    @require_numpy1_on_windows
+    @require_torch
+    @require_torchvision
+    @require_pil
+    def test_torch_formatter_nested_image(self):
+        import torch
+
+        from datasets.formatting import TorchFormatter
+
+        pa_table = pa.table(
+            {
+                "images": [
+                    [
+                        {"bytes": None, "path": str(IMAGE_PATH_1)},
+                        {"bytes": None, "path": str(IMAGE_PATH_1)},
+                    ]
+                ]
+            }
+        )
+        formatter = TorchFormatter(features=Features({"images": Sequence(Image())}))
+        row = formatter.format_row(pa_table)
+        self.assertIsInstance(row["images"], torch.Tensor)
+        self.assertEqual(row["images"].shape, (2, 3, 480, 640))
+        self.assertEqual(row["images"].dtype, torch.uint8)
 
     def test_torch_formatter_audio(self):
         import torch

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -26,6 +26,7 @@ from .utils import (
     require_tf,
     require_torch,
     require_torchcodec,
+    require_torchvision,
 )
 
 
@@ -429,8 +430,84 @@ class FormatterTest(TestCase):
         self.assertEqual(batch["image"][0].dtype, torch.uint8)
         self.assertEqual(batch["image"][0].shape, (3, 480, 640))
 
+    @require_numpy1_on_windows
     @require_torch
-    @require_torchcodec
+    @require_torchvision
+    @require_pil
+    def test_torch_formatter_image_from_bytes(self):
+        import torch
+
+        from datasets.formatting import TorchFormatter
+
+        with open(IMAGE_PATH_1, "rb") as f:
+            img_bytes = f.read()
+
+        pa_table = pa.table({"image": [{"bytes": img_bytes, "path": None}]})
+        formatter = TorchFormatter(features=Features({"image": Image()}))
+        row = formatter.format_row(pa_table)
+        self.assertEqual(row["image"].dtype, torch.uint8)
+        self.assertEqual(row["image"].shape, (3, 480, 640))
+        col = formatter.format_column(pa_table)
+        self.assertEqual(col.dtype, torch.uint8)
+        self.assertEqual(col.shape, (1, 3, 480, 640))
+        batch = formatter.format_batch(pa_table)
+        self.assertEqual(batch["image"].dtype, torch.uint8)
+        self.assertEqual(batch["image"].shape, (1, 3, 480, 640))
+
+    @require_numpy1_on_windows
+    @require_torch
+    @require_torchvision
+    @require_pil
+    def test_torch_formatter_image_torchvision_fallback(self):
+        from unittest.mock import patch
+
+        import torch
+
+        from datasets.formatting import TorchFormatter
+
+        pa_table = pa.table({"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}]})
+        formatter = TorchFormatter(features=Features({"image": Image()}))
+
+        # When decode_image raises, should fall back to PIL + pil_to_tensor
+        with patch("torchvision.io.decode_image", side_effect=RuntimeError("Simulated failure")):
+            row = formatter.format_row(pa_table)
+            self.assertEqual(row["image"].dtype, torch.uint8)
+            self.assertEqual(row["image"].shape, (3, 480, 640))
+
+    @require_numpy1_on_windows
+    @require_torch
+    @require_pil
+    def test_torch_formatter_image_no_torchvision(self):
+        from unittest.mock import patch
+
+        import torch
+
+        from datasets.formatting import TorchFormatter
+
+        # When TORCHVISION_AVAILABLE is False, should use the old PIL path entirely
+        pa_table = pa.table({"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}]})
+        with patch("datasets.formatting.torch_formatter.config.TORCHVISION_AVAILABLE", False):
+            formatter = TorchFormatter(features=Features({"image": Image()}))
+            row = formatter.format_row(pa_table)
+            self.assertEqual(row["image"].dtype, torch.uint8)
+            self.assertEqual(row["image"].shape, (3, 480, 640))
+
+    @require_numpy1_on_windows
+    @require_torch
+    @require_torchvision
+    @require_pil
+    def test_torch_formatter_image_mode(self):
+        import torch
+
+        from datasets.formatting import TorchFormatter
+
+        # RGB image decoded as grayscale
+        pa_table = pa.table({"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}]})
+        formatter = TorchFormatter(features=Features({"image": Image(mode="L")}))
+        row = formatter.format_row(pa_table)
+        self.assertEqual(row["image"].dtype, torch.uint8)
+        self.assertEqual(row["image"].shape, (1, 480, 640))
+
     def test_torch_formatter_audio(self):
         import torch
 


### PR DESCRIPTION
This PR uses `torchvision.io.decode_image` instead of `PIL.open()` to decode images when the `torch` formatter is used.

TorchVision is typically faster than PIL to decode images, and this also saves the `pil_to_tensor` conversion. See https://github.com/huggingface/transformers/pull/45195 for benchmarks on `transfomers` where the same changes were applied.

----

Very open to any feedback regarding the implem. I went for creating a new `TorchFeaturesDecoder` class which mirrors what exists for `pandas`. There are other ways to enable this, like making the `Image` class 'formatter-aware'.

As discussed offline, I considered making `Image.decode_example()` return a lazy `PIL.Image` (no .load()) so the torch formatter could extract the path/bytes and pass them to torchvision. But this doesn't work cleanly because `PIL.Image.open(path)` without .load() keeps OS file handles open, which caused https://github.com/huggingface/datasets/issues/3985. Additionally, EXIF/mode destroys lazy state:[ `decode_example()` needs to apply EXIF transpose and mode conversion](https://github.com/NicolasHug/datasets/blame/e88a484cf05869e13f535e097ff116ffb00b2608/src/datasets/features/image.py#L194-L198). Both trigger `.load()` and produce a new image that loses filename and fp. So we can't both do EXIF/mode AND keep the image lazy.

