### PR TITLE
fix: bound Dataset.take range to prevent IndexError when n > len(dataset)

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4699,7 +4699,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
          'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .'}]
         ```
         """
-        return self.select(range(n))
+        return self.select(range(min(max(0, n), len(self))))
 
     @transmit_format
     @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -2311,6 +2311,27 @@ class BaseDatasetTest(TestCase):
                     self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
                     self.assertDictEqual(dset_select_five.features, Features({"filename": Value("string")}))
 
+    def test_take(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir) as dset:
+                # normal take
+                taken_3 = dset.take(3)
+                self.assertEqual(len(taken_3), 3)
+                self.assertEqual(list(taken_3["filename"]), [f"my_name-train_{i}" for i in range(3)])
+
+                # take more than dataset size returns whole dataset instead of raising IndexError
+                taken_all = dset.take(len(dset) + 10)
+                self.assertEqual(len(taken_all), len(dset))
+                self.assertEqual(list(taken_all["filename"]), list(dset["filename"]))
+
+                # take 0 returns empty dataset
+                taken_zero = dset.take(0)
+                self.assertEqual(len(taken_zero), 0)
+
+                # take negative returns empty dataset
+                taken_neg = dset.take(-5)
+                self.assertEqual(len(taken_neg), 0)
+
     def test_select_then_map(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir) as dset:


### PR DESCRIPTION
## Summary

Fixes #8483

Currently \Dataset.take(n)\ executes \self.select(range(n))\. When \
\ exceeds the dataset size \len(self)\, \ange(n)\ attempts to index beyond the end of the table and raises an \IndexError\. Meanwhile, \IterableDataset.take(n)\ gracefully yields up to \
\ items.

## Changes

- In \src/datasets/arrow_dataset.py\, clamp the range indices for \	ake(n)\ to \min(max(0, n), len(self))\.
- Added unit tests in \	ests/test_arrow_dataset.py\ covering:
  - normal \	ake(3)\
  - \	ake(len(dset) + 10)\ returning the full dataset without throwing \IndexError\
  - \	ake(0)\ and negative \
\ returning an empty dataset.