### PR TITLE
Skip test_interleave_dataset_with_sharding when torch is not installed

### DIFF
--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2868,6 +2868,7 @@ def test_format_polars(dataset: IterableDataset):
     assert next(iter(ds)) == {**next(iter(dataset)), "new_col": 0, "new_col_batched": 1}
 
 
+@require_torch
 @pytest.mark.parametrize("num_shards1, num_shards2, num_workers", [(2, 1, 1), (2, 2, 2), (1, 3, 1), (4, 3, 3)])
 def test_interleave_dataset_with_sharding(num_shards1, num_shards2, num_workers):
     from torch.utils.data import DataLoader


### PR DESCRIPTION
### The problem

`test_interleave_dataset_with_sharding` imports `torch.utils.data` and calls `.with_format("torch")`, but it is the only torch-using test in `tests/test_iterable_dataset.py` without `@require_torch`. Without torch installed it fails rather than skipping:

```
FAILED tests/test_iterable_dataset.py::test_interleave_dataset_with_sharding[2-1-1]
FAILED tests/test_iterable_dataset.py::test_interleave_dataset_with_sharding[2-2-2]
FAILED tests/test_iterable_dataset.py::test_interleave_dataset_with_sharding[1-3-1]
FAILED tests/test_iterable_dataset.py::test_interleave_dataset_with_sharding[4-3-3]
E   ModuleNotFoundError: No module named 'torch'
```

torch is an optional dependency, so running the suite without it is a supported configuration — and every other torch-using test in the file already handles it. I checked the whole file: eight tests import torch and carry `@require_torch`; this one is the single exception.

It matters beyond tidiness. Those four failures are indistinguishable from real ones when you are checking whether your own change broke something, which is how I ran into it.

### The fix

Add the decorator, matching its eight neighbours.

### Verification

Without torch, `tests/test_iterable_dataset.py` goes from 4 failed / 441 passed / 47 skipped to **0 failed / 441 passed / 51 skipped**, the four now reporting "test requires PyTorch" alongside the other torch-gated tests. Nothing else changes, and with torch installed the decorator is a no-op so the test runs exactly as before.
