### PR TITLE
Validate by_column and fix the error message in Dataset.batch

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4111,11 +4111,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         """
         if batch_size is None and by_column is None:
-            raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+            raise ValueError("Dataset.batch() misses `batch_size` or `by_column` argument.")
         if by_column is not None:
             if num_proc:
                 raise NotImplementedError("Multiprocessed batching by column is not implemented yet")
             columns = [by_column] if isinstance(by_column, str) else by_column
+            missing_columns = [column for column in columns if column not in self._data.column_names]
+            if missing_columns:
+                raise ValueError(
+                    f"Column to batch by {missing_columns} not in the dataset. "
+                    f"Current columns in the dataset: {self._data.column_names}"
+                )
             _batch_fn = partial(
                 _batch_accumulate_arrow_table_by_columns, columns=columns, tables_accumulator=[], length=len(self)
             )

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4918,6 +4918,19 @@ def test_dataset_batch():
     assert batches[2]["text"] == ["Text 8", "Text 9"]
 
 
+def test_dataset_batch_without_batch_size_or_by_column():
+    dataset = Dataset.from_dict({"col_1": [0, 1, 2]})
+    with pytest.raises(ValueError, match=r"^Dataset\.batch\(\)"):
+        dataset.batch()
+
+
+@pytest.mark.parametrize("by_column", ["col_2", ["col_1", "col_2"]])
+def test_dataset_batch_by_missing_column(by_column):
+    dataset = Dataset.from_dict({"col_1": [0, 1, 2]})
+    with pytest.raises(ValueError):
+        dataset.batch(by_column=by_column)
+
+
 def test_dataset_batch_by_column():
     # Create a Dataset with a column to group by
     data = {


### PR DESCRIPTION
Two small problems in `Dataset.batch()`.

**1. The error names the wrong class.**

```python
ds.batch()
# ValueError: IterableDataset.batch() misses `batch_size` or `by_column` argument.
```

`IterableDataset.batch()` has its own copy of the same check, so this occurrence in `arrow_dataset.py` is just a copy-paste that sends the reader to the wrong class.

**2. `by_column` is not validated.**

It is passed straight through to `_batch_accumulate_arrow_table_by_columns`, so a typo only fails once pyarrow tries to read the field, inside a `map` worker:

```python
ds.batch(by_column="labels")
# KeyError: 'Field "labels" does not exist in schema'
```

Every other column-taking method (`map(input_columns=...)`, `map(remove_columns=...)`, `sort`, `select_columns`, `remove_columns`, ...) checks up front and lists the available columns. This PR does the same for `by_column`, for both the `str` and the `list[str]` form.

### Tests

`test_dataset_batch_without_batch_size_or_by_column` (asserts the message starts with `Dataset.batch()` — note a loose `match="Dataset.batch"` would also match `IterableDataset.batch`) and `test_dataset_batch_by_missing_column`, parametrized over a single column name and a list. All three fail on `main`.
