### PR TITLE
Fix broken markdown link to audio_load guide

### DIFF
--- a/docs/source/about_mapstyle_vs_iterable.mdx
+++ b/docs/source/about_mapstyle_vs_iterable.mdx
@@ -84,7 +84,7 @@ for example in my_iterable_dataset:  # this reads the CSV file progressively as 
 ```
 
 Many file formats are supported, like CSV, JSONL, and Parquet, as well as image and audio files.
-You can find more information in the corresponding guides for loading [tabular](./tabular_load), [text](./nlp_load), [vision](./image_load), and [audio](./audio_load]) datasets.
+You can find more information in the corresponding guides for loading [tabular](./tabular_load), [text](./nlp_load), [vision](./image_load), and [audio](./audio_load) datasets.
 
 ## Eager data processing and lazy data processing
 


### PR DESCRIPTION
## What
Fixed a stray closing bracket in about_mapstyle_vs_iterable.mdx that broke the markdown link to the audio_load guide.

## Why
A small, objectively-verifiable improvement (broken-link) found during a
daily open-source maintenance pass (2026-08-30).

## How verified
Read the source line, confirmed the audio link had an extra ']' before ')' unlike the three sibling links (tabular/text/vision) on the same line; fixed and re-checked via git diff.
Automated gates: 2 changed lines across 1 files (within limits); cargo check: not needed.

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.