### PR TITLE
Fix label inference for folder-based builders on archives

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -107,7 +107,7 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                     archive, downloaded_dir = str(archive), str(downloaded_dir)
                     for downloaded_dir_file in dl_manager.iter_files(downloaded_dir):
                         _, downloaded_dir_file_ext = os.path.splitext(downloaded_dir_file)
-                        if downloaded_dir_file_ext in self.EXTENSIONS:
+                        if downloaded_dir_file_ext.lower() in self.EXTENSIONS:
                             if not self.config.drop_labels:
                                 labels.add(os.path.basename(os.path.dirname(downloaded_dir_file)))
                                 path_depths.add(count_path_segments(downloaded_dir_file))
@@ -446,13 +446,16 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                     if isinstance(self.config.filters, list)
                     else self.config.filters
                 )
-            for shard_idx, (original_file, _, downloaded_files) in enumerate(files):
+            for shard_idx, (original_file, downloaded_dir, downloaded_files) in enumerate(files):
                 if isinstance(downloaded_files, str):
                     downloaded_files = [downloaded_files]
                 for sample_idx, downloaded_file in enumerate(downloaded_files):
                     sample = {self.BASE_COLUMN_NAME: downloaded_file}
                     if add_labels:
-                        sample["label"] = os.path.basename(os.path.dirname(original_file or downloaded_file))
+                        # for archives, `original_file` is the archive itself, so the label has to be
+                        # inferred from the path of the extracted file (like in `analyze()` above)
+                        labeled_file = downloaded_file if downloaded_dir else (original_file or downloaded_file)
+                        sample["label"] = os.path.basename(os.path.dirname(labeled_file))
                     if self.config.filters is not None:
                         pa_table = pa.Table.from_pylist([sample]).filter(filter_expr)
                         if len(pa_table) == 0:

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -253,6 +253,28 @@ def data_files_with_zip_archives(tmp_path, auto_text_file):
     return data_files_with_zip_archives
 
 
+@pytest.fixture
+def data_files_with_labels_in_zip_archive_no_metadata(tmp_path, auto_text_file, request):
+    extension = request.param if hasattr(request, "param") else ".txt"
+    data_dir = tmp_path / f"data_files_with_labels_in_zip_archive{extension}"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir = data_dir / "archive"
+    subdir_class_0 = archive_dir / "class0"
+    subdir_class_0.mkdir(parents=True, exist_ok=True)
+    subdir_class_1 = archive_dir / "class1"
+    subdir_class_1.mkdir(parents=True, exist_ok=True)
+
+    shutil.copyfile(auto_text_file, subdir_class_0 / f"file0{extension}")
+    shutil.copyfile(auto_text_file, subdir_class_1 / f"file1{extension}")
+
+    shutil.make_archive(str(archive_dir), "zip", str(archive_dir))
+    shutil.rmtree(str(archive_dir))
+
+    data_files = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+    assert len(data_files["train"]) == 1
+    return data_files
+
+
 def test_config_raises_when_invalid_name() -> None:
     with pytest.raises(InvalidConfigName, match="Bad characters"):
         _ = FolderBasedBuilderConfig(name="name-with-*-invalid-character")
@@ -272,6 +294,23 @@ def test_inferring_labels_from_data_dirs(data_files_with_labels_no_metadata, cac
     assert autofolder.info.features["label"] == ClassLabel(names=["class0", "class1"])
     generator = autofolder._generate_examples(**gen_kwargs)
     assert all(example["label"] in {"class0", "class1"} for _, example in generator)
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("data_files_with_labels_in_zip_archive_no_metadata", [".txt", ".TXT"], indirect=True)
+def test_inferring_labels_from_data_dirs_in_archives(
+    data_files_with_labels_in_zip_archive_no_metadata, streaming, cache_dir
+):
+    # the labels of the files inside an archive must come from the path of the extracted files,
+    # not from the path of the archive itself
+    autofolder = DummyFolderBasedBuilder(
+        data_files=data_files_with_labels_in_zip_archive_no_metadata, cache_dir=cache_dir, drop_labels=False
+    )
+    download_manager = StreamingDownloadManager() if streaming else DownloadManager()
+    gen_kwargs = autofolder._split_generators(download_manager)[0].gen_kwargs
+    assert autofolder.info.features["label"] == ClassLabel(names=["class0", "class1"])
+    generated_examples = list(autofolder._generate_examples(**gen_kwargs))
+    assert sorted(example["label"] for _, example in generated_examples) == ["class0", "class1"]
 
 
 def test_default_folder_builder_not_usable(data_files_with_labels_no_metadata, cache_dir):


### PR DESCRIPTION
`imagefolder` / `audiofolder` / `videofolder` datasets whose media files live inside a ZIP archive get the wrong labels, and usually fail to build at all.

## The bug

In `_split_generators()` the entries of `files` have two different shapes:

```python
# loose files:  (original_file, None, downloaded_file)
files = tuple(zip(files, [None] * len(files), downloaded_files))
# archives:     (original_archive, downloaded_dir, downloaded_files)
files += tuple(
    (archive, downloaded_dir, dl_manager.iter_files(downloaded_dir))
    for archive, downloaded_dir in zip(archives, downloaded_dirs)
)
```

but `_generate_examples()` labels every sample from `original_file`:

```python
sample["label"] = os.path.basename(os.path.dirname(original_file or downloaded_file))
```

For an archive `original_file` is the archive, not the sample, so every sample in the archive is labelled with the name of the directory that contains the archive. `analyze()` meanwhile infers the `ClassLabel` names from the extracted paths, so the label that is produced isn't one of the allowed names and generation fails:

```
ValueError: Invalid string class label <name of the dir containing the archive>
```

Repro (`data.zip` contains `class0/a.jpg` and `class1/b.jpg`):

```python
load_dataset("imagefolder", data_dir="zdir", split="train")
# ValueError: Invalid string class label zdir
```

The same directory layout loads fine when the files are not zipped.

## Second, related bug

`analyze()` lowercases the extension for loose files but not for the files inside an archive:

```python
if original_file_ext.lower() in self.EXTENSIONS:     # loose files
...
if downloaded_dir_file_ext in self.EXTENSIONS:       # inside an archive
```

`EXTENSIONS` is lowercase, so an archive containing `class0/a.JPG` contributes nothing to `labels`, and the dataset silently comes out with no `label` column at all — again inconsistent with the same files unzipped.

## Fix

Use the extracted file's path for the label when the entry comes from an archive (which is exactly what `analyze()` already does when collecting the label names), and lowercase the extension in the archive branch.

## Test

`test_inferring_labels_from_data_dirs_in_archives` builds a zip with `class0/` and `class1/` subdirectories and checks the inferred `ClassLabel` names and the generated labels, parametrized over streaming/non-streaming and over `.txt` / `.TXT`. On `main` the `.txt` parameters fail on the generated labels and the `.TXT` parameters fail on the inferred names; all pass with the fix.
