### PR TITLE
Handle null values when batching by column

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4068,6 +4068,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         drop_last_batch: bool = False,
         num_proc: Optional[int] = None,
         new_fingerprint: Optional[str] = None,
+        *,
+        max_batch_size: Optional[int] = None,
     ) -> "Dataset":
         """
         Group samples from the dataset into batches.
@@ -4082,12 +4084,19 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 The number of samples in each batch.
             by_column (`Union[str, list[str]`, optional):
                 The column used to batch examples together.
-                Successive examples with the same value for that column are in grouped the same batch.
+                Successive examples with the same value for that column are grouped in the same batch.
                 This can also be a list of columns if you want to batch by multiple columns.
                 If batching by column, the batch_size is only used to control the size of the batches
-                to group together or slice during acculumation.
+                to group together or slice during accumulation.
 
                 <Added version="4.9.0"/>
+            max_batch_size (`int`, optional):
+                Maximum number of examples in each batch when batching by column. Groups larger than
+                `max_batch_size` are split into consecutive batches while preserving their order. If
+                `batch_size` is not specified, `max_batch_size` is also used as the internal processing
+                batch size. This argument can only be used with `by_column`.
+
+                <Added version="5.0.2"/>
             drop_last_batch (`bool`, defaults to `False`):
                 Whether to drop the last incomplete batch.
             num_proc (`int`, *optional*, defaults to `None`):
@@ -4110,16 +4119,29 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         'label': [1, 1, 1, 1]}
         ```
         """
+
+        if max_batch_size is not None:
+            if by_column is None:
+                raise ValueError("`max_batch_size` can only be specified when batching by column.")
+            if isinstance(max_batch_size, bool) or not isinstance(max_batch_size, int) or max_batch_size <= 0:
+                raise ValueError(f"`max_batch_size` must be a positive integer, but got {max_batch_size!r}.")
+
         if batch_size is None and by_column is None:
             raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+
         if by_column is not None:
             if num_proc:
                 raise NotImplementedError("Multiprocessed batching by column is not implemented yet")
             columns = [by_column] if isinstance(by_column, str) else by_column
             _batch_fn = partial(
-                _batch_accumulate_arrow_table_by_columns, columns=columns, tables_accumulator=[], length=len(self)
+                _batch_accumulate_arrow_table_by_columns,
+                columns=columns,
+                tables_accumulator=[],
+                length=len(self),
+                max_batch_size=max_batch_size,
             )
             with_indices = True
+            batch_size = batch_size if batch_size is not None else max_batch_size
         else:
             _batch_fn = _batch_arrow_table
             with_indices = False

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4422,6 +4422,8 @@ class IterableDataset(DatasetInfoMixin):
         batch_size: Optional[int] = None,
         by_column: Optional[Union[str, list[str]]] = None,
         drop_last_batch: bool = False,
+        *,
+        max_batch_size: Optional[int] = None,
     ) -> "IterableDataset":
         """
         Group samples from the dataset into batches.
@@ -4431,12 +4433,19 @@ class IterableDataset(DatasetInfoMixin):
                 The number of samples in each batch.
             by_column (`Union[str, list[str]`, optional):
                 The column used to batch examples together.
-                Successive examples with the same value for that column are in grouped the same batch.
+                Successive examples with the same value for that column are grouped in the same batch.
                 This can also be a list of columns if you want to batch by multiple columns.
                 If batching by column, the batch_size is only used to control the size of the batches
-                to group together or slice during acculumation.
+                to group together or slice during accumulation.
 
                 <Added version="4.9.0"/>
+            max_batch_size (`int`, optional):
+                Maximum number of examples in each batch when batching by column. Groups larger than
+                `max_batch_size` are split into consecutive batches while preserving their order. If
+                `batch_size` is not specified, `max_batch_size` is also used as the internal processing
+                batch size. This argument can only be used with `by_column`.
+
+                <Added version="5.0.2"/>
             drop_last_batch (`bool`, defaults to `False`):
                 Whether to drop the last incomplete batch.
 
@@ -4446,6 +4455,11 @@ class IterableDataset(DatasetInfoMixin):
         >>> batched_ds = ds.batch(batch_size=32)
         ```
         """
