### PR TITLE
Allow swapping column names in IterableDataset.rename_columns

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -106,13 +106,17 @@ def identity_func(x):
 
 
 def _rename_columns_fn(example: dict, column_mapping: dict[str, str]):
-    if any(col not in example for col in column_mapping):
+    missing_columns = set(column_mapping) - set(example)
+    if missing_columns:
         raise ValueError(
-            f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {set(column_mapping) - set(example)} are not in the dataset."
+            f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {sorted(missing_columns)} are not in the dataset."
         )
-    if any(col in example for col in column_mapping.values()):
+    # A new name only clashes with a column that is not itself being renamed away, so
+    # swapping two names is allowed, as it is for `Dataset.rename_columns`.
+    conflicting_columns = (set(column_mapping.values()) & set(example)) - set(column_mapping)
+    if conflicting_columns:
         raise ValueError(
-            f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {set(example) - set(column_mapping.values())} are already in the dataset."
+            f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: columns {sorted(conflicting_columns)} are already in the dataset."
         )
     return {
         new_column_name: example[original_column_name]

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2445,6 +2445,26 @@ def test_iterable_dataset_rename_columns(dataset_with_several_columns: IterableD
     assert all(c in new_dataset.column_names for c in ["new_id", "filename"])
 
 
+def test_iterable_dataset_rename_columns_swap(dataset_with_several_columns: IterableDataset):
+    """Swapping two names is legal: each new name is freed by the same mapping."""
+    resolved = dataset_with_several_columns._resolve_features()
+    swap = {"id": "filepath", "filepath": "id"}
+    swapped = resolved.rename_columns(swap)
+    assert list(swapped) == [
+        {swap.get(k, k): v for k, v in example.items()} for example in resolved
+    ]
+    assert set(swapped.column_names) == set(resolved.column_names)
+
+
+def test_iterable_dataset_rename_columns_conflict_names_the_right_column(
+    dataset_with_several_columns: IterableDataset,
+):
+    """The conflicting column is the new name that is taken, not the untouched ones."""
+    resolved = dataset_with_several_columns._resolve_features()
+    with pytest.raises(ValueError, match=r"columns \['filepath'\] are already in the dataset"):
+        list(resolved.rename_columns({"id": "filepath"}))
+
+
 def test_iterable_dataset_remove_columns(dataset_with_several_columns: IterableDataset):
     new_dataset = dataset_with_several_columns.remove_columns("id")
     assert list(new_dataset) == [


### PR DESCRIPTION
### The bug

Two problems in `_rename_columns_fn`, both in the clash check.

**Swapping two names is refused.** The check rejects any new name that is already a column, without noticing that the same mapping renames that column away:

```python
it = Dataset.from_dict({"a": [1, 2], "b": ["x", "y"], "c": [1.0, 2.0]}).to_iterable_dataset()._resolve_features()

list(it.rename_columns({"a": "b", "b": "a"}))
# ValueError: ... columns {'c'} are already in the dataset.
```

`Dataset.rename_columns` accepts the same call, and the features rebuilt just above in `rename_columns` already handle a swap correctly — only the per-example function refuses it.

**The reported set is wrong in both directions.** It computes `set(example) - set(column_mapping.values())`, which is the columns that are *not* new names:

- On the swap above it names `{'c'}`, which is not part of the rename at all.
- On a genuine clash it names the wrong columns and omits the real one:

```python
list(it.rename_columns({"a": "c"}))
# before: columns {'a', 'b'} are already in the dataset.   <- 'c' is the actual clash
# after:  columns ['c'] are already in the dataset.
```

### The fix

A new name only clashes when it is an existing column that is *not* itself being renamed away:

```python
conflicting_columns = (set(column_mapping.values()) & set(example)) - set(column_mapping)
```

That permits the swap and reports exactly the taken names. The missing-column check above it was already correct and is unchanged apart from sorting its output for a stable message.

### Verification

Both new tests fail on `main` and pass with the change. After the fix the swap result is identical to `Dataset.rename_columns` on the same input, and a genuine clash and a missing column both still raise. Full `tests/test_iterable_dataset.py` is 4 failed before and after — all four `test_interleave_dataset_with_sharding`, unrelated and failing identically on my machine without this change.
