### PR TITLE
Fix crash on millisecond-scale started_at in hermes agent traces

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -181,9 +181,9 @@ class Json(datasets.ArrowBasedBuilder):
                     for i, training_example in enumerate(training_examples):
                         if training_example["metadata"]["trace_type"] == "hermes":
                             timestamp = ujson_loads(lines[i])["started_at"]
-                            milliseconds = timestamp if timestamp <= 10_000_000_000 else timestamp * 1_000
+                            seconds = timestamp if timestamp <= 10_000_000_000 else timestamp / 1_000
                             sent_at = (
-                                datetime.fromtimestamp(milliseconds, tz=timezone.utc)
+                                datetime.fromtimestamp(seconds, tz=timezone.utc)
                                 .isoformat(timespec="milliseconds")
                                 .replace("+00:00", "Z")
                             )

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -447,6 +447,10 @@ HERMES_SESSION = {
     ],
 }
 
+# Same session, but `started_at` expressed in milliseconds (e.g. JS `Date.now()`-style)
+# instead of seconds -- the same real-world instant as HERMES_SESSION.
+HERMES_SESSION_MS = {**HERMES_SESSION, "started_at": 1_780_665_768_307}
+
 
 DROID_SESSION = [
     {
@@ -720,6 +724,14 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
             "hermes_two_sessions.jsonl",
             [HERMES_SESSION] * 2,
             ("hermes", "20260605_092247_d018ec", "Run pwd and date.", "2026-06-05T13:22:48.307Z", 1, 1),
+        ),
+        pytest.param(
+            "hermes_ms.jsonl",
+            [HERMES_SESSION_MS],
+            # Same instant as the seconds-form "hermes" case above -- `started_at` is
+            # just expressed in milliseconds here.
+            ("hermes", "20260605_092247_d018ec", "Run pwd and date.", "2026-06-05T13:22:48.307Z", 1, 1),
+            id="hermes-ms",
         ),
         pytest.param(
             "droid.jsonl",


### PR DESCRIPTION
## Summary

Parsing a hermes-format agent trace whose `started_at` is expressed in milliseconds crashes with `OSError: [Errno 22] Invalid argument`.

## The bug

`src/datasets/packaged_modules/json/json.py` normalizes `started_at` before feeding it to `datetime.fromtimestamp` (which expects **seconds**), using a magnitude check to detect whether the input is already in milliseconds:

```python
timestamp = ujson_loads(lines[i])["started_at"]
milliseconds = timestamp if timestamp <= 10_000_000_000 else timestamp * 1_000
sent_at = datetime.fromtimestamp(milliseconds, tz=timezone.utc)...
```

The large-magnitude branch (`timestamp > 10_000_000_000`, i.e. already milliseconds) should convert **down** to seconds by dividing by 1000 — instead it multiplies by 1000 again. For a real millisecond-scale `started_at` (a common convention, e.g. `Date.now()`-style timestamps), this produces a value representing a date roughly 56 million years in the future, and `datetime.fromtimestamp` raises `OSError: [Errno 22] Invalid argument` on Windows (`OverflowError`/`ValueError` on other platforms for the same reason), aborting the whole trace-loading path.

```python
>>> from datetime import datetime, timezone
>>> ts = 1_780_665_768_307  # same instant as the existing seconds-form test fixture, in ms
>>> ms = ts if ts <= 10_000_000_000 else ts * 1_000
>>> datetime.fromtimestamp(ms, tz=timezone.utc)
OSError: [Errno 22] Invalid argument
```

## The fix

Divide instead of multiply, and rename the variable to `seconds` (what it actually holds, and what `datetime.fromtimestamp` expects):

```python
timestamp = ujson_loads(lines[i])["started_at"]
seconds = timestamp if timestamp <= 10_000_000_000 else timestamp / 1_000
sent_at = datetime.fromtimestamp(seconds, tz=timezone.utc)...
```

## Tests

Adds `HERMES_SESSION_MS` — the existing `HERMES_SESSION` fixture with `started_at` re-expressed in milliseconds for the same real-world instant — and a new `hermes-ms` parametrized case in `test_json_generate_tables_with_agent_trace_metadata`, asserting the exact same `sent_at` output as the existing seconds-form `hermes` case.

Verified fail-before / pass-after against the real library (via `PYTHONPATH` pointed at this checkout, with `teich` installed so the `@require_teich`-gated tests actually run): the new `hermes-ms` case raises `OSError` before the fix and passes after; the two pre-existing hermes cases are unaffected either way. Full file: `36 passed`.

```
pytest tests/packaged_modules/test_json.py -k hermes
```

`ruff format --check` and `ruff check` are clean.
