### PR TITLE
Fix MetadataConfigs dropping parquet shards for non-consecutive configs

### DIFF
--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -106,6 +106,12 @@ class MetadataConfigs(dict[str, dict[str, Any]]):
         exported_parquet_files: list[dict[str, Any]],
         dataset_infos: DatasetInfosDict,
     ) -> "MetadataConfigs":
+        # itertools.groupby only groups *consecutive* equal keys, so sort by
+        # (config, split) first. Otherwise, if the exported list has the same
+        # config (or split) in non-consecutive positions, groupby yields it as
+        # multiple groups and the earlier shard URLs are silently dropped. The
+        # sort is stable, so shard order within a split is preserved.
+        exported_parquet_files = sorted(exported_parquet_files, key=itemgetter("config", "split"))
         metadata_configs = {
             config_name: {
                 "data_files": [

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -356,3 +356,27 @@ def test_split_order_in_metadata_configs_from_exported_parquet_files_and_dataset
     )
     split_names = [data_file["split"] for data_file in metadata_configs["default"]["data_files"]]
     assert split_names == ["train", "validation", "test"]
+
+
+def test_from_exported_parquet_files_keeps_all_shards_when_configs_non_consecutive():
+    # Regression for #8269: itertools.groupby only groups *consecutive* keys, so
+    # a config that appears non-consecutively in the exported list must not lose
+    # its earlier shard URLs.
+    base = "https://huggingface.co/datasets/ds/resolve/refs%2Fconvert%2Fparquet"
+    exported_parquet_files = [
+        {"dataset": "ds", "config": "default", "split": "train",
+         "url": f"{base}/default/train/0000.parquet", "filename": "0000.parquet", "size": 1},
+        {"dataset": "ds", "config": "other", "split": "train",
+         "url": f"{base}/other/train/0000.parquet", "filename": "0000.parquet", "size": 1},
+        {"dataset": "ds", "config": "default", "split": "train",
+         "url": f"{base}/default/train/0001.parquet", "filename": "0001.parquet", "size": 1},
+    ]
+    metadata_configs = MetadataConfigs._from_exported_parquet_files_and_dataset_infos(
+        "123", exported_parquet_files, {}
+    )
+    assert "other" in metadata_configs
+    default_paths = metadata_configs["default"]["data_files"][0]["path"]
+    # both shards are kept (not just the last one), with the commit hash substituted
+    assert len(default_paths) == 2
+    assert default_paths == [f"{base.replace('refs%2Fconvert%2Fparquet', '123')}/default/train/0000.parquet",
+                             f"{base.replace('refs%2Fconvert%2Fparquet', '123')}/default/train/0001.parquet"]


### PR DESCRIPTION
Fixes #8269

## Problem

`MetadataConfigs._from_exported_parquet_files_and_dataset_infos()` groups the exported parquet files with `itertools.groupby(exported_parquet_files, itemgetter("config"))`. `groupby` only groups **consecutive** equal keys, but the result is built as a dict keyed by config name:

```python
metadata_configs = {
    config_name: { ... }
    for config_name, parquet_files_for_config in groupby(exported_parquet_files, itemgetter("config"))
}
```

So if the same config appears again after a different config (e.g. `default`, `other`, `default`), `groupby` yields `default` as two separate groups and the second one **overwrites** the first in the dict — the earlier shard URLs are silently lost. The same applies to the inner `groupby` over splits.

## Fix

Sort the exported files by `(config, split)` before grouping, so all rows for a given config/split are consecutive. The sort is stable, so shard order within a split (`0000.parquet`, `0001.parquet`, …) is preserved.

## Tests

Added `test_from_exported_parquet_files_keeps_all_shards_when_configs_non_consecutive` — it feeds a non-consecutive `default` config and asserts both shard URLs survive (the test fails on `main` and passes with this change). The existing `test_split_order_...` test still passes (final ordering is still driven by `dataset_infos`). `pytest tests/test_metadata_util.py` → 9 passed; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)