### PR TITLE
Save the shuffle buffer content in the state dict so resuming is exact

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1927,57 +1927,99 @@ class BufferShuffledExamplesIterable(_BaseExamplesIterable):
         return self._iter_arrow if self.ex_iterable.iter_arrow else None
 
     def _init_state_dict(self) -> dict:
+        # the buffer state is stored in the same dict as the wrapped iterable's state, so that
+        # state dicts from versions that didn't save the buffer content can still be loaded.
+        # The buffer content is stored as a tuple so that state merging and copying treat it
+        # as an atomic value.
         self._state_dict = self.ex_iterable._init_state_dict()
-        self._original_state_dict = self.state_dict()
+        self._state_dict["shuffle_buffer"] = ()
+        self._state_dict["shuffle_buffer_num_picks"] = 0
+        self._state_dict["shuffle_buffer_end_of_data_shuffled"] = False
         return self._state_dict
 
-    def load_state_dict(self, state_dict: dict) -> dict:
+    def state_dict(self) -> dict:
         if self._state_dict:
-            if state_dict != self._original_state_dict:
-                logger.warning(
-                    "Loading a state dict of a shuffle buffer of a dataset without the buffer content."
-                    "The shuffle buffer will be refilled before starting to yield new examples."
-                )
-        return super().load_state_dict(state_dict)
+            # avoid deep-copying the buffer content: the tuple is immutable and its entries are
+            # only ever replaced, never mutated in place. This runs on every state capture.
+            return {
+                key: (value if key == "shuffle_buffer" else deepcopy(value)) for key, value in self._state_dict.items()
+            }
+        raise RuntimeError("State dict is not initialized, please call ex_iterable._init_state_dict() first.")
+
+    def load_state_dict(self, state_dict: dict) -> dict:
+        if "shuffle_buffer" not in state_dict:
+            # state dict from a version that didn't save the buffer content
+            logger.warning(
+                "Loading a state dict of a shuffle buffer of a dataset without the buffer content."
+                "The shuffle buffer will be refilled before starting to yield new examples."
+            )
+        inner_state_dict = {key: value for key, value in state_dict.items() if not key.startswith("shuffle_buffer")}
+        self.ex_iterable.load_state_dict(inner_state_dict)
+        self._state_dict = self.ex_iterable._state_dict
+        self._state_dict["shuffle_buffer"] = tuple(state_dict.get("shuffle_buffer", ()))
+        self._state_dict["shuffle_buffer_num_picks"] = state_dict.get("shuffle_buffer_num_picks", 0)
+        self._state_dict["shuffle_buffer_end_of_data_shuffled"] = state_dict.get(
+            "shuffle_buffer_end_of_data_shuffled", False
+        )
+        return self._state_dict
 
     @staticmethod
     def _iter_random_indices(rng: np.random.Generator, buffer_size: int, random_batch_size=1000) -> Iterator[int]:
         while True:
             yield from (int(i) for i in rng.integers(0, buffer_size, size=random_batch_size))
 
-    def __iter__(self):
+    def _iter_with_buffer(self, iterator: Iterator):
         buffer_size = self.buffer_size
         rng = deepcopy(self.generator)
         indices_iterator = self._iter_random_indices(rng, buffer_size)
-        # this is the shuffle buffer that we keep in memory
-        mem_buffer = []
-        for x in self.ex_iterable:
-            if len(mem_buffer) == buffer_size:  # if the buffer is full, pick and example from it
+        if self._state_dict:
+            # resume from the saved buffer content and advance the rng to where it stopped
+            mem_buffer = list(self._state_dict["shuffle_buffer"])
+            for _ in range(self._state_dict["shuffle_buffer_num_picks"]):
+                next(indices_iterator)
+        else:
+            mem_buffer = []
+        for x in iterator:
+            if len(mem_buffer) == buffer_size:  # if the buffer is full, pick an example from it
                 i = next(indices_iterator)
-                yield mem_buffer[i]
+                selected = mem_buffer[i]
                 mem_buffer[i] = x  # replace the picked example by a new one
+                if self._state_dict:
+                    self._state_dict["shuffle_buffer"] = tuple(mem_buffer)
+                    self._state_dict["shuffle_buffer_num_picks"] += 1
+                yield selected
             else:  # otherwise, keep filling the buffer
                 mem_buffer.append(x)
         # when we run out of examples, we shuffle the remaining examples in the buffer and yield them
