### PR TITLE
Fix negative percent split boundary anchoring to the start when it rounds to 0

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -444,9 +444,12 @@ def _rel_to_abs_instr(rel_instr, name2len):
     else:
         from_ = 0 if from_ is None else from_
         to = num_examples if to is None else to
-    if from_ < 0:
+    # Use the sign of the boundary as written in the spec to decide whether it is relative
+    # to the end: a negative percent boundary can round to 0 (e.g. -1% of 30 examples),
+    # in which case the sign of the rounded value is lost.
+    if rel_instr.from_ is not None and rel_instr.from_ < 0:
         from_ = max(num_examples + from_, 0)
-    if to < 0:
+    if rel_instr.to is not None and rel_instr.to < 0:
         to = max(num_examples + to, 0)
     from_ = min(from_, num_examples)
     to = min(to, num_examples)

--- a/tests/test_arrow_reader.py
+++ b/tests/test_arrow_reader.py
@@ -158,6 +158,22 @@ def test_read_instruction_spec():
     assert ReadInstruction.from_spec(spec_train_test_pct_rounding).to_spec() == spec_train_test_pct_rounding
 
 
+@pytest.mark.parametrize(
+    "spec, expected_from, expected_to",
+    [
+        ("train[-1%:]", 30, 30),  # -1% of 30 examples rounds to 0: must match train[99%:]
+        ("train[99%:]", 30, 30),
+        ("train[:-1%]", 0, 30),  # must match train[:99%]
+        ("train[:99%]", 0, 30),
+        ("train[-5%:]", 28, 30),  # boundary that doesn't round to 0 is unaffected
+        ("train[:-5%]", 0, 28),
+    ],
+)
+def test_to_absolute_negative_pct_boundary_rounding_to_zero(spec, expected_from, expected_to):
+    abs_instr = ReadInstruction.from_spec(spec).to_absolute({"train": 30})[0]
+    assert (abs_instr.from_, abs_instr.to) == (expected_from, expected_to)
+
+
 def test_make_file_instructions_basic():
     name = "dummy"
     split_infos = [SplitInfo(name="train", num_examples=100)]
@@ -191,10 +207,14 @@ def test_make_file_instructions_basic():
         ("train", "train[:200]", 100, (0, 100)),
         ("train", "train[:-200]", 100, None),
         ("train", "train[-200:]", 100, (0, 100)),
+        ("train", "train[-1%:]", 30, None),
+        ("train", "train[:-1%]", 30, (0, 30)),
         ("train", "train[-20%:]", [10] * 10, (80, 100)),
         ("train", "train[:200]", [10] * 10, (0, 100)),
         ("train", "train[:-200]", [10] * 10, None),
         ("train", "train[-200:]", [10] * 10, (0, 100)),
+        ("train", "train[-1%:]", [10] * 3, None),
+        ("train", "train[:-1%]", [10] * 3, (0, 30)),
     ],
 )
 def test_make_file_instructions(split_name, instruction, shard_lengths, read_range):


### PR DESCRIPTION
Fixes #8473.

### What this fixes

With the default `closest` rounding, a negative percent split boundary whose absolute value rounds to 0 loses its sign, so "relative to the end" silently becomes "relative to the start":

```python
# on a 30-example split
train[-1%:]   -> (0, 30)   all 30 rows, while train[99%:] correctly gives (30, 30)
train[:-1%]   -> (0, 0)    ValueError: Instruction "train[:-1%]" corresponds to no data!,
                           while train[:99%] correctly gives (0, 30)
```

The docs define `test[:-5%]` as "first 95% of test" (`ReadInstruction.from_spec` docstring) and use `train[-80%:]` for "last 80%" (loading.mdx), so both spellings of the same boundary should agree. The worst case is `train[-X%:]` silently returning 100% of the data.

### Root cause

`_rel_to_abs_instr` first rounds the boundary (`_pct_to_abs_closest(-1, 30) == int(round(-0.3)) == 0`) and then decides end-relativity from the sign of the *rounded* value (`if from_ < 0:`). When the rounded value is exactly 0, the sign is gone and the boundary anchors to the start. This triggers whenever `round(|pct| * n / 100) == 0`.

### Fix

Decide end-relativity from the sign of the boundary as written in the spec (`rel_instr.from_ < 0` / `rel_instr.to < 0`, with `None` guards) instead of the rounded value. This is equivalent for every other input:

- percent boundaries: rounding preserves the sign except at 0 (negative pct rounds to ≤ 0, positive to ≥ 0), and at 0 both `max(num_examples + 0, 0) == num_examples` (from an original negative) and the untouched 0 (from an original positive) are correct;
- `abs` boundaries are passed through unrounded, so the spec sign and the value sign are the same;
- `pct1_dropremainder` forbids splits with < 100 examples, so its boundaries never round to 0.

### Tests

Added parametrized cases to `tests/test_arrow_reader.py`: a unit test asserting `train[-1%:]`/`train[:-1%]` on 30 examples resolve like `train[99%:]`/`train[:99%]` (plus `-5%` cases pinning the unaffected path), and `train[-1%:]`/`train[:-1%]` cases (plain and sharded) in `test_make_file_instructions`.

- Before the fix: the 6 new cases fail (`6 failed, 23 passed`).
- After the fix: `pytest tests/test_arrow_reader.py tests/test_splits.py` → `37 passed`.
- `ruff check` / `ruff format --check` clean on both changed files.

I did not run the full test suite locally, only `tests/test_arrow_reader.py` and `tests/test_splits.py`.

---
Disclosure: this fix was prepared with AI assistance; I reproduced the bug and reviewed the change and tests locally.
