### PR TITLE
Fix StopIteration when the JSON data files are empty

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -98,10 +98,16 @@ class Json(datasets.ArrowBasedBuilder):
             )
         if self.info.features is None:
             try:
-                pa_table = next(iter(self._generate_tables(**splits[0].gen_kwargs, allow_full_read=False)))[1]
-                self.info.features = datasets.Features.from_arrow_schema(pa_table.schema)
-                if self.config.parse_agent_traces and has_agent_traces_markers(self.info.features):
-                    self.info.features = AGENT_TRACES_FEATURES
+                # the generator is empty when the data files contain no data at all,
+                # in which case the features stay unknown instead of raising StopIteration
+                first_key_and_table = next(
+                    iter(self._generate_tables(**splits[0].gen_kwargs, allow_full_read=False)), None
+                )
+                if first_key_and_table is not None:
+                    pa_table = first_key_and_table[1]
+                    self.info.features = datasets.Features.from_arrow_schema(pa_table.schema)
+                    if self.config.parse_agent_traces and has_agent_traces_markers(self.info.features):
+                        self.info.features = AGENT_TRACES_FEATURES
             except FullReadDisallowed:
                 pass
         return splits

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -7,6 +7,7 @@ import pytest
 from datasets import Features, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
+from datasets.download.streaming_download_manager import StreamingDownloadManager
 from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES, Json, JsonConfig
 
 from ..utils import require_teich
@@ -614,6 +615,23 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
     )
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa_table.column_names == ["ID", "Language", "Topic"]
+
+
+def test_json_split_generators_with_empty_file(tmp_path):
+    # inferring the features reads the first table of the first split, which doesn't
+    # exist when the file is empty: it used to raise a bare StopIteration
+    json_file = tmp_path / "empty.jsonl"
+    json_file.write_text("", encoding="utf-8")
+    json = Json(data_files=str(json_file))
+    splits = json._split_generators(StreamingDownloadManager())
+    assert json.info.features is None
+    assert list(json._generate_tables(**splits[0].gen_kwargs)) == []
+
+
+def test_json_load_dataset_streaming_empty_file(tmp_path):
+    json_file = tmp_path / "empty.jsonl"
+    json_file.write_text("", encoding="utf-8")
+    assert list(load_dataset("json", data_files=str(json_file), split="train", streaming=True)) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Feature inference in `json.py` did `next(iter(...))` catching only `FullReadDisallowed`, so an empty `.jsonl` leaked a bare `StopIteration` out of `load_dataset` (the PEP 479 hazard).

This brings `json.py` in line with its neighbours rather than adding a special case: `arrow.py` and `parquet.py` already infer with a `for file in files: ... break` loop, which naturally leaves `info.features` as `None` when there is nothing to read. `json.py` was the odd one out.

**Scope — the non-streaming path still raises.** Only the streaming load is fixed:

```
load_dataset("json", data_files=empty, split="train", streaming=True)   -> [] (fixed here)
load_dataset("json", data_files=empty, split="train")                   -> SchemaInferenceError
```

That is not a regression (on `main` the same call dies earlier with the bare `StopIteration`), and it is the behaviour `text` already has — you genuinely cannot infer a schema from zero examples, and `SchemaInferenceError` says so clearly. After this PR `json` matches `text` on both axes:

| loader | streaming=True | streaming=False |
|---|---|---|
| json (this PR) | ok, 0 rows | SchemaInferenceError |
| text | ok, 0 rows | SchemaInferenceError |
| csv | EmptyDataError | EmptyDataError |

Test covers the streaming case, which is the one whose behaviour changes.
