### PR TITLE
Fix numpy formatting of a list column whose first row is null

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -194,8 +194,11 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
             # a scalar nan among the ndarrays. A flat homogeneous numeric column whose
             # nulls surface as scalar nan must stay numeric, so guard the whole check on
             # the presence of an ndarray element first.
-            if any(isinstance(x, np.ndarray) for x in array) and any(
-                (isinstance(x, np.ndarray) and (x.dtype == object or x.shape != array[0].shape))
+            # the reference shape comes from the first row that is an array: the first row itself
+            # may be a null, which surfaces as None or as a scalar nan and has no shape
+            first_ndarray = next((x for x in array if isinstance(x, np.ndarray)), None)
+            if first_ndarray is not None and any(
+                (isinstance(x, np.ndarray) and (x.dtype == object or x.shape != first_ndarray.shape))
                 or (isinstance(x, float) and np.isnan(x))
                 for x in array
             ):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -973,6 +973,29 @@ def arrow_table():
     return pa.Table.from_pydict({"col_int": [0, 1, 2], "col_float": [0.0, 1.0, 2.0]})
 
 
+@pytest.mark.parametrize(
+    "col",
+    [
+        [None, [3, 4]],  # the null row comes first
+        [[1, 2], None],
+        [[1, 2], None, [5, 6]],
+        [None, [3], [4, 5]],  # ragged, with the null row first
+    ],
+)
+def test_numpy_formatter_list_column_with_none(col):
+    # a null row has no shape, so it must not be used as the reference to compare the other rows to
+    pa_table = pa.table({"col": pa.array(col, type=pa.list_(pa.int64()))})
+    formatter = NumpyFormatter()
+
+    column = formatter.format_column(pa_table)
+    assert column.dtype == object
+    assert [None if row is None else row.tolist() for row in column] == col
+
+    batch = formatter.format_batch(pa_table)
+    assert batch["col"].dtype == object
+    assert [None if row is None else row.tolist() for row in batch["col"]] == col
+
+
 @require_tf
 @pytest.mark.parametrize(
     "cast_schema",


### PR DESCRIPTION
Formatting a list column to numpy or torch crashes when the **first** row is null:

```python
from datasets import Dataset, Features, List, Value

ds = Dataset.from_dict({"c": [None, [3, 4]]}, features=Features({"c": List(Value("int64"))}))
ds.with_format("numpy")[:]["c"]
```

```
AttributeError: 'NoneType' object has no attribute 'shape'
```

The exact same column works when the null sits anywhere else:

```python
Dataset.from_dict({"c": [[1, 2], None]}, ...).with_format("numpy")[:]["c"]
# array([array([1, 2]), None], dtype=object)     <- fine
```

So whether a dataset can be formatted at all depends on the position of a null row. `pandas` and `polars` formatting handle it fine, which makes this specific to the numpy-based tensor formatters (numpy, torch, tf, jax).

### Cause

`NumpyArrowExtractor._arrow_array_to_numpy` decides whether to promote the column to `dtype=object` by comparing every row's shape against the **first** row:

```python
if any(isinstance(x, np.ndarray) for x in array) and any(
    (isinstance(x, np.ndarray) and (x.dtype == object or x.shape != array[0].shape))
    ...
```

A null row surfaces as `None` (or as a scalar `nan`), and neither has a `.shape`, so `array[0].shape` raises as soon as the check reaches a row that is an array.

The loop directly below already does this correctly — it walks the column to find the first element that *is* an `ndarray` and uses that as the reference. This change makes the check above use the same reference.

### Fix

Take the reference shape from the first row that actually is an array. When no row is an array the check is skipped entirely, which is what already happened for flat columns.

The promote-to-object decision is otherwise unchanged: when `array[0]` is an `ndarray` the reference is identical to before, so only the previously-crashing case behaves differently — and it now produces the same object array the null-in-any-other-position case already produced.

### Tests

`tests/test_formatting.py::test_numpy_formatter_list_column_with_none` covers the null in first, last and middle position, plus a ragged column with the null first, through both `format_column` and `format_batch`. The two null-first parametrizations fail on `main` with the `AttributeError` above.

`tests/test_formatting.py`, `tests/features/`, `tests/test_table.py`, `tests/test_arrow_dataset.py` and `tests/test_iterable_dataset.py`: 1471 passed with this change vs 1467 on `main` (+4 = the new parametrizations), with an identical set of 35 pre-existing collection errors from missing optional dependencies.
