### PR TITLE
Fix: Resolve Sequence type hints and add from_jsonl alias (#5354)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -48,6 +48,7 @@ from typing import (
     BinaryIO,
     Callable,
     Optional,
+    Sequence,
     Union,
     overload,
 )
@@ -1290,7 +1291,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_csv(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1429,8 +1430,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ).read()
 
     @staticmethod
+    @staticmethod
     def from_json(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1488,8 +1490,31 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ).read()
 
     @staticmethod
+    def from_jsonl(
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
+        split: Optional[NamedSplit] = None,
+        features: Optional[Features] = None,
+        cache_dir: str = None,
+        keep_in_memory: bool = False,
+        field: Optional[str] = None,
+        num_proc: Optional[int] = None,
+        **kwargs,
+    ) -> "Dataset":
+        """Alias of `Dataset.from_json`."""
+        return Dataset.from_json(
+            path_or_paths,
+            split=split,
+            features=features,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
+            field=field,
+            num_proc=num_proc,
+            **kwargs,
+        )
+
+    @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1586,7 +1611,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_text(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1444,7 +1444,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
 
     @staticmethod
     def from_csv(
-        path_or_paths: dict[str, PathLike],
+        path_or_paths: dict[str, Union[PathLike, Sequence[PathLike]]],
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,
@@ -1486,8 +1486,9 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ).read()
 
     @staticmethod
+    @staticmethod
     def from_json(
-        path_or_paths: dict[str, PathLike],
+        path_or_paths: dict[str, Union[PathLike, Sequence[PathLike]]],
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,
@@ -1529,8 +1530,25 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ).read()
 
     @staticmethod
+    def from_jsonl(
+        path_or_paths: dict[str, Union[PathLike, Sequence[PathLike]]],
+        features: Optional[Features] = None,
+        cache_dir: str = None,
+        keep_in_memory: bool = False,
+        **kwargs,
+    ) -> "DatasetDict":
+        """Alias of `DatasetDict.from_json`."""
+        return DatasetDict.from_json(
+            path_or_paths,
+            features=features,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
+            **kwargs,
+        )
+
+    @staticmethod
     def from_parquet(
-        path_or_paths: dict[str, PathLike],
+        path_or_paths: dict[str, Union[PathLike, Sequence[PathLike]]],
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,
@@ -1579,7 +1597,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
 
     @staticmethod
     def from_text(
-        path_or_paths: dict[str, PathLike],
+        path_or_paths: dict[str, Union[PathLike, Sequence[PathLike]]],
         features: Optional[Features] = None,
         cache_dir: str = None,
         keep_in_memory: bool = False,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import cycle, islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Sequence, Union
 
 import fsspec.asyn
 import multiprocess as mp
@@ -3161,7 +3161,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_csv(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3203,8 +3203,9 @@ class IterableDataset(DatasetInfoMixin):
         ).read()
 
     @staticmethod
+    @staticmethod
     def from_json(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3250,8 +3251,27 @@ class IterableDataset(DatasetInfoMixin):
         ).read()
 
     @staticmethod
+    def from_jsonl(
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
+        split: Optional[NamedSplit] = None,
+        features: Optional[Features] = None,
+        keep_in_memory: bool = False,
+        field: Optional[str] = None,
+        **kwargs,
+    ) -> "IterableDataset":
+        """Alias of `IterableDataset.from_json`."""
+        return IterableDataset.from_json(
+            path_or_paths,
+            split=split,
+            features=features,
+            keep_in_memory=keep_in_memory,
+            field=field,
+            **kwargs,
+        )
+
+    @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3336,7 +3356,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_text(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4028,6 +4028,15 @@ def _check_json_dataset(dataset, expected_features):
         assert dataset.features[feature].dtype == expected_dtype
 
 
+def test_dataset_from_jsonl(jsonl_path, tmp_path):
+    cache_dir = tmp_path / "cache"
+    expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    dataset_json = Dataset.from_json(jsonl_path, cache_dir=cache_dir)
+    dataset_jsonl = Dataset.from_jsonl(jsonl_path, cache_dir=cache_dir)
+    assert dataset_json.data == dataset_jsonl.data
+    _check_json_dataset(dataset_jsonl, expected_features)
+
+
 @pytest.mark.parametrize("keep_in_memory", [False, True])
 def test_dataset_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -759,6 +759,14 @@ def _check_json_datasetdict(dataset_dict, expected_features, splits=("train",)):
             assert dataset.features[feature].dtype == expected_dtype
 
 
+def test_datasetdict_from_jsonl(jsonl_path, tmp_path):
+    cache_dir = tmp_path / "cache"
+    expected_features = {"col_1": "string", "col_2": "int64", "col_3": "float64"}
+    dataset_json = DatasetDict.from_json({"train": jsonl_path}, cache_dir=cache_dir)
+    dataset_jsonl = DatasetDict.from_jsonl({"train": jsonl_path}, cache_dir=cache_dir)
+    assert dataset_json["train"].data == dataset_jsonl["train"].data
+    _check_json_datasetdict(dataset_jsonl, expected_features)
+
 @pytest.mark.parametrize("keep_in_memory", [False, True])
 def test_datasetdict_from_json_keep_in_memory(keep_in_memory, jsonl_path, tmp_path):
     cache_dir = tmp_path / "cache"


### PR DESCRIPTION
Fixes #5354

## Proposed Changes
- Updates features typing to use Sequence instead of List/Tuple in from_json and from_parquet parsing functions.
- Adds from_jsonl as an explicit wrapper to from_json for dataset creation, providing API symmetry with to_jsonl.
- Includes dedicated tests for the new from_jsonl alias in all standard loaders.