### PR TITLE
Keep flat numeric columns with nulls numeric in numpy format

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -201,7 +201,17 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
             ):
                 if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
                     return np.asarray(array, dtype=object)
-                return np.array(array, copy=False, dtype=object)
+            for first_subarray in array:
+                if isinstance(first_subarray, np.ndarray):
+                    if any(
+                        (isinstance(x, np.ndarray) and (x.dtype == object or x.shape != first_subarray.shape))
+                        or ((isinstance(x, float) and np.isnan(x) or x is None) and first_subarray.ndim > 0)
+                        for x in array
+                    ):
+                        if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
+                            return np.asarray(array, dtype=object)
+                        return np.array(array, copy=False, dtype=object)
+                    break
         if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             return np.asarray(array)
         else:

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -188,7 +188,13 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
                 array: list = pa_array.to_numpy(zero_copy_only=zero_copy_only).tolist()
 
         if len(array) > 0:
-            if any(
+            # Only promote to dtype=object when the column is made of per-row arrays
+            # (ArrayXD/list columns) that cannot be stacked into a homogeneous numeric
+            # array: ragged shapes, an already-object element, or a null row arriving as
+            # a scalar nan among the ndarrays. A flat homogeneous numeric column whose
+            # nulls surface as scalar nan must stay numeric, so guard the whole check on
+            # the presence of an ndarray element first.
+            if any(isinstance(x, np.ndarray) for x in array) and any(
                 (isinstance(x, np.ndarray) and (x.dtype == object or x.shape != array[0].shape))
                 or (isinstance(x, float) and np.isnan(x))
                 for x in array

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -98,6 +98,36 @@ class ArrowExtractorTest(TestCase):
         self.assertEqual(batch["c"][0].dtype, object)
         self.assertEqual(batch["c"].dtype, object)
 
+    def test_numpy_extractor_flat_numeric_with_nulls(self):
+        # A flat homogeneous numeric column with nulls must stay numeric (nulls -> nan),
+        # not be promoted to dtype=object. Previously only float32 was spared because
+        # np.float64/np.int64 nulls surface as np.float64(nan), which is a Python float
+        # subclass and wrongly tripped the object-dtype promotion.
+        extractor = NumpyArrowExtractor()
+        for pa_type, expected_dtype in [
+            (pa.float64(), np.float64),
+            (pa.float32(), np.float32),
+            (pa.int64(), np.float64),  # nulls force pyarrow to a floating result
+        ]:
+            pa_table = pa.table({"c": pa.array([1.0, None, 3.0], type=pa_type)})
+            col = extractor.extract_column(pa_table)
+            self.assertEqual(col.dtype, expected_dtype)
+            self.assertTrue(np.isnan(col[1]))
+            np.testing.assert_array_equal(col[[0, 2]], np.array([1.0, 3.0], dtype=expected_dtype))
+            batch = extractor.extract_batch(pa_table)
+            self.assertEqual(batch["c"].dtype, expected_dtype)
+
+    def test_numpy_extractor_nested_with_nulls(self):
+        # A per-row array column with a null row cannot be stacked into a homogeneous
+        # numeric array, so it must still be returned as dtype=object (the case the
+        # object-dtype promotion exists for). The flat-column fix must not regress this.
+        extractor = NumpyArrowExtractor()
+        pa_table = pa.table({"c": pa.array([[1.0, 2.0], [3.0, 4.0, 5.0], None], type=pa.list_(pa.float64()))})
+        col = extractor.extract_column(pa_table)
+        self.assertEqual(col.dtype, object)
+        batch = extractor.extract_batch(pa_table)
+        self.assertEqual(batch["c"].dtype, object)
+
     def test_numpy_extractor_temporal(self):
         pa_table = self._create_dummy_table().drop(["a", "b", "c"])
         extractor = NumpyArrowExtractor()


### PR DESCRIPTION
Fixes #8351

## Root cause

`NumpyArrowExtractor._arrow_array_to_numpy` decides `dtype=object` with:

```python
if any(
    (isinstance(x, np.ndarray) and (x.dtype == object or x.shape != array[0].shape))
    or (isinstance(x, float) and np.isnan(x))
    for x in array
):
```

The second clause was added in #3195 to handle a null row in an *array* column, but it fires on any scalar float nan. For a flat homogeneous numeric column with nulls, `array` is a list of numpy scalars and the null surfaces as `np.float64(nan)`. Since `np.float64` is a subclass of Python `float` but `np.float32` is not, only `float64` (and `int`, which pyarrow promotes to floating when nulls are present) trips the clause, so identical data returns object or numeric depending on the column dtype.

## Fix

Guard the whole promotion on the presence of an ndarray element:

```python
if any(isinstance(x, np.ndarray) for x in array) and any(
    ... same conditions ...
):
```

Invariant: `dtype=object` is only returned when the column actually contains per-row arrays. A column made entirely of scalars (a flat numeric column) can always be stacked into a homogeneous numeric array, so it stays numeric.

This preserves the behavior of every array-column path exactly. When an ndarray is present the guard is `True`, so the inner check is evaluated unchanged; the only behavior that changes is the flat-scalar-with-nan case, which is the bug.

## Verification

Run in a clean `python:3.11-slim` container against this branch (`pyarrow` 25.0.0, `numpy` 2.4.6). Provenance checked via `datasets.formatting.formatting.__file__`.

- `extract_column` on `[1.0, None, 3.0]`: `float64 -> float64`, `float32 -> float32`, `int64 -> float64` (nulls as `nan`). On `main` `float64`/`int64` return `object`.
- Per-row array column with a null row (`list<float64>` `[[1,2],[3,4,5],None]`) still returns `dtype=object`, unchanged.
- Existing `ArrowExtractorTest` suite passes (including `test_numpy_extractor_nested`, which pins the object dtype for nested-array columns).

Two regression tests added:

- `test_numpy_extractor_flat_numeric_with_nulls`: flat float64/float32/int columns with a null stay numeric. Fails on `main` (`dtype('O') != float64`), passes here.
- `test_numpy_extractor_nested_with_nulls`: an array column with a null row still yields `dtype=object` (guards against a regression of the case #3195 added the clause for).

I did not touch a separate, pre-existing issue where a same-shape `list<float32>` column with a null row raises on stacking; that is unrelated to this dtype-consistency fix.
