### PR TITLE
Fix PolarsFeaturesDecoder.decode_row

### DIFF
--- a/src/datasets/formatting/polars_formatter.py
+++ b/src/datasets/formatting/polars_formatter.py
@@ -70,18 +70,16 @@ class PolarsFeaturesDecoder:
         import polars as pl  # noqa: F401 - import pl at initialization
 
     def decode_row(self, row: "pl.DataFrame") -> "pl.DataFrame":
-        decode = (
-            {
-                column_name: no_op_if_value_is_null(partial(decode_nested_example, feature))
-                for column_name, feature in self.features.items()
-                if self.features._column_requires_decoding[column_name]
-            }
-            if self.features
-            else {}
+        if not self.features:
+            return row
+        # `row` may hold only a subset of the features when a `columns` format is set
+        return row.with_columns(
+            [
+                self.decode_column(row[column_name], column_name).alias(column_name)
+                for column_name in row.columns
+                if column_name in self.features and self.features._column_requires_decoding[column_name]
+            ]
         )
-        if decode:
-            row[list(decode.keys())] = row.map_rows(decode)
-        return row
 
     def decode_column(self, column: "pl.Series", column_name: str) -> "pl.Series":
         decode = (

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from datasets import Audio, Features, Image, IterableDataset
+from datasets import Audio, Features, Image, IterableDataset, Value
 from datasets.formatting import NumpyFormatter, PandasFormatter, PythonFormatter, query_table
 from datasets.formatting.formatting import (
     LazyBatch,
@@ -381,6 +381,27 @@ class FormatterTest(TestCase):
         self.assertIsInstance(batch, pl.DataFrame)
         assert pl.Series.eq(batch["a"], pl.Series("a", _COL_A)).all()
         assert pl.Series.eq(batch["b"], pl.Series("b", _COL_B)).all()
+
+    @require_polars
+    def test_polars_formatter_image(self):
+        import PIL.Image
+        import polars as pl
+
+        from datasets.formatting import PolarsFormatter
+
+        pa_table = pa.table({"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}] * 2, "label": [0, 1]})
+        formatter = PolarsFormatter(features=Features({"image": Image(), "label": Value("int64")}))
+        row = formatter.format_row(pa_table)
+        self.assertIsInstance(row, pl.DataFrame)
+        self.assertIsInstance(row["image"][0], PIL.Image.Image)
+        self.assertEqual(row["label"][0], 0)
+        col = formatter.format_column(pa_table)
+        self.assertIsInstance(col[0], PIL.Image.Image)
+        batch = formatter.format_batch(pa_table)
+        self.assertIsInstance(batch, pl.DataFrame)
+        self.assertIsInstance(batch["image"][0], PIL.Image.Image)
+        # the table may only hold a subset of the features when a `columns` format is set
+        self.assertEqual(formatter.format_row(pa_table.select(["label"]))["label"][0], 0)
 
     @require_numpy1_on_windows
     @require_torch


### PR DESCRIPTION
`PolarsFeaturesDecoder.decode_row` is a verbatim copy of the pandas implementation, but polars' `map_rows` takes a callable rather than a dict of column transforms:

```python
ds.with_format("polars")[0]
# TypeError: 'dict' object is not callable
```

So `with_format("polars")` is unusable on any dataset with an `Image`, `Audio`, `Video` or `Pdf` column — row access, slicing and iteration all fail. `format_column` takes a different path and works, which is why this went unnoticed.

Added a test with an `Image` column asserting the decoded value matches what the pandas formatter returns. Fails on `main` with the `TypeError`, passes with the change; 38 tests in `tests/test_formatting.py` green.
