### PR TITLE
Use the documented default batch_size in the batched IterableDataset exports

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4500,7 +4500,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> ds.to_dict()
         ```
         """
-        batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
+        batch_size = batch_size if batch_size is not None else config.DEFAULT_MAX_BATCH_SIZE
         if batched:
             for table in self.with_format("arrow").iter(batch_size=batch_size):
                 yield Dataset(table, fingerprint="unset").to_dict()
@@ -4552,7 +4552,7 @@ class IterableDataset(DatasetInfoMixin):
                 return cast_table_to_features(table, self.features)
             return table
 
-        batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
+        batch_size = batch_size if batch_size is not None else config.DEFAULT_MAX_BATCH_SIZE
         if batched:
             return (
                 Dataset(maybe_cast_to_declared_features(table), info=info, fingerprint="unset").to_pandas()
@@ -4594,7 +4594,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> ds.to_polars()
         ```
         """
-        batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
+        batch_size = batch_size if batch_size is not None else config.DEFAULT_MAX_BATCH_SIZE
         if batched:
             for table in self.with_format("arrow").iter(batch_size=batch_size):
                 yield Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4500,6 +4500,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> ds.to_dict()
         ```
         """
+        batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
         if batched:
             for table in self.with_format("arrow").iter(batch_size=batch_size):
                 yield Dataset(table, fingerprint="unset").to_dict()
@@ -4551,6 +4552,7 @@ class IterableDataset(DatasetInfoMixin):
                 return cast_table_to_features(table, self.features)
             return table
 
+        batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
         if batched:
             return (
                 Dataset(maybe_cast_to_declared_features(table), info=info, fingerprint="unset").to_pandas()
@@ -4592,6 +4594,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> ds.to_polars()
         ```
         """
+        batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
         if batched:
             for table in self.with_format("arrow").iter(batch_size=batch_size):
                 yield Dataset(table, fingerprint="unset").to_polars(schema_overrides=schema_overrides, rechunk=rechunk)

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1759,6 +1759,19 @@ def test_iterable_dataset_from_generator_with_shards():
     assert dataset.num_shards == len(shard_names)
 
 
+def test_iterable_dataset_batched_export_default_batch_size():
+    # batched=True without an explicit batch_size must use config.DEFAULT_MAX_BATCH_SIZE,
+    # like Dataset does, instead of yielding the whole dataset as one batch
+    num_rows = 2 * config.DEFAULT_MAX_BATCH_SIZE + 1
+    expected = [config.DEFAULT_MAX_BATCH_SIZE, config.DEFAULT_MAX_BATCH_SIZE, 1]
+    dataset = Dataset.from_dict({"col": range(num_rows)})
+    assert [len(df) for df in dataset.to_pandas(batched=True)] == expected
+
+    iterable_dataset = dataset.to_iterable_dataset()
+    assert [len(df) for df in iterable_dataset.to_pandas(batched=True)] == expected
+    assert [len(batch["col"]) for batch in iterable_dataset.to_dict(batched=True)] == expected
+
+
 def test_iterable_dataset_to_pandas_preserves_declared_features():
     features = Features({"col": Value("int32")})
     dataset = Dataset.from_dict({"col": [0, None]}, features=features).to_iterable_dataset()


### PR DESCRIPTION
`IterableDataset.to_dict()`, `to_pandas()` and `to_polars()` all document `batch_size` as:

> batch_size (`int`, *optional*): The size (number of rows) of the batches if `batched` is `True`. Defaults to `datasets.config.DEFAULT_MAX_BATCH_SIZE`.

but the default is never applied. `batch_size` (`None`) is passed straight through to `iter()`, where it means "don't rebatch", so the whole dataset comes back as a single batch:

```python
ds = Dataset.from_dict({"col": range(2500)})

[len(df) for df in ds.to_pandas(batched=True)]
# [1000, 1000, 500]           <- Dataset applies the default

[len(df) for df in ds.to_iterable_dataset().to_pandas(batched=True)]
# [2500]                      <- IterableDataset returns everything at once
```

Same for `to_dict(batched=True)` and `to_polars(batched=True)`.

This defeats the purpose of `batched=True` on the streaming type specifically: the reason to ask for batches is to avoid holding the dataset in memory, and here `to_pandas(batched=True)` builds one DataFrame over the entire stream. Passing `batch_size` explicitly works fine — only the documented default is missing.

## Fix

Apply `config.DEFAULT_MAX_BATCH_SIZE` when `batch_size` is not set, using the same idiom `Dataset.to_pandas()` already uses:

```python
batch_size = batch_size if batch_size else config.DEFAULT_MAX_BATCH_SIZE
```

It is placed before the `if batched:` branch; the non-batched branches hardcode their own chunk size and are unaffected.

## Test

`test_iterable_dataset_batched_export_default_batch_size` builds a dataset of `2 * DEFAULT_MAX_BATCH_SIZE + 1` rows and asserts `Dataset` and `IterableDataset` produce the same batch sizes from `to_pandas(batched=True)` and `to_dict(batched=True)`. It fails on `main`, where the iterable version yields one batch.

Note: #8382 fixes a separate bug in the same `batched=True` branches of `to_dict` / `to_polars` (a bare `yield` making them return an empty generator), and #8434 fixes the non-batched branches crashing on an empty dataset. The three are complementary.
