### PR TITLE
Fix info from data_dir/data_files or malformed yaml

### DIFF
--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -316,7 +316,10 @@ class DatasetInfo:
         if yaml_data.get("features") is not None:
             yaml_data["features"] = Features._from_yaml_list(yaml_data["features"])
         if yaml_data.get("splits") is not None:
-            yaml_data["splits"] = SplitDict._from_yaml_list(yaml_data["splits"])
+            try:
+                yaml_data["splits"] = SplitDict._from_yaml_list(yaml_data["splits"])
+            except ValueError as e:
+                logger.warning(f"Ignoring part of dataset_info from the dataset card: {e}")
         field_names = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in yaml_data.items() if k in field_names})
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1337,7 +1337,11 @@ def load_dataset_builder(
         "config_name", name or dataset_module.builder_configs_parameters.default_config_name
     )
     dataset_name = builder_kwargs.pop("dataset_name", None)
-    info = dataset_module.dataset_infos.get(config_name) if dataset_module.dataset_infos else None
+    info = (
+        dataset_module.dataset_infos.get(config_name)
+        if dataset_module.dataset_infos and not data_dir and not data_files
+        else None
+    )
 
     if (
         path in _PACKAGED_DATASETS_MODULES

--- a/src/datasets/splits.py
+++ b/src/datasets/splits.py
@@ -607,6 +607,16 @@ class SplitDict(dict[str, SplitInfo]):
 
     @classmethod
     def _from_yaml_list(cls, yaml_data: list) -> "SplitDict":
+        if not all(
+            isinstance(split_info, dict)
+            and "name" in split_info
+            and "num_examples" in split_info
+            and "num_bytes" in split_info
+            for split_info in yaml_data
+        ):
+            raise ValueError(
+                "The `splits` field in YAML is malformed or missing the name/num_examples/num_bytes fields"
+            )
         return cls.from_split_dict(yaml_data)
 
 


### PR DESCRIPTION
- don't reuse the info from a config if data_files or data_dir are passed
- ignore malformed split info in yaml

cc @anton-l 