### PR TITLE
Fix save_to_disk writing no shard for a dataset with no rows

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1845,7 +1845,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             num_shards = int(dataset_nbytes / max_shard_size) + 1
             num_shards = max(num_shards, num_proc or 1)
             # if we have only a few large samples, we should only create as many shards as samples
-            num_shards = min(len(self.data), num_shards)
+            # but we always write at least one shard, even for an empty dataset
+            num_shards = max(min(len(self.data), num_shards), 1)
 
         fs: fsspec.AbstractFileSystem
         fs, _ = url_to_fs(dataset_path, **(storage_options or {}))

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5063,6 +5063,16 @@ def test_dataset_from_dict_with_large_list():
     assert pa.types.is_large_list(ds.data.schema.field("col_1").type)
 
 
+def test_dataset_save_to_disk_and_load_from_disk_round_trip_with_no_rows(tmp_path):
+    ds = Dataset.from_dict({"col_1": []}, features=Features({"col_1": Value("int64")}))
+    dataset_path = tmp_path / "dataset_dir"
+    ds.save_to_disk(dataset_path)
+    assert (dataset_path / "data-00000-of-00001.arrow").exists()
+    loaded_ds = load_from_disk(dataset_path)
+    assert len(loaded_ds) == 0
+    assert loaded_ds.features == ds.features
+
+
 def test_dataset_save_to_disk_with_large_list(tmp_path):
     data = {"col_1": [[1, 2], [3, 4]]}
     features = Features({"col_1": LargeList(Value("int64"))})


### PR DESCRIPTION
`save_to_disk` computes the number of shards from the estimated size and then clamps it to the number of rows (added in #7912):

```python
num_shards = min(len(self.data), num_shards)
```

For a dataset with no rows that gives `0` shards. No `.arrow` file is written, `state.json` gets an empty `"_data_files"`, and loading it back fails:

```python
ds = Dataset.from_dict({"col_1": []}, features=Features({"col_1": Value("int64")}))
ds.save_to_disk(path)   # succeeds, writes only state.json + dataset_info.json
load_from_disk(path)    # IndexError: list index out of range
```

`save_to_disk` reports success, so the data loss is silent until the load fails later.

It is reachable from an ordinary pipeline rather than only from a hand-built empty dataset:

```python
ds.filter(lambda x: False).flatten_indices().save_to_disk(path)
```

and the same applies through `DatasetDict.save_to_disk` when one split filters down to nothing.

Passing `num_shards=1` explicitly already worked, so only the automatic path was affected. This clamps the computed value to at least one shard.

Added a regression test asserting the shard file exists and the dataset round-trips; it fails on `main` with `assert (dataset_path / "data-00000-of-00001.arrow").exists()` and passes with the change. `tests/test_arrow_dataset.py` and `tests/test_dataset_dict.py` pass (469 passed, 26 skipped).