### PR TITLE
Reject a non-positive batch_size in Dataset.iter

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2787,6 +2787,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             drop_last_batch (:obj:`bool`, default `False`): Whether a last batch smaller than the batch_size should be
                 dropped
         """
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be a positive integer, but got {batch_size}.")
         if self._indices is None:
             # Fast iteration
             # Benchmark: https://gist.github.com/mariosasko/0248288a2e3a7556873969717c1fe52b (fast_iter_batch)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3862,6 +3862,17 @@ def test_dataset_iter_batch(batch_size, drop_last_batch):
         assert len(batches[-1]["i"]) <= batch_size
 
 
+@pytest.mark.parametrize("batch_size", [0, -1])
+@pytest.mark.parametrize("with_indices_mapping", [False, True])
+def test_dataset_iter_non_positive_batch_size(batch_size, with_indices_mapping):
+    dset = Dataset.from_dict({"i": list(range(5))})
+    if with_indices_mapping:
+        dset = dset.select([4, 0, 1, 2, 3])
+        assert dset._indices is not None
+    with pytest.raises(ValueError):
+        next(dset.iter(batch_size))
+
+
 @pytest.mark.parametrize(
     "column, expected_dtype",
     [(["a", "b", "c", "d"], "string"), ([1, 2, 3, 4], "int64"), ([1.0, 2.0, 3.0, 4.0], "float64")],


### PR DESCRIPTION
`Dataset.iter(0)` never returns on a dataset without an indices mapping:

```python
from datasets import Dataset

ds = Dataset.from_dict({"i": list(range(5))})
next(ds.iter(0))   # hangs forever
```

The fast path calls `table_iter(self.data, batch_size=0)`, which asks pyarrow for chunks of `max_chunksize=0`; every chunk comes back empty and is skipped by `if len(chunk) == 0: continue`, so the loop spins forever without yielding anything.

The three other combinations of an invalid `batch_size` each fail differently:

| | `batch_size=0` | `batch_size=-1` |
|---|---|---|
| no indices mapping | hangs forever | `SystemError: <built-in function len> returned NULL without setting an exception` |
| with indices mapping | `ValueError: range() arg 3 must not be zero` | silently yields nothing |

So the same invalid argument produces four different outcomes, and the two most likely ones (a hang and a `SystemError`) give the user nothing to go on.

This PR validates `batch_size` at the top of `Dataset.iter` and raises a plain `ValueError` in all four cases. Valid batch sizes are unaffected.

Added `tests/test_arrow_dataset.py::test_dataset_iter_non_positive_batch_size`, parametrized over `batch_size` in `{0, -1}` and with/without an indices mapping. On `main`, the `[False-0]` case hangs (so the suite never finishes) and `[False--1]` / `[True--1]` fail.
