### PR TITLE
Docs: Fix dataset link in access tutorial

### DIFF
--- a/docs/source/access.mdx
+++ b/docs/source/access.mdx
@@ -8,7 +8,7 @@ This tutorial will show you how to load and access a [`Dataset`] and an [`Iterab
 
 When you load a dataset split, you'll get a [`Dataset`] object. You can do many things with a [`Dataset`] object, which is why it's important to learn how to manipulate and interact with the data stored inside. 
  
-This tutorial uses the [rotten_tomatoes](https://huggingface.co/datasets/rotten_tomatoes) dataset, but feel free to load any dataset you'd like and follow along!
+This tutorial uses the [rotten_tomatoes](https://huggingface.co/datasets/cornell-movie-review-data/rotten_tomatoes) dataset, but feel free to load any dataset you'd like and follow along!
 
 ```py
 >>> from datasets import load_dataset


### PR DESCRIPTION
Actual link returns 404. Updated the URL to the new dataset location