### PR TITLE
docs: fix broken audio link in mapstyle vs iterable guide

### DIFF
--- a/docs/source/about_mapstyle_vs_iterable.mdx
+++ b/docs/source/about_mapstyle_vs_iterable.mdx
@@ -84,7 +84,7 @@ for example in my_iterable_dataset:  # this reads the CSV file progressively as 
 ```
 
 Many file formats are supported, like CSV, JSONL, and Parquet, as well as image and audio files.
-You can find more information in the corresponding guides for loading [tabular](./tabular_load), [text](./nlp_load), [vision](./image_load), and [audio](./audio_load]) datasets.
+You can find more information in the corresponding guides for loading [tabular](./tabular_load), [text](./nlp_load), [vision](./image_load), and [audio](./audio_load) datasets.
 
 ## Eager data processing and lazy data processing
 


### PR DESCRIPTION
The "map-style vs iterable" guide links the four loading guides on one line, but the `audio` link has a stray `]` inside its target (`./audio_load]`), which makes the Markdown link malformed and breaks it.

The three sibling links on the same line are correct (`./tabular_load`, `./nlp_load`, `./image_load`), and the target page `docs/source/audio_load.mdx` exists, so this is just the stray bracket. Removed it so the link resolves.
