### PR TITLE
Fix CI: commit operation equality (hfh 1.20.0) and pytest parametrize collection error

### DIFF
--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -66,21 +66,27 @@ def test_delete_from_hub(temporary_repo, hf_api, hf_token, csv_path, ci_hub_conf
     assert mock_method.called
     assert mock_method.call_args.kwargs.get("commit_message") == "Delete 'dogs' config"
     assert mock_method.call_args.kwargs.get("create_pr")
-    expected_operations = [
-        CommitOperationDelete(path_in_repo="dogs/train/0000.csv", is_folder=False),
-        CommitOperationAdd(
-            path_in_repo="README.md",
-            path_or_fileobj=dedent(
-                f"""\
-            ---
-            {METADATA_CONFIGS_FIELD}:
-            - config_name: cats
-              data_files:
-              - split: train
-                path: cats/train/*
-            ---
-            """
-            ).encode(),
-        ),
-    ]
-    assert mock_method.call_args.kwargs.get("operations") == expected_operations
+    expected_readme = dedent(
+        f"""\
+        ---
+        {METADATA_CONFIGS_FIELD}:
+        - config_name: cats
+          data_files:
+          - split: train
+            path: cats/train/*
+        ---
+        """
+    ).encode()
+    # Note: we compare operations attribute by attribute rather than relying on `==`. Since
+    # huggingface_hub 1.20.0 (https://github.com/huggingface/huggingface_hub/pull/4331),
+    # `CommitOperationAdd`/`CommitOperationDelete` no longer implement value equality, so two
+    # operations with identical content are not considered equal.
+    operations = mock_method.call_args.kwargs.get("operations")
+    assert len(operations) == 2
+    delete_operation, add_operation = operations
+    assert isinstance(delete_operation, CommitOperationDelete)
+    assert delete_operation.path_in_repo == "dogs/train/0000.csv"
+    assert delete_operation.is_folder is False
+    assert isinstance(add_operation, CommitOperationAdd)
+    assert add_operation.path_in_repo == "README.md"
+    assert add_operation.path_or_fileobj == expected_readme

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -921,7 +921,7 @@ def test_load_dataset_from_hub(kwargs, expected_train_num_rows, expected_test_nu
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("stream_from_cache, ", [False, True])
+@pytest.mark.parametrize("stream_from_cache", [False, True])
 def test_load_dataset_cached_from_hub(stream_from_cache, caplog):
     dataset = load_dataset(SAMPLE_DATASET_IDENTIFIER3)
     assert isinstance(dataset, DatasetDict)


### PR DESCRIPTION
Fixes two unrelated CI failures (seen e.g. in the `huggingface_hub` 1.21.0.rc0 test run, but **the first one already affects `main` with the latest stable `huggingface_hub`**).

## 1. `tests/test_hub.py::test_delete_from_hub`

Since `huggingface_hub` 1.20.0 (introduced in https://github.com/huggingface/huggingface_hub/pull/4331), `UploadInfo` is no longer a dataclass and therefore `CommitOperationAdd` / `CommitOperationDelete` no longer implement value equality. Two commit operations with identical content are no longer considered equal, which broke:

```python
assert mock_method.call_args.kwargs.get("operations") == expected_operations
```

with an `AssertionError` between two byte-identical `CommitOperationAdd` objects.

Updated the test to compare operations attribute by attribute (type, `path_in_repo`, `is_folder`, `path_or_fileobj`) instead of relying on `==`.

## 2. `tests/test_load.py` collection error

```
TypeError: object of type 'bool' has no len()
```

A trailing comma in `@pytest.mark.parametrize("stream_from_cache, ", [False, True])` made recent `pytest` versions parse it as **two** argnames and expect each parameter value to be a 2-tuple, failing at collection time (which errors out the whole `test_load.py` module). This is unrelated to `huggingface_hub`. Fixed by dropping the trailing comma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)