### PR TITLE
Raise a clear error for values that cannot be encoded as an image

### DIFF
--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
@@ -125,6 +126,8 @@ class Image:
         elif isinstance(value, PIL.Image.Image):
             # convert the PIL image to bytes (default format is PNG/TIFF)
             return encode_pil_image(value)
+        elif not isinstance(value, Mapping):
+            raise TypeError(f"Unsupported encode_example type: {type(value)}")
         elif value.get("path") is not None and os.path.isfile(value["path"]):
             # we set "bytes": None to not duplicate the data if they're already available locally
             return {"bytes": None, "path": value.get("path")}
@@ -378,6 +381,9 @@ def encode_np_array(array: np.ndarray) -> dict:
         import PIL.Image
     else:
         raise ImportError("To support encoding images, please install 'Pillow'.")
+
+    if array.ndim == 0:
+        raise ValueError(f"An image array should have at least one dimension, but got shape {array.shape}.")
 
     dtype = array.dtype
     dtype_byteorder = dtype.byteorder if dtype.byteorder != "=" else _NATIVE_BYTEORDER

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -78,6 +78,31 @@ def test_image_feature_encode_example(shared_datadir, build_example):
 
 
 @require_pil
+@pytest.mark.parametrize("value", [123, 1.5, True, {1, 2}, object()])
+def test_image_feature_encode_example_unsupported_type(value):
+    # these used to fall through to `value.get("path")` and raise
+    # "AttributeError: 'int' object has no attribute 'get'"
+    with pytest.raises(TypeError, match="Unsupported encode_example type"):
+        Image().encode_example(value)
+
+
+@require_pil
+def test_image_feature_encode_example_zero_dimensional_array():
+    # a 0-d array holds no image, and used to raise "IndexError: tuple index out of range"
+    with pytest.raises(ValueError, match="at least one dimension"):
+        Image().encode_example(np.array(5))
+    with pytest.raises(ValueError, match="at least one dimension"):
+        encode_np_array(np.array(5))
+
+
+@require_pil
+def test_image_feature_encode_example_missing_keys():
+    # a mapping without usable keys keeps its own, already explicit, error
+    with pytest.raises(ValueError, match="should have one of 'path' or 'bytes'"):
+        Image().encode_example({"foo": 1})
+
+
+@require_pil
 def test_image_decode_example(shared_datadir):
     import PIL.Image
 


### PR DESCRIPTION
Putting an unsupported value in an `Image()` column fails with an error from deep inside the encoder rather than a message about the image:

```python
from datasets import Dataset, Features, Image

Dataset.from_dict({"im": [123]}, features=Features({"im": Image()}))
```

```
AttributeError: 'int' object has no attribute 'get'
```

Same for a float, a bool, a set, or any other unsupported object. A 0-dimensional numpy array fails differently but just as opaquely:

```python
Image().encode_example(np.array(5))
IndexError: tuple index out of range
```

### Cause

`Image.encode_example` handles `str`, `Path`, `bytes`, `np.ndarray` and `PIL.Image.Image`, and then falls straight through to the mapping branches:

```python
elif value.get("path") is not None and os.path.isfile(value["path"]):
```

so any value that is not one of the supported types and not a mapping raises `AttributeError` on `.get`.

The `Video` feature already guards exactly this case:

```python
# src/datasets/features/video.py
else:
    raise TypeError(f"Unsupported encode_example type: {type(value)}")
```

`Image` simply never got the same guard.

### Fix

- reject values that are neither a supported type nor a mapping with the same `TypeError: Unsupported encode_example type: ...` message `Video` already uses, so the two features report this identically;
- reject 0-dimensional arrays in `encode_np_array` with an explicit `ValueError` instead of letting the shape indexing blow up.

`Mapping` is used rather than `dict` so that any mapping type keeps working. Mappings that are missing both `path` and `bytes` still raise the existing, already explicit `ValueError`, and every currently supported input is unchanged — `str`, `Path`, `bytes`, dicts, PIL images and 1D/2D/3D arrays all still encode exactly as before.

### Tests

- `test_image_feature_encode_example_unsupported_type` covers `int`, `float`, `bool`, `set` and a plain object;
- `test_image_feature_encode_example_zero_dimensional_array` covers the 0-d array through both `Image.encode_example` and `encode_np_array`;
- `test_image_feature_encode_example_missing_keys` pins the existing `ValueError` for a mapping without usable keys, so this change cannot swallow it.

The first two fail on `main` (6 parametrizations); the third passes before and after and is there as a regression guard.

`tests/features/`, `tests/test_formatting.py`, `tests/test_table.py` and `tests/test_arrow_dataset.py`: 1068 passed, 0 failures.
