### PR TITLE
Reject an unknown column in IterableDataset.cast_column

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4239,6 +4239,10 @@ class IterableDataset(DatasetInfoMixin):
         """
         feature = _fix_for_backward_compatible_features(feature)
         info = self._info.copy()
+        if info.features is not None and column not in info.features:
+            raise ValueError(
+                f"Column name {column} not in the dataset. Columns in the dataset: {list(info.features)}."
+            )
         info.features[column] = feature
         return IterableDataset(
             ex_iterable=self._ex_iterable,

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2494,6 +2494,15 @@ def test_iterable_dataset_cast_column():
     assert list(casted_dataset) == [casted_features.encode_example(ex) for _, ex in ex_iterable]
 
 
+def test_iterable_dataset_cast_column_missing_column():
+    # casting a column that doesn't exist used to add it to the features and to the examples
+    ex_iterable = ExamplesIterable(generate_examples_fn, {"label": 10})
+    features = Features({"id": Value("int64"), "label": Value("int64")})
+    dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features))
+    with pytest.raises(ValueError, match="Column name missing_column not in the dataset"):
+        dataset.cast_column("missing_column", Value("bool"))
+
+
 def test_iterable_dataset_cast():
     ex_iterable = ExamplesIterable(generate_examples_fn, {"label": 10})
     features = Features({"id": Value("int64"), "label": Value("int64")})


### PR DESCRIPTION
`IterableDataset.cast_column()` writes the feature straight into the features dict:

```python
feature = _fix_for_backward_compatible_features(feature)
info = self._info.copy()
info.features[column] = feature
```

There is no check that `column` is actually a column of the dataset, so a typo doesn't fail — it **invents** the column, both in the schema and in the data:

```python
ds = Dataset.from_dict({"x": [1, 2], "y": ["a", "b"]}).to_iterable_dataset()

ds.cast_column("nope", Value("int64")).features
# {'x': Value('int64'), 'y': Value('string'), 'nope': Value('int64')}

list(ds.cast_column("nope", Value("int64")))
# [{'x': 1, 'y': 'a', 'nope': None}, {'x': 2, 'y': 'b', 'nope': None}]
```

Every example gains a `nope: None` field, because the declared features are applied to the examples on the fly. The same call on a map-style dataset raises:

```
ValueError: The columns in features (['x', 'y', 'nope']) must be identical as the columns in the dataset: ['x', 'y']
```

This is easy to hit for real: `ds.cast_column("audio", Audio(sampling_rate=16000))` on a dataset whose column is actually named `sound` quietly produces an all-null `audio` column instead of telling you the name is wrong.

## Fix

Raise `ValueError` when the features are known and the column isn't among them — the same shape of check `IterableDataset.select_columns()` already performs.

Datasets whose features are not resolved yet (`info.features is None`) are untouched and behave exactly as before.

## Test

`test_iterable_dataset_cast_column_missing_column` casts a column that isn't in the dataset and expects `ValueError`. It fails on `main`, where the call succeeds.