-        rng.shuffle(mem_buffer)
-        yield from mem_buffer
+        if not (self._state_dict and self._state_dict["shuffle_buffer_end_of_data_shuffled"]):
+            rng.shuffle(mem_buffer)
+            if self._state_dict:
+                self._state_dict["shuffle_buffer_end_of_data_shuffled"] = True
+        while mem_buffer:
+            selected = mem_buffer.pop(0)
+            if self._state_dict:
+                self._state_dict["shuffle_buffer"] = tuple(mem_buffer)
+            yield selected
+
+    def __iter__(self):
+        yield from self._iter_with_buffer(iter(self.ex_iterable))
 
     def _iter_arrow(self):
-        buffer_size = self.buffer_size
-        rng = deepcopy(self.generator)
-        indices_iterator = self._iter_random_indices(rng, buffer_size)
-        # this is the shuffle buffer that we keep in memory
-        mem_buffer = []
-        for key, pa_table in self.ex_iterable.iter_arrow():
-            if len(mem_buffer) == buffer_size:  # if the buffer is full, pick and example from it
-                i = next(indices_iterator)
-                yield mem_buffer[i]
-                mem_buffer[i] = (key, pa_table)  # replace the picked example by a new one
-            else:  # otherwise, keep filling the buffer
-                mem_buffer.append((key, pa_table))
-        # when we run out of examples, we shuffle the remaining examples in the buffer and yield them
-        rng.shuffle(mem_buffer)
-        yield from mem_buffer
+        iterator = self.ex_iterable.iter_arrow()
+        if self._state_dict:
+            iterator = self._iter_compacted(iterator)
+        yield from self._iter_with_buffer(iterator)
+
+    @staticmethod
+    def _iter_compacted(iterator: Iterator[tuple[Key, pa.Table]]) -> Iterator[tuple[Key, pa.Table]]:
+        # buffered tables are often zero-copy slices that reference the buffers of a whole
+        # source table, in which case copying or serializing the buffer state would write
+        # the full source buffers for every buffered example. Rewrite those slices as
+        # stand-alone tables before they enter the buffer.
+        for key, pa_table in iterator:
+            if pa_table.get_total_buffer_size() > 2 * pa_table.nbytes:
+                pa_table = pa_table.take(list(range(len(pa_table))))
+            yield key, pa_table
 
     def shuffle_data_sources(self, generator: np.random.Generator) -> "BufferShuffledExamplesIterable":
         """Shuffle the wrapped examples iterable as well as the shuffling buffer."""

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import pickle
 import sys
 import time
@@ -377,6 +378,17 @@ def test_buffer_shuffled_examples_iterable(seed):
     assert next(iter(ex_iterable)) == expected[0]
     assert list(ex_iterable) == expected
     assert sorted(ex_iterable) == sorted(all_examples)
+    assert_load_state_dict_resumes_iteration(ex_iterable)
+
+
+@pytest.mark.parametrize("seed", [42, 1337])
+def test_buffer_shuffled_examples_iterable_resume_arrow_iteration(seed):
+    generator = np.random.default_rng(seed)
+    base_ex_iterable = ArrowExamplesIterable(generate_tables_fn, {"n": 40})
+    ex_iterable = BufferShuffledExamplesIterable(
+        RebatchedArrowExamplesIterable(base_ex_iterable, batch_size=1), buffer_size=7, generator=generator
+    )
+    assert_load_state_dict_resumes_arrow_iteration(ex_iterable)
 
 
 def test_cycling_multi_sources_examples_iterable():
@@ -1521,8 +1533,7 @@ def test_horizontally_concatenated_examples_iterable():
 )
 def test_no_iter_arrow(ex_iterable: _BaseExamplesIterable):
     assert ex_iterable.iter_arrow is None
