### PR TITLE
Preserve special NumPy scalar types in NumPy formatting

### DIFF
--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -48,12 +48,16 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
             return value
         elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value
-        elif isinstance(value, np.number):
+        elif isinstance(value, np.generic):
             return value
 
         default_dtype = {}
 
-        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
+        if (
+            isinstance(value, np.ndarray)
+            and np.issubdtype(value.dtype, np.integer)
+            and not np.issubdtype(value.dtype, np.timedelta64)
+        ):
             default_dtype = {"dtype": np.int64}
         elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
             default_dtype = {"dtype": np.float32}
@@ -86,7 +90,7 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
             if isinstance(data_struct, torch.Tensor):
                 return self._tensorize(data_struct.detach().cpu().numpy()[()])
-        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.character, np.number)):
+        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.generic)):
             data_struct = data_struct.__array__()
         # support for nested types like struct of list of struct
         if isinstance(data_struct, np.ndarray):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -304,6 +304,24 @@ class FormatterTest(TestCase):
         self.assertEqual(batch["a"].dtype, np.dtype(np.float16))
         self.assertEqual(batch["c"].dtype, np.dtype(np.float16))
 
+    def test_numpy_formatter_special_scalars_and_durations(self):
+        table = pa.table(
+            {
+                "boolean": pa.array([True], type=pa.bool_()),
+                "timestamp": pa.array([datetime.datetime(2024, 1, 1)], type=pa.timestamp("us")),
+                "duration": pa.array([datetime.timedelta(seconds=5)], type=pa.duration("us")),
+            }
+        )
+        formatter = NumpyFormatter()
+
+        row = formatter.format_row(table)
+        batch = formatter.format_batch(table)
+
+        self.assertIsInstance(row["boolean"], np.bool_)
+        self.assertIsInstance(row["timestamp"], np.datetime64)
+        self.assertIsInstance(row["duration"], np.timedelta64)
+        self.assertEqual(batch["duration"].dtype, np.dtype("timedelta64[us]"))
+
     @require_pil
     def test_numpy_formatter_image(self):
         # same dimensions


### PR DESCRIPTION
Fixes #8500.\n\nTreat NumPy scalar types uniformly in NumpyFormatter so boolean, datetime, and duration values remain scalar values during row formatting. Also avoid applying the integer default dtype to timedelta arrays, preserving duration units for batch and column formatting.\n\nAdded regression coverage for boolean, timestamp, and duration formatting.\n\nValidation: git diff --check and python3 -m py_compile passed. The targeted pytest could not be collected locally because pyarrow and the editable datasets package are not installed.