### PR TITLE
Fix docstring example for select_columns in IterableDatasetDict

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -2253,7 +2253,7 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         ```py
         >>> from datasets import load_dataset
         >>> ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", streaming=True)
-        >>> ds = ds.select("text")
+        >>> ds = ds.select_columns("text")
         >>> next(iter(ds["train"]))
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```


### PR DESCRIPTION
Fix docstring example for select_columns in IterableDatasetDict.

This PR updates the usage example for selecting columns in a streaming dataset. The example now correctly uses the `select_columns` method instead of the outdated `select` method.

### Changes

- **Documentation update:**
  * Updated the example in the docstring of `select_columns` in `dataset_dict.py` to use `select_columns("text")` instead of the deprecated `select("text")`.