### PR TITLE
Check the per-split arguments of DatasetDict

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -60,6 +60,21 @@ class bind(partial):
         return self.func(*fn_args, *self.args, **fn_kwargs)
 
 
+def _check_per_split_arg(arg, arg_name: str, splits):
+    """Check that a per-split argument has one entry per dataset of the dataset dictionary."""
+    if not isinstance(arg, dict):
+        raise ValueError(
+            f"`{arg_name}` must be a dict with one entry per dataset of the dataset dictionary, "
+            f"but got {type(arg).__name__}."
+        )
+    missing_splits = [split for split in splits if split not in arg]
+    if missing_splits:
+        raise ValueError(
+            f"`{arg_name}` is missing an entry for {missing_splits}. "
+            f"Please provide one entry per dataset of the dataset dictionary."
+        )
+
+
 class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
     """A dictionary (dict of str: datasets.Dataset) with dataset transforms methods (map, filter, etc.)"""
 
@@ -960,6 +975,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         self._check_values_type()
         if cache_file_names is None:
             cache_file_names = dict.fromkeys(self)
+        else:
+            _check_per_split_arg(cache_file_names, "cache_file_names", self)
 
         dataset_dict = {}
         for split, dataset in self.items():
@@ -1085,6 +1102,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         self._check_values_type()
         if cache_file_names is None:
             cache_file_names = dict.fromkeys(self)
+        else:
+            _check_per_split_arg(cache_file_names, "cache_file_names", self)
         return DatasetDict(
             {
                 k: dataset.filter(
@@ -1143,6 +1162,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         self._check_values_type()
         if cache_file_names is None:
             cache_file_names = dict.fromkeys(self)
+        else:
+            _check_per_split_arg(cache_file_names, "cache_file_names", self)
         return DatasetDict(
             {
                 k: dataset.flatten_indices(
@@ -1210,6 +1231,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         self._check_values_type()
         if indices_cache_file_names is None:
             indices_cache_file_names = dict.fromkeys(self)
+        else:
+            _check_per_split_arg(indices_cache_file_names, "indices_cache_file_names", self)
         return DatasetDict(
             {
                 k: dataset.sort(
@@ -1290,10 +1313,16 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             seeds = dict.fromkeys(self)
         elif not isinstance(seeds, dict):
             seeds = dict.fromkeys(self, seeds)
+        else:
+            _check_per_split_arg(seeds, "seeds", self)
         if generators is None:
             generators = dict.fromkeys(self)
+        else:
+            _check_per_split_arg(generators, "generators", self)
         if indices_cache_file_names is None:
             indices_cache_file_names = dict.fromkeys(self)
+        else:
+            _check_per_split_arg(indices_cache_file_names, "indices_cache_file_names", self)
         return DatasetDict(
             {
                 k: dataset.shuffle(

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -674,6 +674,36 @@ class DatasetDictTest(TestCase):
         self.assertListEqual(test_expected_label_names, test_aligned_label_names)
 
 
+def _make_dataset_dict():
+    return DatasetDict(
+        {"train": Dataset.from_dict({"col_1": [0, 1, 2]}), "test": Dataset.from_dict({"col_1": [3, 4]})}
+    )
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda ds, arg: ds.map(lambda x: x, cache_file_names=arg),
+        lambda ds, arg: ds.filter(lambda x: True, cache_file_names=arg),
+        lambda ds, arg: ds.flatten_indices(cache_file_names=arg),
+        lambda ds, arg: ds.sort("col_1", indices_cache_file_names=arg),
+        lambda ds, arg: ds.shuffle(indices_cache_file_names=arg),
+        lambda ds, arg: ds.shuffle(seeds=arg),
+        lambda ds, arg: ds.shuffle(generators=arg),
+    ],
+)
+def test_datasetdict_per_split_arg_missing_split(transform):
+    dataset_dict = _make_dataset_dict()
+    with pytest.raises(ValueError, match="train|test"):
+        transform(dataset_dict, {"train": None})
+
+
+def test_datasetdict_generators_must_be_a_dict():
+    dataset_dict = _make_dataset_dict()
+    with pytest.raises(ValueError, match="generators"):
+        dataset_dict.shuffle(generators=np.random.default_rng(42))
+
+
 def test_dummy_datasetdict_serialize_fs(mockfs):
     dataset_dict = DatasetDict(
         {


### PR DESCRIPTION
`DatasetDict.map`, `filter`, `flatten_indices`, `sort` and `shuffle` take per-split arguments — `cache_file_names`, `indices_cache_file_names`, `seeds`, `generators` — documented as *"You have to provide one ... per dataset in the dataset dictionary"*. None of them checks that, they just index the dict:

```python
from datasets import Dataset, DatasetDict
import numpy as np

dd = DatasetDict({"train": Dataset.from_dict({"col_1": [0, 1, 2]}),
                  "test":  Dataset.from_dict({"col_1": [3, 4]})})

dd.map(lambda x: x, cache_file_names={"train": "train.arrow"})
# KeyError: 'test'

dd.shuffle(generators=np.random.default_rng(42))
# TypeError: 'numpy.random._generator.Generator' object is not subscriptable
```

A bare `KeyError: 'test'` out of a `DatasetDict.map` call gives no hint about which argument is wrong, and the `TypeError` is worse — `seeds` accepts a single value for all splits, so passing a single `generator` the same way is a natural thing to try.

This PR adds a small `_check_per_split_arg` helper and calls it wherever such a dict is consumed. The message names the argument and lists the missing splits:

```
ValueError: `cache_file_names` is missing an entry for ['test']. Please provide one entry per dataset of the dataset dictionary.
ValueError: `generators` must be a dict with one entry per dataset of the dataset dictionary, but got Generator.
```

`seeds` keeps accepting a single value for all the splits, as documented — only the dict form is checked.

Added `tests/test_dataset_dict.py::test_datasetdict_per_split_arg_missing_split` (parametrized over the seven affected call shapes) and `test_datasetdict_generators_must_be_a_dict`. All 8 cases fail on `main`.
