### PR TITLE
Fix DataFrame masking on ArrayXD columns with an integer value type

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -964,13 +964,17 @@ class PandasArrayExtensionArray(PandasExtensionArray):
     ) -> "PandasArrayExtensionArray":
         indices: np.ndarray = np.asarray(indices, dtype=int)
         if allow_fill:
-            fill_value = (
-                self.dtype.na_value if fill_value is None else np.asarray(fill_value, dtype=self.dtype.value_type)
-            )
             mask = indices == -1
             if (indices < -1).any():
                 raise ValueError("Invalid value in `indices`, must be all >= -1 for `allow_fill` is True")
-            elif len(self) > 0:
+            if mask.any():
+                # Only materialize the fill value when some position actually has to be filled:
+                # pandas passes `allow_fill=True` with a NaN `fill_value` even when `indices` has no -1
+                # (e.g. when masking a `DataFrame`), and NaN can't be cast to an integer value type.
+                fill_value = (
+                    self.dtype.na_value if fill_value is None else np.asarray(fill_value, dtype=self.dtype.value_type)
+                )
+            if len(self) > 0:
                 pass
             elif not np.all(mask):
                 raise IndexError("Invalid take for empty PandasArrayExtensionArray, must be all -1.")

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -12,7 +12,12 @@ from absl.testing import parameterized
 import datasets
 from datasets.arrow_writer import ArrowWriter
 from datasets.features import Array2D, Array3D, Array4D, Array5D, Value
-from datasets.features.features import Array3DExtensionType, PandasArrayExtensionDtype, _ArrayXD
+from datasets.features.features import (
+    Array3DExtensionType,
+    PandasArrayExtensionArray,
+    PandasArrayExtensionDtype,
+    _ArrayXD,
+)
 from datasets.formatting.formatting import NumpyArrowExtractor, SimpleArrowExtractor
 
 
@@ -365,6 +370,23 @@ def test_table_to_pandas(dtype, dummy_value):
     assert isinstance(df.foo.dtype, PandasArrayExtensionDtype)
     arr = df.foo.to_numpy()
     np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
+
+
+@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+def test_pandas_array_extension_array_take_allow_fill(dtype, dummy_value):
+    data = np.array([[[dummy_value] * 2] * 2] * 2, dtype=np.dtype(dtype))
+    arr = PandasArrayExtensionArray(data)
+    # pandas passes `allow_fill=True` together with a NaN `fill_value` even when no index is -1,
+    # e.g. when selecting the rows of a DataFrame with a boolean mask
+    taken = arr.take([1], allow_fill=True, fill_value=np.nan)
+    assert isinstance(taken, PandasArrayExtensionArray)
+    np.testing.assert_equal(np.asarray(taken), data[[1]])
+    # -1 indices are still filled
+    taken = arr.take([0, -1], allow_fill=True, fill_value=dummy_value)
+    np.testing.assert_equal(np.asarray(taken), data)
+    # and indices below -1 are still rejected
+    with pytest.raises(ValueError):
+        arr.take([-2], allow_fill=True, fill_value=np.nan)
 
 
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])


### PR DESCRIPTION
Selecting rows with a boolean mask on a `DataFrame` that has an `Array2D`/`Array3D`/... column with an integer value type raises:

```python
import datasets, numpy as np

features = datasets.Features({"id": datasets.Value("int64"), "foo": datasets.Array2D(dtype="int32", shape=(2, 2))})
ds = datasets.Dataset.from_dict({"id": [0, 1], "foo": [[[1, 1], [1, 1]]] * 2}, features=features)
df = ds._data.to_pandas()
df[df["id"] == 0]
```

```
ValueError: cannot convert float NaN to integer
```

### Cause

pandas reindexes a block by calling `ExtensionArray.take(indices, allow_fill=True, fill_value=<na_value>)` — see `pandas/core/array_algos/take.py` — and for a boolean mask `indices` contains no `-1` at all, so nothing actually has to be filled. `PandasArrayExtensionArray.take` nevertheless coerced the fill value up front:

```python
if allow_fill:
    fill_value = (
        self.dtype.na_value if fill_value is None else np.asarray(fill_value, dtype=self.dtype.value_type)
    )
```

`np.asarray(np.nan, dtype="int32")` raises, so the coercion failed before the code could notice that `mask.any()` is `False`.

### Fix

Only materialize the fill value when at least one index is `-1`. Behaviour when filling really is needed is unchanged, and out-of-range indices are still rejected — the `(indices < -1).any()` check now runs first, so `take([-2], allow_fill=True, fill_value=nan)` reports the intended "Invalid value in `indices`" error instead of the incidental NaN cast error.

### Test

`tests/features/test_array_xd.py::test_pandas_array_extension_array_take_allow_fill` covers `int32`, `bool` and `float64`; the `int32` case fails on `main` with the `ValueError` above and passes with this change. It also asserts that `-1` indices are still filled and that indices below `-1` still raise.

### Note

This is one of two independent bugs that break `df[mask]` on `Array2D` columns. The other one — `PandasArrayExtensionDtype._metadata` being a string instead of a tuple, which makes pandas raise `AttributeError: 'PandasArrayExtensionDtype' object has no attribute 'v'` — is already handled by #8376. This PR does not touch `_metadata`, so the two changes are complementary and conflict-free; both are needed for the end-to-end repro in #8375 to work with an integer value type.

Refs #8375
