### PR TITLE
Shutdown ThreadPoolExecutor in CyclingMultiSourcesExamplesIterable

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -864,6 +864,7 @@ class CyclingMultiSourcesExamplesIterable(_BaseExamplesIterable):
             while iterators:
                 iterator = iterators.pop()
                 del iterator
+            executor.shutdown(wait=True)
             if any(ex_iterable.sleep_on_threads_shutdown for ex_iterable in self.ex_iterables):
                 time.sleep(config.SLEEP_TIME_ON_THREADS_SHUTDOWN)
 


### PR DESCRIPTION
Add missing executor.shutdown(wait=True) call in the finally block of _iter_arrow(), matching the behavior in __iter__ to ensure threads are shut down before cleanup and sleep.