### PR TITLE
Keep the id of List and LargeList features when visiting them

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1733,9 +1733,9 @@ def _visit(feature: FeatureType, func: Callable[[FeatureType], Optional[FeatureT
     elif isinstance(feature, dict):
         out = func({k: _visit(f, func) for k, f in feature.items()})
     elif isinstance(feature, LargeList):
-        out = func(LargeList(_visit(feature.feature, func)))
+        out = func(LargeList(_visit(feature.feature, func), id=feature.id))
     elif isinstance(feature, List):
-        out = func(List(_visit(feature.feature, func), length=feature.length))
+        out = func(List(_visit(feature.feature, func), length=feature.length, id=feature.id))
     else:
         out = func(feature)
     return feature if out is None else out
@@ -1768,9 +1768,12 @@ def _visit_with_path(
     elif isinstance(feature, dict):
         out = func({k: _visit_with_path(f, func, visit_path + [k]) for k, f in feature.items()}, visit_path)
     elif isinstance(feature, List):
-        out = func(List(_visit_with_path(feature.feature, func, visit_path + [0]), length=feature.length), visit_path)
+        out = func(
+            List(_visit_with_path(feature.feature, func, visit_path + [0]), length=feature.length, id=feature.id),
+            visit_path,
+        )
     elif isinstance(feature, LargeList):
-        out = func(LargeList(_visit_with_path(feature.feature, func, visit_path + [0])), visit_path)
+        out = func(LargeList(_visit_with_path(feature.feature, func, visit_path + [0]), id=feature.id), visit_path)
     else:
         out = func(feature, visit_path)
     return feature if out is None else out

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -18,6 +18,7 @@ from datasets.features.features import (
     _check_non_null_non_empty_recursive,
     _is_null_feature,
     _visit,
+    _visit_with_path,
     cast_to_python_objects,
     decode_nested_example,
     encode_nested_example,
@@ -1036,6 +1037,22 @@ def test_visit_with_list_types(feature, expected):
 
     result = _visit(feature, func)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "feature",
+    [
+        List(Value("int32"), id="my feature"),
+        List(Value("int32"), length=2, id="my feature"),
+        LargeList(Value("int32"), id="my feature"),
+    ],
+)
+def test_visit_with_list_types_keeps_id(feature):
+    assert _visit(feature, lambda x: x).id == "my feature"
+    assert _visit_with_path(feature, lambda x, path: x).id == "my feature"
+    # Features() visits every column to convert the legacy [feature] syntax
+    assert Features({"col": feature})["col"].id == "my feature"
+    assert Features({"col": {"sub": feature}})["col"]["sub"].id == "my feature"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`_visit()` and `_visit_with_path()` rebuild `List` / `LargeList` in order to recurse into the inner feature, but they don't carry `id` over, so it is silently reset to `None`. Every other feature type is passed through untouched and keeps its `id`.

`Features.__init__` runs `_visit()` on every column (to convert the legacy `[feature]` syntax to `List`), so this is reachable from plain user code:

```python
>>> Features({"a": Value("int32", id="my feature")})["a"].id
'my feature'
>>> Features({"a": List(Value("int32"), id="my feature")})["a"].id
None
```

`id` is a live, tested concept — `tests/features/test_features.py` already asserts it survives for `Value`.

This passes `id` through in both visitors so list features behave like the rest. Nested cases are covered too (`Features({"a": {"b": List(..., id=...)}})`).

Added `test_visit_with_list_types_keeps_id`, parametrized over `List`, `List` with `length`, and `LargeList`; all three fail on `main` with `assert None == 'my feature'` and pass with the change. Regression run across `tests/features/`, `tests/test_arrow_writer.py`, `tests/test_table.py`, `tests/test_arrow_dataset.py` and `tests/test_info.py` → 1150 passed, 129 skipped.