### PR TITLE
Validate num_shards in Dataset.to_iterable_dataset

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5853,6 +5853,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         from .iterable_dataset import ArrowExamplesIterable, IterableDataset
 
+        if num_shards <= 0:
+            raise ValueError(f"num_shards must be a positive integer, but got {num_shards}.")
+
         if self._format_type is not None:
             if self._format_kwargs or (
                 self._format_columns is not None and set(self._format_columns) != set(self.column_names)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3694,6 +3694,13 @@ def test_concatenate_datasets(dataset_type, axis, expected_shape, dataset_dict, 
     assert_arrow_metadata_are_synced_with_dataset_features(dataset)
 
 
+@pytest.mark.parametrize("num_shards", [0, -1])
+def test_dataset_to_iterable_dataset_with_non_positive_num_shards(num_shards):
+    dataset = Dataset.from_dict({"col_1": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        dataset.to_iterable_dataset(num_shards=num_shards)
+
+
 def test_concatenate_datasets_new_columns():
     dataset1 = Dataset.from_dict({"col_1": ["a", "b", "c"]})
     dataset2 = Dataset.from_dict({"col_1": ["d", "e", "f"], "col_2": [True, False, True]})


### PR DESCRIPTION
`Dataset.to_iterable_dataset(num_shards=0)` (or any negative value) returns an `IterableDataset` that silently yields **nothing**:

```python
from datasets import Dataset

ds = Dataset.from_dict({"col_1": [1, 2, 3]})
list(ds.to_iterable_dataset(num_shards=0))    # []  -- no error
list(ds.to_iterable_dataset(num_shards=-1))   # []
```

The shard list is built with

```python
[self.shard(num_shards=num_shards, index=shard_idx, contiguous=True) for shard_idx in range(num_shards)]
```

and `range(0)` is empty, so the resulting `ArrowExamplesIterable` has no shards and the data is dropped without a word. Silently returning an empty dataset is the worst outcome here — it typically surfaces much later as a training loop that does nothing.

The method already rejects the other invalid end of the range:

```python
if num_shards > len(self):
    raise ValueError(f"Unable to shard a dataset of size {len(self)} into {num_shards} shards ...")
```

This PR adds the matching check for non-positive values.

Added `tests/test_arrow_dataset.py::test_dataset_to_iterable_dataset_with_non_positive_num_shards`, parametrized over `0` and `-1`; both fail on `main`.
