### PR TITLE
Improve missing tsfile dependency error

### DIFF
--- a/src/datasets/packaged_modules/tsfile/tsfile.py
+++ b/src/datasets/packaged_modules/tsfile/tsfile.py
@@ -53,9 +53,16 @@ logger = datasets.utils.logging.get_logger(__name__)
 # Type helpers
 # ---------------------------------------------------------------------------
 
+def _require_tsfile():
+    try:
+        import tsfile  # noqa: F401
+    except ImportError as e:
+        raise ImportError("To support loading TSFile datasets, please install 'tsfile'.") from e
+
 
 def _arrow_type(ts_dtype, *, unit: str, tz: Optional[str]) -> pa.DataType:
     """Map a tsfile ``TSDataType`` to its Arrow representation."""
+    _require_tsfile()
     from tsfile.constants import TSDataType
 
     return {
@@ -86,6 +93,7 @@ def _promote_tsdatatype(a, b):
     if a == b:
         return a
 
+    _require_tsfile()
     from tsfile.constants import TSDataType
 
     table = {
@@ -301,6 +309,7 @@ class TsFile(datasets.ArrowBasedBuilder):
 
     def _scan_metadata(self, files) -> Optional[dict]:
         """Walk every file and unify table name, TAG columns, FIELD types."""
+        _require_tsfile()
         from tsfile.constants import TIME_COLUMN, ColumnCategory
 
         wanted_table = self._table
@@ -431,6 +440,7 @@ class TsFile(datasets.ArrowBasedBuilder):
         - ``file_meta``: maps each readable file to its per-file context
           (``tag_cols``, ``field_cols``, ``time_col``).
         """
+        _require_tsfile()
         from tsfile.constants import ColumnCategory
 
         device_to_files: dict[tuple, list[str]] = {}
@@ -541,6 +551,7 @@ class TsFile(datasets.ArrowBasedBuilder):
         field columns that this file owns *and* that the builder requested;
         callers fill missing fields with all-null contributions.
         """
+        _require_tsfile()
         from tsfile import tag_eq
 
         file_tag_cols: list[str] = meta["tag_cols"]
@@ -730,6 +741,7 @@ class TsFile(datasets.ArrowBasedBuilder):
         segfaults. The 6-byte ``TsFile`` magic header is checked first to
         bail out cleanly.
         """
+        _require_tsfile()
         from tsfile import TsFileReader
 
         try:

--- a/tests/packaged_modules/test_tsfile_missing_dependency.py
+++ b/tests/packaged_modules/test_tsfile_missing_dependency.py
@@ -1,0 +1,11 @@
+import pytest
+
+from datasets import load_dataset
+
+
+def test_tsfile_missing_dependency_message(tmp_path):
+    tsfile_path = tmp_path / "sample.tsfile"
+    tsfile_path.write_bytes(b"fake tsfile content")
+
+    with pytest.raises(ImportError, match=r"To support loading TSFile datasets, please install 'tsfile'\."):
+        load_dataset("tsfile", data_files=str(tsfile_path))


### PR DESCRIPTION
Related to #8256

This PR improves the error message when the optional `tsfile` dependency is unavailable.

Currently, loading a TSFile dataset without `tsfile` installed raises a raw:

ModuleNotFoundError: No module named 'tsfile'

This change raises a clearer ImportError instead:

ImportError: To support loading TSFile datasets, please install 'tsfile'.

A regression test is included for the missing dependency case.