### PR TITLE
Make `PandasArrayExtensionDtype._metadata` a tuple

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -854,7 +854,10 @@ class ArrayExtensionArray(pa.ExtensionArray):
 
 
 class PandasArrayExtensionDtype(PandasExtensionDtype):
-    _metadata = "value_type"
+    # Pandas iterates over ``_metadata`` to compare and hash dtypes, so it has to be a
+    # tuple of attribute names. A plain string is iterated character by character, which
+    # makes ``__eq__`` and ``__hash__`` look up attributes named "v", "a", "l", ...
+    _metadata = ("value_type",)
 
     def __init__(self, value_type: Union["PandasArrayExtensionDtype", np.dtype]):
         self._value_type = value_type

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -368,6 +368,30 @@ def test_table_to_pandas(dtype, dummy_value):
 
 
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+def test_table_to_pandas_dtype_is_comparable_and_hashable(dtype, dummy_value):
+    # Pandas iterates over `PandasArrayExtensionDtype._metadata` to compare and hash dtypes,
+    # so both raised `AttributeError: ... has no attribute 'v'` back when it was the string
+    # "value_type" rather than a tuple of attribute names.
+    features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    df = dataset._data.to_pandas()
+    assert isinstance(df.foo.dtype, PandasArrayExtensionDtype)
+    assert df.foo.dtype == df.foo.dtype
+    assert hash(df.foo.dtype) == hash(df.foo.dtype)
+
+
+def test_table_to_pandas_boolean_mask():
+    # Selecting rows compares the block dtype against itself, which used to raise.
+    features = datasets.Features({"foo": datasets.Array2D(dtype="float64", shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[0.0] * 2] * 2, [[1.0] * 2] * 2]}, features=features)
+    df = dataset._data.to_pandas()
+
+    masked = df[pd.Series([False, True])]
+    assert len(masked) == 1
+    np.testing.assert_equal(masked.foo.to_numpy(), np.array([[[1.0] * 2] * 2], dtype=np.dtype("float64")))
+
+
+@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
 def test_array_xd_numpy_arrow_extractor(dtype, dummy_value):
     features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
     dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)


### PR DESCRIPTION
Fixes #8375.

## The bug

`PandasArrayExtensionDtype._metadata` was the plain string `"value_type"`. Pandas expects a **tuple of attribute names** and iterates over it in `ExtensionDtype.__eq__` and `ExtensionDtype.__hash__`:

```python
all(getattr(self, attr) == getattr(other, attr) for attr in self._metadata)
```

A string iterates character by character, so pandas looks up attributes named `v`, `a`, `l`, `u`, `e`, ... and dies on the first one:

```
AttributeError: 'PandasArrayExtensionDtype' object has no attribute 'v'
```

## Impact

The issue reports it for `df[mask]`, but the same root cause breaks dtype equality and hashing directly — every comparison of two `PandasArrayExtensionDtype` instances:

```python
dtype = df["values"].dtype   # array[float64], from an Array2D column
dtype == dtype               # AttributeError
hash(dtype)                  # AttributeError
df[df["episode_index"].isin([0])]   # AttributeError
```

Row selection hits it because pandas compares the block dtype against itself in `Block.take_nd` (`if new_values.dtype != self.dtype`). It is reachable from any `Array2D`/`Array3D`/`Array4D`/`Array5D` column that reaches pandas, including `pd.read_parquet` on a file written by `datasets`.

## The fix

One character class of change — make `_metadata` a tuple:

```diff
-    _metadata = "value_type"
+    _metadata = ("value_type",)
```

## Tests

Added to `tests/features/test_array_xd.py`:

- `test_table_to_pandas_dtype_is_comparable_and_hashable` — parametrized over `int32`/`bool`/`float64`, covers `==` and `hash()`.
- `test_table_to_pandas_boolean_mask` — covers the row-selection symptom from the issue.

All four cases fail on `main` with the `AttributeError` and pass with the fix. `tests/features/`, `tests/test_formatting.py` and `tests/test_table.py` are otherwise unchanged (`ruff check` and `ruff format --check` clean).

## One thing I left out

While parametrizing the mask test I hit a **separate, pre-existing** bug, which is why that test only covers `float64`: `PandasArrayExtensionArray.take` coerces `fill_value` up front

```python
fill_value = self.dtype.na_value if fill_value is None else np.asarray(fill_value, dtype=self.dtype.value_type)
```

even when `indices` contains no `-1` and nothing will be filled. Pandas passes `fill_value=nan` on an ordinary boolean mask, so integer-valued arrays raise `ValueError: cannot convert float NaN to integer` on `df[mask]`.

It is masked by this bug today (execution never gets that far), so it becomes reachable once this lands. I did not fold it in because the right NA semantics for an integer array is a design question rather than a typo — happy to open a follow-up issue, or add the fix here if you would prefer it in one go.
