### PR TITLE
Fix casting a chunked array that has no chunk

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1858,7 +1858,10 @@ def _wrap_for_chunked_arrays(func):
 
     def wrapper(array, *args, **kwargs):
         if isinstance(array, pa.ChunkedArray):
-            return pa.chunked_array([func(chunk, *args, **kwargs) for chunk in array.chunks])
+            # `pa.chunked_array([])` can't infer the resulting type, so an array with no chunk at all
+            # (e.g. an empty slice of a table) is replaced by a single empty chunk of the right type
+            chunks = array.chunks or [array.combine_chunks()]
+            return pa.chunked_array([func(chunk, *args, **kwargs) for chunk in chunks])
         else:
             return func(array, *args, **kwargs)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1414,6 +1414,44 @@ def test_embed_table_storage(image_file):
 
 
 @pytest.mark.parametrize(
+    "pa_type, feature",
+    [
+        (pa.int64(), Value("float64")),
+        (pa.list_(pa.int64()), List(Value("int64"))),
+        (pa.struct([("a", pa.int64())]), {"a": Value("int64")}),
+        (pa.list_(pa.list_(pa.float32())), Array2D(shape=(2, 2), dtype="float32")),
+    ],
+)
+def test_cast_chunked_array_with_no_chunk(pa_type, feature):
+    # slicing an empty table gives a chunked array with no chunk at all,
+    # which `pa.chunked_array([])` cannot rebuild without an explicit type
+    array = pa.chunked_array([], type=pa_type)
+    assert array.num_chunks == 0
+
+    casted_array = cast_array_to_feature(array, feature)
+    assert len(casted_array) == 0
+    assert casted_array.type == get_nested_type(feature)
+
+    casted_array = array_cast(array, pa_type)
+    assert len(casted_array) == 0
+    assert casted_array.type == pa_type
+
+    embedded_array = embed_array_storage(array, feature)
+    assert len(embedded_array) == 0
+
+
+def test_table_cast_with_table_with_no_chunk():
+    features = Features({"foo": Value("int64")})
+    new_features = Features({"foo": Value("float64")})
+    table = pa.Table.from_batches([], schema=features.arrow_schema)
+    assert table.column("foo").num_chunks == 0
+
+    casted_table = table_cast(table, new_features.arrow_schema)
+    assert casted_table.num_rows == 0
+    assert Features.from_arrow_schema(casted_table.schema) == new_features
+
+
+@pytest.mark.parametrize(
     "table",
     [
         InMemoryTable(pa.table({"foo": range(10)})),


### PR DESCRIPTION
A batched `map` on an arrow-formatted dataset crashes when the function filters out every row of a batch and the output features are given explicitly:

```python
import pyarrow.compute as pc
from datasets import Dataset, Features, Value

ds = Dataset.from_dict({"a": [1, 2, 3, 4]}).with_format("arrow")
ds.map(
    lambda t: t.filter(pc.greater(t["a"], 10)),
    batched=True,
    batch_size=2,
    features=Features({"a": Value("float64")}),
)
```

```
  File "src/datasets/arrow_writer.py", line 773, in _write_table
  File "src/datasets/table.py", line 2378, in table_cast
  File "src/datasets/table.py", line 2312, in cast_table_to_schema
  File "src/datasets/table.py", line 1861, in wrapper
pyarrow.lib.ArrowInvalid: cannot construct ChunkedArray from empty vector and omitted type
```

### Cause

`array_cast`, `cast_array_to_feature` and `embed_array_storage` are all wrapped by `_wrap_for_chunked_arrays`:

```python
def wrapper(array, *args, **kwargs):
    if isinstance(array, pa.ChunkedArray):
        return pa.chunked_array([func(chunk, *args, **kwargs) for chunk in array.chunks])
```

A `ChunkedArray` may legitimately hold **zero** chunks, and then the list comprehension yields `[]`. `pa.chunked_array([])` has no chunk to infer the type from, so it raises.

Zero-chunk arrays are not exotic — they are what pyarrow and this library produce for empty data:

```python
>>> pa.Table.from_batches([], schema=schema).column("a").num_chunks
0
>>> Dataset.from_dict({"a": []}).with_format("arrow")[:].column("a").num_chunks
0
```

`IndexedTableMixin.fast_slice` returns `pa.Table.from_batches([], schema=self._schema)` for an empty slice, which is how the table reaches `table_cast` in the traceback above.

Note the type is not lost — it is on the `ChunkedArray` itself, only the list of chunks is empty.

### Fix

When there is no chunk to convert, use a single empty chunk of the right type, obtained from `array.combine_chunks()`. The result is an empty chunked array with the correct target type, which is what the non-empty path produces.

### Tests

- `tests/test_table.py::test_cast_chunked_array_with_no_chunk` covers `array_cast`, `cast_array_to_feature` and `embed_array_storage` over a primitive, a list, a struct and an `Array2D` extension type.
- `tests/test_table.py::test_table_cast_with_table_with_no_chunk` covers `table_cast` on a `pa.Table.from_batches([], schema=...)`.

All 5 parametrizations fail on `main` with the `ArrowInvalid` above.

`tests/test_table.py`, `tests/test_arrow_dataset.py`, `tests/test_arrow_writer.py`, `tests/test_formatting.py`, `tests/test_iterable_dataset.py` and `tests/features/` pass.
