### PR TITLE
Forward iter_arrow, is_typed and features from RepeatExamplesIterable

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2131,6 +2131,18 @@ class RepeatExamplesIterable(_BaseExamplesIterable):
         self.ex_iterable = ex_iterable
         self.num_times = num_times
 
+    @property
+    def iter_arrow(self):
+        return self._iter_arrow if self.ex_iterable.iter_arrow else None
+
+    @property
+    def is_typed(self):
+        return self.ex_iterable.is_typed
+
+    @property
+    def features(self):
+        return self.ex_iterable.features
+
     def _init_state_dict(self) -> dict:
         self._state_dict = {
             "repeat_index": 0,
@@ -2145,6 +2157,17 @@ class RepeatExamplesIterable(_BaseExamplesIterable):
             if self.num_times is not None and repeat_index >= max(self.num_times, 0):
                 break
             yield from self.ex_iterable
+            repeat_index += 1
+            if self._state_dict:
+                self._state_dict["repeat_index"] = repeat_index
+                self._state_dict["examples_iterable"] = self.ex_iterable._init_state_dict()
+
+    def _iter_arrow(self):
+        repeat_index = self._state_dict["repeat_index"] if self._state_dict else 0
+        while True:
+            if self.num_times is not None and repeat_index >= max(self.num_times, 0):
+                break
+            yield from self.ex_iterable.iter_arrow()
             repeat_index += 1
             if self._state_dict:
                 self._state_dict["repeat_index"] = repeat_index

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1445,6 +1445,26 @@ def test_repeat_examples_iterable(n, num_times):
             assert next(iterator)[1] == all_examples[i % len(all_examples)], f"iteration {i} failed,"
 
 
+@pytest.mark.parametrize("num_times", [2, 0])
+def test_repeat_examples_iterable_arrow(num_times):
+    base_ex_iterable = ArrowExamplesIterable(generate_tables_fn, {"n": 10})
+    ex_iterable = RepeatExamplesIterable(base_ex_iterable, num_times=num_times)
+    assert ex_iterable.iter_arrow is not None
+    assert ex_iterable.is_typed == base_ex_iterable.is_typed
+    assert ex_iterable.features == base_ex_iterable.features
+    expected = sum([pa_table.to_pylist() for _, pa_table in generate_tables_fn(n=10)], []) * num_times
+    assert [example for _, pa_table in ex_iterable.iter_arrow() for example in pa_table.to_pylist()] == expected
+    assert [example for _, example in ex_iterable] == expected
+    assert_load_state_dict_resumes_iteration(ex_iterable)
+    assert_load_state_dict_resumes_arrow_iteration(ex_iterable)
+
+
+def test_repeat_examples_iterable_without_arrow_stays_without_arrow():
+    base_ex_iterable = ExamplesIterable(generate_examples_fn, {"n": 3})
+    ex_iterable = RepeatExamplesIterable(base_ex_iterable, num_times=2)
+    assert ex_iterable.iter_arrow is None
+
+
 def test_vertically_concatenated_examples_iterable():
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"label": 10})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"label": 5})
@@ -2320,6 +2340,14 @@ def test_iterable_dataset_repeat(dataset: IterableDataset, n):
     assert isinstance(repeat_dataset._ex_iterable, RepeatExamplesIterable)
     assert repeat_dataset._ex_iterable.num_times == n
     assert list(repeat_dataset) == list(dataset) * n
+
+
+def test_iterable_dataset_repeat_keeps_numpy_dtypes():
+    features = Features({"i32": Value("int32"), "f32": Value("float32"), "u8": Value("uint8")})
+    ds = Dataset.from_dict({"i32": [1, 2], "f32": [1.5, 2.5], "u8": [3, 4]}, features=features)
+    ds = ds.to_iterable_dataset().with_format("numpy")
+    expected = {key: value.dtype for key, value in next(iter(ds)).items()}
+    assert {key: value.dtype for key, value in next(iter(ds.repeat(2))).items()} == expected
 
 
 def test_iterable_dataset_shard():


### PR DESCRIPTION
`RepeatExamplesIterable` never forwarded `iter_arrow`, `is_typed` or `features` to the iterable it wraps, so `.repeat()` stranded an Arrow-capable child behind a non-Arrow parent: iteration fell back to the per-example path and the dtypes were re-inferred from Python objects.

This copies the three-property block and the `_iter_arrow` loop from `SkipExamplesIterable` and `TakeExamplesIterable`, which sit either side of it. `_iter_arrow` mirrors `__iter__` exactly, including the per-pass reset of the child state dict, so `state_dict()`/`load_state_dict()` behaves the same on both paths.

### Verification

On `main` at `b7cb10b`, Python 3.12, pyarrow 25.0.0, numpy 2.5.1:

- The three new tests fail before the change and pass after. `test_iterable_dataset_repeat_keeps_numpy_dtypes` reports `int64/float64/int64` before against a declared `int32/float32/uint8`; `test_repeat_examples_iterable_arrow` asserts `iter_arrow is not None` and runs both `assert_load_state_dict_resumes_iteration` and `assert_load_state_dict_resumes_arrow_iteration`.
- `tests/test_iterable_dataset.py` goes from 441 passed to 445 passed, with the same 4 pre-existing `test_interleave_dataset_with_sharding` failures on both sides (a missing optional dependency in my environment, unrelated to this change).
- Arrow-format iteration over 100k rows drops from 6.644s to 0.469s, which is parity with `.take(100000)` at 0.465s. `list(ds.repeat(2))` is unchanged.
- `ruff format --check` and `ruff check` are clean on both files.

What I did not check: the torch formatter, and non-scalar feature types such as `Image`. The dtype claim above is scoped to scalar `Value` columns under `numpy` format.

Fixes #8394
