### PR TITLE
Reject a repeated column name in Dataset.remove_columns

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2533,6 +2533,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 f"Current columns in the dataset: {dataset._data.column_names}"
             )
 
+        duplicate_columns = sorted({col for col in column_names if column_names.count(col) > 1})
+        if duplicate_columns:
+            raise ValueError(
+                f"Column name {duplicate_columns} is repeated. "
+                "Each column to remove must be given once."
+            )
+
         for column_name in column_names:
             del dataset._info.features[column_name]
 
@@ -2714,6 +2721,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 f"Column name {list(missing_columns)} not in the "
                 "dataset. Current columns in the dataset: "
                 f"{self._data.column_names}."
+            )
+
+        duplicate_columns = sorted({col for col in column_names if column_names.count(col) > 1})
+        if duplicate_columns:
+            raise ValueError(
+                f"Column name {duplicate_columns} is repeated. "
+                "Each column to select must be given once."
             )
 
         dataset = copy.deepcopy(self)

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2723,13 +2723,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 f"{self._data.column_names}."
             )
 
-        duplicate_columns = sorted({col for col in column_names if column_names.count(col) > 1})
-        if duplicate_columns:
-            raise ValueError(
-                f"Column name {duplicate_columns} is repeated. "
-                "Each column to select must be given once."
-            )
-
         dataset = copy.deepcopy(self)
         dataset._data = dataset._data.select(column_names)
         dataset._info.features = Features({col: self._info.features[col] for col in dataset._data.column_names})

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -729,6 +729,22 @@ class BaseDatasetTest(TestCase):
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
 
+    def test_select_remove_columns_repeated_name(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
+                # Repeating a name used to build a table with two identically named
+                # columns whose Features had only one entry.
+                with self.assertRaises(ValueError) as ctx:
+                    dset.select_columns(column_names=["col_1", "col_1"])
+                self.assertIn("is repeated", str(ctx.exception))
+                # And here it deleted the same feature twice, raising a bare KeyError.
+                with self.assertRaises(ValueError) as ctx:
+                    dset.remove_columns(column_names=["col_1", "col_1"])
+                self.assertIn("is repeated", str(ctx.exception))
+                # Distinct names are unaffected.
+                with dset.select_columns(column_names=["col_1", "col_2"]) as new_dset:
+                    self.assertListEqual(list(new_dset.column_names), ["col_1", "col_2"])
+
     def test_concatenate(self, in_memory):
         data1, data2, data3 = {"id": [0, 1, 2]}, {"id": [3, 4, 5]}, {"id": [6, 7]}
         info1 = DatasetInfo(description="Dataset1")

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -729,21 +729,18 @@ class BaseDatasetTest(TestCase):
                     self.assertNotEqual(new_dset._fingerprint, fingerprint)
                     assert_arrow_metadata_are_synced_with_dataset_features(new_dset)
 
-    def test_select_remove_columns_repeated_name(self, in_memory):
+    def test_remove_columns_repeated_name(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir, multiple_columns=True) as dset:
-                # Repeating a name used to build a table with two identically named
-                # columns whose Features had only one entry.
-                with self.assertRaises(ValueError) as ctx:
-                    dset.select_columns(column_names=["col_1", "col_1"])
-                self.assertIn("is repeated", str(ctx.exception))
-                # And here it deleted the same feature twice, raising a bare KeyError.
+                # This used to delete the same feature twice and surface the second
+                # delete as a bare KeyError.
                 with self.assertRaises(ValueError) as ctx:
                     dset.remove_columns(column_names=["col_1", "col_1"])
                 self.assertIn("is repeated", str(ctx.exception))
                 # Distinct names are unaffected.
-                with dset.select_columns(column_names=["col_1", "col_2"]) as new_dset:
-                    self.assertListEqual(list(new_dset.column_names), ["col_1", "col_2"])
+                with dset.remove_columns(column_names=["col_1", "col_2"]) as new_dset:
+                    self.assertNotIn("col_1", new_dset.column_names)
+                    self.assertNotIn("col_2", new_dset.column_names)
 
     def test_concatenate(self, in_memory):
         data1, data2, data3 = {"id": [0, 1, 2]}, {"id": [3, 4, 5]}, {"id": [6, 7]}


### PR DESCRIPTION
### The bug

`Dataset.remove_columns` does not deduplicate its argument, so a repeated name deletes the same feature twice:

```python
d = Dataset.from_dict({"a": [1, 2], "b": ["x", "y"]})
d.remove_columns(["a", "a"])
# KeyError: 'a'
```

The second `del dataset._info.features[column_name]` raises a bare `KeyError`, with nothing pointing at the repeat. A duplicate is easy to produce when the list is built programmatically, and the error does not say what was wrong.

### The fix

Reject the repeat, in the style of the missing-column check that already sits directly above it.

### Scope

I originally had this covering `select_columns` too, where a repeat produced a `Dataset` whose `column_names` was `['a', 'a']` while its `features` had one entry. **@AbdullahRasheed45's #8368 already fixes that**, on both `Dataset` and `IterableDataset`, so I have dropped that half — I only spotted #8368 after opening this. What is left is `Dataset.remove_columns`, which #8368 does not touch, so the two do not overlap.

I chose rejecting over silently deduplicating because quietly changing the result seemed worse than saying what is wrong, and it matches how #8368 handles the sibling method. Happy to make it a dedup instead if you would rather.

### Verification

The new test fails on `main` and passes with the change, for both `in_memory` values. Comparing full `tests/test_arrow_dataset.py` runs with and without the change shows no test that fails only with it. One failure is present either way, `test_dataset_to_iterable_dataset`, which needs PyTorch and is not installed in my venv.
