### PR TITLE
Make the dataset fingerprint independent of Arrow chunking

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -707,6 +707,15 @@ class InMemoryTable(TableBlock):
     stay low.
     """
 
+    def __getstate__(self):
+        # Serialize only the underlying table: the `_batches`/`_offsets` index is
+        # derived and rebuilt in `__init__`, and pickling it makes the fingerprint
+        # cost scale with the number of chunks (see #8327).
+        return {"table": self.table}
+
+    def __setstate__(self, state):
+        InMemoryTable.__init__(self, state["table"])
+
     @classmethod
     def from_file(cls, filename: str):
         table = _in_memory_arrow_table_from_file(filename)

--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -157,7 +157,7 @@ def _save_arrowTable(pickler, obj):
     # regardless of chunking. See
     # https://github.com/huggingface/datasets/issues/8327.
     def create_arrowTable(schema, columns):
-        return pa.table({field.name: column for field, column in zip(schema, columns)}).cast(schema)
+        return pa.Table.from_arrays(columns, schema=schema)
 
     log(pickler, f"Ta: {obj}")
     args = (obj.schema, [column.combine_chunks() for column in obj.columns])

--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -19,6 +19,7 @@ from io import BytesIO
 from types import CodeType, FunctionType
 
 import dill
+import pyarrow as pa
 from packaging import version
 
 from .. import config
@@ -144,6 +145,37 @@ def _save_set(pickler, obj):
 
     pickler.save_reduce(set, args, obj=obj)
     log(pickler, "# Se")
+
+
+@pklregister(pa.Table)
+def _save_arrowTable(pickler, obj):
+    # pyarrow's default pickle serializes each chunk's buffers separately, so the
+    # pickled size (and therefore the fingerprint cost) scales with the number of
+    # chunks rather than the amount of data. Serialize a chunk-count-independent
+    # form instead: combine each column's chunks one at a time (bounded memory,
+    # never a full-table copy) so identical data produces identical bytes
+    # regardless of chunking. See
+    # https://github.com/huggingface/datasets/issues/8327.
+    def create_arrowTable(schema, columns):
+        return pa.table({field.name: column for field, column in zip(schema, columns)}).cast(schema)
+
+    log(pickler, f"Ta: {obj}")
+    args = (obj.schema, [column.combine_chunks() for column in obj.columns])
+    pickler.save_reduce(create_arrowTable, args, obj=obj)
+    log(pickler, "# Ta")
+
+
+@pklregister(pa.ChunkedArray)
+def _save_arrowChunkedArray(pickler, obj):
+    # Same rationale as _save_arrowTable: hash a chunk-count-independent form by
+    # combining the chunks into a single array.
+    def create_arrowChunkedArray(array):
+        return pa.chunked_array([array])
+
+    log(pickler, f"Ca: {obj}")
+    args = (obj.combine_chunks(),)
+    pickler.save_reduce(create_arrowChunkedArray, args, obj=obj)
+    log(pickler, "# Ca")
 
 
 def _save_regexPattern(pickler, obj):

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -239,6 +239,21 @@ class HashingTest(TestCase):
         self.assertEqual(hash1, hash2)
         self.assertNotEqual(hash1, hash3)
 
+    def test_hash_arrow_table_is_independent_of_chunking(self):
+        import pyarrow as pa
+
+        def table_with_chunks(num_chunks, num_rows=600):
+            rows_per_chunk = num_rows // num_chunks
+            values = pa.array(["a" * 40] * num_rows)
+            chunks = [values.slice(i * rows_per_chunk, rows_per_chunk) for i in range(num_chunks)]
+            return pa.table({"text": pa.chunked_array(chunks)})
+
+        hash_few_chunks = Hasher.hash(InMemoryTable(table_with_chunks(2)))
+        hash_many_chunks = Hasher.hash(InMemoryTable(table_with_chunks(600)))
+        hash_other_data = Hasher.hash(InMemoryTable(pa.table({"text": pa.array(["b" * 40] * 600)})))
+        self.assertEqual(hash_few_chunks, hash_many_chunks)
+        self.assertNotEqual(hash_few_chunks, hash_other_data)
+
     def test_hash_update(self):
         hasher = Hasher()
         for x in ["hello", Foo("hello")]:


### PR DESCRIPTION
Fixes #8327.

As discussed in the issue, the OOM in `Dataset.from_pandas` comes from `generate_fingerprint`, not from the Arrow conversion. Fingerprinting hashes `dataset.__dict__`, and the underlying `pa.Table` (and the `InMemoryTable` wrapping it) pickles chunk-by-chunk, so the serialized size and the hashing cost scale with the number of chunks rather than the amount of data. `shuffle().to_pandas()` produces one chunk per row, which is where it really blows up.

Following @lhoestq's suggestion to make the table hash chunk-count-independent (rather than calling `combine_chunks()` on the stored data), this PR does two things:

- `InMemoryTable` now serializes via its underlying `table` only. The `_batches`/`_offsets` index is derived and rebuilt in `__init__`, so there's no need to pickle it. This mirrors how `MemoryMappedTable` and `ConcatenationTable` already define `__getstate__`/`__setstate__`.
- `pa.Table` and `pa.ChunkedArray` get dill reducers that serialize a chunk-count-independent form. They combine one column at a time, so memory stays bounded and a table with the same data hashes the same regardless of how it's chunked.

The combine is transient and per-column, so it never materializes a full extra copy of the table.

### Result

On the repro from the issue (25k rows shuffled to one chunk per row), `Dataset.from_pandas` goes from a ~1.5 GB allocation to a few MB. I measured RSS on the scaled 2000-chunk case: the delta across `from_pandas` dropped from ~1500 MB to ~4 MB.

The fingerprint is now stable across different chunkings of the same data and still distinguishes different data. `pickle` round-trips of a dataset reconstruct correctly. `tests/test_fingerprint.py` and `tests/test_table.py` pass (the two failures I see, `test_hash_torch_compiled_module` and `test_move_script_doesnt_change_hash`, also fail on `main` in my environment and are unrelated).

I added `test_hash_arrow_table_is_independent_of_chunking` to cover the invariant.

One thing that I would flag is that this changes the fingerprint values for existing datasets, so it will invalidate caches once. This seems unavoidable for a fix that changes how the table is hashed.
