### PR TITLE
Reject non-positive batch sizes in batch()

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -633,6 +633,12 @@ def _check_column_names(column_names: list[str]):
         raise ValueError(f"The table can't have duplicated columns but columns {duplicated_columns} are duplicated.")
 
 
+def _check_batch_size(batch_size: Optional[int]):
+    """Check the `batch_size` of methods that process a dataset by batches."""
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive integer, but got {batch_size}.")
+
+
 def _check_valid_indices_value(index, size):
     if (index < 0 and index + size < 0) or (index >= size):
         raise IndexError(f"Index {index} out of range for dataset of size {size}.")
@@ -4112,6 +4118,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         if batch_size is None and by_column is None:
             raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+        _check_batch_size(batch_size)
         if by_column is not None:
             if num_proc:
                 raise NotImplementedError("Multiprocessed batching by column is not implemented yet")

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -35,7 +35,7 @@ from huggingface_hub.utils import RepositoryNotFoundError
 from packaging import version
 
 from . import __version__, config
-from .arrow_dataset import Dataset, DatasetInfoMixin, _push_to_bucket, _push_to_repo
+from .arrow_dataset import Dataset, DatasetInfoMixin, _check_batch_size, _push_to_bucket, _push_to_repo
 from .features import Features
 from .features.features import (
     FeatureType,
@@ -4448,6 +4448,7 @@ class IterableDataset(DatasetInfoMixin):
         """
         if batch_size is None and by_column is None:
             raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+        _check_batch_size(batch_size)
         if self.features:
             features = Features({col: List(feature) for col, feature in self.features.items()})
         else:

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4918,6 +4918,16 @@ def test_dataset_batch():
     assert batches[2]["text"] == ["Text 8", "Text 9"]
 
 
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_dataset_batch_with_non_positive_batch_size(batch_size):
+    ds = Dataset.from_dict({"a": [0, 1, 2]})
+
+    with pytest.raises(ValueError) as error:
+        ds.batch(batch_size)
+
+    assert str(error.value) == f"batch_size must be a positive integer, but got {batch_size}."
+
+
 def test_dataset_batch_by_column():
     # Create a Dataset with a column to group by
     data = {

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -3049,6 +3049,24 @@ def test_iterable_dataset_batch(num_shards: int):
         assert batch["text"] == [f"Text {3 * i}", f"Text {3 * i + 1}", f"Text {3 * i + 2}"]
 
 
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_iterable_dataset_batch_with_non_positive_batch_size(batch_size):
+    generator_calls = 0
+
+    def generate_examples():
+        nonlocal generator_calls
+        generator_calls += 1
+        yield {"a": 0}
+
+    ds = IterableDataset.from_generator(generate_examples)
+
+    with pytest.raises(ValueError) as error:
+        ds.batch(batch_size)
+
+    assert str(error.value) == f"batch_size must be a positive integer, but got {batch_size}."
+    assert generator_calls == 0
+
+
 def test_iterable_dataset_batch_by_column_survives_resharding():
     # Re-creating the iterable (shard / shuffle / split_by_node, e.g. inside torch DataLoader
     # workers) must keep accumulating whole groups instead of crashing with a missing


### PR DESCRIPTION
## Summary

- reject non-positive `batch_size` values in `Dataset.batch()` and `IterableDataset.batch()`
- raise before mapping or consuming an iterable source
- add focused regression tests for `0` and `-1`

Fixes #8472

## Related work

This includes the small `_check_batch_size` helper also proposed by @LeSingh1 in #8446, then applies it to the two `batch()` APIs that #8446 does not cover. If #8446 lands first, I can rebase this PR and drop the overlapping helper.

## Validation

- original #8472 reproducer now raises the expected `ValueError` for `0` and `-1`
- focused regression tests: 4 passed
- affected batching tests: 20 passed, 2 skipped
- Ruff lint and format checks passed