### PR TITLE
Keep the dtype of an empty column when formatting to numpy or torch

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -212,6 +212,17 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
                             return np.asarray(array, dtype=object)
                         return np.array(array, copy=False, dtype=object)
                     break
+        else:
+            # numpy infers float64 from an empty list, which would silently change the dtype of an
+            # empty column, e.g. one that `Dataset.filter` emptied out. Let pyarrow derive the dtype
+            # from the arrow type instead, whenever it maps to a concrete numpy dtype.
+            empty_array = (
+                pa_array.to_numpy()
+                if isinstance(pa_array, pa.ChunkedArray)
+                else pa_array.to_numpy(zero_copy_only=False)
+            )
+            if empty_array.dtype != object:
+                return empty_array
         if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             return np.asarray(array)
         else:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1042,6 +1042,59 @@ def test_torch_formatter_sets_default_dtypes(cast_schema, arrow_table):
     torch.testing.assert_close(batch["col_float"], torch.tensor(list_float, dtype=torch.float32))
 
 
+@pytest.mark.parametrize(
+    "pa_type, expected_dtype",
+    [
+        (pa.int64(), np.int64),
+        (pa.int32(), np.int64),
+        (pa.float64(), np.float32),
+        (pa.bool_(), np.bool_),
+    ],
+)
+def test_numpy_formatter_keeps_dtype_of_empty_column(pa_type, expected_dtype):
+    # an empty column used to be converted by numpy to its default float64 dtype,
+    # e.g. after `Dataset.filter` filtered out every row
+    pa_table = pa.table({"col": pa.array([], type=pa_type)})
+    formatter = NumpyFormatter()
+
+    col = formatter.format_column(pa_table)
+    assert len(col) == 0
+    assert col.dtype == expected_dtype
+
+    batch = formatter.format_batch(pa_table)
+    assert len(batch["col"]) == 0
+    assert batch["col"].dtype == expected_dtype
+
+
+@require_numpy1_on_windows
+@require_torch
+@pytest.mark.parametrize(
+    "pa_type, expected_dtype_name",
+    [
+        (pa.int64(), "int64"),
+        (pa.int32(), "int64"),
+        (pa.float64(), "float32"),
+        (pa.bool_(), "bool"),
+    ],
+)
+def test_torch_formatter_keeps_dtype_of_empty_column(pa_type, expected_dtype_name):
+    import torch
+
+    from datasets.formatting import TorchFormatter
+
+    pa_table = pa.table({"col": pa.array([], type=pa_type)})
+    formatter = TorchFormatter()
+    expected_dtype = getattr(torch, expected_dtype_name)
+
+    col = formatter.format_column(pa_table)
+    assert len(col) == 0
+    assert col.dtype == expected_dtype
+
+    batch = formatter.format_batch(pa_table)
+    assert len(batch["col"]) == 0
+    assert batch["col"].dtype == expected_dtype
+
+
 def test_iterable_dataset_of_arrays_format_to_arrow(any_arrays_dataset: IterableDataset):
     formatted = any_arrays_dataset.with_format("arrow")
     assert all(isinstance(example, pa.Table) for example in formatted)


### PR DESCRIPTION
An empty column silently changes dtype when formatted to numpy or torch:

```python
from datasets import Dataset

ds = Dataset.from_dict({"a": [1, 2, 3]}).with_format("torch")
print(ds[:]["a"].dtype)                          # torch.int64
print(ds.filter(lambda x: False)[:]["a"].dtype)  # torch.float32  <-- expected torch.int64
```

The same happens for `bool` columns (`torch.bool` -> `torch.float32`), for `numpy` format, and for any dataset that simply has no rows:

```python
from datasets import Dataset, Features, Value

Dataset.from_dict({"a": []}, features=Features({"a": Value("int64")})).with_format("numpy")[:]["a"]
# array([], dtype=float32)   <-- expected dtype int64
```

This shows up when a filter/split/shard happens to be empty: `torch.cat` and `np.concatenate` then fail or silently upcast, and a `DataLoader` producing an empty batch hands the model a float tensor where the model expects `int64` indices.

### Cause

`NumpyArrowExtractor._arrow_array_to_numpy` materializes the arrow array into a python list before converting it:

```python
array: list = [row for chunk in pa_array.chunks for row in chunk.to_numpy(...)]
...
return np.asarray(array)
```

For an empty column `array` is `[]`, and `np.asarray([])` infers `float64` — the arrow type is never consulted. The torch/tf/jax formatters all build on this extractor, so they inherit the wrong dtype (`float64` then becomes `float32` through the formatters' default float dtype).

The pandas and polars formatters go through `pa_table.to_pandas()` / `polars.from_arrow()`, which keep the arrow type, so they were already correct — this only made the tensor formatters inconsistent with the rest of the library.

### Fix

When the column is empty, let pyarrow derive the numpy dtype from the arrow type instead of letting numpy guess from an empty list.

The change is deliberately narrow: the pyarrow-derived array is only returned when it maps to a concrete numpy dtype. Columns of strings, lists, structs and `ArrayXD` resolve to `object` and keep their current behaviour, so nothing changes for them.

### Tests

`tests/test_formatting.py::test_numpy_formatter_keeps_dtype_of_empty_column` and `::test_torch_formatter_keeps_dtype_of_empty_column` cover `int64`, `int32`, `float64` and `bool`. On `main` 6 of the 8 parametrizations fail (the `float64` ones pass by coincidence, since numpy's `float64` guess maps to the same `float32` the formatters use by default).

Full `tests/test_formatting.py`, `tests/test_arrow_dataset.py`, `tests/test_iterable_dataset.py`, `tests/test_table.py` and `tests/features/` pass.
