### PR TITLE
Use the active Python interpreter in fingerprint test

### DIFF
--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -2,6 +2,7 @@ import json
 import os
 import pickle
 import subprocess
+import sys
 from functools import partial
 from pathlib import Path
 from tempfile import gettempdir
@@ -413,8 +414,8 @@ def test_move_script_doesnt_change_hash(tmp_path: Path):
         f.write(code)
     with script_path2.open("w") as f:
         f.write(code)
-    fingerprint1 = subprocess.check_output(["python", str(script_path1)])
-    fingerprint2 = subprocess.check_output(["python", str(script_path2)])
+    fingerprint1 = subprocess.check_output([sys.executable, str(script_path1)])
+    fingerprint2 = subprocess.check_output([sys.executable, str(script_path2)])
     assert fingerprint1 == fingerprint2
 
 


### PR DESCRIPTION
Fixes #7090.

`test_move_script_doesnt_change_hash` now invokes both temporary scripts with `sys.executable` instead of relying on a `python` command being available on `PATH`. This keeps the subprocess interpreter aligned with the interpreter running pytest and fixes environments such as FreeBSD where only `python3` may be present.

Validation:
- isolated `PATH` without a `python` alias: focused regression passed
- full `tests/test_fingerprint.py`: 23 passed, 9 skipped
- Ruff check and format check passed

AI assistance disclosure: OpenAI Codex was used to investigate, implement, and test this change.