### PR TITLE
Fix fixed size binary

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -117,6 +117,10 @@ def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
         return "large_string"
     elif pyarrow.types.is_string_view(arrow_type):
         return "string_view"
+    elif pyarrow.types.is_fixed_size_binary(arrow_type):
+        return f"fixed_size_binary[{arrow_type.byte_width}]"
+    elif pyarrow.types.is_list(arrow_type):
+        return f"list[{_arrow_to_datasets_dtype(arrow_type.value_type)}]"
     elif pyarrow.types.is_dictionary(arrow_type):
         return _arrow_to_datasets_dtype(arrow_type.value_type)
     else:
@@ -266,6 +270,11 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                     ],
                 )
             )
+        
+    fixed_size_binary_matches = re.search(r"^fixed_size_binary\[(\d+)\]$", datasets_dtype)
+    if fixed_size_binary_matches:
+        byte_width = fixed_size_binary_matches.group(1)
+        return pa.binary(int(byte_width))
 
     raise ValueError(
         f"Neither {datasets_dtype} nor {datasets_dtype + '_'} seems to be a pyarrow data type. "

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -119,8 +119,6 @@ def _arrow_to_datasets_dtype(arrow_type: pa.DataType) -> str:
         return "string_view"
     elif pyarrow.types.is_fixed_size_binary(arrow_type):
         return f"fixed_size_binary[{arrow_type.byte_width}]"
-    elif pyarrow.types.is_list(arrow_type):
-        return f"list[{_arrow_to_datasets_dtype(arrow_type.value_type)}]"
     elif pyarrow.types.is_dictionary(arrow_type):
         return _arrow_to_datasets_dtype(arrow_type.value_type)
     else:

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -268,7 +268,7 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
                     ],
                 )
             )
-        
+
     fixed_size_binary_matches = re.search(r"^fixed_size_binary\[(\d+)\]$", datasets_dtype)
     if fixed_size_binary_matches:
         byte_width = fixed_size_binary_matches.group(1)

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -76,6 +76,7 @@ class FeaturesTest(TestCase):
             pa.int32(),
             pa.float64(),
             pa.array([datetime.time(1, 1, 1)]).type,  # arrow type: DataType(time64[us])
+            pa.binary(16),
         ]
         for dt in supported_pyarrow_datatypes:
             self.assertEqual(dt, string_to_arrow(_arrow_to_datasets_dtype(dt)))


### PR DESCRIPTION
The original issue is a crash in _arrow_to_datasets_dtype because the miss of support of fixed_size_binary:

```
Exception:    SplitsNotFoundError
Message:      The split names could not be parsed from the dataset config.
Traceback:    Traceback (most recent call last):
                File "/usr/local/lib/python3.12/site-packages/datasets/inspect.py", line 286, in get_dataset_config_info
                  for split_generator in builder._split_generators(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/packaged_modules/parquet/parquet.py", line 118, in _split_generators
                  self.info.features = datasets.Features.from_arrow_schema(pq.read_schema(f))
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/features/features.py", line 1858, in from_arrow_schema
                  else generate_from_arrow_type(field.type)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/features/features.py", line 1518, in generate_from_arrow_type
                  return Value(dtype=_arrow_to_datasets_dtype(pa_type))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/features/features.py", line 121, in _arrow_to_datasets_dtype
                  raise ValueError(f"Arrow type {arrow_type} does not have a datasets dtype equivalent.")
              ValueError: Arrow type fixed_size_binary[3] does not have a datasets dtype equivalent.
              
              The above exception was the direct cause of the following exception:
              
              Traceback (most recent call last):
                File "/src/services/worker/src/worker/job_runners/config/split_names.py", line 65, in compute_split_names_from_streaming_response
                  for split in get_dataset_split_names(
                               ^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/inspect.py", line 340, in get_dataset_split_names
                  info = get_dataset_config_info(
                         ^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/local/lib/python3.12/site-packages/datasets/inspect.py", line 291, in get_dataset_config_info
                  raise SplitsNotFoundError("The split names could not be parsed from the dataset config.") from err
              datasets.inspect.SplitsNotFoundError: The split names could not be parsed from the dataset config.

```

In this pull request I add the support for fixed size binary