### PR TITLE
Add force_sample_level to split_dataset_by_node

### DIFF
--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -250,9 +250,16 @@ Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of t
 
 For iterable datasets:
 
-If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
+By default, if the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
 then the shards are evenly assigned across the nodes, which is the most optimized.
 Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+
+When the number of physical shards is small or imbalanced relative to `world_size`, you can pass `force_sample_level=True` to force sample-level splitting even when shard counts divide evenly. Each node then keeps 1 example out of `world_size`, which avoids duplicating expensive transformations applied after `split_dataset_by_node` across nodes:
+
+```python
+ds = split_dataset_by_node(ds, rank=rank, world_size=world_size, force_sample_level=True)
+ds = ds.map(tokenize_fn)  # only runs on the examples this rank will actually consume
+```
 
 This can also be combined with a `torch.utils.data.DataLoader` if you want each node to use multiple workers to load the data.
 

--- a/src/datasets/distributed.py
+++ b/src/datasets/distributed.py
@@ -7,7 +7,12 @@ from .iterable_dataset import IterableDataset, _split_by_node_iterable_dataset
 DatasetType = TypeVar("DatasetType", Dataset, IterableDataset)
 
 
-def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> DatasetType:
+def split_dataset_by_node(
+    dataset: DatasetType,
+    rank: int,
+    world_size: int,
+    force_sample_level: bool = False,
+) -> DatasetType:
     """
     Split a dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
@@ -15,12 +20,19 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
 
     Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of the dataset.
     To maximize data loading throughput, chunks are made of contiguous data on disk if possible.
+    The `force_sample_level` argument is ignored for map-style datasets.
 
     For iterable datasets:
 
-    If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
-    then the shards are evenly assigned across the nodes, which is the most optimized.
-    Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+    By default, if the dataset has a number of shards that is a factor of `world_size` (i.e. if
+    `dataset.num_shards % world_size == 0`), then the shards are evenly assigned across the nodes,
+    which is the most optimized. Otherwise, each node keeps 1 example out of `world_size`, skipping
+    the other examples.
+
+    Pass `force_sample_level=True` to force sample-level splitting regardless of shard count
+    (each node keeps 1 example out of `world_size`). This is useful when the number of physical
+    shards is small or imbalanced relative to `world_size`, so that expensive transformations applied
+    after `split_dataset_by_node` are not duplicated across nodes.
 
     > [!WARNING]
     > If you shuffle your iterable dataset in a distributed setup, make sure to set a fixed `seed` in [`IterableDataset.shuffle`]
@@ -33,6 +45,9 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
             Rank of the current node.
         world_size (`int`):
             Total number of nodes.
+        force_sample_level (`bool`, defaults to `False`):
+            For iterable datasets, force sample-level splitting even when shards divide evenly across
+            nodes. Ignored for map-style datasets.
 
     Returns:
         [`Dataset`] or [`IterableDataset`]: The dataset to be used on the node at rank `rank`.
@@ -40,4 +55,6 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
     if isinstance(dataset, Dataset):
         return _split_by_node_map_style_dataset(dataset, rank=rank, world_size=world_size)
     else:
-        return _split_by_node_iterable_dataset(dataset, rank=rank, world_size=world_size)
+        return _split_by_node_iterable_dataset(
+            dataset, rank=rank, world_size=world_size, force_sample_level=force_sample_level
+        )

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2426,6 +2426,7 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
 class DistributedConfig:
     rank: int
     world_size: int
+    force_sample_level: bool = False
 
 
 def _maybe_add_torch_iterable_dataset_parent_class(cls):
@@ -2666,8 +2667,11 @@ class IterableDataset(DatasetInfoMixin):
 
     @property
     def num_shards(self) -> int:
-        if self._distributed and self._ex_iterable.num_shards % self._distributed.world_size == 0:
-            return self._ex_iterable.num_shards // self._distributed.world_size
+        if self._distributed:
+            world_size = self._distributed.world_size
+            divisible = self._ex_iterable.num_shards % world_size == 0
+            if divisible and not self._distributed.force_sample_level:
+                return self._ex_iterable.num_shards // world_size
         return self._ex_iterable.num_shards
 
     @property
@@ -2753,7 +2757,8 @@ class IterableDataset(DatasetInfoMixin):
         if self._distributed:
             rank = self._distributed.rank
             world_size = self._distributed.world_size
-            if ex_iterable.num_shards % world_size == 0:
+            divisible = ex_iterable.num_shards % world_size == 0
+            if divisible and not self._distributed.force_sample_level:
                 if self._is_main_process():
                     num_shards_per_node = ex_iterable.num_shards // world_size
                     plural = "s" if num_shards_per_node > 1 else ""
@@ -2766,11 +2771,12 @@ class IterableDataset(DatasetInfoMixin):
                     logger.info(
                         f"Assigning 1 out of {world_size} examples of the dataset to each node. The others are skipped during the iteration."
                     )
-                    logger.info(
-                        f"It is more optimized to distribute the dataset shards (or data sources) across nodes. "
-                        f"You can do that by using a dataset with number of shards that is a factor of world_size={world_size}. "
-                        f"The current dataset has {ex_iterable.num_shards} which is not a factor of {world_size}"
-                    )
+                    if not self._distributed.force_sample_level and not divisible:
+                        logger.info(
+                            f"It is more optimized to distribute the dataset shards (or data sources) across nodes. "
+                            f"You can do that by using a dataset with number of shards that is a factor of world_size={world_size}. "
+                            f"The current dataset has {ex_iterable.num_shards} which is not a factor of {world_size}"
+                        )
                 ex_iterable = StepExamplesIterable(ex_iterable, step=world_size, offset=rank)
 
         if ex_iterable.iter_arrow:
@@ -5341,13 +5347,24 @@ def _interleave_iterable_datasets(
     )
 
 
-def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_size: int) -> IterableDataset:
+def _split_by_node_iterable_dataset(
+    dataset: IterableDataset,
+    rank: int,
+    world_size: int,
+    force_sample_level: bool = False,
+) -> IterableDataset:
     """
     Split an iterable dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
