### PR TITLE
close input stream in _in_memory_arrow_table_from_file to prevent file descriptor leaks

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -31,9 +31,9 @@ def inject_arrow_table_documentation(arrow_table_method):
 
 
 def _in_memory_arrow_table_from_file(filename: str) -> pa.Table:
-    in_memory_stream = pa.input_stream(filename)
-    opened_stream = pa.ipc.open_stream(in_memory_stream)
-    pa_table = opened_stream.read_all()
+    with pa.input_stream(filename) as in_memory_stream:
+        opened_stream = pa.ipc.open_stream(in_memory_stream)
+        pa_table = opened_stream.read_all()
     return pa_table
 
 


### PR DESCRIPTION
In `src/datasets/table.py`, `_in_memory_arrow_table_from_file` opens a `pa.input_stream(filename)` without a `with` context manager block. 
When exceptions occur during stream parsing or when exception tracebacks retain frame variables in memory (e.g., in logging handlers or data loader error queues), local `in_memory_stream` variables are held alive by stack frame references. This prevents CPython reference counting from closing the underlying OS file descriptor, resulting in open file descriptor leaks (`OSError: [Errno 24] Too many open files`) during multi-shard dataset processing.
This PR wraps `pa.input_stream` in a `with` context manager and executes `opened_stream.read_all()` inside the block to guarantee immediate file descriptor closure upon reading.