### PR TITLE
Include archive path in WebDataset TAR read errors

### DIFF
--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -1,6 +1,7 @@
 import io
 import json
 import re
+import tarfile
 from itertools import islice
 from typing import Any, Callable
 
@@ -28,6 +29,14 @@ class WebDataset(datasets.GeneratorBasedBuilder):
 
     @classmethod
     def _get_pipeline_from_tar(cls, tar_path, tar_iterator):
+        try:
+            yield from cls._get_pipeline_from_tar_without_error_context(tar_path, tar_iterator)
+        except tarfile.ReadError as error:
+            # Avoid tracked_str.__repr__, which can include a presigned origin URL in the traceback.
+            raise tarfile.ReadError(f"Failed to read TAR archive {str(tar_path)!r}: {error}") from error
+
+    @classmethod
+    def _get_pipeline_from_tar_without_error_context(cls, tar_path, tar_iterator):
         current_example = {}
         for filename, f in tar_iterator:
             example_key, field_name = base_plus_ext(filename)

--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -4,6 +4,7 @@ import re
 import tarfile
 from itertools import islice
 from typing import Any, Callable
+from urllib.parse import urlsplit, urlunsplit
 
 import numpy as np
 import pyarrow as pa
@@ -17,6 +18,21 @@ from datasets.utils.track import tracked_str
 
 
 logger = datasets.utils.logging.get_logger(__name__)
+
+
+def _sanitize_origin_for_error(origin: str) -> str:
+    """Strip userinfo and query from origin URLs before embedding in exceptions.
+
+    Keeps scheme/host/path (e.g. hf://…) for debugging while avoiding leaking
+    basic-auth credentials or presigned URL query parameters into logs/tracebacks.
+    """
+    parts = urlsplit(origin)
+    if not parts.scheme:
+        return origin
+    netloc = parts.netloc.rsplit("@", 1)[-1] if "@" in parts.netloc else parts.netloc
+    if netloc == parts.netloc and not parts.query:
+        return origin
+    return urlunsplit((parts.scheme, netloc, parts.path, "", parts.fragment))
 
 
 class WebDataset(datasets.GeneratorBasedBuilder):
@@ -39,8 +55,9 @@ class WebDataset(datasets.GeneratorBasedBuilder):
             if isinstance(tar_path, tracked_str):
                 origin = tar_path.get_origin()
                 if origin != archive:
+                    safe_origin = _sanitize_origin_for_error(origin)
                     raise tarfile.ReadError(
-                        f"Failed to read TAR archive {archive!r} (origin={origin}): {error}"
+                        f"Failed to read TAR archive {archive!r} (origin={safe_origin}): {error}"
                     ) from error
             raise tarfile.ReadError(f"Failed to read TAR archive {archive!r}: {error}") from error
 

--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -13,6 +13,7 @@ from datasets.builder import Key
 from datasets.features.features import cast_to_python_objects
 from datasets.filesystems import EXTENSION_TO_COMPRESSION_FS_FILE_CLS
 from datasets.utils.file_utils import xbasename
+from datasets.utils.track import tracked_str
 
 
 logger = datasets.utils.logging.get_logger(__name__)
@@ -32,8 +33,16 @@ class WebDataset(datasets.GeneratorBasedBuilder):
         try:
             yield from cls._get_pipeline_from_tar_without_error_context(tar_path, tar_iterator)
         except tarfile.ReadError as error:
-            # Avoid tracked_str.__repr__, which can include a presigned origin URL in the traceback.
-            raise tarfile.ReadError(f"Failed to read TAR archive {str(tar_path)!r}: {error}") from error
+            # Include both the resolved local path and origin (e.g. hf://…) for debugging.
+            # Prefer str()/get_origin() over tracked_str.__repr__ so formatting stays explicit.
+            archive = str(tar_path)
+            if isinstance(tar_path, tracked_str):
+                origin = tar_path.get_origin()
+                if origin != archive:
+                    raise tarfile.ReadError(
+                        f"Failed to read TAR archive {archive!r} (origin={origin}): {error}"
+                    ) from error
+            raise tarfile.ReadError(f"Failed to read TAR archive {archive!r}: {error}") from error
 
     @classmethod
     def _get_pipeline_from_tar_without_error_context(cls, tar_path, tar_iterator):

