### PR TITLE
Fix batch(by_column=...) crashing after shard/shuffle/split

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1723,6 +1723,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             formatting=self.formatting,
             features=self.features,
             max_num_running_async_map_functions_in_parallel=self.max_num_running_async_map_functions_in_parallel,
+            is_batch_accumulate_arrow_table_function=self.is_batch_accumulate_arrow_table_function,
         )
 
     def shard_data_sources(self, num_shards: int, index: int, contiguous=True) -> "MappedExamplesIterable":
@@ -1740,6 +1741,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             formatting=self.formatting,
             features=self.features,
             max_num_running_async_map_functions_in_parallel=self.max_num_running_async_map_functions_in_parallel,
+            is_batch_accumulate_arrow_table_function=self.is_batch_accumulate_arrow_table_function,
         )
 
     def reshard_data_sources(self) -> "MappedExamplesIterable":
@@ -1756,6 +1758,7 @@ class MappedExamplesIterable(_BaseExamplesIterable):
             formatting=self.formatting,
             features=self.features,
             max_num_running_async_map_functions_in_parallel=self.max_num_running_async_map_functions_in_parallel,
+            is_batch_accumulate_arrow_table_function=self.is_batch_accumulate_arrow_table_function,
         )
 
     @property

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2897,6 +2897,25 @@ def test_iterable_dataset_batch(num_shards: int):
         assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
 
 
+def test_iterable_dataset_batch_by_column_survives_resharding():
+    # Re-creating the iterable (shard / shuffle / split_by_node, e.g. inside torch DataLoader
+    # workers) must keep accumulating whole groups instead of crashing with a missing
+    # tables_accumulator argument (regression test).
+    data = {
+        "id": list(range(10)),
+        "category": ["A"] * 5 + ["B"] * 5,
+    }
+    ds = IterableDataset.from_dict(data, num_shards=2)
+    batched_ds = ds.batch(by_column="category")
+
+    sharded = [batch["category"][0] for i in range(2) for batch in batched_ds.shard(num_shards=2, index=i)]
+    assert sorted(sharded) == ["A", "B"]
+
+    shuffled = list(batched_ds.shuffle(seed=0, buffer_size=2))
+    assert sorted(batch["category"][0] for batch in shuffled) == ["A", "B"]
+    assert all(len(set(batch["category"])) == 1 for batch in shuffled)
+
+
 @pytest.mark.parametrize("num_shards", [1, 2, 3, 7, 10])
 def test_iterable_dataset_batch_by_column(num_shards: int):
     # Create a Dataset with a column to group by


### PR DESCRIPTION
## Bug

`batch(by_column=...)` (#8172) works when you iterate the dataset directly, but crashes as soon as the dataset gets copied into a new shape — which happens in very common situations: calling `.shard()` or `.shuffle()`, using `split_dataset_by_node`, or just using a torch `DataLoader` with `num_workers > 0` (each worker gets its own copy):

```python
from datasets import Dataset

ds = Dataset.from_dict({"episode": [0] * 5 + [1] * 5, "x": list(range(10))}).to_iterable_dataset(num_shards=2)
batched = ds.batch(by_column="episode")

list(batched)                               # works
list(batched.shard(num_shards=2, index=0))  # crashes:
# TypeError: _batch_accumulate_arrow_table_by_columns() missing 2 required
# positional arguments: 'tables_accumulator' and 'length'
```

## Cause

Under the hood, `batch(by_column=...)` is a map whose function needs two extra arguments (`tables_accumulator`, `length`) to collect rows until a group is complete. A boolean flag on `MappedExamplesIterable` tells the iteration loop to pass those arguments in.

When the iterable is rebuilt by `shuffle_data_sources`, `shard_data_sources`, or `reshard_data_sources`, every constructor argument is forwarded to the new copy **except that flag** — it silently falls back to its `False` default. The copy then calls the function *without* the two extra arguments, and the function (which still requires them) raises the `TypeError` above.

## Fix

Forward the flag in those three methods (one line each), and add a regression test that runs `.shard()` and `.shuffle()` on a `by_column` batched stream and checks groups stay whole.