### PR TITLE
Fix: preserve features after IterableDataset.add_column (GH#5752)

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4032,7 +4032,15 @@ class IterableDataset(DatasetInfoMixin):
         Returns:
             `IterableDataset`
         """
-        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
+        # GH#5752: Infer feature type for the new column and merge with existing
+        # features so that the returned dataset's .features are preserved.
+        column_features = _infer_features_from_batch({name: list(column) if not isinstance(column, list) else column})
+        if self.features is not None:
+            features = self.features.copy()
+            features.update(column_features)
+        else:
+            features = column_features
+        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True, features=features)
 
     def rename_column(self, original_column_name: str, new_column_name: str) -> "IterableDataset":
         """

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2327,6 +2327,20 @@ def test_iterable_dataset_add_column(dataset_with_several_columns: IterableDatas
     assert "new_column" in new_dataset.column_names
 
 
+def test_iterable_dataset_add_column_preserves_features(dataset_with_several_columns: IterableDataset):
+    # GH#5752 - .features was lost (became None) after .add_column
+    ds_with_features = dataset_with_several_columns._resolve_features()
+    assert ds_with_features.features is not None
+    original_feature_names = set(ds_with_features.features)
+
+    new_column = ["x"] * (3 * DEFAULT_N_EXAMPLES)
+    new_dataset = ds_with_features.add_column("new_column", new_column)
+
+    assert new_dataset.features is not None, ".features should be preserved after add_column"
+    assert "new_column" in new_dataset.features, "new_column should appear in features"
+    assert original_feature_names.issubset(new_dataset.features), "original features should be preserved"
+
+
 def test_iterable_dataset_rename_column(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.rename_column("id", "new_id")
     assert list(new_dataset) == [


### PR DESCRIPTION
## Problem

After calling `.add_column()` on a streaming `IterableDataset`, accessing `.features` returns `None`:

```python
from datasets import load_dataset

ds = load_dataset("...", streaming=True)
print(ds.features)  # {'text': Value('string'), ...}

ds2 = ds.add_column("new_column", ["val"] * len(ds))
print(ds2.features)  # None  <-- bug
print(ds2.features.keys())  # AttributeError: 'NoneType' object has no attribute 'keys'
```

## Root Cause

`add_column` calls `self.map(...)` without passing the `features` argument. Inside `_map`, the new dataset's info is constructed as:

```python
info = self.info.copy()
info.features = features  # None if not passed
```

This unconditionally overwrites the copied features with `None`.

## Fix

Infer the feature type of the new column from the provided data, merge it with the existing features, and pass the combined `Features` object to `map()`:

```python
column_features = _infer_features_from_batch({name: list(column) if not isinstance(column, list) else column})
if self.features is not None:
    features = self.features.copy()
    features.update(column_features)
else:
    features = column_features
return self.map(..., features=features)
```

## Tests

- Added `test_iterable_dataset_add_column_preserves_features` which explicitly checks that `.features` is not `None` and contains both original and new columns after `add_column`.
- Existing `test_iterable_dataset_add_column` continues to pass.

Closes #5752