### PR TITLE
Keep the column order in Features.flatten()

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -2388,17 +2388,19 @@ class Features(dict):
         """
         for depth in range(1, max_depth):
             no_change = True
-            flattened = self.copy()
+            # build a new dict rather than updating a copy, so that the subfields of a column
+            # take the place of that column instead of being appended at the end
+            flattened = {}
             for column_name, subfeature in self.items():
                 if isinstance(subfeature, dict):
                     no_change = False
                     flattened.update({f"{column_name}.{k}": v for k, v in subfeature.items()})
-                    del flattened[column_name]
                 elif hasattr(subfeature, "flatten") and subfeature.flatten() != subfeature:
                     no_change = False
                     flattened.update({f"{column_name}.{k}": v for k, v in subfeature.flatten().items()})
-                    del flattened[column_name]
-            self = flattened
+                else:
+                    flattened[column_name] = subfeature
+            self = Features(flattened)
             if no_change:
                 break
         return self

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -270,6 +270,31 @@ class FeaturesTest(TestCase):
         assert flattened_features == {"foo.bar": List({"my_value": Value("int32")})}
         assert features == _features, "calling flatten shouldn't alter the current features"
 
+    def test_flatten_keeps_column_order(self):
+        features = Features(
+            {
+                "foo": Value("int32"),
+                "bar": {"sub1": Value("int32"), "sub2": {"subsub": Value("string")}},
+                "baz": Value("int32"),
+            }
+        )
+        flattened_features = features.flatten()
+        # the subfields take the place of the column they come from
+        assert list(flattened_features) == ["foo", "bar.sub1", "bar.sub2.subsub", "baz"]
+
+    def test_flatten_matches_dataset_flatten(self):
+        features = Features(
+            {
+                "foo": Value("int32"),
+                "bar": {"sub1": Value("int32"), "sub2": Value("string")},
+                "baz": Value("int32"),
+            }
+        )
+        dset = Dataset.from_dict({"foo": [1], "bar": [{"sub1": 2, "sub2": "a"}], "baz": [3]}, features=features)
+        flattened_dset = dset.flatten()
+        assert flattened_dset.column_names == list(features.flatten())
+        assert flattened_dset.features == features.flatten()
+
     def test_features_dicts_are_synced(self):
         def assert_features_dicts_are_synced(features: Features):
             assert (


### PR DESCRIPTION
`Features.flatten()` and `Dataset.flatten()` disagree on the resulting column order:

```python
from datasets import Dataset, Features, Value

features = Features({"a": Value("int64"), "s": {"x": Value("string")}, "l": Value("int64")})
ds = Dataset.from_dict({"a": [1], "s": [{"x": "q"}], "l": [2]}, features=features)

print(ds.flatten().column_names)     # ['a', 's.x', 'l']
print(list(features.flatten()))      # ['a', 'l', 's.x']   <-- 's.x' moved to the end
```

`Dataset.flatten()` expands a struct column in place, `Features.flatten()` appends its subfields at the end. The two arrow schemas are therefore not equal, and casting a flattened dataset to `features.flatten()` silently reorders its columns:

```python
ds.flatten()._data.schema.equals(features.flatten().arrow_schema, check_metadata=False)  # False
ds.flatten().cast(features.flatten()).column_names                                       # ['a', 'l', 's.x']
```

### Cause

```python
flattened = self.copy()
for column_name, subfeature in self.items():
    if isinstance(subfeature, dict):
        flattened.update({f"{column_name}.{k}": v for k, v in subfeature.items()})
        del flattened[column_name]
```

`dict.update` appends the new keys at the end, and `del` then removes the original key with its position, so every expanded column ends up after all the columns that were not expanded.

### The docstring already documents the correct behaviour

The example in `Features.flatten`'s own docstring shows the subfields in place:

```
>>> ds = load_dataset("rajpurkar/squad", split="train")
>>> ds.features.flatten()
{'answers.answer_start': List(Value('int32'), id=None),
 'answers.text': List(Value('string'), id=None),
 'context': Value('string'),
 'id': Value('string'),
 'question': Value('string'),
 'title': Value('string')}
```

but the current code returns `context`, `id`, `question`, `title`, `answers.answer_start`, `answers.text` for those features. With this change the output matches the documented example again.

### Fix

Build the flattened dict in iteration order instead of mutating a copy, so the subfields take the place of the column they come from.

### Tests

- `test_flatten_keeps_column_order` asserts the subfields land in place, including for a nested struct.
- `test_flatten_matches_dataset_flatten` asserts `Dataset.flatten()` and `Features.flatten()` agree.

Both fail on `main`. The existing `test_flatten`, `test_flatten_with_sequence` and `test_features_flatten_with_list_types` are unchanged and still pass — they compare with `==`, which ignores order.

`tests/features/`, `tests/test_table.py`, `tests/test_arrow_dataset.py`, `tests/test_formatting.py`, `tests/test_iterable_dataset.py`, `tests/test_arrow_writer.py` and `tests/test_dataset_dict.py` pass.
