### PR TITLE
Support empty input shards in ArrowBasedBuilder

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1853,10 +1853,9 @@ class ArrowBasedBuilder(DatasetBuilder):
                             gen_kwargs=gen_kwargs,
                             token=self.token,
                         )
-                    if len(original_shard_lengths) == original_shard_id:
-                        original_shard_lengths.append(len(table))
-                    else:
-                        original_shard_lengths[original_shard_id] += len(table)
+                    if len(original_shard_lengths) <= original_shard_id:
+                        original_shard_lengths.extend([0] * (1 + original_shard_id - len(original_shard_lengths)))
+                    original_shard_lengths[original_shard_id] += len(table)
                     num_examples_progress_update += len(table)
                     if time.time() > _time + config.PBAR_REFRESH_TIME_INTERVAL:
                         _time = time.time()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -168,6 +168,21 @@ class DummyArrowBasedBuilderWithShards(ArrowBasedBuilder):
                 yield Key(shard_idx, i), pa.table({"id": range(10 * i, 10 * (i + 1)), "filepath": [filepath] * 10})
 
 
+class DummyArrowBasedBuilderWithEmptyShards(ArrowBasedBuilder):
+    def _info(self):
+        return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
+
+    def _split_generators(self, dl_manager):
+        return [SplitGenerator(name=Split.TRAIN, gen_kwargs={"filepaths": [f"data{i}.txt" for i in range(4)]})]
+
+    def _generate_tables(self, filepaths):
+        # shards 0 and 2 are empty
+        for shard_idx, filepath in enumerate(filepaths):
+            if shard_idx % 2 == 0:
+                continue
+            yield Key(shard_idx, 0), pa.table({"id": range(10), "filepath": [filepath] * 10})
+
+
 class DummyGeneratorBasedBuilderWithShards(GeneratorBasedBuilder):
     def _info(self):
         return DatasetInfo(features=Features({"id": Value("int8"), "filepath": Value("string")}))
@@ -923,6 +938,18 @@ def test_arrow_based_builder_download_and_prepare_with_num_proc(tmp_path):
     assert ds.to_dict() == {
         "id": [i for _ in range(4) for i in range(100)],
         "filepath": [f"data{i}.txt" for i in range(4) for _ in range(100)],
+    }
+
+
+@pytest.mark.parametrize("num_proc", [None, 2])
+def test_arrow_based_builder_download_and_prepare_with_empty_shards(num_proc, tmp_path):
+    builder = DummyArrowBasedBuilderWithEmptyShards(cache_dir=tmp_path)
+    builder.download_and_prepare(num_proc=num_proc)
+    assert builder.info.splits["train"].num_examples == 20
+    ds = builder.as_dataset("train")
+    assert ds.to_dict() == {
+        "id": [i for _ in range(2) for i in range(10)],
+        "filepath": [f"data{i}.txt" for i in [1, 3] for _ in range(10)],
     }
 
 


### PR DESCRIPTION
`ArrowBasedBuilder._prepare_split_single` assumes every input shard yields at least one table, so `original_shard_lengths` is indexed out of range when a shard yields nothing:

```python
load_dataset("json", data_files=["00.jsonl", "01.jsonl"])   # 00.jsonl is empty
# DatasetGenerationError
#   cause: IndexError: list index out of range  (builder.py:1859)
```

One empty file therefore breaks loading for the whole dataset. This affects json, csv, text, parquet, arrow and webdataset — everything built on `ArrowBasedBuilder`.

The same bug was fixed in the `GeneratorBasedBuilder` copy by f428626 (#8023); the `ArrowBasedBuilder` copy was missed. This applies the identical fix, with `len(table)` in place of `1`.

Added `test_arrow_based_builder_empty_shard`. Fails on `main` with the `IndexError` above, passes with the change.
