### PR TITLE
Don't include writer_batch_size in the fingerprint

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3439,7 +3439,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             # we create a unique hash from the function,
             # current dataset file and the mapping args
             transform = format_transform_for_fingerprint(Dataset._map_single)
-            kwargs_for_fingerprint = format_kwargs_for_fingerprint(Dataset._map_single, (), dataset_kwargs)
+            kwargs_for_fingerprint = format_kwargs_for_fingerprint(
+                Dataset._map_single, (), dataset_kwargs, ignore_kwargs=["writer_batch_size"]
+            )
             kwargs_for_fingerprint["fingerprint_name"] = "new_fingerprint"
             new_fingerprint = update_fingerprint(self._fingerprint, transform, kwargs_for_fingerprint)
         else:
@@ -4138,7 +4140,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @transmit_format
     @fingerprint_transform(
-        inplace=False, ignore_kwargs=["load_from_cache_file", "cache_file_name", "desc"], version="2.0.1"
+        inplace=False,
+        ignore_kwargs=["load_from_cache_file", "cache_file_name", "desc", "writer_batch_size"],
+        version="2.0.1",
     )
     def filter(
         self,
@@ -4285,7 +4289,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return new_dataset
 
     @transmit_format
-    @fingerprint_transform(inplace=False, ignore_kwargs=["cache_file_name"])
+    @fingerprint_transform(inplace=False, ignore_kwargs=["cache_file_name", "writer_batch_size", "num_proc"])
     def flatten_indices(
         self,
         keep_in_memory: bool = False,
@@ -4364,7 +4368,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         )
 
     @transmit_format
-    @fingerprint_transform(inplace=False, ignore_kwargs=["indices_cache_file_name"])
+    @fingerprint_transform(inplace=False, ignore_kwargs=["indices_cache_file_name", "writer_batch_size"])
     def select(
         self,
         indices: Iterable,
@@ -4510,7 +4514,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             )
 
     @transmit_format
-    @fingerprint_transform(inplace=False, ignore_kwargs=["indices_cache_file_name"])
+    @fingerprint_transform(inplace=False, ignore_kwargs=["indices_cache_file_name", "writer_batch_size"])
     def _select_with_indices_mapping(
         self,
         indices: Iterable,
@@ -4702,7 +4706,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return self.select(range(n))
 
     @transmit_format
-    @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"])
+    @fingerprint_transform(
+        inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name", "writer_batch_size"]
+    )
     def sort(
         self,
         column_names: Union[str, Sequence_[str]],
@@ -4831,7 +4837,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @transmit_format
     @fingerprint_transform(
-        inplace=False, randomized_function=True, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"]
+        inplace=False,
+        randomized_function=True,
+        ignore_kwargs=["load_from_cache_file", "indices_cache_file_name", "writer_batch_size"],
     )
     def shuffle(
         self,
@@ -4966,7 +4974,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         inplace=False,
         randomized_function=True,
         fingerprint_names=["train_new_fingerprint", "test_new_fingerprint"],
-        ignore_kwargs=["load_from_cache_file", "train_indices_cache_file_name", "test_indices_cache_file_name"],
+        ignore_kwargs=[
+            "load_from_cache_file",
+            "train_indices_cache_file_name",
+            "test_indices_cache_file_name",
+            "writer_batch_size",
+        ],
     )
     def train_test_split(
         self,

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -557,6 +557,36 @@ def test_temp_cache_dir_tmpdir_not_directory(tmp_path, monkeypatch):
     assert "is not a directory" in msg
 
 
+def _add_one(example):
+    return {"col_1": example["col_1"] + 1}
+
+
+def _keep_all(example):
+    return True
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda ds, **kwargs: ds.map(_add_one, **kwargs),
+        lambda ds, **kwargs: ds.filter(_keep_all, **kwargs),
+        lambda ds, **kwargs: ds.select([2, 0, 1], **kwargs),
+        lambda ds, **kwargs: ds.sort("col_1", **kwargs),
+        lambda ds, **kwargs: ds.shuffle(seed=42, **kwargs),
+        lambda ds, **kwargs: ds.flatten_indices(**kwargs),
+        lambda ds, **kwargs: ds.train_test_split(test_size=1, seed=42, **kwargs)["train"],
+    ],
+)
+def test_fingerprint_ignores_writer_batch_size(transform):
+    dataset = datasets.Dataset.from_dict({"col_1": [0, 1, 2]})
+    assert transform(dataset)._fingerprint == transform(dataset, writer_batch_size=2)._fingerprint
+
+
+def test_fingerprint_of_flatten_indices_ignores_num_proc():
+    dataset = datasets.Dataset.from_dict({"col_1": [0, 1, 2]}).select([2, 0, 1])
+    assert dataset.flatten_indices()._fingerprint == dataset.flatten_indices(num_proc=1)._fingerprint
+
+
 def test_fingerprint_when_transform_version_changes():
     data = {"a": [0, 1, 2]}
 


### PR DESCRIPTION
`writer_batch_size` is documented as

> Number of rows per write operation for the cache file writer. This value is a good trade-off between memory usage during the processing, and processing speed.

It cannot change the data of the resulting dataset — only how it is written. Yet it is part of the fingerprint of `map`, `filter`, `select`, `sort`, `shuffle`, `flatten_indices` and `train_test_split`, so tuning it invalidates the cache:

```python
from datasets import Dataset

ds = Dataset.from_dict({"col_1": [0, 1, 2]})
def add_one(example):
    return {"col_1": example["col_1"] + 1}

ds.map(add_one)._fingerprint == ds.map(add_one, writer_batch_size=2)._fingerprint
# False  -> same data, different fingerprint, full recompute
```

Someone lowering `writer_batch_size` to fit a memory budget silently loses every cached result downstream of that call, since the fingerprint propagates.

`Dataset.flatten_indices` has the same problem with `num_proc`, which `Dataset.map` already leaves out of its fingerprint (and `map`'s cache lookup explicitly reconciles cache files written with a *different* `num_proc`, so a `num_proc`-dependent fingerprint works against that machinery).

This PR adds `writer_batch_size` to the relevant `ignore_kwargs` lists (and to `map`'s manual `format_kwargs_for_fingerprint` call), plus `num_proc` for `flatten_indices`.

### Existing caches are not invalidated

`format_kwargs_for_fingerprint` already drops any kwarg equal to its default before hashing, and `writer_batch_size=1000` / `num_proc=None` are the defaults. I checked the fingerprints produced by default calls before and after the change:

```
                main              this PR
map        bb48b650a9acd965   bb48b650a9acd965
filter     1000cff870758b8a   1000cff870758b8a
select     a695df89866b7f6c   a695df89866b7f6c
sort       ff2261f719c73f36   ff2261f719c73f36
shuffle    875b7e2a4f1e9930   875b7e2a4f1e9930
flatten    72fd0474c0602758   72fd0474c0602758
tts        d032f37d5733e7a7   d032f37d5733e7a7
```

Only calls that passed a non-default value change, and those were the broken ones.

### Tests

`tests/test_fingerprint.py::test_fingerprint_ignores_writer_batch_size` (parametrized over the seven transforms) and `test_fingerprint_of_flatten_indices_ignores_num_proc`. All 8 cases fail on `main`.
