### PR TITLE
Preserve features after IterableDataset.add_column

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4061,7 +4061,10 @@ class IterableDataset(DatasetInfoMixin):
         Returns:
             `IterableDataset`
         """
-        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True)
+        features = self.features.copy() if self.features is not None else None
+        if features is not None:
+            features.update(_infer_features_from_batch({name: column}))
+        return self.map(partial(add_column_fn, name=name, column=column), with_indices=True, features=features)
 
     def rename_column(self, original_column_name: str, new_column_name: str) -> "IterableDataset":
         """

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2414,6 +2414,15 @@ def test_iterable_dataset_add_column(dataset_with_several_columns: IterableDatas
     assert "new_column" in new_dataset.column_names
 
 
+def test_iterable_dataset_add_column_preserves_features(dataset_with_several_columns: IterableDataset):
+    dataset = dataset_with_several_columns._resolve_features()
+    new_column = list(range(3 * DEFAULT_N_EXAMPLES))
+    new_dataset = dataset.add_column("new_column", new_column)
+    assert new_dataset.features is not None
+    assert new_dataset.features["new_column"] == Value("int64")
+    assert new_dataset.column_names == [*dataset.column_names, "new_column"]
+
+
 def test_iterable_dataset_rename_column(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.rename_column("id", "new_id")
     assert list(new_dataset) == [


### PR DESCRIPTION
## Summary

- preserve known `IterableDataset` features when `add_column` appends a streaming column
- infer the appended column feature from the provided column values
- add a regression test for `add_column` after resolving iterable dataset features

Fixes #5752.

## Testing

- local repro with `IterableDataset.from_generator(...).add_column(...)`
- `python -m pytest tests/test_iterable_dataset.py::test_iterable_dataset_add_column tests/test_iterable_dataset.py::test_iterable_dataset_add_column_preserves_features`
- `python -m pytest tests/test_iterable_dataset.py::test_pickle_after_many_transforms`
