### PR TITLE
Fix IterableDataset.to_dict() and to_polars() returning an empty generator

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4501,8 +4501,10 @@ class IterableDataset(DatasetInfoMixin):
         ```
         """
         if batched:
-            for table in self.with_format("arrow").iter(batch_size=batch_size):
-                yield Dataset(table, fingerprint="unset").to_dict()
+            return (
+                Dataset(table, fingerprint="unset").to_dict()
+                for table in self.with_format("arrow").iter(batch_size=batch_size)
+            )
         else:
             table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
             return Dataset(table, fingerprint="unset").to_dict()
@@ -4593,8 +4595,10 @@ class IterableDataset(DatasetInfoMixin):
         ```
         """
         if batched:
-            for table in self.with_format("arrow").iter(batch_size=batch_size):
-                yield Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)
+            return (
+                Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)
+                for table in self.with_format("arrow").iter(batch_size=batch_size)
+            )
         else:
             table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
             return Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1796,6 +1796,29 @@ def test_iterable_dataset_to_pandas_casts_when_schema_mismatch():
     assert len(batches) == 2
 
 
+def test_iterable_dataset_to_dict():
+    dataset = Dataset.from_dict({"col": [0, 1, 2]}).to_iterable_dataset()
+
+    assert dataset.to_dict() == {"col": [0, 1, 2]}
+
+    batches = list(dataset.to_dict(batch_size=2, batched=True))
+    assert batches == [{"col": [0, 1]}, {"col": [2]}]
+
+
+@require_polars
+def test_iterable_dataset_to_polars():
+    import polars as pl
+
+    dataset = Dataset.from_dict({"col": [0, 1, 2]}).to_iterable_dataset()
+
+    df = dataset.to_polars()
+    assert isinstance(df, pl.DataFrame)
+    assert df["col"].to_list() == [0, 1, 2]
+
+    batches = list(dataset.to_polars(batch_size=2, batched=True))
+    assert [batch["col"].to_list() for batch in batches] == [[0, 1], [2]]
+
+
 @require_numpy1_on_windows
 def test_iterable_dataset_from_file(dataset: IterableDataset, arrow_file: str):
     with assert_arrow_memory_doesnt_increase():


### PR DESCRIPTION
### The bug

`IterableDataset.to_dict()` and `IterableDataset.to_polars()` each contain a bare `yield` in their `batched=True` branch. A bare `yield` anywhere in a function body makes the whole function a generator function, so both methods return a generator on every call, including the `batched=False` default. That generator yields nothing, and the value the `else` branch returns is swallowed into `StopIteration.value`, so the call shown in each docstring hands back an empty generator rather than the dict or the DataFrame.

`to_pandas()` had the same shape and was changed to a returned generator expression in #8068. `to_dict` and `to_polars` were left alone, so they are the only two `to_*` methods on the class still affected. This applies the same shape to both: `batched=True` stays lazy, and the non-batched branch can now return.

After the change `inspect.isgeneratorfunction` is `False` for all eight `to_*` methods on `IterableDataset`, and the only generator functions left on the class are `__iter__`, `iter` and `_iter_pytorch`.

Fixes #8381

### Verification

- Two new tests in `tests/test_iterable_dataset.py` pin both methods in both modes. Both fail on `main` (`to_dict` returns a generator, `to_polars` returns a generator) and pass on this branch, run in a clean container with the two trees mounted side by side and `datasets.__file__` printed on each run.
- Full `tests/test_iterable_dataset.py`: 445 passed here against 443 on `main`. The only failures on either side are the same four `test_interleave_dataset_with_sharding` cases, which fail identically on `main` and are unrelated to this change.
- `ruff check` and `ruff format --check` over `tests src benchmarks utils setup.py`, the `check_code_quality` job, are clean.
- Not checked: the Windows, deps-minimum, integration and py3.14 legs, and any suite other than `tests/test_iterable_dataset.py`.
