### PR TITLE
fix(datasets): preserve dtype in Image.cast_storage

### DIFF
--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -262,8 +262,15 @@ class Image:
                 path_array = pa.array([None] * len(storage), type=pa.string())
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         elif pa.types.is_list(storage.type):
+            pa_type = storage.type
+            while pa.types.is_list(pa_type):
+                pa_type = pa_type.value_type
+            np_dtype = np.dtype(pa_type.to_pandas_dtype())
             bytes_array = pa.array(
-                [encode_np_array(np.array(arr))["bytes"] if arr is not None else None for arr in storage.to_pylist()],
+                [
+                    encode_np_array(np.array(arr, dtype=np_dtype))["bytes"] if arr is not None else None
+                    for arr in storage.to_pylist()
+                ],
                 type=pa.binary(),
             )
             path_array = pa.array([None] * len(storage), type=pa.string())

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -261,9 +261,13 @@ class Image:
             else:
                 path_array = pa.array([None] * len(storage), type=pa.string())
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
-        elif pa.types.is_list(storage.type):
+        elif (
+            pa.types.is_list(storage.type)
+            or pa.types.is_large_list(storage.type)
+            or pa.types.is_fixed_size_list(storage.type)
+        ):
             pa_type = storage.type
-            while pa.types.is_list(pa_type):
+            while pa.types.is_list(pa_type) or pa.types.is_large_list(pa_type) or pa.types.is_fixed_size_list(pa_type):
                 pa_type = pa_type.value_type
             np_dtype = np.dtype(pa_type.to_pandas_dtype())
             bytes_array = pa.array(


### PR DESCRIPTION
Fixes spurious dtype downcast warning in Image.cast_storage.

Bug: Image.cast_storage at image.py:266 warns about downcasting int64 to uint8 even though storage is already uint8. When storage is a nested pa.list type like list<item: list<item: list<item: uint8>>>, to_pylist returns Python ints and np.array(arr) without dtype infers int64, triggering encode_np_array to warn about downcasting to uint8.

Fix: Unwrap storage.type nested list value types (list, large_list, fixed_size_list) to the innermost primitive type, convert to numpy dtype via to_pandas_dtype, and pass dtype to np.array. This preserves the original uint8 dtype and eliminates the warning. Valid downcasts still warn correctly if the true source dtype differs.

Evidence:
- RED before fix: pa.list_(pa.list_(pa.list_(pa.uint8()))) with 2x2x3 uint8 array produced 2 warnings "Downcasting array dtype int64 to uint8"
- GREEN after fix: 0 warnings, cast_storage succeeds and decode_example returns valid PIL image 2x2
- Widened in 3bfbc13 to also unwrap large_list and fixed_size_list, per review feedback
- Regression test added in ce85809: test_image_cast_storage_from_nested_list_preserves_dtype, parametrized over list, large_list and fixed_size_list. On main it fails all three with "UserWarning: Downcasting array dtype int64 to uint8". On this branch all three pass.
- tests/features/test_image.py: 46 passed on main, 49 passed on this branch, 0 warnings
- ruff check and ruff format --check both clean on the two touched files

Rebased onto main at 3e2c1a6c, no conflicts.
