### PR TITLE
Let a dataset with an Audio column be flattened

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -221,15 +221,17 @@ class Audio:
         return audio
 
     def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
-        """If in the decodable state, raise an error, otherwise flatten the feature into a dictionary."""
+        """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""
         from .features import Value
 
-        if self.decode:
-            raise ValueError("Cannot flatten a decoded Audio feature.")
-        return {
-            "bytes": Value("binary"),
-            "path": Value("string"),
-        }
+        return (
+            self
+            if self.decode
+            else {
+                "bytes": Value("binary"),
+                "path": Value("string"),
+            }
+        )
 
     def cast_storage(self, storage: Union[pa.StringArray, pa.StructArray]) -> pa.StructArray:
         """Cast an Arrow array to the Audio arrow storage type.

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -59,6 +59,19 @@ def test_audio_feature_type_to_arrow():
     assert features.arrow_schema == pa.schema({"sequence_of_audios": pa.list_(Audio().pa_type)})
 
 
+def test_audio_feature_flatten():
+    # a decodable Audio is left alone, like the Image, Video and Pdf features already do,
+    # so that a dataset holding an audio column can still be flattened
+    assert Audio().flatten() == Audio()
+    assert Audio(decode=False).flatten() == {"bytes": Value("binary"), "path": Value("string")}
+
+    features = Features({"audio": Audio(), "text": Value("string")})
+    assert features.flatten() == features
+
+    dset = Dataset.from_dict({"audio": [None], "text": ["a"]}, features=features)
+    assert dset.flatten().column_names == ["audio", "text"]
+
+
 @require_torchcodec
 @pytest.mark.parametrize(
     "build_example",


### PR DESCRIPTION
`Dataset.flatten()` fails on any dataset that holds a decodable `Audio` column:

```python
from datasets import Dataset, Features, Audio, Value

features = Features({"audio": Audio(), "text": Value("string")})
ds = Dataset.from_dict({"audio": [None], "text": ["a"]}, features=features)
ds.flatten()
```

```
ValueError: Cannot flatten a decoded Audio feature.
```

The same dataset with an `Image`, `Video` or `Pdf` column flattens without complaint:

| feature | `Features.flatten()` | `Dataset.flatten()` |
|---|---|---|
| `Image()` | `{'audio': Image(...), 'text': ...}` | `['audio', 'text']` |
| `Video()` | leaves it alone | `['audio', 'text']` |
| `Pdf()` | leaves it alone | `['audio', 'text']` |
| `Audio()` | **ValueError** | **ValueError** |

So a single audio column makes the whole dataset impossible to flatten — even when the user only wants to expand an unrelated struct column, and even though flattening does not decode anything.

### Cause

`Image.flatten`, `Video.flatten` and `Pdf.flatten` all share the same docstring and shape:

> "If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."

`Audio.flatten` is the odd one out:

```python
def flatten(self):
    """If in the decodable state, raise an error, otherwise flatten the feature into a dictionary."""
    if self.decode:
        raise ValueError("Cannot flatten a decoded Audio feature.")
```

`Features.flatten` calls `subfeature.flatten()` on every feature that has the method, so the raise propagates out of `Features.flatten()` and `Dataset.flatten()`.

### Fix

Return the feature itself when it is decodable, exactly like the other three media features. `Audio(decode=False)` still flattens to `{"bytes": Value("binary"), "path": Value("string")}` as before.

No test asserted the old error — `grep -rn "Cannot flatten" src/ tests/` matched only the line being removed — so nothing existing had to be adjusted.

### Tests

`tests/features/test_audio.py::test_audio_feature_flatten` checks `Audio().flatten()`, `Audio(decode=False).flatten()`, `Features.flatten()` and `Dataset.flatten()`. It fails on `main` with the `ValueError` above, and needs no audio backend so it runs without `torchcodec`.

`tests/features/`, `tests/test_formatting.py`, `tests/test_table.py`, `tests/test_arrow_dataset.py` and `tests/test_dataset_dict.py`: 1134 passed, 0 failures.
