### PR TITLE
Fix webdataset type inference when a field is null in the first examples (#7549)

### DIFF
--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -25,6 +25,7 @@ class WebDataset(datasets.GeneratorBasedBuilder):
     MESH_EXTENSIONS: list[str]  # definition at the bottom of the script
     DECODERS: dict[str, Callable[[Any], Any]]  # definition at the bottom of the script
     NUM_EXAMPLES_FOR_FEATURES_INFERENCE = 5
+    MAX_NUM_EXAMPLES_FOR_FEATURES_INFERENCE = 1_000  # max number of examples to scan to resolve null-typed fields
 
     @classmethod
     def _get_pipeline_from_tar(cls, tar_path, tar_iterator):
@@ -89,6 +90,30 @@ class WebDataset(datasets.GeneratorBasedBuilder):
                 for example in first_examples
             ]
             inferred_arrow_schema = pa.concat_tables(pa_tables, promote_options="default").schema
+            # Some fields may be null-typed at this point if their values are null in all the first examples
+            # (e.g. a JSON field that is null in the beginning of the dataset).
+            # Scan more examples to infer the types of these fields, otherwise writing
+            # subsequent non-null values would fail with e.g. "Couldn't cast array of type string to null".
+            num_scanned_examples = len(first_examples)
+            while any(_contains_null_type(field.type) for field in inferred_arrow_schema):
+                example = None
+                if num_scanned_examples < self.MAX_NUM_EXAMPLES_FOR_FEATURES_INFERENCE:
+                    example = next(pipeline, None)
+                if example is None:
+                    null_fields = [field.name for field in inferred_arrow_schema if _contains_null_type(field.type)]
+                    logger.warning(
+                        f"Failed to infer the type of the fields {null_fields} since their values are null in "
+                        f"the first {num_scanned_examples} examples. Pass `features` manually to set their types."
+                    )
+                    break
+                example_table = pa.Table.from_pylist(cast_to_python_objects([example], only_1d_for_numpy=True))
+                example_schema = pa.schema(
+                    field for field in example_table.schema if field.name in inferred_arrow_schema.names
+                )
+                inferred_arrow_schema = pa.unify_schemas(
+                    [inferred_arrow_schema, example_schema], promote_options="permissive"
+                )
+                num_scanned_examples += 1
             features = datasets.Features.from_arrow_schema(inferred_arrow_schema)
 
             for field_name in first_examples[0]:
@@ -138,6 +163,13 @@ class WebDataset(datasets.GeneratorBasedBuilder):
                             "bytes": example[field_name],
                         }
                 yield Key(tar_idx, example_idx), example
+
+
+def _contains_null_type(pa_type: pa.DataType) -> bool:
+    """Check if a pyarrow type is or contains a null type, i.e. if it has fields whose type couldn't be inferred."""
+    if pa.types.is_null(pa_type):
+        return True
+    return any(_contains_null_type(pa_type.field(i).type) for i in range(pa_type.num_fields))
 
 
 # Source: https://github.com/webdataset/webdataset/blob/87bd5aa41602d57f070f65a670893ee625702f2f/webdataset/tariterators.py#L25

--- a/tests/packaged_modules/test_webdataset.py
+++ b/tests/packaged_modules/test_webdataset.py
@@ -102,6 +102,41 @@ def bad_wds_file(tmp_path, image_file, text_file):
 
 
 @pytest.fixture
