### PR TITLE
Fix jax formatting of temporal and decimal columns

### DIFF
--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Lint as: python3
+import datetime
+import decimal
 import sys
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
@@ -88,6 +90,15 @@ class JaxFormatter(TensorFormatter[Mapping, "jax.Array", Mapping]):
             return value
         elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value.tolist()
+        elif isinstance(value, (np.datetime64, np.timedelta64)) or (
+            isinstance(value, np.ndarray) and value.dtype.kind in "mM"
+        ):
+            # jax has no dtype for dates, timestamps and durations. `np.timedelta64` is a subtype of
+            # `np.signedinteger`, so without this it would silently become a unit-less integer.
+            return value.tolist()
+        elif isinstance(value, (datetime.date, datetime.time, datetime.timedelta, decimal.Decimal)):
+            # time32/time64 and decimal columns are extracted as objects, which jax cannot hold either
+            return value
 
         default_dtype = {}
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 from pathlib import Path
 from unittest import TestCase
 
@@ -1074,3 +1075,30 @@ def test_iterable_dataset_of_arrays_format_to_jax(any_arrays_dataset: IterableDa
 
     formatted = any_arrays_dataset.with_format("jax")
     assert all(isinstance(example["array"], jnp.ndarray) for example in formatted)
+
+
+@require_jax
+@pytest.mark.parametrize(
+    "pa_type, value, expected",
+    [
+        (pa.timestamp("s"), datetime.datetime(2023, 1, 1), datetime.datetime(2023, 1, 1)),
+        (pa.date32(), datetime.date(2023, 1, 1), datetime.date(2023, 1, 1)),
+        (pa.duration("s"), datetime.timedelta(seconds=5), datetime.timedelta(seconds=5)),
+        # numpy represents a nanosecond duration as an int, since it does not fit in a timedelta
+        (pa.duration("ns"), datetime.timedelta(seconds=5), 5_000_000_000),
+        (pa.time64("us"), datetime.time(1, 2, 3), datetime.time(1, 2, 3)),
+        (pa.decimal128(5, 2), decimal.Decimal("1.50"), decimal.Decimal("1.50")),
+    ],
+)
+def test_jax_formatter_keeps_values_jax_cannot_hold(pa_type, value, expected):
+    from datasets.formatting import JaxFormatter
+
+    # jax has no dtype for temporal and decimal values, so they must be returned as they are,
+    # the way string columns already are. Durations used to silently become unit-less integers,
+    # and 5_000_000_000 nanoseconds overflowed the default int32 down to 705_032_704.
+    pa_table = pa.table({"col": pa.array([value] * 2, type=pa_type)})
+    formatter = JaxFormatter()
+
+    assert formatter.format_row(pa_table)["col"] == expected
+    assert list(formatter.format_column(pa_table)) == [expected] * 2
+    assert list(formatter.format_batch(pa_table)["col"]) == [expected] * 2


### PR DESCRIPTION
Temporal columns are either rejected or **silently corrupted** by the jax format.

### 1. Timestamps, dates, times and decimals raise

```python
import datetime
from datasets import Dataset

ds = Dataset.from_dict({"t": [datetime.datetime(2020, 1, 1)]})
ds.with_format("jax")[0]["t"]
```

```
TypeError: Error interpreting argument to jax.numpy.asarray as an abstract array.
```

Same for `date32`/`date64`, `time32`/`time64` and `decimal128`.

### 2. Durations are silently corrupted

numpy represents durations as `timedelta64`, and `np.timedelta64` is a subtype of `np.signedinteger`. They therefore take the integer branch of `_tensorize` and become **unit-less** integers cast to the jax default `int32`. The same 5 second duration reads back differently depending only on the column's resolution — and the nanosecond one silently overflows `int32`:

```python
for unit in ["s", "ms", "us", "ns"]:
    ds = Dataset.from_dict({"d": [datetime.timedelta(seconds=5)]},
                           features=Features({"d": Value(f"duration[{unit}]")}))
    print(unit, ds.with_format("numpy")[:]["d"], ds.with_format("jax")[:]["d"])
```

```
s   [5]           [5]
ms  [5000]        [5000]
us  [5000000]     [5000000]
ns  [5000000000]  [705032704]     <-- int32 overflow, 5000000000 mod 2**32
```

The numpy formatter gets all four right; only jax truncates.

### Fix

jax has no dtype for any of these. `JaxFormatter._tensorize` already returns `str`, `bytes` and `None` unchanged and converts numpy character arrays with `.tolist()`; this adds temporal and decimal values to that list, before the integer branch that was swallowing `timedelta64`.

This is the jax counterpart of #8440, which does the same for `TorchFormatter`. The two are independent files and can be merged in either order; I kept them separate so each is verifiable on its own. I did not touch `TFFormatter` because I could not run TensorFlow locally to verify it, though it looks like it has the same gap.

Note: `.tolist()` on `timedelta64[ns]`/`datetime64[ns]` yields an `int` rather than a `datetime`, because nanosecond resolution does not fit in `datetime.timedelta`. That is numpy's own behaviour and, unlike the current code, it is lossless — the test asserts `5_000_000_000` explicitly for that case.

Behaviour change worth calling out: `duration` columns previously produced a jax integer array and now produce the duration values. That path was inconsistent across resolutions and wrong for `ns`, so I believe returning the values is the right call, but I am happy to adjust if you would rather keep an integer array for durations.

### Tests

`tests/test_formatting.py::test_jax_formatter_keeps_values_jax_cannot_hold` covers `timestamp`, `date32`, `duration[s]`, `duration[ns]`, `time64` and `decimal128` through `format_row`, `format_column` and `format_batch`. All 6 parametrizations fail on `main`.

`tests/test_formatting.py`, `tests/features/`, `tests/test_table.py`, `tests/test_arrow_dataset.py` and `tests/test_iterable_dataset.py`: 1530 passed, 0 failures.
