### PR TITLE
Return None for a null row of a dynamic-shape ArrayXD column

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -948,9 +948,14 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         return self._data.nbytes
 
     def isna(self) -> np.ndarray:
-        # A null row of a dynamic-shape ArrayXD column is a scalar np.nan rather than an
-        # array, and the plain bool `pd.isna` returns for it has no `.any()`.
-        return np.array([np.any(pd.isna(arr)) for arr in self._data])
+        if self._data.dtype == object:
+            # Dynamic shape: a missing row is a scalar sentinel, present rows are
+            # arrays. isna is a per-value mask, so a NaN inside a present row must
+            # not mark the row missing.
+            return np.array([not isinstance(arr, np.ndarray) and bool(pd.isna(arr)) for arr in self._data])
+        # Fixed shape: every row is an array and the null row is materialised as
+        # NaNs, so the validity bitmap is already gone by this point.
+        return np.array([pd.isna(arr).any() for arr in self._data])
 
     def __setitem__(self, key: Union[int, slice, np.ndarray], value: Any) -> None:
         raise NotImplementedError()

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -838,17 +838,16 @@ class ArrayExtensionArray(pa.ExtensionArray):
         return numpy_arr
 
     def to_pylist(self, maps_as_pydicts: Optional[Literal["lossy", "strict"]] = None):
+        if self.storage.null_count:
+            # to_numpy writes np.nan in the null rows and the python path cannot undo that: a
+            # fixed shape has its whole column cast to float64, losing integers above 2**53, and
+            # a dynamic first dimension leaves a bare float where a list belongs. The nested-list
+            # storage already carries the exact values and None for the null rows, so use it.
+            return self.storage.to_pylist()
         zero_copy_only = _is_zero_copy_only(self.storage.type, unnest=True)
         numpy_arr = self.to_numpy(zero_copy_only=zero_copy_only)
         if self.type.shape[0] is None and numpy_arr.dtype == object:
             return [arr.tolist() for arr in numpy_arr.tolist()]
-        elif self.type.shape[0] is not None and self.storage.null_count:
-            # For a fixed-shape array, to_numpy casts the whole column to float64 to
-            # hold np.nan in the null rows. On the python read path that silently
-            # corrupts every non-null value: integers become floats and values above
-            # 2**53 lose precision. The nested-list storage already carries the exact
-            # values and None for the null rows, so build the list from it directly.
-            return self.storage.to_pylist()
         else:
             return numpy_arr.tolist()
 
@@ -949,7 +948,9 @@ class PandasArrayExtensionArray(PandasExtensionArray):
         return self._data.nbytes
 
     def isna(self) -> np.ndarray:
-        return np.array([pd.isna(arr).any() for arr in self._data])
+        # A null row of a dynamic-shape ArrayXD column is a scalar np.nan rather than an
+        # array, and the plain bool `pd.isna` returns for it has no `.any()`.
+        return np.array([np.any(pd.isna(arr)) for arr in self._data])
 
     def __setitem__(self, key: Union[int, slice, np.ndarray], value: Any) -> None:
         raise NotImplementedError()

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -419,6 +419,31 @@ def test_array_xd_with_none_python_format_keeps_integers():
     assert arr.dtype == np.float64 and np.isnan(arr[1]).all()
 
 
+def test_array_xd_dynamic_shape_with_none_python_format():
+    # A dynamic first dimension must surface a null row as None too. The python path went
+    # through to_numpy, where a null row is a bare np.nan: reading it alone returned that
+    # nan, and reading it next to a non-null row raised on nan.tolist().
+    features = datasets.Features({"foo": datasets.Array2D(dtype="int32", shape=(None, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[1, 2], [3, 4]], None, [[5, 6]]]}, features=features)
+    assert dataset.to_dict()["foo"] == [[[1, 2], [3, 4]], None, [[5, 6]]]
+    assert dataset[1]["foo"] is None
+    assert dataset[:]["foo"] == [[[1, 2], [3, 4]], None, [[5, 6]]]
+    assert dataset.select([1]).to_dict()["foo"] == [None]
+
+    # The numpy format is unchanged: the null row stays np.nan.
+    arr = NumpyArrowExtractor().extract_column(dataset._data)
+    assert arr.dtype == object and np.isnan(arr[1])
+
+
+def test_array_xd_dynamic_shape_with_none_pandas_isna():
+    # pandas asks the extension array for a boolean mask; the scalar np.nan standing in for
+    # a null row made the per-row pd.isna(...).any() call raise, which also broke to_csv.
+    features = datasets.Features({"foo": datasets.Array2D(dtype="int32", shape=(None, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[1, 2], [3, 4]], None, [[5, 6]]]}, features=features)
+    mask = dataset.to_pandas().isna()["foo"]
+    assert mask.dtype == np.bool_ and mask.tolist() == [False, True, False]
+
+
 @pytest.mark.parametrize("seq_type", ["no_sequence", "sequence", "sequence_of_sequence"])
 @pytest.mark.parametrize(
     "dtype",

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -510,3 +510,21 @@ def test_dataset_map(with_none):
             assert example["image"].shape == (3, 3, 3)
             if with_none and i == 0:
                 assert np.all(np.isnan(example["image"]))
+
+
+def test_array_xd_dynamic_shape_isna_keeps_rows_with_inner_nan():
+    """isna is a per-value mask, so a NaN inside a present row is not a missing row."""
+    ds = datasets.Dataset.from_dict(
+        {"a": [[[1.0, np.nan]], None, [[5.0, 6.0]]]},
+        features=datasets.Features({"a": Array2D((None, 2), "float32")}),
+    )
+    column = ds.data.column("a")
+    arrow_nulls = [not column[i].is_valid for i in range(len(column))]
+
+    df = ds.with_format("pandas")[:]
+    assert list(map(bool, df["a"].array.isna())) == arrow_nulls == [False, True, False]
+
+    # the present row that holds a NaN must survive to_csv rather than blanking
+    csv_rows = df.to_csv(index=False).strip().split("\n")[1:]
+    assert csv_rows[0].strip() != ""
+    assert csv_rows[1].strip() in ("", '""')


### PR DESCRIPTION
`ArrayExtensionArray.to_pylist` builds the python values from `to_numpy`, where a null row is a bare `np.nan`. That is fine for the numpy format but not for the python one, and the guard added in #8363 only covered a fixed first dimension.

So for a column like `Array2D(dtype="int32", shape=(None, 2))` with a `None` row:

```python
ds[1]        # {'foo': nan}   instead of {'foo': None}
ds.to_dict() # AttributeError: 'float' object has no attribute 'tolist'
```

The same crash hits `to_list`, `ds[:]`, `Dataset.iter`, `map` and `filter`. The identical column declared with a fixed shape returns `None` correctly. Dynamic first dimensions are a documented feature and `test_array_xd_with_none` already covers them.

The null guard is really about nulls, not about the shape, so it now runs before the numpy conversion and covers both.

`PandasArrayExtensionArray.isna` met the same scalar nan from the other side: `pd.isna` returns a plain bool for it and bool has no `.any()`, which broke `Dataset.to_csv` and `DataFrame.isna()`.

Two regression tests added next to the existing ones. The numpy, pandas and arrow formats are unchanged, verified across all twelve ArrayXD value dtypes.