### PR TITLE
Fix casting a sliced list array to a fixed size list

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1969,9 +1969,8 @@ def array_cast(
                         _c(array_values, pa_type.value_type), pa_type.list_size, mask=array.is_null()
                     )
                 else:
-                    array_values = array.values[
-                        array.offset * pa_type.list_size : (array.offset + len(array)) * pa_type.list_size
-                    ]
+                    # flatten() applies the array offsets, unlike .values which is the unsliced child array
+                    array_values = array.flatten()
                     return pa.FixedSizeListArray.from_arrays(_c(array_values, pa_type.value_type), pa_type.list_size)
         elif pa.types.is_list(pa_type):
             # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
@@ -2110,9 +2109,8 @@ def cast_array_to_feature(
                             casted_array_values, feature.length, mask=array.is_null()
                         )
                     else:
-                        array_values = array.values[
-                            array.offset * feature.length : (array.offset + len(array)) * feature.length
-                        ]
+                        # flatten() applies the array offsets, unlike .values which is the unsliced child array
+                        array_values = array.flatten()
                         return pa.FixedSizeListArray.from_arrays(_c(array_values, feature.feature), feature.length)
             else:
                 casted_array_values = _c(array.values, feature.feature)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3637,6 +3637,14 @@ def test_cast_with_sliced_list():
     assert casted_dataset.features == new_features
 
 
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 4])
+def test_cast_with_sliced_list_to_fixed_length_list(batch_size):
+    values = [None, [1, 2], [3, 4], [5, 6]]
+    dataset = Dataset.from_dict({"foo": values}, features=Features({"foo": List(Value("int64"))}))
+    casted_dataset = dataset.cast(Features({"foo": List(Value("int64"), length=2)}), batch_size=batch_size)
+    assert casted_dataset["foo"] == values
+
+
 @pytest.mark.parametrize("include_nulls", [False, True])
 def test_class_encode_column_with_none(include_nulls):
     dataset = Dataset.from_dict({"col_1": ["a", "b", "c", None, "d", None]})

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1272,6 +1272,25 @@ def test_cast_list_array_to_features_sequence(arr, slice, target_value_feature):
     assert casted_array.to_pylist() == arr.to_pylist()
 
 
+@pytest.mark.parametrize(
+    "arr",
+    [
+        pa.array([None, [1, 2], [3, 4]], pa.list_(pa.int32())),  # first row holds no value
+        pa.array([[7], [1, 2], [3, 4]], pa.list_(pa.int32())),  # first row is shorter
+        pa.array([[7, 8, 9], [1, 2], [3, 4]], pa.list_(pa.int32())),  # first row is longer
+    ],
+)
+def test_cast_sliced_list_array_to_fixed_size_list(arr):
+    # the sliced array is uniform and has no null, only the rows before the slice differ
+    sliced_arr = arr.slice(1)
+    casted_array = cast_array_to_feature(sliced_arr, List(Value("int64"), length=2))
+    assert casted_array.type == get_nested_type(List(Value("int64"), length=2))
+    assert casted_array.to_pylist() == sliced_arr.to_pylist()
+    casted_array = array_cast(sliced_arr, pa.list_(pa.int64(), 2))
+    assert casted_array.type == pa.list_(pa.int64(), 2)
+    assert casted_array.to_pylist() == sliced_arr.to_pylist()
+
+
 @pytest.mark.parametrize("sequence_feature_dtype", ["string", "int64"])
 @pytest.mark.parametrize("from_list_type", ["list", "fixed_size_list", "large_list"])
 @pytest.mark.parametrize("list_within_struct", [False, True])


### PR DESCRIPTION
`array_cast` and `cast_array_to_feature` build the child window for a fixed-size list as `array.values[array.offset * length : ...]`. But `.values` is the **unsliced** child array, so that arithmetic is only correct when every earlier row holds exactly `length` items. `Dataset.cast` slices into batches, so this fires with default arguments:

```python
ds.cast(Features({"x": List(Value("int64"), length=2)}), batch_size=2)["x"]
# [None, [1, 2], [5, 6]]     -> [3, 4] is gone
```

Three distinct corruptions, depending on the prefix:

```
null first row   [[1,2],[3,4]]  ->  [[3,4]]        row dropped
long first row   [[1,2],[3,4]]  ->  [[9,1],[2,3]]  wrong values
ragged prefix                   ->  bogus ArrowInvalid
```

`array.flatten()` applies the offsets, which is what these branches want. Both only run when `null_count == 0` and the lengths already match, so the change is confined to sliced input.

The existing `test_cast_list_array_to_features_sequence` never reaches this branch — its fixture has nulls in every slice, which takes the masked path.

Added coverage for all three shapes. Fails on `main`, passes with the change; `tests/test_table.py` (281) and `tests/test_arrow_dataset.py` (403) both green.
