### PR TITLE
Fix malformed audio link in mapstyle vs iterable docs

### DIFF
--- a/docs/source/about_mapstyle_vs_iterable.mdx
+++ b/docs/source/about_mapstyle_vs_iterable.mdx
@@ -84,7 +84,7 @@ for example in my_iterable_dataset:  # this reads the CSV file progressively as 
 ```
 
 Many file formats are supported, like CSV, JSONL, and Parquet, as well as image and audio files.
-You can find more information in the corresponding guides for loading [tabular](./tabular_load), [text](./nlp_load), [vision](./image_load), and [audio](./audio_load]) datasets.
+You can find more information in the corresponding guides for loading [tabular](./tabular_load), [text](./nlp_load), [vision](./image_load), and [audio](./audio_load) datasets.
 
 ## Eager data processing and lazy data processing
 


### PR DESCRIPTION
# What does this PR do?

Fixes a malformed link in `docs/source/about_mapstyle_vs_iterable.mdx`.

The audio guide link was written as `[audio](./audio_load])` (a stray closing parenthesis inside the link target), so it resolved to a non-existent path. This PR removes the stray `)` so the link points to the actual `audio_load` guide, consistent with the other links on the same line (`tabular_load`, `nlp_load`, `image_load`).