### PR TITLE
Don't crash when formatting temporal and decimal columns to torch

### DIFF
--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Lint as: python3
+import datetime
+import decimal
 import sys
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
@@ -53,6 +55,14 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
             return value
         elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value.tolist()
+        elif isinstance(value, (np.datetime64, np.timedelta64)) or (
+            isinstance(value, np.ndarray) and value.dtype.kind in "mM"
+        ):
+            # torch has no dtype for dates, timestamps and durations
+            return value.tolist()
+        elif isinstance(value, (datetime.date, datetime.time, datetime.timedelta, decimal.Decimal)):
+            # time32/time64 and decimal columns are extracted as objects, which torch cannot hold either
+            return value
 
         default_dtype = {}
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 from pathlib import Path
 from unittest import TestCase
 
@@ -677,6 +678,39 @@ class FormatterTest(TestCase):
         batch = formatter.format_batch(pa_table)
         assert batch["a"].devices().pop() == device
         assert batch["c"].devices().pop() == device
+
+
+@require_numpy1_on_windows
+@require_torch
+@pytest.mark.parametrize(
+    "pa_type, value",
+    [
+        (pa.timestamp("s"), datetime.datetime(2023, 1, 1)),
+        (pa.date32(), datetime.date(2023, 1, 1)),
+        (pa.duration("s"), datetime.timedelta(seconds=5)),
+        (pa.time64("us"), datetime.time(1, 2, 3)),
+        (pa.decimal128(5, 2), decimal.Decimal("1.50")),
+    ],
+)
+def test_torch_formatter_keeps_values_torch_cannot_hold(pa_type, value):
+    from datasets.formatting import TorchFormatter
+
+    # torch has no dtype for temporal and decimal values, so they must be returned
+    # as they are, the way string columns already are, instead of raising
+    pa_table = pa.table({"col": pa.array([value] * 2, type=pa_type)})
+    formatter = TorchFormatter()
+
+    assert formatter.format_row(pa_table)["col"] == value
+    assert list(formatter.format_column(pa_table)) == [value] * 2
+    assert list(formatter.format_batch(pa_table)["col"]) == [value] * 2
+
+    # the same holds when the value is nested in a list or in a struct
+    pa_table = pa.table({"col": pa.array([[value] * 2] * 2, type=pa.list_(pa_type))})
+    assert list(formatter.format_row(pa_table)["col"]) == [value] * 2
+    assert [list(row) for row in formatter.format_batch(pa_table)["col"]] == [[value] * 2] * 2
+
+    pa_table = pa.table({"col": pa.array([{"f": value}] * 2, type=pa.struct([("f", pa_type)]))})
+    assert formatter.format_row(pa_table)["col"] == {"f": value}
 
 
 class QueryTest(TestCase):


### PR DESCRIPTION
A dataset with a temporal or decimal column cannot be used with the torch format at all:

```python
import datetime
from datasets import Dataset

ds = Dataset.from_dict({"t": [datetime.datetime(2020, 1, 1)]})
ds.with_format("torch")[0]["t"]
```

```
TypeError: can't convert np.ndarray of type numpy.datetime64.
The only supported types are: float64, float32, ...
```

Every temporal and decimal `Value` type is affected, for rows, columns and batches alike:

| feature | error on `with_format("torch")` |
|---|---|
| `timestamp[s]`, `timestamp[ns]` | `TypeError: can't convert np.ndarray of type numpy.datetime64` |
| `date32`, `date64` | `TypeError: can't convert np.ndarray of type numpy.datetime64` |
| `duration[s]`, `duration[ns]` | `TypeError: can't convert np.ndarray of type numpy.timedelta64` |
| `time32[s]`, `time64[us]` | `RuntimeError: Could not infer dtype of datetime.time` |
| `decimal128(p, s)` | `RuntimeError: Could not infer dtype of decimal.Decimal` |

The `numpy`, `pandas`, `polars` and `python` formatters all handle these columns fine — only `torch` raises, so a single date column forces the user to drop it before training.

### Cause

torch has no dtype for any of these, and `TorchFormatter._tensorize` ends up calling `torch.tensor(...)` on them.

The formatter already anticipates values torch cannot hold — it returns `str`, `bytes` and `None` unchanged, and converts numpy character arrays with `.tolist()`. `test_torch_formatter` relies on exactly that (`assert batch["b"] == _COL_B` for the string column). Temporal and decimal values were simply never added to that list.

### Fix

Return them the same way instead of raising:

- numpy `datetime64`/`timedelta64` scalars and arrays go through `.tolist()`, matching the character-array branch directly above, which yields `datetime.datetime` / `datetime.date` / `datetime.timedelta`;
- `datetime.date`, `datetime.time`, `datetime.timedelta` and `decimal.Decimal` are returned as they are — `time32`/`time64`/`decimal` columns reach the formatter as object arrays of these.

Nothing else changes: integer, float, bool and string columns still produce exactly the same tensors and values as before.

One note for reviewers: `.tolist()` on `datetime64[ns]`/`timedelta64[ns]` returns an `int` rather than a `datetime`, because nanosecond precision does not fit in `datetime.datetime`. That is numpy's own behaviour and is lossless, but if you would rather have the numpy array passed straight through for every precision, that is a one-line change and I am happy to switch.

### Tests

`tests/test_formatting.py::test_torch_formatter_keeps_values_torch_cannot_hold` covers `timestamp`, `date32`, `duration`, `time64` and `decimal128` through `format_row`, `format_column` and `format_batch`. All 5 parametrizations fail on `main` with the errors above.

`tests/test_formatting.py`, `tests/features/`, `tests/test_table.py`, `tests/test_arrow_dataset.py` and `tests/test_iterable_dataset.py`: 1521 passed, 0 failures.
