### PR TITLE
Preserve nullable integer columns in to_json/to_csv/to_sql

### DIFF
--- a/src/datasets/io/csv.py
+++ b/src/datasets/io/csv.py
@@ -105,7 +105,7 @@ class CsvDatasetWriter:
             key=slice(offset, offset + self.batch_size),
             indices=self.dataset._indices,
         )
-        csv_str = batch.to_pandas().to_csv(
+        csv_str = batch.to_pandas(integer_object_nulls=True).to_csv(
             path_or_buf=None, header=header if (offset == 0) else False, index=index, **to_csv_kwargs
         )
         return csv_str.encode(self.encoding)

--- a/src/datasets/io/json.py
+++ b/src/datasets/io/json.py
@@ -131,7 +131,7 @@ class JsonDatasetWriter:
             key=slice(offset, offset + self.batch_size),
             indices=self.dataset._indices,
         )
-        batch = batch.to_pandas()
+        batch = batch.to_pandas(integer_object_nulls=True)
         for json_field_path in get_json_field_paths_from_feature(self.dataset.features):
             col, *json_field_subpath = json_field_path
             batch[col] = batch[col].apply(partial(json_decode_field, json_field_path=json_field_subpath))

--- a/src/datasets/io/sql.py
+++ b/src/datasets/io/sql.py
@@ -87,7 +87,7 @@ class SqlDatasetWriter:
             key=slice(offset, offset + self.batch_size),
             indices=self.dataset._indices,
         )
-        df = batch.to_pandas()
+        df = batch.to_pandas(integer_object_nulls=True)
         num_rows = df.to_sql(self.name, self.con, index=index, **to_sql_kwargs)
         return num_rows or len(df)
 

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -173,3 +173,19 @@ def test_dataset_to_csv_fsspec(dataset, mockfs):
 
     with fsspec.open(dataset_path, "rb", **mockfs.storage_options) as f:
         assert f.read()
+
+
+@pytest.mark.parametrize(
+    "dtype, big",
+    [("int64", 9007199254740993), ("uint64", 9007199254740993), ("int32", 2147483647)],
+)
+def test_dataset_to_csv_preserves_nullable_int(dtype, big, tmp_path):
+    # A nullable integer column must be written as integers, not float64-coerced values.
+    # batch.to_pandas() defaults to integer_object_nulls=False, casting an integer column
+    # that contains a null to float64 and losing precision beyond 2**53.
+    dataset = Dataset.from_dict({"a": [big, None, 5]}, features=Features({"a": Value(dtype)}))
+    output_csv = os.path.join(tmp_path, "out.csv")
+    CsvDatasetWriter(dataset, output_csv, num_proc=1).write()
+    with open(output_csv, newline="") as f:
+        rows = list(csv.DictReader(f))
+    assert [row["a"] for row in rows] == [str(big), "", "5"]

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -305,3 +305,20 @@ class TestJsonDatasetWriter:
 
         with fsspec.open(dataset_path, "rb", **mockfs.storage_options) as f:
             assert f.read()
+
+    @pytest.mark.parametrize(
+        "dtype, big",
+        [("int64", 9007199254740993), ("uint64", 9007199254740993), ("int32", 2147483647)],
+    )
+    def test_dataset_to_json_preserves_nullable_int(self, dtype, big):
+        # A nullable integer column must be written as JSON integers. batch.to_pandas()
+        # defaults to integer_object_nulls=False, which casts an integer column that
+        # contains a null to float64, dropping the integer type and any precision beyond
+        # 2**53 (9007199254740993 becomes 9007199254740992.0).
+        dataset = Dataset.from_dict({"a": [big, None, 5]}, features=Features({"a": Value(dtype)}))
+        with io.BytesIO() as buffer:
+            JsonDatasetWriter(dataset, buffer, lines=True).write()
+            buffer.seek(0)
+            rows = load_json_lines(buffer)
+        assert [row["a"] for row in rows] == [big, None, 5]
+        assert all(isinstance(row["a"], int) for row in rows if row["a"] is not None)

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -100,3 +100,18 @@ def test_dataset_to_sql_invalidproc(sqlite_path, tmp_path, set_sqlalchemy_silenc
     dataset = SqlDatasetReader("dataset", "sqlite:///" + sqlite_path, cache_dir=cache_dir).read()
     with pytest.raises(ValueError):
         SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=0).write()
+
+
+@require_sqlalchemy
+@pytest.mark.parametrize("dtype, big", [("int64", 9007199254740993), ("uint64", 9007199254740993)])
+def test_dataset_to_sql_preserves_nullable_int(dtype, big, tmp_path, set_sqlalchemy_silence_uber_warning):
+    # A nullable integer column must land in an INTEGER SQL column with its exact value.
+    # batch.to_pandas() defaults to integer_object_nulls=False, casting an integer column
+    # that contains a null to float64, so the value is stored as REAL and precision beyond
+    # 2**53 is lost.
+    dataset = Dataset.from_dict({"a": [big, None, 5]}, features=Features({"a": Value(dtype)}))
+    output_sqlite_path = os.path.join(tmp_path, "tmp.sql")
+    SqlDatasetWriter(dataset, "dataset", "sqlite:///" + output_sqlite_path, num_proc=1).write()
+    with contextlib.closing(sqlite3.connect(output_sqlite_path)) as con:
+        rows = con.execute("SELECT a, typeof(a) FROM dataset").fetchall()
+    assert rows == [(big, "integer"), (None, "null"), (5, "integer")]


### PR DESCRIPTION
### What this fixes

`Dataset.to_json`, `to_csv` and `to_sql` write a nullable integer column as floating point rather than integers.

Fixes #8365.

### Root cause

The three writers build a pandas frame with a bare `batch.to_pandas()`:

- `io/json.py` `_batch_json`
- `io/csv.py` `_batch_csv`
- `io/sql.py` `_batch_sql`

pyarrow's `to_pandas` defaults to `integer_object_nulls=False`, which casts any integer column that contains a null to `float64`. On export that drops the integer type, and for values beyond `2**53` it corrupts the value, since those are not representable in float64. A `to_json` then `load_dataset("json")` round-trip silently changes `int64` into `float64`.

### Fix

Pass `integer_object_nulls=True` to the three writers' `to_pandas()` calls. A null-containing integer column then materializes as Python integers (object dtype) and is written as integers; the null stays null. Columns with no nulls are untouched by the flag, so their numpy dtype is preserved.

Tradeoff: `integer_object_nulls=True` uses object dtype for integer columns that contain a null, which costs memory and speed for those columns only. An arrow-backed nullable dtype (pandas `Int64` via a `types_mapper`) would avoid object dtype but touches more of the export path. Glad to switch to that approach if you prefer it.

### Verification

Ran in a clean container against this branch (datasets 5.0.1.dev0, pyarrow 25.0.0, pandas 3.0.5):

- Added regression tests for all three writers, parametrized over `int64`/`uint64`/`int32`. They fail on `main` (the column exports as float, e.g. `9007199254740992.0`, and SQLite stores `real`) and pass here (exact integers, SQLite `integer`).
- `tests/io/test_json.py tests/io/test_csv.py tests/io/test_sql.py`: 96 passed, no regressions.
- `ruff check` and `ruff format --check` clean on the changed files.

I did not run the full non-io test suite or the Windows and minimum-deps CI matrix locally.
