### PR TITLE
Fix DatasetDict.push_to_hub leaving removed splits in the dataset card

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6977,7 +6977,8 @@ def _get_updated_dataset_card(
     # update the metadata configs
     if config_name in metadata_configs:
         metadata_config = metadata_configs[config_name]
-        if "data_files" in metadata_config:
+        # keep the existing splits, unless they are meant to be removed
+        if "data_files" in metadata_config and not remove_other_splits:
             data_files_to_dump = sanitize_patterns(metadata_config["data_files"])
         else:
             data_files_to_dump = {}

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -11,10 +11,11 @@ import datasets.load as datasets_load
 from datasets import DownloadConfig, config
 from datasets.arrow_dataset import _get_updated_dataset_card
 from datasets.features import Features, Value
-from datasets.info import DatasetInfo
+from datasets.info import DatasetInfo, DatasetInfosDict
 from datasets.iterable_dataset import IterableDataset
 from datasets.load import HubBucketDatasetModuleFactory
 from datasets.splits import SplitDict, SplitInfo
+from datasets.utils.metadata import MetadataConfigs
 
 
 README_WITH_CONFIG = (
@@ -149,3 +150,61 @@ def test_get_updated_dataset_card_returns_legacy_infos_as_dict():
     assert isinstance(new_legacy_dataset_infos, dict)
     assert "default" in new_legacy_dataset_infos
     assert isinstance(json.loads(json.dumps(new_legacy_dataset_infos)), dict)
+
+
+@pytest.mark.unit
+def test_get_updated_dataset_card_drops_removed_splits_when_replacing_split_set():
+    mem = MemoryFileSystem(skip_instance_cache=True)
+    fs = DirFileSystem("/shrink", fs=mem)
+
+    with fs.open(config.REPOCARD_FILENAME, "w") as f:
+        f.write(
+            "---\nconfigs:\n- config_name: default\n  data_files:\n"
+            "  - split: train\n    path: data/train-*\n"
+            "  - split: test\n    path: data/test-*\n---\n"
+        )
+
+    # push "train" only: "test" shards are deleted by the caller, so its pattern must go too
+    dataset_card, _ = _get_updated_dataset_card(
+        fs=fs,
+        config_name="default",
+        splits_info=[SplitInfo(name="train", num_bytes=40, num_examples=5)],
+        features=Features({"x": Value("int64")}),
+        data_dir="data",
+        set_default=None,
+        uploaded_sizes=[40],
+        deleted_sizes=[],
+        remove_other_splits=True,
+    )
+
+    data_files = MetadataConfigs.from_dataset_card_data(dataset_card.data)["default"]["data_files"]
+    assert [entry["split"] for entry in data_files] == ["train"]
+    # the card must agree with itself: a split listed in dataset_info but not in data_files
+    # (or vice versa) makes the dataset unloadable
+    dataset_info = DatasetInfosDict.from_dataset_card_data(dataset_card.data)["default"]
+    assert list(dataset_info.splits) == ["train"]
+
+
+@pytest.mark.unit
+def test_get_updated_dataset_card_keeps_existing_splits_when_appending():
+    mem = MemoryFileSystem(skip_instance_cache=True)
+    fs = DirFileSystem("/append", fs=mem)
+
+    with fs.open(config.REPOCARD_FILENAME, "w") as f:
+        f.write(README_WITH_CONFIG)
+
+    # Dataset.push_to_hub passes remove_other_splits=False and must stay additive
+    dataset_card, _ = _get_updated_dataset_card(
+        fs=fs,
+        config_name="default",
+        splits_info=[SplitInfo(name="test", num_bytes=40, num_examples=5)],
+        features=Features({"x": Value("int64")}),
+        data_dir="data",
+        set_default=None,
+        uploaded_sizes=[40],
+        deleted_sizes=[0],
+        remove_other_splits=False,
+    )
+
+    data_files = MetadataConfigs.from_dataset_card_data(dataset_card.data)["default"]["data_files"]
+    assert [entry["split"] for entry in data_files] == ["train", "test"]


### PR DESCRIPTION
Pushing a `DatasetDict` that drops a split leaves the repo unloadable:

```python
DatasetDict({"train": ds_train, "test": ds_test}).push_to_hub("user/repo")
DatasetDict({"train": ds_train}).push_to_hub("user/repo")   # "test" is gone

load_dataset("user/repo")
# ValueError: Couldn't infer the same data file format for all splits.
# Got {'train': ('parquet', {}), 'test': (None, {})}
```

## Context

Two things matter here:

- `configs.data_files` paths are **globs**, and every split listed there must expand to real files at load time.
- `DatasetDict.push_to_hub` **replaces** the split set: any split not in the dict has its parquet files deleted from the repo, and the card is rewritten with `remove_other_splits=True`. (`Dataset.push_to_hub` only appends, and passes `remove_other_splits=False`.)

After the second push above, the card's YAML header looks like this:

```yaml
configs:
- config_name: default
  data_files:
  - split: train
    path: data/train-*
  - split: test           # <-- stale: this push just deleted these files
    path: data/test-*
dataset_info:
  splits:
  - name: train           # <-- dataset_info correctly dropped "test"
```

`data/test-*` now matches no files, so `load_dataset` can't infer a format for `test` and fails.

## Root cause

`remove_other_splits=True` was only honored for the `dataset_info` block. The `configs.data_files` block was rebuilt like this:

```python
data_files_to_dump = sanitize_patterns(metadata_config["data_files"])  # start from the old card
for split_info in splits_info:                                         # then add this push's splits
    data_files_to_dump[split_info.name] = [f"{data_dir}/{split_info.name}-*"]
```

Splits are only ever **added** to that dict — nothing removes one, so `test` survives from the old card even though this push deleted its files.

## Fix

When `remove_other_splits=True`, don't seed from the old card — start empty so the patterns describe exactly the splits this push wrote.

```python
if "data_files" in metadata_config and not remove_other_splits:
```

`Dataset.push_to_hub` is unaffected — it stays on the additive path and keeps whatever the card already lists.

## Tests

Two hermetic tests in `tests/test_buckets.py` (in-memory filesystems, no Hub), alongside the existing `_get_updated_dataset_card` test:

- `test_get_updated_dataset_card_drops_removed_splits_when_replacing_split_set` — verified to fail before the fix. Asserts both blocks agree, since it's the disagreement that breaks loading.
- `test_get_updated_dataset_card_keeps_existing_splits_when_appending` — pins the additive `remove_other_splits=False` path so `Dataset.push_to_hub` doesn't regress.
