### PR TITLE
Fix CSV loader dropping on_bad_lines/encoding_errors on pandas 2.0-2.2

### DIFF
--- a/src/datasets/packaged_modules/csv/csv.py
+++ b/src/datasets/packaged_modules/csv/csv.py
@@ -124,7 +124,7 @@ class CsvConfig(datasets.BuilderConfig):
                 del pd_read_csv_kwargs[pd_read_csv_parameter]
 
         # Remove 1.3 new arguments
-        if not (datasets.config.PANDAS_VERSION.major >= 1 and datasets.config.PANDAS_VERSION.minor >= 3):
+        if datasets.config.PANDAS_VERSION.release < (1, 3):
             for pd_read_csv_parameter in _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS:
                 del pd_read_csv_kwargs[pd_read_csv_parameter]
 

--- a/tests/packaged_modules/test_csv.py
+++ b/tests/packaged_modules/test_csv.py
@@ -3,7 +3,9 @@ import textwrap
 
 import pyarrow as pa
 import pytest
+from packaging import version
 
+import datasets.config
 from datasets import ClassLabel, Features, Image
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
@@ -151,3 +153,40 @@ def test_csv_convert_int_list(csv_file_with_int_list):
     assert pa.types.is_list(pa_table.schema.field("int_list").type)
     generated_content = pa_table.to_pydict()["int_list"]
     assert generated_content == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+
+@pytest.mark.parametrize("pandas_version", ["2.0.3", "2.1.4", "2.2.3"])
+def test_csv_pd_read_csv_kwargs_keeps_new_1_3_0_params_on_pandas_2x(monkeypatch, pandas_version):
+    # pandas 2.x supports encoding_errors / on_bad_lines (added in 1.3.0), so they must be
+    # forwarded to pd.read_csv. Regression for the ">= 1.3" guard that compared major and minor
+    # independently, wrongly dropping them on pandas 2.0-2.2 (minor 0/1/2 fails minor >= 3).
+    monkeypatch.setattr(datasets.config, "PANDAS_VERSION", version.parse(pandas_version))
+    kwargs = CsvConfig(encoding_errors="replace", on_bad_lines="skip").pd_read_csv_kwargs
+    assert kwargs["encoding_errors"] == "replace"
+    assert kwargs["on_bad_lines"] == "skip"
+
+
+@pytest.mark.parametrize("pandas_version", ["1.1.5", "1.2.5"])
+def test_csv_pd_read_csv_kwargs_drops_new_1_3_0_params_below_pandas_1_3(monkeypatch, pandas_version):
+    # The other half of the invariant: pandas < 1.3 lacks these params, so they must still be dropped.
+    monkeypatch.setattr(datasets.config, "PANDAS_VERSION", version.parse(pandas_version))
+    kwargs = CsvConfig(encoding_errors="replace", on_bad_lines="skip").pd_read_csv_kwargs
+    assert "encoding_errors" not in kwargs
+    assert "on_bad_lines" not in kwargs
+
+
+@pytest.mark.skipif(
+    datasets.config.PANDAS_VERSION.release < (1, 3),
+    reason="on_bad_lines requires pandas >= 1.3",
+)
+def test_csv_generate_tables_skips_malformed_row_with_on_bad_lines_skip(csv_file, malformed_csv_file):
+    # End-to-end on the installed pandas: on_bad_lines="skip" must reach pd.read_csv, so the
+    # malformed row is skipped instead of raising. On pandas 2.0-2.2 the buggy guard dropped it
+    # and this raised "Error tokenizing data".
+    csv = Csv(on_bad_lines="skip")
+    base_files = [malformed_csv_file]
+    files_iterables = [[file] for file in base_files]
+    generator = csv._generate_tables(base_files=base_files, files_iterables=files_iterables)
+    pa_table = pa.concat_tables([table for _, table in generator])
+    assert pa_table.num_rows == 1
+    assert pa_table.to_pydict() == {"header1": [1], "header2": [2]}


### PR DESCRIPTION
### Bug

`CsvConfig.pd_read_csv_kwargs` silently drops `on_bad_lines` and `encoding_errors` on pandas 2.0, 2.1, and 2.2, so `load_dataset("csv", ..., on_bad_lines="skip")` (or `"warn"`, or a non-default `encoding_errors`) is ignored and a malformed row raises `ParserError` instead of being skipped.

The version guard encodes ">= 1.3" by comparing major and minor independently:

```python
if not (datasets.config.PANDAS_VERSION.major >= 1 and datasets.config.PANDAS_VERSION.minor >= 3):
    for pd_read_csv_parameter in _PANDAS_READ_CSV_NEW_1_3_0_PARAMETERS:  # ["encoding_errors", "on_bad_lines"]
        del pd_read_csv_kwargs[pd_read_csv_parameter]
```

For pandas 2.0/2.1/2.2 the minor is 0/1/2, so `minor >= 3` is False, the guard fires, and the two params (added in pandas 1.3.0) are deleted before they reach `pd.read_csv`. The bug window is exactly `[2.0, 2.3)`: pandas 1.3-1.5 and 2.3+ happen to satisfy the buggy predicate, so they were unaffected.

### Fix

Use the release tuple, mirroring the `PANDAS_VERSION.release >= (2, 2)` idiom already used two blocks below in the same property:

```python
if datasets.config.PANDAS_VERSION.release < (1, 3):
```

`< (1, 3)` is the intended "pandas that lacks these params". Behavior is identical on every version except the 2.0-2.2 window, where the params are now forwarded: unchanged for pandas < 1.3 (still dropped) and for 1.3-1.5 / 2.3+ (already kept). `on_bad_lines` is CSV-only, and this block is the only code that deletes these two params. The neighboring `PANDAS_VERSION.major >= 2` guard for `date_format` uses a single comparison, so it does not share the bug.

### Verification

On pandas 2.2.3 (real install, editable checkout):

- Before: `CsvConfig(on_bad_lines="skip").pd_read_csv_kwargs` omits `on_bad_lines`, and `Csv(on_bad_lines="skip")._generate_tables(...)` on a malformed file raises `Error tokenizing data. C error: Expected 2 fields in line 3, saw 3`.
- After: the param is forwarded and the malformed row is skipped.

Added regression tests in `tests/packaged_modules/test_csv.py`:

- `test_csv_pd_read_csv_kwargs_keeps_new_1_3_0_params_on_pandas_2x` monkeypatches `PANDAS_VERSION` to 2.0.3 / 2.1.4 / 2.2.3 and asserts both params survive (fails on `main`, passes here, independent of the installed pandas).
- `test_csv_pd_read_csv_kwargs_drops_new_1_3_0_params_below_pandas_1_3` pins the other half of the invariant (1.1.5 / 1.2.5 still drop them).
- `test_csv_generate_tables_skips_malformed_row_with_on_bad_lines_skip` exercises the real `pd.read_csv` path end-to-end on the installed pandas.

`tests/packaged_modules/test_csv.py` and `tests/io/test_csv.py` pass (41 passed, 1 skipped); `ruff check` and `ruff format --check` are clean on both changed files.
