### PR TITLE
Fix Dataset.map(batched=True, drop_last_batch=True) returning unchanged input when dataset is smaller than batch_size

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4056,6 +4056,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 yield rank, True, Dataset.from_file(cache_file_name, info=info, split=shard.split)
             else:
                 yield rank, True, Dataset.from_buffer(buf_writer.getvalue(), info=info, split=shard.split)
+        elif batched and drop_last_batch and len(shard) > 0 and len(shard) < batch_size:
+            # Every batch was incomplete and therefore dropped, so the function was never called.
+            # Return an empty dataset (matching `IterableDataset.batch`/`Dataset.iter`) instead of
+            # silently passing through the original, unprocessed shard.
+            yield rank, True, shard.select([])
         else:
             yield rank, True, shard
 

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4060,7 +4060,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             # Every batch was incomplete and therefore dropped, so the function was never called.
             # Return an empty dataset (matching `IterableDataset.batch`/`Dataset.iter`) instead of
             # silently passing through the original, unprocessed shard.
-            yield rank, True, shard.select([])
+            if features is not None:
+                # An explicit `features` was requested for the output: honor it instead of falling
+                # back to the (pre-map) input schema, since the caller already knows the intended
+                # output schema and it can't be inferred from a function that was never called.
+                empty_shard = Dataset.from_dict({col: [] for col in features}, features=features, split=shard.split)
+            else:
+                empty_shard = shard.select([])
+                if remove_columns:
+                    empty_shard = empty_shard.remove_columns(
+                        [col for col in remove_columns if col in empty_shard.column_names]
+                    )
+            yield rank, True, empty_shard
         else:
             yield rank, True, shard
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1319,6 +1319,19 @@ class BaseDatasetTest(TestCase):
                     )
                     assert_arrow_metadata_are_synced_with_dataset_features(dset_test_with_indices)
 
+    def test_map_batched_drop_last_batch_smaller_than_batch_size(self, in_memory):
+        # Regression test: when `drop_last_batch=True` and the dataset has fewer rows than
+        # `batch_size`, every batch is incomplete, so the function is never called and the
+        # result should be an empty dataset (matching `IterableDataset.batch`/`Dataset.iter`),
+        # not the original, unprocessed dataset passed through unchanged.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                self.assertEqual(len(dset), 30)
+                with dset.map(
+                    lambda batch: batch, batched=True, batch_size=1000, drop_last_batch=True
+                ) as dset_test_batched:
+                    self.assertEqual(len(dset_test_batched), 0)
+
     def test_map_batched(self, in_memory):
         def map_batched(example):
             return {"filename_new": [x + "_extension" for x in example["filename"]]}


### PR DESCRIPTION
Fixes #8386

## Bug

When `drop_last_batch=True` and the dataset has fewer rows than `batch_size`, `Dataset.map(batched=True, ...)` was returning the **input dataset unchanged** instead of an empty dataset. Every batch is incomplete in this situation, so the mapped function is never invoked and `update_data` stays falsy; `_map_single` then fell through to `yield rank, True, shard`, silently passing the original, unprocessed rows straight through.

This disagreed with `IterableDataset.batch()` and `Dataset.iter()`, which both correctly yield zero rows when every batch is incomplete, and it also affected `Dataset.batch()` since it is implemented on top of `map(batched=True)`.

```python
from datasets import Dataset

ds = Dataset.from_dict({"a": [1, 2, 3]})

out = ds.map(lambda b: b, batched=True, batch_size=5, drop_last_batch=True)
print(len(out))  # 3 before the fix, expected 0

print(len(ds.batch(5, drop_last_batch=True)))  # 3 before the fix, expected 0
```

## Fix

In `Dataset._map_single`, when `batched=True`, `drop_last_batch=True`, and the shard has fewer rows than `batch_size` (so the function was never called and `update_data` is still falsy), return an empty dataset (`shard.select([])`) carrying the input schema instead of the untouched `shard`. This matches option (1) discussed in the issue, and aligns the eager `map`/`batch` behavior with the streaming `IterableDataset.batch`/`Dataset.iter` behavior.

## Test

Added `test_map_batched_drop_last_batch_smaller_than_batch_size` in `tests/test_arrow_dataset.py`, which fails on `main` (`AssertionError: 30 != 0`) and passes with this fix.