### PR TITLE
Fix to_pandas() on a dataset with no rows and an ArrayXD column

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -861,7 +861,14 @@ class PandasArrayExtensionDtype(PandasExtensionDtype):
 
     def __from_arrow__(self, array: Union[pa.Array, pa.ChunkedArray]):
         if isinstance(array, pa.ChunkedArray):
-            array = array.type.wrap_array(pa.concat_arrays([chunk.storage for chunk in array.chunks]))
+            # `pa.concat_arrays` requires at least one array, but pyarrow hands us a chunked array
+            # with no chunk at all when the column is empty
+            storage = (
+                pa.concat_arrays([chunk.storage for chunk in array.chunks])
+                if array.num_chunks > 0
+                else pa.array([], type=array.type.storage_type)
+            )
+            array = array.type.wrap_array(storage)
         zero_copy_only = _is_zero_copy_only(array.storage.type, unnest=True)
         numpy_arr = array.to_numpy(zero_copy_only=zero_copy_only)
         return PandasArrayExtensionArray(numpy_arr)

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -485,3 +485,20 @@ def test_dataset_map(with_none):
             assert example["image"].shape == (3, 3, 3)
             if with_none and i == 0:
                 assert np.all(np.isnan(example["image"]))
+
+
+@pytest.mark.parametrize("dtype", ["int32", "bool", "float64"])
+def test_to_pandas_with_empty_array_xd(dtype):
+    # an empty column reaches `PandasArrayExtensionDtype.__from_arrow__` as a chunked array
+    # with no chunk at all, which `pa.concat_arrays` rejects
+    features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": []}, features=features)
+
+    df = dataset.to_pandas()
+    assert len(df) == 0
+    assert isinstance(df.foo.dtype, PandasArrayExtensionDtype)
+    assert df.foo.dtype.value_type == np.dtype(dtype)
+
+    formatted_df = dataset.with_format("pandas")[:]
+    assert len(formatted_df) == 0
+    assert isinstance(formatted_df.foo.dtype, PandasArrayExtensionDtype)


### PR DESCRIPTION
Converting a dataset that has no rows and an `ArrayXD` column to pandas raises:

```python
import datasets
from datasets import Dataset, Features, Array2D

features = Features({"foo": Array2D(shape=(2, 2), dtype="float32")})
ds = Dataset.from_dict({"foo": []}, features=features)
ds.to_pandas()
```

```
pyarrow.lib.ArrowInvalid: Must pass at least one array
```

The same traceback comes out of `ds.with_format("pandas")[:]` and `ds.with_format("polars")[:]`. Only the `ArrayXD` features are affected — an empty dataset whose columns are all `Value`/`List`/`ClassLabel` converts fine — so this bites when an empty split, an empty shard, or a filter that matched nothing is handed to pandas.

### Cause

```python
def __from_arrow__(self, array: Union[pa.Array, pa.ChunkedArray]):
    if isinstance(array, pa.ChunkedArray):
        array = array.type.wrap_array(pa.concat_arrays([chunk.storage for chunk in array.chunks]))
```

`pa.concat_arrays` requires at least one array. For an empty column pyarrow passes a `ChunkedArray` with **zero** chunks, so the list comprehension yields `[]` and the call fails.

It is specifically the zero-chunk case: a chunked array holding one empty chunk works. `query_table` — which backs both `Dataset.to_pandas()` and the pandas/polars formatters — slices the table, and slicing an empty table drops the chunk entirely:

```python
>>> table.column("foo").num_chunks        # 1
>>> table.slice(0, 0).column("foo").num_chunks  # 0
```

### Fix

Build an empty storage array from the extension type's `storage_type` when there is no chunk to concatenate. The resulting `PandasArrayExtensionArray` is empty and keeps the right `array[<dtype>]` pandas dtype, matching the non-empty case.

### Tests

`tests/features/test_array_xd.py::test_to_pandas_with_empty_array_xd` covers `int32`, `bool` and `float64` through both `Dataset.to_pandas()` and the pandas formatter. All three parametrizations fail on `main` with the `ArrowInvalid` above.

`tests/features/`, `tests/test_formatting.py`, `tests/test_table.py` and `tests/test_arrow_dataset.py` all pass.
