### PR TITLE
Preserve NumPy temporal and boolean scalars

### DIFF
--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -48,12 +48,16 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
             return value
         elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value
-        elif isinstance(value, np.number):
+        elif isinstance(value, np.generic):
             return value
 
         default_dtype = {}
 
-        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
+        if (
+            isinstance(value, np.ndarray)
+            and np.issubdtype(value.dtype, np.integer)
+            and not np.issubdtype(value.dtype, np.timedelta64)
+        ):
             default_dtype = {"dtype": np.int64}
         elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
             default_dtype = {"dtype": np.float32}

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -293,6 +293,25 @@ class FormatterTest(TestCase):
         np.testing.assert_equal(batch, {"a": np.array(_COL_A), "b": np.array(_COL_B), "c": np.array(_COL_C)})
         assert batch["c"].shape == np.array(_COL_C).shape
 
+    def test_numpy_formatter_preserves_temporal_and_boolean_scalars(self):
+        formatter = NumpyFormatter()
+
+        row = formatter.recursive_tensorize(
+            {
+                "boolean": np.bool_(True),
+                "timestamp": np.datetime64("2024-01-01"),
+                "duration": np.timedelta64(5, "s"),
+            }
+        )
+        assert isinstance(row["boolean"], np.bool_)
+        assert isinstance(row["timestamp"], np.datetime64)
+        assert isinstance(row["duration"], np.timedelta64)
+
+        batch = formatter.recursive_tensorize(
+            {"duration": np.array([5, 10], dtype="timedelta64[s]")}
+        )
+        assert np.issubdtype(batch["duration"].dtype, np.timedelta64)
+
     def test_numpy_formatter_np_array_kwargs(self):
         pa_table = self._create_dummy_table().drop(["b"])
         formatter = NumpyFormatter(dtype=np.float16)


### PR DESCRIPTION
Fixes #8500\n\nSummary:\n- Preserve NumPy boolean, datetime, and timedelta scalars during formatting.\n- Avoid coercing timedelta arrays to int64.\n- Add focused formatter coverage.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because the local datasets package is not installed.