### PR TITLE
Fix size_str(0) returning "Unknown size" instead of "0 bytes"

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -79,7 +79,7 @@ def size_str(size_in_bytes):
         size_in_bytes: `int` or `None`, the size, in bytes, that we want to
             format as a human-readable size string.
     """
-    if not size_in_bytes:
+    if size_in_bytes is None:
         return "Unknown size"
 
     _NAME_LIST = [("PiB", 2**50), ("TiB", 2**40), ("GiB", 2**30), ("MiB", 2**20), ("KiB", 2**10)]

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -15,6 +15,7 @@ from datasets.utils.py_utils import (
     asdict,
     iflatmap_unordered,
     map_nested,
+    size_str,
     string_to_dict,
     temp_seed,
     temporary_assignment,
@@ -270,6 +271,21 @@ def test_iflatmap_unordered():
         assert out.count("a") == 2
         assert out.count("b") == 2
         assert len(out) == 4
+
+
+@pytest.mark.parametrize(
+    "size_in_bytes, expected",
+    [
+        (None, "Unknown size"),
+        (0, "0 bytes"),
+        (512, "512 bytes"),
+        (1536, "1.50 KiB"),
+        (2**20, "1.00 MiB"),
+    ],
+)
+def test_size_str(size_in_bytes, expected):
+    # Only `None` is an unknown size; 0 is a valid size that must render as "0 bytes".
+    assert size_str(size_in_bytes) == expected
 
 
 def test_string_to_dict():


### PR DESCRIPTION
`size_str` uses `if not size_in_bytes:` to return `"Unknown size"`, which also catches `0`. But `0` is a valid size (0 bytes), and the docstring states that only `None` means "Unknown size". So a 0-byte size (e.g. an empty split) currently renders as "Unknown size":

```python
>>> from datasets.utils.py_utils import size_str
>>> size_str(0)
'Unknown size'   # expected '0 bytes'
```
This checks `size_in_bytes is None` instead. Added a regression test covering `None`, `0`, and non-zero sizes.