### PR TITLE
Fix column drop in Arrow path of axis=1 concatenation

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1176,7 +1176,7 @@ class HorizontallyConcatenatedMultiSourcesExamplesIterable(_BaseExamplesIterable
                         new_pa_table = table
                     else:
                         for name, col in zip(table.column_names, table.columns):
-                            new_pa_table = pa_table.append_column(name, col)
+                            new_pa_table = new_pa_table.append_column(name, col)
                 new_key = "_".join(str(key) for key in keys)
                 yield new_key, new_pa_table
             else:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2523,6 +2523,18 @@ def test_concatenate_datasets_axis_1_with_different_lengths():
     assert list(concatenated_dataset) == [{**x, **y} for x, y in zip(extended_dataset2_list, dataset1)]
 
 
+def test_concatenate_datasets_axis_1_arrow_format():
+    # Regression test: the arrow fast-path (_iter_arrow) of horizontal concatenation must
+    # accumulate every source's columns onto new_pa_table, exactly like the plain-Python
+    # __iter__ path above. It previously appended onto the leaked outer-loop table variable,
+    # dropping the first source's columns.
+    ds1 = Dataset.from_dict({"a": [1, 2], "b": [3, 4]}).to_iterable_dataset()
+    ds2 = Dataset.from_dict({"c": [5, 6]}).to_iterable_dataset()
+    table = pa.concat_tables(concatenate_datasets([ds1, ds2], axis=1).with_format("arrow"))
+    assert table.column_names == ["a", "b", "c"]
+    assert table.to_pydict() == {"a": [1, 2], "b": [3, 4], "c": [5, 6]}
+
+
 @require_torch
 @require_tf
 @require_jax


### PR DESCRIPTION
Fixes #8341

### Root cause

`HorizontallyConcatenatedMultiSourcesExamplesIterable._iter_arrow` accumulates the concatenated batch with:

```python
for name, col in zip(table.column_names, table.columns):
    new_pa_table = pa_table.append_column(name, col)
```

`pa_table` here is the loop variable that leaked from the fetch loop above (`key, pa_table = next(pa_table_iterator)`), so it is the *last* source's table, not the accumulator `new_pa_table`. Each iteration also rebuilds `new_pa_table` from scratch. For sources with columns `[a, b]` and `[c]`, the batch becomes the second source's table with `c` appended to itself (columns `[c, c]`), and the first source's columns are lost. With resolved features this surfaces as a `CastError`.

The plain-Python `__iter__` path directly above accumulates correctly (`new_example.update(example)`); only the Arrow fast path diverges.

### Fix

Append onto the accumulator instead of the leaked variable:

```python
new_pa_table = new_pa_table.append_column(name, col)
```

One token. The invariant restored: the Arrow fast path yields the same column set, in the same order, as the plain-Python path.

### Verification

Run in a clean `python:3.11-slim` container against this branch, editable install, `datasets.__file__` confirmed to resolve to the source tree (not site-packages):

- Added `test_concatenate_datasets_axis_1_arrow_format` (public API: two `to_iterable_dataset()` sources with disjoint columns, `concatenate_datasets(axis=1).with_format("arrow")`, asserting columns `['a', 'b', 'c']` and values). It fails on `main` (the `CastError` above) and passes on this branch.
- The three existing `test_concatenate_datasets_axis_1*` tests pass on both `main` and this branch, so behavior of the plain-Python path is unchanged.
- `ruff check` and `ruff format --check` pass on `tests src benchmarks utils setup.py`.

I ran the axis=1 concatenation and `with_format` slice of `tests/test_iterable_dataset.py` (11 passed, 25 skipped for optional torch/tf/jax), not the full test suite.
