### PR TITLE
Raise on Dataset.rename_columns name collision with an existing column

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2655,6 +2655,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if empty_new_columns:
             raise ValueError(f"New column names {empty_new_columns} are empty.")
 
+        colliding_new_columns = set(column_mapping.values()) & (
+            set(dataset.column_names) - set(column_mapping.keys())
+        )
+        if colliding_new_columns:
+            raise ValueError(
+                f"New column names {colliding_new_columns} already in the dataset. "
+                f"Please choose column names which are not already in the dataset. "
+                f"Current columns in the dataset: {dataset._data.column_names}"
+            )
+
         def rename(columns):
             return [column_mapping[col] if col in column_mapping else col for col in columns]
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2655,9 +2655,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if empty_new_columns:
             raise ValueError(f"New column names {empty_new_columns} are empty.")
 
-        colliding_new_columns = set(column_mapping.values()) & (
-            set(dataset.column_names) - set(column_mapping.keys())
-        )
+        colliding_new_columns = set(column_mapping.values()) & (set(dataset.column_names) - set(column_mapping.keys()))
         if colliding_new_columns:
             raise ValueError(
                 f"New column names {colliding_new_columns} already in the dataset. "

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -110,9 +110,10 @@ def _rename_columns_fn(example: dict, column_mapping: dict[str, str]):
         raise ValueError(
             f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {set(column_mapping) - set(example)} are not in the dataset."
         )
-    if any(col in example for col in column_mapping.values()):
+    colliding_new_columns = set(column_mapping.values()) & (set(example) - set(column_mapping))
+    if colliding_new_columns:
         raise ValueError(
-            f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {set(example) - set(column_mapping.values())} are already in the dataset."
+            f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {colliding_new_columns} are already in the dataset."
         )
     return {
         new_column_name: example[original_column_name]
@@ -4106,6 +4107,14 @@ class IterableDataset(DatasetInfoMixin):
         """
 
         original_features = self._info.features.copy() if self._info.features else None
+        if original_features is not None:
+            colliding_new_columns = set(column_mapping.values()) & (set(original_features) - set(column_mapping))
+            if colliding_new_columns:
+                raise ValueError(
+                    f"New column names {colliding_new_columns} already in the dataset. "
+                    "Please choose column names which are not already in the dataset. "
+                    f"Current columns in the dataset: {list(original_features)}"
+                )
         ds_iterable = self.map(
             partial(_rename_columns_fn, column_mapping=column_mapping), remove_columns=list(column_mapping)
         )

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -688,6 +688,17 @@ class BaseDatasetTest(TestCase):
                 with self.assertRaises(ValueError):
                     dset.rename_columns({"col_1": "new_name", "col_2": "new_name"})
 
+                # New name collides with an existing column that isn't itself being renamed:
+                # this must raise instead of silently producing two columns named "col_2"
+                # while `features`/`column_names` disagree with the underlying arrow table.
+                with self.assertRaises(ValueError):
+                    dset.rename_columns({"col_1": "col_2"})
+
+                # A swap (each renamed column's new name is itself being renamed away) must still work.
+                with dset.rename_columns({"col_1": "col_2", "col_2": "col_1"}) as new_dset:
+                    self.assertEqual(new_dset.num_columns, 3)
+                    self.assertListEqual(list(new_dset.column_names), ["col_2", "col_1", "col_3"])
+
     def test_select_columns(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2445,6 +2445,24 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns: IterableD
     assert all(c in new_dataset.column_names for c in ["new_id", "filename"])
 
 
+def test_iterable_dataset_rename_columns_swap(dataset_with_several_columns: IterableDataset):
+    column_mapping = {"id": "filepath", "filepath": "id"}
+    expected = [{column_mapping.get(k, k): v for k, v in example.items()} for example in dataset_with_several_columns]
+
+    assert list(dataset_with_several_columns.rename_columns(column_mapping)) == expected
+    assert list(dataset_with_several_columns._resolve_features().rename_columns(column_mapping)) == expected
+
+
+def test_iterable_dataset_rename_columns_collision(dataset_with_several_columns: IterableDataset):
+    column_mapping = {"id": "filepath"}
+
+    with pytest.raises(ValueError, match="already in the dataset"):
+        list(dataset_with_several_columns.rename_columns(column_mapping))
+
+    with pytest.raises(ValueError, match="already in the dataset"):
+        dataset_with_several_columns._resolve_features().rename_columns(column_mapping)
+
+
 def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.remove_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
### What

`Dataset.rename_column` (singular) already rejects a new column name that collides with an
existing column:

```python
>>> ds.rename_column("foo", "bar")  # "bar" already exists
ValueError: New column name bar already in the dataset. ...
```

`Dataset.rename_columns` (plural, dict-based) has no equivalent check. Renaming a column to a
name that collides with an existing, untouched column silently produces a `Dataset` whose
underlying Arrow table has two columns with the same name, while `dataset.features` (built
from a Python dict) collapses to one entry for that name. The two become inconsistent, and in
the reproduction below the renamed column's data becomes unreachable through the normal read
paths (`ds[:]`, `to_dict()`, `to_pandas()`, iteration, ...) with no exception raised anywhere.

```python
from datasets import Dataset

ds = Dataset.from_dict({"foo": [1, 2, 3], "bar": [10, 20, 30], "baz": [100, 200, 300]})
ds2 = ds.rename_columns({"foo": "bar"})

ds2.column_names   # ['bar', 'bar', 'baz']  -- two Arrow columns named "bar"
ds2.features       # {'bar': ..., 'baz': ...} -- only one "bar" entry
ds2[:]             # {'bar': [10, 20, 30], 'baz': [...]}  -- foo's [1, 2, 3] is gone
```

Since `DatasetDict.rename_columns` forwards directly to `Dataset.rename_columns` per split,
the same corruption is reachable from `DatasetDict` too.

### Fix

Add the same collision check `rename_column` already performs, generalized to the mapping
case: a new name is rejected only if it collides with a column that isn't itself being renamed
away in the same call (so swaps like `{"a": "b", "b": "a"}` and no-op renames like
`{"a": "a"}` keep working).

```python
colliding_new_columns = set(column_mapping.values()) & (
    set(dataset.column_names) - set(column_mapping.keys())
)
if colliding_new_columns:
    raise ValueError(
        f"New column names {colliding_new_columns} already in the dataset. "
        f"Please choose column names which are not already in the dataset. "
        f"Current columns in the dataset: {dataset._data.column_names}"
    )
```

### Test

Added to `tests/test_arrow_dataset.py::BaseDatasetTest.test_rename_columns`:
- Asserts `ValueError` on a colliding rename (`{"col_1": "col_2"}` where `col_2` already
  exists and isn't being renamed).
- Asserts a swap (`{"col_1": "col_2", "col_2": "col_1"}`) still succeeds, to confirm the fix
  doesn't over-reject legitimate renames.

Confirmed the added assertions fail on `main` with `AssertionError: ValueError not raised`
(not a generic error) and pass with the fix (`pytest tests/test_arrow_dataset.py -k rename`:
2 failed on the unmodified baseline, 4 passed with the fix). A prior full run of
`tests/test_arrow_dataset.py` with this change: 360 passed, 61 skipped, 1 pre-existing
unrelated failure (a PyTorch-formatting test that fails identically on `main` because torch
isn't installed in the test env).

### Compatibility

Pure Python, no new imports, no version-gated syntax. Only affects the specific case where a
`rename_columns` mapping's target name collides with an existing column outside the mapping;
that call previously produced silently-corrupted output, so this is a bug fix, not a behavior
users could be relying on for correct results.
