### PR TITLE
Use cached .no_exist entries from the hub cache in cached_path (#7686)

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -30,6 +30,7 @@ import fsspec
 import httpx
 import huggingface_hub
 import huggingface_hub.errors
+import huggingface_hub.file_download
 import requests
 from fsspec.core import strip_protocol, url_to_fs
 from fsspec.utils import can_be_local
@@ -178,6 +179,22 @@ def cached_path(
             resolved_path = huggingface_hub.HfFileSystem(
                 endpoint=config.HF_ENDPOINT, token=download_config.token
             ).resolve_path(url_or_filename)
+            # If the revision is a commit hash, it is immutable, so we can reuse cached non-existence
+            # (the ".no_exist" entries written by huggingface_hub on EntryNotFoundError)
+            # instead of requesting the Hub again for files known to be missing at this revision
+            if not download_config.force_download and huggingface_hub.file_download.REGEX_COMMIT_HASH.match(
+                resolved_path.revision
+            ):
+                cached_file = huggingface_hub.try_to_load_from_cache(
+                    repo_id=resolved_path.repo_id,
+                    filename=resolved_path.path_in_repo,
+                    repo_type=resolved_path.repo_type,
+                    revision=resolved_path.revision,
+                )
+                if cached_file is huggingface_hub._CACHED_NO_EXIST:
+                    raise FileNotFoundError(
+                        f"{url_or_filename} doesn't exist on the Hub (cached non-existence at revision {resolved_path.revision})"
+                    )
             try:
                 output_path = huggingface_hub.HfApi(
                     endpoint=config.HF_ENDPOINT,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -57,6 +57,8 @@ Charmander, fire
 Squirtle, water
 Bulbasaur, grass"""
 
+SAMPLE_COMMIT_HASH = "0123456789abcdef0123456789abcdef01234567"
+
 
 @pytest.fixture(scope="session")
 def zstd_path(tmp_path_factory):
@@ -131,6 +133,52 @@ def test_cached_path_missing_local(tmp_path):
     missing_file = "./__missing_file__.txt"
     with pytest.raises(FileNotFoundError):
         cached_path(missing_file)
+
+
+@pytest.fixture
+def temporary_hub_cache(tmp_path, monkeypatch):
+    hub_cache_dir = tmp_path / "hub_cache"
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(hub_cache_dir))
+    # Resolving a hf:// path checks on the Hub that the repo and revision exist
+    monkeypatch.setattr(
+        "huggingface_hub.HfFileSystem._repo_and_revision_exist",
+        lambda self, repo_type, repo_id, revision: (True, None),
+    )
+    return hub_cache_dir
+
+
+def test_cached_path_hub_cached_no_exist(temporary_hub_cache):
+    # Reuse cached non-existence (".no_exist" entries written by huggingface_hub) for hf:// paths
+    # pinned to a commit hash instead of requesting the Hub again
+    no_exist_file_path = temporary_hub_cache / "datasets--org--name" / ".no_exist" / SAMPLE_COMMIT_HASH / "missing.txt"
+    no_exist_file_path.parent.mkdir(parents=True)
+    no_exist_file_path.touch()
+    with patch("huggingface_hub.HfApi.hf_hub_download") as mock_hf_hub_download:
+        with pytest.raises(FileNotFoundError):
+            cached_path(f"hf://datasets/org/name@{SAMPLE_COMMIT_HASH}/missing.txt")
+        mock_hf_hub_download.assert_not_called()
+
+
+def test_cached_path_hub_cached_no_exist_non_commit_hash_revision(temporary_hub_cache, text_file):
+    # Only revisions that are commit hashes are immutable, so for other revisions
+    # the ".no_exist" entries are ignored and the Hub is requested
+    no_exist_file_path = temporary_hub_cache / "datasets--org--name" / ".no_exist" / "main" / "missing.txt"
+    no_exist_file_path.parent.mkdir(parents=True)
+    no_exist_file_path.touch()
+    with patch("huggingface_hub.HfApi.hf_hub_download", return_value=str(text_file)) as mock_hf_hub_download:
+        cached_path("hf://datasets/org/name@main/missing.txt")
+        mock_hf_hub_download.assert_called_once()
+
+
+def test_cached_path_hub_cached_no_exist_force_download(temporary_hub_cache, text_file):
+    # force_download should ignore the ".no_exist" entries
+    no_exist_file_path = temporary_hub_cache / "datasets--org--name" / ".no_exist" / SAMPLE_COMMIT_HASH / "missing.txt"
+    no_exist_file_path.parent.mkdir(parents=True)
+    no_exist_file_path.touch()
+    download_config = DownloadConfig(force_download=True)
+    with patch("huggingface_hub.HfApi.hf_hub_download", return_value=str(text_file)) as mock_hf_hub_download:
+        cached_path(f"hf://datasets/org/name@{SAMPLE_COMMIT_HASH}/missing.txt", download_config=download_config)
+        mock_hf_hub_download.assert_called_once()
 
 
 def test_get_from_cache_fsspec(tmpfs_file):


### PR DESCRIPTION
Fixes #7686.

`cached_path` requested the Hub on every call for files that usually don't exist in dataset repos (`.huggingface.yaml`, `dataset_infos.json`) because its `hf://` branch goes straight to `HfApi.hf_hub_download`. It now consults `huggingface_hub.try_to_load_from_cache` first and raises `FileNotFoundError` right away on a cached non-existence hit — the same error the `EntryNotFoundError` path raises, so callers are unaffected.

One correction to the issue: the write half already works. `hf_hub_download` has written the `.no_exist/<sha>/<file>` entries on `EntryNotFoundError` since before our minimum pin (checked 0.25.0, 0.33.2 and 1.19.0) — they just don't show up in plain `ls` because `.no_exist` is a dot-directory. So only the read side was missing, and the fix mirrors `transformers.utils.hub.cached_files`: the negative cache is only trusted when the resolved revision is a commit hash (immutable), and it is skipped with `force_download=True`.

Running the issue's metadata-counting repro against a small dataset with a fresh `HF_HOME`: 2 missing-file metadata requests on the first `load_dataset` call and 0 on every subsequent one (previously 2 on every call).

Added regression tests in `tests/test_file_utils.py` covering the negative-cache hit (no `hf_hub_download` call), non-sha revisions (still request the Hub), and `force_download` (ignores `.no_exist`).
