### PR TITLE
Fix casting a nullable LargeList to a different inner type

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1867,7 +1867,7 @@ def _combine_list_array_offsets_with_mask(array: pa.ListArray) -> pa.Array:
     if array.null_count > 0:
         offsets = pa.concat_arrays(
             [
-                pc.replace_with_mask(offsets[:-1], array.is_null(), pa.nulls(len(array), pa.int32())),
+                pc.replace_with_mask(offsets[:-1], array.is_null(), pa.nulls(len(array), offsets.type)),
                 offsets[-1:],
             ]
         )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1334,6 +1334,16 @@ def test_cast_array_to_feature_with_list_array_and_large_list_feature(from_list_
     assert cast_array.type == expected_array_type
 
 
+def test_cast_array_to_feature_with_nullable_large_list_and_new_inner_type():
+    # A nullable LargeList has int64 offsets, but the null bitmap was combined
+    # with an int32 null-fill in _combine_list_array_offsets_with_mask, so
+    # casting it to a different inner type raised ArrowNotImplementedError.
+    array = pa.array([[1, 2], None, [3]], type=pa.large_list(pa.int64()))
+    cast_array = cast_array_to_feature(array, LargeList(Value("int32")))
+    assert cast_array.type == pa.large_list(pa.int32())
+    assert cast_array.to_pylist() == [[1, 2], None, [3]]
+
+
 def test_cast_array_xd_to_features_sequence():
     arr = np.random.randint(0, 10, size=(8, 2, 3)).tolist()
     arr = Array2DExtensionType(shape=(2, 3), dtype="int64").wrap_array(pa.array(arr, pa.list_(pa.list_(pa.int64()))))


### PR DESCRIPTION
## What's the bug

`_combine_list_array_offsets_with_mask` (in `src/datasets/table.py`) rebuilds a list array's offsets with the null bitmap applied, using an `int32` null-fill:

```python
offsets = array.offsets
if array.null_count > 0:
    offsets = pa.concat_arrays(
        [
            pc.replace_with_mask(offsets[:-1], array.is_null(), pa.nulls(len(array), pa.int32())),
            offsets[-1:],
        ]
    )
```

A `pa.ListArray` has `int32` offsets, so this happens to match. But a `pa.LargeListArray` has `int64` offsets, and `pc.replace_with_mask(int64_offsets, mask, int32_nulls)` has no matching pyarrow kernel:

```
pyarrow.lib.ArrowNotImplementedError: Function 'replace_with_mask' has no kernel matching input types (int64, bool, int32)
```

This is reached from `array_cast` (large_list branch) and `cast_array_to_feature` (`LargeList` branch) whenever a `LargeList` column **has nulls** and its **inner type changes**. A same-inner-type cast hits the no-op early return, which is why it stayed hidden.

Minimal reproduction:

```python
import pyarrow as pa
from datasets.table import cast_array_to_feature
from datasets import LargeList, Value

arr = pa.array([[1, 2], None, [3]], type=pa.large_list(pa.int64()))
cast_array_to_feature(arr, LargeList(Value("int32")))   # ArrowNotImplementedError
```

The equivalent user-facing call `Dataset.cast_column("col", LargeList(Value("int32")))` raises the same error. The same cast on a regular `List` succeeds.

## Fix

Use `offsets.type` for the null-fill instead of a hardcoded `pa.int32()`, so it matches the offset width for both list kinds (`int32` for `ListArray`, `int64` for `LargeListArray`):

```python
pc.replace_with_mask(offsets[:-1], array.is_null(), pa.nulls(len(array), offsets.type)),
```

This is the root-cause fix and covers all three caller paths; regular-list casts are unchanged.

## Tests

Added `tests/test_table.py::test_cast_array_to_feature_with_nullable_large_list_and_new_inner_type` (the existing `test_cast_array_to_feature_with_list_array_and_large_list_feature` uses non-nullable data, so it never exercised this path).

```bash
python -m pytest tests/test_table.py -q
```

- Before: the new test errors with `ArrowNotImplementedError`.
- After: `278 passed, 1 skipped`; the cast returns `large_list<int32>` with `[[1, 2], None, [3]]`.
