### PR TITLE
Add support audio from video

### DIFF
--- a/src/datasets/features/_torchcodec.py
+++ b/src/datasets/features/_torchcodec.py
@@ -1,5 +1,10 @@
+from pathlib import Path
+from typing import Optional
+
 import numpy as np
+from torch import Tensor
 from torchcodec.decoders import AudioDecoder as _AudioDecoder
+from torchcodec.decoders import VideoDecoder as _VideoDecoder
 
 
 class AudioDecoder(_AudioDecoder):
@@ -13,3 +18,51 @@ class AudioDecoder(_AudioDecoder):
             return super().__getitem__(key)
         else:
             raise TypeError("'torchcodec.decoders.AudioDecoder' object is not subscriptable")
+
+
+class VideoDecoder(_VideoDecoder):
+    def __init__(
+        self,
+        source,
+        *args,
+        audio_stream_index: Optional[int] = None,
+        audio_sample_rate: Optional[int] = None,
+        audio_num_channels: Optional[int] = None,
+        **kwargs,
+    ):
+        # File-like sources have a single cursor, so a separate AudioDecoder
+        # reading from the same object would stomp on the VideoDecoder's reads.
+        # Read the bytes up-front so both decoders can be constructed from them.
+        if not isinstance(source, (str, Path, bytes, Tensor)) and hasattr(source, "read"):
+            if hasattr(source, "seek"):
+                source.seek(0)
+            source = source.read()
+        super().__init__(source, *args, **kwargs)
+        self._source = source
+        self._audio_stream_index = audio_stream_index
+        self._audio_sample_rate = audio_sample_rate
+        self._audio_num_channels = audio_num_channels
+        self._audio: Optional[AudioDecoder] = None
+        self._audio_initialized = False
+
+    @property
+    def audio(self) -> Optional[AudioDecoder]:
+        """An :class:`AudioDecoder` for the best audio stream in the same
+        source, or ``None`` if the source has no audio stream or is a
+        ``torch.Tensor`` (raw encoded bytes with no container).
+
+        The decoder is created lazily on first access and cached.
+        """
+        if not self._audio_initialized:
+            if not isinstance(self._source, Tensor):
+                try:
+                    self._audio = AudioDecoder(
+                        self._source,
+                        stream_index=self._audio_stream_index,
+                        sample_rate=self._audio_sample_rate,
+                        num_channels=self._audio_num_channels,
+                    )
+                except ValueError:
+                    pass
+            self._audio_initialized = True
+        return self._audio

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -63,6 +63,14 @@ class Video:
             Exact guarantees that requesting frame i will always return frame i, but doing so requires an initial scan of the file.
             Approximate is faster as it avoids scanning the file, but less accurate as it uses the file's metadata to calculate where i probably is.
             read more [here](https://docs.pytorch.org/torchcodec/stable/generated_examples/approximate_mode.html#sphx-glr-generated-examples-approximate-mode-py)
+        audio_stream_index (`int`, *optional*):
+            Stream index of the audio stream to use when the decoded video's
+            `audio` attribute is accessed. If `None`, the best audio stream is used.
+        audio_sample_rate (`int`, *optional*):
+            Target sample rate for the `audio` decoder. If `None`, the native sample rate is used.
+        audio_num_channels (`int`, *optional*):
+            Target number of channels for the `audio` decoder. If `None`, the source's
+            channel count is used.
 
     Examples:
 
@@ -93,6 +101,9 @@ class Video:
     num_ffmpeg_threads: int = 1
     device: Optional[Union[str, "torch.device"]] = "cpu"
     seek_mode: Literal["exact", "approximate"] = "exact"
+    audio_stream_index: Optional[int] = None
+    audio_sample_rate: Optional[int] = None
+    audio_num_channels: Optional[int] = None
     id: Optional[str] = field(default=None, repr=False)
     # Automatically constructed
     dtype: ClassVar[str] = "torchcodec.decoders.VideoDecoder"
@@ -176,7 +187,7 @@ class Video:
             raise RuntimeError("Decoding is disabled for this feature. Please use Video(decode=True) instead.")
 
         if config.TORCHCODEC_AVAILABLE:
-            from torchcodec.decoders import VideoDecoder
+            from ._torchcodec import VideoDecoder
 
         else:
             raise ImportError("To support decoding videos, please install 'torchcodec'.")
@@ -200,6 +211,9 @@ class Video:
                     num_ffmpeg_threads=self.num_ffmpeg_threads,
                     device=self.device,
                     seek_mode=self.seek_mode,
+                    audio_stream_index=self.audio_stream_index,
+                    audio_sample_rate=self.audio_sample_rate,
+                    audio_num_channels=self.audio_num_channels,
                 )
             else:
                 video = hf_video_reader(
@@ -209,6 +223,9 @@ class Video:
                     num_ffmpeg_threads=self.num_ffmpeg_threads,
                     device=self.device,
                     seek_mode=self.seek_mode,
+                    audio_stream_index=self.audio_stream_index,
+                    audio_sample_rate=self.audio_sample_rate,
+                    audio_num_channels=self.audio_num_channels,
                 )
         else:
             video = VideoDecoder(
@@ -218,6 +235,9 @@ class Video:
                 num_ffmpeg_threads=self.num_ffmpeg_threads,
                 device=self.device,
                 seek_mode=self.seek_mode,
+                audio_stream_index=self.audio_stream_index,
+                audio_sample_rate=self.audio_sample_rate,
+                audio_num_channels=self.audio_num_channels,
             )
         video._hf_encoded = {"path": path, "bytes": bytes_}
         video.metadata.path = path
