### PR TITLE
Validate the columns in IterableDataset.rename_columns

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4106,6 +4106,27 @@ class IterableDataset(DatasetInfoMixin):
         """
 
         original_features = self._info.features.copy() if self._info.features else None
+        if original_features is not None:
+            # same checks as in _rename_columns_fn(), but early so that the features
+            # of the returned dataset are never inconsistent with the examples it yields
+            missing_columns = set(column_mapping) - set(original_features)
+            if missing_columns:
+                raise ValueError(
+                    f"Original column names {missing_columns} not in the dataset. "
+                    f"Current columns in the dataset: {list(original_features)}"
+                )
+            number_of_duplicates_in_new_columns = len(column_mapping.values()) - len(set(column_mapping.values()))
+            if number_of_duplicates_in_new_columns != 0:
+                raise ValueError(
+                    "New column names must all be different, but this column mapping "
+                    f"has {number_of_duplicates_in_new_columns} duplicates"
+                )
+            already_existing_columns = set(column_mapping.values()) & set(original_features)
+            if already_existing_columns:
+                raise ValueError(
+                    f"New column names {already_existing_columns} are already in the dataset. "
+                    f"Current columns in the dataset: {list(original_features)}"
+                )
         ds_iterable = self.map(
             partial(_rename_columns_fn, column_mapping=column_mapping), remove_columns=list(column_mapping)
         )

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2445,6 +2445,23 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns: IterableD
     assert all(c in new_dataset.column_names for c in ["new_id", "filename"])
 
 
+def test_iterable_dataset_rename_columns_invalid(dataset_with_several_columns: IterableDataset):
+    # when the features are known, renaming must fail right away instead of returning
+    # a dataset whose features don't match the examples it yields
+    dataset = dataset_with_several_columns._resolve_features()
+    with pytest.raises(ValueError, match="not in the dataset"):
+        dataset.rename_columns({"id": "new_id", "missing_column": "foo"})
+    with pytest.raises(ValueError, match="not in the dataset"):
+        dataset.rename_column("missing_column", "foo")
+    with pytest.raises(ValueError, match="must all be different"):
+        dataset.rename_columns({"id": "foo", "filepath": "foo"})
+    with pytest.raises(ValueError, match="already in the dataset"):
+        dataset.rename_column("id", "filepath")
+    # the features are still unknown here, so the error is only raised when iterating
+    with pytest.raises(ValueError):
+        list(dataset_with_several_columns.rename_column("missing_column", "foo"))
+
+
 def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.remove_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
`IterableDataset.rename_columns()` doesn't check the column names it is given, so when `info.features` is known it can return a dataset whose `features` contradict the examples it yields. The error is only raised much later, by `_rename_columns_fn()`, when the dataset is iterated.

```python
ds = Dataset.from_dict({"a": [0, 1, 2], "b": ["x", "y", "z"]}).to_iterable_dataset()

ds.rename_column("missing", "z").column_names
# ['a', 'b']       <- the rename silently didn't happen

ds.rename_column("a", "b").column_names
# ['b']            <- a column disappeared from the features
list(ds.rename_column("a", "b"))
# ValueError: Error when renaming ['a'] to ['b']: columns {'a'} are already in the dataset.
```

The second case is the worse one: the features are built with

```python
{column_mapping[col] if col in column_mapping else col: feature for col, feature in original_features.items()}
```

so when the new name collides with an existing column the dict comprehension collapses the two entries and `features` / `column_names` / `num_columns` are all wrong until you iterate.

`Dataset` raises immediately in all of these cases, and `IterableDataset.select_columns()` already does the same kind of eager check when `self._info.features` is set.

## Fix

Run the checks in `rename_columns()` when the features are known, before building the new features:

* original column names that are not in the dataset — same check and message as `Dataset.rename_columns()`
* duplicated new column names — same check and message as `Dataset.rename_columns()`
* new column names that are already in the dataset — this is the condition `_rename_columns_fn()` already rejects at iteration time, just raised early

Nothing changes when the features are unknown (streaming datasets whose features haven't been resolved): those still fail lazily exactly as before, which the new test also asserts.
