### PR TITLE
Match Dataset.map's on_mixed_types default in DatasetDict.map

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3322,7 +3322,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             try_original_type (`Optional[bool]`, defaults to `True`):
                 Try to keep the types of the original columns (e.g. int32 -> int32).
                 Set to False if you want to always infer new types.
-            on_mixed_types (`Literal["use_json"]`, *optional*, defaults to `None`):
+            on_mixed_types (`Literal["use_json"]`, *optional*, defaults to `"use_json"`):
                 If "use_json", use the Json() type for mixed-types fields,
                 i.e. unstructured fields that contain data without a predefined schema.
                 In this case, a field with mixed type is set to Json().
@@ -3731,7 +3731,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             try_original_type: (`Optional[bool]`, defaults to `True`):
                 Try to keep the types of the original columns (e.g. int32 -> int32).
                 Set to False if you want to always infer new types.
-            on_mixed_types (`Literal["use_json"]`, *optional*, defaults to `None`):
+            on_mixed_types (`Literal["use_json"]`, *optional*, defaults to `"use_json"`):
                 If "use_json", use the Json() type for mixed-types fields,
                 i.e. unstructured fields that contain data without a predefined schema.
                 In this case, a field with mixed type is set to Json().

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -842,7 +842,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         num_proc: Optional[int] = None,
         desc: Optional[str] = None,
         try_original_type: Optional[bool] = True,
-        on_mixed_types: Optional[Literal["use_json"]] = None,
+        on_mixed_types: Optional[Literal["use_json"]] = "use_json",
     ) -> "DatasetDict":
         """
         Apply a function to all the examples in the table (individually or in batches) and update the table.
@@ -927,7 +927,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             try_original_type (`Optional[bool]`, defaults to `True`):
                 Try to keep the types of the original columns (e.g. int32 -> int32).
                 Set to False if you want to always infer new types.
-            on_mixed_types (`Literal["use_json"]`, *optional*, defaults to `None`):
+            on_mixed_types (`Literal["use_json"]`, *optional*, defaults to `"use_json"`):
                 If "use_json", use the Json() type for mixed-types fields,
                 i.e. unstructured fields that contain data without a predefined schema.
                 In this case, a field with mixed type is set to Json().

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -354,6 +354,17 @@ class DatasetDictTest(TestCase):
                     for label in labels:
                         self.assertIsInstance(label, float)
 
+    def test_map_on_mixed_types(self):
+        # DatasetDict.map must handle mixed types the same way Dataset.map does
+        mixed_data = {
+            "mixed_type": [-1, 1, "foo"],
+            "mixed_dict_keys": [{"a": 0}, {"b": 0}, {"c": 0}],
+        }
+        dsets = self._create_dummy_dataset_dict()
+        with dsets.map(lambda ex: mixed_data, remove_columns=dsets["train"].column_names) as mapped_dsets:
+            for dset in mapped_dsets.values():
+                self.assertDictEqual(dset[0], mixed_data)
+
     def test_iterable_map(self):
         dsets = self._create_dummy_iterable_dataset_dict()
         fn_kwargs = {"n": 3}


### PR DESCRIPTION
### Problem

`Dataset.map` defaults `on_mixed_types` to `"use_json"`, so a mapped column with no
predefined schema becomes a `Json()` feature instead of failing type inference.
`DatasetDict.map` defaults the same parameter to `None` and forwards it to every split
unconditionally, so wrapping the splits in a `DatasetDict` changes the result of the
identical function on the identical data:

```python
from datasets import Dataset, DatasetDict

def add_mixed(example):
    return {"meta": [0, "foo", {"subfield": "bar"}]}

base = Dataset.from_dict({"x": [1, 2]})

base.map(add_mixed)                          # ok, meta = List(Json(decode=True))
DatasetDict({"train": base}).map(add_mixed)  # ArrowInvalid: Could not convert 'foo'
                                             #   with type str: tried to convert to int64
DatasetDict({"train": base}).map(add_mixed, on_mixed_types="use_json")  # ok again
```

`DatasetDict.map` documents itself as "The transformation is applied to all the datasets
of the dataset dictionary", so the two should agree, and passing `on_mixed_types="use_json"`
explicitly restores the `Dataset.map` behaviour.

### Fix

Give `DatasetDict.map` the same `"use_json"` default as `Dataset.map`.

The docstrings needed a pass too. `Dataset.map` and `Dataset._map_single` already read
`defaults to None` against signatures that say `"use_json"`, so those are corrected here as
well. `Dataset.from_dict` and `Dataset.from_list` deliberately keep the `None` default and
their docstrings are already accurate, so they are untouched.

### Test

`DatasetDictTest::test_map_on_mixed_types` mirrors the existing
`test_map_on_mixed_types` in `tests/test_arrow_dataset.py` but does not pass
`on_mixed_types`, so it pins the default rather than the explicit value. It fails on `main`
with `pyarrow.lib.ArrowInvalid: Could not convert 'foo' with type str: tried to convert to
int64` and passes with this change.

`tests/test_dataset_dict.py` goes from 68 passed / 2 skipped to 69 passed / 2 skipped (the
new test), and the `on_mixed_types or map_` subset of `tests/test_arrow_dataset.py` is
49 passed / 6 skipped both before and after. `make quality` is clean on the three touched
files, and equally clean on the same files before the change.
