### PR TITLE
Fix IterableDataset.remove_columns when a single column name is passed

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4143,6 +4143,9 @@ class IterableDataset(DatasetInfoMixin):
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
+        if isinstance(column_names, str):
+            column_names = [column_names]
+
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(remove_columns=column_names)
         if original_features is not None:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2465,6 +2465,15 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableD
     assert all(c not in new_dataset.column_names for c in ["id", "filepath"])
 
 
+def test_iterable_dataset_remove_columns_str():
+    # the column name must not be matched character by character against the other column names
+    dataset = Dataset.from_dict({"label": [0, 1], "label_text": ["a", "b"]}).to_iterable_dataset()
+    new_dataset = dataset.remove_columns("label_text")
+    assert new_dataset.column_names == ["label"]
+    assert list(new_dataset.features) == ["label"]
+    assert list(new_dataset) == [{"label": 0}, {"label": 1}]
+
+
 def test_iterable_dataset_select_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.select_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
`IterableDataset.remove_columns` accepts either a single column name or a list, but it only ever tests `col in column_names`. When a string is passed, that becomes a substring test, so any existing column whose name is contained in the one being removed is dropped from `info.features`:

```python
ds = Dataset.from_dict({"label": [0, 1], "label_text": ["a", "b"]})
it = ds.to_iterable_dataset().remove_columns("label_text")

it.column_names  # []  -> should be ['label']
it.features      # {}
next(iter(it))   # {'label': 0}  -> the column is still being yielded
```

`features` and `column_names` then disagree with the actual examples, which breaks anything that reads the schema afterwards — `select_columns`, `cast`, or writing to parquet. The map-style `Dataset.remove_columns("label_text")` correctly returns `['label']`, so the two paths disagree.

The existing `test_iterable_dataset_remove_columns` passes only incidentally: it removes `"id"` and no sibling column name contains `"id"`.

This normalizes a string argument to a list first, which is what `select_columns` in the same class already does.

Added coverage for the single-string case with a sibling whose name is a substring; it fails on `main` with `assert [] == ['label']` and passes with the change. `tests/test_iterable_dataset.py` and `tests/test_dataset_dict.py` pass (531 passed, 30 skipped; the 2 remaining failures are pre-existing network-dependent tests unrelated to this change).