### PR TITLE
Fix PandasArrayExtensionDtype._metadata: must be a tuple, not a string

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -847,7 +847,7 @@ class ArrayExtensionArray(pa.ExtensionArray):
 
 
 class PandasArrayExtensionDtype(PandasExtensionDtype):
-    _metadata = "value_type"
+    _metadata = ("value_type",)
 
     def __init__(self, value_type: Union["PandasArrayExtensionDtype", np.dtype]):
         self._value_type = value_type


### PR DESCRIPTION
## Summary
Fixes #8375 — `PandasArrayExtensionDtype._metadata` is a plain string instead of a tuple, causing `AttributeError: 'PandasArrayExtensionDtype' object has no attribute 'v'` whenever pandas compares two instances of this dtype (e.g. during a boolean-mask filter on a DataFrame with an array-feature column read back from parquet).

**Root cause:** [`pandas.api.extensions.ExtensionDtype`](https://pandas.pydata.org/docs/reference/api/pandas.api.extensions.ExtensionDtype.html) expects `_metadata` to be a tuple of attribute names used for equality comparison. As a plain string `"value_type"`, pandas iterates over it character-by-character (`'v'`, `'a'`, `'l'`, `'u'`, `'e'`, ...) when comparing dtypes, and crashes looking up an attribute named `'v'`.

```python
_metadata = "value_type"
```
→
```python
_metadata = ("value_type",)
```

## Verification
Reproduced the underlying bug in isolation — a minimal `ExtensionDtype` subclass using only pandas, no `datasets` import required:

```python
import pandas as pd
from pandas.api.extensions import ExtensionDtype

class BadDtype(ExtensionDtype):
    _metadata = "value_type"
    name = "bad"; type = object; na_value = None
    def __init__(self, value_type): self.value_type = value_type
    @classmethod
    def construct_array_type(cls): return None

class GoodDtype(ExtensionDtype):
    _metadata = ("value_type",)
    name = "good"; type = object; na_value = None
    def __init__(self, value_type): self.value_type = value_type
    @classmethod
    def construct_array_type(cls): return None

BadDtype("float64") == BadDtype("float64")   # AttributeError: 'BadDtype' object has no attribute 'v'
GoodDtype("float64") == GoodDtype("float64") # True
```

This confirms the string-vs-tuple distinction is the actual cause of the reported `AttributeError`, and that the tuple form resolves it, independent of anything else in `datasets`.

## Test plan
- [x] Reproduced the exact failure mode (`AttributeError: no attribute 'v'`) in isolation and confirmed the fix resolves it.
- [ ] Didn't run the full `datasets` reproduction script from the issue (parquet round-trip + `Array2D` features) in this environment — didn't want to pull in the full `datasets`/`pyarrow` stack just to verify a one-character change whose root cause is fully isolated above. Happy to iterate if CI surfaces anything additional.
