### PR TITLE
Split the torch assertions out of test_dataset_to_iterable_dataset

### DIFF
--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4645,6 +4645,10 @@ def test_dataset_to_iterable_dataset(dataset: Dataset):
     assert iterable_dataset.num_shards == 3
     with pytest.raises(ValueError):
         dataset.to_iterable_dataset(num_shards=len(dataset) + 1)
+
+
+@require_torch
+def test_dataset_to_iterable_dataset_with_torch_format(dataset: Dataset):
     assert dataset.with_format("torch").to_iterable_dataset()._formatting.format_type == "torch"
     with pytest.raises(NotImplementedError):
         dataset.with_format("torch", columns=[dataset.column_names[0]]).to_iterable_dataset()


### PR DESCRIPTION
### The problem

`test_dataset_to_iterable_dataset` fails when torch is not installed:

```
FAILED tests/test_arrow_dataset.py::test_dataset_to_iterable_dataset
E   ValueError: PyTorch needs to be installed to be able to return PyTorch tensors.
```

torch is an optional dependency, so running the suite without it is a supported configuration. It is the only test in this file that touches torch without `@require_torch`.

### The fix

Most of the test does not need torch. It covers `to_iterable_dataset()`, the `num_shards` argument, the features round-trip, and the `ValueError` for too many shards. Only the final two assertions use `with_format("torch")`.

So rather than decorate the existing test, which would have skipped that torch-free coverage as well, I moved the two torch assertions into their own `@require_torch` test. Everything else keeps running everywhere.

### Verification

Without torch, `tests/test_arrow_dataset.py` goes from **1 failed / 362 passed / 61 skipped** to **0 failed / 363 passed / 62 skipped** — the torch-free half now passes where the whole test used to fail, and the new torch half skips. With torch installed both run exactly as before.

Companion to #8530, which is the same gap in `tests/test_iterable_dataset.py`. That one is a whole-test skip because the test there needs torch throughout; this one needed splitting instead.
