### PR TITLE
Reject a non-positive buffer_size in IterableDataset.shuffle

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3803,6 +3803,8 @@ class IterableDataset(DatasetInfoMixin):
          'label': 1}]
         ```
         """
+        if buffer_size <= 0:
+            raise ValueError(f"buffer_size must be a positive integer, but got {buffer_size}.")
         if generator is None:
             generator = np.random.default_rng(seed)
         else:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2212,6 +2212,15 @@ def test_iterable_dataset_shuffle(dataset: IterableDataset, seed, epoch):
     assert next(iter(dataset)) == list(islice(expected_ex_iterable, expected_first_example_index + 1))[-1][1]
 
 
+@pytest.mark.parametrize("buffer_size", [0, -1])
+def test_iterable_dataset_shuffle_non_positive_buffer_size(buffer_size):
+    # a negative buffer size used to disable the "buffer is full" check entirely,
+    # which silently loads the whole dataset in memory
+    dataset = Dataset.from_dict({"a": range(10)}).to_iterable_dataset()
+    with pytest.raises(ValueError, match="buffer_size must be a positive integer"):
+        dataset.shuffle(seed=42, buffer_size=buffer_size)
+
+
 @pytest.mark.parametrize(
     "features",
     [


### PR DESCRIPTION
`IterableDataset.shuffle()` doesn't check `buffer_size`, and the two bad values fail in very different ways.

## A negative buffer_size buffers the whole dataset

`BufferShuffledExamplesIterable.__iter__` fills the buffer with an equality test:

```python
for x in self.ex_iterable:
    if len(mem_buffer) == buffer_size:   # buffer full -> yield one and replace it
        ...
    else:                                # otherwise keep filling
        mem_buffer.append(x)
```

`len(mem_buffer)` is never negative, so with `buffer_size=-1` the condition is never true and the `else` branch appends every single example. The buffer grows without bound and the entire dataset is materialized in memory — the opposite of what a streaming shuffle is for — with no error and no warning:

```python
ds = Dataset.from_dict({"x": range(20)}).to_iterable_dataset()

[e["x"] for e in ds.shuffle(seed=42, buffer_size=-1)]
# identical to buffer_size=1000, i.e. a full in-memory shuffle
```

On a real streaming dataset that is an OOM instead of a bounded buffer.

## buffer_size=0 fails late with a numpy error

```python
list(ds.shuffle(seed=42, buffer_size=0))
# ValueError: high <= 0
```

from `rng.integers(0, buffer_size)`, raised only once iteration starts, with nothing pointing at `buffer_size`.

## Fix

Raise `ValueError` for `buffer_size <= 0` in `shuffle()`, matching the wording `Dataset.iter()` uses for `batch_size`. The docstring already describes `buffer_size` as the number of elements to fill the buffer with, so non-positive values have no meaning.

## Test

`test_iterable_dataset_shuffle_non_positive_buffer_size`, parametrized over `0` and `-1`. Both fail on `main`.
