### PR TITLE
Fix dead PDF processing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ For more details on using the library, check the [quick start guide](https://hug
   - [Processing audio data](https://huggingface.co/docs/datasets/audio_process)
   - [Processing image data](https://huggingface.co/docs/datasets/image_process)
   - [Processing text data](https://huggingface.co/docs/datasets/nlp_process)
-  - [Processing PDF data](https://huggingface.co/docs/datasets/pdf_process)
+  - [Processing PDF data](https://huggingface.co/docs/datasets/document_dataset)
   - [Processing video data](https://huggingface.co/docs/datasets/video_process)
 - [Streaming a dataset](https://huggingface.co/docs/datasets/stream)
 


### PR DESCRIPTION
## What
Fixed README.md link to PDF processing docs that pointed to a non-existent page (docs/datasets/pdf_process); redirected to docs/datasets/document_dataset, which contains the actual PDF processing content.

## Why
A small, objectively-verifiable improvement (broken-link) found during a
daily open-source maintenance pass (2026-08-24).

## How verified
Confirmed docs/source/pdf_process.mdx does not exist and 'pdf' is absent from docs/source/_toctree.yml (no such page is built/published), while docs/source/document_dataset.mdx exists and documents PdfFolder/PDF dataset creation.
Automated gates: 2 changed lines across 1 files (within limits); cargo check: not needed.

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.