### PR TITLE
Preserve nanosecond precision in Python dataset construction

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -32,6 +32,7 @@ from .features.features import (
     FeatureType,
     List,
     _ArrayXDExtensionType,
+    _contains_nanosecond_temporal_feature,
     _visit,
     cast_to_python_objects,
     generate_from_arrow_type,
@@ -337,7 +338,22 @@ class TypedSequence:
                     for json_field_path in json_field_paths:
                         examples = [json_encode_field(examples, json_field_path) for examples in examples]
                 # to arrow array
-                out = pa.array(cast_to_python_objects(examples, only_1d_for_numpy=True))
+                if type is not None and _contains_nanosecond_temporal_feature(type):
+                    try:
+                        # Let PyArrow convert pandas temporal scalars directly. Converting them to Python objects first
+                        # limits their resolution to microseconds, before the declared Arrow type can be applied.
+                        out = pa.array(examples, type=pa_type)
+                    except (
+                        TypeError,
+                        pa.lib.ArrowTypeError,
+                        pa.lib.ArrowInvalid,
+                        pa.lib.ArrowNotImplementedError,
+                    ):
+                        trying_cast_to_python_objects = True
+                        out = pa.array(cast_to_python_objects(examples, only_1d_for_numpy=True))
+                else:
+                    trying_cast_to_python_objects = True
+                    out = pa.array(cast_to_python_objects(examples, only_1d_for_numpy=True))
                 # cast to json type if needed
                 if json_field_paths:
                     pa_table = pa.Table.from_arrays([out], names=["obj"])

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -281,7 +281,9 @@ def string_to_arrow(datasets_dtype: str) -> pa.DataType:
     )
 
 
