### PR TITLE
Cast multi-dimensional numpy arrays when inferring IterableDataset features

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -127,7 +127,7 @@ def add_column_fn(example: dict, idx: int, name: str, column: list[dict]):
 
 
 def _infer_features_from_batch(batch: dict[str, list], try_features: Optional[Features] = None) -> Features:
-    pa_table = pa.Table.from_pydict(batch)
+    pa_table = pa.Table.from_pydict(cast_to_python_objects(batch, only_1d_for_numpy=True))
     if try_features is not None:
         try:
             pa_table = table_cast(pa_table, pa.schema(try_features.type))

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -3182,3 +3182,19 @@ class TestIterableColumn:
         texts = ds["text"]
         assert isinstance(texts, IterableColumn)
         assert list(texts) == [["Good", "Bad"], ["Good again", "Bad again"]]
+
+
+def test_iterable_dataset_resolve_features_from_multidim_numpy():
+    # Regression for https://github.com/huggingface/datasets/issues/7100: resolving
+    # the features of an IterableDataset whose map yields multi-dimensional numpy
+    # arrays must not raise "Can only convert 1-dimensional array values". The batch
+    # is routed through cast_to_python_objects(..., only_1d_for_numpy=True) like the
+    # other Arrow-table builders in iterable_dataset.py.
+    ds = (
+        Dataset.from_dict({"a": [[[1, 2, 3], [1, 2, 3]]]})
+        .to_iterable_dataset()
+        .map(lambda x: {"a": [np.array(x["a"])]})
+    )
+    ds = ds._resolve_features()
+    assert ds.features is not None
+    assert "a" in ds.features


### PR DESCRIPTION
## Summary

`IterableDataset._resolve_features()` crashes when a `map` function yields multi-dimensional numpy arrays:

```python
from datasets import Dataset
import numpy as np
ds = Dataset.from_dict({"a": [[[1, 2, 3], [1, 2, 3]]]}).to_iterable_dataset().map(lambda x: {"a": [np.array(x["a"])]})
ds._resolve_features()
# pyarrow.lib.ArrowInvalid: Can only convert 1-dimensional array values
```

Feature inference goes `_resolve_features()` -> `_infer_features_from_batch(...)` -> `pa.Table.from_pydict(batch)`, and PyArrow's `from_pydict` only accepts 1-dimensional array values, so any 2D+ numpy array in a column crashes it.

Every other place in `iterable_dataset.py` that builds an Arrow table from raw examples first routes the data through `cast_to_python_objects(..., only_1d_for_numpy=True)` (lines 173 and 184), which recursively turns multi-dimensional numpy/tensor values into nested lists of 1-D arrays that PyArrow accepts. The non-streaming `Dataset`/`ArrowWriter` path does the same. `_infer_features_from_batch` was simply missing that cast.

## Fix

Route the batch through `cast_to_python_objects(batch, only_1d_for_numpy=True)` before `from_pydict`. The helper is already imported in this module, and it is a no-op for ordinary Python data, so plain batches infer identically.

Fixes #7100.

## Test

`tests/test_iterable_dataset.py::test_iterable_dataset_resolve_features_from_multidim_numpy` resolves the features of an `IterableDataset` whose `map` yields multi-dimensional numpy arrays. It raises `ArrowInvalid` before the fix and passes after (resolving to a nested `List(...)`).