### PR TITLE
Fix archive path check allowing sibling-directory escapes

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -105,7 +105,11 @@ class TarExtractor(BaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            # Also, a plain startswith(base) would still match sibling directories
+            # whose name starts with the base name (e.g. "../base_evil/x" when
+            # extracting into ".../base"), so require the base plus a separator
+            target = resolved(os.path.join(base, path))
+            return target != base and not target.startswith(base + os.sep)
 
         def badlink(info: tarfile.TarInfo, base: str) -> bool:
             # Links are interpreted relative to the directory containing the link
@@ -205,7 +209,11 @@ class ZipExtractor(MagicNumberBaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            # Also, a plain startswith(base) would still match sibling directories
+            # whose name starts with the base name (e.g. "../base_evil/x" when
+            # extracting into ".../base"), so require the base plus a separator
+            target = resolved(os.path.join(base, path))
+            return target != base and not target.startswith(base + os.sep)
 
         base = resolved(output_path)
 
@@ -258,7 +266,11 @@ class RarExtractor(MagicNumberBaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            # Also, a plain startswith(base) would still match sibling directories
+            # whose name starts with the base name (e.g. "../base_evil/x" when
+            # extracting into ".../base"), so require the base plus a separator
+            target = resolved(os.path.join(base, path))
+            return target != base and not target.startswith(base + os.sep)
 
         def badlink(info: "rarfile.RarInfo", base: str) -> bool:
             # Links are interpreted relative to the directory containing the link
@@ -334,7 +346,11 @@ class SevenZipExtractor(MagicNumberBaseExtractor):
 
         def badpath(path: str, base: str) -> bool:
             # joinpath will ignore base if path is absolute
-            return not resolved(os.path.join(base, path)).startswith(base)
+            # Also, a plain startswith(base) would still match sibling directories
+            # whose name starts with the base name (e.g. "../base_evil/x" when
+            # extracting into ".../base"), so require the base plus a separator
+            target = resolved(os.path.join(base, path))
+            return target != base and not target.startswith(base + os.sep)
 
         def badlink(info: "py7zr.FileInfo", base: str) -> bool:
             # Links are interpreted relative to the directory containing the link

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -165,16 +165,42 @@ def tar_file_with_sym_link(tmp_path):
     return path
 
 
+@pytest.fixture
+def tar_file_with_sibling_prefix(tmp_path, text_file):
+    # A member like "../extracted_evil/x" escapes into a *sibling* of the output
+    # directory whose name starts with the output directory's name, which a plain
+    # startswith(base) check used to allow.
+    import tarfile
+
+    directory = tmp_path / "data_sibling_prefix"
+    directory.mkdir()
+    path = directory / "tar_file_with_sibling_prefix.tar"
+    with tarfile.TarFile(path, "w") as f:
+        f.add(text_file, arcname="../extracted_evil/" + text_file.name)
+    return path
+
+
 @pytest.mark.parametrize(
     "insecure_tar_file, error_log",
-    [("tar_file_with_dot_dot", "illegal path"), ("tar_file_with_sym_link", "Symlink")],
+    [
+        ("tar_file_with_dot_dot", "illegal path"),
+        ("tar_file_with_sym_link", "Symlink"),
+        ("tar_file_with_sibling_prefix", "illegal path"),
+    ],
 )
 def test_tar_extract_insecure_files(
-    insecure_tar_file, error_log, tar_file_with_dot_dot, tar_file_with_sym_link, tmp_path, caplog
+    insecure_tar_file,
+    error_log,
+    tar_file_with_dot_dot,
+    tar_file_with_sym_link,
+    tar_file_with_sibling_prefix,
+    tmp_path,
+    caplog,
 ):
     insecure_tar_files = {
         "tar_file_with_dot_dot": tar_file_with_dot_dot,
         "tar_file_with_sym_link": tar_file_with_sym_link,
+        "tar_file_with_sibling_prefix": tar_file_with_sibling_prefix,
     }
     input_path = insecure_tar_files[insecure_tar_file]
     output_path = tmp_path / "extracted"


### PR DESCRIPTION
## Bug

The `safemembers` path check that guards archive extraction (the CVE-2007-4559 mitigation, duplicated across the tar/zip/rar/7z extractors) uses a plain `startswith(base)`. That also matches **sibling directories whose name starts with the output directory's name**:

```py
target = resolved(os.path.join(base, path))
return not target.startswith(base)     # "/cache/extracted_evil/x".startswith("/cache/extracted") → True → allowed
```

Extracting into `.../extracted/<hash>` therefore lets a member named `../<hash>_evil/x` write outside the output directory, into a sibling the archive itself names. On a shared machine this is a cache-poisoning vector: one dataset's archive can overwrite files inside *another* dataset's extraction directory. Reproduced on current `main` with a three-line tar before the fix:

```
TarExtractor.extract(evil.tar, tmp/"extracted")
(tmp/"extracted_evil"/"escaped.txt").exists()  → True   # file written outside the output dir
```

Paths escaping to unrelated directories (`../..`) stay blocked; only the shared-prefix sibling passes the old check.

## Fix

`badpath` now requires the resolved target to be the base itself (a member named `.`) or start with `base + os.sep`, in all four `safemembers` copies. The link checks (`badlink`) share `badpath`, so they get the same tightening.

## Verification

- New regression fixture `tar_file_with_sibling_prefix` added to the parametrized `test_tar_extract_insecure_files`, asserting the member is blocked with the "illegal path" error, alongside the existing dot-dot and symlink cases.
- Manual probe before/after the fix: escape succeeded on `main`, is blocked after, and legitimate nested members (`sub/good.txt`) still extract.
- `tests/test_extract.py`: 20 passed.
