### PR TITLE
Restore the _legacy_no_dict_keys_sorting branch in Pickler._batch_setitems

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -71,6 +71,8 @@ class Pickler(dill.Pickler):
         dill.Pickler.save(self, obj, save_persistent_id=save_persistent_id)
 
     def _batch_setitems(self, items, *args, **kwargs):
+        if self._legacy_no_dict_keys_sorting:
+            return super()._batch_setitems(items, *args, **kwargs)
         # Ignore the order of keys in a dict
         try:
             # Faster, but fails for unorderable elements

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -588,3 +588,44 @@ def test_dependency_on_dill():
     # AttributeError: module 'dill._dill' has no attribute 'stack'
     hasher = Hasher()
     hasher.update(lambda x: x)
+
+
+def test_hash_is_insensitive_to_dict_key_order():
+    # The default Pickler sorts dict items, so insertion order must not change the hash
+    assert Hasher.hash({"train": ["train.csv"], "test": ["test.csv"]}) == Hasher.hash(
+        {"test": ["test.csv"], "train": ["train.csv"]}
+    )
+
+
+def test_legacy_no_dict_keys_sorting_preserves_dict_key_order():
+    # `_check_legacy_cache2` patches this flag on to reproduce the 2.15.0 config_id,
+    # which was computed without sorting dict items
+    from datasets.utils._dill import Pickler
+
+    with patch.object(Pickler, "_legacy_no_dict_keys_sorting", True):
+        assert Hasher.hash({"train": ["train.csv"], "test": ["test.csv"]}) != Hasher.hash(
+            {"test": ["test.csv"], "train": ["train.csv"]}
+        )
+
+
+def test_legacy_no_dict_keys_sorting_forwards_extra_args():
+    # The legacy branch must forward *args/**kwargs like the sorting branch does,
+    # because Python 3.14 calls `_batch_setitems(items, obj=obj)`
+    import dill
+
+    from datasets.utils._dill import Pickler
+
+    calls = []
+
+    def fake_batch_setitems(self, items, *args, **kwargs):
+        calls.append((list(items), args, kwargs))
+
+    pickler = Pickler.__new__(Pickler)
+    with patch.object(dill.Pickler, "_batch_setitems", fake_batch_setitems):
+        with patch.object(Pickler, "_legacy_no_dict_keys_sorting", True):
+            pickler._batch_setitems(iter([("b", 1), ("a", 2)]), "positional", keyword=3)
+
+    items, args, kwargs = calls[0]
+    assert items == [("b", 1), ("a", 2)]  # unsorted -> the legacy branch ran
+    assert args == ("positional",)
+    assert kwargs == {"keyword": 3}


### PR DESCRIPTION
### Root cause

`Pickler._legacy_no_dict_keys_sorting` lost its only reader in #7817. That PR rewrote `_batch_setitems` to accept the argument Python 3.14 passes, and in the same hunk dropped the early return:

```diff
-    def _batch_setitems(self, items):
-        if self._legacy_no_dict_keys_sorting:
-            return super()._batch_setitems(items)
+    def _batch_setitems(self, items, *args, **kwargs):
```

`_check_legacy_cache2` still patches the flag on to rebuild the 2.15.0 `config_id`, so that lookup now hashes with sorted dict keys and no longer matches the directory 2.15.0 wrote. The flag appears twice in `src/`, as a definition and as that `patch.object` write, and nothing reads it.

### The fix

Restore the branch, keeping the `*args`/`**kwargs` passthrough #7817 added so the 3.14 fix is preserved on both paths.

### Verification

- The two new legacy tests fail on `main` (`assert [('a', 2), ('b', 1)] == [('b', 1), ('a', 2)]`) and pass with this change; the third pins the default order-insensitive behaviour and passes either way.
- `pytest tests/test_fingerprint.py`: 24 passed / 9 skipped before, 26 passed / 9 skipped after, in a clean container on Python 3.11.15 with `dill` 0.4.1.
- With the fix, `Hasher.hash({"train": ["train.csv"], "test": ["test.csv"]})` under the patched flag returns `711511d8f1d9bc25`, which is the value `datasets==2.15.0` actually produces for that object. On `main` it returns the sorted-key hash `cfd3b51f0f8e9fd8`. 4.4.0 is the first release where that regressed, matching `git tag --contains f7c8e46ec`.
- Not checked: I did not build a 2.15.0 cache directory and load it under HEAD. The hash mismatch is measured; the effect on the directory lookup is read from `_check_legacy_cache2`.

If you would rather retire the 2.14/2.15 compat path than restore it, that is the alternative I raised in the issue and I am happy to send that instead.

Fixes #8410
