### PR TITLE
fix: skip filename-based split detection for media files in get_data_…

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -25,6 +25,14 @@ SingleOriginMetadata = Union[tuple[str, str], tuple[str], tuple[()]]
 
 
 SANITIZED_DEFAULT_SPLIT = str(Split.TRAIN)
+MEDIA_EXTENSIONS = {
+    # Images
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif"
+    # Audio
+    ".mp3", ".wav", ".flac", ".ogg", ".aac", ".m4a",
+    # Video
+    ".mp4", ".avi", ".mov", ".mkv", ".webm",
+}
 
 
 logger = logging.get_logger(__name__)
@@ -291,8 +299,14 @@ def _get_data_files_patterns(pattern_resolver: Callable[[str], list[str]]) -> di
                 except FileNotFoundError:
                     continue
                 if len(data_files) > 0:
+                    # Skip all matched files are media files and we're using filename patterns
+                    if patterns_dict is DEFAULT_PATTERNS_SPLIT_IN_FILENAME and all(
+                        any(f.lower().endswith(ext) for ext in MEDIA_EXTENSIONS)
+                        for f in data_files
+                    ):
+                        continue
                     non_empty_splits.append(split)
-                    break
+                    break            
         if non_empty_splits:
             return {split: patterns_dict[split] for split in non_empty_splits}
     raise FileNotFoundError(f"Couldn't resolve pattern {pattern} with resolver {pattern_resolver}")

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -27,7 +27,7 @@ SingleOriginMetadata = Union[tuple[str, str], tuple[str], tuple[()]]
 SANITIZED_DEFAULT_SPLIT = str(Split.TRAIN)
 MEDIA_EXTENSIONS = {
     # Images
-    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif"
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif",
     # Audio
     ".mp3", ".wav", ".flac", ".ogg", ".aac", ".m4a",
     # Video

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -11,6 +11,7 @@ from datasets.download.streaming_download_manager import StreamingDownloadManage
 from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder, ImageFolderConfig
 
 from ..utils import require_pil
+from pathlib import Path 
 
 
 @pytest.fixture
@@ -442,3 +443,25 @@ def test_data_files_with_with_metadata_in_different_formats(cache_dir, tmp_path,
     with pytest.raises(ValueError) as exc_info:
         imagefolder.download_and_prepare()
     assert "metadata files with different extensions" in str(exc_info.value)
+
+@require_pil
+def test_data_files_with_image_named_after_split(cache_dir, tmp_path, image_file):
+    # Test that an image named "train.png" is not mistaken for a split name
+    data_dir = tmp_path / "data_dir_with_image_named_train"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+
+    # Copy 3 images into a flat folder - one named "train.png"
+    shutil.copyfile(image_file, data_dir / "train.png")
+    shutil.copyfile(image_file, data_dir / "pika.png")
+    shutil.copyfile(image_file, data_dir / "pika_pika.png")
+
+    data_files = DataFilesDict.from_patterns(
+        get_data_patterns(str(data_dir)), data_dir.as_posix()
+    )
+    imagefolder = ImageFolder(data_files=data_files, cache_dir=cache_dir)
+    imagefolder.download_and_prepare()
+    dataset = imagefolder.as_dataset()
+
+    # All 3 images should be in the dataset, not just train.png
+    assert len(dataset["train"]) == 3


### PR DESCRIPTION
Fixes #7201

## Problem
When a user has an image file named `train.png` in a flat folder, 
the library mistakenly treats it as a split name instead of an image,
resulting in only that one file being loaded.

## Fix
Modified `_get_data_files_patterns` in `data_files.py` to skip 
filename-based split detection when all matched files are media files
(images, audio, video). This causes it to fall through to 
`DEFAULT_PATTERNS_ALL` which correctly loads all files.

## Test
Added `test_data_files_with_image_named_after_split` to verify
that all images are loaded when one is named after a split.