### PR TITLE
Hash frozensets deterministically

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -146,6 +146,21 @@ def _save_set(pickler, obj):
     log(pickler, "# Se")
 
 
+@pklregister(frozenset)
+def _save_frozenset(pickler, obj):
+    log(pickler, f"Fr: {obj}")
+    try:
+        # Faster, but fails for unorderable elements
+        args = (sorted(obj),)
+    except Exception:  # TypeError, decimal.InvalidOperation, etc.
+        from datasets.fingerprint import Hasher
+
+        args = (sorted(obj, key=Hasher.hash),)
+
+    pickler.save_reduce(frozenset, args, obj=obj)
+    log(pickler, "# Fr")
+
+
 def _save_regexPattern(pickler, obj):
     import regex  # type: ignore
 

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -2,6 +2,7 @@ import json
 import os
 import pickle
 import subprocess
+import sys
 from functools import partial
 from pathlib import Path
 from tempfile import gettempdir
@@ -291,6 +292,16 @@ class HashingTest(TestCase):
         hash3 = Hasher.hash(set_)
         self.assertEqual(hash1, hash3)
         self.assertNotEqual(hash1, hash2)
+
+    def test_frozenset_stable(self):
+        # Python randomizes the string hash seed per process, so a frozenset of strings
+        # iterates in a different order in each session. Without a deterministic reducer
+        # the fingerprint of a transform that captures a frozenset changes every session
+        # and the cache never hits. This mirrors the guarantee made for `set`.
+        code = "from datasets.fingerprint import Hasher; print(Hasher.hash(frozenset('abcdefghij')))"
+        hash1 = subprocess.check_output([sys.executable, "-c", code], env={**os.environ, "PYTHONHASHSEED": "0"})
+        hash2 = subprocess.check_output([sys.executable, "-c", code], env={**os.environ, "PYTHONHASHSEED": "1"})
+        self.assertEqual(hash1, hash2)
 
     @require_tiktoken
     def test_hash_tiktoken_encoding(self):


### PR DESCRIPTION
While looking at how transforms get fingerprinted I noticed `frozenset` isn't hashed deterministically, unlike `set`.

`set` has a custom reducer (`_save_set`) that pickles its elements sorted, so the fingerprint is stable across runs. `frozenset` has no such reducer and falls back to the default one, which keeps the iteration order. Because Python randomizes the string hash seed per process, a transform that captures a `frozenset` of strings gets a different fingerprint every session, so the cache never hits.

Repro:
```python
from datasets.fingerprint import Hasher
# prints a different hash on every run (PYTHONHASHSEED is random by default)
print(Hasher.hash(frozenset("abcdefghij")))
```

I registered the same sorted reducer for `frozenset` that `set` already uses (falling back to sorting by `Hasher.hash` for unorderable elements). Added a test that hashes a frozenset in two subprocesses with different `PYTHONHASHSEED` and checks the hashes match, mirroring the existing `set` coverage.