+def null_fields_wds_file(tmp_path):
+    json_file = tmp_path / "data.json"
+    filename = tmp_path / "file.tar"
+    num_examples = 20
+    with tarfile.open(str(filename), "w") as f:
+        for example_idx in range(num_examples):
+            # null/empty values in the first examples used for feature inference, actual values afterwards
+            null_values = example_idx < 10
+            json_file.write_text(
+                json.dumps(
+                    {
+                        "id": example_idx,
+                        "caption": None if null_values else f"this is an image {example_idx}",
+                        "tags": [] if null_values else ["foo", "bar"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            f.add(json_file, f"{example_idx:05d}.json")
+    return str(filename)
+
+
+@pytest.fixture
+def only_null_field_wds_file(tmp_path):
+    json_file = tmp_path / "data.json"
+    filename = tmp_path / "file.tar"
+    num_examples = 20
+    with tarfile.open(str(filename), "w") as f:
+        for example_idx in range(num_examples):
+            json_file.write_text(json.dumps({"id": example_idx, "caption": None}), encoding="utf-8")
+            f.add(json_file, f"{example_idx:05d}.json")
+    return str(filename)
+
+
+@pytest.fixture
 def tensor_wds_file(tmp_path, tensor_file):
     json_file = tmp_path / "data.json"
     filename = tmp_path / "file.tar"
@@ -331,6 +366,43 @@ def test_webdataset_with_features(image_wds_file):
     assert isinstance(decoded["json"], dict)
     assert isinstance(decoded["json"]["caption"], str)
     assert isinstance(decoded["jpg"], PIL.Image.Image)
+
+
+def test_webdataset_with_null_values_in_first_examples(tmp_path, null_fields_wds_file):
+    data_files = {"train": [null_fields_wds_file]}
+    webdataset = WebDataset(data_files=data_files, cache_dir=str(tmp_path / "cache"))
+    split_generators = webdataset._split_generators(DownloadManager())
+    assert webdataset.info.features == Features(
+        {
+            "__key__": Value("string"),
+            "__url__": Value("string"),
+            "json": {"id": Value("int64"), "caption": Value("string"), "tags": List(Value("string"))},
+        }
+    )
+    assert len(split_generators) == 1
+    split_generator = split_generators[0]
+    assert split_generator.name == "train"
+    generator = webdataset._generate_examples(**split_generator.gen_kwargs)
+    _, examples = zip(*generator)
+    assert len(examples) == 20
+    # it used to raise "Couldn't cast array of type string to null" when writing the non-null values
+    webdataset.download_and_prepare()
+    ds = webdataset.as_dataset(split="train")
+    assert ds[0]["json"] == {"id": 0, "caption": None, "tags": []}
+    assert ds[-1]["json"] == {"id": 19, "caption": "this is an image 19", "tags": ["foo", "bar"]}
+
+
+def test_webdataset_with_only_null_values(only_null_field_wds_file):
+    data_files = {"train": [only_null_field_wds_file]}
+    webdataset = WebDataset(data_files=data_files)
+    webdataset._split_generators(DownloadManager())
+    assert webdataset.info.features == Features(
+        {
+            "__key__": Value("string"),
+            "__url__": Value("string"),
+            "json": {"id": Value("int64"), "caption": Value("null")},
+        }
+    )
 
 
 @require_numpy1_on_windows


### PR DESCRIPTION
Fixes #7549.

The webdataset builder types any JSON field that is null (or an empty list) in all of the first `NUM_EXAMPLES_FOR_FEATURES_INFERENCE = 5` examples as arrow `null`, and the first later batch with a real value then fails the strict cast in `cast_array_to_feature`. Promoting the schema mid-write isn't an option since `ArrowWriter` fixes its schema on the first write, so this resolves it at inference time.

`_split_generators` now keeps consuming examples from the already-open inference pipeline while the inferred schema contains a null type (including nested in structs/lists), unifying each example's schema with `pa.unify_schemas`. The scan resumes at example 6 — `iter_archive`'s `ArchiveIterable` restarts its generator on each `__iter__`, so this doesn't consume anything from `_generate_examples` — and only runs at all when a null type was inferred, so fully-typed datasets do exactly the same work as before.

The scan is capped at 1000 examples; if a field is still null after that (or the first shard is exhausted, i.e. the column is genuinely all-null), it logs a warning naming the fields and keeps the previous behavior of a null-typed feature.

Added regression tests with a tar whose first half has null/empty JSON values: feature inference now yields `string`/`List(string)` and `download_and_prepare` round-trips, plus an all-null-column test guarding the fallback.
