### PR TITLE
Fix typos in docstrings, comments and an error message

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -1841,7 +1841,7 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
     @property
     def num_columns(self) -> dict[str, Optional[int]]:
         """Number of columns in each split of the dataset.
-        This can contain None valies if some splits have unknown features (e.g. after a map() operation).
+        This can contain None values if some splits have unknown features (e.g. after a map() operation).
 
         Example:
 
@@ -1858,7 +1858,7 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
     @property
     def column_names(self) -> dict[str, Optional[list[str]]]:
         """Names of the columns in each split of the dataset.
-        This can contain None valies if some splits have unknown features (e.g. after a map() operation).
+        This can contain None values if some splits have unknown features (e.g. after a map() operation).
 
         Example:
 

--- a/src/datasets/filesystems/compression.py
+++ b/src/datasets/filesystems/compression.py
@@ -23,7 +23,7 @@ class BaseCompressedFileFileSystem(AbstractArchiveFileSystem):
         The compressed file system can be instantiated from any compressed file.
         It reads the contents of compressed file as a filesystem with one file inside, as if it was an archive.
 
-        The single file inside the filesystem is named after the compresssed file,
+        The single file inside the filesystem is named after the compressed file,
         without the compression extension at the end of the filename.
 
         Args:

--- a/src/datasets/fingerprint.py
+++ b/src/datasets/fingerprint.py
@@ -315,7 +315,7 @@ def validate_fingerprint(fingerprint: str, max_length=64):
             )
     if len(fingerprint) > max_length:
         raise ValueError(
-            f"Invalid fingerprint. Maximum lenth is {max_length} but '{fingerprint}' has length {len(fingerprint)}."
+            f"Invalid fingerprint. Maximum length is {max_length} but '{fingerprint}' has length {len(fingerprint)}."
             "It could create issues when creating cache files."
         )
 

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3488,7 +3488,7 @@ class IterableDataset(DatasetInfoMixin):
           Note that the last batch may have less than `n` examples.
           A batch is a dictionary, e.g. a batch of `n` examples is `{"text": ["Hello there !"] * n}`.
 
-        If the function is asynchronous, then `map` will run your function in parallel, with up to one thousand simulatenous calls.
+        If the function is asynchronous, then `map` will run your function in parallel, with up to one thousand simultaneous calls.
         It is recommended to use a `asyncio.Semaphore` in your function if you want to set a maximum number of operations that can run at the same time.
 
         Args:
@@ -3655,7 +3655,7 @@ class IterableDataset(DatasetInfoMixin):
         """Apply a filter function to all the elements so that the dataset only includes examples according to the filter function.
         The filtering is done on-the-fly when iterating over the dataset.
 
-        If the function is asynchronous, then `filter` will run your function in parallel, with up to one thousand simulatenous calls (configurable).
+        If the function is asynchronous, then `filter` will run your function in parallel, with up to one thousand simultaneous calls (configurable).
         It is recommended to use a `asyncio.Semaphore` in your function if you want to set a maximum number of operations that can run at the same time.
 
         Args:
@@ -4434,7 +4434,7 @@ class IterableDataset(DatasetInfoMixin):
                 Successive examples with the same value for that column are in grouped the same batch.
                 This can also be a list of columns if you want to batch by multiple columns.
                 If batching by column, the batch_size is only used to control the size of the batches
-                to group together or slice during acculumation.
+                to group together or slice during accumulation.
 
                 <Added version="4.9.0"/>
             drop_last_batch (`bool`, defaults to `False`):

--- a/src/datasets/parallel/parallel.py
+++ b/src/datasets/parallel/parallel.py
@@ -44,7 +44,7 @@ def _map_with_multiprocessing_pool(
     function, iterable, num_proc, batched, batch_size, types, disable_tqdm, desc, single_map_nested_func
 ):
     num_proc = num_proc if num_proc <= len(iterable) else len(iterable)
-    split_kwds = []  # We organize the splits ourselve (contiguous splits)
+    split_kwds = []  # We organize the splits ourselves (contiguous splits)
     for index in range(num_proc):
         div = len(iterable) // num_proc
         mod = len(iterable) % num_proc

--- a/src/datasets/utils/sharding.py
+++ b/src/datasets/utils/sharding.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def _number_of_shards_in_gen_kwargs(gen_kwargs: dict) -> int:
     """Return the number of possible shards according to the input gen_kwargs"""
-    # Having lists of different sizes makes sharding ambigious, raise an error in this case
+    # Having lists of different sizes makes sharding ambiguous, raise an error in this case
     # until we decide how to define sharding without ambiguity for users
     lists_lengths = {key: len(value) for key, value in gen_kwargs.items() if isinstance(value, list)}
     if len(set(lists_lengths.values())) > 1:
@@ -47,7 +47,7 @@ def _distribute_shards(num_shards: int, max_num_jobs: int) -> list[range]:
 
 def _split_gen_kwargs(gen_kwargs: dict, max_num_jobs: int) -> list[dict]:
     """Split the gen_kwargs into `max_num_job` gen_kwargs"""
-    # Having lists of different sizes makes sharding ambigious, raise an error in this case
+    # Having lists of different sizes makes sharding ambiguous, raise an error in this case
     num_shards = _number_of_shards_in_gen_kwargs(gen_kwargs)
     if num_shards == 1:
         return [dict(gen_kwargs)]


### PR DESCRIPTION
Typo fixes only — no identifiers renamed, no behavior change:

- `filesystems/compression.py`: "compresssed" -> "compressed"
- `fingerprint.py`: error message "Maximum lenth is" -> "Maximum length is"
- `dataset_dict.py` (x2): "contain None valies" -> "values"
- `iterable_dataset.py` (x2): "one thousand simulatenous calls" -> "simultaneous"; and "slice during acculumation" -> "accumulation"
- `utils/sharding.py` (x2): comment "makes sharding ambigious" -> "ambiguous" (the error message a few lines below already spells it correctly)
- `parallel/parallel.py`: comment "organize the splits ourselve" -> "ourselves"