### PR TITLE
Validate each element in ClassLabel.int2str

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1140,8 +1140,17 @@ class ClassLabel:
             return_list = False
 
         for v in values:
-            if not 0 <= v < self.num_classes:
-                raise ValueError(f"Invalid integer class label {v:d}")
+            # Validate each element, not just the container: a non-integral value used to be
+            # silently truncated by `int(v)` below (e.g. 1.7 -> "pos"), and a string element
+            # raised a cryptic TypeError from the comparison instead of a useful message.
+            try:
+                int_v = int(v)
+            except (TypeError, ValueError) as e:
+                raise ValueError(f"Invalid integer class label {v!r}: expected an integer") from e
+            if int_v != v:
+                raise ValueError(f"Invalid integer class label {v!r}: expected an integer")
+            if not 0 <= int_v < self.num_classes:
+                raise ValueError(f"Invalid integer class label {int_v:d}")
 
         output = [self._int2str[int(v)] for v in values]
         return output if return_list else output[0]

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -344,6 +344,31 @@ def test_classlabel_int2str():
         classlabel.int2str(None)
 
 
+def test_classlabel_int2str_validates_elements():
+    names = ["negative", "positive"]
+    classlabel = ClassLabel(names=names)
+
+    # valid inputs keep working, including numpy integers
+    assert classlabel.int2str([0, 1]) == names
+    assert classlabel.int2str(np.array([0, 1])) == names
+    assert classlabel.int2str([np.int64(0), np.int64(1)]) == names
+
+    # a non-integral element used to be silently truncated by int(v): 1.7 -> "positive"
+    with pytest.raises(ValueError):
+        classlabel.int2str([1.7])
+    # a string element used to raise a cryptic TypeError from the range comparison
+    with pytest.raises(ValueError):
+        classlabel.int2str(["1"])
+    with pytest.raises(ValueError):
+        classlabel.int2str(["abc"])
+    with pytest.raises(ValueError):
+        classlabel.int2str([None])
+    # an out-of-range non-integral value used to fail formatting with
+    # "Unknown format code 'd' for object of type 'float'"
+    with pytest.raises(ValueError):
+        classlabel.int2str([99.5])
+
+
 def test_classlabel_cast_storage():
     names = ["negative", "positive"]
     classlabel = ClassLabel(names=names)


### PR DESCRIPTION
Partially fixes #8481

### Problem

`int2str` validates the container it is given, but never the elements inside it. Three consequences, in decreasing order of severity:

```python
>>> cl = ClassLabel(names=["neg", "pos"])

>>> cl.int2str([1.7])
['pos']                    # silently truncated by the int(v) used to index _int2str

>>> cl.int2str(["1"])
TypeError: '<=' not supported between instances of 'int' and 'str'

>>> cl.int2str([99.5])
ValueError: Unknown format code 'd' for object of type 'float'
```

The first is the one worth fixing: it returns a plausible-looking label for a value that was never a valid class id, with no error. The third is the existing `f"...{v:d}"` raise failing on the very value it was trying to report.

The `TypeError` case is the nested form of what #8416 fixes at the top level — that PR guards `int2str("1")`, this one covers `int2str(["1"])`.

### Change

Validate each element in the loop that already walks them. A value is accepted if it converts to an integer exactly, so this keeps working for every input the docstring promises:

```python
cl.int2str([0, 1])                        # ['neg', 'pos']
cl.int2str(np.array([0, 1]))              # ['neg', 'pos']
cl.int2str([np.int64(0), np.int64(1)])    # ['neg', 'pos']
```

I deliberately checked integrality (`int(v) != v`) rather than `isinstance(v, int)`, because iterating a numpy array or a torch/tf tensor yields scalar objects that are not Python `int`s — a type check would have broken the framework-tensor inputs the docstring explicitly supports.

### Scope note

#8481 also reports `str2int([1])` returning `[1]`. Having read the code I think that one is more defensible than I made it sound in the issue: `_strval2int` does `str(value)` first and numeric strings like `"1"` are deliberately supported, so an integer falling through is a natural consequence of that feature rather than a separate bug. I've left it alone — happy to revisit if you read it differently.

### Tests

`test_classlabel_int2str_validates_elements` covers the valid inputs (list, numpy array, numpy scalars) and each rejected case. It fails on `main` and passes with the change.

```
$ pytest tests/features/test_features.py -q
201 passed, 3 skipped
```

`ruff format --check` and `ruff check` are clean on both files.