-    if not isinstance(ex_iterable, BufferShuffledExamplesIterable):
-        assert_load_state_dict_resumes_iteration(ex_iterable)
+    assert_load_state_dict_resumes_iteration(ex_iterable)
 
 
 @pytest.mark.parametrize(
@@ -2983,6 +2994,68 @@ def test_iterable_dataset_filter_resume_state_dict(consume, batched):
     resumed.load_state_dict(state_dict)
     rest = [example["a"] for example in resumed]
     assert seen + rest == list(range(n))
+
+
+@pytest.mark.parametrize("num_shards", [1, 4])
+@pytest.mark.parametrize("consume", [3, 20, 45])
+def test_iterable_dataset_shuffle_resume_state_dict(num_shards, consume):
+    # Resuming a shuffled dataset must continue exactly where it left off: the shuffle
+    # buffer content and the position of the rng are part of the state, so no example
+    # is lost and no already-yielded example is emitted a second time
+    n = 50
+
+    def build():
+        return (
+            Dataset.from_dict({"a": list(range(n))})
+            .to_iterable_dataset(num_shards=num_shards)
+            .shuffle(seed=17, buffer_size=16)
+        )
+
+    expected = [example["a"] for example in build()]
+    assert sorted(expected) == list(range(n))
+    ds = build()
+    it = iter(ds)
+    seen = [next(it)["a"] for _ in range(consume)]
+    state_dict = ds.state_dict()
+    resumed = build()
+    resumed.load_state_dict(state_dict)
+    rest = [example["a"] for example in resumed]
+    assert seen + rest == expected
+
+
+def test_iterable_dataset_shuffle_load_state_dict_without_buffer_content(caplog):
+    # state dicts from versions that didn't save the shuffle buffer content can still
+    # be loaded: the buffer is refilled and roughly buffer_size examples are lost
+    n = 50
+
+    def build():
+        return (
+            Dataset.from_dict({"a": list(range(n))}).to_iterable_dataset(num_shards=4).shuffle(seed=17, buffer_size=16)
+        )
+
+    ds = build()
+    it = iter(ds)
+    for _ in range(20):
+        next(it)
+    state_dict = ds.state_dict()
+
+    def strip_buffer_content(state):
+        if isinstance(state, dict):
+            return {
+                key: strip_buffer_content(value)
+                for key, value in state.items()
+                if not str(key).startswith("shuffle_buffer")
+            }
+        elif isinstance(state, list):
+            return [strip_buffer_content(value) for value in state]
+        return state
+
+    resumed = build()
+    with caplog.at_level(logging.WARNING):
+        resumed.load_state_dict(strip_buffer_content(state_dict))
+        rest = [example["a"] for example in resumed]
+    assert "without the buffer content" in caplog.text
+    assert len(rest) == len(set(rest))
 
 
 @pytest.mark.parametrize("num_shards", [1, 2, 3, 7])


### PR DESCRIPTION
## Overview

There are two problems when resuming a shuffled iterable dataset. The known one from the warning and the discussion in #7901 is that the shuffle buffer content isn't saved in the state dict so you lose roughly `buffer_size` examples every resume.

The second is you can get an example twice. The `RebatchedArrowExamplesIterable` that wraps the pipeline resumes by rewinding to a `previous_state` snapshot and skipping chunks it already delviered which assumes the inner stream is deterministic from its state. The shuffle buffer isn't as it restarts empty with a fresh rng so the rewound rows get reshuffled differently and an already yielded row can come out again. I instrumented it at the issue's k=20: the resume re-reads rows 58 and 158. 158 was still in the buffer but 58 had already been yielded so that's the {58: 2} in the issue. Silent duplicates in a training run that resumes often is worse than the documented loss.

## Fix

Save the buffer content, the rng pick count and the end-of-data shuffle flag in the state dict. Resume restores the buffer and fast-forwards the rng, so it carries on exactly where it left off and both problems go away.

Two costs dealt with: state gets captured once per yielded example, so `state_dict()` keeps the buffer as a tuple instead of deep-copying it. And the buffered arrow tables are usually zero-copy slices of a whole source table, a buffer_size=1000 checkpoint over 50k rows came out at 1.6 GiB. Slices get rewritten as stand-alone tables before entering the buffer, which brings it down to ~400 KiB.

- The repro from #7901: no duplicates, nothing missing. Sweeping the checkpoint over k=1..100 for buffer sizes 4/8/16/32: zero duplicates (was 22/9/3/0).
- Resumed iteration is identical to an uninterrupted run across shard counts, buffer sizes and checkpoint positions, including mid-drain and resume/checkpoint/resume chains.
- Removed the BufferShuffledExamplesIterable exemption in test_no_iter_arrow so the standard resume assertion covers it, plus new resume tests. All of them fail without the fix.
- 501 passed in test_iterable_dataset.py, ruff clean, iteration order unchanged from main for a fixed seed.
- 50k examples with buffer_size=1000: ~2% overhead with state tracking, checkpoint ~400 KiB.

 Resolves #7901 