### PR TITLE
Fix exporting an IterableDataset that has no examples

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -152,6 +152,18 @@ def _batch_to_examples(batch: dict[str, list]) -> Iterator[dict[str, Any]]:
         yield {col: array[i] for col, array in batch.items()}
 
 
+def _concat_tables(tables: list[pa.Table], features: Optional[Features]) -> pa.Table:
+    """Concatenate the tables of an IterableDataset.
+
+    Unlike `pa.concat_tables`, it supports an empty list of tables, which happens when the
+    dataset doesn't yield any example. In that case an empty table is returned, using the
+    features of the dataset as the schema when they are known.
+    """
+    if tables:
+        return pa.concat_tables(tables)
+    return pa.Table.from_pylist([], schema=features.arrow_schema if features is not None else None)
+
+
 def _convert_to_arrow(
     iterable: Iterable[tuple[Key, dict]],
     batch_size: int,
@@ -4504,7 +4516,7 @@ class IterableDataset(DatasetInfoMixin):
             for table in self.with_format("arrow").iter(batch_size=batch_size):
                 yield Dataset(table, fingerprint="unset").to_dict()
         else:
-            table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
+            table = _concat_tables(list(self.with_format("arrow").iter(batch_size=1000)), self.features)
             return Dataset(table, fingerprint="unset").to_dict()
 
     def to_list(self) -> list:
@@ -4519,7 +4531,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> ds.to_list()
         ```
         """
-        table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
+        table = _concat_tables(list(self.with_format("arrow").iter(batch_size=1000)), self.features)
         return Dataset(table, fingerprint="unset").to_list()
 
     def to_pandas(
@@ -4557,8 +4569,9 @@ class IterableDataset(DatasetInfoMixin):
                 for table in self.with_format("arrow").iter(batch_size=batch_size)
             )
         else:
-            table = pa.concat_tables(
-                [maybe_cast_to_declared_features(table) for table in self.with_format("arrow").iter(batch_size=1000)]
+            table = _concat_tables(
+                [maybe_cast_to_declared_features(table) for table in self.with_format("arrow").iter(batch_size=1000)],
+                self.features,
             )
             return Dataset(table, info=info, fingerprint="unset").to_pandas()
 
@@ -4596,7 +4609,7 @@ class IterableDataset(DatasetInfoMixin):
             for table in self.with_format("arrow").iter(batch_size=batch_size):
                 yield Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)
         else:
-            table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
+            table = _concat_tables(list(self.with_format("arrow").iter(batch_size=1000)), self.features)
             return Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)
 
     def to_csv(
@@ -4634,7 +4647,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> ds.to_csv("path/to/dataset/directory")
         ```
         """
-        table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
+        table = _concat_tables(list(self.with_format("arrow").iter(batch_size=1000)), self.features)
         return Dataset(table, fingerprint="unset").to_csv(
             path_or_buf,
             batch_size=batch_size,
@@ -4688,7 +4701,7 @@ class IterableDataset(DatasetInfoMixin):
         ```
 
         """
-        table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
+        table = _concat_tables(list(self.with_format("arrow").iter(batch_size=1000)), self.features)
         return Dataset(table, fingerprint="unset").to_json(
             path_or_buf,
             batch_size=batch_size,
@@ -4735,7 +4748,7 @@ class IterableDataset(DatasetInfoMixin):
         ...     ds.to_sql("data", con)
         ```
         """
-        table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
+        table = _concat_tables(list(self.with_format("arrow").iter(batch_size=1000)), self.features)
         return Dataset(table, fingerprint="unset").to_sql(name, con, batch_size=batch_size, **sql_writer_kwargs)
 
     def to_parquet(
@@ -4781,7 +4794,7 @@ class IterableDataset(DatasetInfoMixin):
         from .arrow_writer import get_arrow_writer_batch_size_from_features
 
         batch_size = get_arrow_writer_batch_size_from_features(self.features) or config.DEFAULT_MAX_BATCH_SIZE
-        table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=batch_size)))
+        table = _concat_tables(list(self.with_format("arrow").iter(batch_size=batch_size)), self.features)
         return Dataset(table, fingerprint="unset").to_parquet(
             path_or_buf, storage_options=storage_options, **parquet_writer_kwargs
         )

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
+import pyarrow.parquet as pq
 import pytest
 from huggingface_hub import HfFileSystemResolvedPath
 from packaging import version
@@ -1794,6 +1795,23 @@ def test_iterable_dataset_to_pandas_casts_when_schema_mismatch():
     assert list(df.columns) == ["col"]
     assert df["col"].iloc[0] == 0
     assert len(batches) == 2
+
+
+def test_iterable_dataset_export_when_empty(tmp_path):
+    # a dataset that doesn't yield any example must export like an empty Dataset,
+    # instead of failing with "pyarrow.lib.ArrowInvalid: Must pass at least one table"
+    features = Features({"col": Value("int64")})
+    dataset = Dataset.from_dict({"col": [0, 1]}, features=features).to_iterable_dataset()
+    empty_dataset = dataset.filter(lambda example: False)
+
+    assert empty_dataset.to_list() == []
+    assert list(empty_dataset.to_pandas().columns) == ["col"]
+    assert len(empty_dataset.to_pandas()) == 0
+    assert empty_dataset.to_csv(tmp_path / "data.csv") == 0
+    assert empty_dataset.to_json(tmp_path / "data.json") == 0
+    assert empty_dataset.to_parquet(tmp_path / "data.parquet") == 0
+    assert pq.read_table(tmp_path / "data.parquet").num_rows == 0
+    assert pq.read_table(tmp_path / "data.parquet").schema.names == ["col"]
 
 
 @require_numpy1_on_windows


### PR DESCRIPTION
Every conversion/export method of `IterableDataset` materializes the dataset with `pa.concat_tables()` over its Arrow batches:

```python
table = pa.concat_tables(list(self.with_format("arrow").iter(batch_size=1000)))
return Dataset(table, fingerprint="unset").to_list()
```

If the dataset doesn't yield any example the list is empty and pyarrow raises, while the equivalent `Dataset` methods return an empty result:

```python
ds = Dataset.from_dict({"col": [0, 1]}).to_iterable_dataset().filter(lambda example: False)

ds.to_list()
# pyarrow.lib.ArrowInvalid: Must pass at least one table
ds.to_pandas()
# pyarrow.lib.ArrowInvalid: Must pass at least one table
ds.to_parquet("data.parquet")
# pyarrow.lib.ArrowInvalid: Must pass at least one table
```

It affects `to_dict`, `to_list`, `to_pandas`, `to_polars`, `to_csv`, `to_json` and `to_parquet`. A `filter()` that discards everything is the easiest way to hit it, but so is streaming a split that turns out to be empty, or exporting the tail shard of a `split_dataset_by_node()` that received no data.

## Fix

Add a small `_concat_tables()` helper that returns an empty table when there is nothing to concatenate, using the dataset's features as the schema when they are known (and a schema-less empty table otherwise), and use it at the seven call sites.

The results now match the map-style `Dataset` exactly for an empty dataset:

| | `Dataset` | `IterableDataset` (after) |
|---|---|---|
| `to_list()` | `[]` | `[]` |
| `to_pandas()` columns | `['col']` | `['col']` |
| `to_csv` / `to_json` / `to_parquet` bytes | `0` | `0` |

and the written Parquet file keeps the right schema with 0 rows.

## Test

`test_iterable_dataset_export_when_empty` exercises `to_list`, `to_pandas`, `to_csv`, `to_json` and `to_parquet` on an emptied iterable dataset and checks the Parquet schema is preserved. It fails on `main` with `ArrowInvalid: Must pass at least one table`.

Note: this only changes the non-batched branches. #8382 fixes the separate problem that `to_dict()` / `to_polars()` return an empty generator because of a bare `yield` in their `batched=True` branch — the two changes are complementary and don't overlap.
