### PR TITLE
Add Spark Connect support for Spark datasets

### DIFF
--- a/src/datasets/packaged_modules/spark/spark.py
+++ b/src/datasets/packaged_modules/spark/spark.py
@@ -46,6 +46,16 @@ def _reorder_dataframe_by_partition(df: "pyspark.sql.DataFrame", new_partition_o
     return df_combined
 
 
+def _get_partition_ids(df: "pyspark.sql.DataFrame") -> list[int]:
+    import pyspark
+
+    partition_ids = (
+        df.select(pyspark.sql.functions.spark_partition_id().alias("part_id")).select("part_id").distinct().collect()
+    )
+    # Keep one logical shard for an empty DataFrame so that it can still be iterated.
+    return sorted(row.part_id for row in partition_ids) or [0]
+
+
 def _generate_iterable_examples(
     df: "pyspark.sql.DataFrame",
     partition_order: list[int],
@@ -83,7 +93,7 @@ class SparkExamplesIterable(_BaseExamplesIterable):
     ):
         super().__init__()
         self.df = df
-        self.partition_order = partition_order or range(self.df.rdd.getNumPartitions())
+        self.partition_order = partition_order or _get_partition_ids(self.df)
 
     def _init_state_dict(self) -> dict:
         self._state_dict = {"partition_idx": 0, "partition_example_idx": 0}
@@ -97,7 +107,7 @@ class SparkExamplesIterable(_BaseExamplesIterable):
         yield from _generate_iterable_examples(self.df, self.partition_order, self._state_dict)
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "SparkExamplesIterable":
-        partition_order = list(range(self.df.rdd.getNumPartitions()))
+        partition_order = list(self.partition_order)
         generator.shuffle(partition_order)
         return SparkExamplesIterable(self.df, partition_order=partition_order)
 
@@ -134,19 +144,20 @@ class Spark(datasets.DatasetBuilder):
 
     def _validate_cache_dir(self):
         # Define this so that we don't reference self in create_cache_and_write_probe, which will result in a pickling
-        # error due to pickling the SparkContext.
+        # error due to pickling the Spark session.
         cache_dir = self._cache_dir
 
         # Returns the path of the created file.
-        def create_cache_and_write_probe(context):
+        def create_cache_and_write_probe(iterator):
             # makedirs with exist_ok will recursively create the directory. It will not throw an error if directories
             # already exist.
             os.makedirs(cache_dir, exist_ok=True)
             probe_file = os.path.join(cache_dir, "fs_test" + uuid.uuid4().hex)
             # Opening the file in append mode will create a new file unless it already exists, in which case it will not
             # change the file contents.
-            open(probe_file, "a")
-            return [probe_file]
+            with open(probe_file, "a"):
+                pass
+            yield pa.RecordBatch.from_pydict({"probe_file": [probe_file]})
 
         if self._spark.conf.get("spark.master", "").startswith("local"):
             return
@@ -155,10 +166,11 @@ class Spark(datasets.DatasetBuilder):
         # accessible to the driver.
         # TODO: Stream batches to the driver using ArrowCollectSerializer instead of throwing an error.
         if self._cache_dir:
-            probe = (
-                self._spark.sparkContext.parallelize(range(1), 1).mapPartitions(create_cache_and_write_probe).collect()
+            probe = self._spark.range(1, numPartitions=1).mapInArrow(
+                create_cache_and_write_probe, "probe_file: string"
             )
-            if os.path.isfile(probe[0]):
+            probe_file = probe.collect()[0].probe_file
+            if os.path.isfile(probe_file):
                 return
 
         raise ValueError(
@@ -328,7 +340,7 @@ class Spark(datasets.DatasetBuilder):
             split_generator.split_info.shard_lengths = all_shard_lengths
 
             # Define fs outside of _rename_shard so that we don't reference self in the function, which will result in a
-            # pickling error due to pickling the SparkContext.
+            # pickling error due to pickling the Spark session.
             fs = self._fs
 
             # use the -SSSSS-of-NNNNN pattern
@@ -350,7 +362,21 @@ class Spark(datasets.DatasetBuilder):
                 for shard_id in range(num_shards):
                     args.append([task_id, shard_id, global_shard_id])
                     global_shard_id += 1
-            self._spark.sparkContext.parallelize(args, len(args)).map(lambda args: _rename_shard(*args)).collect()
+
+            def _rename_shards(iterator):
+                for batch in iterator:
+                    for task_id, shard_id, global_shard_id in zip(
+                        batch["task_id"].to_pylist(),
+                        batch["shard_id"].to_pylist(),
+                        batch["global_shard_id"].to_pylist(),
+                    ):
+                        _rename_shard(task_id, shard_id, global_shard_id)
+                    yield batch
+
+            schema = "task_id: long, shard_id: long, global_shard_id: long"
+            self._spark.createDataFrame(args, schema).repartition(len(args)).mapInArrow(
+                _rename_shards, schema
+            ).collect()
         else:
             # don't use any pattern
             shard_id = 0

--- a/tests/packaged_modules/test_spark.py
+++ b/tests/packaged_modules/test_spark.py
@@ -12,6 +12,7 @@ from datasets.packaged_modules.spark.spark import (
     SparkConfig,
     SparkExamplesIterable,
     _generate_iterable_examples,
+    _get_partition_ids,
 )
 
 from ..utils import (
@@ -66,6 +67,25 @@ def test_generate_iterable_examples():
         expected_row_id, expected_row_dict = expected_row_ids_and_row_dicts[i]
         assert row_id == expected_row_id
         assert row_dict == expected_row_dict
+
+
+@require_not_windows
+@require_dill_gt_0_3_2
+def test_get_partition_ids():
+    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    df = spark.range(10).repartition(2)
+    assert _get_partition_ids(df) == [0, 1]
+    assert _get_partition_ids(df.limit(0)) == [0]
+
+
+@require_not_windows
+@require_dill_gt_0_3_2
+def test_validate_cache_dir_without_spark_context(tmp_path):
+    spark = pyspark.sql.SparkSession.builder.master("local[*]").appName("pyspark").getOrCreate()
+    spark_builder = Spark(spark.range(1), cache_dir=str(tmp_path))
+    with patch.object(type(spark.conf), "get", return_value="spark://remote"):
+        spark_builder._validate_cache_dir()
+    assert list(tmp_path.rglob("fs_test*"))
 
 
 @require_not_windows

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4341,7 +4341,7 @@ def test_from_spark():
         ("2", 2, 2.0),
         ("3", 3, 3.0),
     ]
-    df = spark.createDataFrame(data, "col_1: string, col_2: int, col_3: float")
+    df = spark.createDataFrame(data, "col_1: string, col_2: int, col_3: float").repartition(2)
     dataset = Dataset.from_spark(df)
     assert isinstance(dataset, Dataset)
     assert dataset.num_rows == 4


### PR DESCRIPTION
## What does this PR do?

Adds Spark Connect support to `Dataset.from_spark` and `IterableDataset.from_spark` by replacing client-side RDD and `SparkContext` calls with DataFrame APIs supported by Spark Connect.

- discovers partitions with `spark_partition_id()` for streaming datasets
- runs the shared-cache probe with `mapInArrow`
- distributes shard renames with `createDataFrame` and `mapInArrow`
- adds coverage for partition discovery, empty DataFrames, the remote-cache probe, and multi-shard output

## Testing

- `ruff check src/datasets/packaged_modules/spark/spark.py tests/packaged_modules/test_spark.py tests/test_arrow_dataset.py`
- `ruff format --check src/datasets/packaged_modules/spark/spark.py tests/packaged_modules/test_spark.py tests/test_arrow_dataset.py`
- PySpark 4.2 classic and Spark Connect smoke tests for partition discovery, worker cache probing, and distributed shard renaming