### PR TITLE
Fix align_labels_with_mapping on a list of ClassLabel

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6608,10 +6608,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         label_feature = self._info.features[label_column]
         if not (
             isinstance(label_feature, ClassLabel)
-            or (isinstance(label_feature, Sequence) and isinstance(label_feature.feature, ClassLabel))
+            or (isinstance(label_feature, List) and isinstance(label_feature.feature, ClassLabel))
         ):
             raise ValueError(
-                f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} column or {Sequence.__name__} column with the inner type {ClassLabel.__name__}, and column {label_feature} is of type {type(label_feature).__name__}."
+                f"Aligning labels with a mapping is only supported for {ClassLabel.__name__} column or {List.__name__} column with the inner type {ClassLabel.__name__}, and column {label_feature} is of type {type(label_feature).__name__}."
             )
 
         # Sort input mapping by ID value to ensure the label names are aligned

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3649,6 +3649,20 @@ def test_class_encode_column_with_none(include_nulls):
     assert (None in dataset.unique("col_1")) == (not include_nulls)
 
 
+def test_align_labels_with_mapping_on_list_of_class_labels():
+    features = Features({"ner_tags": List(ClassLabel(names=["O", "PER", "LOC"]))})
+    dataset = Dataset.from_dict({"ner_tags": [[0, 1], [2]]}, features=features)
+    aligned_dataset = dataset.align_labels_with_mapping({"O": 0, "LOC": 1, "PER": 2}, "ner_tags")
+    assert aligned_dataset.features["ner_tags"] == List(ClassLabel(names=["O", "LOC", "PER"]))
+    assert aligned_dataset["ner_tags"] == [[0, 2], [1]]
+
+
+def test_align_labels_with_mapping_on_unsupported_column():
+    dataset = Dataset.from_dict({"col_1": ["a", "b"]})
+    with pytest.raises(ValueError):
+        dataset.align_labels_with_mapping({"a": 0, "b": 1}, "col_1")
+
+
 @pytest.mark.parametrize("null_placement", ["first", "last"])
 def test_sort_with_none(null_placement):
     dataset = Dataset.from_dict({"col_1": ["item_2", "item_3", "item_1", None, "item_4", None]})

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3954,6 +3954,20 @@ def test_dataset_add_item(item, in_memory, dataset_dict, arrow_path, transform):
         assert dataset_indices == dataset_to_test_indices + [len(dataset_to_test._data)]
 
 
+def test_align_labels_with_mapping_on_list_of_class_labels():
+    features = Features({"ner_tags": List(ClassLabel(names=["O", "PER", "LOC"]))})
+    dataset = Dataset.from_dict({"ner_tags": [[0, 1], [2]]}, features=features)
+    aligned_dataset = dataset.align_labels_with_mapping({"O": 0, "LOC": 1, "PER": 2}, "ner_tags")
+    assert aligned_dataset.features["ner_tags"] == List(ClassLabel(names=["O", "LOC", "PER"]))
+    assert aligned_dataset["ner_tags"] == [[0, 2], [1]]
+
+
+def test_align_labels_with_mapping_on_unsupported_column():
+    dataset = Dataset.from_dict({"col_1": ["a", "b"]})
+    with pytest.raises(ValueError):
+        dataset.align_labels_with_mapping({"a": 0, "b": 1}, "col_1")
+
+
 def test_dataset_add_item_new_columns():
     dataset = Dataset.from_dict({"col_1": [0, 1, 2]}, features=Features({"col_1": Value("uint8")}))
     dataset = dataset.add_item({"col_1": 3, "col_2": "a"})


### PR DESCRIPTION
#7634 dropped `Sequence` from the `.features` import but left two references in `align_labels_with_mapping`, so every non-plain-`ClassLabel` column raises:

```python
ds.align_labels_with_mapping({"O": 0, "LOC": 1, "PER": 2}, "ner_tags")
# NameError: name 'Sequence' is not defined
```

That covers the token-classification case the branch was added for (#4277), and the path that should raise a descriptive `ValueError`.

`Sequence(...)` returns a `List` instance, so `List` is the correct check.

The branch is untested upstream — only the plain `ClassLabel` path is covered — which is why the dead reference survived.

Added tests for the list-of-`ClassLabel` column and for the error path. Both fail on `main` with the `NameError`, both pass with the change.
