### PR TITLE
Fix cryptic TypeError from ClassLabel.int2str on a string input

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1130,7 +1130,8 @@ class ClassLabel:
         'neg'
         ```
         """
-        if not isinstance(values, int) and not isinstance(values, Iterable):
+        # str is Iterable but not a valid label, so reject it explicitly (as str2int does).
+        if isinstance(values, str) or (not isinstance(values, int) and not isinstance(values, Iterable)):
             raise ValueError(
                 f"Values {values} should be an integer or an Iterable (list, numpy array, pytorch, tensorflow tensors)"
             )

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1141,8 +1141,12 @@ class ClassLabel:
             return_list = False
 
         for v in values:
-            if not 0 <= v < self.num_classes:
-                raise ValueError(f"Invalid integer class label {v:d}")
+            try:
+                in_range = 0 <= v < self.num_classes
+            except TypeError:  # not comparable to an int, so not a label
+                in_range = False
+            if not in_range:
+                raise ValueError(f"Invalid integer class label {v!r}")
 
         output = [self._int2str[int(v)] for v in values]
         return output if return_list else output[0]

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -342,6 +342,10 @@ def test_classlabel_int2str():
         classlabel.int2str(-1)
     with pytest.raises(ValueError):
         classlabel.int2str(None)
+    # A string is iterable but not a valid integer label: reject it clearly
+    # instead of iterating over its characters (which raised a cryptic TypeError).
+    with pytest.raises(ValueError):
+        classlabel.int2str("1")
 
 
 def test_classlabel_cast_storage():

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -346,6 +346,12 @@ def test_classlabel_int2str():
     # instead of iterating over its characters (which raised a cryptic TypeError).
     with pytest.raises(ValueError):
         classlabel.int2str("1")
+    # A non-integer element used to reach the range check and fail there instead:
+    # a str was compared against an int, and a float broke the error's own formatting.
+    with pytest.raises(ValueError, match="Invalid integer class label"):
+        classlabel.int2str(["1"])
+    with pytest.raises(ValueError, match="Invalid integer class label"):
+        classlabel.int2str([2.5])
 
 
 def test_classlabel_cast_storage():


### PR DESCRIPTION
`ClassLabel.int2str("1")` raises a cryptic `TypeError: '<=' not supported between instances of 'int' and 'str'` instead of a clear error.

`int2str` guards its input with `isinstance(values, Iterable)`, but a `str` is iterable, so a string is not wrapped as a single value; the code then iterates over the string's characters and compares `0 <= <char> < num_classes`, raising the `TypeError`. The sibling `str2int` already special-cases `str`; `int2str` was missing the symmetric guard.

Two commits here:

1. **Top-level `str`.** Rejected with the method's existing `ValueError` — a string is not a valid integer label (`str2int` is the string → int direction).
2. **Non-integer elements** (after review feedback from @shashvat-singham). The guard above only inspects `values` itself, so a non-integer *inside* the iterable still reached the range check and raised the same `TypeError` (`int2str(["1"])`). An out-of-range float didn't even get that far — it passed the comparison and then broke the error message's own `{v:d}` formatting with `Unknown format code 'd' for object of type 'float'`. Both now report the offending value.

The element check duck-types the comparison rather than testing `isinstance(v, (int, np.integer))`, because a type whitelist would reject inputs that work today and that the error message itself advertises: iterating a torch tensor yields 0-d `Tensor`s rather than ints, and floats are accepted. "Not comparable to an int" is the property that actually matters, and it covers `str`, `None` and arbitrary objects without enumerating types.

Unchanged: ints, lists/tuples of ints, floats, numpy arrays and scalars, torch tensors, and `bytes` (a genuine iterable of ints — `ClassLabel(num_classes=100).int2str(b"\x01")` returns `['1']`).

**Out of scope**, both pre-existing and both surfaced in review — happy to fold either in if wanted: `str2int([1])` returns `[1]` rather than rejecting it, and 0-d inputs fail in the `for` itself before any check can run (`int2str(torch.tensor(1))` → `TypeError: iteration over a 0-d tensor`).

### Testing
Added `pytest.raises(ValueError)` cases for `int2str("1")`, `int2str(["1"])` and `int2str([2.5])` to `test_classlabel_int2str`; each fails on the unpatched code. `tests/features/test_features.py` passes (201 passed, 2 skipped); `ruff check` and `ruff format --check` clean.

---
Used AI assistance on this; I reviewed and tested the change myself.
