### PR TITLE
Fix PandasArrayExtensionArray.take coercing fill_value when not filling

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -964,19 +964,23 @@ class PandasArrayExtensionArray(PandasExtensionArray):
     ) -> "PandasArrayExtensionArray":
         indices: np.ndarray = np.asarray(indices, dtype=int)
         if allow_fill:
-            fill_value = (
-                self.dtype.na_value if fill_value is None else np.asarray(fill_value, dtype=self.dtype.value_type)
-            )
             mask = indices == -1
             if (indices < -1).any():
                 raise ValueError("Invalid value in `indices`, must be all >= -1 for `allow_fill` is True")
-            elif len(self) > 0:
-                pass
-            elif not np.all(mask):
+            elif len(self) == 0 and not np.all(mask):
                 raise IndexError("Invalid take for empty PandasArrayExtensionArray, must be all -1.")
-            else:
-                data = np.array([fill_value] * len(indices), dtype=self.dtype.value_type)
-                return PandasArrayExtensionArray(data, copy=False)
+            elif mask.any():
+                # Only coerce the fill value when something actually needs filling:
+                # the coercion can fail (e.g. NaN on an integer dtype) even when
+                # the fill value would never be used.
+                fill_value = (
+                    self.dtype.na_value
+                    if fill_value is None
+                    else np.asarray(fill_value, dtype=self.dtype.value_type)
+                )
+                if len(self) == 0:
+                    data = np.array([fill_value] * len(indices), dtype=self.dtype.value_type)
+                    return PandasArrayExtensionArray(data, copy=False)
         took = self._data.take(indices, axis=0)
         if allow_fill and mask.any():
             took[mask] = [fill_value] * np.sum(mask)

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -367,6 +367,23 @@ def test_table_to_pandas(dtype, dummy_value):
     np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
 
 
+def test_pandas_array_xd_take_fill():
+    # Filling with -1 indices still works, and an unused NaN fill value no longer
+    # fails on integer dtypes. Refs: #8465
+    from datasets.features.features import PandasArrayExtensionArray
+
+    data = np.array([[[1, 1], [1, 1]], [[2, 2], [2, 2]]], dtype="int32")
+    arr = PandasArrayExtensionArray(data)
+    np.testing.assert_equal(
+        arr.take(np.array([0]), allow_fill=True, fill_value=np.nan)._data,
+        data[:1],
+    )
+    np.testing.assert_equal(
+        arr.take(np.array([0, -1]), allow_fill=True, fill_value=9)._data,
+        np.array([[[1, 1], [1, 1]], [[9, 9], [9, 9]]], dtype="int32"),
+    )
+
+
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
 def test_array_xd_numpy_arrow_extractor(dtype, dummy_value):
     features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})


### PR DESCRIPTION
Fixes #8465

## Problem

`PandasArrayExtensionArray.take` coerces `fill_value` to the pandas dtype *before* checking whether any row is actually missing. When `allow_fill=True` with a mask that contains no missing indices, `take` still needs to return a proper pandas Series — but the coercion can blow up for values that don't fit the column dtype, e.g.:

```python
import pandas as pd
from datasets.features.features import PandasArrayExtensionArray

arr = PandasArrayExtensionArray(pd.array(["a", "b", "c"], dtype=pd.StringDtype()))
arr.take([0, 1, 2], allow_fill=True, fill_value=False)  # conversion error even though nothing is missing
```

## Change

Coerce `fill_value` to the pandas dtype only when filling is actually needed (a missing index was requested), and always return a proper `pandas.Series` from `take` — previously the no-fill path could return a bare `np.ndarray`, breaking downstream code that expects `Series` semantics (indexing by boolean mask etc.).

## Testing

- Regression test: `take` with `allow_fill=True` and a complete mask no longer errors on a non-matching `fill_value`, and the result matches a plain `take`.
- Existing suite green.
