### PR TITLE
Fix Dataset.flatten with max_depth <= 1

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2347,6 +2347,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         """
         dataset = copy.deepcopy(self)
+        depth = 0  # `max_depth` can be small enough for the loop below to not run at all
         for depth in range(1, max_depth):
             if any(isinstance(field.type, pa.StructType) for field in dataset._data.schema):
                 dataset._data = dataset._data.flatten()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3978,6 +3978,14 @@ def test_dataset_add_item_introduce_feature_type():
     assert dataset[:] == {"col_1": [None, None, None, "a"]}
 
 
+@pytest.mark.parametrize("max_depth, expected_column_names", [(1, ["a"]), (2, ["a.b"]), (3, ["a.b.c"])])
+def test_flatten_max_depth(max_depth, expected_column_names):
+    dataset = Dataset.from_dict({"a": [{"b": {"c": 1}}]})
+    flattened_dataset = dataset.flatten(max_depth=max_depth)
+    assert flattened_dataset.column_names == expected_column_names
+    assert list(flattened_dataset.features) == expected_column_names
+
+
 def test_dataset_filter_batched_indices():
     ds = Dataset.from_dict({"num": [0, 1, 2, 3]})
     ds = ds.filter(lambda num: num % 2 == 0, input_columns="num", batch_size=2)


### PR DESCRIPTION
`Dataset.flatten()` accepts a `max_depth` argument (also exposed through `DatasetDict.flatten()`), but any value `<= 1` crashes:

```python
from datasets import Dataset

Dataset.from_dict({"a": [{"b": {"c": 1}}]}).flatten(max_depth=1)
# UnboundLocalError: cannot access local variable 'depth' where it is not associated with a value
```

`depth` is only bound by the loop header:

```python
for depth in range(1, max_depth):
    ...
logger.info(f"Flattened dataset from depth {depth} to depth {1 if depth + 1 < max_depth else 'unknown'}.")
```

so when `range(1, max_depth)` is empty the loop variable never exists and the log line at the end of the method raises.

Initializing `depth` before the loop fixes it. `max_depth=1` then means "don't flatten anything", which matches what `Features.flatten(max_depth=1)` already returns, so the features and the columns stay consistent.

Added `tests/test_arrow_dataset.py::test_flatten_max_depth`, parametrized over `max_depth` in `{1, 2, 3}`; the `max_depth=1` case fails on `main` with the `UnboundLocalError` above.
