### PR TITLE
Return a new Dataset when transforming a dataset with no rows

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3367,17 +3367,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         # If the array is empty we do nothing (but we make sure to handle an empty indices mapping and remove the requested columns anyway)
         if len(self) == 0:
-            if self._indices is not None:  # empty indices mapping
-                self = Dataset(
-                    self.data.slice(0, 0),
-                    info=self.info.copy(),
-                    split=self.split,
-                    fingerprint=new_fingerprint,
-                )
-            if remove_columns:
-                return self.remove_columns(remove_columns)
-            else:
-                return self
+            dataset = Dataset(
+                self.data.slice(0, 0),  # also resolves an empty indices mapping
+                info=self.info.copy(),
+                split=self.split,
+                fingerprint=new_fingerprint,
+            )
+            return dataset.remove_columns(remove_columns) if remove_columns else dataset
 
         if function is None:
             function = lambda x: x  # noqa: E731
@@ -4242,8 +4238,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if function is None:
             function = lambda x: True  # noqa: E731
 
+        # If the array is empty we do nothing, but we still return a new dataset with the new fingerprint
         if len(self) == 0:
-            return self
+            return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 
         # We generally batch the underlying map() to get faster throughput,
         # but in case of async we force batch_size=1 to enable parallelism
@@ -4415,9 +4412,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
             )
 
-        # If the array is empty we do nothing
+        # If the array is empty we do nothing, but we still return a new dataset with the new fingerprint
         if len(self) == 0:
-            return self
+            return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 
         # If indices is a PyArrow array, we convert to NumPy
         if isinstance(indices, (pa.Array, pa.ChunkedArray)):
@@ -4487,9 +4484,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
             )
 
-        # If the array is empty we do nothing
+        # If the array is empty we do nothing, but we still return a new dataset with the new fingerprint
         if len(self) == 0:
-            return self
+            return Dataset(
+                self.data,
+                info=self.info.copy(),
+                split=self.split,
+                indices_table=self._indices,
+                fingerprint=new_fingerprint,
+            )
 
         _check_valid_indices_value(start, len(self))
         _check_valid_indices_value(start + length - 1, len(self))
@@ -4553,9 +4556,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 "Using `.select` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
             )
 
-        # If the array is empty we do nothing
+        # If the array is empty we do nothing, but we still return a new dataset with the new fingerprint
         if len(self) == 0:
-            return self
+            return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 
         # Prepare the writer for our indices arrow table
         if keep_in_memory or indices_cache_file_name is None:
@@ -4761,9 +4764,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise DatasetTransformationNotAllowedError(
                 "Using `.sort` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
             )
-        # If the array is empty we do nothing
+        # If the array is empty we do nothing, but we still return a new dataset with the new fingerprint
         if len(self) == 0:
-            return self
+            return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 
         # Check proper format of and for duplicates in column_names
         if isinstance(column_names, str):
@@ -4918,9 +4921,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise DatasetTransformationNotAllowedError(
                 "Using `.shuffle` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
             )
-        # If the array is empty we do nothing
+        # If the array is empty we do nothing, but we still return a new dataset with the new fingerprint
         if len(self) == 0:
-            return self
+            return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 
         if keep_in_memory and indices_cache_file_name is not None:
             raise ValueError("Please use either `keep_in_memory` or `indices_cache_file_name` but not both.")
@@ -5079,9 +5082,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             raise DatasetTransformationNotAllowedError(
                 "Using `.train_test_split` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it."
             )
-        # If the array is empty we do nothing
+        # If the array is empty we do nothing, but we still return new datasets with the new fingerprints
         if len(self) == 0:
-            return DatasetDict({"train": self, "test": self})
+            return DatasetDict(
+                {
+                    "train": self._select_contiguous(0, 0, new_fingerprint=train_new_fingerprint),
+                    "test": self._select_contiguous(0, 0, new_fingerprint=test_new_fingerprint),
+                }
+            )
 
         if test_size is None and train_size is None:
             test_size = 0.25

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4616,6 +4616,42 @@ class StratifiedTest(TestCase):
             assert len(d1["test"]["text"]) == test_size
 
 
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda ds: ds.map(lambda x: x),
+        lambda ds: ds.filter(lambda x: True),
+        lambda ds: ds.select([]),
+        lambda ds: ds.sort("col_1"),
+        lambda ds: ds.shuffle(seed=42),
+        lambda ds: ds.shard(2, 0),
+        lambda ds: ds.take(2),
+        lambda ds: ds.skip(1),
+    ],
+)
+def test_transform_on_dataset_with_no_rows_returns_a_new_dataset(transform):
+    dataset = Dataset.from_dict({"col_1": []}, features=Features({"col_1": Value("int64")}))
+    output = transform(dataset)
+    assert output is not dataset
+    assert len(output) == 0
+    assert output.features == dataset.features
+    # in-place methods on the output must not affect the input dataset
+    output.set_format("numpy")
+    assert dataset.format["type"] is None
+
+
+def test_train_test_split_on_dataset_with_no_rows_returns_new_datasets():
+    dataset = Dataset.from_dict({"col_1": []}, features=Features({"col_1": Value("int64")}))
+    output = dataset.train_test_split(test_size=0.5)
+    assert output["train"] is not dataset
+    assert output["test"] is not dataset
+    assert output["train"] is not output["test"]
+    assert output["train"]._fingerprint != output["test"]._fingerprint
+    output["train"].set_format("numpy")
+    assert dataset.format["type"] is None
+    assert output["test"].format["type"] is None
+
+
 def test_dataset_estimate_nbytes():
     ds = Dataset.from_dict({"a": ["0" * 100] * 100})
     assert 0.9 * ds._estimate_nbytes() < 100 * 100, "must be smaller than full dataset size"


### PR DESCRIPTION
`Dataset.map`, `.filter`, `.select`, `.sort`, `.shuffle` and `.train_test_split` short-circuit when the dataset has no rows and return `self` — the very same object. `train_test_split` even returns that same object as *both* splits.

Because `set_format` / `set_transform` / `reset_format` / `add_faiss_index` mutate a dataset in place, mutating the "new" dataset silently mutates the input one:

```python
from datasets import Dataset

empty = Dataset.from_dict({"a": []})
out = empty.filter(lambda x: True)
out.set_format("numpy")
print(empty.format["type"])   # numpy  <- the input dataset was mutated

d = empty.train_test_split(test_size=0.5)
print(d["train"] is d["test"] is empty)   # True
```

The short-circuits also drop the fingerprint computed by `@fingerprint_transform`, so the result keeps the input's fingerprint (and both `train_test_split` splits share it).

This is not hypothetical for empty datasets: a `filter()` that matches nothing, an empty split, or a shard smaller than `num_shards` all produce zero-row datasets that are then processed further.

### Fix

Each short-circuit now returns a **new** `Dataset` carrying the new fingerprint, sharing the same (immutable) Arrow tables so nothing is copied. `Dataset.map` already did exactly this when the dataset had an empty indices mapping — the two branches are now consistent. `sort`/`shuffle`/`select`/`filter` and both `train_test_split` splits delegate to `_select_contiguous(0, 0, new_fingerprint=...)`, which keeps the data and indices tables untouched.

`shard`, `take`, `skip` and `flatten_indices` go through `select`, so they are covered too.

### Tests

`test_transform_on_dataset_with_no_rows_returns_a_new_dataset` (parametrized over `map`, `filter`, `select`, `sort`, `shuffle`, `shard`, `take`, `skip`) and `test_train_test_split_on_dataset_with_no_rows_returns_new_datasets`. All 9 cases fail on `main`.
