### PR TITLE
docs: make repository structure guide prominent in quickstart (#5971)

### DIFF
--- a/docs/source/create_dataset.mdx
+++ b/docs/source/create_dataset.mdx
@@ -6,6 +6,8 @@ In this tutorial, you'll learn how to use 🤗 Datasets low-code methods for cre
 
 > **Note**
 >
+> To learn how to structure your dataset repository (defining splits, subsets, and supported file formats) for automatic loading on the Hub, see the [Structure your repository](repository_structure) guide.
+>
 > If you want to learn how to load existing datasets, or how to load local and remote files (CSV, JSON, Parquet, etc.), see the [Load guide](https://huggingface.co/docs/datasets/loading).
 
 This tutorial covers:

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -6,7 +6,7 @@
 
 Load a dataset in a single line of code, and use our powerful data processing and streaming methods to quickly get your dataset ready for training in a deep learning model. Backed by the Apache Arrow format, process large datasets with zero-copy reads without any memory constraints for optimal speed and efficiency. We also feature a deep integration with the [Hugging Face Hub](https://huggingface.co/datasets), allowing you to easily load and share a dataset with the wider machine learning community.
 
-Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), and take an in-depth look inside of it with the live viewer.
+Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), and take an in-depth look inside of it with the live viewer. To learn how to structure your dataset files when sharing on the Hub, check out the [Structure your repository](repository_structure) guide.
 
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">


### PR DESCRIPTION
Fixes #5971

### Summary of Documentation Improvements:
- **\docs/source/create_dataset.mdx\**: Added a callout link in the introductory **Note** block pointing to the \epository_structure\ guide so users creating a dataset can easily find guidance on organizing files, splits, and formats.
- **\docs/source/index.mdx\**: Added a reference link to the \epository_structure\ guide in the introductory overview section.