### PR TITLE
Take the image dtype from Arrow storage in Image.cast_storage

### DIFF
--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -262,8 +262,26 @@ class Image:
                 path_array = pa.array([None] * len(storage), type=pa.string())
             storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
         elif pa.types.is_list(storage.type):
+            # to_pylist() returns plain Python ints, so np.array would infer int64
+            # and encode_np_array would warn about a downcast the storage does not
+            # need. Take the dtype from the Arrow value type instead.
+            value_type = storage.type
+            while (
+                pa.types.is_list(value_type)
+                or pa.types.is_large_list(value_type)
+                or pa.types.is_fixed_size_list(value_type)
+            ):
+                value_type = value_type.value_type
+            dtype = (
+                value_type.to_pandas_dtype()
+                if pa.types.is_integer(value_type) or pa.types.is_floating(value_type)
+                else None
+            )
             bytes_array = pa.array(
-                [encode_np_array(np.array(arr))["bytes"] if arr is not None else None for arr in storage.to_pylist()],
+                [
+                    encode_np_array(np.array(arr, dtype=dtype))["bytes"] if arr is not None else None
+                    for arr in storage.to_pylist()
+                ],
                 type=pa.binary(),
             )
             path_array = pa.array([None] * len(storage), type=pa.string())

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -277,6 +277,11 @@ class Image:
                 if pa.types.is_integer(value_type) or pa.types.is_floating(value_type)
                 else None
             )
+            # encode_np_array only narrows within a kind, and int8 and float16 have
+            # no valid target to narrow to, so keep a dtype it can already encode
+            # and otherwise leave the inference alone.
+            if dtype is not None and np.dtype(dtype) not in _VALID_IMAGE_ARRAY_DTPYES:
+                dtype = None
             bytes_array = pa.array(
                 [
                     encode_np_array(np.array(arr, dtype=dtype))["bytes"] if arr is not None else None

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -712,3 +712,22 @@ def test_encode_np_array(array, dtype_cast, expected_image_format):
     decoded_image = Image().decode_example(encoded_image)
     assert decoded_image.format == expected_image_format
     np.testing.assert_array_equal(np.array(decoded_image), array)
+
+
+@require_pil
+@pytest.mark.parametrize(
+    "value_type, warns",
+    [(pa.uint8(), False), (pa.int64(), True), (pa.int32(), True)],
+)
+def test_image_cast_storage_list_keeps_arrow_dtype(value_type, warns):
+    array = np.random.default_rng(0).integers(0, 256, (2, 4, 4, 3), dtype=np.uint8)
+    storage = pa.array(array.tolist(), type=pa.list_(pa.list_(pa.list_(value_type))))
+    if warns:
+        with pytest.warns(UserWarning, match="Downcasting array dtype"):
+            casted = Image().cast_storage(storage)
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            casted = Image().cast_storage(storage)
+    decoded = np.stack([np.array(Image().decode_example(row)) for row in casted.to_pylist()])
+    np.testing.assert_array_equal(decoded, array)

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -731,3 +731,17 @@ def test_image_cast_storage_list_keeps_arrow_dtype(value_type, warns):
             casted = Image().cast_storage(storage)
     decoded = np.stack([np.array(Image().decode_example(row)) for row in casted.to_pylist()])
     np.testing.assert_array_equal(decoded, array)
+
+
+@require_pil
+@pytest.mark.parametrize("dtype", ["int8", "float16"])
+def test_image_cast_storage_list_narrow_dtype_falls_back(dtype):
+    # encode_np_array narrows within a kind, and int8 and float16 have no valid
+    # target, so the Arrow dtype must not be forced on them. GH#8511
+    from datasets import Sequence
+
+    ds = Dataset.from_dict(
+        {"col": [[[1, 2], [3, 4]]]},
+        features=Features({"col": Sequence(Sequence(Value(dtype)))}),
+    )
+    assert ds.cast_column("col", Image())[0]["col"] is not None


### PR DESCRIPTION
Closes #8511.

`storage.to_pylist()` materializes the values as plain Python `int`s, which drops the Arrow value type. `np.array(arr)` on nested lists of Python ints then defaults to `int64`, and `encode_np_array` warns about a downcast to `uint8` that the storage never needed:

```python
arr = np.random.randint(0, 256, (2, 4, 4, 3), dtype=np.uint8)
storage = pa.array(arr.tolist(), type=pa.list_(pa.list_(pa.list_(pa.uint8()))))
Image().cast_storage(storage)
# UserWarning: Downcasting array dtype int64 to uint8 to be compatible with 'Pillow'  (x2)
```

Reading the dtype off the Arrow value type instead keeps `uint8` storage quiet. Storage that genuinely needs a downcast still warns, and still names its own dtype:

| storage | before | after |
|---|---|---|
| `uint8` | warns | silent |
| `int64` | warns | warns |
| `int32` | warns | warns |

The descent loop handles `large_list` and `fixed_size_list` too, and the dtype is only taken for integer and floating value types so anything else falls back to the previous inference.

Encoded bytes are unchanged: decoded pixels are identical to the source array for both the `uint8` and `int64` paths.

Test is parametrized over the three cases above; the `uint8` one fails on `main` and passes here.
