### PR TITLE
fix: report the correct variable type in fingerprint_transform ignore_kwargs validation error

### DIFF
--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -414,7 +414,7 @@ def fingerprint_transform(
         raise ValueError(f"use_kwargs is supposed to be a list, not {type(use_kwargs)}")
 
     if ignore_kwargs is not None and not isinstance(ignore_kwargs, list):
-        raise ValueError(f"ignore_kwargs is supposed to be a list, not {type(use_kwargs)}")
+        raise ValueError(f"ignore_kwargs is supposed to be a list, not {type(ignore_kwargs)}")
 
     if inplace and fingerprint_names:
         raise ValueError("fingerprint_names are only used when inplace is False")


### PR DESCRIPTION
The `ignore_kwargs` validation branch in `fingerprint_transform` builds its error from `type(use_kwargs)` instead of `type(ignore_kwargs)`, so an invalid `ignore_kwargs` is reported with the wrong type while `use_kwargs` is at its default. The preceding `use_kwargs` branch already uses `type(use_kwargs)` correctly; this one-token fix reports the actual offending type.