### PR TITLE
Add the supports of missing types in conversion between arrow and dtype types

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -117,6 +117,10 @@ def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
         return "large_string"
     elif pyarrow.types.is_string_view(arrow_type):
         return "string_view"
+    elif pyarrow.types.is_fixed_size_binary(arrow_type):
+        return f"fixed_size_binary[{arrow_type.byte_width}]"
+    elif pyarrow.types.is_list(arrow_type):
+        return f"list[{_arrow_to_datasets_dtype(arrow_type.value_type)}]"
     elif pyarrow.types.is_dictionary(arrow_type):
         return _arrow_to_datasets_dtype(arrow_type.value_type)
     else:
@@ -266,6 +270,11 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                     ],
                 )
             )
+        
+    fixed_size_binary_matches = re.search(r"^fixed_size_binary\[(\d+)\]$", datasets_dtype)
+    if fixed_size_binary_matches:
+        byte_width = fixed_size_binary_matches.group(1)
+        return pa.binary(int(byte_width))
 
     raise ValueError(
         f"Neither {datasets_dtype} nor {datasets_dtype + '_'} seems to be a pyarrow data type. "

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -119,12 +119,50 @@ def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
         return "string_view"
     elif pyarrow.types.is_fixed_size_binary(arrow_type):
         return f"fixed_size_binary[{arrow_type.byte_width}]"
+    elif pyarrow.types.is_fixed_size_list(arrow_type):
+        return f"fixed_size_list[{_arrow_to_datasets_dtype(arrow_type.value_type)}]({arrow_type.list_size})"
     elif pyarrow.types.is_list(arrow_type):
         return f"list[{_arrow_to_datasets_dtype(arrow_type.value_type)}]"
+    elif pyarrow.types.is_large_list(arrow_type):
+        return f"large_list[{_arrow_to_datasets_dtype(arrow_type.value_type)}]"
+    elif pyarrow.types.is_struct(arrow_type):
+        return f"struct{{{', '.join(f'{arrow_type[i].name}: {_arrow_to_datasets_dtype(arrow_type[i].type)}' for i in range(len(arrow_type)))}}}"
+    elif pyarrow.types.is_map(arrow_type):
+        return f"map[{_arrow_to_datasets_dtype(arrow_type.key_type)}, {_arrow_to_datasets_dtype(arrow_type.item_type)}]"
+    elif pyarrow.types.is_union(arrow_type):
+        fields_str = ', '.join(f'{arrow_type[i].name}: {_arrow_to_datasets_dtype(arrow_type[i].type)}' for i in range(len(arrow_type)))
+        type_codes = ', '.join(str(code) for code in arrow_type.type_codes)
+        return f"{arrow_type.mode}_union[{{{fields_str}}}, ({type_codes})]"
+    elif pyarrow.types.is_run_end_encoded(arrow_type):
+        return f"run_end_encoded[{_arrow_to_datasets_dtype(arrow_type.run_end_type)}, {_arrow_to_datasets_dtype(arrow_type.value_type)}]"
     elif pyarrow.types.is_dictionary(arrow_type):
         return _arrow_to_datasets_dtype(arrow_type.value_type)
+    elif str(arrow_type) == "month_day_nano_interval":
+        return "month_day_nano_interval"
     else:
         raise ValueError(f"Arrow type {arrow_type} does not have a datasets dtype equivalent.")
+
+
+def _split_on_top_level_comma(s: str) -> list[str]:
+    """Split a string on commas that are at the top nesting level (respecting brackets and braces)."""
+    parts = []
+    depth = 0
+    current = []
+    for ch in s:
+        if ch in '[{(':
+            depth += 1
+            current.append(ch)
+        elif ch in ']})':
+            depth -= 1
+            current.append(ch)
+        elif ch == ',' and depth == 0:
+            parts.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        parts.append(''.join(current).strip())
+    return parts
 
 
 def string_to_arrow(datasets_dtype: str) -> pa.DataType:
@@ -275,6 +313,106 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     if fixed_size_binary_matches:
         byte_width = fixed_size_binary_matches.group(1)
         return pa.binary(int(byte_width))
+    
+    list_matches = re.search(r"^list\[(.*)\]$", datasets_dtype)
+    if list_matches:
+        value_type = list_matches.group(1)
+        return pa.list_(string_to_arrow(value_type))
+    
+    large_list_matches = re.search(r"^large_list\[(.*)\]$", datasets_dtype)
+    if large_list_matches:
+        value_type = large_list_matches.group(1)
+        return pa.large_list(string_to_arrow(value_type))
+
+    fixed_size_list_matches = re.search(r"^fixed_size_list\[(.*)\]\((\d+)\)$", datasets_dtype)
+    if fixed_size_list_matches:
+        value_type = fixed_size_list_matches.group(1)
+        list_size = int(fixed_size_list_matches.group(2))
+        return pa.list_(string_to_arrow(value_type), list_size)
+
+    struct_matches = re.search(r"^struct\{(.*)\}$", datasets_dtype)
+    if struct_matches:
+        fields_content = struct_matches.group(1)
+        fields = []
+        for field_str in _split_on_top_level_comma(fields_content):
+            name, dtype_str = field_str.split(':', 1)
+            fields.append(pa.field(name.strip(), string_to_arrow(dtype_str.strip())))
+        return pa.struct(fields)
+
+    map_matches = re.search(r"^map\[(.*)\]$", datasets_dtype)
+    if map_matches:
+        content = map_matches.group(1)
+        parts = _split_on_top_level_comma(content)
+        if len(parts) != 2:
+            raise ValueError(
+                _dtype_error_msg(
+                    datasets_dtype,
+                    "map",
+                    examples=["map[string, int32]", "map[string, list[float64]]"],
+                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.map_.html"],
+                )
+            )
+        return pa.map_(string_to_arrow(parts[0].strip()), string_to_arrow(parts[1].strip()))
+
+    union_matches = re.search(r"^(dense|sparse)_union\[(.*)\]$", datasets_dtype)
+    if union_matches:
+        mode = union_matches.group(1)
+        content = union_matches.group(2)
+        parts = _split_on_top_level_comma(content)
+        if len(parts) != 2:
+            raise ValueError(
+                _dtype_error_msg(
+                    datasets_dtype,
+                    "union",
+                    examples=["dense_union[{a: int32, b: string}, (0, 1)]"],
+                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.union.html"],
+                )
+            )
+        fields_str = parts[0].strip()
+        codes_str = parts[1].strip()
+        # Extract fields from {FIELDS}
+        fields_inner = re.search(r"^\{(.*)\}$", fields_str)
+        if not fields_inner:
+            raise ValueError(
+                _dtype_error_msg(
+                    datasets_dtype,
+                    "union",
+                    examples=["dense_union[{a: int32, b: string}, (0, 1)]"],
+                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.union.html"],
+                )
+            )
+        fields = []
+        for field_str in _split_on_top_level_comma(fields_inner.group(1)):
+            name, dtype_str = field_str.split(':', 1)
+            fields.append(pa.field(name.strip(), string_to_arrow(dtype_str.strip())))
+        # Extract type codes from (CODES)
+        codes_inner = re.search(r"^\((.*)\)$", codes_str)
+        if not codes_inner:
+            raise ValueError(
+                _dtype_error_msg(
+                    datasets_dtype,
+                    "union",
+                    examples=["dense_union[{a: int32, b: string}, (0, 1)]"],
+                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.union.html"],
+                )
+            )
+        type_codes = [int(c.strip()) for c in codes_inner.group(1).split(',')]
+        return pa.union(fields, mode, type_codes)
+
+    run_end_encoded_matches = re.search(r"^run_end_encoded\[(.*)\]$", datasets_dtype)
+    if run_end_encoded_matches:
+        content = run_end_encoded_matches.group(1)
+        parts = _split_on_top_level_comma(content)
+        if len(parts) != 2:
+            raise ValueError(
+                _dtype_error_msg(
+                    datasets_dtype,
+                    "run_end_encoded",
+                    examples=["run_end_encoded[int32, int32]"],
+                    urls=["https://arrow.apache.org/docs/python/generated/pyarrow.run_end_encoded.html"],
+                )
+            )
+        return pa.run_end_encoded(string_to_arrow(parts[0].strip()), string_to_arrow(parts[1].strip()))
 
     raise ValueError(
         f"Neither {datasets_dtype} nor {datasets_dtype + '_'} seems to be a pyarrow data type. "

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -77,14 +77,19 @@ class FeaturesTest(TestCase):
             pa.float64(),
             pa.array([datetime.time(1, 1, 1)]).type,  # arrow type: DataType(time64[us])
             pa.binary(16),
+            pa.list_(pa.string()),
+            pa.list_(pa.float64()),
+            pa.large_list(pa.string()),
+            pa.struct({"a": pa.int32(), "b": pa.string()}),
+            pa.list_(pa.int32(), 5),  # fixed_size_list
+            pa.map_(pa.string(), pa.int32()),
+            pa.union([pa.field('a', pa.int32()), pa.field('b', pa.string())], 'dense'),
+            pa.union([pa.field('a', pa.int32()), pa.field('b', pa.string())], 'sparse'),
+            pa.run_end_encoded(pa.int32(), pa.int32()),
+            pa.month_day_nano_interval(),
         ]
         for dt in supported_pyarrow_datatypes:
             self.assertEqual(dt, string_to_arrow(_arrow_to_datasets_dtype(dt)))
-
-        unsupported_pyarrow_datatypes = [pa.list_(pa.float64())]
-        for dt in unsupported_pyarrow_datatypes:
-            with self.assertRaises(ValueError):
-                string_to_arrow(_arrow_to_datasets_dtype(dt))
 
         supported_datasets_dtypes = [
             "time32[s]",
@@ -94,6 +99,12 @@ class FeaturesTest(TestCase):
             "decimal128(30, -4)",
             "int32",
             "float64",
+            "fixed_size_list[int32](5)",
+            "struct{a: int32, b: string}",
+            "map[string, int32]",
+            "dense_union[{a: int32, b: string}, (0, 1)]",
+            "run_end_encoded[int32, int32]",
+            "month_day_nano_interval",
         ]
         for sdt in supported_datasets_dtypes:
             self.assertEqual(sdt, _arrow_to_datasets_dtype(string_to_arrow(sdt)))

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -76,6 +76,7 @@ class FeaturesTest(TestCase):
             pa.int32(),
             pa.float64(),
             pa.array([datetime.time(1, 1, 1)]).type,  # arrow type: DataType(time64[us])
+            pa.binary(16),
         ]
         for dt in supported_pyarrow_datatypes:
             self.assertEqual(dt, string_to_arrow(_arrow_to_datasets_dtype(dt)))


