### PR TITLE
Return numpy scalars from numpy formatting and keep duration dtypes

### DIFF
--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -48,12 +48,20 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
             return value
         elif isinstance(value, (np.character, np.ndarray)) and np.issubdtype(value.dtype, np.character):
             return value
-        elif isinstance(value, np.number):
+        elif isinstance(value, np.generic):
+            # np.bool_ and np.datetime64 are not np.number, so they used to fall
+            # through to np.asarray and come back as unhashable 0-d arrays.
             return value
 
         default_dtype = {}
 
-        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
+        if (
+            isinstance(value, np.ndarray)
+            and np.issubdtype(value.dtype, np.integer)
+            and not np.issubdtype(value.dtype, np.timedelta64)
+        ):
+            # np.issubdtype counts timedelta64 as an integer subtype, which
+            # would drop the unit and hand back a plain int64 column.
             default_dtype = {"dtype": np.int64}
         elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
             default_dtype = {"dtype": np.float32}
@@ -86,7 +94,7 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
 
             if isinstance(data_struct, torch.Tensor):
                 return self._tensorize(data_struct.detach().cpu().numpy()[()])
-        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.character, np.number)):
+        if hasattr(data_struct, "__array__") and not isinstance(data_struct, (np.ndarray, np.generic)):
             data_struct = data_struct.__array__()
         # support for nested types like struct of list of struct
         if isinstance(data_struct, np.ndarray):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -293,6 +293,43 @@ class FormatterTest(TestCase):
         np.testing.assert_equal(batch, {"a": np.array(_COL_A), "b": np.array(_COL_B), "c": np.array(_COL_C)})
         assert batch["c"].shape == np.array(_COL_C).shape
 
+    def test_numpy_formatter_scalars_are_numpy_scalars(self):
+        """Row access should give numpy scalars, not 0-d arrays.
+
+        np.bool_ and np.datetime64 are not np.number, so they used to fall
+        through to np.asarray and come back unhashable.
+        """
+        pa_table = pa.table(
+            {
+                "b": pa.array([True]),
+                "t": pa.array([datetime.datetime(2020, 1, 1)], type=pa.timestamp("us")),
+                "d": pa.array([datetime.timedelta(seconds=5)], type=pa.duration("us")),
+                "i": pa.array([3]),
+            }
+        )
+        row = NumpyFormatter().format_row(pa_table)
+        for name, expected in (
+            ("b", np.bool_),
+            ("t", np.datetime64),
+            ("d", np.timedelta64),
+            ("i", np.integer),
+        ):
+            self.assertIsInstance(row[name], expected)
+            self.assertNotIsInstance(row[name], np.ndarray)
+            hash(row[name])
+
+    def test_numpy_formatter_keeps_duration_dtype(self):
+        """np.issubdtype counts timedelta64 as an integer subtype.
+
+        The int64 default dtype used to apply to duration columns, so the same
+        column came back as timedelta64 by row and int64 by batch.
+        """
+        pa_table = pa.table({"d": pa.array([datetime.timedelta(seconds=5)], type=pa.duration("us"))})
+        formatter = NumpyFormatter()
+        self.assertEqual(formatter.format_batch(pa_table)["d"].dtype, np.dtype("timedelta64[us]"))
+        self.assertEqual(formatter.format_column(pa_table).dtype, np.dtype("timedelta64[us]"))
+        self.assertIsInstance(formatter.format_row(pa_table)["d"], np.timedelta64)
+
     def test_numpy_formatter_np_array_kwargs(self):
         pa_table = self._create_dummy_table().drop(["b"])
         formatter = NumpyFormatter(dtype=np.float16)


### PR DESCRIPTION
Closes #8500.

Two problems in `NumpyFormatter`, both falling out of numpy's type hierarchy.

**Scalars.** `np.bool_` and `np.datetime64` are not `np.number`, so `_tensorize`
did not early-return them and `_recursive_tensorize` ran them through
`__array__` first. Row access handed back 0-d `ndarray`s, which are unhashable
and fail `isinstance(x, np.bool_)`. Both checks now use `np.generic`, which
covers every numpy scalar; `np.character` and `np.number` are already subclasses
of it, so the two existing branches collapse into it cleanly.

**Durations.** `np.issubdtype(np.dtype("timedelta64[us]"), np.integer)` is
`True`, so the int64 default dtype applied to duration columns. That is why the
same column reported `timedelta64` by row and `int64` by batch. The default now
skips timedelta64.

Before and after, on `{"b": True, "t": datetime, "d": timedelta, "i": 3}`:

```
row    b: ndarray(0-d, unhashable) -> np.bool_
       t: ndarray(0-d, unhashable) -> np.datetime64
batch  d: int64                    -> timedelta64[us]
```

`int64` and `float32` defaults for ordinary integer and float columns are
unchanged, and so are strings.

Two tests added, both failing without the change. `tests/test_formatting.py`,
`tests/test_arrow_dataset.py` and `tests/test_table.py` stay at 664 passed with
the same single pre-existing failure (`test_dataset_to_iterable_dataset`, which
fails identically on a clean checkout here). `ruff check` and `ruff format`
clean.

Separate from #8518, which touches `table_cast`.
