### PR TITLE
Fix require_storage_embed recursing into require_storage_cast

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1813,11 +1813,11 @@ def require_storage_embed(feature: FeatureType) -> bool:
         :obj:`bool`
     """
     if isinstance(feature, dict):
-        return any(require_storage_cast(f) for f in feature.values())
+        return any(require_storage_embed(f) for f in feature.values())
     elif isinstance(feature, LargeList):
-        return require_storage_cast(feature.feature)
+        return require_storage_embed(feature.feature)
     elif isinstance(feature, List):
-        return require_storage_cast(feature.feature)
+        return require_storage_embed(feature.feature)
     else:
         return hasattr(feature, "embed_storage")
 

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1796,8 +1796,6 @@ def require_storage_cast(feature: FeatureType) -> bool:
     """
     if isinstance(feature, dict):
         return any(require_storage_cast(f) for f in feature.values())
-    elif isinstance(feature, (list, tuple)):
-        return require_storage_cast(feature[0])
     elif isinstance(feature, LargeList):
         return require_storage_cast(feature.feature)
     elif isinstance(feature, List):

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1796,6 +1796,8 @@ def require_storage_cast(feature: FeatureType) -> bool:
     """
     if isinstance(feature, dict):
         return any(require_storage_cast(f) for f in feature.values())
+    elif isinstance(feature, (list, tuple)):
+        return require_storage_cast(feature[0])
     elif isinstance(feature, LargeList):
         return require_storage_cast(feature.feature)
     elif isinstance(feature, List):
@@ -1814,6 +1816,8 @@ def require_storage_embed(feature: FeatureType) -> bool:
     """
     if isinstance(feature, dict):
         return any(require_storage_embed(f) for f in feature.values())
+    elif isinstance(feature, (list, tuple)):
+        return require_storage_embed(feature[0])
     elif isinstance(feature, LargeList):
         return require_storage_embed(feature.feature)
     elif isinstance(feature, List):

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1018,6 +1018,13 @@ def test_require_storage_embed_with_list_types(feature):
     assert require_storage_embed(feature)
 
 
+@pytest.mark.parametrize("feature", [LargeList(ClassLabel(names=["a", "b"])), List(ClassLabel(names=["a", "b"]))])
+def test_require_storage_embed_with_non_embeddable_list_types(feature):
+    # ClassLabel implements cast_storage but not embed_storage, so a nested
+    # ClassLabel does not require storage embedding
+    assert require_storage_embed(feature) is False
+
+
 @pytest.mark.parametrize(
     "feature, expected",
     [(List(Value("int32")), List(1)), (LargeList(Value("int32")), LargeList(1)), (List(Value("int32")), List(1))],

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1025,6 +1025,15 @@ def test_require_storage_embed_with_non_embeddable_list_types(feature):
     assert require_storage_embed(feature) is False
 
 
+@pytest.mark.parametrize("feature", [[Audio()], (Audio(),)])
+def test_require_storage_cast_and_embed_recurse_into_raw_list_schema(feature):
+    # A bare list/tuple such as [Audio()] is a valid FeatureType that
+    # get_nested_type accepts, so the storage helpers must recurse into it
+    # like require_decoding does instead of falling through to the leaf check.
+    assert require_storage_cast(feature)
+    assert require_storage_embed(feature)
+
+
 @pytest.mark.parametrize(
     "feature, expected",
     [(List(Value("int32")), List(1)), (LargeList(Value("int32")), LargeList(1)), (List(Value("int32")), List(1))],


### PR DESCRIPTION
### Summary

`require_storage_embed` decides whether a (possibly nested) feature needs its data embedded into storage. For nested features it dispatches to the wrong helper and can report the wrong answer.

### Root cause

The recursive branches call `require_storage_cast` instead of recursing into `require_storage_embed`:

```python
def require_storage_embed(feature: FeatureType) -> bool:
    if isinstance(feature, dict):
        return any(require_storage_cast(f) for f in feature.values())
    elif isinstance(feature, LargeList):
        return require_storage_cast(feature.feature)
    elif isinstance(feature, List):
        return require_storage_cast(feature.feature)
    else:
        return hasattr(feature, "embed_storage")
```

The two sibling predicates, `require_storage_cast` and `require_decoding`, both recurse into themselves; only `require_storage_embed` recurses into the wrong function. As a result, a nested feature whose inner type implements `cast_storage` but not `embed_storage` (for example `List(ClassLabel)`) is checked for `cast_storage` and wrongly reported as requiring embedding.

`ArrowWriter._build_writer` uses `require_storage_embed` per column to choose Parquet encoding, so such a column is treated as an embed column and written without compression / with `PLAIN` encoding and no dictionary, producing larger, less optimally encoded output. Types that do implement `embed_storage` (Image, Audio, Video, Pdf) also implement `cast_storage`, so the bug does not drop embedding where it is needed; it only over-reports.

### Fix

Recurse into `require_storage_embed`, mirroring the sibling predicates, so the leaf check is `embed_storage` rather than `cast_storage`.

### Verification

The existing `test_require_storage_embed_with_list_types` only parametrizes over `Audio` (which implements both `cast_storage` and `embed_storage`), so it passes with the bug present. Added `test_require_storage_embed_with_non_embeddable_list_types` covering `List`/`LargeList` of `ClassLabel` (cast_storage but not embed_storage), which returns `True` before the fix and `False` after. Reproduced directly: `require_storage_embed(List(ClassLabel(...)))` returns `True` on the current code and `False` after the change, while `List(Audio())` remains `True`.
