### PR TITLE
Add return_file_name parameter to JSON dataset loader (Fixes #5806)

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -42,7 +42,6 @@ class FullReadDisallowed(Exception):
     pass
 
 
-@dataclass
 class JsonConfig(datasets.BuilderConfig):
     """BuilderConfig for JSON."""
 
@@ -56,9 +55,35 @@ class JsonConfig(datasets.BuilderConfig):
     newlines_in_values: Optional[bool] = None
     on_mixed_types: Optional[Literal["use_json"]] = "use_json"
     parse_agent_traces: bool = True
+    return_file_name: bool = False
 
-    def __post_init__(self):
-        super().__post_init__()
+    def __init__(
+        self,
+        features: Optional[datasets.Features] = None,
+        encoding: str = "utf-8",
+        encoding_errors: Optional[str] = None,
+        field: Optional[str] = None,
+        use_threads: bool = True,
+        block_size: Optional[int] = None,
+        chunksize: int = 10 << 20,
+        newlines_in_values: Optional[bool] = None,
+        on_mixed_types: Optional[Literal["use_json"]] = "use_json",
+        parse_agent_traces: bool = True,
+        return_file_name: bool = False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.features = features
+        self.encoding = encoding
+        self.encoding_errors = encoding_errors
+        self.field = field
+        self.use_threads = use_threads
+        self.block_size = block_size
+        self.chunksize = chunksize
+        self.newlines_in_values = newlines_in_values
+        self.on_mixed_types = on_mixed_types
+        self.parse_agent_traces = parse_agent_traces
+        self.return_file_name = return_file_name
 
 
 class Json(datasets.ArrowBasedBuilder):
@@ -75,6 +100,14 @@ class Json(datasets.ArrowBasedBuilder):
         if self.config.newlines_in_values is not None:
             raise ValueError("The JSON loader parameter `newlines_in_values` is no longer supported")
         return datasets.DatasetInfo(features=self.config.features)
+
+    def _add_file_name_column(self, pa_table: pa.Table, file_path: str) -> pa.Table:
+        """Add a column with the file name to the table if return_file_name is enabled."""
+        if not self.config.return_file_name:
+            return pa_table
+        file_name = os.path.basename(file_path)
+        file_name_array = pa.array([file_name] * len(pa_table), type=pa.string())
+        return pa_table.append_column("file_name", file_name_array)
 
     def _split_generators(self, dl_manager):
         """We handle string, list and dicts in datafiles"""
@@ -166,7 +199,9 @@ class Json(datasets.ArrowBasedBuilder):
                     if df.columns.tolist() == [0]:
                         df.columns = list(self.config.features) if self.config.features else ["text"]
                     pa_table = pa.Table.from_pandas(df, preserve_index=False)
-                    yield Key(shard_idx, 0), self._cast_table(pa_table)
+                    yield Key(shard_idx, 0), self._cast_table(
+                        self._add_file_name_column(pa_table, file),
+                    )
 
                 # If the files are agent traces (one row = one file except for hermes which can have multiple sessions per file)
                 elif is_agent_traces:
@@ -218,7 +253,9 @@ class Json(datasets.ArrowBasedBuilder):
                             example = json_encode_field(example, json_field_path)
                         examples.append(example)
                     pa_table = pa.Table.from_pylist(examples)
-                    yield Key(shard_idx, 0), self._cast_table(pa_table)
+                    yield Key(shard_idx, 0), self._cast_table(
+                        self._add_file_name_column(pa_table, file),
+                    )
 
                 # If the file has one json object per line
                 else:
@@ -340,7 +377,10 @@ class Json(datasets.ArrowBasedBuilder):
                                 break
                             yield (
                                 Key(shard_idx, batch_idx),
-                                self._cast_table(pa_table, json_field_paths=json_field_paths),
+                                self._cast_table(
+                                    self._add_file_name_column(pa_table, file),
+                                    json_field_paths=json_field_paths,
+                                ),
                             )
                             batch_idx += 1
 

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -807,3 +807,47 @@ def test_json_load_dataset_without_droid_marker_stays_ordinary_json(tmp_path):
 
     assert dataset.column_names == ["type", "id", "version", "timestamp", "message"]
     assert dataset[0]["type"] == "session_start"
+
+
+def test_json_return_file_name(tmp_path):
+    """Test that return_file_name adds a file_name column to the dataset."""
+    jsonl_file = tmp_path / "file1.jsonl"
+    data = textwrap.dedent(
+        """\
+        {"col_1": 1, "col_2": "a"}
+        {"col_1": 2, "col_2": "b"}
+        """
+    )
+    with open(jsonl_file, "w") as f:
+        f.write(data)
+
+    jsonl_file2 = tmp_path / "file2.jsonl"
+    data2 = textwrap.dedent(
+        """\
+        {"col_1": 3, "col_2": "c"}
+        {"col_1": 4, "col_2": "d"}
+        """
+    )
+    with open(jsonl_file2, "w") as f:
+        f.write(data2)
+
+    # Test with return_file_name=True
+    dataset = load_dataset(
+        "json",
+        data_files=[str(jsonl_file), str(jsonl_file2)],
+        split="train",
+        return_file_name=True,
+    )
+
+    assert "file_name" in dataset.column_names
+    assert dataset["file_name"] == ["file1.jsonl", "file1.jsonl", "file2.jsonl", "file2.jsonl"]
+    assert dataset["col_1"] == [1, 2, 3, 4]
+    assert dataset["col_2"] == ["a", "b", "c", "d"]
+
+    # Test with return_file_name=False (default)
+    dataset_no_filename = load_dataset(
+        "json",
+        data_files=[str(jsonl_file), str(jsonl_file2)],
+        split="train",
+    )
+    assert "file_name" not in dataset_no_filename.column_names


### PR DESCRIPTION
## Summary

This PR adds a `return_file_name` parameter to the JSON dataset loader. When enabled, the dataset will include a `file_name` column containing the source file name for each row.

## Changes

1. **Added `return_file_name` parameter to `JsonConfig`** - A new boolean parameter that defaults to `False` for backward compatibility.

2. **Added file name column to dataset** - When `return_file_name=True`, a `file_name` column is added to the dataset containing the source file name (basename of the file path).

3. **Supports multiple file formats** - Works with:
   - JSON Lines (.jsonl) files
   - Single JSON object files (with `field` parameter)
   - Agent traces format

## Usage

```python
from datasets import load_dataset

# Enable file name tracking
dataset = load_dataset("json", data_files=["file1.jsonl", "file2.jsonl"], return_file_name=True)

# The dataset will have a 'file_name' column
print(dataset.column_names)  # ['col_1', 'col_2', 'file_name']
print(dataset['file_name'])  # ['file1.jsonl', 'file1.jsonl', 'file2.jsonl', 'file2.jsonl']
```

## Testing

- Added test `test_json_return_file_name` that verifies:
  - File name column is added when `return_file_name=True`
  - File names are correct for multiple files
  - File name column is not added when `return_file_name=False` (default)

Fixes #5806