### PR TITLE
Decode Json() columns in Dataset.to_pandas()

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5498,6 +5498,19 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             **to_json_kwargs,
         ).write()
 
+    def _decode_json_columns_pandas(self, df: "pd.DataFrame") -> "pd.DataFrame":
+        """Decode `Json` feature columns of a pandas `DataFrame` from their raw Arrow string
+        storage back to Python objects, in place. Keeps `to_pandas` consistent with
+        `to_dict`/`to_list`/`to_json` and `with_format("pandas")`, which already decode."""
+        from functools import partial
+
+        from .utils.json import get_json_field_paths_from_feature, json_decode_field
+
+        for json_field_path in get_json_field_paths_from_feature(self.features):
+            col, *json_field_subpath = json_field_path
+            df[col] = df[col].apply(partial(json_decode_field, json_field_path=json_field_subpath))
+        return df
+
     def to_pandas(
         self, batch_size: Optional[int] = None, batched: bool = False
     ) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
@@ -5521,19 +5534,22 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         """
         if not batched:
-            return query_table(
+            df = query_table(
                 table=self._data,
                 key=slice(0, len(self)),
                 indices=self._indices,
             ).to_pandas(types_mapper=pandas_types_mapper)
+            return self._decode_json_columns_pandas(df)
         else:
             batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
             return (
-                query_table(
-                    table=self._data,
-                    key=slice(offset, offset + batch_size),
-                    indices=self._indices,
-                ).to_pandas(types_mapper=pandas_types_mapper)
+                self._decode_json_columns_pandas(
+                    query_table(
+                        table=self._data,
+                        key=slice(offset, offset + batch_size),
+                        indices=self._indices,
+                    ).to_pandas(types_mapper=pandas_types_mapper)
+                )
                 for offset in range(0, len(self), batch_size)
             )
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3522,6 +3522,32 @@ class MiscellaneousDatasetTest(TestCase):
         assert isinstance(result_dict["col"][0], dict), f"expected dict, got {type(result_dict[0]['col'])}"
         assert result_dict == {"col": [{"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}]}
 
+    def test_to_pandas_decode_json(self):
+        # Regression test: to_pandas() must decode Json() columns to Python objects, matching
+        # to_dict()/to_list() and with_format("pandas"), instead of returning raw JSON strings.
+        data = {"col": [{"a": 1}, None, {"b": 2}]}
+        test_dataset = Dataset.from_dict(data, features=Features({"col": Json()}))
+
+        df = test_dataset.to_pandas()
+        assert isinstance(df["col"][0], dict), f"expected dict, got {type(df['col'][0])}"
+        assert df["col"].tolist() == [{"a": 1}, None, {"b": 2}]
+
+        # the batched generator path decodes too
+        batched = pd.concat(list(test_dataset.to_pandas(batched=True, batch_size=2)), ignore_index=True)
+        assert batched["col"].tolist() == [{"a": 1}, None, {"b": 2}]
+
+    def test_to_pandas_decode_nested_json(self):
+        # Regression test: nested Json() and List(Json()) columns must also decode in to_pandas().
+        nested = {"col": [{"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}]}
+        test_dataset = Dataset.from_dict(nested, features=Features({"col": Json()}))
+        assert test_dataset.to_pandas()["col"][0] == {"a": {"b": {"c": 1}}, "d": [2, {"e": 3}]}
+
+        list_of_json = {"col": [[{"a": 1}], [{"b": 2}]]}
+        test_dataset = Dataset.from_dict(list_of_json, features=Features({"col": List(Json())}))
+        df = test_dataset.to_pandas()
+        assert list(df["col"][0]) == [{"a": 1}]
+        assert list(df["col"][1]) == [{"b": 2}]
+
     def test_json_feature_keeps_none_as_null(self):
         # Regression test for the JSON type: a missing value (None) must be stored as a real
         # Arrow null, not as the JSON string "null". Otherwise null_count is wrong and a missing


### PR DESCRIPTION
## What does this PR do?

`Dataset.to_pandas()` returned the raw Arrow storage strings for `Json()` feature columns, while every other in-memory export path decodes them. `to_dict()`, `to_list()`, `to_json()` and `with_format("pandas")` all apply `get_json_field_paths_from_feature` + `json_decode_field`; `to_pandas()` skipped that step, so it alone produced `'{"a":1}'` (str) where the siblings produce `{'a': 1}` (dict). Nested `List(Json())` columns had the same gap.

This applies the same decode after the Arrow-to-pandas conversion, in both the single and batched code paths, so a `Json()` column materializes as decoded Python objects (pandas `object` dtype), consistent with the other export methods.

Before:

```python
ds = Dataset.from_dict({"col": [{"a": 1}]}, features=Features({"col": Json()}))
ds.to_dict()["col"][0]      # {'a': 1}
ds.to_pandas()["col"][0]    # '{"a":1}'  (str)  <- fixed to {'a': 1}
```

Fixes #8343

## How was it tested?

- Added `test_to_pandas_decode_json` and `test_to_pandas_decode_nested_json` next to the existing `to_dict`/`to_list` decode tests, covering a top-level `Json()` column (including a `None` value), a nested object, `List(Json())`, and the batched generator path. They fail on `main` (`to_pandas` returns raw strings) and pass with this change.
- Verified in a clean container on this commit: the two new tests fail before the fix and pass after; the existing `to_dict`/`to_list` decode, `json_feature`, `to_pandas` and `to_polars` tests still pass.
- `ruff check` and `ruff format --check` are clean on the changed files.

## Not covered (possible follow-up)

`to_polars()` shows the same raw-JSON-string behavior, but I left it out of this PR deliberately. Unlike pandas, whose `object` dtype holds arbitrary decoded objects faithfully, polars has no per-cell Python-object column, and letting it infer a schema is lossy for heterogeneous `Json()` data: `[{"a": 1}, {"b": [2, 3]}]` collapses to `Struct({'a': Int64})` and the second row becomes `{'a': None}`, silently dropping `b`. The faithful alternative is a `pl.Object` column, which is a representation choice I would rather leave to you. Happy to send a separate PR for `to_polars()` if you confirm the behavior you want.
