### PR TITLE
Fix offline cache lookup with custom data files

### DIFF
--- a/src/datasets/packaged_modules/cache/cache.py
+++ b/src/datasets/packaged_modules/cache/cache.py
@@ -22,6 +22,15 @@ def _get_modification_time(cached_directory_path):
     return (Path(cached_directory_path)).stat().st_mtime
 
 
+def _get_config_name(cached_directory_path: str) -> Optional[str]:
+    try:
+        return json.loads(Path(cached_directory_path, "dataset_info.json").read_text(encoding="utf-8"))[
+            "config_name"
+        ]
+    except (FileNotFoundError, KeyError, json.JSONDecodeError):
+        return None
+
+
 def _find_hash_in_cache(
     dataset_name: str,
     config_name: Optional[str],
@@ -53,6 +62,23 @@ def _find_hash_in_cache(
             == Path(cached_directory_path).parts[-3]  # no extra params => config_id == config_name
         )
     ]
+    if not cached_directory_paths and "data_files" in config_kwargs:
+        # Hub data files are resolved to revision-pinned URLs before their config ID is computed.
+        # In offline mode only the unresolved user patterns are available, so the exact config ID
+        # cannot be reconstructed. Falling back is safe if only one cached custom configuration
+        # corresponds to the requested base config name.
+        requested_config_name = config_name or "default"
+        matching_directory_paths = [
+            cached_directory_path
+            for cached_directory_path in glob.glob(
+                os.path.join(cached_datasets_directory_path_root, "*", "*", "*")
+            )
+            if os.path.isdir(cached_directory_path)
+            and _get_config_name(cached_directory_path) == requested_config_name
+        ]
+        matching_config_ids = {Path(path).parts[-3] for path in matching_directory_paths}
+        if len(matching_config_ids) == 1:
+            cached_directory_paths = matching_directory_paths
     if not cached_directory_paths:
         cached_directory_paths = [
             cached_directory_path

--- a/tests/packaged_modules/test_cache.py
+++ b/tests/packaged_modules/test_cache.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -56,6 +57,44 @@ def test_cache_auto_hash_with_custom_config(text_dir: Path, tmp_path: Path):
     assert list(ds["train"]) == list(reloaded["train"])
     assert list(another_ds) == list(another_reloaded)
     assert list(another_ds["train"]) == list(another_reloaded["train"])
+
+
+def test_cache_auto_hash_with_unresolved_data_files(tmp_path: Path):
+    cache_dir = tmp_path / "test_cache_auto_hash_with_unresolved_data_files"
+    cached_directory = cache_dir / "namespace___dataset" / "en-resolved-data-files-hash" / "0.0.0" / "hash"
+    cached_directory.mkdir(parents=True)
+    (cached_directory / "dataset_info.json").write_text(json.dumps({"config_name": "en"}), encoding="utf-8")
+
+    cache = Cache(
+        cache_dir=str(cache_dir),
+        dataset_name="dataset",
+        repo_id="namespace/dataset",
+        config_name="en",
+        data_files={"train": "data/train.jsonl"},
+        version="auto",
+        hash="auto",
+    )
+
+    assert Path(cache.cache_dir) == cached_directory
+
+
+def test_cache_auto_hash_with_unresolved_data_files_is_ambiguous(tmp_path: Path):
+    cache_dir = tmp_path / "test_cache_auto_hash_with_unresolved_data_files_is_ambiguous"
+    for config_id in ["en-first-data-files-hash", "en-second-data-files-hash"]:
+        cached_directory = cache_dir / "namespace___dataset" / config_id / "0.0.0" / "hash"
+        cached_directory.mkdir(parents=True)
+        (cached_directory / "dataset_info.json").write_text(json.dumps({"config_name": "en"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Couldn't find cache"):
+        Cache(
+            cache_dir=str(cache_dir),
+            dataset_name="dataset",
+            repo_id="namespace/dataset",
+            config_name="en",
+            data_files={"train": "data/train.jsonl"},
+            version="auto",
+            hash="auto",
+        )
 
 
 def test_cache_missing(text_dir: Path, tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes #7551.

Datasets loaded from the Hub with a `data_files` override could not be reloaded in offline mode.

During online loading, relative data file patterns are resolved to revision-pinned Hub URLs before computing the cache configuration ID. During offline lookup, only the original unresolved patterns are available, producing a different ID.

This change falls back to the sole cached custom configuration matching the requested base configuration name. If multiple candidates exist, it preserves the existing error rather than choosing ambiguously.

## Tests

- `pytest tests/packaged_modules/test_cache.py -q`
- `ruff check src/datasets/packaged_modules/cache/cache.py tests/packaged_modules/test_cache.py`
- Verified offline loading against an existing partial `allenai/c4` cache without modifying or aliasing its cache directory