### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/source/image_dataset.mdx
+++ b/docs/source/image_dataset.mdx
@@ -207,7 +207,7 @@ f18b91585c4d3f3e.json
 ...
 ```
 
-For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://webdataset.github.io/webdataset).
+For more details on the WebDataset format and the python library, please check the [WebDataset documentation](https://github.com/webdataset/webdataset).
 
 ## Lance
 

--- a/docs/source/object_detection.mdx
+++ b/docs/source/object_detection.mdx
@@ -1,6 +1,6 @@
 # Object detection
 
-Object detection models identify something in an image, and object detection datasets are used for applications such as autonomous driving and detecting natural hazards like wildfire. This guide will show you how to apply transformations to an object detection dataset following the [tutorial](https://albumentations.ai/docs/examples/example_bboxes/) from [Albumentations](https://albumentations.ai/docs/).
+Object detection models identify something in an image, and object detection datasets are used for applications such as autonomous driving and detecting natural hazards like wildfire. This guide will show you how to apply transformations to an object detection dataset following the [tutorial](https://albumentations.ai/docs/examples/example-bboxes/) from [Albumentations](https://albumentations.ai/docs/).
 
 To run these examples, make sure you have up-to-date versions of [albumentations](https://albumentations.ai/docs/) and [cv2](https://docs.opencv.org/4.10.0/) installed:
 

--- a/docs/source/use_with_spark.mdx
+++ b/docs/source/use_with_spark.mdx
@@ -44,7 +44,7 @@ You can set the cache location by passing `cache_dir=` to [`Dataset.from_spark`]
 Make sure to use a disk that is available to both your workers and your current machine (the driver).
 
 > [!WARNING]
-> In a different session, a Spark DataFrame doesn't have the same [semantic hash](https://spark.apache.org/docs/3.2.0/api/python/reference/api/pyspark.sql.DataFrame.semanticHash.html), and it will rerun a Spark job and store it in a new cache.
+> In a different session, a Spark DataFrame doesn't have the same [semantic hash](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.semanticHash.html), and it will rerun a Spark job and store it in a new cache.
 
 ### Feature types
 


### PR DESCRIPTION
Several documentation pages link to URLs that now return 404. This PR updates them to their current locations.

| File | Old (404) | New |
|------|-----------|-----|
| `object_detection.mdx` | `albumentations.ai/docs/examples/example_bboxes/` | `albumentations.ai/docs/examples/example-bboxes/` |
| `image_dataset.mdx` | `webdataset.github.io/webdataset` | `github.com/webdataset/webdataset` |
| `use_with_spark.mdx` | Spark 3.2.0 `semanticHash` API page | current `latest` PySpark reference URL |

All three replacement URLs were verified to resolve (HTTP 200) in a browser. Docs-only change.