### PR TITLE
Support hermes traces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ TESTS_REQUIRE = [
     "torchcodec>=0.7.0; python_version < '3.14'",  # minium version to get windows support, torchcodec doesn't have wheels for 3.14 yet
     "nibabel>=5.3.1",
     "trimesh>=4.10.0",
-    "teich==0.1.1a76",
+    "teich==0.1.2",
 ]
 
 NUMPY2_INCOMPATIBLE_LIBRARIES = [

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -1,6 +1,7 @@
 import io
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, Optional
 
@@ -145,7 +146,7 @@ class Json(datasets.ArrowBasedBuilder):
             if self.info.features == AGENT_TRACES_FEATURES:
                 is_agent_traces = True
                 if datasets.config.TEICH_AVAILABLE:
-                    from teich import convert_trace_to_training_example
+                    from teich import convert_traces_to_training_data
                 else:
                     raise ImportError("To support decoding agent traces, please install 'teich'.")
             json_field_paths = get_json_field_paths_from_feature(self.info.features)
@@ -166,32 +167,56 @@ class Json(datasets.ArrowBasedBuilder):
                     pa_table = pa.Table.from_pandas(df, preserve_index=False)
                     yield Key(shard_idx, 0), self._cast_table(pa_table)
 
-                # If the files are agent traces (one row = one file)
+                # If the files are agent traces (one row = one file except for hermes which can have multiple sessions per file)
                 elif is_agent_traces:
                     trace_file = Path(file)
-                    trace_events = trace_file.read_text(encoding="utf-8").splitlines()
-                    harness, session_id, prompt, sent_at, num_user_messages, num_tool_calls = parse_traces_info(
-                        trace_events
-                    )
+                    trace = trace_file.read_text(encoding="utf-8")
+                    lines = trace.splitlines()
                     file_path = original_files[shard_idx]
                     if self.base_path is not None and file_path.startswith(self.base_path):
                         file_path = os.path.relpath(file_path, self.base_path)
-                    training_example = convert_trace_to_training_example(trace_file)
-                    example = {
-                        **dict.fromkeys(AGENT_TRACES_FEATURES),
-                        **training_example.to_dict(),
-                        "harness": harness,
-                        "session_id": session_id,
-                        "prompt": prompt,
-                        "sent_at": sent_at,
-                        "num_user_messages": num_user_messages,
-                        "num_tool_calls": num_tool_calls,
-                        "trace": trace_events,
-                        "file_path": file_path,
-                    }
-                    for json_field_path in json_field_paths:
-                        example = json_encode_field(example, json_field_path)
-                    pa_table = pa.Table.from_pylist([example])
+                    training_examples = convert_traces_to_training_data(trace_file)
+                    examples = []
+                    for i, training_example in enumerate(training_examples):
+                        if training_example["metadata"]["trace_type"] == "hermes":
+                            timestamp = ujson_loads(lines[i])["started_at"]
+                            milliseconds = timestamp if timestamp <= 10_000_000_000 else timestamp * 1_000
+                            sent_at = (
+                                datetime.fromtimestamp(milliseconds, tz=timezone.utc)
+                                .isoformat(timespec="milliseconds")
+                                .replace("+00:00", "Z")
+                            )
+                            bonus_fields = {
+                                "harness": training_example["metadata"]["trace_type"],
+                                "session_id": training_example["metadata"]["session_id"],
+                                "sent_at": sent_at,
+                                "num_user_messages": training_example["metadata"]["turn_count"],
+                                "num_tool_calls": training_example["metadata"]["tool_call_count"],
+                                "trace": lines[i],
+                            }
+                        else:
+                            harness, session_id, prompt, sent_at, num_user_messages, num_tool_calls = (
+                                parse_traces_info(lines)
+                            )
+                            bonus_fields = {
+                                "harness": harness,
+                                "session_id": session_id,
+                                "prompt": prompt,
+                                "sent_at": sent_at,
+                                "num_user_messages": num_user_messages,
+                                "num_tool_calls": num_tool_calls,
+                                "trace": trace,
+                            }
+                        example = {
+                            **dict.fromkeys(AGENT_TRACES_FEATURES),
+                            **training_example,
+                            **bonus_fields,
+                            "file_path": file_path,
+                        }
+                        for json_field_path in json_field_paths:
+                            example = json_encode_field(example, json_field_path)
+                        examples.append(example)
+                    pa_table = pa.Table.from_pylist(examples)
                     yield Key(shard_idx, 0), self._cast_table(pa_table)
 
                 # If the file has one json object per line
@@ -324,13 +349,7 @@ for _harness, _trace_types in AGENT_TRACES_TYPES_VALUES.items():
 
 
 AGENT_TRACES_FEATURES_MARKERS = {
-    "claude_code": datasets.Features(
-        {
-            "type": Value("string"),
-            "message": datasets.Json(),
-        }
-    ),
-    "pi": datasets.Features(
+    "claude_code_or_pi_or_openclaw": datasets.Features(
         {
             "type": Value("string"),
             "message": datasets.Json(),
@@ -340,6 +359,15 @@ AGENT_TRACES_FEATURES_MARKERS = {
         {
             "type": Value("string"),
             "payload": datasets.Json(),
+        }
+    ),
+    "hermes": datasets.Features(
+        {
+            "id": Value("string"),
+            "source": datasets.Value("string"),
+            "model": datasets.Value("string"),
+            "system_prompt": datasets.Value("string"),
+            "messages": datasets.Json(),
         }
     ),
 }
@@ -358,7 +386,7 @@ AGENT_TRACES_FEATURES = datasets.Features(
         "sent_at": Value("string"),
         "num_user_messages": Value("int64"),
         "num_tool_calls": Value("int64"),
-        "trace": List(datasets.Json()),
+        "trace": datasets.Json(),
         "file_path": Value("string"),
     }
 )

--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -351,23 +351,23 @@ for _harness, _trace_types in AGENT_TRACES_TYPES_VALUES.items():
 AGENT_TRACES_FEATURES_MARKERS = {
     "claude_code_or_pi_or_openclaw": datasets.Features(
         {
-            "type": Value("string"),
-            "message": datasets.Json(),
+            "type": lambda f: f == Value("string"),
+            "message": lambda f: f == datasets.Json(),
         }
     ),
     "codex": datasets.Features(
         {
-            "type": Value("string"),
-            "payload": datasets.Json(),
+            "type": lambda f: f == Value("string"),
+            "payload": lambda f: f == datasets.Json(),
         }
     ),
     "hermes": datasets.Features(
         {
-            "id": Value("string"),
-            "source": datasets.Value("string"),
-            "model": datasets.Value("string"),
-            "system_prompt": datasets.Value("string"),
-            "messages": datasets.Json(),
+            "id": lambda f: f == Value("string"),
+            "source": lambda f: f == datasets.Value("string"),
+            "model": lambda f: f == datasets.Value("string"),
+            "system_prompt": lambda f: f == datasets.Value("string"),
+            "messages": lambda f: isinstance(f, (datasets.List, datasets.Json)),
         }
     ),
 }
@@ -394,7 +394,7 @@ AGENT_TRACES_FEATURES = datasets.Features(
 
 def has_agent_traces_markers(features: datasets.Features) -> bool:
     for agent_traces_features_marker in AGENT_TRACES_FEATURES_MARKERS.values():
-        if all(features.get(key) == feature for key, feature in agent_traces_features_marker.items()):
+        if all(feature_marker(features.get(key)) for key, feature_marker in agent_traces_features_marker.items()):
             return True
     return False
 

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -314,12 +314,12 @@ def generate_agent_traces_output(trace_file):
     return Features.from_arrow_schema(pa_table.schema).decode_batch(pa_table.to_pydict())
 
 
-def assert_agent_traces_output(tmp_path, filename, rows, expected):
+def assert_agent_traces_output(tmp_path, filename, rows, expected, num_sessions=1):
     trace_file = write_jsonl(tmp_path / filename, rows)
     out = generate_agent_traces_output(trace_file)
     for key, value in zip(AGENT_TRACE_FIELD_NAMES_TO_CHECK, expected):
-        assert out[key] == [value]
-    assert out["file_path"] == [trace_file]
+        assert out[key] == [value] * num_sessions
+    assert out["file_path"] == [trace_file] * num_sessions
     assert isinstance(out["messages"], list)
     assert out["messages"]
     assert all(
@@ -329,6 +329,7 @@ def assert_agent_traces_output(tmp_path, filename, rows, expected):
     )
     assert isinstance(out["tools"], list)
     assert isinstance(out["metadata"], (dict, list))
+    assert isinstance(out["trace"], (dict, list))
     return trace_file, out
 
 
@@ -380,6 +381,55 @@ CODEX_EXPECTED_AGENT_TRACE_FIELDS = (
     1,
     1,
 )
+
+HERMES_SESSION = {
+    "id": "20260605_092247_d018ec",
+    "source": "cli",
+    "model": "Qwen/Qwen3.5-35B-A3B",
+    "system_prompt": "You are Hermes.",
+    "started_at": 1_780_665_768.307,
+    "message_count": 4,
+    "tool_call_count": 1,
+    "messages": [
+        {
+            "session_id": "20260605_092247_d018ec",
+            "role": "user",
+            "content": "Run pwd and date.",
+            "timestamp": 1_780_665_767.307,
+        },
+        {
+            "session_id": "20260605_092247_d018ec",
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "The user asked for two shell commands.",
+            "timestamp": 1_780_665_767.308,
+            "tool_calls": [
+                {
+                    "id": "call_677f321e2b3047b4b8c7a1e1",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": "pwd && date -u +%Y-%m-%dT%H:%M:%SZ"}),
+                    },
+                },
+            ],
+        },
+        {
+            "session_id": "20260605_092247_d018ec",
+            "role": "tool",
+            "content": json.dumps({"output": "/tmp/work\n2026-06-05T13:22:47Z", "exit_code": 0, "error": None}),
+            "tool_call_id": "call_677f321e2b3047b4b8c7a1e1",
+            "timestamp": 1_780_665_767.309,
+        },
+        {
+            "session_id": "20260605_092247_d018ec",
+            "role": "assistant",
+            "content": "Working directory: `/tmp/work`.",
+            "reasoning": "The commands executed successfully.",
+            "timestamp": 1_780_665_767.31,
+        },
+    ],
+}
 
 
 def test_config_raises_when_invalid_name() -> None:
@@ -573,6 +623,16 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
             id="openclaw",
         ),
         pytest.param(
+            "hermes.jsonl",
+            [HERMES_SESSION],
+            ("hermes", "20260605_092247_d018ec", "Run pwd and date.", "2026-06-05T13:22:48.307Z", 1, 1),
+        ),
+        pytest.param(
+            "hermes_two_sessions.jsonl",
+            [HERMES_SESSION] * 2,
+            ("hermes", "20260605_092247_d018ec", "Run pwd and date.", "2026-06-05T13:22:48.307Z", 1, 1),
+        ),
+        pytest.param(
             "missing_prompt.jsonl",
             [
                 {"type": "session_meta", "payload": {"id": "codex-session"}},
@@ -588,7 +648,8 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
 )
 @require_teich
 def test_json_generate_tables_with_agent_trace_metadata(tmp_path, filename, rows, expected):
-    _, out = assert_agent_traces_output(tmp_path, filename, rows, expected)
+    num_sessions = 2 if filename == "hermes_two_sessions.jsonl" else 1
+    _, out = assert_agent_traces_output(tmp_path, filename, rows, expected, num_sessions=num_sessions)
     assert "models" not in out
 
 


### PR DESCRIPTION
Parse hermes agent traces export using teich

supports both single session export and multi-sessions export

```bash
# single session
>>> hermes sessions export session.jsonl --session-id 20250305_091523_a1b2c3d4
# multi-sessions
>>> hermes sessions export sessions.jsonl
```

+ bump teich to 0.1.2

breaking change: "trace" is now Json() instead of List(Json())

example using [dacorvo/hf-hub-session-hermes-traces](https://huggingface.co/datasets/dacorvo/hf-hub-session-hermes-traces):

```python
In [1]: from datasets import load_dataset

In [2]: ds = load_dataset("dacorvo/hf-hub-session-hermes-traces", split="train")

In [3]: ds
Out[3]: 
Dataset({
    features: ['harness', 'session_id', 'prompt', 'messages', 'tools', 'metadata', 'sent_at', 'num_user_messages', 'num_tool_calls', 'trace', 'file_path'],
    num_rows: 228
})
```

this also makes me think we should document more how to use `teich` with `datasets`