### PR TITLE
Fix data file patterns starting with "./" for Hub datasets (#7727)

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -347,6 +347,12 @@ def resolve_pattern(
         List[str]: List of paths or URLs to the local or remote files that match the patterns.
     """
     if is_relative_path(pattern):
+        # remove single dot segments (e.g. "./data/*" -> "data/*"), since remote filesystems
+        # like HfFileSystem treat "." as a literal directory name when globbing
+        while pattern.startswith("./"):
+            pattern = pattern[2:].lstrip("/")
+        while "/./" in pattern:
+            pattern = pattern.replace("/./", "/")
         pattern = xjoin(base_path, pattern)
     elif is_local_path(pattern):
         base_path = os.path.splitdrive(pattern)[0] + os.sep

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -189,6 +189,14 @@ def test_resolve_pattern_locally_with_dot_in_base_path(complex_data_dir):
     assert len(resolved_data_files) == 1
 
 
+def test_resolve_pattern_locally_with_dot_segments(complex_data_dir):
+    resolved_data_files = resolve_pattern("./data/./*.txt", complex_data_dir)
+    assert resolved_data_files == resolve_pattern("data/*.txt", complex_data_dir)
+    assert len(resolved_data_files) == 2
+    # degenerate extra slashes must not turn the pattern into an absolute path escaping the base path
+    assert resolve_pattern(".//data/*.txt", complex_data_dir) == resolved_data_files
+
+
 @pytest.mark.parametrize("archive_jsonl", ["tar_jsonl_path", "zip_jsonl_path"])
 def test_resolve_pattern_locally_prefixed_archive_glob(archive_jsonl, request):
     archive_path = str(request.getfixturevalue(archive_jsonl))
@@ -310,6 +318,15 @@ def test_resolve_pattern_in_dataset_repository_with_base_path(hub_dataset_repo_p
             resolve_pattern(pattern, base_path)
 
 
+def test_resolve_pattern_in_dataset_repository_with_dot_segments(hub_dataset_repo_path):
+    # patterns like "./data/*" (e.g. from data_files in YAML configs) should resolve as if the "./" wasn't there
+    resolved_data_files = resolve_pattern("./data/*", hub_dataset_repo_path)
+    assert resolved_data_files == resolve_pattern("data/*", hub_dataset_repo_path)
+    assert len(resolved_data_files) == 2
+    resolved_data_files = resolve_pattern("data/./*", hub_dataset_repo_path)
+    assert resolved_data_files == resolve_pattern("data/*", hub_dataset_repo_path)
+
+
 @pytest.mark.parametrize("pattern,size,extensions", [("**", 4, [".txt"]), ("**", 4, None), ("**", 0, [".blablabla"])])
 def test_resolve_pattern_in_dataset_repository_with_extensions(hub_dataset_repo_path, pattern, size, extensions):
     if size > 0:
@@ -375,6 +392,13 @@ def dummy_fs():
 def test_resolve_pattern_fs(dummy_fs):
     resolved_data_files = resolve_pattern("mock://train.txt", base_path="")
     assert resolved_data_files == ["mock://train.txt"]
+
+
+def test_resolve_pattern_fs_with_dot_segments(dummy_fs):
+    resolved_data_files = resolve_pattern("./train.txt", base_path="mock://")
+    assert resolved_data_files == ["mock://train.txt"]
+    # degenerate extra slashes must not escape the base path to the local filesystem
+    assert resolve_pattern(".//train.txt", base_path="mock://") == ["mock://train.txt"]
 
 
 @pytest.mark.parametrize("pattern", _TEST_PATTERNS)


### PR DESCRIPTION
Fixes #7727.

`data_files` patterns starting with `./` raise `FileNotFoundError` when the dataset is loaded from the Hub, even though the same patterns work locally.

The asymmetry comes from `resolve_pattern()`: it joins relative patterns onto the base path with `xjoin` (a plain `posixpath.join`), which keeps the `.` segments, so the glob pattern ends up as `hf://datasets/<repo>/./plain_text/*.parquet`. `HfFileSystem.glob` (like fsspec's generic glob) treats `.` as a literal directory name and matches nothing, while `LocalFileSystem` normalizes the dot segments away — hence local loading works and Hub loading doesn't.

This PR strips `.` segments from relative patterns in `resolve_pattern()` before joining, so `./data/*` resolves the same as `data/*` on every filesystem. The stripping also removes any leading slashes it uncovers (e.g. in `.//data/*`), so a relative pattern can never turn absolute and resolve outside the base path. `..` segments are left untouched, as before.

Added tests for the local, mock-fs and mock-dataset-repository cases (they fail without the fix, no network needed), and checked manually that `resolve_pattern("./plain_text/*.parquet", "hf://datasets/rajpurkar/squad")` now resolves the two parquet files instead of raising.
