### PR TITLE
Reject an invalid axis in concatenate_datasets

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -7054,6 +7054,9 @@ def _concatenate_map_style_datasets(
     >>> ds3 = _concatenate_map_style_datasets([ds1, ds2])
     ```
     """
+    if axis not in (0, 1):
+        raise ValueError(f"axis must be 0 (rows) or 1 (columns), but got {axis}.")
+
     # Ignore datasets with no rows
     if any(dset.num_rows > 0 for dset in dsets):
         dsets = [dset for dset in dsets if dset.num_rows > 0]

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3712,6 +3712,14 @@ def test_concatenate_datasets_new_columns():
     }
 
 
+@pytest.mark.parametrize("axis", [2, -1, "1"])
+def test_concatenate_datasets_with_invalid_axis(axis):
+    dataset1 = Dataset.from_dict({"col_1": [0, 1, 2]})
+    dataset2 = Dataset.from_dict({"col_2": [3, 4, 5]})
+    with pytest.raises(ValueError):
+        concatenate_datasets([dataset1, dataset2], axis=axis)
+
+
 @pytest.mark.parametrize("axis", [0, 1])
 def test_concatenate_datasets_complex_features(axis):
     n = 5


### PR DESCRIPTION
`concatenate_datasets()` documents `axis` as `{0, 1}`, but does not check it. Any other value silently returns **only the first dataset**:

```python
from datasets import Dataset, concatenate_datasets

a = Dataset.from_dict({"a": [1, 2, 3]})
b = Dataset.from_dict({"b": [4, 5, 6]})

concatenate_datasets([a, b], axis=2).to_dict()
# {'a': [1, 2, 3]}          <- b is gone, no error

concatenate_datasets([a, b], axis="1").to_dict()
# {'a': [1, 2, 3]}          <- a string axis does the same
```

In `_concatenate_map_style_datasets` every branch is written as `if axis == 0: ... else: ...`, so an invalid value takes the `axis=1` path through the checks (row counts must match, no duplicate column names — both pass here) and is then forwarded to `concat_tables(..., axis=axis)`, which builds nothing for it.

`axis="1"` is the realistic version of this: it comes straight out of a config file or a CLI argument, and instead of an error you get a dataset that is missing half its columns.

The iterable implementation concatenates horizontally for `axis=2`, so the map-style and streaming paths disagree on top of that.

This PR raises a `ValueError` for anything but `0` or `1` at the top of `_concatenate_map_style_datasets`.

Added `tests/test_arrow_dataset.py::test_concatenate_datasets_with_invalid_axis`, parametrized over `2`, `-1` and `"1"`; all three fail on `main`.
