### PR TITLE
Fix PandasArrayExtensionDtype._metadata to use a tuple

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -847,7 +847,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
 
 
 class PandasArrayExtensionDtype(PandasExtensionDtype):
-    _metadata = "value_type"
+    _metadata = ("value_type",)
 
     def __init__(self, value_type: Union["PandasArrayExtensionDtype", np.dtype]):
         self._value_type = value_type


### PR DESCRIPTION
## What was wrong
`PandasArrayExtensionDtype` set `_metadata = "value_type"` (a string), but pandas expects a tuple of attribute names, e.g. `("value_type",)`.
When pandas compares dtypes (during things like `df[mask]`), it loops over `_metadata` and looks up each entry as an attribute. With a string, it iterates over individual characters (`"v"`, `"a"`, `"l"`, ...), which raises:
`AttributeError: 'PandasArrayExtensionDtype' object has no attribute 'v'`

This breaks boolean indexing on parquet DataFrames that have `array[float64]` columns. I specifically hit it when splitting a LeRobot dataset after import.

## What changed
```
_metadata = ("value_type",)  # was: "value_type"
```

Fixes #8375 