### PR TITLE
Allow to_iterable_dataset() on a dataset with no rows

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5860,7 +5860,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 raise NotImplementedError(
                     "Converting a formatted dataset with kwargs or selected columns to a formatted iterable dataset is not implemented yet. Please run `my_dataset = my_dataset.with_format(None)` before calling to_iterable_dataset"
                 )
-        if num_shards > len(self):
+        if num_shards > max(len(self), 1):  # a dataset with no rows still has one (empty) shard
             raise ValueError(
                 f"Unable to shard a dataset of size {len(self)} into {num_shards} shards (the number of shards exceeds the number of samples)."
             )

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4650,6 +4650,17 @@ def test_dataset_to_iterable_dataset(dataset: Dataset):
         dataset.with_format("torch", columns=[dataset.column_names[0]]).to_iterable_dataset()
 
 
+def test_dataset_to_iterable_dataset_empty():
+    dataset = Dataset.from_dict({"col_1": []})
+    iterable_dataset = dataset.to_iterable_dataset()
+    assert isinstance(iterable_dataset, IterableDataset)
+    assert list(iterable_dataset) == []
+    assert iterable_dataset.features == dataset.features
+    assert iterable_dataset.num_shards == 1
+    with pytest.raises(ValueError):
+        dataset.to_iterable_dataset(num_shards=2)
+
+
 @require_pil
 def test_dataset_format_with_unformatted_image():
     import PIL


### PR DESCRIPTION
`Dataset.to_iterable_dataset()` defaults to `num_shards=1`, but the guard rejects any `num_shards > len(self)`, so it always raises on an empty dataset:

```python
>>> Dataset.from_dict({"a": []}).to_iterable_dataset()
ValueError: Unable to shard a dataset of size 0 into 1 shards (the number of shards exceeds the number of samples).
```

A dataset with no rows still has one (empty) shard, and the `num_shards == 1` branch below never calls `.shard()`, so no other change was needed. Requesting more than one shard from an empty dataset still raises as before.

This matches the empty-dataset exemption proposed for `Dataset.shard` in #8190, and is the same family as #8385 (`save_to_disk` on a dataset with no rows).

Added `test_dataset_to_iterable_dataset_empty`; it fails on `main` with the `ValueError` above and passes with the change. `tests/test_arrow_dataset.py` → 400 passed, 25 skipped.