### PR TITLE
docs(video_load): fix typos 'effiently' and 'whithin'

### DIFF
--- a/docs/source/video_load.mdx
+++ b/docs/source/video_load.mdx
@@ -37,7 +37,7 @@ Access frames directly from a video using the `VideoReader` using `next()`:
 ```
 
 To get multiple frames at once, you can call `.get_frames_in_range(start: int, stop: int, step: int)`. This will return a frame batch.
-This is the efficient way to obtain a long list of frames refer to the [torchcodec docs](https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.VideoDecoder.html) to see more functions for effiently accessing the data:
+This is the efficient way to obtain a long list of frames refer to the [torchcodec docs](https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.VideoDecoder.html) to see more functions for efficiently accessing the data:
 
 ```python
 >>> import torch
@@ -46,7 +46,7 @@ This is the efficient way to obtain a long list of frames refer to the [torchcod
 torch.Size([5, 3, 240, 320])
 ```
 
-There is also `.get_frames_played_in_range(start_seconds: float, stop_seconds: float)` to access all frames played whithin a certain time range.
+There is also `.get_frames_played_in_range(start_seconds: float, stop_seconds: float)` to access all frames played within a certain time range.
 
 ```python
 >>> frames = video.get_frames_played_in_range(.5, 1.2)


### PR DESCRIPTION
Fixes two typos in `docs/source/video_load.mdx`:
- "effiently" -> "efficiently" in the description of `get_frames_in_range`
- "whithin" -> "within" in the description of `get_frames_played_in_range`

Both flagged by `typos` (typos-cli 1.47.2) and verified by reading the surrounding context.

## AI assistance

This patch was drafted with the help of an AI coding assistant. The two corrections are limited to the prose on lines 40 and 49 of the file and have been reviewed line-by-line before submission.