-    If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
-    then the shards are evenly assigned across the nodes, which is the most optimized.
-    Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+    By default, if the dataset has a number of shards that is a factor of `world_size` (i.e. if
+    `dataset.num_shards % world_size == 0`), then the shards are evenly assigned across the nodes,
+    which is the most optimized. Otherwise, each node keeps 1 example out of `world_size`, skipping
+    the other examples.
+
+    Pass `force_sample_level=True` to force sample-level splitting regardless of shard count
+    (each node keeps 1 example out of `world_size`). This is useful when the number of physical
+    shards is small or imbalanced relative to `world_size`, so that expensive transformations applied
+    after `split_dataset_by_node` are not duplicated across nodes.
 
     Args:
         dataset ([`IterableDataset`]):
@@ -5356,6 +5373,8 @@ def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_s
             Rank of the current node.
         world_size (`int`):
             Total number of nodes.
+        force_sample_level (`bool`, defaults to `False`):
+            If `True`, force sample-level splitting even when shards divide evenly across nodes.
 
     Returns:
         [`IterableDataset`]: The iterable dataset to be used on the node at rank `rank`.
@@ -5363,7 +5382,8 @@ def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_s
     if dataset._distributed:
         rank = world_size * dataset._distributed.rank + rank
         world_size = world_size * dataset._distributed.world_size
