### PR TITLE
Fix Dataset.skip(n) raising IndexError when n == len(dataset)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4491,8 +4491,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         if len(self) == 0:
             return self
 
-        _check_valid_indices_value(start, len(self))
-        _check_valid_indices_value(start + length - 1, len(self))
+        # Bounds only constrain a non-empty slice. An empty one is valid at any start,
+        # including start == len(self): `ds.skip(len(ds))` asks for range(len, len), which
+        # is contiguous and lands here with length == 0.
+        if length > 0:
+            _check_valid_indices_value(start, len(self))
+            _check_valid_indices_value(start + length - 1, len(self))
         if self._indices is None or length == 0:
             return Dataset(
                 self.data.slice(start, length),

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5136,6 +5136,20 @@ def test_add_column():
     assert ds[1] == {"a": 2, "b": 4}
 
 
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 4, 10])
+def test_dataset_skip_at_and_beyond_length(n):
+    # skipping exactly len(ds) used to raise IndexError, while skipping *more* than
+    # len(ds) returned an empty dataset
+    ds = Dataset.from_dict({"a": [1, 2, 3]})
+
+    skipped = ds.skip(n)
+
+    assert len(skipped) == max(len(ds) - n, 0)
+    assert skipped["a"] == [1, 2, 3][n:]
+    # and it agrees with the IterableDataset counterpart
+    assert len(list(ds.to_iterable_dataset().skip(n))) == len(skipped)
+
+
 def test_process_large_few_examples(tmp_path):
     # GH 7911
     from datasets import Dataset


### PR DESCRIPTION
Skipping exactly as many elements as the dataset has raises, but skipping *more* than that works and returns an empty dataset:

```python
>>> ds = Dataset.from_dict({"a": [1, 2, 3]})
>>> ds.skip(2)
Dataset({features: ['a'], num_rows: 1})
>>> ds.skip(3)
IndexError: Index 3 out of range for dataset of size 3.
>>> ds.skip(4)
Dataset({features: ['a'], num_rows: 0})
>>> ds.skip(10)
Dataset({features: ['a'], num_rows: 0})
```

The discontinuity at exactly `len(ds)` is what makes it look unintended rather than a deliberate bounds check — `skip` is otherwise monotonic, and `IterableDataset.skip` already returns an empty dataset for every `n >= len`:

```python
>>> len(list(ds.to_iterable_dataset().skip(3)))
0
```

### Cause

`skip` is implemented as `self.select(range(n, len(self)))`.

For `n == len(self)` that's `range(3, 3)`, which `_is_range_contiguous` accepts (`step == 1 and stop >= start`), so `select` takes the contiguous fast path with `start=3, length=0` and calls `_select_contiguous(3, 0)`. There:

```python
_check_valid_indices_value(start, len(self))            # 3 >= 3 -> IndexError
_check_valid_indices_value(start + length - 1, len(self))
```

For `n > len(self)` the range is `range(4, 3)`, where `stop >= start` is false, so it isn't treated as contiguous and falls through to `_select_with_indices_mapping`, which handles the empty range fine. That's the whole reason the two cases differ.

### Fix

Bounds only constrain a *non-empty* slice. An empty slice is valid at any start, including `start == len(self)` — the same way `lst[3:3]` is valid in Python and `pa.Table.slice(3, 0)` is valid in Arrow. So the checks are skipped when `length == 0`.

Out-of-range non-empty slices are still rejected: `_select_contiguous(5, 2)` still raises `IndexError`.

### Tests

Added `test_dataset_skip_at_and_beyond_length`, parametrised over `n = 0, 1, 2, 3, 4, 10`, asserting the length, the contents, and agreement with `IterableDataset.skip`. Without the change it fails on exactly the `n == 3` case and passes the other five.

```
$ python -m pytest tests/test_arrow_dataset.py -q -k "select or skip or take or shard"
8 passed, 49 skipped

$ python -m pytest tests/test_arrow_dataset.py -q
14 failed, 361 passed, 49 skipped
```

The 14 failures are all `test_dataset_from_parquet_*` / `test_dataset_to_iterable_dataset` and reproduce identically on a clean `main` in my environment, so they're unrelated to this change.

`ruff format --check` and `ruff check` are clean on both files.
