### PR TITLE
Raise when a batched filter function returns the wrong number of values

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -7300,6 +7300,16 @@ def _split_by_node_map_style_dataset(dataset: Dataset, rank: int, world_size: in
 # This is outside Dataset.filter as it needs to be picklable for multiprocessing
 
 
+def _check_mask_length(mask, indices: list[int]):
+    """Check that a `filter` function returned one value per example of the batch."""
+    if hasattr(mask, "__len__") and len(mask) != len(indices):
+        raise ValueError(
+            f"Provided `function` which is applied to all elements of table returns {len(mask)} values "
+            f"for a batch of {len(indices)} examples. When using `batched=True`, make sure provided `function` "
+            f"returns one value per example of the batch."
+        )
+
+
 def get_indices_from_mask_function(
     function: Callable,
     batched: bool,
@@ -7321,6 +7331,7 @@ def get_indices_from_mask_function(
         mask = function(*inputs, *additional_args, **fn_kwargs)
         if isinstance(mask, (pa.Array, pa.ChunkedArray)):
             mask = mask.to_pylist()
+        _check_mask_length(mask, indices)
     else:
         # we get batched data (to return less data than input) but `function` only accepts one example
         # therefore we need to call `function` on each example of the batch to get the mask
@@ -7380,6 +7391,7 @@ async def async_get_indices_from_mask_function(
         mask = await function(*inputs, *additional_args, **fn_kwargs)
         if isinstance(mask, (pa.Array, pa.ChunkedArray)):
             mask = mask.to_pylist()
+        _check_mask_length(mask, indices)
     else:
         # we get batched data (to return less data than input) but `function` only accepts one example
         # therefore we need to call `function` on each example of the batch to get the mask

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4550,6 +4550,13 @@ def test_build_local_temp_path(uri_or_path):
     ), f"Local temp path: {local_temp_path}"
 
 
+@pytest.mark.parametrize("mask_length", [1, 5])
+def test_dataset_filter_batched_with_wrong_mask_length(mask_length):
+    dataset = Dataset.from_dict({"col_1": list(range(3))})
+    with pytest.raises(ValueError):
+        dataset.filter(lambda batch: [True] * mask_length, batched=True)
+
+
 class StratifiedTest(TestCase):
     def test_errors_train_test_split_stratify(self):
         ys = [


### PR DESCRIPTION
`Dataset.filter(..., batched=True)` builds the kept indices with a `zip`:

```python
indices_array = [i for i, to_keep in zip(indices, mask) if to_keep]
```

`zip` stops at the shorter of its arguments, so a `function` that does not return exactly one value per example is not an error — it silently changes the result:

```python
from datasets import Dataset

ds = Dataset.from_dict({"col_1": [0, 1, 2]})

len(ds.filter(lambda batch: [True], batched=True))       # 1  -- 2 rows silently dropped
len(ds.filter(lambda batch: [True] * 5, batched=True))   # 3  -- extra values silently ignored
```

The first case is silent data loss: the mask is off by one (a common bug when the function filters its own output, or returns a mask for a differently-sized intermediate), and `filter` happily returns a truncated dataset.

This PR checks the mask length against the batch size and raises a `ValueError` naming both numbers, in `get_indices_from_mask_function` and its async twin. The check is skipped for masks that have no `__len__` (e.g. a generator), so those keep working exactly as before, and it costs nothing for the normal `list`/`np.ndarray`/`pd.Series` cases. The non-batched path builds the mask itself, one entry per example, so it is unaffected.

Added `tests/test_arrow_dataset.py::test_dataset_filter_batched_with_wrong_mask_length`, parametrized over a too-short and a too-long mask; both fail on `main`.