-def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_casting: bool) -> tuple[Any, bool]:
+def _cast_to_python_objects(
+    obj: Any, only_1d_for_numpy: bool, optimize_list_casting: bool, preserve_pandas_temporal: bool = False
+) -> tuple[Any, bool]:
     """
     Cast pytorch/tensorflow/pandas objects to python numpy array/lists.
     It works recursively.
@@ -297,6 +299,8 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             Indeed Arrow only support converting 1-dimensional array values.
         optimize_list_casting (bool): whether to optimize list casting by checking the first non-null element to see if it needs to be casted
             and if it doesn't, not checking the rest of the list elements.
+        preserve_pandas_temporal (bool): whether to preserve pandas Timestamp and Timedelta objects instead of converting
+            them to Python objects, which are limited to microsecond precision.
 
     Returns:
         casted_obj: the casted object
@@ -333,7 +337,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
+                        preserve_pandas_temporal=preserve_pandas_temporal,
                     )[0]
                     for x in obj
                 ],
@@ -345,6 +352,7 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
                 obj.detach().to(torch.float).cpu().numpy(),
                 only_1d_for_numpy=only_1d_for_numpy,
                 optimize_list_casting=optimize_list_casting,
+                preserve_pandas_temporal=preserve_pandas_temporal,
             )[0], True
         if obj.ndim == 0:
             return obj.detach().cpu().numpy()[()], True
@@ -354,7 +362,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
+                        preserve_pandas_temporal=preserve_pandas_temporal,
                     )[0]
                     for x in obj.detach().cpu().numpy()
                 ],
@@ -369,7 +380,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
+                        preserve_pandas_temporal=preserve_pandas_temporal,
                     )[0]
                     for x in obj.numpy()
                 ],
@@ -384,7 +398,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
             return (
                 [
                     _cast_to_python_objects(
-                        x, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                        x,
+                        only_1d_for_numpy=only_1d_for_numpy,
+                        optimize_list_casting=optimize_list_casting,
+                        preserve_pandas_temporal=preserve_pandas_temporal,
                     )[0]
                     for x in np.asarray(obj)
                 ],
@@ -399,7 +416,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
     elif isinstance(obj, pd.Series):
         return (
             _cast_to_python_objects(
-                obj.tolist(), only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                obj.tolist(),
+                only_1d_for_numpy=only_1d_for_numpy,
+                optimize_list_casting=optimize_list_casting,
+                preserve_pandas_temporal=preserve_pandas_temporal,
             )[0],
             True,
         )
@@ -407,22 +427,28 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         return (
             {
                 key: _cast_to_python_objects(
-                    value, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                    value,
+                    only_1d_for_numpy=only_1d_for_numpy,
+                    optimize_list_casting=optimize_list_casting,
+                    preserve_pandas_temporal=preserve_pandas_temporal,
                 )[0]
                 for key, value in obj.to_dict("series").items()
             },
             True,
         )
     elif isinstance(obj, pd.Timestamp):
-        return obj.to_pydatetime(), True
+        return (obj, False) if preserve_pandas_temporal else (obj.to_pydatetime(), True)
     elif isinstance(obj, pd.Timedelta):
-        return obj.to_pytimedelta(), True
+        return (obj, False) if preserve_pandas_temporal else (obj.to_pytimedelta(), True)
     elif isinstance(obj, Mapping):
         has_changed = not isinstance(obj, dict)
         output = {}
         for k, v in obj.items():
             casted_v, has_changed_v = _cast_to_python_objects(
-                v, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                v,
+                only_1d_for_numpy=only_1d_for_numpy,
+                optimize_list_casting=optimize_list_casting,
+                preserve_pandas_temporal=preserve_pandas_temporal,
             )
             has_changed |= has_changed_v
             output[k] = casted_v
@@ -433,7 +459,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         else:
             return (
                 _cast_to_python_objects(
-                    obj.__array__(), only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                    obj.__array__(),
+                    only_1d_for_numpy=only_1d_for_numpy,
+                    optimize_list_casting=optimize_list_casting,
+                    preserve_pandas_temporal=preserve_pandas_temporal,
                 )[0],
                 True,
             )
@@ -443,13 +472,19 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
                 if _check_non_null_non_empty_recursive(first_elmt):
                     break
             casted_first_elmt, has_changed_first_elmt = _cast_to_python_objects(
-                first_elmt, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                first_elmt,
+                only_1d_for_numpy=only_1d_for_numpy,
+                optimize_list_casting=optimize_list_casting,
+                preserve_pandas_temporal=preserve_pandas_temporal,
             )
             if has_changed_first_elmt or not optimize_list_casting:
                 return (
                     [
                         _cast_to_python_objects(
-                            elmt, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+                            elmt,
+                            only_1d_for_numpy=only_1d_for_numpy,
+                            optimize_list_casting=optimize_list_casting,
+                            preserve_pandas_temporal=preserve_pandas_temporal,
                         )[0]
                         for elmt in obj
                     ],
@@ -472,7 +507,9 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         return obj, False
 
 
-def cast_to_python_objects(obj: Any, only_1d_for_numpy=False, optimize_list_casting=True) -> Any:
+def cast_to_python_objects(
+    obj: Any, only_1d_for_numpy=False, optimize_list_casting=True, preserve_pandas_temporal=False
+) -> Any:
     """
     Cast numpy/pytorch/tensorflow/pandas objects to python lists.
     It works recursively.
