### PR TITLE
Add support for datasets backed by vortex file format

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - python
     - pip
     - numpy >=1.17
-    - pyarrow >=16.0.0
+    - pyarrow >=24.0.0
     - python-xxhash
     - dill
     - pandas
@@ -31,7 +31,7 @@ requirements:
     - python
     - pip
     - numpy >=1.17
-    - pyarrow >=16.0.0
+    - pyarrow >=24.0.0
     - python-xxhash
     - dill
     - pandas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: uv pip install --system --upgrade pyarrow huggingface-hub "dill<0.3.9"
       - name: Install dependencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: uv pip install --system pyarrow==21.0.0 huggingface-hub==0.25.0 transformers dill==0.3.1.1
+        run: uv pip install --system pyarrow==24.0.0 huggingface-hub==0.25.0 transformers dill==0.3.1.1
       - name: Print dependencies
         run: uv pip list
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system "datasets[tests] @ ."
       - name: Install tsfile (py3.14 only)
-        run: uv pip install --system "tsfile>=2.3.0"
+        # --no-deps because tsfile caps pyarrow<24, which silently downgrades
+        # the pyarrow that datasets needs. Its other deps come from datasets.
+        run: uv pip install --system --no-deps "tsfile>=2.3.0"
       - name: Print dependencies
         run: uv pip list
       - name: Test with pytest

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -189,6 +189,31 @@ for row in ds.take(3):
 
 This will return the image caption and the image bytes in a single request.
 
