### PR TITLE
Fix IndexError on negative list indices for datasets with an indices mapping

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -72,7 +72,7 @@ def _query_table_with_indices_mapping(
         table = table.select([key])
         return _query_table(table, indices.column(0).to_pylist())
     if isinstance(key, Iterable):
-        return _query_table(table, [indices.fast_slice(i, 1).column(0)[0].as_py() for i in key])
+        return _query_table(table, [indices.fast_slice(i % indices.num_rows, 1).column(0)[0].as_py() for i in key])
 
     _raise_bad_key_type(key)
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -918,6 +918,14 @@ class QueryTest(TestCase):
             subtable,
             pa.Table.from_pydict({"a": [_COL_A[_INDICES[0]]], "b": [_COL_B[_INDICES[0]]], "c": [_COL_C[_INDICES[0]]]}),
         )
+        # negative indices wrap around the indices mapping length
+        subtable = query_table(table, [-1], indices=indices)
+        self.assertTableEqual(
+            subtable,
+            pa.Table.from_pydict(
+                {"a": [_COL_A[_INDICES[-1]]], "b": [_COL_B[_INDICES[-1]]], "c": [_COL_C[_INDICES[-1]]]}
+            ),
+        )
         with self.assertRaises(IndexError):
             assert len(indices) < n
             query_table(table, [len(indices)], indices=indices)


### PR DESCRIPTION
## Summary

In `src/datasets/formatting/formatting.py`, `_query_table_with_indices_mapping`'s iterable branch passes each index directly to `indices.fast_slice(i, 1)`:

```python
return _query_table(table, [indices.fast_slice(i, 1).column(0)[0].as_py() for i in key])
```

`fast_slice` raises `IndexError("Offset must be non-negative")` for a negative offset, so any negative index in a list/array key crashes — **but only when an indices mapping is present**. The three sibling branches all normalize the index first:

- the `int` branch in the same function: `indices.fast_slice(key % indices.num_rows, 1)`
- `_query_table` (no mapping), `int`: `table.fast_slice(key % table.num_rows, 1)`
- `_query_table` (no mapping), iterable: `table.fast_gather(key % table.num_rows)`

Negative indices are explicitly allowed by `_check_valid_index_key` (down to `-size`), so they reach this line and crash.

## Reproduction

```python
from datasets import Dataset
ds = Dataset.from_dict({"a": [0, 1, 2, 3, 4]})
ds[[-1]]                     # {'a': [4]}          (no indices mapping)
ds.shuffle(seed=42)[[-1]]    # IndexError: Offset must be non-negative
```

Any dataset with an indices mapping (`.shuffle()`, `.select()` with non-contiguous indices, `.filter()`, `.shard()`, `.train_test_split()`) is affected, including the `__getitems__` path used by PyTorch `DataLoader`.

## Fix

```diff
-        return _query_table(table, [indices.fast_slice(i, 1).column(0)[0].as_py() for i in key])
+        return _query_table(table, [indices.fast_slice(i % indices.num_rows, 1).column(0)[0].as_py() for i in key])
```

## Tests

Extended `test_query_table_iterable`'s "with indices" section with a negative-index case (`query_table(table, [-1], indices=indices)` now returns the last mapped row). It fails on the current code with `IndexError` and passes with the fix.
