### PR TITLE
Raise a clear error for a deeply nested mesh file

### DIFF
--- a/src/datasets/features/mesh.py
+++ b/src/datasets/features/mesh.py
@@ -124,7 +124,7 @@ class Mesh:
                 file_type = _infer_mesh_file_type(path)
                 if file_type is None:
                     raise ValueError("A mesh path should have a .glb, .ply, or .stl extension.")
-                return trimesh.load(path, file_type=file_type)
+                return _load_mesh(trimesh, path, file_type=file_type)
             source_url = path.split("::")[-1]
             pattern = (
                 config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
@@ -141,7 +141,7 @@ class Mesh:
                 "Decoding mesh bytes requires a 'path' value with a .glb, .ply, or .stl extension "
                 "to infer the mesh file type."
             )
-        return trimesh.load(BytesIO(bytes_), file_type=file_type)
+        return _load_mesh(trimesh, BytesIO(bytes_), file_type=file_type)
 
     def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
         """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""
@@ -283,6 +283,22 @@ def _infer_mesh_file_type(path: Optional[str]) -> Optional[str]:
     path_without_query = path_without_archive.split("?", 1)[0]
     extension = os.path.splitext(path_without_query)[1].lower().lstrip(".")
     return extension if extension in supported_file_types else None
+
+
+def _load_mesh(trimesh: Any, source: Any, file_type: str) -> Union["trimesh.Trimesh", "trimesh.Scene"]:
+    """Load a mesh with `trimesh`, turning a stack overflow into a regular error.
+
+    A GLB file can embed an arbitrarily nested JSON chunk, and parsing it exhausts the
+    interpreter stack rather than failing on the file. `RecursionError` also leaves very
+    little stack to run the handler in, so keep the body of the `except` minimal.
+    """
+    try:
+        return trimesh.load(source, file_type=file_type)
+    except RecursionError:
+        raise ValueError(
+            f"Could not decode the {file_type} mesh because it is too deeply nested. "
+            "This usually means the file is corrupted or crafted to exhaust the interpreter stack."
+        ) from None
 
 
 def encode_trimesh_mesh(mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> dict[str, Optional[bytes | str]]:

--- a/tests/features/test_mesh.py
+++ b/tests/features/test_mesh.py
@@ -1,3 +1,4 @@
+import struct
 from pathlib import Path
 
 import pyarrow as pa
@@ -140,6 +141,34 @@ def test_mesh_feature_encode_trimesh_object():
     assert encoded_example["bytes"] is not None
     decoded_example = Mesh().decode_example(encoded_example)
     assert isinstance(decoded_example, trimesh.Scene)
+
+
+def _deeply_nested_glb_bytes(depth: int = 5000) -> bytes:
+    """A structurally valid GLB whose JSON chunk is nested `depth` levels deep."""
+    json_chunk = b'{"a":' * depth + b"1" + b"}" * depth
+    return (
+        b"glTF"
+        + struct.pack("<I", 2)  # version
+        + struct.pack("<I", 12 + 8 + len(json_chunk))  # total length
+        + struct.pack("<I", len(json_chunk))  # chunk length
+        + struct.pack("<I", 0x4E4F534A)  # chunk type: JSON
+        + json_chunk
+    )
+
+
+@require_trimesh
+def test_mesh_decode_deeply_nested_glb_from_bytes():
+    encoded_example = {"bytes": _deeply_nested_glb_bytes(), "path": "deeply_nested.glb"}
+    with pytest.raises(ValueError, match="too deeply nested"):
+        Mesh().decode_example(encoded_example)
+
+
+@require_trimesh
+def test_mesh_decode_deeply_nested_glb_from_path(tmp_path):
+    mesh_path = tmp_path / "deeply_nested.glb"
+    mesh_path.write_bytes(_deeply_nested_glb_bytes())
+    with pytest.raises(ValueError, match="too deeply nested"):
+        Mesh().decode_example({"bytes": None, "path": str(mesh_path)})
 
 
 def test_require_decoding():


### PR DESCRIPTION
Fixes #8246.

## The bug

A GLB file carries its scene description as an embedded JSON chunk, and that JSON can be nested arbitrarily deeply. Parsing it exhausts the interpreter stack, so `Mesh.decode_example` propagates a bare

```
RecursionError: maximum recursion depth exceeded while decoding a JSON object from a unicode string
```

`RecursionError` is not what a caller reading a dataset is prepared to handle, and the message says nothing about which file caused it. Every other undecodable case in this method raises `ValueError` (bad extension, missing `path`/`bytes`), so this one is inconsistent as well as unhelpful.

Reproduced on `main` with the script from the issue:

```
RecursionError (unhandled): maximum recursion depth exceeded while decoding a JSON object from a unicode string
```

## The fix

Both `trimesh.load` call sites — the local-path branch and the bytes branch — now go through a small `_load_mesh` helper that converts `RecursionError` into `ValueError`:

```
ValueError: Could not decode the glb mesh because it is too deeply nested. This usually
means the file is corrupted or crafted to exhaust the interpreter stack.
```

The `except` body is deliberately minimal: a `RecursionError` is raised with the stack already at its limit, so there is very little headroom to run the handler in. `raise ... from None` keeps the traceback readable rather than chaining thousands of frames.

## Tests

Two tests in `tests/features/test_mesh.py`, one per call site, sharing a `_deeply_nested_glb_bytes` helper that builds a structurally valid GLB with a 5000-level JSON chunk:

- `test_mesh_decode_deeply_nested_glb_from_bytes`
- `test_mesh_decode_deeply_nested_glb_from_path`

Both fail on `main` with `RecursionError` and pass with the fix. Full `tests/features/test_mesh.py` is green (20 passed), `ruff check` and `ruff format --check` clean.

## Note on scope

This makes the failure reportable, it does not make the file loadable — a mesh nested past the recursion limit is still rejected. That seems right: the nesting is either corruption or a deliberate attempt to exhaust the stack, and neither is something to recover a mesh from. Raising the recursion limit to parse it would just move the crash.
