### PR TITLE
Preserve storage options across URL hops

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -886,7 +886,7 @@ def _prepare_path_and_storage_options(
         hop, storage_options = _prepare_single_hop_path_and_storage_options(hop, download_config=download_config)
         prepared_urlpath.append(hop)
         prepared_storage_options.update(storage_options)
-    return "::".join(prepared_urlpath), storage_options
+    return "::".join(prepared_urlpath), prepared_storage_options
 
 
 def _prepare_single_hop_path_and_storage_options(

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -12,6 +12,7 @@ from huggingface_hub.errors import OfflineModeIsEnabled
 from datasets.download.download_config import DownloadConfig
 from datasets.utils.file_utils import (
     _get_extraction_protocol,
+    _prepare_path_and_storage_options,
     _prepare_single_hop_path_and_storage_options,
     cached_path,
     fsspec_get,
@@ -222,6 +223,19 @@ def test_prepare_single_hop_path_and_storage_options(
     assert storage_options == expected_storage_options
     # Check that DownloadConfig.storage_options are not modified:
     assert str(download_config.storage_options) == original_download_config_storage_options
+
+
+def test_prepare_path_and_storage_options_multiple_hops():
+    urlpath = "zip://data.jsonl::https://domain.org/archive.zip"
+    download_config = DownloadConfig(storage_options={"zip": {"mode": "r"}, "https": {"block_size": "omit"}})
+
+    prepared_urlpath, storage_options = _prepare_path_and_storage_options(urlpath, download_config)
+
+    assert prepared_urlpath == urlpath
+    assert storage_options == {
+        "zip": {"mode": "r"},
+        "https": {"block_size": "omit", "client_kwargs": {"trust_env": True}},
+    }
 
 
 class DummyTestFS(AbstractFileSystem):


### PR DESCRIPTION
## Summary

- return the accumulated storage options for every hop in chained fsspec URLs
- add a regression test covering protocol-specific options on both `zip` and `https` hops

## Problem

`_prepare_path_and_storage_options` builds `prepared_storage_options` while iterating over a multi-hop path, but returned the loop-local `storage_options` value instead. As a result, options for every hop except the last one were silently discarded. This can drop archive settings, credentials, or other protocol-specific configuration from paths such as `zip://data.jsonl::https://example.org/archive.zip`.

## Validation

- `make quality`
- `pytest tests/test_file_utils.py` (138 passed, 3 skipped)
- focused multi-hop and single-hop preparation tests (9 passed)

I also ran the broader test suite: 3,172 tests passed and 18 skipped before it was stopped after 15 minutes; the 97 failures were confined to optional local integrations such as TorchCodec/FFmpeg media decoding, Spark/Java, Faiss, and distributed multiprocessing, unrelated to this change.
