### PR TITLE
fix(types): expose PyTorch dataset compatibility

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -158,9 +158,16 @@ if TYPE_CHECKING:
     import polars as pl
     import pyspark
     import sqlalchemy
+    from torch.utils.data import Dataset as _TorchDatasetBase
 
     from .dataset_dict import DatasetDict
     from .iterable_dataset import IterableDataset
+else:
+
+    class _TorchDatasetBase:
+        def __class_getitem__(cls, item):
+            return cls
+
 
 logger = logging.get_logger(__name__)
 
@@ -715,7 +722,7 @@ class Column(Sequence_):
             return value == list(self)
 
 
-class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
+class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin, _TorchDatasetBase[Any]):
     """A Dataset backed by an Arrow table."""
 
     def __init__(

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -165,8 +165,20 @@ if TYPE_CHECKING:
 else:
 
     class _TorchDatasetBase:
+        """Runtime stand-in for :class:`torch.utils.data.Dataset`.
+
+        The class statement below uses ``_TorchDatasetBase[Any]`` as a base so type
+        checkers (which see the real torch class imported under ``TYPE_CHECKING``)
+        accept ``Dataset`` as a ``torch.utils.data.DataLoader`` input. At runtime the
+        base is dropped through PEP 560 ``__mro_entries__``, so ``Dataset.__mro__``
+        stays identical to main and no fake torch class leaks into introspection.
+        """
+
         def __class_getitem__(cls, item):
-            return cls
+            return cls()
+
+        def __mro_entries__(self, bases):
+            return ()
 
 
 logger = logging.get_logger(__name__)

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -93,8 +93,15 @@ if TYPE_CHECKING:
     import polars as pl
     import sqlalchemy
     import torch
+    from torch.utils.data import IterableDataset as _TorchIterableDatasetBase
 
     from .builder import Key as BuilderKey
+else:
+
+    class _TorchIterableDatasetBase:
+        def __class_getitem__(cls, item):
+            return cls
+
 
 logger = get_logger(__name__)
 
@@ -2500,7 +2507,7 @@ class IterableColumn:
         return IterableColumn(self, column_name)
 
 
-class IterableDataset(DatasetInfoMixin):
+class IterableDataset(DatasetInfoMixin, _TorchIterableDatasetBase[Any]):
     """A Dataset backed by an iterable."""
 
     def __init__(

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -99,8 +99,19 @@ if TYPE_CHECKING:
 else:
 
     class _TorchIterableDatasetBase:
+        """Runtime stand-in for :class:`torch.utils.data.IterableDataset`.
+
+        Only the type checker sees the real torch class (imported under
+        ``TYPE_CHECKING``); at runtime PEP 560 ``__mro_entries__`` drops the base so
+        ``IterableDataset.__bases__`` stays identical to main and
+        :func:`_maybe_add_torch_iterable_dataset_parent_class` keeps working.
+        """
+
         def __class_getitem__(cls, item):
-            return cls
+            return cls()
+
+        def __mro_entries__(self, bases):
+            return ()
 
 
 logger = get_logger(__name__)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -89,6 +89,13 @@ def test_import_datasets_does_not_import_torch():
     assert output.strip() == "False"
 
 
+def test_dataset_mro_has_no_fake_torch_bases():
+    # The torch-compatibility base is typing-only: it must not show up in the runtime
+    # __bases__/__mro__ (see review on #8457).
+    assert not any("Torch" in base.__name__ for base in Dataset.__bases__)
+    assert not any("Torch" in base.__name__ for base in IterableDataset.__bases__)
+
+
 def _normalize_batched_output(batch):
     def to_python(value):
         if isinstance(value, np.ndarray):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -6,6 +6,7 @@ import json
 import os
 import pickle
 import re
+import subprocess
 import sys
 import tempfile
 import time
@@ -78,6 +79,14 @@ class Unpicklable:
 
     def __getstate__(self):
         raise pickle.PicklingError()
+
+
+def test_import_datasets_does_not_import_torch():
+    output = subprocess.check_output(
+        [sys.executable, "-c", "import sys; import datasets; print('torch' in sys.modules)"],
+        text=True,
+    )
+    assert output.strip() == "False"
 
 
 def _normalize_batched_output(batch):


### PR DESCRIPTION
## What does this PR do?

Make `Dataset` and `IterableDataset` visible to static type checkers as compatible with PyTorch's dataset classes, so Pyright accepts both map-style and iterable datasets as `torch.utils.data.DataLoader` inputs, including `dataset.with_format(torch)`. This addresses the typing gap described in #7500.

The runtime behavior remains unchanged:

- `torch` is only imported under `TYPE_CHECKING` for the new bases; `import datasets` never imports torch.
- `Dataset` is not changed into a runtime subclass of `torch.utils.data.Dataset`.
- The existing runtime parent-class behavior for `IterableDataset` (via `_maybe_add_torch_iterable_dataset_parent_class`) is preserved.

## Runtime behavior / MRO notes

The torch base classes are typing-only. The base used in the class statement is a stand-in that, at runtime, resolves to *no base at all* through PEP 560 `__mro_entries__`. As a result:

- `Dataset.__mro__` and `Dataset.__bases__` are identical to `main`: no private shim class (and no torch class) ever appears in the runtime MRO, including for users who never touch torch.
- `IterableDataset.__bases__` stays exactly `(DatasetInfoMixin,)` until `_maybe_add_torch_iterable_dataset_parent_class` appends the real `torch.utils.data.IterableDataset` when torch is in use — the same bases `main` sees, so the `__bases__` mutation is unaffected and the shim never coexists with the real torch class.

## Testing

- `ruff check src/datasets/arrow_dataset.py src/datasets/iterable_dataset.py tests/test_arrow_dataset.py`
- `ruff format --check src/datasets/arrow_dataset.py src/datasets/iterable_dataset.py tests/test_arrow_dataset.py`
- `git diff --check`
- Focused import regression: `import datasets` does not import torch (test added in this PR)
- New regression test asserting no torch-named base appears in the runtime `__bases__`
- `tests/test_arrow_dataset.py -k "pickle or format"`: 36 passed, 17 skipped (matches the review's verification)
- Pyright 1.1.411 with a minimal PyTorch type stub covering `Dataset.__getitem__`, `IterableDataset`, and `DataLoader`: 0 errors

Fixes #7500
