### PR TITLE
Fix OverflowError in Dataset.select on in-range negative indices

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4579,7 +4579,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         size = len(self)
         if indices:
             _check_valid_indices_value(int(max(indices)), size=size)
-            _check_valid_indices_value(int(min(indices)), size=size)
+            min_index = int(min(indices))
+            _check_valid_indices_value(min_index, size=size)
+            if min_index < 0:
+                # In-range negative indices (allowed by the check above) are normalized
+                # to positive values, since the indices mapping is stored as uint64
+                indices = [int(i) % size for i in indices]
         else:
             return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2311,6 +2311,22 @@ class BaseDatasetTest(TestCase):
                     self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(dset_select_five.features, Features({"filename": Value("string")}))
 
+    def test_select_negative_indices(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                # in-range negative indices are resolved like in python, consistently with __getitem__
+                with dset.select([0, -1]) as dset_select:
+                    self.assertListEqual(list(dset_select["filename"]), [dset["filename"][0], dset["filename"][-1]])
+                with dset.select(range(-2, 0)) as dset_select:
+                    self.assertListEqual(list(dset_select["filename"]), list(dset["filename"][-2:]))
+                # also when the dataset already has an indices mapping
+                with dset.select([2, 1, 0]) as dset_with_mapping:
+                    with dset_with_mapping.select([-1]) as dset_select:
+                        self.assertListEqual(list(dset_select["filename"]), [dset["filename"][0]])
+                # out-of-range negative indices still raise IndexError
+                with self.assertRaises(IndexError):
+                    dset.select([-len(dset) - 1])
+
     def test_select_then_map(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:


### PR DESCRIPTION
Fixes #8475.

### What this fixes

`Dataset.select` validates indices with `_check_valid_indices_value`, which implements Python-style negative indexing (it only rejects a negative index when `index + size < 0`), but `_select_with_indices_mapping` then converts the indices with `pa.array(indices, type=pa.uint64())`, which crashes on any negative value:

```python
ds = Dataset.from_dict({"x": list(range(10))})
ds[[0, -1]]        # {'x': [0, 9]} — __getitem__ has supported negative indices since #679
ds.select([-11])   # IndexError: Index -11 out of range for dataset of size 10.  (clean)
ds.select([-1])    # OverflowError: can't convert negative value to unsigned int
```

Negative indices can't reach the contiguous fast path either (it requires `start >= 0`), so every negative index ends up in `_select_with_indices_mapping` and crashes with the raw pyarrow error.

### Fix

Normalize in-range negative indices after the existing validation and before the uint64 conversion, using the same `% size` resolution as the `__getitem__` family (`_query_table` uses `key % table.num_rows`):

```python
if min_index < 0:
    indices = [int(i) % size for i in indices]
```

Only the branch where `min(indices) < 0` changes behavior: those inputs previously always crashed, so no currently-working call is affected. Out-of-range indices still raise the same `IndexError` from `_check_valid_indices_value`, and the positive-only path is untouched (same values, same types, one extra comparison).

### Tests

Added `test_select_negative_indices` to `tests/test_arrow_dataset.py` (next to `test_select`, running for both in-memory and on-disk datasets): negative list indices, a negative `range`, a chained `select` on a dataset that already has an indices mapping, and the out-of-range `IndexError` case.

- Before the fix: `2 failed` — both new tests crash with `OverflowError: can't convert negative value to unsigned int`.
- After the fix: `pytest tests/test_arrow_dataset.py -k "select"` → `8 passed`, and the broader `-k "select or sort or shuffle or shard or train_test_split or skip or take"` → `22 passed, 61 skipped` (skips are pre-existing optional-dependency skips).
- `ruff check` / `ruff format --check` clean on both changed files.

I did not run the full test suite locally, only the selections above.

---
Disclosure: this fix was prepared with AI assistance; I reproduced the bug and reviewed the change and tests locally.
