### PR TITLE
Fix silent dataset truncation in batched map with mismatched empty column (#6879)

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -718,7 +718,7 @@ class ArrowWriter:
         writer_batch_size: Optional[int] = None,
         try_original_type: Optional[bool] = True,
     ):
-        if batch_examples and len(next(iter(batch_examples.values()))) == 0:
+        if batch_examples and all(len(col_values) == 0 for col_values in batch_examples.values()):
             return
         features = None if self.pa_writer is None and self.update_features else self._features
         try_features = self._features if self.pa_writer is None and self.update_features else None

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -166,6 +166,17 @@ def test_write_batch(fields, writer_batch_size):
     _check_output(output.getvalue(), expected_num_chunks=num_examples if writer_batch_size == 1 else 1)
 
 
+def test_write_batch_with_mismatched_empty_column_raises():
+    # Regression test for https://github.com/huggingface/datasets/issues/6879
+    # A batch is only skipped when *every* column is empty. A batch that mixes an
+    # empty column with a non-empty one is length-mismatched and must raise instead
+    # of being silently dropped (which used to truncate the dataset to 0 rows).
+    output = pa.BufferOutputStream()
+    with ArrowWriter(stream=output) as writer:
+        with pytest.raises(pa.lib.ArrowInvalid):
+            writer.write_batch({"col_1": [], "col_2": [1]})
+
+
 @pytest.mark.parametrize("writer_batch_size", [None, 1, 10])
 @pytest.mark.parametrize(
     "fields", [None, {"col_1": pa.string(), "col_2": pa.int64()}, {"col_1": pa.string(), "col_2": pa.int32()}]


### PR DESCRIPTION
## What does this PR do?

Fixes #6879.

`Dataset.map(fn, batched=True)` silently truncates the dataset to **0 rows** (instead of raising) when the mapping function empties an *existing* column while another column stays non-empty.

### Reproducer (from the issue)

```python
import datasets
data = datasets.Dataset.from_dict({"test": [1]})

def mapping_fn(examples):
    return {"test": [], "y": [1]}

data = data.map(mapping_fn, batched=True)
print(len(data))   # 0  -> silent data loss
```

Returning an empty list for a *new* column (e.g. `{"x": []}`) already raises `pyarrow.lib.ArrowInvalid`, so the two cases were inconsistent.

### Root cause

`ArrowWriter._write_batch` skips a batch that "appears empty", but the emptiness check only looked at the **first** column:

```python
if batch_examples and len(next(iter(batch_examples.values()))) == 0:
    return
```

When a batched `map` overwrites an existing column with `[]`, that column stays first in the merged dict, so the whole length-mismatched batch was dropped instead of erroring.

### Fix

Skip the batch only when **every** column is empty. Genuinely empty batches (e.g. a batch that filters out all its rows) are still ignored, while mismatched batches now fall through to `pa.Table.from_arrays`, which raises the same informative `ArrowInvalid` already produced for the new-column case.

```python
if batch_examples and all(len(col_values) == 0 for col_values in batch_examples.values()):
    return
```

### Behavior

| | issue reproducer |
| --- | --- |
| before | no exception, `len(data) == 0` |
| after | `ArrowInvalid: Column 1 named y expected length 0 but got length 1` |

Normal batched `map` and legitimate "all columns empty" batches are unchanged.

### Tests

Added `test_write_batch_with_mismatched_empty_column_raises` in `tests/test_arrow_writer.py`. The existing `test_write_batch` already covers the legitimate all-empty-batch skip, so that path stays protected.

`ruff check` / `ruff format --check` pass; `tests/test_arrow_writer.py` passes locally.
