### PR TITLE
Bug Fix: Resuming Twice Resets the Dataloader

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2712,6 +2712,8 @@ class IterableDataset(DatasetInfoMixin):
             }
             if self._starting_state_dict and self.epoch == self._starting_state_dict["epoch"]:
                 ex_iterable.load_state_dict(self._starting_state_dict["examples_iterable"])
+                # re-point at the live ex_iterable state so progress tracking
+                self._state_dict["examples_iterable"] = ex_iterable._state_dict
 
             if self._formatting and (ex_iterable.iter_arrow or self._formatting.is_table):
                 formatter = get_formatter(self._formatting.format_type, features=self.features)
@@ -2796,6 +2798,8 @@ class IterableDataset(DatasetInfoMixin):
         }
         if self._starting_state_dict and self.epoch == self._starting_state_dict["epoch"]:
             ex_iterable.load_state_dict(self._starting_state_dict["examples_iterable"])
+            # re-point at the live ex_iterable state so progress tracking
+            self._state_dict["examples_iterable"] = ex_iterable._state_dict
         return ex_iterable
 
     def __iter__(self):

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2834,39 +2834,36 @@ def test_resume_dataloader(dataset: IterableDataset):
 
 
 @require_torchdata_stateful_dataloader
-def test_resume_dataloader_twice(dataset: IterableDataset):
-    # Regression test: a checkpoint taken from an already-resumed dataloader must itself
-    # resume correctly. Previously, once load_state_dict() had been called the dataset's
-    # state_dict froze at the initial position (the example-iterable rebound its _state_dict
-    # and detached from IterableDataset._state_dict["examples_iterable"]), so the second
-    # checkpoint restarted iteration from the beginning.
+@pytest.mark.parametrize("num_workers", [0, 1, 2])
+def test_resume_dataloader_twice(num_workers):
     from torchdata.stateful_dataloader import StatefulDataLoader
 
-    all_examples = list(StatefulDataLoader(dataset))
-    assert len(all_examples) >= 6
+    ex_iterable = ExamplesIterable(generate_examples_fn, {"filepaths": [f"file{i}.txt" for i in range(4)]})
+    dataset = IterableDataset(ex_iterable)
 
-    # checkpoint #1 after consuming 2 examples
-    dl = StatefulDataLoader(dataset)
-    for i, _ in enumerate(dl):
-        if i == 1:
-            state_1 = dl.state_dict()
-            break
+    def make_dataloader():
+        return StatefulDataLoader(dataset, batch_size=None, num_workers=num_workers)
+
+    all_examples = list(make_dataloader())
+
+    # consume 2 examples, then checkpoint #1
+    dl = make_dataloader()
+    it = iter(dl)
+    consumed = [next(it) for _ in range(2)]
+    state_1 = dl.state_dict()
 
     # resume from #1, consume 2 more, then checkpoint #2 (taken from a resumed loader)
-    dl = StatefulDataLoader(dataset)
+    dl = make_dataloader()
     dl.load_state_dict(state_1)
-    resumed_after_1 = []
-    for i, x in enumerate(dl):
-        resumed_after_1.append(x)
-        if i == 1:
-            state_2 = dl.state_dict()
-            break
-    assert resumed_after_1 == all_examples[2:4]
+    it = iter(dl)
+    consumed += [next(it) for _ in range(2)]
+    state_2 = dl.state_dict()
 
-    # resume from #2: must continue from example 4, not restart from the beginning
-    dl = StatefulDataLoader(dataset)
+    # resuming from #2 must continue from where it left off, not restart from the beginning
+    dl = make_dataloader()
     dl.load_state_dict(state_2)
-    assert list(dl) == all_examples[4:]
+    remainder = list(dl)
+    assert consumed + remainder == all_examples
 
 
 @pytest.mark.parametrize("num_shards", [1, 2, 3, 7])

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2833,6 +2833,42 @@ def test_resume_dataloader(dataset: IterableDataset):
     assert remaining == list(dl)
 
 
