### PR TITLE
Format bool and temporal values as numpy scalars and keep the duration dtype in numpy format

### DIFF
--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -48,12 +48,13 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
             return value
         elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value
-        elif isinstance(value, np.number):
+        elif isinstance(value, (np.number, np.bool_, np.datetime64, np.timedelta64)):
             return value
 
         default_dtype = {}
 
-        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
+        # note: don't use np.issubdtype(value.dtype, np.integer) here, since timedelta64 is a subdtype of np.integer
+        if isinstance(value, np.ndarray) and value.dtype.kind in ("i", "u"):
             default_dtype = {"dtype": np.int64}
         elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
             default_dtype = {"dtype": np.float32}
@@ -86,7 +87,7 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
             if isinstance(data_struct, torch.Tensor):
                 return self._tensorize(data_struct.detach().cpu().numpy()[()])
-        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.character, np.number)):
+        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.generic)):
             data_struct = data_struct.__array__()
         # support for nested types like struct of list of struct
         if isinstance(data_struct, np.ndarray):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -293,6 +293,36 @@ class FormatterTest(TestCase):
         np.testing.assert_equal(batch, {"a": np.array(_COL_A), "b": np.array(_COL_B), "c": np.array(_COL_C)})
         assert batch["c"].shape == np.array(_COL_C).shape
 
+    def test_numpy_formatter_scalar_bool_and_temporal(self):
+        # bool and temporal values must be formatted as numpy scalars like every
+        # other dtype, not wrapped in 0-dimensional (unhashable) arrays
+        pa_table = pa.table(
+            {
+                "bool": pa.array([True, False]),
+                "timestamp": pa.array([datetime.datetime(2023, 1, 1)] * 2, type=pa.timestamp("us")),
+                "duration": pa.array([datetime.timedelta(seconds=1)] * 2, type=pa.duration("us")),
+            }
+        )
+        formatter = NumpyFormatter()
+        row = formatter.format_row(pa_table)
+        self.assertIsInstance(row["bool"], np.bool_)
+        self.assertIsInstance(row["timestamp"], np.datetime64)
+        self.assertIsInstance(row["duration"], np.timedelta64)
+        self.assertEqual(row["bool"], np.bool_(True))
+        self.assertEqual(row["timestamp"], np.datetime64("2023-01-01T00:00:00", "us"))
+        self.assertEqual(row["duration"], np.timedelta64(1_000_000, "us"))
+
+    def test_numpy_formatter_duration_column_keeps_dtype(self):
+        # in numpy, timedelta64 is a subdtype of np.integer: the int64 default dtype
+        # must not strip the timedelta64 dtype from duration columns
+        pa_table = pa.table({"duration": pa.array([datetime.timedelta(seconds=1)] * 2, type=pa.duration("us"))})
+        formatter = NumpyFormatter()
+        col = formatter.format_column(pa_table)
+        self.assertEqual(col.dtype, np.dtype("timedelta64[us]"))
+        batch = formatter.format_batch(pa_table)
+        self.assertEqual(batch["duration"].dtype, np.dtype("timedelta64[us]"))
+        np.testing.assert_array_equal(batch["duration"], np.array([1_000_000] * 2, dtype="timedelta64[us]"))
+
     def test_numpy_formatter_np_array_kwargs(self):
         pa_table = self._create_dummy_table().drop(["b"])
         formatter = NumpyFormatter(dtype=np.float16)


### PR DESCRIPTION
Fixes #8500

`NumpyFormatter._tensorize` now early-returns `np.bool_`/`np.datetime64`/`np.timedelta64` scalars like other numpy scalars, `_recursive_tensorize` excludes all `np.generic` scalars from `__array__` conversion (previously it re-wrapped bool/datetime scalars into 0-d arrays), and the int64 default dtype only applies to dtype kind `i`/`u`, so duration arrays keep `timedelta64[us]` (in numpy's type hierarchy `timedelta64` is a subdtype of `np.integer`, which the previous `np.issubdtype` check caught by accident). The float32/int64 default-dtype policy for numeric arrays is unchanged.

Adds two regression tests that fail on main: `test_numpy_formatter_scalar_bool_and_temporal` (row access returns hashable numpy scalars for bool/timestamp/date, consistent with int/float/str) and `test_numpy_formatter_duration_column_keeps_dtype` (batch access keeps `timedelta64[us]` and agrees with row access). Full `tests/test_formatting.py`: 26 passed; `tests/test_arrow_dataset.py -k format`: 22 passed. `ruff check` + `ruff format --check` clean on touched files.

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.