### PR TITLE
Stop `Dataset.sort()` emitting a pyarrow FutureWarning

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4819,7 +4819,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             (col, "ascending" if not col_reverse else "descending") for col, col_reverse in zip(column_names, reverse)
         ]
 
-        indices = pc.sort_indices(sort_table, sort_keys=sort_keys, null_placement=null_placement)
+        if config.PYARROW_VERSION.major >= 25:
+            # pyarrow 25 deprecated the top-level `null_placement` in favour of a per-key one.
+            # The three-tuple form does not exist before 25, so both spellings are needed to
+            # cover the supported range without a warning.
+            indices = pc.sort_indices(sort_table, sort_keys=[(col, order, null_placement) for col, order in sort_keys])
+        else:
+            indices = pc.sort_indices(sort_table, sort_keys=sort_keys, null_placement=null_placement)
 
         return self.select(
             indices=indices,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -9,6 +9,7 @@ import re
 import sys
 import tempfile
 import time
+import warnings
 from functools import partial
 from pathlib import Path
 from unittest import TestCase
@@ -3657,6 +3658,20 @@ def test_sort_with_none(null_placement):
         assert dataset["col_1"] == [None, None, "item_1", "item_2", "item_3", "item_4"]
     else:
         assert dataset["col_1"] == ["item_1", "item_2", "item_3", "item_4", None, None]
+
+
+@pytest.mark.parametrize("null_placement", ["first", "last"])
+def test_sort_does_not_warn(null_placement):
+    # pyarrow 25 deprecated the top-level `null_placement` of `sort_indices` in favour of a
+    # per-key one, so every `sort()` call emitted a FutureWarning.
+    dataset = Dataset.from_dict({"col_1": ["item_2", None, "item_1"]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        sorted_dataset = dataset.sort("col_1", null_placement=null_placement)
+    if null_placement == "first":
+        assert sorted_dataset["col_1"] == [None, "item_1", "item_2"]
+    else:
+        assert sorted_dataset["col_1"] == ["item_1", "item_2", None]
 
 
 def test_update_metadata_with_features(dataset_dict):


### PR DESCRIPTION
## The bug

Every `Dataset.sort()` call emits a pyarrow `FutureWarning` on pyarrow >= 25:

```
FutureWarning: Specifying null_placement in SortOptions is deprecated as of 25.0.0.
Specify null_placement per sort_key instead.
```

It comes from `Dataset.sort` itself, not from user code:

```python
indices = pc.sort_indices(sort_table, sort_keys=sort_keys, null_placement=null_placement)
```

so there is no way for a caller to avoid it, and it fires once per sort.

## Why it is not a one-line swap

The obvious fix — move `null_placement` into the sort key — does not work on the versions `setup.py` still supports (`pyarrow>=21.0.0`). The three-tuple `(name, order, null_placement)` form simply does not exist before 25.

I checked each version in a clean venv:

| pyarrow | `null_placement=` (current) | `(name, order, null_placement)` |
|---|---|---|
| 21.0.0 | ok | `ValueError: too many values to unpack (expected 2)` |
| 24.0.0 | ok | `ValueError: too many values to unpack (expected 2)` |
| 25.0.0 | **FutureWarning** | ok |

So no single spelling is warning-free across the supported range, and switching unconditionally would break `datasets` on pyarrow 21–24 outright — a hard `ValueError` in place of a warning.

## The fix

Branch on `config.PYARROW_VERSION.major >= 25` and use the per-key form only where it exists.

Behaviour is unchanged on both sides. Verified `at_end`, `at_start`, `reverse=True` and multi-column sorts give identical results, with `-W error::FutureWarning`:

```
sort at_end   : [1, 3, None]
sort at_start : [None, 1, 3]
sort reverse  : [3, 1, None]
multi-col     : [9, 1, 2]
no FutureWarning raised
```

## Tests

`test_sort_does_not_warn`, parametrized over `null_placement="first"/"last"`, turns `FutureWarning` into an error around the `sort()` call and then asserts the ordering is still right — so it pins the fix and the behaviour together. Both cases fail on `main` and pass here.

`tests/test_arrow_dataset.py -k sort`: 6 passed. `ruff check` / `ruff format --check` clean.

## Note

The version guard is only needed while `pyarrow<25` is supported. Whenever the floor in `setup.py` moves to 25, the `else` branch and the comment can go and the call collapses to the per-key form.

Tested on Windows 11 / Python 3.11.9, against pyarrow 21.0.0, 24.0.0 and 25.0.1.
