### PR TITLE
Keep the dtype of an empty column in the numpy formatter

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -212,6 +212,16 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
                             return np.asarray(array, dtype=object)
                         return np.array(array, copy=False, dtype=object)
                     break
+        if len(array) == 0:
+            # The conversions above go through Python lists, which drops the arrow type.
+            # `np.asarray([])` then defaults to float64 and the tensor formatters coerce
+            # that to float32, so an empty column would lose the dtype that the very same
+            # column keeps as soon as it holds a single row.
+            try:
+                empty_dtype = np.dtype(pa_array.type.to_pandas_dtype())
+            except (NotImplementedError, TypeError):
+                empty_dtype = object
+            return np.asarray(array, dtype=empty_dtype)
         if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             return np.asarray(array)
         else:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1042,6 +1042,33 @@ def test_torch_formatter_sets_default_dtypes(cast_schema, arrow_table):
     torch.testing.assert_close(batch["col_float"], torch.tensor(list_float, dtype=torch.float32))
 
 
+@pytest.mark.parametrize(
+    "pa_type, expected_dtype",
+    [
+        (pa.int64(), np.dtype("int64")),
+        (pa.int32(), np.dtype("int32")),
+        (pa.float64(), np.dtype("float64")),
+        (pa.bool_(), np.dtype("bool")),
+        (pa.timestamp("ns"), np.dtype("datetime64[ns]")),
+    ],
+)
+def test_numpy_arrow_extractor_keeps_dtype_of_empty_column(pa_type, expected_dtype):
+    # An empty column used to come back as float64 -- and then float32 through the tensor
+    # formatters -- because the arrow type is dropped by the intermediate Python list.
+    pa_table = pa.table({"col": pa.array([], type=pa_type)})
+    extracted = NumpyArrowExtractor().extract_column(pa_table)
+    assert len(extracted) == 0
+    assert extracted.dtype == expected_dtype
+
+
+def test_numpy_arrow_extractor_empty_column_matches_non_empty():
+    pa_table = pa.table({"col": pa.array([1, 2, 3], type=pa.int64())})
+    non_empty = NumpyArrowExtractor().extract_column(pa_table)
+    empty = NumpyArrowExtractor().extract_column(pa_table.slice(0, 0))
+    assert len(empty) == 0
+    assert empty.dtype == non_empty.dtype
+
+
 def test_iterable_dataset_of_arrays_format_to_arrow(any_arrays_dataset: IterableDataset):
     formatted = any_arrays_dataset.with_format("arrow")
     assert all(isinstance(example, pa.Table) for example in formatted)


### PR DESCRIPTION
Fixes #8469.

## The bug

Under `numpy` format, a column holding zero rows comes back as `float32` regardless of its declared dtype — while the same column keeps its dtype as soon as it holds one row, and `pandas`/`arrow` keep it either way.

```python
feats = Features({"a": Value("int64")})
ds = Dataset.from_dict({"a": [1, 2, 3]}, features=feats).with_format("numpy")

ds.filter(lambda x: x["a"] > 1)[:]["a"].dtype    # int64
ds.filter(lambda x: x["a"] > 99)[:]["a"].dtype   # float32
```

| declared | non-empty | empty (before) | empty (after) |
|---|---|---|---|
| `int64` | `int64` | **`float32`** | `int64` |
| `int32` | `int64` | **`float32`** | `int32` |
| `bool` | `bool` | **`float32`** | `bool` |
| `timestamp[ns]` | `datetime64[ns]` | **`float32`** | `datetime64[ns]` |

It is easy to hit — any `filter` that matches nothing, or `select([])` — and it silently promotes integers in a pipeline that concatenates per-batch results:

```python
np.concatenate([empty_result, int64_result]).dtype   # float64
```

## Root cause

`_arrow_array_to_numpy` converts through a Python list:

```python
array: list = pa_array.to_numpy(zero_copy_only=zero_copy_only).tolist()
```

`.tolist()` drops the arrow type. Numpy re-infers it for a non-empty list, but `np.asarray([])` falls back to `float64`, and `NumpyFormatter._tensorize` then applies its float default on top, turning that into `float32`. Traced on an empty `int64` column:

```
arrow schema      : a: int64
arrow col to_numpy: int64      <- still correct
extract_column    : float64    <- lost by .tolist()
formatted         : float32
```

## The fix

When the column is empty, build the array from the arrow type rather than letting numpy guess, falling back to `object` for types numpy has no equivalent for (`struct`, which raises `NotImplementedError` from `to_pandas_dtype()`).

Only the empty branch is touched, so the non-empty path — including the formatter's documented `int32 -> int64` / `float64 -> float32` defaults — is unchanged.

## Tests

In `tests/test_formatting.py`:

- `test_numpy_arrow_extractor_keeps_dtype_of_empty_column` — parametrized over `int64`, `int32`, `float64`, `bool`, `timestamp[ns]`.
- `test_numpy_arrow_extractor_empty_column_matches_non_empty` — the invariant that actually matters: same column, zero rows vs three rows, same dtype.

5 of the 6 fail on `main` and all pass here (the `float64` case passes on `main` too, since that is the accidental default it already lands on).

`tests/test_formatting.py` 30 passed / 30 skipped, `tests/features/` 350 passed, and `tests/test_arrow_dataset.py -k "format or filter or select or empty or numpy"` 48 passed / 17 skipped. `ruff check` and `ruff format --check` clean.

## One case I did not make match

An empty `string` column now yields `dtype=object` where a non-empty one yields `<U1`. `object` is what the pandas formatter gives for strings and it holds strings correctly, so it seemed the right target; making it `<U...` would mean inventing an itemsize for zero rows. Happy to change it if you would rather it matched `<U0`.

Tested on Windows 11 / Python 3.11.9 / pandas 3.0.5 / pyarrow 25.0.1 / numpy 2.4.6.
