### PR TITLE
Let Dataset.take(n) return what it has when n > len(dataset)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4699,7 +4699,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
          'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .'}]
         ```
         """
-        return self.select(range(n))
+        # Clamp to the dataset length so asking for more elements than exist returns
+        # what is there, matching `IterableDataset.take`, `itertools.islice` and list
+        # slicing, rather than raising from the out-of-range index.
+        return self.select(range(min(n, len(self))))
 
     @transmit_format
     @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -5136,6 +5136,20 @@ def test_add_column():
     assert ds[1] == {"a": 2, "b": 4}
 
 
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 4, 10])
+def test_dataset_take_beyond_length(n):
+    # take(n) with n > len(ds) used to raise IndexError, while IterableDataset.take
+    # returned the elements it had.
+    ds = Dataset.from_dict({"a": [1, 2, 3]})
+
+    taken = ds.take(n)
+
+    assert len(taken) == min(n, len(ds))
+    assert taken["a"] == [1, 2, 3][:n]
+    # and it agrees with the IterableDataset counterpart
+    assert len(list(ds.to_iterable_dataset().take(n))) == len(taken)
+
+
 def test_process_large_few_examples(tmp_path):
     # GH 7911
     from datasets import Dataset


### PR DESCRIPTION
Fixes #8483

### Problem

`Dataset.take(n)` is `select(range(n))`, so asking for more elements than the dataset has raises from the out-of-range index — while the `IterableDataset` counterpart returns the elements it has:

```python
>>> ds = Dataset.from_dict({"a": [1, 2, 3]})
>>> ds.take(3)
Dataset({features: ['a'], num_rows: 3})
>>> ds.take(4)
IndexError: Index 3 out of range for dataset of size 3.

>>> len(list(ds.to_iterable_dataset().take(4)))
3
```

Both are documented identically as *"Create a new [...] with only the first `n` elements"*, so the same call against the same data succeeds or raises depending only on which of the two classes you're holding.

### Change

Clamp `n` to the dataset length. This matches `IterableDataset.take`, and also `itertools.islice` and list slicing, which are the other things "first n" reasonably means:

```
take(  0) -> Dataset=0 Iterable=0  MATCH
take(  1) -> Dataset=1 Iterable=1  MATCH
take(  3) -> Dataset=3 Iterable=3  MATCH
take(  4) -> Dataset=3 Iterable=3  MATCH
take( 10) -> Dataset=3 Iterable=3  MATCH
take( -1) -> Dataset=0 Iterable=0  MATCH
```

Negative `n` is unchanged (`range(-1)` was already empty, and `min()` leaves it that way).

### On the alternative

The issue notes the other option — keep `take` strict and instead document the difference / change `IterableDataset`. I've gone with clamping because it's the behaviour every comparable API has and because the strict version can't be relied on as a bounds assertion anyway (it only fires for `Dataset`, not for the iterable form). Happy to flip it if you'd rather standardise the other way.

### Tests

`test_dataset_take_beyond_length`, parametrised over `n = 0, 1, 2, 3, 4, 10`, asserting the length, the contents, and agreement with `IterableDataset.take`. It fails on `main` for `n = 4` and `n = 10`.

```
$ pytest tests/test_arrow_dataset.py -q -k take_beyond
6 passed
```

`ruff format --check` and `ruff check` are clean.

### Note

This is independent of #8482 (`skip(len(ds))` raising while `skip(len(ds)+1)` works) — different method, different branch in `select`, and either can land without the other.
