### PR TITLE
Fix `add_column` parameter order so `feature` precedes `new_fingerprint`

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6244,8 +6244,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         self,
         name: str,
         column: Union[list, np.ndarray],
-        new_fingerprint: Optional[str] = None,
         feature: Optional[FeatureType] = None,
+        new_fingerprint: Optional[str] = None,
     ):
         """Add column to Dataset.
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5100,6 +5100,27 @@ def test_add_column():
     assert ds[1] == {"a": 2, "b": 4}
 
 
+def test_add_column_feature_argument():
+    # https://github.com/huggingface/datasets/issues/7864
+    # `feature` is the documented third argument of add_column, so passing it
+    # positionally must work (previously this raised TypeError because
+    # `new_fingerprint` sat before `feature` in the signature).
+    from datasets import Dataset
+
+    ds = Dataset.from_dict({"a": [1, 2]})
+
+    ds_positional = ds.add_column("b", [3, 4], Value("int32"))
+    assert ds_positional.features["b"] == Value("int32")
+    assert ds_positional[0] == {"a": 1, "b": 3}
+
+    ds_keyword = ds.add_column("b", [3, 4], feature=Value("int32"))
+    assert ds_keyword.features["b"] == Value("int32")
+
+    # `new_fingerprint` keyword still works and is honored.
+    ds_fingerprint = ds.add_column("b", [3, 4], new_fingerprint="fixed_fingerprint")
+    assert ds_fingerprint._fingerprint == "fixed_fingerprint"
+
+
 def test_process_large_few_examples(tmp_path):
     # GH 7911
     from datasets import Dataset


### PR DESCRIPTION
### What

`Dataset.add_column`'s signature is `(name, column, new_fingerprint=None, feature=None)`, but:

- its own docstring documents the third argument as `feature` (not `new_fingerprint`), and
- every sibling `@fingerprint_transform` method keeps `new_fingerprint` as the **last** parameter (e.g. `cast_column(column, feature, new_fingerprint=None)`, `rename_column`, `remove_columns`, `select_columns`).

Because `new_fingerprint` sits before `feature`, a docstring-conformant positional call raises:

```python
>>> from datasets import Dataset, Value
>>> ds = Dataset.from_dict({"a": [1, 2]})
>>> ds.add_column("b", [3, 4], Value("int32"))
TypeError: Dataset.add_column() got multiple values for argument 'new_fingerprint'
```

The `fingerprint_transform` decorator injects `new_fingerprint` as a keyword argument, so the positional value collides with it.

### Fix

Reorder the signature to `(name, column, feature=None, new_fingerprint=None)`, matching the docstring and the `cast_column` convention. The decorator references `new_fingerprint` by keyword, so this is safe for existing keyword callers, and no `Dataset.add_column` caller in the repo passes `feature`/`new_fingerprint` positionally.

### Test

Added `test_add_column_feature_argument` in `tests/test_arrow_dataset.py`, asserting that a positional `feature` is honored, the keyword form still works, and the `new_fingerprint` keyword is still respected. The test fails on `main` (`TypeError`) and passes with this change.

Fixes #7864

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.