### PR TITLE
Apply the indices mapping in Dataset.unique

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2230,12 +2230,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if column not in self._data.column_names:
             raise ValueError(f"Column ({column}) not in table columns ({self._data.column_names}).")
 
-        if self._indices is not None and self._indices.num_rows != self._data.num_rows:
-            dataset = self.flatten_indices()
+        if self._indices is not None:
+            # the indices mapping can also repeat or drop rows without changing the number of rows,
+            # so it always has to be applied - only the requested column is materialized
+            column_data = query_table(table=self._data, key=column, indices=self._indices).column(0)
         else:
-            dataset = self
+            column_data = self._data.column(column)
 
-        return dataset._data.column(column).unique().to_pylist()
+        return column_data.unique().to_pylist()
 
     def class_encode_column(self, column: str, include_nulls: bool = False) -> "Dataset":
         """Casts the given column as [`~datasets.features.ClassLabel`] and updates the table.

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3649,6 +3649,20 @@ def test_class_encode_column_with_none(include_nulls):
     assert (None in dataset.unique("col_1")) == (not include_nulls)
 
 
+def test_unique_with_indices_mapping_of_same_length():
+    dataset = Dataset.from_dict({"col_1": ["a", "b", "c"]})
+    # the indices mapping has as many rows as the table but doesn't select every row
+    dataset = dataset.select([0, 0, 1])
+    assert dataset["col_1"] == ["a", "a", "b"]
+    assert dataset.unique("col_1") == ["a", "b"]
+
+
+def test_class_encode_column_with_indices_mapping_of_same_length():
+    dataset = Dataset.from_dict({"col_1": ["a", "b", "c"]})
+    dataset = dataset.select([0, 0, 1]).class_encode_column("col_1")
+    assert dataset.features["col_1"].names == ["a", "b"]
+
+
 @pytest.mark.parametrize("null_placement", ["first", "last"])
 def test_sort_with_none(null_placement):
     dataset = Dataset.from_dict({"col_1": ["item_2", "item_3", "item_1", None, "item_4", None]})


### PR DESCRIPTION
`Dataset.unique` only takes the indices mapping into account when it has a different number of rows than the underlying table:

```python
if self._indices is not None and self._indices.num_rows != self._data.num_rows:
```

An indices mapping can also repeat some rows and drop others while keeping the same length. In that case `unique` reads the raw table and returns values that are not in the dataset:

```python
ds = Dataset.from_dict({"col_1": ["a", "b", "c"]}).select([0, 0, 1])
ds["col_1"]         # ['a', 'a', 'b']
ds.unique("col_1")  # ['a', 'b', 'c']  <- 'c' is not in the dataset
```

`class_encode_column` builds its `ClassLabel` names from `unique`, so it inherits the bug and creates a class for rows that were dropped:

```python
ds.class_encode_column("col_1").features["col_1"].names  # ['a', 'b', 'c']
```

This is reachable from ordinary use — `select` with repeats (bootstrap resampling), and any indices mapping whose length happens to match the table.

This applies the indices mapping whenever there is one. Only the requested column is materialized, via the existing `query_table(..., key=column, indices=self._indices)` path, so it deliberately avoids falling back to `flatten_indices()` — that would make `shuffle().unique()` rewrite the whole dataset.

Added `test_unique_with_indices_mapping_of_same_length` and `test_class_encode_column_with_indices_mapping_of_same_length`; both fail on `main` with `assert ['a', 'b', 'c'] == ['a', 'b']` and pass with the change. `tests/test_arrow_dataset.py`, `tests/test_dataset_dict.py` and `tests/test_search.py` pass (470 passed, 38 skipped).