+        if max_batch_size is not None:
+            if by_column is None:
+                raise ValueError("`max_batch_size` can only be specified when batching by column.")
+            if isinstance(max_batch_size, bool) or not isinstance(max_batch_size, int) or max_batch_size <= 0:
+                raise ValueError(f"`max_batch_size` must be a positive integer, but got {max_batch_size!r}.")
         if batch_size is None and by_column is None:
             raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
         if self.features:
@@ -4454,10 +4468,15 @@ class IterableDataset(DatasetInfoMixin):
             features = None
         if by_column is not None:
             columns = [by_column] if isinstance(by_column, str) else by_column
+            batch_size = batch_size if batch_size is not None else max_batch_size
             ds = (
                 self.with_format("arrow")
                 ._map(
-                    partial(_batch_accumulate_arrow_table_by_columns, columns=columns),
+                    partial(
+                        _batch_accumulate_arrow_table_by_columns,
+                        columns=columns,
+                        max_batch_size=max_batch_size,
+                    ),
                     with_indices=True,
                     batched=True,
                     batch_size=batch_size,

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -68,14 +68,29 @@ def _batch_arrow_table(table: pa.Table) -> pa.Table:
     return pa.Table.from_arrays(batched_columns, names=table.column_names)
 
 
+# handles nulls seperaty since arrow comparisons return null for them
+def _not_equal_with_nulls(
+    left: Union[pa.Array, pa.ChunkedArray, pa.Scalar], right: Union[pa.Array, pa.ChunkedArray, pa.Scalar]
+) -> Union[pa.Array, pa.ChunkedArray, pa.Scalar]:
+    null_mismatch = pc.xor(pc.is_null(left), pc.is_null(right))
+    if pa.types.is_null(left.type):
+        return null_mismatch
+    return pc.or_(pc.fill_null(pc.not_equal(left, right), False), null_mismatch)
+
+
 def _batch_accumulate_arrow_table_by_columns(
-    table: pa.Table, indices: list[int], columns: tuple[str], tables_accumulator: list[pa.Table], length: Optional[int]
+    table: pa.Table,
+    indices: list[int],
+    columns: tuple[str],
+    tables_accumulator: list[pa.Table],
+    length: Optional[int],
+    max_batch_size: Optional[int] = None,
 ) -> pa.Table:
     accumulate_last_batch = length is None or indices[-1] + 1 < length
     # keep accumulating if key is the same, otherwise include the accumulated tables
-    if tables_accumulator and accumulate_last_batch:
+    if max_batch_size is None and tables_accumulator and accumulate_last_batch:
         for column in columns:
-            if any(pc.not_equal(table[column], tables_accumulator[0][column][0]).to_pylist()):
+            if any(_not_equal_with_nulls(table[column], tables_accumulator[0][column][0]).to_pylist()):
                 break
         else:
             tables_accumulator.append(table)
@@ -93,25 +108,34 @@ def _batch_accumulate_arrow_table_by_columns(
         return table
     # cut the table per key, i.e. when the columns change value
     if len(table) > 1:
-        cut_array = pc.not_equal(table[columns[0]][1:], table[columns[0]][:-1])
+        cut_array = _not_equal_with_nulls(table[columns[0]][1:], table[columns[0]][:-1])
         for column in columns[1:]:
-            cut_array = pc.or_(cut_array, pc.not_equal(table[column][1:], table[column][:-1]))
+            cut_array = pc.or_(cut_array, _not_equal_with_nulls(table[column][1:], table[column][:-1]))
     else:
-        cut_array = pa.array([], type=pa.uint64())
-    offsets = pc.indices_nonzero(cut_array)
+        cut_array = pa.array([], type=pa.bool_())
+    cut_offsets = pc.add(1, pc.indices_nonzero(cut_array)).to_pylist()
+    run_offsets = [0, *cut_offsets, len(table)]
+    offsets = [0]
+    last_offset = len(table)
+    for start, end in zip(run_offsets, run_offsets[1:]):
+        if max_batch_size is not None:
+            chunk_end = start + max_batch_size
+            while chunk_end <= end:
+                offsets.append(chunk_end)
+                chunk_end += max_batch_size
+        if end == len(table) and accumulate_last_batch:
+            last_offset = offsets[-1]
+        elif offsets[-1] != end:
+            offsets.append(end)
     # make the batched table
-    offsets = pc.add(1, offsets)
-    offsets = pa.concat_arrays([pa.array([0], type=pa.int32()), offsets.cast(pa.int32())])
-    if not accumulate_last_batch:
-        offsets = pa.concat_arrays([offsets, pa.array([len(table)], type=pa.int32())])
+    offsets_array = pa.array(offsets, type=pa.int32())
     batched_columns = []
     for column_name in table.column_names:
         column = table[column_name].combine_chunks()
-        batched_columns.append(pa.ListArray.from_arrays(offsets, column))
+        batched_columns.append(pa.ListArray.from_arrays(offsets_array, column))
     batched_table = pa.Table.from_arrays(batched_columns, names=table.column_names)
     # add the last batch to the accumulator since it might not be full yet
-    if accumulate_last_batch:
-        last_offset = offsets[-1].as_py()
+    if last_offset < len(table):
         tables_accumulator.append(table.slice(last_offset, len(table) - last_offset))
     return batched_table
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5028,6 +5028,71 @@ def test_dataset_batch_by_column():
     assert batches_with_buffer[1]["value"] == list(range(17, 20))
 
 
+def test_dataset_batch_by_column_with_nulls():
+    ds = Dataset.from_dict(
+        {
+            "id": list(range(6)),
+            "group": [None, None, "A", "A", None, "B"],
+        }
+    )
+    assert [batch["id"] for batch in ds.batch(by_column="group", batch_size=2)] == [[0, 1], [2, 3], [4], [5]]
+
+    all_null_ds = Dataset.from_dict({"id": list(range(3)), "group": [None, None, None]})
+    assert [batch["id"] for batch in all_null_ds.batch(by_column="group", batch_size=1)] == [[0, 1, 2]]
+
+    multi_column_ds = Dataset.from_dict(
+        {
+            "id": list(range(5)),
+            "group": [None] * 5,
+            "subgroup": [None, None, "A", "A", None],
+        }
+    )
+    assert [batch["id"] for batch in multi_column_ds.batch(by_column=["group", "subgroup"], batch_size=2)] == [
+        [0, 1],
+        [2, 3],
+        [4],
+    ]
+
+
+def test_dataset_batch_by_column_with_max_batch_size():
+    ds = Dataset.from_dict(
+        {
+            "id": list(range(10)),
+            "group": ["A"] * 7 + ["B"] * 3,
+        }
+    )
+
+    assert [batch["id"] for batch in ds.batch(by_column="group")] == [list(range(7)), list(range(7, 10))]
+    assert [batch["id"] for batch in ds.batch(by_column="group", max_batch_size=3)] == [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6],
+        [7, 8, 9],
+    ]
+    assert [
+        batch["id"] for batch in ds.batch(by_column="group", batch_size=2, max_batch_size=3, drop_last_batch=True)
+    ] == [[0, 1, 2], [3, 4, 5], [6], [7, 8, 9]]
+
+
+@pytest.mark.parametrize("max_batch_size", [0, -1, True, 1.5, "2"])
+def test_dataset_batch_by_column_with_invalid_max_batch_size(max_batch_size):
+    ds = Dataset.from_dict({"id": [0, 1], "group": ["A", "A"]})
+
+    # with pytest.raises(ValueError) as exc_info:
+    #     ds.batch(by_column="group", max_batch_size=max_batch_size)
+    # assert "must be positive integer" in str(exc_info.value)
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        ds.batch(by_column="group", max_batch_size=max_batch_size)
+
+
+def test_dataset_batch_with_max_batch_size_requires_by_column():
+    ds = Dataset.from_dict({"id": [0, 1]})
+
+    with pytest.raises(ValueError, match="can only be specified when batching by column"):
+        ds.batch(batch_size=1, max_batch_size=1)
+
+
 @pytest.mark.parametrize("format_type", ["pyarrow", "pandas"])
 def test_dataset_batch_with_table_format(format_type):
     ds = Dataset.from_dict({"a": [1, 2, 3, 4]})

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -3191,6 +3191,75 @@ def test_iterable_dataset_batch_by_column(num_shards: int):
         )
 
 
+def test_iterable_dataset_batch_by_column_with_nulls():
+    ds = IterableDataset.from_dict(
+        {
+            "id": list(range(6)),
+            "group": [None, None, "A", "A", None, "B"],
+        },
+        num_shards=2,
+    )
+    assert [batch["id"] for batch in ds.batch(by_column="group", batch_size=2)] == [[0, 1], [2, 3], [4], [5]]
+
+    all_null_ds = IterableDataset.from_dict({"id": list(range(3)), "group": [None, None, None]}, num_shards=2)
+    assert [batch["id"] for batch in all_null_ds.batch(by_column="group", batch_size=1)] == [[0, 1, 2]]
+
+    multi_column_ds = IterableDataset.from_dict(
+        {
+            "id": list(range(5)),
+            "group": [None] * 5,
+            "subgroup": [None, None, "A", "A", None],
+        },
+        num_shards=2,
+    )
+    assert [batch["id"] for batch in multi_column_ds.batch(by_column=["group", "subgroup"], batch_size=2)] == [
+        [0, 1],
+        [2, 3],
+        [4],
+    ]
+
+
+def test_iterable_dataset_batch_by_column_with_max_batch_size():
+    ds = IterableDataset.from_dict(
+        {
+            "id": list(range(10)),
+            "group": ["A"] * 7 + ["B"] * 3,
+        },
+        num_shards=2,
+    )
+
+    assert [batch["id"] for batch in ds.batch(by_column="group")] == [list(range(7)), list(range(7, 10))]
+    batched_ds = ds.batch(by_column="group", max_batch_size=3)
+    assert [batch["id"] for batch in batched_ds] == [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6],
+        [7, 8, 9],
+    ]
+    assert [
+        batch["id"] for batch in ds.batch(by_column="group", batch_size=2, max_batch_size=3, drop_last_batch=True)
+    ] == [[0, 1, 2], [3, 4, 5], [6], [7, 8, 9]]
+    for batch_size in [1, 2, 3, 7, 10, 20]:
+        assert_load_state_dict_resumes_arrow_iteration(
+            batched_ds._prepare_ex_iterable_for_iteration(batch_size=batch_size)
+        )
+
+
+@pytest.mark.parametrize("max_batch_size", [0, -1, True, 1.5, "2"])
+def test_iterable_dataset_batch_by_column_with_invalid_max_batch_size(max_batch_size):
+    ds = IterableDataset.from_dict({"id": [0, 1], "group": ["A", "A"]})
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        ds.batch(by_column="group", max_batch_size=max_batch_size)
+
+
+def test_iterable_dataset_batch_with_max_batch_size_requires_by_column():
+    ds = IterableDataset.from_dict({"id": [0, 1]})
+
+    with pytest.raises(ValueError, match="can only be specified when batching by column"):
+        ds.batch(batch_size=1, max_batch_size=1)
+
+
 @pytest.mark.parametrize("format_type", ["pyarrow", "pandas"])
 def test_iterable_dataset_batch_with_table_format(format_type):
     ds = IterableDataset.from_dict({"a": [1, 2, 3, 4]})


