### PR TITLE
fix(tsfile): guard optional Apache TsFile SDK import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,8 @@ jobs:
         run: pip install --upgrade uv
       - name: Install dependencies
         run: uv pip install --system "datasets[tests] @ ."
-      - name: Install tsfile (py3.14 only)
-        run: uv pip install --system "tsfile>=2.3.0"
+      - name: Install tsfile extra (py3.14 only)
+        run: uv pip install --system "datasets[tsfile] @ ."
       - name: Print dependencies
         run: uv pip list
       - name: Test with pytest

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ pip install datasets[vision]
 # For PDFs/NIfTI (pdfplumber, nibabel)
 pip install datasets[pdfs,nibabel]
 
+# For Apache TsFile (time-series)
+pip install datasets[tsfile]
+
 # For PyTorch/TensorFlow/JAX integration
 pip install datasets[torch,tensorflow,jax]
 

--- a/docs/source/about_dataset_load.mdx
+++ b/docs/source/about_dataset_load.mdx
@@ -23,7 +23,7 @@ Under the hood, 🤗 Datasets will use an appropriate [`DatasetBuilder`] based o
 * [`datasets.packaged_modules.parquet.Parquet`] for Parquet
 * [`datasets.packaged_modules.arrow.Arrow`] for Arrow (streaming file format)
 * [`datasets.packaged_modules.sql.Sql`] for SQL databases
-* [`datasets.packaged_modules.tsfile.TsFile`] for TsFile (time-series data)
+* [`datasets.packaged_modules.tsfile.TsFile`] for TsFile (time-series data; requires `pip install "datasets[tsfile]"`)
 * [`datasets.packaged_modules.imagefolder.ImageFolder`] for image folders
 * [`datasets.packaged_modules.audiofolder.AudioFolder`] for audio folders
 

--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -213,6 +213,12 @@ To load a TsFile:
 >>> dataset = load_dataset("tsfile", data_files="my_data.tsfile")
 ```
 
+The Apache TsFile SDK is an optional extra:
+
+```bash
+pip install "datasets[tsfile]"
+```
+
 Filter by time range — bounds are pushed down to TsFile's internal time index and accept `int` epochs, `datetime`, `date`, ISO-8601 strings, or `pyarrow` timestamp scalars:
 
 ```py

--- a/docs/source/tsfile_load.mdx
+++ b/docs/source/tsfile_load.mdx
@@ -6,10 +6,10 @@ This loader is provided as a separate guide because it does not follow the usual
 
 ## Installation
 
