### PR TITLE
Validate num_shards in Dataset.save_to_disk

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1834,8 +1834,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         if max_shard_size is not None and num_shards is not None:
             raise ValueError(
-                "Failed to push_to_hub: please specify either max_shard_size or num_shards, but not both."
+                "Failed to save_to_disk: please specify either max_shard_size or num_shards, but not both."
             )
+        if num_shards is not None and num_shards <= 0:
+            raise ValueError(f"Failed to save_to_disk: num_shards must be a positive integer, but got {num_shards}.")
         if self.list_indexes():
             raise ValueError("please remove all the indexes using `dataset.drop_index` before saving a dataset")
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5085,6 +5085,20 @@ def test_dataset_save_to_disk_and_load_from_disk_round_trip_with_large_list(tmp_
     assert loaded_ds.to_dict() == ds.to_dict()
 
 
+@pytest.mark.parametrize("num_shards", [0, -1])
+def test_dataset_save_to_disk_with_non_positive_num_shards(num_shards, tmp_path):
+    ds = Dataset.from_dict({"col_1": [1, 2, 3]})
+    dataset_path = tmp_path / "dataset_dir"
+    with pytest.raises(ValueError):
+        ds.save_to_disk(dataset_path, num_shards=num_shards)
+
+
+def test_dataset_save_to_disk_with_num_shards_and_max_shard_size(tmp_path):
+    ds = Dataset.from_dict({"col_1": [1, 2, 3]})
+    with pytest.raises(ValueError, match="save_to_disk"):
+        ds.save_to_disk(tmp_path / "dataset_dir", num_shards=2, max_shard_size="1GB")
+
+
 @require_polars
 def test_from_polars_with_large_list():
     import polars as pl


### PR DESCRIPTION
`Dataset.save_to_disk()` accepts `num_shards`, but never checks that it is positive. With `num_shards=0` (or a negative value) it reports success while writing **no data file at all**:

```python
from datasets import Dataset, load_from_disk

ds = Dataset.from_dict({"col_1": [1, 2, 3]})
ds.save_to_disk("dir", num_shards=0)          # no error

import os; print(sorted(os.listdir("dir")))
# ['dataset_info.json', 'state.json']          <- no data-*.arrow

load_from_disk("dir")
# IndexError: list index out of range
```

The shard loop is `for shard_idx in range(num_shards)`, so it simply never runs, `state.json` records an empty `_data_files` list, and the rows are gone. `DatasetDict.save_to_disk(num_shards={"train": 0})` forwards the value per split and behaves the same way.

This PR raises a `ValueError` for a non-positive `num_shards`, next to the existing `max_shard_size`/`num_shards` check.

It also fixes that neighbouring error message: raising from `save_to_disk` it currently says

```
Failed to push_to_hub: please specify either max_shard_size or num_shards, but not both.
```

`push_to_hub` has its own copy of the check, so this occurrence just names the wrong method.

### Tests

`test_dataset_save_to_disk_with_non_positive_num_shards` (parametrized over `0` and `-1`) and `test_dataset_save_to_disk_with_num_shards_and_max_shard_size`. All three fail on `main`.
