### PR TITLE
Validate ArrayXD dimensions during Arrow conversion

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1715,9 +1715,25 @@ def to_pyarrow_listarray(data: Any, pa_type: _ArrayXDExtensionType) -> pa.Array:
         pyarrow.Array
     """
     if contains_any_np_array(data):
-        return any_np_array_to_pyarrow_listarray(data, type=pa_type.value_type)
+        out = any_np_array_to_pyarrow_listarray(data, type=pa_type.value_type)
     else:
-        return pa.array(data, pa_type.storage_dtype)
+        out = pa.array(data, pa_type.storage_dtype)
+
+    nested_array = out
+    for dimension, expected_length in enumerate(pa_type.shape):
+        if expected_length is not None:
+            lengths = nested_array.value_lengths()
+            valid_lengths = pc.equal(lengths, expected_length)
+            valid_lengths = pc.fill_null(valid_lengths, dimension == 0)
+            if pc.any(pc.invert(valid_lengths)).as_py():
+                observed_lengths = pc.unique(lengths).to_pylist()
+                raise TypeError(
+                    f"Array shape mismatch at dimension {dimension}: expected {expected_length}, "
+                    f"but found lengths {observed_lengths}"
+                )
+        nested_array = nested_array.flatten()
+
+    return out
 
 
 def _visit(feature: FeatureType, func: Callable[[FeatureType], Optional[FeatureType]]) -> FeatureType:

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -454,6 +454,20 @@ def test_array_xd_with_np(seq_type, dtype, shape, feature_class):
     assert ds[0]["col"] == expected
 
 
+@pytest.mark.parametrize(
+    "feature,data",
+    [
+        (datasets.Array2D(shape=(2, 2), dtype="int64"), [[[1, 2, 3], [4]]]),
+        (datasets.Array2D(shape=(2, 2), dtype="int64"), [np.array([[1, 2, 3, 4]])]),
+        (datasets.Array2D(shape=(None, 2), dtype="int64"), [[[1, 2, 3], [4]]]),
+        (datasets.Array3D(shape=(2, 1, 2), dtype="int64"), [[[[1, 2, 3]], [[4]]]]),
+    ],
+)
+def test_array_xd_rejects_incorrect_shape(feature, data):
+    with pytest.raises(TypeError, match="Array shape mismatch"):
+        datasets.Dataset.from_dict({"col": data}, features=datasets.Features({"col": feature}))
+
+
 @pytest.mark.parametrize("with_none", [False, True])
 def test_dataset_map(with_none):
     ds = datasets.Dataset.from_dict({"path": ["path1", "path2"]})

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -59,6 +59,12 @@ class TypedSequenceTest(TestCase):
         arr = pa.array(TypedSequence([[[1, 2, 3]]], try_type=Array2D((1, 3), "int64")))
         self.assertEqual(arr.type, Array2DExtensionType((1, 3), "int64"))
 
+    def test_try_extension_type_with_incorrect_shape(self):
+        data = [[[1, 2, 3], [4]]]
+        arr = pa.array(TypedSequence(data, try_type=Array2D((2, 2), "int64")))
+        self.assertEqual(arr.to_pylist(), data)
+        self.assertNotIsInstance(arr.type, Array2DExtensionType)
+
     def test_try_incompatible_extension_type(self):
         arr = pa.array(TypedSequence(["foo", "bar"], try_type=Array2D((1, 3), "int64")))
         self.assertEqual(arr.type, pa.string())


### PR DESCRIPTION
Closes #8507

`ArrayXD` storage uses variable-length Arrow lists for compatibility, but reading the array reshapes values to the declared feature shape. This meant malformed nested input could be accepted and later returned with different row boundaries.

This PR:

- checks every fixed `ArrayXD` dimension after converting the input to Arrow list storage
- keeps dynamic dimensions and top-level null values supported
- raises `TypeError` for a shape mismatch, so `TypedSequence(try_type=...)` can still fall back to inferred storage
- adds regression coverage for Python lists, NumPy input, a dynamic first dimension, and `Array3D`