--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -4,7 +4,6 @@ import re
 import tarfile
 from itertools import islice
 from typing import Any, Callable
-from urllib.parse import urlsplit, urlunsplit
 
 import numpy as np
 import pyarrow as pa
@@ -14,25 +13,9 @@ from datasets.builder import Key
 from datasets.features.features import cast_to_python_objects
 from datasets.filesystems import EXTENSION_TO_COMPRESSION_FS_FILE_CLS
 from datasets.utils.file_utils import xbasename
-from datasets.utils.track import tracked_str
 
 
 logger = datasets.utils.logging.get_logger(__name__)
-
-
-def _sanitize_origin_for_error(origin: str) -> str:
-    """Strip userinfo and query from origin URLs before embedding in exceptions.
-
-    Keeps scheme/host/path (e.g. hf://…) for debugging while avoiding leaking
-    basic-auth credentials or presigned URL query parameters into logs/tracebacks.
-    """
-    parts = urlsplit(origin)
-    if not parts.scheme:
-        return origin
-    netloc = parts.netloc.rsplit("@", 1)[-1] if "@" in parts.netloc else parts.netloc
-    if netloc == parts.netloc and not parts.query:
-        return origin
-    return urlunsplit((parts.scheme, netloc, parts.path, "", parts.fragment))
 
 
 class WebDataset(datasets.GeneratorBasedBuilder):
@@ -49,17 +32,9 @@ class WebDataset(datasets.GeneratorBasedBuilder):
         try:
             yield from cls._get_pipeline_from_tar_without_error_context(tar_path, tar_iterator)
         except tarfile.ReadError as error:
-            # Include both the resolved local path and origin (e.g. hf://…) for debugging.
-            # Prefer str()/get_origin() over tracked_str.__repr__ so formatting stays explicit.
-            archive = str(tar_path)
-            if isinstance(tar_path, tracked_str):
-                origin = tar_path.get_origin()
-                if origin != archive:
-                    safe_origin = _sanitize_origin_for_error(origin)
-                    raise tarfile.ReadError(
-                        f"Failed to read TAR archive {archive!r} (origin={safe_origin}): {error}"
-                    ) from error
-            raise tarfile.ReadError(f"Failed to read TAR archive {archive!r}: {error}") from error
+            # tar_path is a tracked_str whose repr appends its sanitized origin (e.g. hf://…),
+            # so every loader that reprs a tracked path gets the same safe error context.
+            raise tarfile.ReadError(f"Failed to read TAR archive {tar_path!r}: {error}") from error
 
     @classmethod
     def _get_pipeline_from_tar_without_error_context(cls, tar_path, tar_iterator):

--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -32,8 +32,6 @@ class WebDataset(datasets.GeneratorBasedBuilder):
         try:
             yield from cls._get_pipeline_from_tar_without_error_context(tar_path, tar_iterator)
         except tarfile.ReadError as error:
-            # tar_path is a tracked_str whose repr appends its sanitized origin (e.g. hf://…),
-            # so every loader that reprs a tracked path gets the same safe error context.
             raise tarfile.ReadError(f"Failed to read TAR archive {tar_path!r}: {error}") from error
 
     @classmethod

--- a/src/datasets/utils/track.py
+++ b/src/datasets/utils/track.py
@@ -1,4 +1,20 @@
 from collections.abc import Iterable, Iterator
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _sanitize_origin(origin: str) -> str:
+    """Strip userinfo and query from origin URLs before embedding them in reprs/errors.
+
+    Keeps scheme/host/path (e.g. hf://…) for debugging while avoiding leaking basic-auth
+    credentials or presigned-URL query parameters into logs and tracebacks.
+    """
+    parts = urlsplit(origin)
+    if not parts.scheme:
+        return origin
+    netloc = parts.netloc.rsplit("@", 1)[-1] if "@" in parts.netloc else parts.netloc
+    if netloc == parts.netloc and not parts.query:
+        return origin
+    return urlunsplit((parts.scheme, netloc, parts.path, "", parts.fragment))
 
 
 class tracked_str(str):