@@ -488,12 +525,17 @@ def cast_to_python_objects(obj: Any, only_1d_for_numpy=False, optimize_list_cast
             Indeed Arrow only support converting 1-dimensional array values.
         optimize_list_casting (bool, default ``True``): whether to optimize list casting by checking the first non-null element to see if it needs to be casted
             and if it doesn't, not checking the rest of the list elements.
+        preserve_pandas_temporal (bool, default ``False``): whether to preserve pandas Timestamp and Timedelta objects
+            instead of converting them to Python objects, which are limited to microsecond precision.
 
     Returns:
         casted_obj: the casted object
     """
     return _cast_to_python_objects(
-        obj, only_1d_for_numpy=only_1d_for_numpy, optimize_list_casting=optimize_list_casting
+        obj,
+        only_1d_for_numpy=only_1d_for_numpy,
+        optimize_list_casting=optimize_list_casting,
+        preserve_pandas_temporal=preserve_pandas_temporal,
     )[0]
 
 
@@ -1445,6 +1487,20 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
     return schema()
 
 
+def _contains_nanosecond_temporal_feature(feature: FeatureType) -> bool:
+    if isinstance(feature, dict):
+        return any(_contains_nanosecond_temporal_feature(subfeature) for subfeature in feature.values())
+    if isinstance(feature, (list, tuple)):
+        return _contains_nanosecond_temporal_feature(feature[0])
+    if isinstance(feature, (LargeList, List)):
+        return _contains_nanosecond_temporal_feature(feature.feature)
+    return (
+        isinstance(feature, Value)
+        and (pa.types.is_timestamp(feature.pa_type) or pa.types.is_duration(feature.pa_type))
+        and feature.pa_type.unit == "ns"
+    )
+
+
 def encode_nested_example(schema, obj, level=0):
     """Encode a nested example.
     This is used since some features (in particular ClassLabel) have some logic during encoding.
@@ -1840,7 +1896,7 @@ def require_storage_embed(feature: FeatureType) -> bool:
 
 def keep_features_dicts_synced(func):
     """
-    Wrapper to keep the secondary dictionary, which tracks whether keys are decodable, of the :class:`datasets.Features` object
+    Wrapper to keep the secondary data structures of the :class:`datasets.Features` object
     in sync with the main dictionary.
     """
 
@@ -1854,6 +1910,10 @@ def keep_features_dicts_synced(func):
         out = func(self, *args, **kwargs)
         assert hasattr(self, "_column_requires_decoding")
         self._column_requires_decoding = {col: require_decoding(feature) for col, feature in self.items()}
+        assert hasattr(self, "_nanosecond_temporal_columns")
+        self._nanosecond_temporal_columns = {
+            col for col, feature in self.items() if _contains_nanosecond_temporal_feature(feature)
+        }
         return out
 
     wrapper._decorator_name_ = "_keep_dicts_synced"
@@ -1903,6 +1963,9 @@ class Features(dict):
         # keep track of columns which require decoding
         self._column_requires_decoding: dict[str, bool] = {
             col: require_decoding(feature) for col, feature in self.items()
+        }
+        self._nanosecond_temporal_columns: set[str] = {
+            col for col, feature in self.items() if _contains_nanosecond_temporal_feature(feature)
         }
 
         # backward compatibility with datasets<4 : [feature] -> List(feature)
@@ -2174,7 +2237,7 @@ class Features(dict):
         Returns:
             `dict[str, Any]`
         """
-        example = cast_to_python_objects(example)
+        example = cast_to_python_objects(example, preserve_pandas_temporal=bool(self._nanosecond_temporal_columns))
         return encode_nested_example(self, example)
 
     def encode_column(self, column, column_name: str):
@@ -2190,7 +2253,9 @@ class Features(dict):
         Returns:
             `list[Any]`
         """
-        column = cast_to_python_objects(column)
+        column = cast_to_python_objects(
+            column, preserve_pandas_temporal=column_name in self._nanosecond_temporal_columns
+        )
         return [encode_nested_example(self[column_name], obj, level=1) for obj in column]
 
     def encode_batch(self, batch):
@@ -2208,7 +2273,7 @@ class Features(dict):
         if set(batch) != set(self):
             raise ValueError(f"Column mismatch between batch {set(batch)} and features {set(self)}")
         for key, column in batch.items():
-            column = cast_to_python_objects(column)
+            column = cast_to_python_objects(column, preserve_pandas_temporal=key in self._nanosecond_temporal_columns)
             encoded_batch[key] = [encode_nested_example(self[key], obj, level=1) for obj in column]
         return encoded_batch
 

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -276,9 +276,14 @@ class FeaturesTest(TestCase):
                 hasattr(features, "_column_requires_decoding")
                 and features.keys() == features._column_requires_decoding.keys()
             )
+            assert (
+                hasattr(features, "_nanosecond_temporal_columns")
+                and features._nanosecond_temporal_columns <= features.keys()
+            )
 
         features = Features({"foo": {"bar": List({"my_value": Value("int32")})}})
         assert_features_dicts_are_synced(features)
+        assert not features._nanosecond_temporal_columns
         features["barfoo"] = Image()
         assert_features_dicts_are_synced(features)
         del features["barfoo"]
@@ -291,8 +296,12 @@ class FeaturesTest(TestCase):
         assert_features_dicts_are_synced(features)
         features.setdefault("xyz", Value("bool"))
         assert_features_dicts_are_synced(features)
