### PR TITLE
Validate the arguments of IterableDataset.shard

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4001,6 +4001,14 @@ class IterableDataset(DatasetInfoMixin):
         })
         ```
         """
+        if not 0 <= index < num_shards:
+            raise ValueError("index should be in [0, num_shards-1]")
+        if num_shards > self.num_shards:
+            raise ValueError(
+                f"Unable to shard a dataset of {self.num_shards} shards into {num_shards} shards "
+                f"(the number of shards exceeds dataset.num_shards={self.num_shards}). "
+                "You can use IterableDataset.reshard() to increase the number of shards of the dataset."
+            )
         ex_iterable = self._ex_iterable.shard_data_sources(num_shards=num_shards, index=index, contiguous=contiguous)
         return IterableDataset(
             ex_iterable=ex_iterable,

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2343,6 +2343,20 @@ def test_iterable_dataset_shard():
     ) == list(dataset)
 
 
+def test_iterable_dataset_shard_invalid_args():
+    dataset = Dataset.from_dict({"a": range(20)}).to_iterable_dataset(num_shards=4)
+    # index out of [0, num_shards-1], like in Dataset.shard
+    with pytest.raises(ValueError, match=r"index should be in \[0, num_shards-1\]"):
+        dataset.shard(num_shards=2, index=2)
+    with pytest.raises(ValueError, match=r"index should be in \[0, num_shards-1\]"):
+        dataset.shard(num_shards=2, index=-1)
+    with pytest.raises(ValueError, match=r"index should be in \[0, num_shards-1\]"):
+        dataset.shard(num_shards=0, index=0)
+    # more shards requested than the dataset has
+    with pytest.raises(ValueError, match="exceeds dataset.num_shards"):
+        dataset.shard(num_shards=dataset.num_shards + 1, index=0)
+
+
 @pytest.mark.parametrize("method", ["skip", "take"])
 @pytest.mark.parametrize("after_shuffle", [False, True])
 @pytest.mark.parametrize("count", [2, 5, 11])


### PR DESCRIPTION
`IterableDataset.shard()` doesn't validate its arguments, so invalid calls either return the wrong data silently or crash with a low-level error from an internal helper. `Dataset.shard()` already validates the index.

```python
ds = Dataset.from_dict({"a": range(20)}).to_iterable_dataset(num_shards=4)

ds.shard(num_shards=2, index=-1)     # returns 3 of the 4 shards instead of raising
list(ds.shard(num_shards=2, index=2))
# IndexError: list index out of range      (in _merge_gen_kwargs)
ds.shard(num_shards=0, index=0)
# ZeroDivisionError: integer division or modulo by zero
list(ds.shard(num_shards=8, index=7))
# IndexError: list index out of range
```

The negative-index case is the worst one: `split_shard_indices_by_worker()` computes `range(start, end)` from `index`, and a negative index just shifts the window, so a wrong (and silently truncated) subset of shards comes back with no error at all.

The last case is also asymmetric — with `num_shards` larger than `dataset.num_shards`, the low indices return data and the high ones raise `IndexError`, so a loop like `[ds.shard(n, i) for i in range(n)]` crashes part-way through. The docstring already states:

> Note: n should be less or equal to the number of shards in the dataset `dataset.num_shards`.

## Fix

Validate in `IterableDataset.shard()`:

* `0 <= index < num_shards`, with the same check and message as `Dataset.shard()` (this also covers `num_shards=0`)
* `num_shards <= self.num_shards`, pointing at `IterableDataset.reshard()` which is the documented way to get more shards

This only touches the public `shard()` method. `_iter_pytorch()` calls `ex_iterable.shard_data_sources()` directly and already guards with `if shards_indices:`, so dataloaders with more workers than shards keep working exactly as before (the existing `test_iterable_dataset_with_too_many_dataloader_workers` and the `test_interleave_dataset_with_sharding` tests still pass).
