### PR TITLE
Allow reading a split with no examples

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -193,7 +193,7 @@ class BaseReader:
                 skip/take indicates which example read in the file: `ds.slice(skip, take)`
             in_memory (bool, default False): Whether to copy the data in-memory.
         """
-        if len(files) == 0 or not all(isinstance(f, dict) for f in files):
+        if not all(isinstance(f, dict) for f in files):
             raise ValueError("please provide valid file informations")
         files = copy.deepcopy(files)
         for f in files:
@@ -246,7 +246,9 @@ class BaseReader:
         """
 
         files = self.get_file_instructions(name, instructions, split_infos)
-        if not files:
+        # no file to read means the requested range is empty (e.g. a split with no examples,
+        # or a slice past the end): return an empty table built from info.features
+        if not files and (self._info is None or self._info.features is None):
             msg = f'Instruction "{instructions}" corresponds to no data!'
             raise ValueError(msg)
         return self.read_files(files=files, original_instructions=instructions, in_memory=in_memory)

--- a/tests/test_arrow_reader.py
+++ b/tests/test_arrow_reader.py
@@ -8,6 +8,7 @@ import pytest
 
 from datasets.arrow_dataset import Dataset
 from datasets.arrow_reader import ArrowReader, BaseReader, FileInstructions, ReadInstruction, make_file_instructions
+from datasets.features import Features, Value
 from datasets.info import DatasetInfo
 from datasets.splits import NamedSplit, Split, SplitDict, SplitInfo
 
@@ -110,6 +111,29 @@ class BaseReaderTest(TestCase):
             self.assertEqual(dset.num_rows, 110)
             self.assertEqual(dset.num_columns, 1)
             del dset
+
+
+@pytest.mark.parametrize(
+    "num_examples, instruction", [(0, "train"), (0, "train[:0]"), (100, "train[:0]"), (100, "train[200:300]")]
+)
+def test_read_empty_range(num_examples, instruction, tmp_path):
+    train_info = SplitInfo(name="train", num_examples=num_examples)
+    split_dict = SplitDict()
+    split_dict.add(train_info)
+    info = DatasetInfo(features=Features({"filename": Value("string")}), splits=split_dict)
+    reader = ReaderTest(str(tmp_path), info)
+    dset = Dataset(**reader.read("my_name", instruction, [train_info]))
+    assert dset.num_rows == 0
+    assert dset.column_names == ["filename"]
+
+
+def test_read_empty_range_without_features(tmp_path):
+    train_info = SplitInfo(name="train", num_examples=0)
+    split_dict = SplitDict()
+    split_dict.add(train_info)
+    reader = ReaderTest(str(tmp_path), DatasetInfo(splits=split_dict))
+    with pytest.raises(ValueError, match="corresponds to no data"):
+        reader.read("my_name", "train", [train_info])
 
 
 @pytest.mark.parametrize("in_memory", [False, True])


### PR DESCRIPTION
`make_file_instructions` skips every file whose take is 0, so `BaseReader.read` receives an empty file list and raises — which means one empty split makes the entire `DatasetDict` unloadable:

```python
load_dataset("json", data_files={"train": [...], "test": []})
# ValueError: Instruction "test" corresponds to no data!
```

`_read_files` already builds an empty table from `info.features`; that path was simply unreachable.

Unknown split names still raise `Unknown split ...` earlier, so the guard is preserved where it matters. This also makes an out-of-range slice return empty rather than raise, matching list slicing (#5891).

Added coverage for an empty split and an out-of-range slice. Four tests fail on `main`, 24 pass with the change. `tests/test_load.py`'s failure set is byte-identical before and after (all pre-existing, network-dependent).