+        features["timestamp"] = Value("timestamp[ns]")
+        assert features._nanosecond_temporal_columns == {"timestamp"}
+        assert_features_dicts_are_synced(features)
         features.clear()
         assert_features_dicts_are_synced(features)
+        assert not features._nanosecond_temporal_columns
 
 
 def test_classlabel_init(tmp_path_factory):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3481,6 +3481,25 @@ class MiscellaneousDatasetTest(TestCase):
         features = Features({"col_1": Value("int64"), "col_2": Value("int64"), "col_3": Value("bool")})
         self.assertRaises(ValueError, Dataset.from_dict, data, features=features)
 
+    def test_python_construction_preserves_nanosecond_temporal_precision(self):
+        features = Features({"timestamp": Value("timestamp[ns]"), "duration": Value("duration[ns]")})
+        row = {
+            "timestamp": pd.Timestamp("2024-01-01 00:00:00.123456789"),
+            "duration": pd.Timedelta("1 days 00:00:00.123456789"),
+        }
+        expected = {"timestamp": row["timestamp"].value, "duration": row["duration"].value}
+        datasets = {
+            "from_dict": Dataset.from_dict({key: [value] for key, value in row.items()}, features=features),
+            "from_list": Dataset.from_list([row], features=features),
+            "map": Dataset.from_dict({"index": [0]}).map(lambda _: row, remove_columns=["index"], features=features),
+        }
+
+        for constructor, dataset in datasets.items():
+            with self.subTest(constructor=constructor):
+                self.assertEqual(dataset[0], row)
+                actual = {key: dataset.data.column(key).cast(pa.int64()).to_pylist()[0] for key in expected}
+                self.assertEqual(actual, expected)
+
     def test_from_dict_on_mixed_types(self):
         data = {"col_1": [-1, 1, "foo"]}
         with Dataset.from_dict(data, on_mixed_types="use_json") as dset:

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -1,4 +1,5 @@
 import copy
+import datetime
 import json
 import os
 import tempfile
@@ -6,13 +7,14 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
 from datasets import config
 from datasets.arrow_writer import ArrowWriter, OptimizedTypedSequence, ParquetWriter, TypedSequence
-from datasets.features import Array2D, ClassLabel, Features, Image, Value
+from datasets.features import Array2D, ClassLabel, Features, Image, List, Value
 from datasets.features.features import Array2DExtensionType, cast_to_python_objects
 
 from .utils import require_pil
@@ -46,6 +48,50 @@ class TypedSequenceTest(TestCase):
     def test_try_incompatible_type(self):
         arr = pa.array(TypedSequence(["foo", "bar"], try_type=Value("int64")))
         self.assertEqual(arr.type, pa.string())
+
+    def test_nanosecond_temporal_type_preserves_precision(self):
+        timestamp = pd.Timestamp("2024-01-01 00:00:00.123456789")
+        zoned_timestamp = pd.Timestamp("2024-01-01 00:00:00.123456789", tz="America/Toronto")
+        python_datetime = datetime.datetime(2024, 1, 2, 3, 4, 5, 123456)
+        duration = pd.Timedelta("1 days 00:00:00.123456789")
+        python_timedelta = datetime.timedelta(seconds=2, microseconds=123456)
+
+        for feature, data, expected in [
+            (
+                Value("timestamp[ns]"),
+                [timestamp, python_datetime, None],
+                [timestamp.value, pd.Timestamp(python_datetime).value, None],
+            ),
+            (
+                Value("duration[ns]"),
+                [duration, python_timedelta, None],
+                [duration.value, pd.Timedelta(python_timedelta).value, None],
+            ),
+            (
+                Value("timestamp[ns, tz=America/Toronto]"),
+                [zoned_timestamp, None],
+                [zoned_timestamp.value, None],
+            ),
+        ]:
+            with self.subTest(feature=feature):
+                arr = pa.array(TypedSequence(data, type=feature))
+                self.assertEqual(arr.cast(pa.int64()).to_pylist(), expected)
+
+    def test_try_nanosecond_temporal_type_preserves_precision(self):
+        timestamp = pd.Timestamp("2024-01-01 00:00:00.123456789")
+        arr = pa.array(TypedSequence([timestamp], try_type=Value("timestamp[ns]")))
+        self.assertEqual(arr.cast(pa.int64()).to_pylist(), [timestamp.value])
+
+    def test_nested_nanosecond_temporal_type_preserves_precision(self):
+        timestamp = pd.Timestamp("2024-01-01 00:00:00.123456789")
+        list_arr = pa.array(TypedSequence([[timestamp], None], type=List(Value("timestamp[ns]"))))
+        self.assertEqual(list_arr.cast(pa.list_(pa.int64())).to_pylist(), [[timestamp.value], None])
+
+        struct_feature = {"event": {"timestamp": Value("timestamp[ns]"), "name": Value("string")}}
+        struct_arr = pa.array(
+            TypedSequence([{"event": {"timestamp": timestamp, "name": "launch"}}], type=struct_feature)
+        )
+        self.assertEqual(struct_arr.field("event").field("timestamp").cast(pa.int64()).to_pylist(), [timestamp.value])
 
     def test_compatible_extension_type(self):
         arr = pa.array(TypedSequence([[[1, 2, 3]]], type=Array2D((1, 3), "int64")))


