### PR TITLE
Include file size in dataset fingerprint

### DIFF
--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -515,7 +515,11 @@ def _get_single_origin_metadata(
     # s3fs uses "ETag", gcsfs uses "etag", and for local we simply check mtime
     for key in ["ETag", "etag", "mtime"]:
         if key in info:
-            return (str(info[key]),)
+            return (
+                str(info[key]) + "-" + str(info["size"])
+                if "size" in info
+                else str(info[key]),
+            )
     return ()
 
 

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -515,11 +515,7 @@ def _get_single_origin_metadata(
     # s3fs uses "ETag", gcsfs uses "etag", and for local we simply check mtime
     for key in ["ETag", "etag", "mtime"]:
         if key in info:
-            return (
-                str(info[key]) + "-" + str(info["size"])
-                if "size" in info
-                else str(info[key]),
-            )
+            return (str(info[key]) + "-" + str(info["size"]) if "size" in info else str(info[key]),)
     return ()
 
 

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -2,7 +2,7 @@ import copy
 import os
 from pathlib import Path
 from typing import List
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import fsspec
 import pytest
@@ -15,6 +15,7 @@ from datasets.data_files import (
     DataFilesPatternsDict,
     DataFilesPatternsList,
     _get_data_files_patterns,
+    _get_single_origin_metadata,
     _is_inside_unrequested_special_dir,
     _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir,
     get_data_patterns,
@@ -691,9 +692,6 @@ def test_get_data_patterns_from_directory_with_the_word_data_twice(tmp_path):
     data_file_patterns = get_data_patterns(repo_dir.as_posix())
     assert data_file_patterns == {"train": ["data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"]}
 
-
-from unittest.mock import MagicMock, patch
-from datasets.data_files import _get_single_origin_metadata
 
 @patch("datasets.data_files.url_to_fs")
 def test_get_single_origin_metadata_includes_size(mock_url_to_fs):

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -690,3 +690,17 @@ def test_get_data_patterns_from_directory_with_the_word_data_twice(tmp_path):
     data_file.touch()
     data_file_patterns = get_data_patterns(repo_dir.as_posix())
     assert data_file_patterns == {"train": ["data/train-[0-9][0-9][0-9][0-9][0-9]-of-[0-9][0-9][0-9][0-9][0-9]*.*"]}
+
+
+from unittest.mock import MagicMock, patch
+from datasets.data_files import _get_single_origin_metadata
+
+@patch("datasets.data_files.url_to_fs")
+def test_get_single_origin_metadata_includes_size(mock_url_to_fs):
+    mock_fs = MagicMock()
+    mock_fs.info.return_value = {"etag": "my_etag_123", "size": 1024}
+    mock_url_to_fs.return_value = (mock_fs, "some_path.txt")
+    
+    metadata = _get_single_origin_metadata("http://example.com/some_path.txt")
+    
+    assert metadata == ("my_etag_123-1024",)

--- a/tests/test_data_files.py
+++ b/tests/test_data_files.py
@@ -698,7 +698,7 @@ def test_get_single_origin_metadata_includes_size(mock_url_to_fs):
     mock_fs = MagicMock()
     mock_fs.info.return_value = {"etag": "my_etag_123", "size": 1024}
     mock_url_to_fs.return_value = (mock_fs, "some_path.txt")
-    
+
     metadata = _get_single_origin_metadata("http://example.com/some_path.txt")
-    
+
     assert metadata == ("my_etag_123-1024",)


### PR DESCRIPTION
### Motivation
Currently, the dataset cache fingerprints rely entirely on the `ETag`/`etag`/`mtime` metadata fetched during `fs.info()`. If a file's byte size changes on the remote end—and the remote backend fails to reliably update the ETag—the dataset fingerprint stays improperly static. This leads to insidious bugs where an old, structurally distinct dataset cache continues mapping to the new remote file.

### Summary of Changes
* **Modified `_get_single_origin_metadata` in `src/datasets/data_files.py`**:
  Checks if `size` is present in the underlying filesystem's `info` payload, and appends it directly to the ETag string (`{ETag}-{size}`). If the size doesn't exist, it elegantly falls back to the original `ETag` string structure.
* **Updated `tests/test_data_files.py`**:
  Implemented `test_get_single_origin_metadata_includes_size` using a mocked `url_to_fs` patch to guarantee that the `size` byte integer correctly concatenates to the final string tuple emitted by `_get_single_origin_metadata()`.

### Testing
Tested unit test logic behavior locally by verifying that the mock tuple returns `("my_etag_123-1024",)`.