### PR TITLE
Reject a negative n in IterableDataset.skip and take

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3864,6 +3864,8 @@ class IterableDataset(DatasetInfoMixin):
          'text': 'if you sometimes like to go to the movies to have fun , wasabi is a good place to start .'}]
         ```
         """
+        if n < 0:
+            raise ValueError(f"Number of elements to skip must be non-negative, but got {n}.")
         ex_iterable = SkipExamplesIterable(
             self._ex_iterable,
             n,
@@ -3941,6 +3943,8 @@ class IterableDataset(DatasetInfoMixin):
          'text': 'the gorgeously elaborate continuation of " the lord of the rings " trilogy is so huge that a column of words cannot adequately describe co-writer/director peter jackson\'s expanded vision of j . r . r . tolkien\'s middle-earth .'}]
         ```
         """
+        if n < 0:
+            raise ValueError(f"Number of elements to take must be non-negative, but got {n}.")
         ex_iterable = TakeExamplesIterable(
             self._ex_iterable,
             n,

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2314,6 +2314,12 @@ def test_iterable_dataset_take(dataset: IterableDataset, n):
     assert list(take_dataset) == list(dataset)[:n]
 
 
+@pytest.mark.parametrize(("method", "word"), [("skip", "skip"), ("take", "take")])
+def test_iterable_dataset_skip_take_negative(dataset: IterableDataset, method, word):
+    with pytest.raises(ValueError, match=f"Number of elements to {word} must be non-negative"):
+        getattr(dataset, method)(-1)
+
+
 @pytest.mark.parametrize("n", [0, 2])
 def test_iterable_dataset_repeat(dataset: IterableDataset, n):
     repeat_dataset = dataset.repeat(n)


### PR DESCRIPTION
### The bug

`IterableDataset.skip` and `take` silently treat a negative `n` as zero:

```python
it = Dataset.from_dict({"a": [1, 2, 3, 4]}).to_iterable_dataset()

list(it.skip(-1))   # [{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}]  -- the whole dataset
list(it.take(-1))   # []                                        -- nothing
```

Neither raises. A sign error in the caller's arithmetic — `take(n - m)` where `m > n`, say — silently produces a plausible-looking result, and in the `skip` case one that quietly contains everything.

### The fix

Raise `ValueError` for a negative `n`, in the same style as the other argument checks on this class. `n == 0` keeps its current meaning for both (skip nothing / take nothing), and the existing parametrized tests cover `0`, `2` and `1e10` unchanged.

### Verification

The new test fails on `main` and passes with the change. Full `tests/test_iterable_dataset.py` is 4 failed both before and after — all four are `test_interleave_dataset_with_sharding`, which fail identically without this change on my machine and are unrelated to it.
