### PR TITLE
Reject features with different columns in IterableDataset.cast

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4285,6 +4285,11 @@ class IterableDataset(DatasetInfoMixin):
         """
         features = _fix_for_backward_compatible_features(features)
         info = self._info.copy()
+        if info.features is not None and sorted(features) != sorted(info.features):
+            raise ValueError(
+                f"The columns in features ({list(features)}) must be identical "
+                f"as the columns in the dataset: {list(info.features)}"
+            )
         info.features = features
         return IterableDataset(
             ex_iterable=self._ex_iterable,

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2503,6 +2503,24 @@ def test_iterable_dataset_cast():
     assert list(casted_dataset) == [new_features.encode_example(ex) for _, ex in ex_iterable]
 
 
+@pytest.mark.parametrize(
+    "new_features",
+    [
+        Features({"id": Value("int64")}),  # missing a column
+        Features({"id": Value("int64"), "label": Value("int64"), "extra": Value("int64")}),  # extra column
+        Features({"id": Value("int64"), "renamed": Value("int64")}),  # renamed column
+    ],
+)
+def test_iterable_dataset_cast_with_different_columns(new_features):
+    # casting to features with different columns used to be accepted: an extra column
+    # was added to the features and yielded as None in every example
+    ex_iterable = ExamplesIterable(generate_examples_fn, {"label": 10})
+    features = Features({"id": Value("int64"), "label": Value("int64")})
+    dataset = IterableDataset(ex_iterable, info=DatasetInfo(features=features))
+    with pytest.raises(ValueError, match="must be identical as the columns in the dataset"):
+        dataset.cast(new_features)
+
+
 def test_iterable_dataset_resolve_features():
     ex_iterable = ExamplesIterable(generate_examples_fn, {})
     dataset = IterableDataset(ex_iterable)


### PR DESCRIPTION
`IterableDataset.cast()` assigns the given features directly:

```python
features = _fix_for_backward_compatible_features(features)
info = self._info.copy()
info.features = features
```

There is no check that the columns match the dataset's, which `Dataset.cast()` does perform. The worst case is an **extra** column: it is accepted silently and then fabricated in the data, because the declared features are applied to the examples on the fly.

```python
ds = Dataset.from_dict({"x": [1, 2], "y": ["a", "b"]}).to_iterable_dataset()

new_features = Features({"x": Value("int64"), "y": Value("string"), "z": Value("int64")})
list(ds.cast(new_features))
# [{'x': 1, 'y': 'a', 'z': None}, {'x': 2, 'y': 'b', 'z': None}]
```

No error at any point — the dataset just grows a column that was never in it. The map-style call raises:

```
ValueError: The columns in features (['x', 'y', 'z']) must be identical as the columns in the dataset: ['x', 'y']
```

Missing and renamed columns are accepted too, and fail later with a `CastError: Couldn't cast` from deep in the Arrow cast, which doesn't say the column set is wrong.

## Fix

Apply the same check and the same message as `Dataset.cast()` when the features are known:

```python
if info.features is not None and sorted(features) != sorted(info.features):
    raise ValueError(...)
```

`sorted()` is used on both sides, exactly like the map-style version, so reordering the columns keeps working. Datasets whose features aren't resolved yet (`info.features is None`) are untouched.

## Test

`test_iterable_dataset_cast_with_different_columns`, parametrized over a missing column, an extra column and a renamed column. All three fail on `main`.
