### PR TITLE
Encode the column in Dataset.add_column when a feature is given

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6302,12 +6302,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         """
 
+        column_table = InMemoryTable.from_pydict({name: column})
         if feature:
-            pyarrow_schema = Features({name: feature}).arrow_schema
-        else:
-            pyarrow_schema = None
-
-        column_table = InMemoryTable.from_pydict({name: column}, schema=pyarrow_schema)
+            # cast instead of building the table with the target schema directly, so that features
+            # with a custom storage (e.g. ClassLabel) can encode the values like in `Dataset.from_dict`
+            column_table = table_cast(column_table, Features({name: feature}).arrow_schema)
         _check_column_names(self._data.column_names + column_table.column_names)
         dataset = self.flatten_indices() if self._indices is not None else self
         # Concatenate tables horizontally

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5136,6 +5136,14 @@ def test_add_column():
     assert ds[1] == {"a": 2, "b": 4}
 
 
+def test_add_column_with_feature_that_requires_encoding():
+    ds = Dataset.from_dict({"a": [1, 2]})
+    label = ClassLabel(names=["neg", "pos"])
+    ds = ds.add_column("b", ["neg", "pos"], feature=label)
+    assert ds.features["b"] == label
+    assert ds.with_format(None)["b"] == [0, 1]
+
+
 def test_process_large_few_examples(tmp_path):
     # GH 7911
     from datasets import Dataset


### PR DESCRIPTION
`Dataset.add_column()` takes a `feature` argument documented as the "column datatype", but it is passed directly as the arrow schema of `InMemoryTable.from_pydict()`. That only works when the raw Python values already match the feature's *storage* type, so any feature that encodes its values fails:

```python
from datasets import ClassLabel, Dataset

ds = Dataset.from_dict({"a": [1, 2]})
ds.add_column("label", ["neg", "pos"], feature=ClassLabel(names=["neg", "pos"]))
# pyarrow.lib.ArrowInvalid: Could not convert 'neg' with type str: tried to convert to int64
```

The two other ways of attaching the same feature to the same values both work:

```python
Dataset.from_dict({"label": ["neg", "pos"]}, features=Features({"label": ClassLabel(names=["neg", "pos"])}))
Dataset.from_dict({"label": ["neg", "pos"]}).cast_column("label", ClassLabel(names=["neg", "pos"]))
```

so `add_column` was the odd one out.

This PR builds the one-column table with inferred types and then `table_cast`s it to the requested feature, which is the same path `cast_column` uses. `ClassLabel` now encodes label names to ids, and `Image()`/`Audio()` now accept a list of file paths as well.

Notes:
- When no `feature` is passed, nothing changes.
- Values that arrow can cast but not build directly are now accepted (e.g. `feature=Value("string")` with ints yields `["1", "2"]`), which matches `cast_column`.

Added `tests/test_arrow_dataset.py::test_add_column_with_feature_that_requires_encoding`; it fails on `main` with the `ArrowInvalid` above.
