### PR TITLE
Fix duplicate word in HubBucketDatasetModuleFactory docstring

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -843,7 +843,7 @@ class CachedDatasetModuleFactory(_DatasetModuleFactory):
 
 class HubBucketDatasetModuleFactory(_DatasetModuleFactory):
     """
-    Get the module of a dataset loaded from data files of a a Storage Bucket.
+    Get the module of a dataset loaded from data files of a Storage Bucket.
     The dataset builder module to use is inferred from the data files extensions.
     """
 


### PR DESCRIPTION
Removes a duplicated "a" in the `HubBucketDatasetModuleFactory` docstring in `src/datasets/load.py`:

"...data files of a a Storage Bucket." → "...data files of a Storage Bucket."

Documentation-only change; no code behavior affected.