### PR DESCRIPTION
The original issue is a crash in _arrow_to_datasets_dtype because the miss of support of fixed_size_binary:

```
Exception:    SplitsNotFoundError
Message:      The split names could not be parsed from the dataset config.
Traceback:    Traceback (most recent call last):
                File "/usr/local/lib/python3.12/site-packages/datasets/inspect.py", line 286, in get_dataset_config_info
                  for split_generator in builder._split_generators(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/packaged_modules/parquet/parquet.py", line 118, in _split_generators
                  self.info.features = datasets.Features.from_arrow_schema(pq.read_schema(f))
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/features/features.py", line 1858, in from_arrow_schema
                  else generate_from_arrow_type(field.type)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/features/features.py", line 1518, in generate_from_arrow_type
                  return Value(dtype=_arrow_to_datasets_dtype(pa_type))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/features/features.py", line 121, in _arrow_to_datasets_dtype
                  raise ValueError(f"Arrow type {arrow_type} does not have a datasets dtype equivalent.")
              ValueError: Arrow type fixed_size_binary[3] does not have a datasets dtype equivalent.
              
              The above exception was the direct cause of the following exception:
              
              Traceback (most recent call last):
                File "/src/services/worker/src/worker/job_runners/config/split_names.py", line 65, in compute_split_names_from_streaming_response
                  for split in get_dataset_split_names(
                               ^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/inspect.py", line 340, in get_dataset_split_names
                  info = get_dataset_config_info(
                         ^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/inspect.py", line 291, in get_dataset_config_info
                  raise SplitsNotFoundError("The split names could not be parsed from the dataset config.") from err
              datasets.inspect.SplitsNotFoundError: The split names could not be parsed from the dataset config.

```

In this pull request I add the support for all the missing types