-    distributed = DistributedConfig(rank=rank, world_size=world_size)
+        force_sample_level = force_sample_level or dataset._distributed.force_sample_level
+    distributed = DistributedConfig(rank=rank, world_size=world_size, force_sample_level=force_sample_level)
     return IterableDataset(
         ex_iterable=dataset._ex_iterable,
         info=dataset._info.copy(),

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -5379,33 +5379,30 @@ def _split_by_node_iterable_dataset(
     Returns:
         [`IterableDataset`]: The iterable dataset to be used on the node at rank `rank`.
     """
+    ex_iterable = dataset._ex_iterable
+    distributed = None
     if force_sample_level:
-        ex_iterable = dataset._ex_iterable
         if dataset._distributed:
-            distributed = dataset._distributed
-            divisible = ex_iterable.num_shards % distributed.world_size == 0
-            if divisible and not distributed.force_sample_level:
+            pending_distributed = dataset._distributed
+            divisible = ex_iterable.num_shards % pending_distributed.world_size == 0
+            if divisible and not pending_distributed.force_sample_level:
                 ex_iterable = ex_iterable.shard_data_sources(
-                    num_shards=distributed.world_size, index=distributed.rank, contiguous=False
+                    num_shards=pending_distributed.world_size, index=pending_distributed.rank, contiguous=False
                 )
             else:
-                ex_iterable = StepExamplesIterable(ex_iterable, step=distributed.world_size, offset=distributed.rank)
+                ex_iterable = StepExamplesIterable(
+                    ex_iterable, step=pending_distributed.world_size, offset=pending_distributed.rank
+                )
         ex_iterable = StepExamplesIterable(ex_iterable, step=world_size, offset=rank)
-        return IterableDataset(
-            ex_iterable=ex_iterable,
-            info=dataset._info.copy(),
-            split=dataset._split,
-            formatting=dataset._formatting,
-            token_per_repo_id=dataset._token_per_repo_id,
-        )
+    else:
+        if dataset._distributed:
+            rank = world_size * dataset._distributed.rank + rank
+            world_size = world_size * dataset._distributed.world_size
+            force_sample_level = dataset._distributed.force_sample_level
+        distributed = DistributedConfig(rank=rank, world_size=world_size, force_sample_level=force_sample_level)
 
-    if dataset._distributed:
-        rank = world_size * dataset._distributed.rank + rank
-        world_size = world_size * dataset._distributed.world_size
-        force_sample_level = force_sample_level or dataset._distributed.force_sample_level
-    distributed = DistributedConfig(rank=rank, world_size=world_size, force_sample_level=force_sample_level)
     return IterableDataset(
-        ex_iterable=dataset._ex_iterable,
+        ex_iterable=ex_iterable,
         info=dataset._info.copy(),
         split=dataset._split,
         formatting=dataset._formatting,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -5379,6 +5379,26 @@ def _split_by_node_iterable_dataset(
     Returns:
         [`IterableDataset`]: The iterable dataset to be used on the node at rank `rank`.
     """
+    if force_sample_level:
+        ex_iterable = dataset._ex_iterable
+        if dataset._distributed:
+            distributed = dataset._distributed
+            divisible = ex_iterable.num_shards % distributed.world_size == 0
+            if divisible and not distributed.force_sample_level:
+                ex_iterable = ex_iterable.shard_data_sources(
+                    num_shards=distributed.world_size, index=distributed.rank, contiguous=False
+                )
+            else:
+                ex_iterable = StepExamplesIterable(ex_iterable, step=distributed.world_size, offset=distributed.rank)
+        ex_iterable = StepExamplesIterable(ex_iterable, step=world_size, offset=rank)
+        return IterableDataset(
+            ex_iterable=ex_iterable,
+            info=dataset._info.copy(),
+            split=dataset._split,
+            formatting=dataset._formatting,
+            token_per_repo_id=dataset._token_per_repo_id,
+        )
+
     if dataset._distributed:
         rank = world_size * dataset._distributed.rank + rank
         world_size = world_size * dataset._distributed.world_size

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -75,6 +75,68 @@ def test_split_dataset_by_node_iterable_distributed():
     assert len({tuple(x.values()) for ds in datasets_per_rank_per_worker for x in ds}) == full_size
 
 
+def test_split_dataset_by_node_iterable_force_sample_level_when_divisible():
+    def gen(shards):
+        for shard in shards:
+            yield from ({"i": i, "shard": shard} for i in range(4))
+
+    world_size = 2
+    num_shards = 4  # divisible by world_size, so default behavior would be shard-level
+    gen_kwargs = {"shards": [f"shard_{idx}.txt" for idx in range(num_shards)]}
+    full_ds = IterableDataset.from_generator(gen, gen_kwargs=gen_kwargs)
+    assert full_ds.num_shards == num_shards
+    full_examples = list(full_ds)
+
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size, force_sample_level=True)
+        for rank in range(world_size)
+    ]
+    # When sample-level is forced, num_shards stays at the underlying value (StepExamplesIterable
+    # does not collapse shards), and each rank receives the strided slice of examples.
+    assert [ds.num_shards for ds in datasets_per_rank] == [num_shards] * world_size
+    for rank, ds in enumerate(datasets_per_rank):
+        expected = full_examples[rank::world_size]
+        assert list(ds) == expected
+
+
+def test_split_dataset_by_node_map_style_ignores_force_sample_level():
+    full_ds = Dataset.from_dict({"i": range(17)})
+    world_size = 3
+    default = [split_dataset_by_node(full_ds, rank=rank, world_size=world_size) for rank in range(world_size)]
+    with_flag = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size, force_sample_level=True)
+        for rank in range(world_size)
+    ]
+    for ds_default, ds_flag in zip(default, with_flag):
+        assert list(ds_default) == list(ds_flag)
+
+
+def test_split_dataset_by_node_iterable_force_sample_level_chaining():
+    def gen():
+        return ({"i": i} for i in range(60))
+
+    world_size = 2
+    num_workers = 3
+    full_ds = IterableDataset.from_generator(gen)
+    full_examples = list(full_ds)
+
+    # Outer split sets the flag; inner split leaves it False and should inherit it.
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size, force_sample_level=True)
+        for rank in range(world_size)
+    ]
+    datasets_per_rank_per_worker = [
+        split_dataset_by_node(ds, rank=worker, world_size=num_workers)
+        for ds in datasets_per_rank
+        for worker in range(num_workers)
+    ]
+    assert sum(len(list(ds)) for ds in datasets_per_rank_per_worker) == len(full_examples)
+    assert len({tuple(x.values()) for ds in datasets_per_rank_per_worker for x in ds}) == len(full_examples)
+    # Combined rank uses world_size * num_workers strides; verify rank 0/worker 0 sees indices 0, 6, 12, ...
+    rank0_worker0 = list(datasets_per_rank_per_worker[0])
+    assert rank0_worker0 == full_examples[0 :: world_size * num_workers]
+
+
 def test_distributed_shuffle_iterable():
     def gen():
         return ({"i": i} for i in range(17))

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -99,6 +99,71 @@ def test_split_dataset_by_node_iterable_force_sample_level_when_divisible():
         assert list(ds) == expected
 
 
