### PR TITLE
fix: validate Arrow IPC record batches

### DIFF
--- a/src/datasets/packaged_modules/arrow/arrow.py
+++ b/src/datasets/packaged_modules/arrow/arrow.py
@@ -67,6 +67,7 @@ class Arrow(datasets.ArrowBasedBuilder):
                         reader = pa.ipc.open_file(f)
                         batches = (reader.get_batch(i) for i in range(reader.num_record_batches))
                     for batch_idx, record_batch in enumerate(batches):
+                        record_batch.validate(full=True)
                         pa_table = pa.Table.from_batches([record_batch])
                         # Uncomment for debugging (will print the Arrow table size and elements)
                         # logger.warning(f"pa_table: {pa_table} num rows: {pa_table.num_rows}")

--- a/tests/packaged_modules/test_arrow.py
+++ b/tests/packaged_modules/test_arrow.py
@@ -1,3 +1,5 @@
+import struct
+
 import pyarrow as pa
 import pytest
 
@@ -34,6 +36,27 @@ def arrow_file_file_format(tmp_path):
     return str(filename)
 
 
+@pytest.fixture
+def arrow_file_with_invalid_offsets(tmp_path):
+    filename = tmp_path / "invalid-offsets.arrow"
+    table = pa.table({"col": pa.array([b"A", b"B"])})
+    with open(filename, "wb") as f:
+        with pa.ipc.new_stream(f, table.schema) as writer:
+            writer.write_table(table)
+
+    payload = bytearray(filename.read_bytes())
+    schema_message_start = payload.index(b"\xff\xff\xff\xff")
+    schema_metadata_length = struct.unpack_from("<I", payload, schema_message_start + 4)[0]
+    record_batch_start = (schema_message_start + 8 + schema_metadata_length + 7) & ~7
+    record_batch_metadata_length = struct.unpack_from("<I", payload, record_batch_start + 4)[0]
+    record_batch_body_start = (record_batch_start + 8 + record_batch_metadata_length + 7) & ~7
+
+    assert struct.unpack_from("<iii", payload, record_batch_body_start) == (0, 1, 2)
+    struct.pack_into("<iii", payload, record_batch_body_start, 0, 2, 1)
+    filename.write_bytes(payload)
+    return str(filename)
+
+
 @pytest.mark.parametrize(
     "file_fixture, config_kwargs",
     [
@@ -48,6 +71,19 @@ def test_arrow_generate_tables(file_fixture, config_kwargs, request):
 
     expected = {"input_ids": [[1, 1, 1], [0, 100, 6], [1, 90, 900]]}
     assert pa_table.to_pydict() == expected
+
+
+def test_arrow_generate_tables_rejects_invalid_record_batch(arrow_file_with_invalid_offsets):
+    with open(arrow_file_with_invalid_offsets, "rb") as f:
+        record_batch = pa.ipc.open_stream(f).read_next_batch()
+
+    record_batch.validate()
+    with pytest.raises(pa.ArrowInvalid):
+        record_batch.validate(full=True)
+
+    arrow = Arrow()
+    with pytest.raises(pa.ArrowInvalid):
+        next(arrow._generate_tables([arrow_file_with_invalid_offsets]))
 
 
 def test_config_raises_when_invalid_name() -> None:

--- a/tests/packaged_modules/test_arrow.py
+++ b/tests/packaged_modules/test_arrow.py
@@ -52,6 +52,7 @@ def arrow_file_with_invalid_offsets(tmp_path):
     record_batch_body_start = (record_batch_start + 8 + record_batch_metadata_length + 7) & ~7
 
     assert struct.unpack_from("<iii", payload, record_batch_body_start) == (0, 1, 2)
+    # Keep every offset inside the data buffer while making them non-monotonic.
     struct.pack_into("<iii", payload, record_batch_body_start, 0, 2, 1)
     filename.write_bytes(payload)
     return str(filename)


### PR DESCRIPTION
## Summary

- fully validate each Arrow IPC record batch before converting it to a table
- reject malformed array offsets at the ingestion boundary
- add a safe regression fixture that is accepted by structural validation but rejected by full validation

`pa.Table.from_batches` does not perform full record batch validation. Calling `record_batch.validate(full=True)` before conversion ensures malformed untrusted IPC input is rejected before it is exposed by the builder.

## Validation

- `python -m pytest tests/packaged_modules/test_arrow.py -q` with PyArrow 22 and PyArrow 25
- `ruff check src/datasets/packaged_modules/arrow/arrow.py tests/packaged_modules/test_arrow.py`
- `ruff format --check src/datasets/packaged_modules/arrow/arrow.py tests/packaged_modules/test_arrow.py`