### PR TITLE
Reject an unknown input_columns in IterableDataset.map and filter

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -105,6 +105,30 @@ def identity_func(x):
     return x
 
 
+def _check_input_columns(
+    input_columns: Optional[Union[str, list[str]]], features: Optional[Features]
+) -> None:
+    """Reject an `input_columns` entry that is not a column of the dataset.
+
+    Without this the name is only looked up while iterating, and surfaces as a bare
+    `KeyError` from deep inside the pipeline rather than from the call that is wrong.
+    `Dataset.map` and `Dataset.filter` both reject it up front; this is the same check.
+
+    Nothing is checked when the features are unknown, which is the case for a streaming
+    dataset whose columns have not been resolved yet.
+    """
+    if input_columns is None or features is None:
+        return
+    if isinstance(input_columns, str):
+        input_columns = [input_columns]
+    missing_columns = set(input_columns) - set(features.keys())
+    if missing_columns:
+        raise ValueError(
+            f"Input column {sorted(missing_columns)} not in the dataset. "
+            f"Current columns in the dataset: {list(features.keys())}"
+        )
+
+
 def _rename_columns_fn(example: dict, column_mapping: dict[str, str]):
     if any(col not in example for col in column_mapping):
         raise ValueError(
@@ -3544,6 +3568,8 @@ class IterableDataset(DatasetInfoMixin):
          {'label': 1, 'text': 'Review: effective but too-tepid biopic'}]
         ```
         """
+        _check_input_columns(input_columns, self._info.features if self._info else None)
+
         return self._map(
             function=function,
             with_indices=with_indices,
@@ -3697,6 +3723,8 @@ class IterableDataset(DatasetInfoMixin):
         """
         if isinstance(input_columns, str):
             input_columns = [input_columns]
+
+        _check_input_columns(input_columns, self._info.features if self._info else None)
 
         # We need the examples to be decoded for certain feature types like Image or Audio,
         # format and type before filtering

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2465,6 +2465,23 @@ def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableD
     assert all(c not in new_dataset.column_names for c in ["id", "filepath"])
 
 
+@pytest.mark.parametrize(
+    ("method", "function"), [("map", lambda v: {"squared": v}), ("filter", lambda v: True)]
+)
+def test_iterable_dataset_input_columns_missing(
+    dataset_with_several_columns: IterableDataset, method, function
+):
+    """An unknown input_columns must be rejected by the call, not by a later KeyError."""
+    resolved = dataset_with_several_columns._resolve_features()
+    match = r"Input column \['unknown'\] not in the dataset"
+    with pytest.raises(ValueError, match=match):
+        getattr(resolved, method)(function, input_columns=["unknown"])
+    with pytest.raises(ValueError, match=match):
+        getattr(resolved, method)(function, input_columns="unknown")
+    # A real column is still accepted and the result still iterates.
+    assert len(list(getattr(resolved, method)(function, input_columns=["id"]))) > 0
+
+
 def test_iterable_dataset_select_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.select_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
### The bug

`input_columns` naming a column that does not exist is not checked on `IterableDataset`. The name is only looked up while iterating, so the call that is actually wrong succeeds and the failure arrives later, detached from its cause:

```python
it = Dataset.from_dict({"a": [1, 2], "b": ["x", "y"]}).to_iterable_dataset()._resolve_features()

m = it.map(lambda v: {"q": 1}, input_columns=["nope"])
# returns an IterableDataset, no error

list(m)
# KeyError: 'nope'
```

`Dataset.map` and `Dataset.filter` both reject it at call time with `ValueError: Input column ['nope'] not in the dataset. Current columns in the dataset: [...]`. On the streaming side you get a bare `KeyError` from inside the pipeline, with nothing pointing at the argument that caused it.

### The fix

Check `input_columns` against `features` in `map` and in `filter`, using the same message as the map-style API.

It is a small shared helper rather than a check in one place because `filter` does not delegate to `map` — it builds its own `FilteredExamplesIterable` — so both entry points need it.

As with `select_columns` on this class, nothing is checked when the features are unknown, since a streaming dataset whose columns have not been resolved cannot know them yet.

### Verification

The new test fails on `main` and passes with the change, for both `map` and `filter`, and with both the list and bare-string forms. Full `tests/test_iterable_dataset.py` is 4 failed before and after — all four `test_interleave_dataset_with_sharding`, which fail identically without this change on my machine and are unrelated.
