### PR TITLE
Fix Dataset.take raising IndexError when taking more elements than available

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4699,7 +4699,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
          'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .'}]
         ```
         """
-        return self.select(range(n))
+        # Clamp `n` to the dataset length so taking more elements than available
+        # returns the whole dataset instead of raising an IndexError, matching
+        # the behavior of `IterableDataset.take`.
+        return self.select(range(min(n, len(self))))
 
     @transmit_format
     @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2885,6 +2885,23 @@ class BaseDatasetTest(TestCase):
                 with dset.shard(num_shards=3, index=0) as dset_sharded_formatted:
                     self.assertEqual(dset_sharded_formatted.format["type"], "numpy")
 
+    def test_take(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                n = len(dset)
+                with dset.take(2) as taken:
+                    self.assertEqual(len(taken), 2)
+                    self.assertEqual(taken["filename"], dset["filename"][:2])
+                with dset.take(n) as taken:
+                    self.assertEqual(len(taken), n)
+                # taking more elements than available returns the whole dataset instead
+                # of raising an IndexError, matching the behavior of IterableDataset.take
+                with dset.take(n + 10) as taken:
+                    self.assertEqual(len(taken), n)
+                    self.assertEqual(taken["filename"], dset["filename"])
+                with dset.take(0) as taken:
+                    self.assertEqual(len(taken), 0)
+
     def test_flatten_indices(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:


### PR DESCRIPTION
### Description
`Dataset.take(n)` is implemented as `self.select(range(n))`, so when `n` is larger than the dataset length it raises `IndexError: Index N out of range for dataset of size M` instead of returning the whole dataset. This is inconsistent with `IterableDataset.take`, which clamps and returns all available elements — the two were meant to be aligned (see #6813). `Dataset.skip` already clamps correctly (`range(n, len(self))`); only `take` was affected.

This clamps `n` to `len(self)` so `take` returns the whole dataset when asked for more, matching `IterableDataset.take` and the "first `n` elements" semantics documented in the method.

### Steps to reproduce (before this change)
```python
from datasets import Dataset
Dataset.from_dict({"a": [0, 1, 2]}).take(5)   # IndexError: Index 4 out of range for dataset of size 3.
```
`IterableDataset.take(5)` on the same data returns all 3 rows.

### Test plan
- Added `test_take` to `BaseDatasetTest` (runs both in-memory and on-disk) covering fewer / exact / more-than-available / zero.
- The `n > len` case fails on current `main` (`IndexError`) and passes with this change; existing behavior for `n <= len` is unchanged.

### AI disclosure
This fix was prepared with the assistance of an AI coding assistant; the bug was reproduced and the behavior verified before submitting.
