### PR TITLE
Accept numpy integers as train_size / test_size in train_test_split

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5086,6 +5086,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if test_size is None and train_size is None:
             test_size = 0.25
 
+        # numpy integers are not instances of `int` (contrary to numpy floats, which are instances of `float`),
+        # so they wouldn't pass the checks below
+        if isinstance(test_size, np.integer):
+            test_size = int(test_size)
+        if isinstance(train_size, np.integer):
+            train_size = int(train_size)
+
         # Safety checks similar to scikit-learn's ones.
         # (adapted from https://github.com/scikit-learn/scikit-learn/blob/fd237278e895b42abe8d8d09105cbb82dc2cbba7/sklearn/model_selection/_split.py#L1750)
         n_samples = len(self)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5086,12 +5086,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if test_size is None and train_size is None:
             test_size = 0.25
 
-        # numpy integers are not instances of `int` (contrary to numpy floats, which are instances of `float`),
-        # so they wouldn't pass the checks below
+        # A numpy scalar is not reliably an instance of the matching Python builtin:
+        # `np.float64` happens to subclass `float`, but `np.float32` does not and no
+        # numpy integer subclasses `int`, so they would fail the checks below.
         if isinstance(test_size, np.integer):
             test_size = int(test_size)
         if isinstance(train_size, np.integer):
             train_size = int(train_size)
+        if isinstance(test_size, np.floating):
+            test_size = float(test_size)
+        if isinstance(train_size, np.floating):
+            train_size = float(train_size)
 
         # Safety checks similar to scikit-learn's ones.
         # (adapted from https://github.com/scikit-learn/scikit-learn/blob/fd237278e895b42abe8d8d09105cbb82dc2cbba7/sklearn/model_selection/_split.py#L1750)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4842,6 +4842,30 @@ def test_train_test_split_with_numpy_integer_sizes(dtype):
     assert len(split["test"]) == 6
 
 
+@pytest.mark.parametrize("dtype", ["float16", "float32", "float64"])
+def test_train_test_split_with_numpy_float_sizes(dtype):
+    # Only np.float64 subclasses Python float, so a float32/float16 ratio -- what you
+    # get from a float32 column or anything that has been through a tensor -- used to
+    # be rejected as an invalid test_size.
+    #
+    # The split is asserted against `float(value)` rather than a fixed row count,
+    # because a narrow float does not hold the ratio exactly: np.float32(0.2) is
+    # 0.20000000298..., which legitimately rounds to a different split size than 0.2.
+    # What matters is that the numpy scalar behaves like the Python float it equals.
+    dataset = Dataset.from_dict({"col_1": list(range(10))})
+    for size in (0.2, 0.5):
+        value = getattr(np, dtype)(size)
+        expected = dataset.train_test_split(test_size=float(value), seed=42)
+        actual = dataset.train_test_split(test_size=value, seed=42)
+        assert len(actual["test"]) == len(expected["test"])
+        assert len(actual["train"]) == len(expected["train"])
+
+        expected = dataset.train_test_split(train_size=float(value), seed=42)
+        actual = dataset.train_test_split(train_size=value, seed=42)
+        assert len(actual["train"]) == len(expected["train"])
+        assert len(actual["test"]) == len(expected["test"])
+
+
 def test_dataset_getitem_int_np_equivalence():
     ds = Dataset.from_dict({"a": [0, 1, 2, 3]})
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4831,6 +4831,17 @@ def test_filter_async():
     assert len(out) == 1
 
 
+@pytest.mark.parametrize("dtype", ["int32", "int64", "uint8"])
+def test_train_test_split_with_numpy_integer_sizes(dtype):
+    dataset = Dataset.from_dict({"col_1": list(range(10))})
+    split = dataset.train_test_split(test_size=getattr(np, dtype)(2), seed=42)
+    assert len(split["test"]) == 2
+    assert len(split["train"]) == 8
+    split = dataset.train_test_split(train_size=getattr(np, dtype)(4), seed=42)
+    assert len(split["train"]) == 4
+    assert len(split["test"]) == 6
+
+
 def test_dataset_getitem_int_np_equivalence():
     ds = Dataset.from_dict({"a": [0, 1, 2, 3]})
 


### PR DESCRIPTION
`Dataset.train_test_split()` uses `isinstance(..., int)` / `isinstance(..., float)` to tell "a number of rows" from "a fraction", and rejects everything else:

```python
if train_size is not None and not isinstance(train_size, (int, float)):
    raise ValueError(f"Invalid value for train_size: {train_size} of type {type(train_size)}")
```

numpy **floats** are subclasses of `float`, so they already work. numpy **integers** are not subclasses of `int`, so they don't:

```python
import numpy as np

ds.train_test_split(test_size=np.float64(0.2))   # works
ds.train_test_split(test_size=np.int64(2))
# ValueError: Invalid value for test_size: 2 of type <class 'numpy.int64'>
```

The asymmetry is accidental, and the error is confusing because the printed value (`2`) looks perfectly valid. numpy integers turn up naturally — `np.floor(0.2 * len(ds)).astype(int)`, a value read out of a numpy array, a pandas `.nunique()`, etc. `sklearn.model_selection.train_test_split`, which this API is modelled on, accepts them.

This PR converts numpy integers to `int` before the checks, leaving the int/float semantics untouched.

Added `tests/test_arrow_dataset.py::test_train_test_split_with_numpy_integer_sizes`, parametrized over `int32`, `int64` and `uint8`, covering both `test_size` and `train_size`. All three fail on `main`.
