### PR TITLE
Validate seed and generator in Dataset.train_test_split

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5156,6 +5156,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         load_from_cache_file = load_from_cache_file if load_from_cache_file is not None else is_caching_enabled()
 
+        if seed is not None and generator is not None:
+            raise ValueError("Both `seed` and `generator` were provided. Please specify just one of them.")
+
+        if generator is not None and not isinstance(generator, np.random.Generator):
+            raise ValueError("The provided generator must be an instance of numpy.random.Generator")
+
         if generator is None and shuffle is True:
             if seed is None:
                 _, seed, pos, *_ = np.random.get_state()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3780,6 +3780,18 @@ def test_concatenate_datasets_duplicate_columns(dataset):
     assert "duplicated" in str(excinfo.value)
 
 
+def test_train_test_split_with_seed_and_generator():
+    dataset = Dataset.from_dict({"col_1": list(range(10))})
+    with pytest.raises(ValueError):
+        dataset.train_test_split(test_size=2, seed=42, generator=np.random.default_rng(42))
+
+
+def test_train_test_split_with_invalid_generator():
+    dataset = Dataset.from_dict({"col_1": list(range(10))})
+    with pytest.raises(ValueError):
+        dataset.train_test_split(test_size=2, generator=np.random.RandomState(42))
+
+
 def test_interleave_datasets():
     d1 = Dataset.from_dict({"a": [0, 1, 2]})
     d2 = Dataset.from_dict({"a": [10, 11, 12, 13]})


### PR DESCRIPTION
`Dataset.shuffle()` validates its two randomness parameters:

```python
if seed is not None and generator is not None:
    raise ValueError("Both `seed` and `generator` were provided. Please specify just one of them.")

if generator is not None and not isinstance(generator, np.random.Generator):
    raise ValueError("The provided generator must be an instance of numpy.random.Generator")
```

`Dataset.train_test_split()` accepts the exact same `seed` and `generator` parameters and checks neither:

```python
if generator is None and shuffle is True:
    if seed is None:
        ...
    generator = np.random.default_rng(seed)
```

So today:

```python
ds.train_test_split(test_size=2, seed=42, generator=np.random.default_rng(0))
# no error -- `seed` is silently ignored and the split is NOT reproducible from it

ds.train_test_split(test_size=2, generator=np.random.RandomState(42))
# no error -- a legacy RandomState is accepted
```

Passing a `seed` and getting a split that does not depend on it is the kind of thing that only shows up when someone tries to reproduce a run. The `RandomState` case is worse for `stratify_by_column`, which forwards the object to `stratified_shuffle_split_generate_indices(rng=...)` where the new `Generator` API is expected.

This PR applies the same two checks `shuffle()` already uses.

Added `test_train_test_split_with_seed_and_generator` and `test_train_test_split_with_invalid_generator`; both fail on `main`.
