### PR TITLE
Share fsspec filesystem across threads when resolving data files

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -5,6 +5,7 @@ from glob import has_magic
 from pathlib import Path, PurePath
 from typing import Callable, Optional, Union
 
+import fsspec
 import huggingface_hub
 from fsspec.core import url_to_fs
 from huggingface_hub import HfFileSystem
@@ -498,6 +499,7 @@ def get_data_patterns(base_path: str, download_config: Optional[DownloadConfig] 
 def _get_single_origin_metadata(
     data_file: str,
     download_config: Optional[DownloadConfig] = None,
+    fs_per_protocol: Optional[dict[str, fsspec.AbstractFileSystem]] = None,
 ) -> SingleOriginMetadata:
     if data_file.startswith(config.HF_ENDPOINT):
         fs = HfFileSystem(endpoint=config.HF_ENDPOINT, token=download_config.token)
@@ -505,8 +507,16 @@ def _get_single_origin_metadata(
         data_file = data_file.replace("/resolve/", "/" if data_file.startswith("hf://buckets/") else "@", 1)
         fs_path = data_file
     else:
+        # fsspec caches filesystems per thread, so reuse the one built in the main thread instead
+        # of rebuilding it here (which re-auths and reopens connections for s3://, gcs://, ...).
+        protocol = data_file.split("://")[0] if "://" in data_file else "file"
         data_file, storage_options = _prepare_path_and_storage_options(data_file, download_config=download_config)
-        fs, fs_path = url_to_fs(data_file, **storage_options)
+        fs = fs_per_protocol.get(protocol) if fs_per_protocol is not None else None
+        if fs is None or "::" in data_file:
+            # chained urls like "zip://*.csv::s3://..." need url_to_fs to build the nested fs
+            fs, fs_path = url_to_fs(data_file, **storage_options)
+        else:
+            fs_path = fs._strip_protocol(data_file)
     if isinstance(fs, HfFileSystem):
         resolved_path = fs.resolve_path(fs_path)
         if hasattr(resolved_path, "revision"):  # no revision for buckets
@@ -537,8 +547,21 @@ def _get_origin_metadata(
                 disable=len(data_files) <= 16 or None,
             )
         ]
+    # Build one filesystem per protocol here and share it with the workers (see
+    # _get_single_origin_metadata). hf:// and chained "::" urls are skipped on purpose:
+    # hf origin metadata is already cached, and chained urls need their nested fs rebuilt.
+    fs_per_protocol: dict[str, fsspec.AbstractFileSystem] = {}
+    for data_file in data_files:
+        if data_file.startswith(config.HF_ENDPOINT) or "::" in data_file:
+            continue
+        protocol = data_file.split("://")[0] if "://" in data_file else "file"
+        if protocol == "hf" or protocol in fs_per_protocol:
+            continue
+        prepared_path, storage_options = _prepare_path_and_storage_options(data_file, download_config=download_config)
+        if "::" not in prepared_path:
+            fs_per_protocol[protocol], _ = url_to_fs(prepared_path, **storage_options)
     return thread_map(
-        partial(_get_single_origin_metadata, download_config=download_config),
+        partial(_get_single_origin_metadata, download_config=download_config, fs_per_protocol=fs_per_protocol),
         data_files,
         max_workers=max_workers,
         tqdm_class=hf_tqdm,

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import threading
 from pathlib import Path
 from typing import List
 from unittest.mock import patch
@@ -15,6 +16,8 @@ from datasets.data_files import (
     DataFilesPatternsDict,
     DataFilesPatternsList,
     _get_data_files_patterns,
+    _get_origin_metadata,
+    _get_single_origin_metadata,
     _is_inside_unrequested_special_dir,
     _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir,
     get_data_patterns,
@@ -398,6 +401,44 @@ def test_DataFilesList_from_patterns_locally_with_extra_files(complex_data_dir, 
 def test_DataFilesList_from_patterns_raises_FileNotFoundError(complex_data_dir):
     with pytest.raises(FileNotFoundError):
         DataFilesList.from_patterns(["file_that_doesnt_exist.txt"], complex_data_dir)
+
+
+def test_get_origin_metadata_shares_filesystem_across_threads(tmp_path, monkeypatch):
+    # fsspec caches filesystem instances per thread (its cache key includes threading.get_ident()),
+    # so without sharing each worker thread would build its own filesystem. The main thread should
+    # instantiate it once and pass it down, so that no filesystem is ever built inside a worker.
+    from fsspec.implementations.local import LocalFileSystem
+
+    data_files = []
+    for i in range(20):
+        path = tmp_path / f"file_{i}.txt"
+        path.write_text(str(i))
+        data_files.append(path.as_posix())
+
+    init_threads = []
+    original_init = LocalFileSystem.__init__
+
+    def counting_init(self, *args, **kwargs):
+        init_threads.append(threading.get_ident())
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(LocalFileSystem, "__init__", counting_init)
+    # start from a clean cache so the (single) instantiation is observable and deterministic
+    # (each fsspec class keeps its own instance cache, so clear LocalFileSystem's specifically)
+    LocalFileSystem.clear_instance_cache()
+
+    main_thread = threading.get_ident()
+    origin_metadata = _get_origin_metadata(data_files, max_workers=8)
+
+    # the filesystem is built once in the main thread; workers must reuse it and build nothing
+    assert init_threads, "expected the shared filesystem to be instantiated in the main thread"
+    assert all(tid == main_thread for tid in init_threads), (
+        f"filesystem was instantiated inside worker thread(s): {set(init_threads) - {main_thread}}"
+    )
+    # the shared filesystem must not change the resolved metadata
+    expected = [_get_single_origin_metadata(data_file) for data_file in data_files]
+    assert origin_metadata == expected
+    assert len(origin_metadata) == len(data_files)
 
 
 class TestDataFilesDict:


### PR DESCRIPTION
## What does this PR do?

Fixes #8149.

`_get_origin_metadata` resolves each data file in a `ThreadPoolExecutor` and every worker builds its own filesystem via `url_to_fs` since fsspec caches filesystem instances per thread. For cloud backends like `s3://` or `gcs://` this re-resolves credentials and opens a new connection pool in each thread.

This builds the filesystem once per protocol in the main thread and passes it to the workers which just strip the protocol off the path instead of rebuilding it. `hf://` paths and chained `::` urls keep the same behavior as before
