### PR TITLE
Fix pandas formatting when a decodable column is excluded by columns=

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -259,7 +259,8 @@ class PandasFeaturesDecoder:
             {
                 column_name: no_op_if_value_is_null(partial(decode_nested_example, feature))
                 for column_name, feature in self.features.items()
-                if self.features._column_requires_decoding[column_name]
+                # `row` may hold only a subset of the features when a `columns` format is set
+                if column_name in row.columns and self.features._column_requires_decoding[column_name]
             }
             if self.features
             else {}

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from datasets import Audio, Features, Image, IterableDataset
+from datasets import Audio, Features, Image, IterableDataset, Value
 from datasets.formatting import NumpyFormatter, PandasFormatter, PythonFormatter, query_table
 from datasets.formatting.formatting import (
     LazyBatch,
@@ -362,6 +362,20 @@ class FormatterTest(TestCase):
         self.assertIsInstance(batch, pd.DataFrame)
         pd.testing.assert_series_equal(batch["a"], pd.Series(_COL_A, name="a"))
         pd.testing.assert_series_equal(batch["b"], pd.Series(_COL_B, name="b"))
+
+    @require_pil
+    def test_pandas_formatter_image_with_columns_subset(self):
+        import PIL.Image
+
+        pa_table = pa.table({"image": [{"bytes": None, "path": str(IMAGE_PATH_1)}] * 2, "label": [0, 1]})
+        formatter = PandasFormatter(features=Features({"image": Image(), "label": Value("int64")}))
+        # the table only holds a subset of the features when a `columns` format is set
+        row = formatter.format_row(pa_table.select(["label"]))
+        self.assertEqual(row["label"][0], 0)
+        batch = formatter.format_batch(pa_table.select(["label"]))
+        self.assertEqual(list(batch["label"]), [0, 1])
+        # the decodable column is still decoded when it is kept
+        self.assertIsInstance(formatter.format_row(pa_table)["image"][0], PIL.Image.Image)
 
     @require_polars
     def test_polars_formatter(self):


### PR DESCRIPTION
The pandas decoder builds its transform map from all of `self.features`, but the frame has already been projected to the format's `columns`:

```python
ds.with_format("pandas", columns=["label"])[0]
# KeyError: "Label(s) ['image'] do not exist"
```

Scoped to pandas — `None`, `numpy`, `torch` and `arrow` all handle a column subset correctly.

The decoder now only transforms columns present in the frame.

Added a test with an `Image` column excluded by `columns=`. Fails on `main` with the `KeyError`, passes with the change; 38 tests in `tests/test_formatting.py` green.