### PR DESCRIPTION
## What it is

Preserves exact nanosecond precision for pandas timestamps and timedeltas when users declare `Value("timestamp[ns]")` or `Value("duration[ns]")`.

Previously, `Dataset.from_dict`, `Dataset.from_list`, and `Dataset.map` reported a nanosecond feature while silently storing values truncated to microseconds. For example, `2024-01-01 00:00:00.123456789` became `2024-01-01 00:00:00.123456`.

## How it works

During Python dataset construction, pandas temporal scalars were first converted to microsecond-resolution Python objects. The writer then created an untyped Arrow array, so the discarded digits could not be recovered by the later cast to `timestamp[ns]` or `duration[ns]`.

- **Feature encoding.** Pandas temporal scalars remain intact when the declared feature contains a nanosecond timestamp or duration.
- **Arrow construction.** The writer passes the known target type to `pa.array(...)`, allowing PyArrow to preserve the requested resolution from the start.
- **Compatibility.** Unsupported inputs fall back to the existing conversion and casting path.
- **Nested features.** Detection covers lists, large lists, tuples, and structs. A cached column set avoids repeatedly traversing schemas on the write path.

## Scope

The new path applies only to explicitly declared nanosecond timestamp and duration features. Default Python-object conversion, other temporal units, and undeclared type inference remain unchanged.

The fix supports naive and timezone-aware timestamps, timedeltas, mixed pandas and Python values, nulls, `try_type`, nested lists, and nested structs.

## Verification

- **Unit and integration suite:** exact Arrow `int64` values for timestamps, durations, timezone-aware values, mixed temporal inputs, nulls, `try_type`, and nested features.
- **Public API coverage:** `Dataset.from_dict`, `Dataset.from_list`, and `Dataset.map`, checking both decoded rows and underlying Arrow storage.
- **Feature mutation coverage:** cached nanosecond columns remain synchronized across all supported `Features` dictionary mutations.
- **E2E wheel top-hat:** built a wheel, installed it in a clean temporary environment, and exercised all three public construction paths outside the source checkout. Each preserved timestamp `1704067200123456789` and duration `86400123456789` exactly.
- **Apple Silicon:** validated on native ARM64 macOS with Python 3.13 and PyArrow 25.0.0.

## Checks

```
.venv/bin/pytest -q tests/features/test_features.py tests/test_arrow_writer.py tests/test_arrow_dataset.py   659 passed, 58 skipped, 6 subtests passed
.venv/bin/ruff check src/datasets/arrow_writer.py src/datasets/features/features.py tests/features/test_features.py tests/test_arrow_writer.py tests/test_arrow_dataset.py   passed
.venv/bin/ruff format --check src/datasets/arrow_writer.py src/datasets/features/features.py tests/features/test_features.py tests/test_arrow_writer.py tests/test_arrow_dataset.py   passed
git diff --check   passed
.venv/bin/python -m build --wheel   passed
clean-wheel E2E top-hat for from_dict, from_list, and map   passed
```

---

Closes #8391.
