### PR TITLE
Validate sample_by in TextConfig

### DIFF
--- a/src/datasets/packaged_modules/text/text.py
+++ b/src/datasets/packaged_modules/text/text.py
@@ -41,6 +41,17 @@ class TextConfig(datasets.BuilderConfig):
     keep_linebreaks: bool = False
     sample_by: Literal["line", "paragraph", "document"] = "line"
 
+    def __post_init__(self):
+        super().__post_init__()
+        # _generate_tables branches on this and has no fallback, so an unrecognised value
+        # silently produces no rows and then fails schema inference, which reports a
+        # missing `features` rather than the argument that is actually wrong.
+        valid_sample_by = ("line", "paragraph", "document")
+        if self.sample_by not in valid_sample_by:
+            raise ValueError(
+                f"sample_by must be one of {valid_sample_by}, but got {self.sample_by!r}"
+            )
+
 
 class Text(datasets.ArrowBasedBuilder):
     BUILDER_CONFIG_CLASS = TextConfig

--- a/tests/packaged_modules/test_text.py
+++ b/tests/packaged_modules/test_text.py
@@ -74,6 +74,12 @@ def test_text_cast_image(text_file_with_image):
     assert generated_content == [{"path": image_file, "bytes": None}]
 
 
+def test_text_sample_by_invalid():
+    """An unrecognised sample_by names the argument instead of failing schema inference."""
+    with pytest.raises(ValueError, match="sample_by must be one of"):
+        Text(sample_by="nope", encoding="utf-8", chunksize=100)
+
+
 @pytest.mark.parametrize("sample_by", ["line", "paragraph", "document"])
 def test_text_sample_by(sample_by, text_file):
     with open(text_file, encoding="utf-8") as f:


### PR DESCRIPTION
### The bug

`Text._generate_tables` branches on `sample_by` as `if "line" / elif "paragraph" / elif "document"` with no fallback, and `TextConfig` never validates the value. An unrecognised one therefore produces no rows at all, and the load fails much later on schema inference:

```python
load_dataset("text", data_files=path, split="train", sample_by="nope")
```

```
DatasetGenerationError: An error occurred while generating the dataset
  caused by
SchemaInferenceError: Please pass `features` or at least one example when writing data
```

Nothing in that mentions `sample_by`. It points at `features`, so the obvious next step — passing `features` — is the wrong fix and will not help.

### The fix

Reject the value in `__post_init__`:

```
ValueError: sample_by must be one of ('line', 'paragraph', 'document'), but got 'nope'
```

`TextConfig` is the odd one out here — the `csv`, `arrow` and `audiofolder` configs all already validate their own arguments in `__post_init__`. The field is annotated `Literal["line", "paragraph", "document"]`, so the allowed set was already the documented contract; nothing enforced it at runtime.

### Verification

The new test fails on `main` and passes with the change. All three valid values still load correctly (2 / 1 / 1 rows for line / paragraph / document on the same file), and `tests/packaged_modules/test_text.py` is 10 passed, 1 skipped.