-The loader depends on the [`tsfile`](https://pypi.org/project/tsfile/) Python package:
+The loader depends on the [`tsfile`](https://pypi.org/project/tsfile/) Python package, installed via the optional extra:
 
 ```bash
-pip install "tsfile>=2.3.0"
+pip install "datasets[tsfile]"
 ```
 
 ## Data model and output layout

--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,7 @@ TESTS_REQUIRE = [
     "nibabel>=5.3.1",
     "trimesh>=4.10.0",
     "teich==0.1.5",
+    "tsfile>=2.3.0; python_version >= '3.14'",
 ]
 
 NUMPY2_INCOMPATIBLE_LIBRARIES = [
@@ -220,6 +221,11 @@ NIBABEL_REQUIRE = ["nibabel>=5.3.2", "ipyniivue==2.4.2"]
 
 ICEBERG_REQUIRE = ["pyiceberg>=0.7.0"]
 
+# Optional: Apache TsFile SDK. On Python < 3.14 the published wheels pin
+# pyarrow<20, which conflicts with datasets' pyarrow>=21, so CI only installs
+# this extra on 3.14 (see .github/workflows/ci.yml).
+TSFILE_REQUIRE = ["tsfile>=2.3.0"]
+
 EXTRAS_REQUIRE = {
     "audio": AUDIO_REQUIRE,
     "vision": VISION_REQUIRE,
@@ -240,6 +246,7 @@ EXTRAS_REQUIRE = {
     "pdfs": PDFS_REQUIRE,
     "nibabel": NIBABEL_REQUIRE,
     "iceberg": ICEBERG_REQUIRE,
+    "tsfile": TSFILE_REQUIRE,
 }
 
 setup(

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -142,6 +142,7 @@ PDFPLUMBER_AVAILABLE = importlib.util.find_spec("pdfplumber") is not None
 NIBABEL_AVAILABLE = importlib.util.find_spec("nibabel") is not None
 TRIMESH_AVAILABLE = importlib.util.find_spec("trimesh") is not None
 TEICH_AVAILABLE = importlib.util.find_spec("teich") is not None
+TSFILE_AVAILABLE = importlib.util.find_spec("tsfile") is not None
 
 # Optional compression tools
 RARFILE_AVAILABLE = importlib.util.find_spec("rarfile") is not None

--- a/src/datasets/packaged_modules/tsfile/tsfile.py
+++ b/src/datasets/packaged_modules/tsfile/tsfile.py
@@ -48,6 +48,24 @@ from datasets.utils.tqdm import tqdm
 
 logger = datasets.utils.logging.get_logger(__name__)
 
+_TSFILE_INSTALL_ERROR = (
+    "Loading TsFile datasets requires the Apache TsFile Python SDK. "
+    "Please install it with `pip install 'datasets[tsfile]'`."
+)
+
+
+def _require_tsfile() -> None:
+    """Import the optional ``tsfile`` SDK or raise an actionable error.
+
+    The SDK is an extra (``datasets[tsfile]``), not a hard dependency. Bare
+    ``ModuleNotFoundError: No module named 'tsfile'`` is what dataset-viewer
+    workers currently surface (huggingface/datasets#8256, #8499).
+    """
+    try:
+        import tsfile  # noqa: F401
+    except ImportError as err:
+        raise ImportError(_TSFILE_INSTALL_ERROR) from err
+
 
 # ---------------------------------------------------------------------------
 # Type helpers
@@ -56,6 +74,7 @@ logger = datasets.utils.logging.get_logger(__name__)
 
 def _arrow_type(ts_dtype, *, unit: str, tz: Optional[str]) -> pa.DataType:
     """Map a tsfile ``TSDataType`` to its Arrow representation."""
+    _require_tsfile()
     from tsfile.constants import TSDataType
 
     return {
@@ -86,6 +105,7 @@ def _promote_tsdatatype(a, b):
     if a == b:
         return a
 
+    _require_tsfile()
     from tsfile.constants import TSDataType
 
     table = {
@@ -301,6 +321,7 @@ class TsFile(datasets.ArrowBasedBuilder):
 
     def _scan_metadata(self, files) -> Optional[dict]:
         """Walk every file and unify table name, TAG columns, FIELD types."""
+        _require_tsfile()
         from tsfile.constants import TIME_COLUMN, ColumnCategory
 
         wanted_table = self._table
@@ -431,6 +452,7 @@ class TsFile(datasets.ArrowBasedBuilder):
         - ``file_meta``: maps each readable file to its per-file context
           (``tag_cols``, ``field_cols``, ``time_col``).
         """
+        _require_tsfile()
         from tsfile.constants import ColumnCategory
 
         device_to_files: dict[tuple, list[str]] = {}
@@ -541,6 +563,7 @@ class TsFile(datasets.ArrowBasedBuilder):
         field columns that this file owns *and* that the builder requested;
         callers fill missing fields with all-null contributions.
         """
+        _require_tsfile()
         from tsfile import tag_eq
 
         file_tag_cols: list[str] = meta["tag_cols"]
@@ -730,6 +753,7 @@ class TsFile(datasets.ArrowBasedBuilder):
         segfaults. The 6-byte ``TsFile`` magic header is checked first to
         bail out cleanly.
         """
+        _require_tsfile()
         from tsfile import TsFileReader
 
         try:

--- a/tests/packaged_modules/test_tsfile.py
+++ b/tests/packaged_modules/test_tsfile.py
@@ -13,6 +13,8 @@ import pytest
 # `tsfile` requires pyarrow<20 for python<3.14, which conflicts with datasets'
 # pyarrow>=21.0.0. It is therefore only installed in the py3.14 CI. Skip this
 # whole module (at collection time) when tsfile is not importable.
+# `@require_tsfile` is the per-test equivalent (see tests/utils.py); importorskip
+# is still required here because the module imports TsFileWriter at import time.
 pytest.importorskip("tsfile")
 
 from tsfile import ColumnCategory, ColumnSchema, TableSchema, Tablet, TsFileWriter  # noqa: E402
@@ -22,6 +24,7 @@ from datasets import IterableDataset, load_dataset  # noqa: E402
 from datasets.builder import InvalidConfigName  # noqa: E402
 from datasets.data_files import DataFilesList  # noqa: E402
 from datasets.packaged_modules.tsfile.tsfile import TsFileConfig, _to_epoch  # noqa: E402
+from ..utils import require_tsfile  # noqa: F401  (marker lives in tests.utils; collection skip is importorskip)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/packaged_modules/test_tsfile_optional.py
+++ b/tests/packaged_modules/test_tsfile_optional.py
@@ -1,0 +1,29 @@
+"""Tests for the TsFile builder that must run without the optional SDK."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from datasets.packaged_modules.tsfile.tsfile import _TSFILE_INSTALL_ERROR, _require_tsfile
+
+
+def test_require_tsfile_missing_sdk_raises_actionable_import_error():
+    real_import = __import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "tsfile" or (isinstance(name, str) and name.startswith("tsfile.")):
+            raise ImportError("No module named 'tsfile'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=blocked):
+        with pytest.raises(ImportError) as ei:
+            _require_tsfile()
+
+    err = ei.value
+    assert type(err) is ImportError
+    assert "datasets[tsfile]" in str(err)
+    assert _TSFILE_INSTALL_ERROR in str(err)
+    assert err.__cause__ is not None
+    assert "tsfile" in str(err.__cause__)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -239,6 +239,18 @@ def require_torchcodec(test_case):
     return test_case
 
 
+def require_tsfile(test_case):
+    """
+    Decorator marking a test that requires the Apache TsFile Python SDK.
+
+    These tests are skipped when tsfile isn't installed.
+
+    """
+    if not config.TSFILE_AVAILABLE:
+        test_case = unittest.skip("test requires tsfile")(test_case)
+    return test_case
+
+
 def require_pdfplumber(test_case):
     """
     Decorator marking a test that requires pdfplumber.


### PR DESCRIPTION
## Summary
- Guard every `tsfile` SDK import behind `_require_tsfile()` so missing extras raise `ImportError: ... pip install 'datasets[tsfile]'` instead of a bare `ModuleNotFoundError`.
- Add a `tsfile` extra (`tsfile>=2.3.0`), install it in the `tests` extra on Python 3.14 (where it does not conflict with `pyarrow>=21`), and install `datasets[tsfile]` in the py3.14 CI job.
- Document the extra in `loading.mdx`, `tsfile_load.mdx`, `about_dataset_load.mdx`, and the README.
- Add `tests/packaged_modules/test_tsfile_optional.py` for the missing-SDK path. Existing round-trip tests remain behind `pytest.importorskip(tsfile)`.

This is the `datasets`-side slice of #8499 (see also #8256, #8160, and the overlapping #8307). It does **not** register a Hub `format:tsfile` facet: that still needs the SDK on every dataset-viewer worker **and** Hub taxonomy registration.

## Test plan
- [x] `pytest tests/packaged_modules/test_tsfile_optional.py` (no `tsfile` SDK required)
- [ ] CI py3.14 job installs `datasets[tsfile]` and runs `tests/packaged_modules/test_tsfile.py`
- [ ] `pip install 'datasets[tsfile]'` then `load_dataset(tsfile, data_files=...)`
- [ ] Without the extra, `load_dataset(smilegeng/pusht)` raises the actionable `ImportError`

Refs #8499, #8160, #8256, #8307