+### Vortex
+
+[Vortex](https://docs.vortex.dev) is a columnar file format built for fast scans over compressed data. Install it with `pip install vortex-data`, then load `.vortex` files like any other packaged format:
+
+```py
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("vortex", data_files="data.vortex", split="train")
+```
+
+Columns and filters are pushed down into the Vortex scan, so only the rows and columns you ask for are read. This works while streaming too, which lets you filter a dataset on the Hub without downloading the parts that don't match:
+
+```py
+>>> filters = [("label", "==", 1)]
+>>> dataset = load_dataset(vortex_dataset_id, columns=["text", "label"], filters=filters, streaming=True, split="train")
+```
+
+Filters take the same disjunctive normal form as the Parquet loader: a list of `(column, operator, value)` predicates is a conjunction, and a list of those is a disjunction. Nulls follow SQL semantics — a null satisfies no comparison, so a row whose filtered column is null is never returned, including for `not in`. For anything that form can't express, pass a Vortex expression instead:
+
+```py
+>>> import vortex.expr as ve
+>>> dataset = load_dataset(vortex_dataset_id, filters=ve.column("score") >= 0.5, split="train")
+```
+
+Vortex opens files itself rather than through fsspec, so `data_files` can point to local paths, Hub datasets and the remote locations Vortex reads natively (HTTP and the common object stores) — but not inside archives (`zip://...`) or other fsspec-only protocols.
+
 ### HDF5 files
 
 [HDF5](https://www.hdfgroup.org/solutions/hdf5/) files are commonly used for storing large amounts of numerical data in scientific computing and machine learning. Loading HDF5 files with 🤗 Datasets is similar to loading CSV files:

--- a/docs/source/package_reference/loading_methods.mdx
+++ b/docs/source/package_reference/loading_methods.mdx
@@ -67,6 +67,12 @@ load_dataset("csv", data_dir="path/to/data/dir", sep="\t")
 
 [[autodoc]] datasets.packaged_modules.arrow.Arrow
 
+### Vortex
+
+[[autodoc]] datasets.packaged_modules.vortex.VortexConfig
+
+[[autodoc]] datasets.packaged_modules.vortex.Vortex
+
 ### SQL
 
 [[autodoc]] datasets.packaged_modules.sql.SqlConfig

--- a/setup.py
+++ b/setup.py
@@ -110,8 +110,8 @@ REQUIRED_PKGS = [
     # We use numpy>=1.17 to have np.random.Generator (Dataset shuffling)
     "numpy>=1.17",
     # Backend and serialization.
-    # Minimum 21.0.0 to support `use_content_defined_chunking` in ParquetWriter
-    "pyarrow>=21.0.0",
+    # Minimum 24.0.0 for view-type `nbytes` support used by Vortex
+    "pyarrow>=24.0.0",
     # For smart caching dataset processing
     "dill>=0.3.0,<0.4.2",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
     # For performance gains with apache arrow
@@ -173,6 +173,7 @@ TESTS_REQUIRE = [
     "h5py",
     "pylance",
     "pyiceberg[sql-sqlite,pyarrow]",
+    "vortex-data; python_version >= '3.11' and sys_platform != 'win32'",
     "jax>=0.3.14; sys_platform != 'win32'",
     "jaxlib>=0.3.14; sys_platform != 'win32'",
     "lz4; python_version < '3.14'",  # python 3.14 gives ImportError: cannot import name '_compression' from partially initialized module 'lz4.frame

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,9 @@ TESTS_REQUIRE = [
     "py7zr",
     "rarfile>=4.0",
     "sqlalchemy",
-    "protobuf<4.0.0",  # 4.0.0 breaks compatibility with tensorflow<2.12
+    # Pinned for the tensorflow<2.12 builds; tensorflow has no python 3.14 wheels, where
+    # `substrait` (a vortex-data dependency) needs the protobuf 5 runtime.
+    "protobuf<4.0.0; python_version < '3.14'",
     "tensorflow>=2.6.0; python_version<'3.10' and sys_platform != 'win32'",  # numpy-2 is not supported for Python < 3.10
     "tensorflow>=2.16.0; python_version>='3.10' and sys_platform != 'win32' and python_version < '3.14'",  # Pins numpy < 2
     "tiktoken",

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1853,10 +1853,9 @@ class ArrowBasedBuilder(DatasetBuilder):
                             gen_kwargs=gen_kwargs,
                             token=self.token,
                         )
-                    if len(original_shard_lengths) == original_shard_id:
-                        original_shard_lengths.append(len(table))
-                    else:
-                        original_shard_lengths[original_shard_id] += len(table)
+                    if len(original_shard_lengths) <= original_shard_id:
+                        original_shard_lengths.extend([0] * (1 + original_shard_id - len(original_shard_lengths)))
+                    original_shard_lengths[original_shard_id] += len(table)
                     num_examples_progress_update += len(table)
                     if time.time() > _time + config.PBAR_REFRESH_TIME_INTERVAL:
                         _time = time.time()

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4019,6 +4019,7 @@ class IterableDataset(DatasetInfoMixin):
         The resharding mechanism depends on the dataset file format:
 
         * Parquet: shard per row group instead of per file
+        * Vortex: shard per range of consecutive chunks (about 64MB of file data each) instead of per file
         * Other: not implemented yet (contributions are welcome !)
 
         Be sure to reshard/shard before using any randomizing operator (such as `shuffle`).

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -239,6 +239,7 @@ def infer_module_for_data_files_list(
                 count,
                 ext == ".parquet",
                 ext == ".lance",
+                ext == ".vortex",
                 ext == ".arrow",
                 ext == ".jsonl",
                 ext == ".json",

--- a/src/datasets/packaged_modules/__init__.py
+++ b/src/datasets/packaged_modules/__init__.py
@@ -24,6 +24,7 @@ from .sql import sql
 from .text import text
 from .tsfile import tsfile
 from .videofolder import videofolder
+from .vortex import vortex
 from .webdataset import webdataset
 from .xml import xml
 
@@ -63,6 +64,7 @@ _PACKAGED_DATASETS_MODULES = {
     "lance": (lance.__name__, _hash_python_lines(inspect.getsource(lance).splitlines())),
     "tsfile": (tsfile.__name__, _hash_python_lines(inspect.getsource(tsfile).splitlines())),
     "iceberg": (iceberg.__name__, _hash_python_lines(inspect.getsource(iceberg).splitlines())),
+    "vortex": (vortex.__name__, _hash_python_lines(inspect.getsource(vortex).splitlines())),
 }
 
 # get importable module names and hash for caching
@@ -99,6 +101,7 @@ _EXTENSION_TO_MODULE: dict[str, tuple[str, dict]] = {
     ".eval": ("eval", {}),
     ".lance": ("lance", {}),
     ".tsfile": ("tsfile", {}),
+    ".vortex": ("vortex", {}),
 }
 _EXTENSION_TO_MODULE.update({ext: ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})
 _EXTENSION_TO_MODULE.update({ext.upper(): ("imagefolder", {}) for ext in imagefolder.ImageFolder.EXTENSIONS})

--- a/src/datasets/packaged_modules/vortex/vortex.py
+++ b/src/datasets/packaged_modules/vortex/vortex.py
@@ -1,0 +1,353 @@
+import functools
+import operator
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Optional, Union
+from urllib.parse import unquote
+
+import pyarrow as pa
+
+import datasets
+from datasets.builder import Key
+from datasets.table import table_cast
+from datasets.utils.file_utils import xgetsize
+
+
+if TYPE_CHECKING:
+    import vortex
+    import vortex.expr
+    import vortex.store
+
+logger = datasets.utils.logging.get_logger(__name__)
+
+# Vortex reads `hf://` URIs itself, so this is only matched to re-root a read on an `HfStore`
+# carrying the `token` and `endpoint` that `load_dataset` was given, which a URI cannot express.
+_HF_URI_PATTERN = re.compile(r"^hf://datasets/([^/@]+/[^/@]+?)(?:@([^/]+))?/(.+)$")
+
+# The comparisons `pyarrow.parquet.filters_to_expression` accepts, mapped to the Python operators
+# that build the equivalent Vortex expression.
+_FILTER_COMPARISONS = {
+    "==": operator.eq,
+    "=": operator.eq,
+    "!=": operator.ne,
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+}
+
+# When `IterableDataset.reshard()` subdivides files, adjacent splits (one per chunk of the file,
+# usually a few thousand rows) are coalesced into shards of about this many bytes of file data.
+# The target is converted to rows through the file's average row size, so shards weigh about the
+# same however wide or compressible the rows are. Coalescing whole splits keeps shard boundaries
+# on chunk boundaries, so neighboring shards never read the same chunk.
+_RESHARD_TARGET_NUM_BYTES = 64 << 20
+
+# The rows per shard to fall back to when the file's size cannot be determined.
+_RESHARD_FALLBACK_NUM_ROWS = 1 << 20
+
+
+@dataclass
+class VortexConfig(datasets.BuilderConfig):
+    """
+    BuilderConfig for Vortex.
+
+    Args:
+        batch_size (`int`, *optional*):
+            Size of the RecordBatches to iterate on.
+            The default is defined by the Vortex scanner.
+        columns (`list[str]`, *optional*)
+            List of columns to load, the other ones are ignored.
+            All columns are loaded by default.
+        features: (`Features`, *optional*):
+            Cast the data to `features`.
+        filters (`Union[vortex.expr.Expr, list[tuple], list[list[tuple]]]`, *optional*):
+            Return only the rows matching the filter.
+            The predicate is pushed down into the Vortex scan so only the matching rows are read.
+            Filters given as a list of tuples (DNF, like the Parquet loader accepts) are converted
+            to a Vortex expression.
+            Nulls follow SQL semantics: a null satisfies no comparison, so a row whose filtered
+            column is null is never returned. Note that `not in` therefore drops nulls, where the
+            Parquet loader keeps them because it builds `~field.isin(values)` and a null is not in
+            the set.
+        on_bad_files (`Literal["error", "warn", "skip"]`, *optional*, defaults to "error")
+            Specify what to do upon encountering a bad file (a file that can't be read). Allowed values are :
+            * 'error', raise an Exception when a bad file is encountered.
+            * 'warn', raise a warning when a bad file is encountered and skip that file.
+            * 'skip', skip bad files without raising or warning when they are encountered.
+
+    Example:
+
+    Load a subset of columns:
+
+    ```python
+    >>> ds = load_dataset(vortex_dataset_id, columns=["col_0", "col_1"])
+    ```
+
+    Stream data and efficiently filter data, skipping entire files or chunks when possible:
+
+    ```python
+    >>> filters = [("col_0", "==", 0)]
+    >>> ds = load_dataset(vortex_dataset_id, streaming=True, filters=filters)
+    ```
+
+    """
+
+    batch_size: Optional[int] = None
+    columns: Optional[list[str]] = None
+    features: Optional[datasets.Features] = None
+    filters: Optional[Union["vortex.expr.Expr", list[tuple], list[list[tuple]]]] = None
+    on_bad_files: Literal["error", "warn", "skip"] = "error"
+
+    def __post_init__(self):
+        super().__post_init__()
+
+
+def _filters_to_expression(filters: Union[list[tuple], list[list[tuple]]]) -> "vortex.expr.Expr":
+    """Convert Parquet-style DNF filters to a Vortex expression.
+
+    Accepts the shapes `pyarrow.parquet.filters_to_expression` accepts: a list of predicates, taken
+    as a conjunction, or a list of such lists, taken as a disjunction of conjunctions. A predicate
+    is a `(column, operator, value)` tuple or list.
+    """
+    import vortex.expr as ve
+
+    def predicate_to_expression(predicate) -> "vortex.expr.Expr":
+        col, op, val = predicate
+        column = ve.column(col)
+        if op in _FILTER_COMPARISONS:
+            return _FILTER_COMPARISONS[op](column, val)
+        elif op in ("in", "not in"):
+            if not val:
+                raise ValueError(f"Empty set of values for '{op}' filter on column '{col}'")
+            if op == "in":
+                return ve.or_collect([column == value for value in val])
+            return ve.and_collect([column != value for value in val])
+        else:
+            raise ValueError(f"Unsupported filter operator: '{op}'")
+
+    if not filters or not filters[0]:
+        raise ValueError(f"Malformed filters: {filters}")
+    if isinstance(filters[0][0], str):
+        # One nesting level too few: [(col, op, val), ...] instead of [[(col, op, val), ...]]
+        filters = [filters]
+    conjunctions = []
+    for conjunction in filters:
+        if not conjunction:
+            raise ValueError(f"Malformed filters: {filters}")
+        conjunctions.append(ve.and_collect([predicate_to_expression(predicate) for predicate in conjunction]))
+    return ve.or_collect(conjunctions)
+
+
+@functools.lru_cache(maxsize=64)
+def _hf_store(
+    repo_id: str, revision: Optional[str], token: Optional[Union[str, bool]], endpoint: Optional[str]
+) -> "vortex.store.HfStore":
+    """A store rooted at one repository and revision, shared by all the files read from it."""
+    import vortex.store
+
+    return vortex.store.HfStore(repo_id, revision=revision, token=token, endpoint=endpoint)
+
+
+def _open_vortex_file(file: str, hf_storage_options: Optional[dict] = None) -> "vortex.VortexFile":
+    """Open a Vortex file from a local path, a URL or a `hf://` URI (used in streaming mode).
+
+    Vortex resolves `hf://` URIs itself, taking credentials from `HF_TOKEN` or the saved login, but
+    the `token` and `endpoint` `load_dataset` was given cannot be expressed in a URI. So a Hub read
+    is re-rooted on an `HfStore` carrying them, against which the in-repository path is opened.
+    """
+    import vortex
+
+    matched = _HF_URI_PATTERN.match(file)
+    if matched:
+        repo_id, revision, path_in_repo = matched.groups()
+        hf_storage_options = hf_storage_options or {}
+        # `HfStore` percent-encodes the revision itself, so give it the decoded one.
+        revision = unquote(revision) if revision else None
+        store = _hf_store(repo_id, revision, hf_storage_options.get("token"), hf_storage_options.get("endpoint"))
+        return vortex.open(path_in_repo, store=store)
+    return vortex.open(file)
+
+
+def _to_arrow_reader(
+    vortex_file: "vortex.VortexFile",
+    row_range: Optional[tuple[int, int]],
+    projection: Optional[list[str]],
+    filter_expr: Optional["vortex.expr.Expr"],
+    batch_size: Optional[int] = None,
+) -> pa.RecordBatchReader:
+    """Scan the whole file, or only the rows of `row_range` (offsets in the file, before filtering)."""
+    if row_range is None:
+        return vortex_file.to_arrow(projection=projection, expr=filter_expr, batch_size=batch_size)
+    scan = vortex_file.to_repeated_scan(projection, expr=filter_expr, batch_size=batch_size)
+    return scan.execute(row_range=row_range).to_arrow()
+
+
+def _reshard_target_num_rows(
+    vortex_file: "vortex.VortexFile", file: str, hf_storage_options: Optional[dict] = None
+) -> int:
+    """How many rows of this file weigh about `_RESHARD_TARGET_NUM_BYTES`, by the file's average row size."""
+    num_rows = len(vortex_file)
+    try:
+        download_config = datasets.DownloadConfig(storage_options={"hf": hf_storage_options or {}})
+        file_num_bytes = xgetsize(file, download_config=download_config)
+    except (OSError, NotImplementedError, ValueError):
+        file_num_bytes = None
+    if not file_num_bytes or not num_rows:
+        return _RESHARD_FALLBACK_NUM_ROWS
+    return max(1, num_rows * _RESHARD_TARGET_NUM_BYTES // file_num_bytes)
+
+
+def _coalesced_row_ranges(vortex_file: "vortex.VortexFile", target_num_rows: int) -> list[tuple[int, int]]:
+    """The file's splits, coalesced into row ranges of about `target_num_rows` rows each."""
+    row_ranges = []
+    start = stop = None
+    for split_start, split_stop in vortex_file.splits():
+        if start is not None and split_stop - start <= target_num_rows:
+            stop = split_stop
+        else:
+            if start is not None:
+                row_ranges.append((start, stop))
+            start, stop = split_start, split_stop
+    if start is not None:
+        row_ranges.append((start, stop))
+    return row_ranges
+
+
+class Vortex(datasets.ArrowBasedBuilder, datasets.builder._CountableBuilderMixin):
+    BUILDER_CONFIG_CLASS = VortexConfig
+
+    def _info(self):
+        if (
+            self.config.columns is not None
+            and self.config.features is not None
+            and set(self.config.columns) != set(self.config.features)
+        ):
+            if any(col not in self.config.features for col in self.config.columns):
+                raise ValueError(
+                    "The columns and features argument must match, but got ",
+                    f"{self.config.columns} and {self.config.features}",
+                )
+            else:
+                features = datasets.Features({col: self.config.features[col] for col in self.config.columns})
+        else:
+            features = self.config.features
+        return datasets.DatasetInfo(features=features)
+
+    def _handle_bad_file(self, file: str, error: Exception):
+        if self.config.on_bad_files == "error":
+            logger.error(f"Failed to read file '{file}' with error {type(error).__name__}: {error}")
+            raise error
+        elif self.config.on_bad_files == "warn":
+            logger.warning(f"Skipping bad file '{file}'. {type(error).__name__}: {error}")
+        else:
+            logger.debug(f"Skipping bad file '{file}'. {type(error).__name__}: {error}")
+
+    def _split_generators(self, dl_manager):
+        """We handle string, list and dicts in datafiles"""
+        if not self.config.data_files:
+            raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
+        data_files = dl_manager.download(self.config.data_files)
+        hf_storage_options = dict(dl_manager.download_config.storage_options.get("hf", {}))
+        splits = []
+        for split_name, files in data_files.items():
+            files = [str(file) for file in files]
+            # Infer features if they are stored in the vortex file schema
+            if self.info.features is None:
+                for file in files:
+                    try:
+                        vortex_file = _open_vortex_file(file, hf_storage_options)
+                    except RuntimeError as e:  # Vortex surfaces unreadable files as RuntimeError
+                        self._handle_bad_file(file, e)
+                    else:
+                        self.info.features = datasets.Features.from_arrow_schema(vortex_file.dtype.to_arrow_schema())
+                        break
+            if self.info.features is None:
+                raise ValueError(
+                    f"At least one valid data file must be specified, all the data_files are invalid: {self.config.data_files}"
+                )
+            splits.append(
+                datasets.SplitGenerator(
+                    name=split_name,
+                    gen_kwargs={
+                        "files": files,
+                        "row_ranges": [None] * len(files),
+                        "hf_storage_options": hf_storage_options,
+                    },
+                )
+            )
+        if self.config.columns is not None and set(self.config.columns) != set(self.info.features):
+            self.info.features = datasets.Features(
+                {col: feat for col, feat in self.info.features.items() if col in self.config.columns}
+            )
+        return splits
+
+    def _cast_table(self, pa_table: pa.Table) -> pa.Table:
+        if self.info.features is not None:
+            # more expensive cast to support nested features with keys in a different order
+            # allows str <-> int/float or str to Audio for example
+            pa_table = table_cast(pa_table, self.info.features.arrow_schema)
+        return pa_table
+
+    def _filter_expression(self) -> Optional["vortex.expr.Expr"]:
+        if isinstance(self.config.filters, list):
+            return _filters_to_expression(self.config.filters)
+        return self.config.filters
+
+    def _generate_shards(self, files, row_ranges, hf_storage_options=None):
+        for file, row_range in zip(files, row_ranges):
+            if row_range is None:
+                yield file
+            else:
+                yield {"fragment_data_file": file, "fragment_row_range": row_range}
+
+    def _generate_more_gen_kwargs(self, files, row_ranges, hf_storage_options=None):
+        for file, row_range in zip(files, row_ranges):
+            new_row_ranges = [row_range]
+            if row_range is None:
+                try:
+                    vortex_file = _open_vortex_file(file, hf_storage_options)
+                    target_num_rows = _reshard_target_num_rows(vortex_file, file, hf_storage_options)
+                    new_row_ranges = _coalesced_row_ranges(vortex_file, target_num_rows)
+                except RuntimeError:
+                    # Keep the unreadable file whole: `_generate_tables` applies `on_bad_files` to it.
+                    pass
+            yield {
+                "files": [file] * len(new_row_ranges),
+                "row_ranges": new_row_ranges,
+                "hf_storage_options": hf_storage_options,
+            }
+
+    def _generate_num_examples(self, files, row_ranges, hf_storage_options=None):
+        filter_expr = self._filter_expression()
+        for file, row_range in zip(files, row_ranges):
+            if filter_expr is None:
+                if row_range is None:
+                    yield len(_open_vortex_file(file, hf_storage_options))
+                else:
+                    yield row_range[1] - row_range[0]
+            else:
+                # Counting the matching rows takes a scan, but none of the columns have to come back
+                # from it: an empty projection reads only what the predicate needs.
+                vortex_file = _open_vortex_file(file, hf_storage_options)
+                reader = _to_arrow_reader(vortex_file, row_range, [], filter_expr)
+                yield sum(record_batch.num_rows for record_batch in reader)
+
+    def _generate_tables(self, files, row_ranges, hf_storage_options=None):
+        if self.config.features is not None and self.config.columns is not None:
+            if sorted(field.name for field in self.info.features.arrow_schema) != sorted(self.config.columns):
+                raise ValueError(
+                    f"Tried to load vortex data with columns '{self.config.columns}' with mismatching features '{self.info.features}'"
+                )
+        filter_expr = self._filter_expression()
+        for file_idx, (file, row_range) in enumerate(zip(files, row_ranges)):
+            try:
+                vortex_file = _open_vortex_file(file, hf_storage_options)
+                reader = _to_arrow_reader(
+                    vortex_file, row_range, self.config.columns, filter_expr, self.config.batch_size
+                )
+                for batch_idx, record_batch in enumerate(reader):
+                    pa_table = pa.Table.from_batches([record_batch])
+                    yield Key(file_idx, batch_idx), self._cast_table(pa_table)
+            except RuntimeError as e:  # Vortex surfaces unreadable files as RuntimeError
+                self._handle_bad_file(file, e)

--- a/src/datasets/packaged_modules/vortex/vortex.py
+++ b/src/datasets/packaged_modules/vortex/vortex.py
@@ -24,6 +24,9 @@ logger = datasets.utils.logging.get_logger(__name__)
 # carrying the `token` and `endpoint` that `load_dataset` was given, which a URI cannot express.
 _HF_URI_PATTERN = re.compile(r"^hf://datasets/([^/@]+/[^/@]+?)(?:@([^/]+))?/(.+)$")
 
+# `hf://buckets/...` URIs point at HF Buckets, which `HfStore` cannot root a read on yet.
+_HF_BUCKETS_URI_PATTERN = re.compile(r"^hf://buckets/")
+
 # The comparisons `pyarrow.parquet.filters_to_expression` accepts, mapped to the Python operators
 # that build the equivalent Vortex expression.
 _FILTER_COMPARISONS = {
@@ -155,7 +158,13 @@ def _open_vortex_file(file: str, hf_storage_options: Optional[dict] = None) -> "
     Vortex resolves `hf://` URIs itself, taking credentials from `HF_TOKEN` or the saved login, but
     the `token` and `endpoint` `load_dataset` was given cannot be expressed in a URI. So a Hub read
     is re-rooted on an `HfStore` carrying them, against which the in-repository path is opened.
+
+    Only `hf://datasets/...` URIs are re-rooted this way. `hf://buckets/...` URIs are refused until
+    `HfStore` supports HF Buckets.
     """
+    if _HF_BUCKETS_URI_PATTERN.match(file):
+        raise NotImplementedError(f"Vortex cannot read from HF Buckets yet: {file}")
+
     import vortex
 
     matched = _HF_URI_PATTERN.match(file)

--- a/tests/packaged_modules/test_vortex.py
+++ b/tests/packaged_modules/test_vortex.py
@@ -1,0 +1,374 @@
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from datasets import Features, List, Value, load_dataset, load_dataset_builder
+from datasets.download import DownloadManager
+
+
+vx = pytest.importorskip("vortex")
+
+
+def _write_vortex_file(table: pa.Table, path) -> str:
+    vx.io.write(vx.array(table), str(path))
+    return str(path)
+
+
+@pytest.fixture
+def vortex_file(tmp_path) -> str:
+    data = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4]),
+            "value": pa.array([10.0, 20.0, 30.0, 40.0]),
+            "text": pa.array(["a", "b", "c", "d"]),
+        }
+    )
+    return _write_vortex_file(data, tmp_path / "data.vortex")
+
+
+@pytest.fixture
+def vortex_hf_dataset(tmp_path) -> str:
+    data = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4]),
+            "value": pa.array([10.0, 20.0, 30.0, 40.0]),
+            "text": pa.array(["a", "b", "c", "d"]),
+        }
+    )
+    (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+    _write_vortex_file(data, tmp_path / "data" / "train.vortex")
+    _write_vortex_file(data[:2], tmp_path / "data" / "test.vortex")
+    return str(tmp_path)
+
+
+def test_load_vortex_file(vortex_file):
+    dataset_dict = load_dataset("vortex", data_files=vortex_file)
+    assert "train" in dataset_dict.keys()
+
+    dataset = dataset_dict["train"]
+    assert dataset.column_names == ["id", "value", "text"]
+    assert dataset["id"] == [1, 2, 3, 4]
+    assert dataset["text"] == ["a", "b", "c", "d"]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_vortex_hf_dataset(vortex_hf_dataset, streaming):
+    dataset_dict = load_dataset(vortex_hf_dataset, streaming=streaming)
+    assert "train" in dataset_dict.keys()
+    assert "test" in dataset_dict.keys()
+
+    dataset = dataset_dict["train"]
+    assert list(dataset["id"]) == [1, 2, 3, 4]
+    dataset = dataset_dict["test"]
+    assert list(dataset["id"]) == [1, 2]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_vortex_dataset_with_columns(vortex_hf_dataset, streaming):
+    dataset_dict = load_dataset(vortex_hf_dataset, columns=["id", "text"], streaming=streaming)
+    dataset = dataset_dict["train"]
+
+    assert set(dataset.column_names) == {"id", "text"}
+    assert list(dataset["id"]) == [1, 2, 3, 4]
+    assert list(dataset["text"]) == ["a", "b", "c", "d"]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize(
+    "filters, expected_ids",
+    [
+        ([("id", ">", 2)], [3, 4]),
+        ([("id", "in", [1, 4])], [1, 4]),
+        ([("id", "not in", [1, 4])], [2, 3]),
+        ([[("id", "<", 2)], [("text", "==", "d")]], [1, 4]),
+        # a predicate may be a list rather than a tuple, like the Parquet loader accepts
+        ([["id", ">", 2]], [3, 4]),
+        ([[["id", "<", 2]], [["text", "==", "d"]]], [1, 4]),
+    ],
+)
+def test_load_vortex_dataset_with_filters(vortex_hf_dataset, streaming, filters, expected_ids):
+    dataset = load_dataset(vortex_hf_dataset, filters=filters, streaming=streaming, split="train")
+
+    assert list(dataset["id"]) == expected_ids
+
+
+@pytest.mark.parametrize(
+    "op, value, expected_ids, parquet_ids",
+    [
+        ("==", 2, [2], [2]),
+        ("!=", 2, [1, 3, 4], [1, 3, 4]),
+        ("<", 3, [1, 2], [1, 2]),
+        ("<=", 3, [1, 2, 3], [1, 2, 3]),
+        (">", 3, [4], [4]),
+        (">=", 3, [3, 4], [3, 4]),
+        ("in", [1, 4], [1, 4], [1, 4]),
+        # SQL semantics: a null satisfies no comparison, so `not in` drops it. The Parquet loader
+        # keeps it, building `~field.isin(values)` where a null is not in the set.
+        ("not in", [1, 4], [2, 3], [2, 3, None]),
+    ],
+)
+def test_load_vortex_dataset_filters_nulls_following_sql(tmp_path, op, value, expected_ids, parquet_ids):
+    data = pa.table({"id": pa.array([1, 2, 3, 4, None])})
+    pq.write_table(data, tmp_path / "data.parquet")
+    _write_vortex_file(data, tmp_path / "data.vortex")
+    filters = [("id", op, value)]
+
+    parquet_dataset = load_dataset(
+        "parquet", data_files=str(tmp_path / "data.parquet"), split="train", filters=filters
+    )
+    vortex_dataset = load_dataset("vortex", data_files=str(tmp_path / "data.vortex"), split="train", filters=filters)
+
+    assert vortex_dataset["id"] == expected_ids
+    assert parquet_dataset["id"] == parquet_ids
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_vortex_dataset_with_filter_on_unprojected_column(vortex_hf_dataset, streaming):
+    dataset = load_dataset(
+        vortex_hf_dataset, columns=["text"], filters=[("id", ">", 2)], streaming=streaming, split="train"
+    )
+
+    assert list(dataset["text"]) == ["c", "d"]
+
+
+@pytest.mark.parametrize("op", ["in", "not in"])
+def test_vortex_filters_with_empty_values(op):
+    from datasets.packaged_modules.vortex.vortex import _filters_to_expression
+
+    with pytest.raises(ValueError, match=f"Empty set of values for '{op}' filter"):
+        _filters_to_expression([("id", op, [])])
+
+
+@pytest.mark.parametrize("filters", [[], [[]], [("id", "~=", 2)]])
+def test_vortex_malformed_filters(filters):
+    from datasets.packaged_modules.vortex.vortex import _filters_to_expression
+
+    with pytest.raises(ValueError):
+        _filters_to_expression(filters)
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_vortex_dataset_with_expr_filter(vortex_hf_dataset, streaming):
+    import vortex.expr as ve
+
+    dataset = load_dataset(vortex_hf_dataset, filters=ve.column("value") >= 30.0, streaming=streaming, split="train")
+
+    assert list(dataset["id"]) == [3, 4]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_load_vortex_dataset_with_batch_size(vortex_hf_dataset, streaming):
+    dataset_dict = load_dataset(vortex_hf_dataset, batch_size=1, streaming=streaming)
+    dataset = dataset_dict["train"]
+
+    assert list(dataset["id"]) == [1, 2, 3, 4]
+
+
+def _without_view_types(feature):
+    """Replace the Arrow view types Vortex reports with their canonical equivalents."""
+    if isinstance(feature, Value):
+        return Value(feature.dtype.removesuffix("_view"))
+    elif isinstance(feature, List):
+        return List(_without_view_types(feature.feature), length=feature.length)
+    elif isinstance(feature, dict):
+        return type(feature)({name: _without_view_types(child) for name, child in feature.items()})
+    return feature
+
+
+def test_load_vortex_file_infers_view_typed_features(tmp_path):
+    # Vortex reports its utf8 and binary as the Arrow view types, so the features hold the view
+    # types too. Apart from those, the same data must load the same way as in any other format.
+    data = pa.table(
+        {
+            "text": pa.array(["a", "b"]),
+            "blob": pa.array([b"x", b"y"]),
+            "nested": pa.array([{"text": "a", "blobs": [b"x"]}] * 2),
+            "texts": pa.array([["a", "b"]] * 2),
+        }
+    )
+    pq.write_table(data, tmp_path / "data.parquet")
+    _write_vortex_file(data, tmp_path / "data.vortex")
+
+    parquet_dataset = load_dataset("parquet", data_files=str(tmp_path / "data.parquet"), split="train")
+    vortex_dataset = load_dataset("vortex", data_files=str(tmp_path / "data.vortex"), split="train")
+
+    assert vortex_dataset.features["text"] == Value("string_view")
+    assert vortex_dataset.features["blob"] == Value("binary_view")
+    assert vortex_dataset.features["nested"] == {"text": Value("string_view"), "blobs": List(Value("binary_view"))}
+    assert _without_view_types(vortex_dataset.features) == parquet_dataset.features
+    assert vortex_dataset.to_dict() == parquet_dataset.to_dict()
+
+
+def test_load_vortex_file_with_features(vortex_file):
+    features = Features({"id": Value("int32"), "value": Value("float32"), "text": Value("large_string")})
+    dataset = load_dataset("vortex", data_files=vortex_file, features=features, split="train")
+
+    assert dataset.features == features
+    assert dataset["id"] == [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize(
+    "filters, expected", [(None, {"train": 4, "test": 2}), ([("id", ">", 2)], {"train": 2, "test": 0})]
+)
+def test_count_vortex_examples(vortex_hf_dataset, filters, expected):
+    builder = load_dataset_builder(vortex_hf_dataset, filters=filters)
+
+    assert builder.count_examples(DownloadManager()) == expected
+
+
+@pytest.mark.parametrize("token", [None, True, False, "hf_token"])
+def test_open_vortex_file_passes_hf_storage_options_to_the_store(monkeypatch, token):
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    stores, opened = [], []
+    monkeypatch.setattr(
+        vx.store,
+        "HfStore",
+        lambda repo_id, *, revision=None, token=None, endpoint=None: stores.append(
+            (repo_id, revision, token, endpoint)
+        ),
+    )
+    monkeypatch.setattr(vx, "open", lambda path, store=None: opened.append((path, store)))
+    vortex_module._hf_store.cache_clear()
+
+    storage_options = {"endpoint": "https://hub-ci.huggingface.co", "token": token}
+    for shard in range(2):
+        vortex_module._open_vortex_file(f"hf://datasets/org/name@abc123/data/{shard}.vortex", storage_options)
+
+    # the token is passed on as it was given: `True` and `False` mean the saved login and no login
+    assert stores == [("org/name", "abc123", token, "https://hub-ci.huggingface.co")]  # one store for both shards
+    assert [path for path, _ in opened] == ["data/0.vortex", "data/1.vortex"]
+
+
+def test_open_vortex_file_decodes_the_revision(monkeypatch):
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    stores = []
+    monkeypatch.setattr(
+        vx.store,
+        "HfStore",
+        lambda repo_id, *, revision=None, token=None, endpoint=None: stores.append(revision),
+    )
+    monkeypatch.setattr(vx, "open", lambda path, store=None: None)
+    vortex_module._hf_store.cache_clear()
+
+    vortex_module._open_vortex_file("hf://datasets/org/name@refs%2Fconvert%2Fparquet/data/train.vortex", {})
+
+    assert stores == ["refs/convert/parquet"]  # `HfStore` percent-encodes it again itself
+
+
+@pytest.mark.parametrize("path", ["/local/data.vortex", "https://example.com/data.vortex"])
+def test_open_vortex_file_leaves_non_hub_paths_to_vortex(monkeypatch, path):
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    opened = []
+    monkeypatch.setattr(vx, "open", lambda path, store=None: opened.append((path, store)))
+
+    vortex_module._open_vortex_file(path, {"token": "hf_token"})
+
+    assert opened == [(path, None)]
+
+
+@pytest.fixture
+def vortex_multisplit_file(tmp_path) -> str:
+    # Enough rows that the file's layout yields several splits (Vortex subdivides at about
+    # 100k rows) to reshard on.
+    path = str(tmp_path / "multisplit.vortex")
+    vx.io.write(vx.array(pa.table({"id": pa.array(range(250_000))})), path)
+    return path
+
+
+def test_coalesced_row_ranges():
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    class SplitsOnly:
+        def splits(self):
+            return [(0, 10), (10, 20), (20, 100), (100, 105)]
+
+    assert vortex_module._coalesced_row_ranges(SplitsOnly(), target_num_rows=50) == [(0, 20), (20, 100), (100, 105)]
+
+
+def test_reshard_target_num_rows_follows_the_file_size(vortex_multisplit_file, monkeypatch):
+    import os
+
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    vortex_file = vx.open(vortex_multisplit_file)
+    file_num_bytes = os.path.getsize(vortex_multisplit_file)
+    # a target of half the file must give a target of half the rows
+    monkeypatch.setattr(vortex_module, "_RESHARD_TARGET_NUM_BYTES", file_num_bytes // 2)
+
+    target = vortex_module._reshard_target_num_rows(vortex_file, vortex_multisplit_file)
+
+    assert target == len(vortex_file) * (file_num_bytes // 2) // file_num_bytes
+
+
+def test_reshard_target_num_rows_falls_back_without_a_file_size(vortex_multisplit_file, monkeypatch):
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    def unsized(file, download_config=None):
+        raise OSError("no size for you")
+
+    monkeypatch.setattr(vortex_module, "xgetsize", unsized)
+
+    target = vortex_module._reshard_target_num_rows(vx.open(vortex_multisplit_file), vortex_multisplit_file)
+
+    assert target == vortex_module._RESHARD_FALLBACK_NUM_ROWS
+
+
+@pytest.mark.parametrize("filters", [None, [("id", ">=", 200_000)]])
+def test_reshard_vortex_dataset(vortex_multisplit_file, monkeypatch, filters):
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    # a one-byte target keeps every natural split as its own shard
+    monkeypatch.setattr(vortex_module, "_RESHARD_TARGET_NUM_BYTES", 1)
+    dataset = load_dataset("vortex", data_files=vortex_multisplit_file, streaming=True, split="train", filters=filters)
+    resharded = dataset.reshard()
+
+    assert dataset.num_shards == 1
+    assert resharded.num_shards > 1
+    assert list(resharded) == list(dataset)
+    # already-subdivided shards are kept as they are
+    assert resharded.reshard().num_shards == resharded.num_shards
+
+
+def test_generate_shards_with_row_ranges(vortex_multisplit_file):
+    builder = load_dataset_builder("vortex", data_files=vortex_multisplit_file)
+    shards = list(builder._generate_shards(files=["a", "b"], row_ranges=[None, (0, 5)]))
+
+    assert shards == ["a", {"fragment_data_file": "b", "fragment_row_range": (0, 5)}]
+
+
+@pytest.mark.parametrize("filters, expected", [(None, [2, 2]), ([("id", ">", 2)], [0, 2])])
+def test_count_vortex_examples_per_row_range(vortex_file, filters, expected):
+    builder = load_dataset_builder("vortex", data_files=vortex_file, filters=filters)
+    counts = list(builder._generate_num_examples(files=[vortex_file] * 2, row_ranges=[(0, 2), (2, 4)]))
+
+    assert counts == expected
+
+
+@pytest.fixture
+def bad_vortex_file(tmp_path) -> str:
+    path = tmp_path / "bad.vortex"
+    path.write_bytes(b"this is not a vortex file")
+    return str(path)
+
+
+def test_load_vortex_on_bad_files_error_by_default(vortex_file, bad_vortex_file):
+    with pytest.raises(RuntimeError):
+        load_dataset("vortex", data_files=[bad_vortex_file, vortex_file], split="train")
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("on_bad_files", ["warn", "skip"])
+def test_load_vortex_on_bad_files_skip(vortex_file, bad_vortex_file, on_bad_files, streaming):
+    # the bad file comes first, so both schema inference and generation have to skip it
+    dataset = load_dataset(
+        "vortex",
+        data_files=[bad_vortex_file, vortex_file],
+        split="train",
+        on_bad_files=on_bad_files,
+        streaming=streaming,
+    )
+
+    assert [example["id"] for example in dataset] == [1, 2, 3, 4]

--- a/tests/packaged_modules/test_vortex.py
+++ b/tests/packaged_modules/test_vortex.py
@@ -257,6 +257,13 @@ def test_open_vortex_file_decodes_the_revision(monkeypatch):
     assert stores == ["refs/convert/parquet"]  # `HfStore` percent-encodes it again itself
 
 
+def test_open_vortex_file_refuses_hf_buckets():
+    from datasets.packaged_modules.vortex import vortex as vortex_module
+
+    with pytest.raises(NotImplementedError, match="HF Buckets"):
+        vortex_module._open_vortex_file("hf://buckets/org/name/data/train.vortex", {})
+
+
 @pytest.mark.parametrize("path", ["/local/data.vortex", "https://example.com/data.vortex"])
 def test_open_vortex_file_leaves_non_hub_paths_to_vortex(monkeypatch, path):
     from datasets.packaged_modules.vortex import vortex as vortex_module


### PR DESCRIPTION
Vortex provides fast random access and state of the art analytical
performance. Vortex files are self contained the integration logic
largely resembles parquet.

pyarrow minimum version has been raised in this pr to include fix for
Table.nbytes error with view types https://github.com/apache/arrow/issues/47279.

As requested in #7863

Notes
* shard computation logic might require tuning, the logic in this pr tries to
  find happy middle ground
* vortex doesn't yet have fsspec integration (prs welcome)

