### PR TITLE
fix(json): defensively recover invalid Arrow tables in JSON loader (#5531)

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -284,12 +284,14 @@ class Json(datasets.ArrowBasedBuilder):
                                 batch = "\n".join(ujson_dumps(example) for example in examples).encode()
                             # Disable parallelism if block size is ~ len(batch) to avoid segfault
                             block_size = len(batch) if len(batch) // 8 > block_size else block_size
+                            pa_table = None
                             try:
                                 while True:
                                     try:
                                         pa_table = paj.read_json(
                                             io.BytesIO(batch), read_options=paj.ReadOptions(block_size=block_size)
                                         )
+                                        pa_table.validate()
                                         break
                                     except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
                                         if batch.startswith(b"["):  # paj.read_json only supports json lines
@@ -315,6 +317,22 @@ class Json(datasets.ArrowBasedBuilder):
                                         else:
                                             raise
                             except pa.ArrowInvalid as e:
+                                if pa_table is not None:
+                                    try:
+                                        examples = [ujson_loads(line) for line in batch.splitlines()]
+                                        pa_table = pa.concat_tables(
+                                            [pa.Table.from_pylist([example]) for example in examples],
+                                            promote_options="default",
+                                        )
+                                        pa_table.validate()
+                                    except (ValueError, pa.ArrowInvalid, pa.ArrowNotImplementedError):
+                                        raise e
+                                    yield (
+                                        Key(shard_idx, batch_idx),
+                                        self._cast_table(pa_table, json_field_paths=json_field_paths),
+                                    )
+                                    batch_idx += 1
+                                    continue
                                 if not allow_full_read:
                                     raise FullReadDisallowed()
                                 try:

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -1,10 +1,11 @@
 import json
 import textwrap
+from unittest.mock import Mock, patch
 
 import pyarrow as pa
 import pytest
 
-from datasets import Features, Value, load_dataset
+from datasets import Dataset, Features, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES, Json, JsonConfig
@@ -614,6 +615,27 @@ def test_json_generate_tables_with_sorted_columns(file_fixture, config_kwargs, r
     )
     pa_table = pa.concat_tables([table for _, table in generator])
     assert pa_table.column_names == ["ID", "Language", "Topic"]
+
+
+def test_json_generate_tables_recovers_from_invalid_arrow_offsets(jsonl_file):
+    malformed_table = Mock()
+    malformed_table.validate.side_effect = [pa.ArrowInvalid("invalid nested offsets")]
+    json_builder = Json(chunksize=1 << 20)
+    base_files = [jsonl_file]
+
+    with patch("datasets.packaged_modules.json.json.paj.read_json", return_value=malformed_table):
+        generator = json_builder._generate_tables(
+            base_files=base_files,
+            files_iterables=[[jsonl_file]],
+            original_files=base_files,
+        )
+        _, table = next(generator)
+
+    table.validate(full=True)
+    dataset = Dataset(table)
+    mapped_dataset = dataset.map(lambda example: example)
+    assert mapped_dataset.num_rows == 3
+    assert mapped_dataset.to_dict() == {"col_1": [-1, 1, 10], "col_2": [None, 2, 20]}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Adds defensive validation and recovery for malformed nested Arrow arrays returned by pyarrow.json.read_json().

When a batch produces invalid nested offsets, the JSON loader reparses only that batch row by row with pa.Table.from_pylist(), concatenates the rows while preserving late-arriving fields, validates the recovered table, and applies the configured schema cast.

Valid JSONL batches retain the existing fast path.

## Testing

- Added a regression test covering malformed Arrow validation, full table validation, Dataset.map(), row count, and late-arriving columns.
- ruff check and ruff format --check pass.
- python -m pytest tests/packaged_modules/test_json.py -q: 25 passed, 11 skipped.
- The broader table and Arrow dataset suite passes except for unrelated Windows WinError 206 cache-lock path-length failures.