### PR TITLE
Support batched=True in Dataset.to_dict

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5399,17 +5399,28 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds.to_dict()
         ```
         """
-        result = query_table(
-            table=self._data,
-            key=slice(0, len(self)),
-            indices=self._indices,
-        ).to_pydict()
         from .utils.json import get_json_field_paths_from_feature, json_decode_field
 
-        for json_field_path in get_json_field_paths_from_feature(self.features):
-            col, *json_field_subpath = json_field_path
-            result[col] = [json_decode_field(row, json_field_subpath) for row in result[col]]
-        return result
+        json_field_paths = get_json_field_paths_from_feature(self.features)
+
+        def query_to_dict(key: slice) -> dict:
+            result = query_table(
+                table=self._data,
+                key=key,
+                indices=self._indices,
+            ).to_pydict()
+            for json_field_path in json_field_paths:
+                col, *json_field_subpath = json_field_path
+                result[col] = [json_decode_field(row, json_field_subpath) for row in result[col]]
+            return result
+
+        if not batched:
+            return query_to_dict(slice(0, len(self)))
+        else:
+            batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
+            return (
+                query_to_dict(slice(offset, offset + batch_size)) for offset in range(0, len(self), batch_size)
+            )
 
     def to_list(self) -> list:
         """Returns the dataset as a Python list.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5418,9 +5418,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             return query_to_dict(slice(0, len(self)))
         else:
             batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
-            return (
-                query_to_dict(slice(offset, offset + batch_size)) for offset in range(0, len(self), batch_size)
-            )
+            return (query_to_dict(slice(offset, offset + batch_size)) for offset in range(0, len(self), batch_size))
 
     def to_list(self) -> list:
         """Returns the dataset as a Python list.

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2557,6 +2557,16 @@ class BaseDatasetTest(TestCase):
                 for col_name in dset.column_names:
                     self.assertLessEqual(len(dset_to_dict[col_name]), len(dset))
 
+                # Batched
+                batch_size = dset.num_rows - 1
+                to_dict_generator = dset.to_dict(batched=True, batch_size=batch_size)
+
+                for batch in to_dict_generator:
+                    self.assertIsInstance(batch, dict)
+                    self.assertListEqual(sorted(batch.keys()), sorted(dset.column_names))
+                    for col_name in dset.column_names:
+                        self.assertLessEqual(len(batch[col_name]), batch_size)
+
                 # With index mapping
                 with dset.select([1, 0, 3]) as dset:
                     dset_to_dict = dset.to_dict()


### PR DESCRIPTION
## What does this do?

`Dataset.to_dict(batch_size=..., batched=True)` silently ignores both arguments and always returns the full dict, even though its signature, docstring ("Set to `True` to return a generator that yields the dataset as batches"), and `-> Union[dict, Iterator[dict]]` return type all promise batching. The sibling methods `to_pandas` and `to_polars` implement batching; `to_dict` was missing the branch.

Because it returns a plain `dict` instead of the promised generator, iterating the result as documented walks the dict *keys* and raises:

```python
from datasets import Dataset
ds = Dataset.from_dict({"a": list(range(10))})
out = ds.to_dict(batched=True, batch_size=3)
type(out)                 # dict, not a generator
for batch in out:
    batch["a"]            # TypeError: string indices must be integers, not 'str'
```

## Fix

Mirror the `to_pandas`/`to_polars` structure: return the full dict when `batched=False`, otherwise return a generator that yields `batch_size`-row slices (defaulting `batch_size` to `config.DEFAULT_MAX_BATCH_SIZE`). A small local closure keeps the per-batch JSON-field decoding from being duplicated across the two branches.

After the fix:

```python
[len(b["a"]) for b in ds.to_dict(batched=True, batch_size=3)]   # [3, 3, 3, 1]
```

Backward compatible: `batched` defaults to `False`, so every existing `.to_dict()` call still returns a plain dict (verified byte-identical). Index mapping (`select(...)`) and `Json()`-feature decoding both work in batched and non-batched modes.

## Test

Added a "Batched" block to `tests/test_arrow_dataset.py::test_to_dict`, mirroring the existing `test_to_pandas`/`test_to_polars` coverage: it asserts each yielded batch is a `dict` with the right columns and no more than `batch_size` rows. It fails before this change (the returned dict is iterated as keys) and passes after.
