### PR TITLE
Reject an unknown column when removing columns from an IterableDataset

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4144,6 +4144,20 @@ class IterableDataset(DatasetInfoMixin):
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
+        if isinstance(column_names, str):
+            column_names = [column_names]
+
+        # `select_columns` already rejects unknown columns, and `Dataset.remove_columns`
+        # does too. Without this check a typo in a column name is silently ignored here.
+        if self._info is not None and self._info.features is not None:
+            missing_columns = set(column_names) - set(self._info.features.keys())
+            if missing_columns:
+                raise ValueError(
+                    f"Column name {list(missing_columns)} not in the "
+                    "dataset. Columns in the dataset: "
+                    f"{list(self._info.features.keys())}."
+                )
+
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(remove_columns=column_names)
         if original_features is not None:

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3544,6 +3544,19 @@ class IterableDataset(DatasetInfoMixin):
          {'label': 1, 'text': 'Review: effective but too-tepid biopic'}]
         ```
         """
+        # Columns that are not there are dropped silently further down, so a typo would
+        # otherwise leave the column in place with no error. `Dataset.map` rejects it, and
+        # so does `select_columns` on this class. `remove_columns` delegates here, so this
+        # covers it too.
+        if remove_columns is not None and self._info is not None and self._info.features is not None:
+            columns_to_remove = [remove_columns] if isinstance(remove_columns, str) else remove_columns
+            missing_columns = set(columns_to_remove) - set(self._info.features.keys())
+            if missing_columns:
+                raise ValueError(
+                    f"Column to remove {sorted(missing_columns)} not in the dataset. "
+                    f"Current columns in the dataset: {list(self._info.features.keys())}"
+                )
+
         return self._map(
             function=function,
             with_indices=with_indices,
@@ -4144,20 +4157,6 @@ class IterableDataset(DatasetInfoMixin):
         {'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'}
         ```
         """
-        if isinstance(column_names, str):
-            column_names = [column_names]
-
-        # `select_columns` already rejects unknown columns, and `Dataset.remove_columns`
-        # does too. Without this check a typo in a column name is silently ignored here.
-        if self._info is not None and self._info.features is not None:
-            missing_columns = set(column_names) - set(self._info.features.keys())
-            if missing_columns:
-                raise ValueError(
-                    f"Column name {list(missing_columns)} not in the "
-                    "dataset. Columns in the dataset: "
-                    f"{list(self._info.features.keys())}."
-                )
-
         original_features = self._info.features.copy() if self._info.features else None
         ds_iterable = self.map(remove_columns=column_names)
         if original_features is not None:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2465,14 +2465,20 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableD
     assert all(c not in new_dataset.column_names for c in ["id", "filepath"])
 
 
-def test_iterable_dataset_remove_columns_missing_column(dataset_with_several_columns: IterableDataset):
+def test_iterable_dataset_remove_missing_column(dataset_with_several_columns: IterableDataset):
     resolved = dataset_with_several_columns._resolve_features()
-    with pytest.raises(ValueError, match="Column name \\['unknown'\\] not in the dataset"):
+    match = "Column to remove \\['unknown'\\] not in the dataset"
+    # Both public entry points, since remove_columns delegates to map.
+    with pytest.raises(ValueError, match=match):
         resolved.remove_columns("unknown")
-    with pytest.raises(ValueError, match="Column name \\['unknown'\\] not in the dataset"):
+    with pytest.raises(ValueError, match=match):
         resolved.remove_columns(["id", "unknown"])
-    # A known column is still removed, and nothing is dropped when the check passes.
+    with pytest.raises(ValueError, match=match):
+        resolved.map(lambda x: x, remove_columns=["unknown"])
+    # A known column is still removed, and renaming, which maps with remove_columns
+    # under the hood, is unaffected.
     assert "id" not in resolved.remove_columns("id").column_names
+    assert "new_id" in resolved.rename_column("id", "new_id").column_names
 
 
 def test_iterable_dataset_select_columns(dataset_with_several_columns: IterableDataset):

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2465,6 +2465,16 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableD
     assert all(c not in new_dataset.column_names for c in ["id", "filepath"])
 
 
+def test_iterable_dataset_remove_columns_missing_column(dataset_with_several_columns: IterableDataset):
+    resolved = dataset_with_several_columns._resolve_features()
+    with pytest.raises(ValueError, match="Column name \\['unknown'\\] not in the dataset"):
+        resolved.remove_columns("unknown")
+    with pytest.raises(ValueError, match="Column name \\['unknown'\\] not in the dataset"):
+        resolved.remove_columns(["id", "unknown"])
+    # A known column is still removed, and nothing is dropped when the check passes.
+    assert "id" not in resolved.remove_columns("id").column_names
+
+
 def test_iterable_dataset_select_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.select_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
### The bug

Removing a column that does not exist is silently ignored on `IterableDataset`, through either entry point:

```python
it = Dataset.from_dict({"a": [1, 2], "b": ["x", "y"]}).to_iterable_dataset()._resolve_features()

list(it.remove_columns(["nope"]))                    # [{'a': 1, 'b': 'x'}, ...] -- nothing removed
list(it.map(lambda e: e, remove_columns=["nope"]))   # same
```

`Dataset` raises `ValueError` for both. The names are forwarded to the mapping machinery, which drops whatever it finds and ignores the rest, so a typo leaves the column in place with no signal.

### The fix

One check, in `map`. `IterableDataset.remove_columns` delegates to `map`, so this covers both entry points.

`Dataset` has a separate check in each of its `remove_columns` and `map` — it needs both because its `remove_columns` does not delegate. This class does delegate, so a second check here would be dead weight. I used `Dataset.map`'s wording since `map` is the API being guarded.

The check only applies when `features` is known, matching `select_columns` on this class: a streaming dataset whose features are unresolved does not yet know its column names.

`rename_columns` maps with `remove_columns` internally, but only with names it has already validated, so it is unaffected — there is a test for that.

### Verification

The new test fails on `main` and passes with the change. Full `tests/test_iterable_dataset.py` is 4 failed both before and after; all four are `test_interleave_dataset_with_sharding`, which fail identically without this change on my machine and are unrelated.

*Updated from the first version of this PR, which put the check in `remove_columns` only. That left `map(remove_columns=...)` unguarded, and moving it one level down covers both without a second check.*
