### PR TITLE
Fix symlink-following arbitrary file write in archive extraction

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -439,6 +439,8 @@ class Extractor:
         # Prevent parallel extractions
         lock_path = str(Path(output_path).with_suffix(".lock"))
         with FileLock(lock_path):
+            if os.path.islink(output_path):
+                os.unlink(output_path)
             shutil.rmtree(output_path, ignore_errors=True)
             extractor = cls.extractors[extractor_format]
             return extractor.extract(input_path, output_path)


### PR DESCRIPTION
Extractor.extract() called shutil.rmtree(output_path, ignore_errors=True) before extracting. Since Python 3.8, shutil.rmtree() raises OSError on a symlink pointing to a directory, which ignore_errors=True silently swallows. An attacker with write access to a shared cache directory could pre-plant a symlink at the predictable extraction output path; rmtree would no-op on it, and extraction would then follow the symlink and write archive contents into the attacker-chosen target, yielding arbitrary file write as the victim.

The existing safemembers() zip-slip mitigation only validates member names and is blind to the output directory itself being a symlink.

Remove the symlink itself before extracting so contents can no longer be written through it.
#8296 