### PR TITLE
Fix the archive member path check against a sibling output directory

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -105,7 +105,10 @@ class TarExtractor(BaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            resolved_path = resolved(os.path.join(base, path))
+            # compare against base + os.sep, otherwise a sibling directory whose name
+            # starts with base (e.g. "../<base name>_evil") would pass the check
+            return resolved_path != base and not resolved_path.startswith(base + os.sep)
 
         def badlink(info: tarfile.TarInfo, base: str) -> bool:
             # Links are interpreted relative to the directory containing the link
@@ -205,7 +208,10 @@ class ZipExtractor(MagicNumberBaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            resolved_path = resolved(os.path.join(base, path))
+            # compare against base + os.sep, otherwise a sibling directory whose name
+            # starts with base (e.g. "../<base name>_evil") would pass the check
+            return resolved_path != base and not resolved_path.startswith(base + os.sep)
 
         base = resolved(output_path)
 
@@ -258,7 +264,10 @@ class RarExtractor(MagicNumberBaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            resolved_path = resolved(os.path.join(base, path))
+            # compare against base + os.sep, otherwise a sibling directory whose name
+            # starts with base (e.g. "../<base name>_evil") would pass the check
+            return resolved_path != base and not resolved_path.startswith(base + os.sep)
 
         def badlink(info: "rarfile.RarInfo", base: str) -> bool:
             # Links are interpreted relative to the directory containing the link
@@ -334,7 +343,10 @@ class SevenZipExtractor(MagicNumberBaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            resolved_path = resolved(os.path.join(base, path))
+            # compare against base + os.sep, otherwise a sibling directory whose name
+            # starts with base (e.g. "../<base name>_evil") would pass the check
+            return resolved_path != base and not resolved_path.startswith(base + os.sep)
 
         def badlink(info: "py7zr.FileInfo", base: str) -> bool:
             # Links are interpreted relative to the directory containing the link

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -153,6 +153,20 @@ def tar_file_with_dot_dot(tmp_path, text_file):
 
 
 @pytest.fixture
+def tar_file_with_sibling_dir(tmp_path, text_file):
+    # a member that escapes the output directory into a sibling directory whose name
+    # starts with the name of the output directory
+    import tarfile
+
+    directory = tmp_path / "data_sibling_dir"
+    directory.mkdir()
+    path = directory / "tar_file_with_sibling_dir.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(text_file, arcname=os.path.join("..", "extracted_evil", text_file.name))
+    return path
+
+
+@pytest.fixture
 def tar_file_with_sym_link(tmp_path):
     import tarfile
 
@@ -183,6 +197,31 @@ def test_tar_extract_insecure_files(
     for record in caplog.records:
         assert record.levelname == "ERROR"
         assert error_log in record.msg
+
+
+def test_tar_extract_outside_of_output_path(tar_file_with_sibling_dir, tmp_path, caplog):
+    # "extracted_evil" starts with "extracted", so it used to pass the `startswith(base)` check
+    output_path = tmp_path / "extracted"
+    TarExtractor.extract(tar_file_with_sibling_dir, output_path)
+    assert not (tmp_path / "extracted_evil").exists()
+    assert caplog.text
+    for record in caplog.records:
+        assert record.levelname == "ERROR"
+        assert "illegal path" in record.msg
+
+
+def test_tar_extract_keeps_members_inside_output_path(tmp_path, text_file):
+    import tarfile
+
+    path = tmp_path / "tar_file_with_dot_entry.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(str(tmp_path), arcname=".", recursive=False)  # the "./" directory entry
+        f.add(text_file, arcname=text_file.name)
+        f.add(text_file, arcname=os.path.join("subdir", text_file.name))
+    output_path = tmp_path / "extracted"
+    TarExtractor.extract(path, output_path)
+    assert (output_path / text_file.name).is_file()
+    assert (output_path / "subdir" / text_file.name).is_file()
 
 
 def test_is_zipfile_false_positive(tmpdir):


### PR DESCRIPTION
The `safemembers()` guards that implement the CVE-2007-4559 mitigation compare the resolved member path to the output directory with a plain `str.startswith()`:

```python
def badpath(path: str, base: str) -> bool:
    # joinpath will ignore base if path is absolute
    return not resolved(os.path.join(base, path)).startswith(base)
```

Without a trailing separator this also accepts any *sibling* directory whose path happens to start with `base` as a string. Archives are extracted into `<cache>/downloads/extracted/<hash>`, so a member named `../<hash>_evil/payload.txt` resolves to `<cache>/downloads/extracted/<hash>_evil/payload.txt`, which starts with `base` and is therefore not blocked — the file is written outside the output directory.

```python
with tarfile.open("evil.tar", "w") as tf:
    ti = tarfile.TarInfo("../abc123_evil/payload.txt"); ti.size = len(data)
    tf.addfile(ti, io.BytesIO(data))

TarExtractor.extract("evil.tar", ".../extracted/abc123")
os.path.exists(".../extracted/abc123_evil/payload.txt")   # True on main
```

A member that escapes to a clearly different directory (`../other/payload.txt`) is correctly blocked, so it is only this prefix case that slips through.

## Fix

Compare against `base + os.sep`, and keep accepting a member that resolves to the output directory itself so the `./` directory entry that tar archives normally contain is still extracted:

```python
resolved_path = resolved(os.path.join(base, path))
return resolved_path != base and not resolved_path.startswith(base + os.sep)
```

The helper is duplicated in `TarExtractor`, `ZipExtractor`, `RarExtractor` and `SevenZipExtractor`, so all four copies are updated. `badlink()` calls the same helper and benefits too.

In practice `zipfile.extractall` sanitizes member names itself, so only the tar path is exercised end to end today — but the check is wrong in all four, and fixing it is what keeps the mitigation meaningful if the underlying library stops sanitizing.

## Tests

* `test_tar_extract_outside_of_output_path` — extracts an archive whose member points at `../extracted_evil/...` into `.../extracted` and asserts the sibling directory is not created and the member is logged as an illegal path. Fails on `main`.
* `test_tar_extract_keeps_members_inside_output_path` — a regression test for the `resolved_path != base` part: an archive containing a `./` entry, a top-level file and a file in a subdirectory still extracts everything.
