### PR TITLE
Fix Dataset.take raising IndexError when n exceeds dataset length

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4699,7 +4699,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
          'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .'}]
         ```
         """
-        return self.select(range(n))
+        return self.select(range(min(n, len(self))))
 
     @transmit_format
     @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2311,6 +2311,20 @@ class BaseDatasetTest(TestCase):
                     self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(dset_select_five.features, Features({"filename": Value("string")}))
 
+    def test_take(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                # taking fewer elements than the dataset holds returns them
+                taken = dset.take(3)
+                self.assertEqual(len(taken), 3)
+                self.assertListEqual(list(taken["filename"]), list(dset[:3]["filename"]))
+
+                # taking more elements than the dataset holds returns everything
+                # that is available, matching IterableDataset.take()
+                taken = dset.take(len(dset) + 10)
+                self.assertEqual(len(taken), len(dset))
+                self.assertListEqual(list(taken["filename"]), list(dset["filename"]))
+
     def test_select_then_map(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:


### PR DESCRIPTION
Fixes #8483

## Problem

`Dataset.take(n)` raises `IndexError: index ... is out of bounds for axis 0 with size ...` when `n` exceeds the number of rows, while `IterableDataset.take(n)` returns everything available (list-slice semantics). The two dataset flavors should behave consistently.

## Change

Clamp the request to the available rows:

```python
return self.select(range(min(n, len(self))))
```

## Testing

- Regression test covering `take(3)` on a dataset with more rows, and `take(len(dset) + 10)` returning all available rows (matching `IterableDataset.take`).
