### PR TITLE
Validate class labels when casting an integer column to ClassLabel

### DIFF
--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -2374,10 +2374,8 @@ def table_cast(table: pa.Table, schema: pa.Schema):
     Returns:
         table (`pyarrow.Table`): the casted table
     """
-    if table.schema != schema:
+    if table.schema != schema or table.schema.metadata != schema.metadata:
         return cast_table_to_schema(table, schema)
-    elif table.schema.metadata != schema.metadata:
-        return table.replace_schema_metadata(schema.metadata)
     else:
         return table
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3637,6 +3637,24 @@ def test_cast_with_sliced_list():
     assert casted_dataset.features == new_features
 
 
+def test_cast_column_to_class_label_out_of_range():
+    names = ["negative", "positive", "irrelevant"]
+    dataset = Dataset.from_dict({"label": [5, 1]})
+    with pytest.raises(ValueError, match="Class label 5 greater than configured num_classes 3"):
+        dataset.cast_column("label", ClassLabel(names=names))
+    features = Features({"label": ClassLabel(names=names)})
+    with pytest.raises(ValueError, match="Class label 5 greater than configured num_classes 3"):
+        dataset.cast(features)
+
+
+def test_cast_column_to_class_label_in_range():
+    names = ["negative", "positive"]
+    dataset = Dataset.from_dict({"label": [1, 0]})
+    casted_dataset = dataset.cast_column("label", ClassLabel(names=names))
+    assert casted_dataset["label"] == [1, 0]
+    assert casted_dataset.features["label"].int2str(1) == "positive"
+
+
 @pytest.mark.parametrize("include_nulls", [False, True])
 def test_class_encode_column_with_none(include_nulls):
     dataset = Dataset.from_dict({"col_1": ["a", "b", "c", None, "d", None]})


### PR DESCRIPTION
`table_cast` took a metadata-only fast path when the arrow schema was unchanged, so casting int64 storage to `ClassLabel` never ran `ClassLabel.cast_storage` and out-of-range label indices were accepted silently. Route metadata-only changes through `cast_table_to_schema` too, so the range check runs like on the write path.

Fixes #8494

Added regression tests in `tests/test_arrow_dataset.py`. `test_table.py` passes (278), and `test_arrow_dataset.py` / `test_dataset_dict.py` / `test_iterable_dataset.py` pass (872) apart from 5 pre-existing interleave/`to_iterable_dataset` failures that also fail on main without this patch.