+def test_split_dataset_by_node_iterable_force_sample_level_before_map():
+    world_size = 4
+    num_examples = 24
+    shards = [range(shard_idx * 6, (shard_idx + 1) * 6) for shard_idx in range(world_size)]
+
+    for rank in range(world_size):
+        counters = {"source": 0, "map": 0}
+
+        def gen(shards):
+            for shard in shards:
+                for i in shard:
+                    counters["source"] += 1
+                    yield {"i": i}
+
+        def counting_map(example):
+            counters["map"] += 1
+            return example
+
+        ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": shards})
+        ds = split_dataset_by_node(ds, rank=rank, world_size=world_size, force_sample_level=True)
+        ds = ds.map(counting_map)
+
+        assert list(ds) == [{"i": i} for i in range(rank, num_examples, world_size)]
+        # A sequential source must still be fully consumed, but transformations added after
+        # split_dataset_by_node only run on this rank's examples.
+        assert counters == {"source": num_examples, "map": num_examples // world_size}
+
+
+def test_split_dataset_by_node_iterable_default_sample_level_remains_lazy():
+    def gen():
+        yield from ({"i": i} for i in range(10))
+
+    world_size = 2
+    full_ds = IterableDataset.from_generator(gen)
+
+    taken = [split_dataset_by_node(full_ds, rank, world_size).take(3) for rank in range(world_size)]
+    assert [list(ds) for ds in taken] == [[{"i": 0}, {"i": 2}], [{"i": 1}]]
+
+
+def test_split_dataset_by_node_iterable_sample_level_before_filter():
+    world_size = 4
+    num_examples = 24
+    shards = [range(shard_idx * 6, (shard_idx + 1) * 6) for shard_idx in range(world_size)]
+
+    for rank in range(world_size):
+        counters = {"source": 0, "filter": 0}
+
+        def gen(shards):
+            for shard in shards:
+                for i in shard:
+                    counters["source"] += 1
+                    yield {"i": i}
+
+        def counting_filter(example):
+            counters["filter"] += 1
+            return True
+
+        ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": shards})
+        ds = split_dataset_by_node(ds, rank=rank, world_size=world_size, force_sample_level=True)
+        ds = ds.filter(counting_filter)
+
+        assert list(ds) == [{"i": i} for i in range(rank, num_examples, world_size)]
+        assert counters == {"source": num_examples, "filter": num_examples // world_size}
+
+
 def test_split_dataset_by_node_map_style_ignores_force_sample_level():
     full_ds = Dataset.from_dict({"i": range(17)})
     world_size = 3
@@ -135,6 +200,31 @@ def test_split_dataset_by_node_iterable_force_sample_level_chaining():
     # Combined rank uses world_size * num_workers strides; verify rank 0/worker 0 sees indices 0, 6, 12, ...
     rank0_worker0 = list(datasets_per_rank_per_worker[0])
     assert rank0_worker0 == full_examples[0 :: world_size * num_workers]
+
+
+def test_split_dataset_by_node_iterable_force_sample_level_after_shard_level_split():
+    def gen(shards):
+        for shard in shards:
+            yield from ({"i": i, "shard": shard} for i in range(4))
+
+    num_nodes = 2
+    num_workers = 2
+    shards = [f"shard_{idx}.txt" for idx in range(4)]
+    full_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": shards})
+
+    for node_rank in range(num_nodes):
+        node_ds = split_dataset_by_node(full_ds, rank=node_rank, world_size=num_nodes)
+        node_examples = [
+            {"i": i, "shard": shard}
+            for shard_idx, shard in enumerate(shards)
+            if shard_idx % num_nodes == node_rank
+            for i in range(4)
+        ]
+        for worker_rank in range(num_workers):
+            worker_ds = split_dataset_by_node(
+                node_ds, rank=worker_rank, world_size=num_workers, force_sample_level=True
+            )
+            assert list(worker_ds) == node_examples[worker_rank::num_workers]
 
 
 def test_distributed_shuffle_iterable():


### PR DESCRIPTION
Allow users to explicitly request sample-level sharding for streaming `IterableDataset` even when `num_shards % world_size == 0`. Default behavior is unchanged.

When `num_physical_files < world_size`, or when shards divide evenly but are too few or too imbalanced for shard-level sharding, applying sample-level sharding before expensive `map`/`filter` avoids duplicating those transformations across nodes:

    ds = split_dataset_by_node(ds, rank, world_size, force_sample_level=True)
    ds = ds.map(tokenize_fn)  # only the examples this rank consumes

Map-style datasets ignore the flag.

Closes #8253