### PR TITLE
Do not fail all of test_file_utils when zstandard is not installed

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import zstandard as zstd
 from fsspec.registry import _registry as _fsspec_registry
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 from huggingface_hub.errors import OfflineModeIsEnabled
@@ -60,6 +59,7 @@ Bulbasaur, grass"""
 
 @pytest.fixture(scope="session")
 def zstd_path(tmp_path_factory):
+    zstd = pytest.importorskip("zstandard")
     path = tmp_path_factory.mktemp("data") / (FILE_PATH + ".zstd")
     data = bytes(FILE_CONTENT, "utf-8")
     with zstd.open(path, "wb") as f:
@@ -75,9 +75,11 @@ def tmpfs_file(tmpfs):
 
 
 @pytest.mark.parametrize("compression_format", ["gzip", "xz", "zstd"])
-def test_cached_path_extract(compression_format, gz_file, xz_file, zstd_path, tmp_path, text_file):
-    input_paths = {"gzip": gz_file, "xz": xz_file, "zstd": zstd_path}
-    input_path = input_paths[compression_format]
+def test_cached_path_extract(compression_format, tmp_path, text_file, request):
+    # Resolved through `request` so that the gzip and xz cases do not pull in the
+    # zstd fixture, and so do not need zstandard installed.
+    fixture_names = {"gzip": "gz_file", "xz": "xz_file", "zstd": "zstd_path"}
+    input_path = request.getfixturevalue(fixture_names[compression_format])
     cache_dir = tmp_path / "cache"
     download_config = DownloadConfig(cache_dir=cache_dir, extract_compressed_file=True)
     extracted_path = cached_path(input_path, download_config=download_config)


### PR DESCRIPTION
### The problem

`tests/test_file_utils.py` imports `zstandard` at module level, so without it installed the entire file fails to collect:

```
ERROR tests/test_file_utils.py
E   ModuleNotFoundError: No module named 'zstandard'
!!!!! Interrupted: 1 error during collection !!!!!
```

136 tests are lost, almost none of which have anything to do with zstd — `cached_path`, `xdirname`, `fsspec_get`/`fsspec_head`, the offline-mode paths, and so on.

The repo already treats zstandard as optional. `config.ZSTANDARD_AVAILABLE` exists, `tests/utils.py` defines `require_zstandard`, and both `test_filesystem.py` and `test_streaming_download_manager.py` use it to degrade gracefully. A module-level import runs before any marker can apply, so this one file bypasses all of it.

### The fix

Two changes, both small:

- `zstd_path` imports zstandard inside the fixture via `pytest.importorskip`, so it skips instead of breaking collection.
- `test_cached_path_extract` resolves its input through `request.getfixturevalue` instead of taking all three compression fixtures as parameters. Previously every parametrization instantiated `zstd_path`, so guarding the fixture alone would have skipped the gzip and xz cases too. Now only the zstd case needs zstandard.

### Verification

Without zstandard, the file goes from **failing to collect** to **136 passed, 4 skipped, 0 failed**, the single zstd-related skip reading "could not import 'zstandard'". gzip and xz still run.

With zstandard installed, `importorskip` is a no-op and `getfixturevalue` resolves the same fixtures, so all three parametrizations run as before.
