### PR TITLE
Fix typos in documentation, comments, and a docstring

### DIFF
--- a/docs/source/process.mdx
+++ b/docs/source/process.mdx
@@ -731,7 +731,7 @@ Here is the list of supported dataframes or tables formats:
 - Polars: format name is "polars", for more information see [Using Datasets with Polars](use_with_polars)
 - PyArrow: format name is "arrow", for more information see [Using Datasets with PyArrow](use_with_tensorflow)
 
-When a dataset is formatted in a dataframe or table format, every dataset row or batches of rows is formatted as a dataframe or table, and dataset colums are formatted as a series or array:
+When a dataset is formatted in a dataframe or table format, every dataset row or batches of rows is formatted as a dataframe or table, and dataset columns are formatted as a series or array:
 
 ```python
 >>> ds = Dataset.from_dict({"text": ["foo", "bar"], "label": [0, 1]})

--- a/docs/source/video_load.mdx
+++ b/docs/source/video_load.mdx
@@ -37,7 +37,7 @@ Access frames directly from a video using the `VideoReader` using `next()`:
 ```
 
 To get multiple frames at once, you can call `.get_frames_in_range(start: int, stop: int, step: int)`. This will return a frame batch.
-This is the efficient way to obtain a long list of frames refer to the [torchcodec docs](https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.VideoDecoder.html) to see more functions for effiently accessing the data:
+This is the efficient way to obtain a long list of frames refer to the [torchcodec docs](https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.VideoDecoder.html) to see more functions for efficiently accessing the data:
 
 ```python
 >>> import torch
@@ -46,7 +46,7 @@ This is the efficient way to obtain a long list of frames refer to the [torchcod
 torch.Size([5, 3, 240, 320])
 ```
 
-There is also `.get_frames_played_in_range(start_seconds: float, stop_seconds: float)` to access all frames played whithin a certain time range.
+There is also `.get_frames_played_in_range(start_seconds: float, stop_seconds: float)` to access all frames played within a certain time range.
 
 ```python
 >>> frames = video.get_frames_played_in_range(.5, 1.2)

--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -194,7 +194,7 @@ class BaseReader:
             in_memory (bool, default False): Whether to copy the data in-memory.
         """
         if len(files) == 0 or not all(isinstance(f, dict) for f in files):
-            raise ValueError("please provide valid file informations")
+            raise ValueError("please provide valid file information")
         files = copy.deepcopy(files)
         for f in files:
             f["filename"] = os.path.join(self._path, f["filename"])
@@ -499,7 +499,7 @@ class ReadInstruction:
     @classmethod
     def _read_instruction_from_relative_instructions(cls, relative_instructions):
         """Returns ReadInstruction obj initialized with relative_instructions."""
-        # Use __new__ to bypass __init__ used by public API and not conveniant here.
+        # Use __new__ to bypass __init__ used by public API and not convenient here.
         result = cls.__new__(cls)
         result._init(relative_instructions)  # pylint: disable=protected-access
         return result

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1875,7 +1875,7 @@ class Features(dict):
           or a dictionary with the relative path to a NIfTI file ("path" key) and its bytes content ("bytes" key).
           This feature loads the NIfTI file lazily with nibabel.
         - [`Translation`] or [`TranslationVariableLanguages`] feature specific to Machine Translation.
-        - [`Json`] feature to store unstructred data, e.g. containing mixed/abritrary types. Under the hood
+        - [`Json`] feature to store unstructured data, e.g. containing mixed/arbitrary types. Under the hood
     """
 
     def __init__(*args, **kwargs):

--- a/src/datasets/utils/sharding.py
+++ b/src/datasets/utils/sharding.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def _number_of_shards_in_gen_kwargs(gen_kwargs: dict) -> int:
     """Return the number of possible shards according to the input gen_kwargs"""
-    # Having lists of different sizes makes sharding ambigious, raise an error in this case
+    # Having lists of different sizes makes sharding ambiguous, raise an error in this case
     # until we decide how to define sharding without ambiguity for users
     lists_lengths = {key: len(value) for key, value in gen_kwargs.items() if isinstance(value, list)}
     if len(set(lists_lengths.values())) > 1:
@@ -47,7 +47,7 @@ def _distribute_shards(num_shards: int, max_num_jobs: int) -> list[range]:
 
 def _split_gen_kwargs(gen_kwargs: dict, max_num_jobs: int) -> list[dict]:
     """Split the gen_kwargs into `max_num_job` gen_kwargs"""
-    # Having lists of different sizes makes sharding ambigious, raise an error in this case
+    # Having lists of different sizes makes sharding ambiguous, raise an error in this case
     num_shards = _number_of_shards_in_gen_kwargs(gen_kwargs)
     if num_shards == 1:
         return [dict(gen_kwargs)]


### PR DESCRIPTION
aFixes a handful of spelling typos across the docs and source comments/docstrings. This is a documentation/comment-only change; no functional code is affected.

Changes:

docs/source/process.mdx: colums -> columns

docs/source/video_load.mdx: effiently -> efficiently; whithin -> within

src/datasets/arrow_reader.py: informations -> information (ValueError message); conveniant -> convenient (comment)

src/datasets/utils/sharding.py: ambigious -> ambiguous (comments)

src/datasets/features/features.py: unstructred -> unstructured; abritrary -> arbitrary (docstring)