### PR DESCRIPTION
## What changed

I encountered an error when batching a dataset by a nullable column. Rows containing null values were not split into the expected groups, and grouping by an all-null Arrow column raised an `ArrowNotImplementedError`.

For example, batching this column:
```python
[None, None, "A", "A", None, "B"]
```
should produce four groups:

```python
[[None, None], ["A", "A"], [None], ["B"]]
```
Instead, the null comparisons caused the boundaries between groups to be missed.

I fixed this by handling null values separately from Arrow's normal inequality comparison. Two null values are now treated as equal, while a null and a non-null value are treated as different.

I also added a keyword-only `max_batch_size` parameter to `Dataset.batch()` and `IterableDataset.batch()` when using `by_column`:

```python
dataset.batch(by_column="group", max_batch_size=1000)
```

This is useful when a column contains a long run of the same value. Previously, that entire run could be returned as one large batch. `max_batch_size` allows those groups to be split into smaller batches without combining rows from different groups.

I also fixed some grammar errors in the multi-line comments of some scripts and added a description of `max_batch_size` to both arrow dataset and IterableDataset.

## Why

Arrow comparisons involving null values return null instead of a boolean. Those null results were ignored when the grouping boundaries were calculated. Arrow also does not provide a `not_equal` kernel for columns whose type is entirely null.

The new null comparison handles both cases while also preserving the existing behavior for non-null values.

## Validation

I added tests for both Dataset and IterableDataset, covering:

- Nullable grouping columns
- All-null Arrow columns
- Multiple grouping columns containing nulls
- Groups that span internal record batches
- Batches limited by max_batch_size
- Invalid max_batch_size values
- Iterable dataset state restoration

I also ran the relevant dataset, iterable dataset, and table tests, along with Ruff formatting and lint check.