@@ -389,8 +409,11 @@ def hf_video_reader(
     num_ffmpeg_threads: int = 1,
     device: Optional[Union[str, "torch.device"]] = "cpu",
     seek_mode: Literal["exact", "approximate"] = "exact",
+    audio_stream_index: Optional[int] = None,
+    audio_sample_rate: Optional[int] = None,
+    audio_num_channels: Optional[int] = None,
 ) -> "VideoDecoder":
-    from torchcodec.decoders import VideoDecoder
+    from ._torchcodec import VideoDecoder
 
     # Load the file from HF
     if token_per_repo_id is None:
@@ -411,5 +434,8 @@ def hf_video_reader(
         num_ffmpeg_threads=num_ffmpeg_threads,
         device=device,
         seek_mode=seek_mode,
+        audio_stream_index=audio_stream_index,
+        audio_sample_rate=audio_sample_rate,
+        audio_num_channels=audio_num_channels,
     )
     return vd

--- a/tests/features/test_video.py
+++ b/tests/features/test_video.py
@@ -153,3 +153,122 @@ def test_load_dataset_with_video_feature(streaming, jsonl_video_dataset_path, sh
     assert isinstance(item["video"], VideoDecoder)
     assert item["video"].get_frame_at(0).data.shape == (3, 50, 66)
     assert item["video"].metadata.path == video_path
+
+
+@pytest.fixture
+def video_with_audio_path(tmp_path):
+    """Synthesize a tiny video with an audio stream so we can exercise the
+    populated-audio path of the wrapped VideoDecoder."""
+    import torch
+    from torchcodec.encoders import Encoder
+
+    sample_rate = 8000
+    num_channels = 1
+    num_frames = 5
+    frame_rate = 10
+    height, width = 32, 32
+
+    encoder = Encoder()
+    video_stream = encoder.add_video(height=height, width=width, frame_rate=frame_rate)
+    audio_stream = encoder.add_audio(sample_rate=sample_rate, num_channels=num_channels)
+    path = tmp_path / "video_with_audio.mp4"
+    with encoder.open_file(str(path)):
+        video_stream.add_frames(torch.zeros((num_frames, 3, height, width), dtype=torch.uint8))
+        audio_stream.add_samples(torch.zeros((num_channels, sample_rate), dtype=torch.float32))
+    return str(path)
+
+
+@require_torchcodec
+class TestVideoDecoderAudio:
+    """Tests for the `audio` property added to the wrapped VideoDecoder."""
+
+    def test_audio_is_none_for_video_only_source(self, shared_datadir):
+        from datasets.features._torchcodec import VideoDecoder
+
+        video_path = str(shared_datadir / "test_video_66x50.mov")
+        decoder = VideoDecoder(video_path)
+        assert decoder.audio is None
+
+    def test_audio_property_returns_wrapped_audio_decoder(self, video_with_audio_path):
+        import numpy as np
+
+        from datasets.features._torchcodec import AudioDecoder, VideoDecoder
+
+        decoder = VideoDecoder(video_with_audio_path)
+        audio = decoder.audio
+        assert isinstance(audio, AudioDecoder)
+        # The wrapped AudioDecoder exposes array/sampling_rate via __getitem__.
+        assert isinstance(audio["array"], np.ndarray)
+        assert audio["sampling_rate"] == 8000
+
+    def test_audio_for_bytes_source(self, video_with_audio_path):
+        from datasets.features._torchcodec import AudioDecoder, VideoDecoder
+
+        with open(video_with_audio_path, "rb") as f:
+            data = f.read()
+        decoder = VideoDecoder(data)
+        assert isinstance(decoder.audio, AudioDecoder)
+
+    def test_audio_for_file_like_source(self, video_with_audio_path):
+        from datasets.features._torchcodec import AudioDecoder, VideoDecoder
+
+        with open(video_with_audio_path, "rb") as f:
+            decoder = VideoDecoder(f)
+        # Video frames must still be decodable even though the audio decoder
+        # also consumed the same source.
+        assert decoder.get_frame_at(0).data.shape[0] == 3
+        assert isinstance(decoder.audio, AudioDecoder)
+
+    def test_audio_sample_rate_kwarg(self, video_with_audio_path):
+        from datasets.features._torchcodec import VideoDecoder
+
+        decoder = VideoDecoder(video_with_audio_path, audio_sample_rate=16000)
+        assert decoder.audio is not None
+        assert decoder.audio["sampling_rate"] == 16000
+
+    def test_audio_is_none_for_tensor_source(self, shared_datadir):
+        import torch
+
+        from datasets.features._torchcodec import VideoDecoder
+
+        video_path = str(shared_datadir / "test_video_66x50.mov")
+        data = torch.frombuffer(Path(video_path).read_bytes(), dtype=torch.uint8)
+        decoder = VideoDecoder(data)
+        assert decoder.audio is None
+
+    def test_audio_is_cached(self, shared_datadir):
+        from datasets.features._torchcodec import VideoDecoder
+
+        video_path = str(shared_datadir / "test_video_66x50.mov")
+        decoder = VideoDecoder(video_path)
+        # Two accesses must return the same (cached) object — None included.
+        assert decoder.audio is decoder.audio
+
+    def test_file_like_source_is_normalized_to_bytes(self, shared_datadir):
+        from datasets.features._torchcodec import VideoDecoder
+
+        video_path = str(shared_datadir / "test_video_66x50.mov")
+        with open(video_path, "rb") as f:
+            decoder = VideoDecoder(f)
+        # File-likes share a cursor with the audio decoder, so they must be
+        # read into bytes up-front. Decoding a frame after construction proves
+        # the video stream is still readable.
+        assert decoder.get_frame_at(0).data.shape == (3, 50, 66)
+        assert decoder.audio is None
+
+    def test_video_feature_forwards_audio_kwargs(self, shared_datadir):
+        from datasets.features._torchcodec import VideoDecoder
+
+        video_path = str(shared_datadir / "test_video_66x50.mov")
+        feature = Video(audio_stream_index=0, audio_sample_rate=16000, audio_num_channels=1)
+        decoded = feature.decode_example({"path": video_path, "bytes": None})
+        assert isinstance(decoded, VideoDecoder)
+        assert decoded._audio_stream_index == 0
+        assert decoded._audio_sample_rate == 16000
+        assert decoded._audio_num_channels == 1
+
+    def test_video_feature_default_audio_kwargs(self):
+        feature = Video()
+        assert feature.audio_stream_index is None
+        assert feature.audio_sample_rate is None
+        assert feature.audio_num_channels is None


### PR DESCRIPTION
Add support for extracting video from audio. Closes https://github.com/huggingface/datasets/issues/8007

Example:
```python
from datasets import load_dataset

test_ds = load_dataset("Samoed/testds")
test_ds["train"][0]["video"].audio
# <datasets.features._torchcodec.AudioDecoder object at 0x34422fb60>
test_ds["train"][0]["video"].audio.metadata
# AudioStreamMetadata:
#   duration_seconds_from_header: 7.635
#   begin_stream_seconds_from_header: 0
#   bit_rate: 104916
#   codec: aac
#   stream_index: 1
#   duration_seconds: 7.635
#   begin_stream_seconds: 0
#   sample_rate: 48000
#   num_channels: 2
#   sample_format: fltp
```