### PR TITLE
Reject a non-positive batch_size in the Dataset export methods

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -633,6 +633,12 @@ def _check_column_names(column_names: list[str]):
         raise ValueError(f"The table can't have duplicated columns but columns {duplicated_columns} are duplicated.")
 
 
+def _check_batch_size(batch_size: Optional[int]):
+    """Check the `batch_size` of the methods that export a dataset by batches."""
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive integer, but got {batch_size}.")
+
+
 def _check_valid_indices_value(index, size):
     if (index < 0 and index + size < 0) or (index >= size):
         raise IndexError(f"Index {index} out of range for dataset of size {size}.")
@@ -5371,6 +5377,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Dynamic import to avoid circular dependency
         from .io.csv import CsvDatasetWriter
 
+        _check_batch_size(batch_size)
         return CsvDatasetWriter(
             self,
             path_or_buf,
@@ -5414,6 +5421,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 result[col] = [json_decode_field(row, json_field_subpath) for row in result[col]]
             return result
 
+        _check_batch_size(batch_size)
         if not batched:
             return query_to_dict(slice(0, len(self)))
         else:
@@ -5498,6 +5506,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Dynamic import to avoid circular dependency
         from .io.json import JsonDatasetWriter
 
+        _check_batch_size(batch_size)
         return JsonDatasetWriter(
             self,
             path_or_buf,
@@ -5542,6 +5551,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds.to_pandas()
         ```
         """
+        _check_batch_size(batch_size)
         if not batched:
             df = query_table(
                 table=self._data,
@@ -5592,6 +5602,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         >>> ds.to_polars()
         ```
         """
+        _check_batch_size(batch_size)
         if config.POLARS_AVAILABLE:
             import polars as pl
 
@@ -5658,6 +5669,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Dynamic import to avoid circular dependency
         from .io.parquet import ParquetDatasetWriter
 
+        _check_batch_size(batch_size)
         return ParquetDatasetWriter(
             self, path_or_buf, batch_size=batch_size, storage_options=storage_options, **parquet_writer_kwargs
         ).write()
@@ -5715,6 +5727,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         # Dynamic import to avoid circular dependency
         from .io.sql import SqlDatasetWriter
 
+        _check_batch_size(batch_size)
         return SqlDatasetWriter(self, name, con, batch_size=batch_size, num_proc=num_proc, **sql_writer_kwargs).write()
 
     def _estimate_nbytes(self) -> int:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4514,6 +4514,21 @@ def test_pickle_dataset_after_transforming_the_table(in_memory, method_and_param
         assert dataset._data.table == reloaded_dataset._data.table
 
 
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_dataset_export_with_non_positive_batch_size(batch_size, tmp_path):
+    dataset = Dataset.from_dict({"col_1": [0, 1, 2]})
+    with pytest.raises(ValueError):
+        list(dataset.to_dict(batch_size=batch_size, batched=True))
+    with pytest.raises(ValueError):
+        list(dataset.to_pandas(batch_size=batch_size, batched=True))
+    with pytest.raises(ValueError):
+        dataset.to_csv(tmp_path / "dataset.csv", batch_size=batch_size)
+    with pytest.raises(ValueError):
+        dataset.to_json(tmp_path / "dataset.json", batch_size=batch_size)
+    with pytest.raises(ValueError):
+        dataset.to_parquet(tmp_path / "dataset.parquet", batch_size=batch_size)
+
+
 def test_dummy_dataset_serialize_fs(dataset, mockfs):
     dataset_path = "mock://my_dataset"
     dataset.save_to_disk(dataset_path, storage_options=mockfs.storage_options)


### PR DESCRIPTION
All the `Dataset.to_*` exports batch with `range(0, len(self), batch_size)`. A negative `batch_size` makes that range empty, so the data is silently dropped — including when writing to a file:

```python
from datasets import Dataset

ds = Dataset.from_dict({"col_1": [0, 1, 2]})

len(list(ds.to_dict(batch_size=-1, batched=True)))     # 0
len(list(ds.to_pandas(batch_size=-1, batched=True)))   # 0

ds.to_csv("out.csv", batch_size=-1)                    # 0   -> out.csv is empty
ds.to_json("out.json", batch_size=-1)                  # 0   -> out.json is empty
ds.to_parquet("out.parquet", batch_size=-1)            # 0
ds.to_sql("t", con, batch_size=-1)                     # 0
```

A "successful" export that writes an empty file is about the worst failure mode available here — the return value is the number of bytes written, and `0` is easy to ignore.

`batch_size=0` is not caught either; it is falsy, so it is silently replaced by `config.DEFAULT_MAX_BATCH_SIZE`.

This mistake is easy to make because `map`, `filter` and `batch` all document `batch_size <= 0` (or `None`) as *"provide the full dataset as a single batch"*. Someone carrying that idiom over to `to_csv` gets an empty file instead.

This PR adds a small `_check_batch_size` helper next to the other `_check_*` helpers and calls it in `to_dict`, `to_pandas`, `to_polars`, `to_csv`, `to_json`, `to_parquet` and `to_sql`, raising the same `ValueError` that `Dataset.iter` raises. `batch_size=None` keeps meaning "use the default".

Note this also turns `batch_size=0` into an error rather than a silent fallback to the default; happy to relax it to `< 0` only if you'd rather keep that.

Added `tests/test_arrow_dataset.py::test_dataset_export_with_non_positive_batch_size`, parametrized over `0` and `-1`; both fail on `main`.
