### PR TITLE
Fix column loss in horizontal concatenation of arrow-backed IterableDatasets

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1176,7 +1176,7 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
                         new_pa_table = table
                     else:
                         for name, col in zip(table.column_names, table.columns):
-                            new_pa_table = pa_table.append_column(name, col)
+                            new_pa_table = new_pa_table.append_column(name, col)
                 new_key = "_".join(str(key) for key in keys)
                 yield new_key, new_pa_table
             else:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2523,6 +2523,20 @@ def test_concatenate_datasets_axis_1_with_different_lengths():
     assert list(concatenated_dataset) == [{**x, **y} for x, y in zip(extended_dataset2_list, dataset1)]
 
 
+def test_concatenate_datasets_axis_1_arrow_backed():
+    # Arrow-backed iterables iterate via the `_iter_arrow` path, which previously
+    # dropped the first dataset's columns during horizontal concatenation (it
+    # appended onto the last source's table instead of the running accumulator).
+    dataset1 = Dataset.from_dict({"a": [1, 2, 3]}).to_iterable_dataset()
+    dataset2 = Dataset.from_dict({"b": [4, 5, 6]}).to_iterable_dataset()
+    concatenated_dataset = concatenate_datasets([dataset1, dataset2], axis=1)
+    assert list(concatenated_dataset) == [
+        {"a": 1, "b": 4},
+        {"a": 2, "b": 5},
+        {"a": 3, "b": 6},
+    ]
+
+
 @require_torch
 @require_tf
 @require_jax


### PR DESCRIPTION
## Bug

`concatenate_datasets([...], axis=1)` over arrow-backed `IterableDataset`s (e.g. from `.to_iterable_dataset()`) silently drops the **first** dataset's columns and duplicates the **last** dataset's column.

In `HorizontallyConcatenatedMultiSourcesExamplesIterable._iter_arrow`, the merged table is built by appending each later source's columns onto the running accumulator `new_pa_table`. But it appended onto `pa_table` — the loop variable left over from the fetch loop just above, which holds the *last* source's table — and reassigned `new_pa_table` on each iteration instead of accumulating onto it.

## Reproduction

```python
from datasets import Dataset, concatenate_datasets

a = Dataset.from_dict({"a": [1, 2, 3]}).to_iterable_dataset()
b = Dataset.from_dict({"b": [4, 5, 6]}).to_iterable_dataset()
print(list(concatenate_datasets([a, b], axis=1)))
# Expected: [{'a': 1, 'b': 4}, {'a': 2, 'b': 5}, {'a': 3, 'b': 6}]
# Actual (before fix): column 'a' is lost (nulled) and 'b' is duplicated,
#                      which then fails casting to the merged features
```

The non-arrow `__iter__` path is correct (it uses `new_example.update(...)`); only the arrow path was affected. That's why the existing `test_concatenate_datasets_axis_1*` tests — which use `ExamplesIterable` and never hit `_iter_arrow` — didn't catch it.

## Fix

Accumulate onto `new_pa_table` instead of `pa_table` (one line).

## Test

Added `test_concatenate_datasets_axis_1_arrow_backed`, which exercises the arrow-backed path and fails without the fix.
