### PR TITLE
Rebatch arrow source before formatting in IterableDataset.filter to fix resume data loss

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3702,10 +3702,17 @@ class IterableDataset(DatasetInfoMixin):
         # format and type before filtering
         ex_iterable = self._ex_iterable
         if self._info.features or self._formatting:
+            if ex_iterable.iter_arrow:
+                # Rebatch before formatting so the formatter reads at most one batch ahead
+                # instead of a whole arrow table. Without this, a non-batched filter consumes
+                # a table in full while emitting examples one at a time, so state_dict()
+                # records the shard position at the table end and resume skips every unemitted
+                # row of that table (mirrors `map`, see #8147).
+                ex_iterable = RebatchedArrowExamplesIterable(ex_iterable, batch_size=batch_size if batched else 1)
             ex_iterable = FormattedExamplesIterable(
                 ex_iterable,
                 formatting=self._formatting,
-                features=ex_iterable.features if ex_iterable.is_typed else self._info.features,
+                features=self._ex_iterable.features if self._ex_iterable.is_typed else self._info.features,
                 token_per_repo_id=self._token_per_repo_id,
             )
 

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2965,6 +2965,26 @@ def test_resume_dataloader_twice(num_workers):
     assert consumed + remainder == all_examples
 
 
+@pytest.mark.parametrize("consume", [1, 500, 1500])
+@pytest.mark.parametrize("batched", [False, True])
+def test_iterable_dataset_filter_resume_state_dict(consume, batched):
+    # Resuming an arrow-backed `filter()` must not skip rows: the formatter reads one
+    # example ahead instead of a whole arrow table, so state_dict() records the shard
+    # position at the emitted example and resume replays every unemitted row exactly once.
+    n = 2000
+    filter_fn = (lambda batch: [True] * len(batch["a"])) if batched else (lambda example: True)
+    ds = Dataset.from_dict({"a": list(range(n))}).to_iterable_dataset(num_shards=1).filter(filter_fn, batched=batched)
+    it = iter(ds)
+    seen = [next(it)["a"] for _ in range(consume)]
+    state_dict = ds.state_dict()
+    resumed = (
+        Dataset.from_dict({"a": list(range(n))}).to_iterable_dataset(num_shards=1).filter(filter_fn, batched=batched)
+    )
+    resumed.load_state_dict(state_dict)
+    rest = [example["a"] for example in resumed]
+    assert seen + rest == list(range(n))
+
+
 @pytest.mark.parametrize("num_shards", [1, 2, 3, 7])
 def test_iterable_dataset_batch(num_shards: int):
     # Create a simple IterableDataset


### PR DESCRIPTION
## Root cause

`IterableDataset.filter()` wraps the Arrow source in `FormattedExamplesIterable` but, unlike `map()`, does not first wrap it in `RebatchedArrowExamplesIterable(batch_size=1)`. `FormattedExamplesIterable.__iter__` takes the Arrow branch and pulls a whole table from `ArrowExamplesIterable`, advancing `shard_example_idx` to the end of that table while emitting one example at a time. The default non-batched filter never records a rewind checkpoint (`previous_state` is only set on the batched branch of `iter_outputs`), so on resume `ArrowExamplesIterable._iter_arrow` sees the saved position already at the table end and `continue`s past every unemitted row of that table.

Effect on `load_dataset(..., streaming=True).filter(...)` + `StatefulDataLoader` training-resume: each checkpoint drops up to a full row group. A single-table shard drops all unconsumed rows.

`map()` avoids this by rebatching the Arrow source to one row before formatting (#8147); `filter()` was left untouched.

## Fix

Mirror `map()`: when the filter source exposes `iter_arrow`, wrap it in `RebatchedArrowExamplesIterable(batch_size=1)` before `FormattedExamplesIterable`, so the formatter reads a single example ahead and `state_dict()` records the shard position at the emitted example. The `features` argument is now read from the original `self._ex_iterable` since `ex_iterable` may have been reassigned to the rebatched wrapper.

## Verification

Reproduced and fixed in a clean `python:3.11-slim` container at HEAD `521a590` (datasets 5.0.1.dev0, pyarrow 25).

- Differential on the new test `test_iterable_dataset_filter_resume_state_dict[batched, consume]`: on `main` the `batched=False` cases fail (resume loses rows) and the `batched=True` cases pass; on this branch all pass. Batched filter is the control, it already resumed correctly.
- The test consumes N examples, checkpoints, resumes, and asserts `seen + rest == list(range(n))` (every row exactly once) for `consume in {1, 500, 1500}`.
- `tests/test_iterable_dataset.py`: 441 passed, 47 skipped (the 4 deselected `test_interleave_dataset_with_sharding` cases require `torch`, which is not installed; they fail on `import torch` independently of this change).
- `ruff check` and `ruff format --check` (pinned `v0.11.8`) clean on both changed files.

I did not exercise the multi-worker `StatefulDataLoader` sharding path with `torch` installed; the fix is verified through `state_dict()`/`load_state_dict()` directly, which is the mechanism that path uses.

Resolves #8359
