### PR TITLE
Fix Audio encoding for path rows with null arrays

### DIFF
--- a/src/datasets/features/audio.py
+++ b/src/datasets/features/audio.py
@@ -126,7 +126,7 @@ class Audio:
             return {"bytes": value, "path": None}
         elif AudioDecoder is not None and isinstance(value, AudioDecoder):
             return encode_torchcodec_audio(value)
-        elif "array" in value:
+        elif value.get("array") is not None:
             # convert the audio array to wav bytes
             buffer = BytesIO()
             AudioEncoder(

--- a/tests/features/test_audio.py
+++ b/tests/features/test_audio.py
@@ -72,6 +72,7 @@ def test_audio_feature_type_to_arrow():
         lambda audio_path: {"path": None, "bytes": open(audio_path, "rb").read()},
         lambda audio_path: {"bytes": open(audio_path, "rb").read()},
         lambda audio_path: {"array": np.array([0.1, 0.2, 0.3]), "sampling_rate": 16_000},
+        lambda audio_path: {"path": audio_path, "array": None},
     ],
 )
 def test_audio_feature_encode_example(shared_datadir, build_example):
@@ -513,6 +514,7 @@ def test_resampling_after_loading_dataset_with_audio_feature_mp3(shared_datadir)
         lambda audio_path: {"audio": [{"path": audio_path, "bytes": open(audio_path, "rb").read()}]},
         lambda audio_path: {"audio": [{"path": None, "bytes": open(audio_path, "rb").read()}]},
         lambda audio_path: {"audio": [{"bytes": open(audio_path, "rb").read()}]},
+        lambda audio_path: {"audio": [{"path": audio_path, "array": None}]},
     ],
 )
 def test_dataset_cast_to_audio_features(shared_datadir, build_data):


### PR DESCRIPTION
## Summary

- treat a null `array` value as absent in `Audio.encode_example()`, so path-backed rows reach the existing path branch
- cover the null-array case in the existing `encode_example` and `cast_to_audio_features` parametrize lists

## Problem

Casting a struct column to `Audio()` fails when a row is path-backed:

```python
from datasets import Dataset, Audio

Dataset.from_dict({"audio": [{"path": path, "array": None}]}).cast_column("audio", Audio())
# AttributeError: 'NoneType' object has no attribute 'astype'
```

`Audio.cast_storage()` sends every row of a struct column through `encode_example()` when the struct type contains an `array` field, so a path-backed row arrives as `{"path": ..., "array": None}`.

`encode_example()` then selects its branch on key presence rather than on whether the value is usable:

```python
elif "array" in value:
    AudioEncoder(torch.from_numpy(value["array"].astype(np.float32)), ...)
elif value.get("path") is not None and os.path.isfile(value["path"]):
    return {"bytes": None, "path": value.get("path")}
```

`"array" in value` is true even when the array is `None`, so the row never reaches the path branch below it and casting raises `AttributeError`.

Checking that the array value is non-null lets the existing path/bytes branches handle the row. This matches how `bytes` already behaves — `{"path": ..., "bytes": None}` is accepted today and covered by both parametrize lists.

## Tests

The null-array case was added to the two existing parametrize lists, next to the equivalent `bytes` cases:

- `test_audio_feature_encode_example` — `{"path": audio_path, "array": None}`
- `test_dataset_cast_to_audio_features` — `{"audio": [{"path": audio_path, "array": None}]}`

Both fail with the `AttributeError` above without the one-line change and pass with it.

## Verification

- `pytest tests/features/test_audio.py -m "not integration"` — 57 passed, 1 deselected
- `ruff check --no-cache tests src benchmarks utils setup.py`
- `ruff format --check --no-cache tests src benchmarks utils setup.py`
- `git diff --check origin/main...HEAD`

The excluded integration test requires network access to the Hugging Face Hub.
