### PR TITLE
Validate on_bad_files in the parquet and vortex configs

### DIFF
--- a/src/datasets/packaged_modules/parquet/parquet.py
+++ b/src/datasets/packaged_modules/parquet/parquet.py
@@ -88,6 +88,13 @@ class ParquetConfig(datasets.BuilderConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        # Anything unrecognised falls into the permissive `else` where the file is
+        # read, so a typo in the strict value silently becomes "skip". TsFileConfig
+        # already rejects the same argument.
+        if self.on_bad_files not in ("error", "warn", "skip"):
+            raise ValueError(
+                f"`on_bad_files` must be one of 'error', 'warn', 'skip', got {self.on_bad_files!r}"
+            )
 
 
 class Parquet(datasets.ArrowBasedBuilder):

--- a/src/datasets/packaged_modules/vortex/vortex.py
+++ b/src/datasets/packaged_modules/vortex/vortex.py
@@ -104,6 +104,13 @@ class VortexConfig(datasets.BuilderConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        # Anything unrecognised falls into the permissive `else` where the file is
+        # read, so a typo in the strict value silently becomes "skip". TsFileConfig
+        # already rejects the same argument.
+        if self.on_bad_files not in ("error", "warn", "skip"):
+            raise ValueError(
+                f"`on_bad_files` must be one of 'error', 'warn', 'skip', got {self.on_bad_files!r}"
+            )
 
 
 def _filters_to_expression(filters: Union[list[tuple], list[list[tuple]]]) -> "vortex.expr.Expr":

--- a/tests/packaged_modules/test_parquet.py
+++ b/tests/packaged_modules/test_parquet.py
@@ -17,6 +17,17 @@ def test_config_raises_when_invalid_data_files(data_files) -> None:
         _ = ParquetConfig(name="name", data_files=data_files)
 
 
+def test_config_raises_when_invalid_on_bad_files() -> None:
+    # An unrecognised value used to fall into the permissive branch and behave as "skip".
+    with pytest.raises(ValueError, match="`on_bad_files` must be one of"):
+        _ = ParquetConfig(name="name", on_bad_files="eror")
+
+
+@pytest.mark.parametrize("on_bad_files", ["error", "warn", "skip"])
+def test_config_accepts_valid_on_bad_files(on_bad_files) -> None:
+    assert ParquetConfig(name="name", on_bad_files=on_bad_files).on_bad_files == on_bad_files
+
+
 def test_parquet_reshard(multi_row_groups_parquet_path):
     ds = load_dataset("parquet", data_files=multi_row_groups_parquet_path, split="train", streaming=True)
     assert ds.num_shards == 1

--- a/tests/packaged_modules/test_vortex.py
+++ b/tests/packaged_modules/test_vortex.py
@@ -9,6 +9,13 @@ from datasets.download import DownloadManager
 vx = pytest.importorskip("vortex")
 
 
+def test_config_raises_when_invalid_on_bad_files() -> None:
+    from datasets.packaged_modules.vortex.vortex import VortexConfig
+
+    with pytest.raises(ValueError, match="`on_bad_files` must be one of"):
+        _ = VortexConfig(name="name", on_bad_files="eror")
+
+
 def _write_vortex_file(table: pa.Table, path) -> str:
     vx.io.write(vx.array(table), str(path))
     return str(path)


### PR DESCRIPTION
### The bug

`ParquetConfig` and `VortexConfig` declare `on_bad_files: Literal["error", "warn", "skip"]` but never check it, and the code branches as `if "error" / elif "warn" / else`. Anything unrecognised lands in the permissive `else`.

So a typo in the *strict* value silently selects the *least* strict behaviour:

```python
# one good parquet file, one corrupt one
load_dataset("parquet", data_files=[good, bad], split="train", on_bad_files="error")
# DatasetGenerationError  <- correct

load_dataset("parquet", data_files=[good, bad], split="train", on_bad_files="eror")
# 2 rows, no error, no warning   <- the corrupt file is silently dropped
```

Someone who asks for strict checking and mistypes it gets the opposite, with the failure they were trying to catch swallowed at `logger.debug`.

### The fix

Reject the value in `__post_init__`, which both configs already define.

This is not a new convention: **`TsFileConfig` already does exactly this** for the same argument —

```python
if self.on_bad_files not in ("error", "warn", "skip"):
    raise ValueError(f"`on_bad_files` must be one of 'error', 'warn', 'skip', got {self.on_bad_files!r}")
```

— and `tests/packaged_modules/test_tsfile.py` covers it. Parquet and vortex are the two that were missed. I reused the message verbatim so all three read the same.

### Verification

For parquet: the new test fails on `main` and passes with the change, the three valid values behave exactly as before, and `test_parquet.py` + `test_tsfile.py` pass.

One caveat worth stating: `tests/packaged_modules/test_vortex.py` starts with a module-level `pytest.importorskip("vortex")`, and I do not have the vortex package installed, so the vortex test skips on my machine. That half is verified by reading and by the parquet analogue rather than by a run — your CI will exercise it.
