### PR TITLE
Coerce ClassLabel.names to plain str to fix invalid YAML in README.md

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1054,6 +1054,12 @@ class ClassLabel:
                 raise ValueError("Please provide either num_classes, names or names_file.")
         elif not isinstance(self.names, SequenceABC):
             raise TypeError(f"Please provide names as a list, is {type(self.names)}")
+        else:
+            # Coerce each name to a plain `str` (e.g. `numpy.str_` instances slip in when `names` is
+            # built from `numpy.unique(...)` or a pandas column). Leaving non-native strings in place
+            # causes the dataset card YAML metadata dump to fall back to unsafe `!!python/object` tags,
+            # producing a README.md that fails to parse back (see issue #6919).
+            self.names = [str(name) for name in self.names]
         # Set self.num_classes
         if self.num_classes is None:
             self.num_classes = len(self.names)

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import yaml
 
 from datasets import Array2D
 from datasets.arrow_dataset import Column, Dataset
@@ -137,6 +138,26 @@ class FeaturesTest(TestCase):
         ds_info = DatasetInfo(features=features)
         reloaded_features = Features.from_dict(asdict(ds_info)["features"])
         assert features == reloaded_features
+
+    def test_class_label_names_are_coerced_to_str(self):
+        """reference: issue #6919
+
+        ClassLabel.names built from numpy.unique(...) (or any other numpy-backed
+        source) contains numpy.str_ elements. Left as-is, those leak into the dataset
+        card YAML metadata dump and force PyYAML to emit unsafe !!python/object tags,
+        producing a README.md that fails to parse back with yaml.safe_load.
+        """
+        names = np.array(["negative", "positive"])
+        assert type(names[0]) is not str  # sanity check: numpy.str_, not a plain str
+
+        class_label = ClassLabel(names=list(names))
+        assert class_label.names == ["negative", "positive"]
+        assert all(type(name) is str for name in class_label.names)
+
+        yaml_list = Features({"label": class_label})._to_yaml_list()
+        dumped = yaml.dump(yaml_list)
+        # must round-trip through the strict loader used to validate README.md metadata
+        assert yaml.safe_load(dumped) == yaml_list
 
     def test_reorder_fields_as(self):
         features = Features(


### PR DESCRIPTION
Coerce ClassLabel.names to plain str to fix invalid YAML in README.md

Fixes #6919

## Problem

`push_to_hub` can fail with:

```
ValueError: Invalid metadata in README.md.
- Invalid YAML in README.md: unknown tag !<tag:yaml.org,2002:python/tuple> (50:11)
```

This happens whenever a `ClassLabel`'s `names` list contains elements that
are not exactly `str` — most commonly `numpy.str_`, which shows up whenever
`names` is built from `numpy.unique(...)` or read out of a pandas column
(a very common pattern for NER/token-classification labels, exactly as
described in the issue).

## Root cause

`ClassLabel.__post_init__` already normalizes the internal `_int2str`
mapping with `str(name)`, but it left the public `names` list untouched.
When the dataset card YAML metadata is generated
(`Features._to_yaml_list` -> `yaml.dump`), PyYAML's default `Dumper`
selects a representer by *exact* type match, not `isinstance`. Since
`numpy.str_` is a subclass of `str` but not `str` itself, it falls
through to the generic object representer, which serializes it with
unsafe `!!python/object/apply:numpy...` tags (including base64-encoded
binary state). The resulting README.md is technically written, but it
can no longer be parsed back with the strict `yaml.safe_load` used to
validate dataset card metadata, hence the "unknown tag" error.

## Fix

Coerce every element of `ClassLabel.names` to a plain `str` in
`__post_init__`, mirroring what already happens for `_int2str`. This
guarantees only native Python strings ever reach the YAML dumper,
regardless of where `names` originally came from.

## Testing

- Added a regression test
  (`test_class_label_names_are_coerced_to_str` in
  `tests/features/test_features.py`) that builds a `ClassLabel` from
  `numpy.str_` values, dumps its YAML representation, and asserts it
  round-trips through `yaml.safe_load` — this reproduces the exact
  failure from the issue and fails without the fix.
- Ran the full `tests/features/test_features.py`, `tests/test_info.py`,
  and `tests/test_metadata_util.py` suites locally: 226 passed, 3
  skipped, no regressions.
- Verified with a minimal repro matching the issue's steps (labels
  derived via `numpy.unique`, cast to
  `Sequence(ClassLabel(names=list(labels)))`, then dumping the resulting
  `DatasetInfo` to YAML) — the dump now round-trips through
  `yaml.safe_load` cleanly instead of raising `ConstructorError`.

## Scope

Only `src/datasets/features/features.py` (the fix) and
`tests/features/test_features.py` (the regression test) are touched. No
unrelated code or docs were changed.

---
Note: this PR was prepared with AI assistance (Claude Code) under my
direction — I reviewed the root-cause analysis, the fix, and the test
before submitting.
