### PR TITLE
Validate rank and world_size in split_dataset_by_node for IterableDataset

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -5389,6 +5389,8 @@ def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_s
     Returns:
         [`IterableDataset`]: The iterable dataset to be used on the node at rank `rank`.
     """
+    if not 0 <= rank < world_size:
+        raise ValueError("rank should be in [0, world_size-1]")
     if dataset._distributed:
         rank = world_size * dataset._distributed.rank + rank
         world_size = world_size * dataset._distributed.world_size

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -137,3 +137,12 @@ def test_torch_distributed_run_streaming_with_num_workers(nproc_per_node, num_wo
     """.split()
     cmd = [sys.executable] + distributed_args + args
     execute_subprocess_async(cmd, env=os.environ.copy())
+
+
+@pytest.mark.parametrize("rank, world_size", [(0, 0), (-1, 2), (2, 2), (5, 2)])
+def test_split_dataset_by_node_iterable_invalid_rank(rank, world_size):
+    # invalid ranks used to be accepted: rank=-1 silently returned the whole dataset,
+    # while the map-style version raises for all of them
+    full_ds = Dataset.from_dict({"i": range(17)}).to_iterable_dataset(num_shards=2)
+    with pytest.raises(ValueError, match=r"rank should be in \[0, world_size-1\]"):
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size)


### PR DESCRIPTION
`split_dataset_by_node()` behaves differently on the two dataset types for invalid `rank` / `world_size`. The map-style version delegates to `Dataset.shard()`, which rejects them:

```python
def _split_by_node_map_style_dataset(dataset, rank, world_size):
    return dataset.shard(num_shards=world_size, index=rank, contiguous=True)
```

The iterable version just stores them in a `DistributedConfig` without checking:

```python
ds = Dataset.from_dict({"x": range(10)}).to_iterable_dataset(num_shards=2)

len(list(split_dataset_by_node(ds, rank=-1, world_size=2)))   # 10 — the whole dataset
list(split_dataset_by_node(ds, rank=0, world_size=0))         # ZeroDivisionError: integer modulo by zero
list(split_dataset_by_node(ds, rank=5, world_size=2))         # IndexError: list index out of range
```

The `rank=-1` case is the one worth fixing: nothing raises, and the node gets **every** example instead of its shard. In a distributed run that silently duplicates the whole dataset on that node rather than failing. The same calls on a map-style dataset all raise `ValueError` immediately.

## Fix

Check `0 <= rank < world_size` in `_split_by_node_iterable_dataset()`, before the `dataset._distributed` nesting combines the values, so nested calls are validated on the arguments the caller actually passed.

Only the iterable path is touched — the map-style path keeps raising from `Dataset.shard()` exactly as before.

## Test

`test_split_dataset_by_node_iterable_invalid_rank`, parametrized over `(0, 0)`, `(-1, 2)`, `(2, 2)` and `(5, 2)`. All four fail on `main`.
