### PR TITLE
Fix keep_in_memory=True in Dataset.sort and Dataset.train_test_split

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4824,7 +4824,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return self.select(
             indices=indices,
             keep_in_memory=keep_in_memory,
-            indices_cache_file_name=indices_cache_file_name,
+            indices_cache_file_name=indices_cache_file_name if not keep_in_memory else None,
             writer_batch_size=writer_batch_size,
             new_fingerprint=new_fingerprint,
         )
@@ -5230,14 +5230,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         train_split = self.select(
             indices=train_indices,
             keep_in_memory=keep_in_memory,
-            indices_cache_file_name=train_indices_cache_file_name,
+            indices_cache_file_name=train_indices_cache_file_name if not keep_in_memory else None,
             writer_batch_size=writer_batch_size,
             new_fingerprint=train_new_fingerprint,
         )
         test_split = self.select(
             indices=test_indices,
             keep_in_memory=keep_in_memory,
-            indices_cache_file_name=test_indices_cache_file_name,
+            indices_cache_file_name=test_indices_cache_file_name if not keep_in_memory else None,
             writer_batch_size=writer_batch_size,
             new_fingerprint=test_new_fingerprint,
         )

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3659,6 +3659,27 @@ def test_sort_with_none(null_placement):
         assert dataset["col_1"] == ["item_1", "item_2", "item_3", "item_4", None, None]
 
 
+@pytest.mark.parametrize("transform", ["sort", "shuffle", "train_test_split"])
+def test_keep_in_memory_on_dataset_with_cache_files(transform, tmp_path):
+    # `sort`, `shuffle` and `train_test_split` fall back to an automatically generated indices cache file name
+    # when the dataset has cache files: it must not be combined with `keep_in_memory=True`
+    dataset_path = str(tmp_path / "dataset")
+    Dataset.from_dict({"col_1": [3, 1, 2]}).save_to_disk(dataset_path)
+    dataset = Dataset.load_from_disk(dataset_path)
+    assert dataset.cache_files
+    if transform == "train_test_split":
+        output = dataset.train_test_split(test_size=1, keep_in_memory=True)
+        assert sorted(list(output["train"]["col_1"]) + list(output["test"]["col_1"])) == [1, 2, 3]
+    elif transform == "sort":
+        output = dataset.sort("col_1", keep_in_memory=True)
+        assert list(output["col_1"]) == [1, 2, 3]
+    else:
+        output = dataset.shuffle(seed=42, keep_in_memory=True)
+        assert sorted(output["col_1"]) == [1, 2, 3]
+    # no indices cache file was written next to the dataset
+    assert not list((tmp_path / "dataset").glob("cache-*.arrow"))
+
+
 def test_update_metadata_with_features(dataset_dict):
     table1 = pa.Table.from_pydict(dataset_dict)
     features1 = Features.from_arrow_schema(table1.schema)


### PR DESCRIPTION
`Dataset.sort()` and `Dataset.train_test_split()` raise as soon as `keep_in_memory=True` is used on a dataset that has cache files — i.e. on anything returned by `load_dataset()` or `load_from_disk()`:

```python
from datasets import Dataset

Dataset.from_dict({"col_1": [3, 1, 2]}).save_to_disk("ds")
ds = Dataset.load_from_disk("ds")

ds.sort("col_1", keep_in_memory=True)
# ValueError: Please use either `keep_in_memory` or `indices_cache_file_name` but not both.

ds.train_test_split(test_size=1, keep_in_memory=True)
# ValueError: Please use either `keep_in_memory` or `indices_cache_file_name` but not both.
```

Both methods fall back to an automatically generated indices cache file name when `self.cache_files` is non-empty:

```python
if self.cache_files:
    if indices_cache_file_name is None:
        indices_cache_file_name = self._get_cache_file_path(new_fingerprint)
```

and then forward it to `Dataset.select()` **together with** `keep_in_memory`, which `select()` explicitly rejects.

`Dataset.shuffle()` already guards against this by passing `indices_cache_file_name if not keep_in_memory else None`. This PR applies the same guard in `sort()` and in the two `select()` calls of `train_test_split()`, so `keep_in_memory=True` keeps the indices mapping in a buffer instead of erroring out.

Added `tests/test_arrow_dataset.py::test_keep_in_memory_on_dataset_with_cache_files`, parametrized over `sort` / `shuffle` / `train_test_split`. On `main` the `sort` and `train_test_split` cases fail with the `ValueError` above; the `shuffle` case already passed and is kept as a regression guard.
