### PR TITLE
Fix interleave_datasets with all_exhausted when a dataset is empty

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -7231,10 +7231,19 @@ def _interleave_map_style_datasets(
 
         # Reasoning behind the following operation: for each dataset indices (i.e column) repeat the indices to have max_length indices per dataset
         # For example, if the max_length is 5 and the i-th dataset has 3 samples, the i-th column will be [0,1,2,0,1]
-        indices = np.mod(np.arange(max(lengths)).reshape(-1, 1), np.array(lengths).reshape(1, -1))
 
-        # We have to keep the indices to their respective dataset offsets and to flatten to effectively interleave the datasets
-        indices = (indices + offsets).flatten().tolist()
+        # Empty datasets have no example to cycle through, so they are exhausted from the start
+        # and must be left out (otherwise the modulo below divides by zero).
+        non_empty = [i for i, length in enumerate(lengths) if length > 0]
+        lengths = [lengths[i] for i in non_empty]
+        offsets = offsets[non_empty]
+        if not lengths:
+            indices = []
+        else:
+            indices = np.mod(np.arange(max(lengths)).reshape(-1, 1), np.array(lengths).reshape(1, -1))
+
+            # We have to keep the indices to their respective dataset offsets and to flatten to effectively interleave the datasets
+            indices = (indices + offsets).flatten().tolist()
 
     else:
         # boolean array indicating if at index i if the dataset_i has been fully exhausted

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3823,6 +3823,20 @@ def test_interleave_datasets_oversampling_strategy():
     assert dataset._fingerprint == interleave_datasets([d1, d2, d3], stopping_strategy="all_exhausted")._fingerprint
 
 
+@pytest.mark.parametrize("empty_index", [0, 1, 2])
+def test_interleave_datasets_oversampling_strategy_with_empty_dataset(empty_index):
+    dsets = [Dataset.from_dict({"a": [0, 1, 2]}), Dataset.from_dict({"a": [10, 11]})]
+    dsets.insert(empty_index, Dataset.from_dict({"a": []}))
+    dataset = interleave_datasets(dsets, stopping_strategy="all_exhausted")
+    # the empty dataset is exhausted from the start and contributes no example
+    assert dataset["a"] == [0, 10, 1, 11, 2, 10]
+
+
+def test_interleave_datasets_oversampling_strategy_with_only_empty_datasets():
+    dsets = [Dataset.from_dict({"a": []}), Dataset.from_dict({"a": []})]
+    assert interleave_datasets(dsets, stopping_strategy="all_exhausted")["a"] == []
+
+
 def test_interleave_datasets_probabilities_oversampling_strategy():
     seed = 42
     probabilities = [0.3, 0.5, 0.2]


### PR DESCRIPTION
With `stopping_strategy="all_exhausted"` and no `probabilities`, the indices come from `np.arange(max(lengths)) % lengths`. A zero-length input makes that a modulo by zero, which yields index 0; after the source offset is added it is either out of range or a valid index into a *different* dataset:

```python
interleave_datasets([empty, a], stopping_strategy="all_exhausted")["a"]
# [0, 0, 0, 1, 0, 2]        expected [0, 1, 2]

interleave_datasets([a, empty], stopping_strategy="all_exhausted")
# IndexError: Index 3 out of range for dataset of size 3
```

Empty inputs are now dropped before the index math, which is what `all_exhausted_without_replacement` already does.

Scoped deliberately to the deterministic branch: open PR #8318 is reworking the `probabilities` branch (and raises on empty sources there), so I left that path untouched to avoid overlapping it.

Added coverage for an empty dataset in first and last position. Three tests fail on `main`, eight pass with the change.