+@require_torchdata_stateful_dataloader
+def test_resume_dataloader_twice(dataset: IterableDataset):
+    # Regression test: a checkpoint taken from an already-resumed dataloader must itself
+    # resume correctly. Previously, once load_state_dict() had been called the dataset's
+    # state_dict froze at the initial position (the example-iterable rebound its _state_dict
+    # and detached from IterableDataset._state_dict["examples_iterable"]), so the second
+    # checkpoint restarted iteration from the beginning.
+    from torchdata.stateful_dataloader import StatefulDataLoader
+
+    all_examples = list(StatefulDataLoader(dataset))
+    assert len(all_examples) >= 6
+
+    # checkpoint #1 after consuming 2 examples
+    dl = StatefulDataLoader(dataset)
+    for i, _ in enumerate(dl):
+        if i == 1:
+            state_1 = dl.state_dict()
+            break
+
+    # resume from #1, consume 2 more, then checkpoint #2 (taken from a resumed loader)
+    dl = StatefulDataLoader(dataset)
+    dl.load_state_dict(state_1)
+    resumed_after_1 = []
+    for i, x in enumerate(dl):
+        resumed_after_1.append(x)
+        if i == 1:
+            state_2 = dl.state_dict()
+            break
+    assert resumed_after_1 == all_examples[2:4]
+
+    # resume from #2: must continue from example 4, not restart from the beginning
+    dl = StatefulDataLoader(dataset)
+    dl.load_state_dict(state_2)
+    assert list(dl) == all_examples[4:]
+
+
 @pytest.mark.parametrize("num_shards", [1, 2, 3, 7])
 def test_iterable_dataset_batch(num_shards: int):
     # Create a simple IterableDataset


### PR DESCRIPTION
## Summary

For a streaming `IterableDataset`, calling `load_state_dict()` and then continuing to iterate leaves `state_dict()`  at the initial position (`shard_idx=0`, `shard_example_idx=0`). Reading resumes from the correct place, but the the state never advances again.

The practical consequence shows up on the second consecutive resume of a training run:

1. An original run tracks state correctly and writes a healthy checkpoint.
2. Resuming from it reads correctly but every checkpoint writes a stale zero-initialized state_dict
3. Resuming from that checkpoint restarts the data stream from the very beginning.

In our case, a torchtitan resumed-twice run over FineWeb produced a different training loss compared to the resume-once run.

## Root cause

The resume call sites in `IterableDataset` (`_iter_pytorch` for `num_workers>=1` and `_prepare_ex_iterable_for_iteration` for `num_workers=0`) build `self._state_dict` so that `self._state_dict["examples_iterable"]` references the example-iterable's own state dict, and then load the resume state into that example-iterable. `_BaseExamplesIterable.load_state_dict` calls `self._init_state_dict()`, which rebinds `self._state_dict` to a brand-new object. After the load, `dataset._state_dict["examples_iterable"]` still points at the stale zero-initialized state dict. During iteration the example-iterable mutates its state dict, while `dataset.state_dict()` keeps deep-copying the stale one, so the reported position is frozen at the zero.

On a fresh run the `load_state_dict` branch is skipped, the reference stays linked, and tracking works, which is why the bug only surfaces *after* a resume.

## The fix

Re-point `self._state_dict["examples_iterable"]` at the live example-iterable state immediately after the resume load, at both `IterableDataset` resume sites:

```python
if self._starting_state_dict and self.epoch == self._starting_state_dict["epoch"]:
    ex_iterable.load_state_dict(self._starting_state_dict["examples_iterable"])
    self._state_dict["examples_iterable"] = ex_iterable._state_dict   # re-link after the rebind
```

## Reproduction

```python
import datasets
def gen():
    for i in range(10): yield {"id": i}
ds = datasets.IterableDataset.from_generator(gen)
full = [x["id"] for x in ds]
it = iter(ds); [next(it) for _ in range(3)]; sd1 = ds.state_dict()
ds.load_state_dict(sd1); it = iter(ds); seen = [next(it)["id"] for _ in range(3)]; sd2 = ds.state_dict()
ds.load_state_dict(sd2); after = [x["id"] for x in ds]
print("reference       :", full)
print("after 1st resume:", seen, "(reads correctly)")
print("after 2nd resume:", after)
print(">>> BUG: 2nd resume restarted from the beginning" if after == full else ">>> OK: continued")
```

## Tests

- Added `tests/test_iterable_dataset.py::test_resume_dataloader_twice`, a test that takes a checkpoint, resumes from it, takes a *second* checkpoint from the resumed loader, and asserts the second checkpoint continues iteration from the right place instead of restarting. It fails on `main` and passes with this fix.