@@ -12,10 +28,10 @@ class tracked_str(str):
         return self.origins.get(super().__repr__(), str(self))
 
     def __repr__(self) -> str:
-        if super().__repr__() not in self.origins or self.origins[super().__repr__()] == self:
+        origin = self.origins.get(super().__repr__())
+        if origin is None or origin == self:
             return super().__repr__()
-        else:
-            return f"{str(self)} (origin={self.origins[super().__repr__()]})"
+        return f"{super().__repr__()} (origin={_sanitize_origin(origin)})"
 
 
 class tracked_list(list):

--- a/tests/packaged_modules/test_webdataset.py
+++ b/tests/packaged_modules/test_webdataset.py
@@ -370,16 +370,32 @@ def test_webdataset_read_error_includes_tar_path_while_reading_member(truncated_
     assert isinstance(raised.value.__cause__, tarfile.ReadError)
 
 
-def test_webdataset_read_error_does_not_include_tracked_origin(corrupted_wds_file):
+def test_webdataset_read_error_includes_path_and_tracked_origin(corrupted_wds_file):
+    origin = "hf://datasets/org/name@main/data/corrupted.tar"
     tar_path = tracked_str(corrupted_wds_file)
-    tar_path.set_origin("https://user:password@example.com/corrupted.tar?signature=SECRET")
+    tar_path.set_origin(origin)
     tar_iterator = DownloadManager().iter_archive(str(tar_path))
 
     with pytest.raises(tarfile.ReadError) as raised:
         next(WebDataset._get_pipeline_from_tar(tar_path, tar_iterator))
 
-    assert corrupted_wds_file in str(raised.value)
-    assert "SECRET" not in str(raised.value)
+    message = str(raised.value)
+    assert corrupted_wds_file in message
+    assert origin in message
+    assert message.startswith(f"Failed to read TAR archive {corrupted_wds_file!r} (origin={origin}):")
+
+
+def test_webdataset_read_error_omits_origin_when_same_as_path(corrupted_wds_file):
+    tar_path = tracked_str(corrupted_wds_file)
+    tar_path.set_origin(corrupted_wds_file)
+    tar_iterator = DownloadManager().iter_archive(str(tar_path))
+
+    with pytest.raises(tarfile.ReadError) as raised:
+        next(WebDataset._get_pipeline_from_tar(tar_path, tar_iterator))
+
+    message = str(raised.value)
+    assert corrupted_wds_file in message
+    assert "origin=" not in message
 
 
 @require_pil

--- a/tests/packaged_modules/test_webdataset.py
+++ b/tests/packaged_modules/test_webdataset.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tarfile
 from pathlib import Path
 
@@ -6,6 +7,7 @@ import pytest
 
 from datasets import Audio, DownloadManager, Features, Image, List, Value, Video
 from datasets.packaged_modules.webdataset.webdataset import WebDataset
+from datasets.utils.track import tracked_str
 
 from ..utils import (
     require_numpy1_on_windows,
@@ -98,6 +100,34 @@ def bad_wds_file(tmp_path, image_file, text_file):
     with tarfile.open(str(filename), "w") as f:
         f.add(image_file)
         f.add(json_file)
+    return str(filename)
+
+
+@pytest.fixture
+def corrupted_wds_file(tmp_path):
+    filename = tmp_path / "corrupted.tar"
+    filename.touch()
+    return str(filename)
+
+
+@pytest.fixture
+def valid_text_wds_file(tmp_path):
+    data_file = tmp_path / "valid.txt"
+    data_file.write_text("valid", encoding="utf-8")
+    filename = tmp_path / "valid.tar"
+    with tarfile.open(filename, "w") as tar:
+        tar.add(data_file, arcname="00000.txt")
+    return str(filename)
+
+
+@pytest.fixture
+def truncated_wds_file(tmp_path):
+    data_file = tmp_path / "data.txt"
+    data_file.write_bytes(b"x" * 1024)
+    filename = tmp_path / "truncated.tar"
+    with tarfile.open(filename, "w") as tar:
+        tar.add(data_file, arcname="00000.txt")
+    filename.write_bytes(filename.read_bytes()[:612])
     return str(filename)
 
 
@@ -303,6 +333,53 @@ def test_webdataset_errors_on_bad_file(bad_wds_file):
     webdataset = WebDataset(data_files=data_files)
     with pytest.raises(ValueError):
         webdataset._split_generators(DownloadManager())
+
+
+def test_webdataset_read_error_includes_tar_path_during_feature_inference(corrupted_wds_file):
+    webdataset = WebDataset(data_files={"train": [corrupted_wds_file]})
+
+    with pytest.raises(tarfile.ReadError, match=re.escape(corrupted_wds_file)) as raised:
+        webdataset._split_generators(DownloadManager())
+
+    assert isinstance(raised.value.__cause__, tarfile.ReadError)
+
+
+def test_webdataset_read_error_identifies_corrupt_shard_after_valid_shard(valid_text_wds_file, corrupted_wds_file):
+    features = Features({"__key__": Value("string"), "__url__": Value("string"), "txt": Value("string")})
+    webdataset = WebDataset(data_files={"train": [valid_text_wds_file, corrupted_wds_file]}, features=features)
+    split_generator = webdataset._split_generators(DownloadManager())[0]
+    generator = webdataset._generate_examples(**split_generator.gen_kwargs)
+
+    _, first_example = next(generator)
+    assert first_example["__url__"] == valid_text_wds_file
+
+    with pytest.raises(tarfile.ReadError, match=re.escape(corrupted_wds_file)) as raised:
+        next(generator)
+
+    assert isinstance(raised.value.__cause__, tarfile.ReadError)
+
+
+def test_webdataset_read_error_includes_tar_path_while_reading_member(truncated_wds_file):
+    features = Features({"__key__": Value("string"), "__url__": Value("string"), "txt": Value("string")})
+    webdataset = WebDataset(data_files={"train": [truncated_wds_file]}, features=features)
+    split_generator = webdataset._split_generators(DownloadManager())[0]
+
+    with pytest.raises(tarfile.ReadError, match=re.escape(truncated_wds_file)) as raised:
+        next(webdataset._generate_examples(**split_generator.gen_kwargs))
+
+    assert isinstance(raised.value.__cause__, tarfile.ReadError)
+
+
+def test_webdataset_read_error_does_not_include_tracked_origin(corrupted_wds_file):
+    tar_path = tracked_str(corrupted_wds_file)
+    tar_path.set_origin("https://user:password@example.com/corrupted.tar?signature=SECRET")
+    tar_iterator = DownloadManager().iter_archive(str(tar_path))
+
+    with pytest.raises(tarfile.ReadError) as raised:
+        next(WebDataset._get_pipeline_from_tar(tar_path, tar_iterator))
+
+    assert corrupted_wds_file in str(raised.value)
+    assert "SECRET" not in str(raised.value)
 
 
 @require_pil

--- a/tests/packaged_modules/test_webdataset.py
+++ b/tests/packaged_modules/test_webdataset.py
@@ -385,6 +385,24 @@ def test_webdataset_read_error_includes_path_and_tracked_origin(corrupted_wds_fi
     assert message.startswith(f"Failed to read TAR archive {corrupted_wds_file!r} (origin={origin}):")
 
 
+def test_webdataset_read_error_strips_userinfo_and_query_from_origin(corrupted_wds_file):
+    origin = "https://user:pass@example.com/bucket/file.tar?X-Amz-Signature=abc&Expires=1"
+    safe_origin = "https://example.com/bucket/file.tar"
+    tar_path = tracked_str(corrupted_wds_file)
+    tar_path.set_origin(origin)
+    tar_iterator = DownloadManager().iter_archive(str(tar_path))
+
+    with pytest.raises(tarfile.ReadError) as raised:
+        next(WebDataset._get_pipeline_from_tar(tar_path, tar_iterator))
+
+    message = str(raised.value)
+    assert corrupted_wds_file in message
+    assert safe_origin in message
+    assert "user:pass" not in message
+    assert "X-Amz-Signature" not in message
+    assert message.startswith(f"Failed to read TAR archive {corrupted_wds_file!r} (origin={safe_origin}):")
+
+
 def test_webdataset_read_error_omits_origin_when_same_as_path(corrupted_wds_file):
     tar_path = tracked_str(corrupted_wds_file)
     tar_path.set_origin(corrupted_wds_file)

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,0 +1,47 @@
+from datasets.utils.track import tracked_str
+
+
+def test_tracked_str_repr_without_origin():
+    path = tracked_str("/tmp/datasets-track-repr-plain.tar")
+    assert repr(path) == repr("/tmp/datasets-track-repr-plain.tar")
+
+
+def test_tracked_str_str_is_local_path():
+    local = "/tmp/datasets-track-repr-str.tar"
+    origin = "hf://datasets/org/name@main/data/file.tar"
+    path = tracked_str(local)
+    path.set_origin(origin)
+    assert str(path) == local
+    assert origin not in str(path)
+
+
+def test_tracked_str_repr_includes_hf_origin():
+    path = tracked_str("/tmp/datasets-track-repr-hf.tar")
+    origin = "hf://datasets/org/name@main/data/file.tar"
+    path.set_origin(origin)
+    assert repr(path) == f"{'/tmp/datasets-track-repr-hf.tar'!r} (origin={origin})"
+
+
+def test_tracked_str_repr_strips_userinfo_and_query():
+    path = tracked_str("/tmp/datasets-track-repr-secret.tar")
+    origin = "https://user:pass@example.com/bucket/file.tar?X-Amz-Signature=abc&Expires=1"
+    path.set_origin(origin)
+    message = repr(path)
+    assert message == f"{'/tmp/datasets-track-repr-secret.tar'!r} (origin=https://example.com/bucket/file.tar)"
+    assert "user:pass" not in message
+    assert "X-Amz-Signature" not in message
+
+
+def test_tracked_str_repr_omits_origin_when_same_as_path():
+    local = "/tmp/datasets-track-repr-same.tar"
+    path = tracked_str(local)
+    path.set_origin(local)
+    assert repr(path) == repr(local)
+    assert "origin=" not in repr(path)
+
+
+def test_tracked_str_get_origin_keeps_raw_url():
+    path = tracked_str("/tmp/datasets-track-repr-raw.tar")
+    origin = "https://user:pass@example.com/file.tar?token=secret"
+    path.set_origin(origin)
+    assert path.get_origin() == origin


### PR DESCRIPTION
Fixes #7280

## What changed

WebDataset catches `tarfile.ReadError` around TAR processing and re-raises with `{tar_path!r}`. The original error remains on `__cause__`.

Covers failures while advancing the archive iterator and while reading a member payload (feature inference and example generation).

Origin is included in `tracked_str.__repr__` (often an `hf://` URL), so any loader that reprs a tracked path gets the remote location. Userinfo and query strings are stripped so presigned URLs and basic-auth credentials are not exposed in tracebacks.

## Before

```text
ReadError: empty file
```

## After

```text
ReadError: Failed to read TAR archive '/path/to/corrupted-shard-00042.tar' (origin=hf://datasets/org/name@main/data/corrupted-shard-00042.tar): empty file
```

## Tests

- corrupt first shard (feature inference)
- valid shard then corrupt shard (example generation)
- truncated member during `f.read()`
- original `ReadError` preserved as cause
- Windows-safe path matching
- `tracked_str.__repr__` includes hf:// origin
- userinfo/query stripped from origin in repr

## Validation

- pytest: `tests/test_track.py` and WebDataset ReadError tests passed
- `ruff check` / `ruff format --check`: passed

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
