### PR TITLE
Fix Mypy typing invariance by updating List to Sequence in dataset loading functions (#5354)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -43,6 +43,7 @@ from math import ceil, floor
 from pathlib import Path
 from random import sample
 from typing import (
+    Sequence,
     TYPE_CHECKING,
     Any,
     BinaryIO,
@@ -1290,7 +1291,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_csv(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1430,7 +1431,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_json(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1489,12 +1490,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,
-        columns: Optional[list[str]] = None,
+        columns: Optional[Sequence[str]] = None,
         num_proc: Optional[int] = None,
         filters: Optional[Union[pds.Expression, list[tuple], list[list[tuple]]]] = None,
         fragment_scan_options: Optional[pds.ParquetFragmentScanOptions] = None,
@@ -1586,7 +1587,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_text(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -3671,11 +3672,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         function: Optional[Callable] = None,
         with_indices: bool = False,
         with_rank: bool = False,
-        input_columns: Optional[list[str]] = None,
+        input_columns: Optional[Sequence[str]] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         drop_last_batch: bool = False,
-        remove_columns: Optional[list[str]] = None,
+        remove_columns: Optional[Sequence[str]] = None,
         keep_in_memory: bool = False,
         cache_file_name: Optional[str] = None,
         writer_batch_size: Optional[int] = 1000,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1534,7 +1534,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,
-        columns: Optional[list[str]] = None,
+        columns: Optional[Sequence[str]] = None,
         **kwargs,
     ) -> "DatasetDict":
         """Create [`DatasetDict`] from Parquet file(s).

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import cycle, islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Union, Sequence
 
 import fsspec.asyn
 import multiprocess as mp
@@ -1347,11 +1347,11 @@ class MappedExamplesIterable(_BaseExamplesIterable):
         ex_iterable: _BaseExamplesIterable,
         function: Callable,
         with_indices: bool = False,
-        input_columns: Optional[list[str]] = None,
+        input_columns: Optional[Sequence[str]] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         drop_last_batch: bool = False,
-        remove_columns: Optional[list[str]] = None,
+        remove_columns: Optional[Sequence[str]] = None,
         fn_kwargs: Optional[dict] = None,
         formatting: Optional["FormattingConfig"] = None,
         features: Optional[Features] = None,
@@ -1799,7 +1799,7 @@ class FilteredExamplesIterable(MappedExamplesIterable):
         ex_iterable: _BaseExamplesIterable,
         function: Callable,
         with_indices: bool = False,
-        input_columns: Optional[list[str]] = None,
+        input_columns: Optional[Sequence[str]] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         fn_kwargs: Optional[dict] = None,
@@ -3157,7 +3157,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_csv(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3200,7 +3200,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_json(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3247,11 +3247,11 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
-        columns: Optional[list[str]] = None,
+        columns: Optional[Sequence[str]] = None,
         filters: Optional[Union[pds.Expression, list[tuple], list[list[tuple]]]] = None,
         fragment_scan_options: Optional[pds.ParquetFragmentScanOptions] = None,
         on_bad_files: Literal["error", "warn", "skip"] = "error",
@@ -3332,7 +3332,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_text(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,


### PR DESCRIPTION
## Description
This PR addresses issue #5354. The standard `typing.List` (or built-in `list`) is invariant in Python, meaning static analyzers like Mypy will complain if a user tries to pass a tuple or another valid sequence into the dataset loading parameters (e.g. `data_files`). By refactoring these type hints from `list` to `typing.Sequence` (which is covariant) across `from_csv`, `from_json`, `from_parquet`, and `from_text`, we satisfy type checkers for read-only sequence data paths.

This change ensures cleaner integration for downstream users who use tuples or custom sequence subclasses when loading datasets.

## Checklist
- [x] Tested locally with type hinting validation.
- [x] Code follows the repository's style guidelines.
