### PR TITLE
Don't mask the original error when finalizing the writer fails in Dataset.map

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4027,8 +4027,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     if writer is not None:
                         try:
                             writer.finalize()
-                        except Exception:  # the writer may be broken already, don't hide the error we are handling
-                            logger.debug("Failed to finalize the writer.")
+                        except Exception as e:  # the writer may be broken already, don't hide the original error
+                            logger.warning(f"Failed to finalize the writer while handling an error: {e!r}")
                     if tmp_file is not None:
                         tmp_file.close()
                         if os.path.exists(tmp_file.name):

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4025,7 +4025,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 yield rank, False, num_examples_progress_update
                 if update_data:
                     if writer is not None:
-                        writer.finalize()
+                        try:
+                            writer.finalize()
+                        except Exception:  # the writer may be broken already, don't hide the error we are handling
+                            logger.debug("Failed to finalize the writer.")
                     if tmp_file is not None:
                         tmp_file.close()
                         if os.path.exists(tmp_file.name):

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -788,7 +788,13 @@ class ArrowWriter:
             self.pa_writer.close()
             self.pa_writer = None
             if close_stream:
-                self.stream.close()
+                try:
+                    self.stream.close()
+                except InterruptedError:
+                    # close(2) was interrupted by a signal: the data is already flushed and, on Linux, the file
+                    # descriptor is already closed. Retrying close() would be wrong since the descriptor may have
+                    # been reused (see `man 2 close`), so just carry on.
+                    logger.debug("Closing the stream was interrupted by a signal, ignoring.")
         else:
             if close_stream:
                 self.stream.close()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4830,6 +4830,25 @@ def test_map_keeps_the_error_raised_when_finalizing():
             dset.map(lambda x: x)
 
 
+def test_map_ignores_interrupted_close(tmp_path):
+    dset = Dataset.from_dict({"x": range(10)})
+    finalize = ArrowWriter.finalize
+
+    def finalize_with_interrupted_close(self, *args, **kwargs):
+        stream_close = self.stream.close
+
+        def close():
+            stream_close()
+            raise InterruptedError(errno.EINTR, "Interrupted system call")
+
+        with patch.object(self.stream, "close", close):
+            return finalize(self, *args, **kwargs)
+
+    with patch.object(ArrowWriter, "finalize", finalize_with_interrupted_close):
+        out = dset.map(lambda x: {"y": x["x"] + 1}, cache_file_name=str(tmp_path / "cache.arrow"))
+    assert out["y"] == list(range(1, 11))
+
+
 def test_filter_async():
     dset = Dataset.from_dict({"x": range(100)})
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import copy
+import errno
 import itertools
 import json
 import os
@@ -27,6 +28,7 @@ import datasets.arrow_dataset
 import datasets.config
 from datasets import concatenate_datasets, interleave_datasets, load_from_disk
 from datasets.arrow_dataset import Dataset, transmit_format, update_metadata_with_features
+from datasets.arrow_writer import ArrowWriter
 from datasets.dataset_dict import DatasetDict
 from datasets.features import (
     Array2D,
@@ -4807,6 +4809,25 @@ def test_map_async():
     out = dset.map(f, batched=True)
     assert time.time() - _start < 2.0
     assert out[0]["y"] == 1
+
+
+def test_map_keeps_the_error_raised_when_finalizing():
+    dset = Dataset.from_dict({"x": range(10)})
+    finalize = ArrowWriter.finalize
+    num_calls = 0
+
+    def finalize_and_fail_once(self, *args, **kwargs):
+        # the stream is closed but finalize() raises, e.g. when close() is interrupted by a signal
+        nonlocal num_calls
+        num_calls += 1
+        out = finalize(self, *args, **kwargs)
+        if num_calls == 1:
+            raise InterruptedError(errno.EINTR, "Interrupted system call")
+        return out
+
+    with patch.object(ArrowWriter, "finalize", finalize_and_fail_once):
+        with pytest.raises(InterruptedError):
+            dset.map(lambda x: x)
 
 
 def test_filter_async():


### PR DESCRIPTION
## Summary

Fixes #8491.

When `writer.finalize()` raises in `_map_single()`, the `except` block calls `finalize()` again on a writer whose stream is already closed. `finalize()` then hits `self.pa_writer is None and self.schema` and calls `_build_writer(self.schema)`, which raises `ValueError: I/O operation on closed file` from pyarrow. That replaces the exception we were handling, so the traceback the user sees points at the cleanup path instead of the real failure (in #8491 an `InterruptedError` from `stream.close()` with `num_proc=512`). It also skips the `tmp_file.close()` / `os.remove()` below it, leaving the partial shard behind.

Wrap the cleanup `finalize()` so the original error reaches the `raise` and the temp file still gets removed.

Second commit (after @HowardZorn's review): `ArrowWriter.finalize` now ignores `InterruptedError` from `stream.close()`. By then `pa_writer.close()` has flushed everything and, on Linux, the fd is already closed even when `close(2)` returns EINTR, so retrying would be wrong (fd reuse, see `man 2 close`; PEP 475 leaves `close()` out for the same reason). We log and continue, so the worker survives. The cleanup path in `_map_single` logs a `warning` (not `debug`) with the finalize error so it isn't silently lost.

## How tested

New tests in `tests/test_arrow_dataset.py`:

`test_map_ignores_interrupted_close`: patch the stream's `close` to close for real then raise `InterruptedError(EINTR)`, assert `map()` succeeds and the output reads back. Fails on `main` with the `InterruptedError`.

`test_map_keeps_the_error_raised_when_finalizing`: patch `ArrowWriter.finalize` so the first call runs for real and then raises `InterruptedError` (the state in the report: `pa_writer` set to None, stream closed), and assert `map()` propagates that `InterruptedError`. On `main` it fails with `ValueError: I/O operation on closed file` raised from `_build_writer`, same as the report.

```
$ python -m pytest tests/test_arrow_dataset.py -q -n 8
1 failed, 363 passed, 61 skipped, 17 warnings
```

(The one failure is `test_dataset_to_iterable_dataset`, which errors with "PyTorch needs to be installed to be able to return PyTorch tensors" because torch is not installed in my environment. Unrelated to this change.)

`make quality` is clean (`ruff check` passed, `ruff format --check` reports 233 files already formatted).

