### PR TITLE
Preserve features after IterableDataset.add_column

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4036,7 +4036,14 @@ class IterableDataset(DatasetInfoMixin):
         Returns:
             `IterableDataset`
         """
-        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
+        original_features = self._info.features.copy() if self._info.features else None
+        ds_iterable = self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
+        if original_features is not None:
+            col_table = pa.table({name: column})
+            new_features = original_features.copy()
+            new_features[name] = Features.from_arrow_schema(col_table.schema)[name]
+            ds_iterable._info.features = new_features
+        return ds_iterable
 
     def rename_column(self, original_column_name: str, new_column_name: str) -> "IterableDataset":
         """


### PR DESCRIPTION
## What

`IterableDataset.add_column` delegates to `map` but never propagates the schema. After the call, `dataset.features` is `None` even when the original dataset had a typed schema, silently breaking all downstream code that inspects features.

## Root cause

The implementation is a one-liner:
```python
return self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
```
`map` without an explicit `features` argument does not infer schema from the mapper output.

## Fix

Follow the same pattern used by `rename_columns`: snapshot the existing features before the map, infer the new column's type from the column data via PyArrow (one line, pyarrow is already a required dependency), merge, and write back to `_info.features`.

```python
original_features = self._info.features.copy() if self._info.features else None
ds_iterable = self.map(...)
if original_features is not None:
    col_table = pa.table({name: column})
    new_features = original_features.copy()
    new_features[name] = Features.from_arrow_schema(col_table.schema)[name]
    ds_iterable._info.features = new_features
return ds_iterable
```

If the original dataset had no features schema (`features is None`), behavior is unchanged.

Fixes #5752.