### PR TITLE
Replace distutils.util.strtobool in tests with a local helper

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,6 @@ import tempfile
 import unittest
 from contextlib import contextmanager
 from copy import deepcopy
-from distutils.util import strtobool
 from enum import Enum
 from importlib.util import find_spec
 from pathlib import Path
@@ -20,6 +19,24 @@ import requests
 from packaging import version
 
 from datasets import config
+
+
+def strtobool(value: str) -> int:
+    """Convert a string representation of truth to 1 (true) or 0 (false).
+
+    True values are ``y``, ``yes``, ``t``, ``true``, ``on`` and ``1``; false values are
+    ``n``, ``no``, ``f``, ``false``, ``off`` and ``0``. Raises :class:`ValueError` if
+    ``value`` is anything else.
+
+    This mirrors the behaviour of the now-removed ``distutils.util.strtobool``
+    (``distutils`` was dropped from the standard library in Python 3.12, see PEP 632).
+    """
+    value = value.lower()
+    if value in {"y", "yes", "t", "true", "on", "1"}:
+        return 1
+    if value in {"n", "no", "f", "false", "off", "0"}:
+        return 0
+    raise ValueError(f"invalid truth value {value!r}")
 
 
 def parse_flag_from_env(key, default=False):


### PR DESCRIPTION
## What this fixes

`tests/utils.py` imports `strtobool` from `distutils.util`:

```python
from distutils.util import strtobool
```

`distutils` was removed from the standard library in **Python 3.12** ([PEP 632](https://peps.python.org/pep-0632/)). `tests/utils.py` is imported (via `from .utils import ...`) by **20 test modules**, so on an interpreter without the `distutils` shim this raises at collection time and the **entire test suite fails to run**:

```
tests/utils.py:10: in <module>
    from distutils.util import strtobool
E   ModuleNotFoundError: No module named 'distutils'
```

### When it triggers

- **setuptools absent** on Python ≥ 3.12 — increasingly common with modern venvs, `uv`, and minimal CI images: hard `ModuleNotFoundError`, whole suite uncollectable.
- **setuptools present**: it vendors a `distutils` shim so the import succeeds today, but the shim is deprecated and is **removed on Python 3.14** — which this project already targets (`setup.py` advertises `Programming Language :: Python :: 3.12/3.13/3.14`, and CI runs on 3.14).

Either way, relying on `distutils` here is on borrowed time.

## The fix

Replace the import with a small local `strtobool` that reproduces the **exact** semantics of `distutils.util.strtobool`:

```python
def strtobool(value: str) -> int:
    value = value.lower()
    if value in {"y", "yes", "t", "true", "on", "1"}:
        return 1
    if value in {"n", "no", "f", "false", "off", "0"}:
        return 0
    raise ValueError(f"invalid truth value {value!r}")
```

This is the standard PEP 632 migration for `strtobool` (the stdlib provides no replacement). It's test-only — no change to shipped code.

## Verification (local, Python 3.12.12, no setuptools)

**Before** — collection fails:
```
tests/utils.py:10: ModuleNotFoundError: No module named 'distutils'
```

**After**:
- Semantics parity checked against the `distutils` spec for every truthy/falsy value (incl. mixed case) and the `ValueError` path — all match.
- Test collection restored, and real tests run green:

```
python -m pytest tests/test_formatting.py tests/features/test_features.py
220 passed, 33 skipped
```
- `ruff check tests/utils.py` → All checks passed!
- `ruff format --check tests/utils.py` → already formatted.

## Notes

- The `strtobool` helper lives in `tests/utils.py` right next to its only caller (`parse_flag_from_env`), matching how the codebase already reads env flags like `RUN_SLOW` / `RUN_REMOTE`.
- No production code touched; behavior for the four env flags (`RUN_SLOW`, `RUN_REMOTE`, `RUN_LOCAL`, `RUN_PACKAGED`) is unchanged.
