### PR TITLE
Implement `construct_from_string` on `PandasArrayExtensionDtype`

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -870,6 +870,23 @@ class PandasArrayExtensionDtype(PandasExtensionDtype):
     def construct_array_type(cls):
         return PandasArrayExtensionArray
 
+    @classmethod
+    def construct_from_string(cls, string: str) -> "PandasArrayExtensionDtype":
+        # `name` is a property here because it depends on `value_type`, so the base
+        # implementation -- which assumes a class-level string -- asserts on it. Pandas
+        # calls this for every `dtype == "some string"` comparison, and expects a
+        # `TypeError` when the string is not one of ours.
+        if not isinstance(string, str):
+            raise TypeError(f"'construct_from_string' expects a string, got {type(string)}")
+        match = re.fullmatch(r"array\[(.+)\]", string)
+        if match is None:
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
+        try:
+            value_type = np.dtype(match.group(1))
+        except TypeError:
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'") from None
+        return cls(value_type)
+
     @property
     def type(self) -> type:
         return np.ndarray

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from absl.testing import parameterized
+from pandas.api.types import is_string_dtype
 
 import datasets
 from datasets.arrow_writer import ArrowWriter
@@ -365,6 +366,35 @@ def test_table_to_pandas(dtype, dummy_value):
     assert isinstance(df.foo.dtype, PandasArrayExtensionDtype)
     arr = df.foo.to_numpy()
     np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
+
+
+@pytest.mark.parametrize("dtype", ["int32", "bool", "float64"])
+def test_pandas_array_extension_dtype_construct_from_string(dtype):
+    constructed = PandasArrayExtensionDtype.construct_from_string(f"array[{dtype}]")
+    assert isinstance(constructed, PandasArrayExtensionDtype)
+    assert constructed.value_type == np.dtype(dtype)
+
+
+@pytest.mark.parametrize("string", ["string", "int64", "array[]", "array[not_a_dtype]", "not_an_array[int32]"])
+def test_pandas_array_extension_dtype_construct_from_string_rejects(string):
+    # Pandas relies on `TypeError` to mean "not my dtype" when comparing a dtype to a string.
+    with pytest.raises(TypeError):
+        PandasArrayExtensionDtype.construct_from_string(string)
+
+
+@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+def test_table_to_pandas_dtype_compares_to_string(dtype, dummy_value):
+    # Pandas compares dtypes against plain strings throughout its internals (`is_string_dtype`
+    # and friends). Without `construct_from_string` the base implementation asserts on
+    # `cls.name`, which is a property here, so every such comparison raised
+    # `AssertionError: (PandasArrayExtensionDtype, <class 'property'>)`.
+    features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    df = dataset._data.to_pandas()
+
+    assert (df.foo.dtype == "string") is False
+    assert is_string_dtype(df.foo.dtype) is False
+    assert df.astype(object).shape == (1, 1)
 
 
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])


### PR DESCRIPTION
Fixes #8467.

## The bug

`PandasArrayExtensionDtype` never implements `construct_from_string`, so it inherits the base `ExtensionDtype` version:

```python
@classmethod
def construct_from_string(cls, string):
    assert isinstance(cls.name, str), (cls, type(cls.name))
```

`name` is an instance `@property` here, because it depends on `value_type` (`array[float64]`). On the class it is a `property` object, so the assertion fires:

```
AssertionError: (<class 'datasets.features.features.PandasArrayExtensionDtype'>, <class 'property'>)
```

`ExtensionDtype.__eq__` routes every `dtype == "some string"` through `construct_from_string`, and pandas compares dtypes against strings throughout its internals. On `main`:

```
FAIL | dtype == 'string'          | AssertionError: (PandasArrayExtensionDtype, <class 'property'>)
FAIL | is_string_dtype(dtype)     | AssertionError: (PandasArrayExtensionDtype, <class 'property'>)
FAIL | df.astype(object)          | AssertionError: (PandasArrayExtensionDtype, <class 'property'>)
FAIL | df.foo.astype(object)      | AssertionError: (PandasArrayExtensionDtype, <class 'property'>)
```

`df.astype(object)` gets there via `astype_is_view` → `is_string_dtype` → `dtype == "string"`.

## The fix

Implement `construct_from_string`: parse `array[<dtype>]` back into a `PandasArrayExtensionDtype`, and raise `TypeError` for anything else — which is how pandas spells "not my dtype", and what `__eq__` catches to return `False`.

## Tests

In `tests/features/test_array_xd.py`:

- `test_pandas_array_extension_dtype_construct_from_string` — `array[int32]` / `array[bool]` / `array[float64]` round-trip to the right `value_type`.
- `test_pandas_array_extension_dtype_construct_from_string_rejects` — `TypeError` for `string`, `int64`, `array[]`, `array[not_a_dtype]`, `not_an_array[int32]`.
- `test_table_to_pandas_dtype_compares_to_string` — the user-facing symptom: `dtype == "string"` is `False`, `is_string_dtype` is `False`, `df.astype(object)` works.

11 of these fail on `main` and pass here; full `tests/features/test_array_xd.py` is green (114 passed). `ruff check` / `ruff format --check` clean.

## Interaction with #8464

Independent fixes, but they compound, so flagging it rather than letting CI surprise you. With **only** this change, pandas gets further and then trips the `_metadata` bug from #8375:

```
ok   | dtype == 'string'                            | False
FAIL | dtype == 'array[float64]'                    | AttributeError: ... has no attribute 'v'
FAIL | df.convert_dtypes()                          | AttributeError: ... has no attribute 'v'
FAIL | df.melt()                                    | AttributeError: ... has no attribute 'v'
FAIL | pd.concat([df, df.astype({'n':'float64'})])  | AttributeError: ... has no attribute 'v'
```

With **both** this and #8464 applied, all of those pass. This PR is based on `main` and does not include the `_metadata` change, so the two can be reviewed and merged in either order — the tests here are written to not depend on #8464.

The one thing still failing with both applied is `df.replace(1.0, 2.0)`, which hits the deliberate `NotImplementedError("Invalid type to compare to: <class 'float'>")` in `PandasArrayExtensionArray.__eq__`. That looks intentional, so I left it alone.

Tested on Windows 11 / Python 3.11.9 / pandas 3.0.5 / pyarrow 25.0.1 / numpy 2.4.6.
