### PR TITLE
Apply the bit-vs-byte suffix rule to the binary size units

### DIFF
--- a/src/datasets/utils/py_utils.py
+++ b/src/datasets/utils/py_utils.py
@@ -109,15 +109,20 @@ def convert_file_size_to_int(size: Union[int, str]) -> int:
     if isinstance(size, int):
         return size
     if size.upper().endswith("PIB"):
-        return int(size[:-3]) * (2**50)
+        int_size = int(size[:-3]) * (2**50)
+        return int_size // 8 if size.endswith("b") else int_size
     if size.upper().endswith("TIB"):
-        return int(size[:-3]) * (2**40)
+        int_size = int(size[:-3]) * (2**40)
+        return int_size // 8 if size.endswith("b") else int_size
     if size.upper().endswith("GIB"):
-        return int(size[:-3]) * (2**30)
+        int_size = int(size[:-3]) * (2**30)
+        return int_size // 8 if size.endswith("b") else int_size
     if size.upper().endswith("MIB"):
-        return int(size[:-3]) * (2**20)
+        int_size = int(size[:-3]) * (2**20)
+        return int_size // 8 if size.endswith("b") else int_size
     if size.upper().endswith("KIB"):
-        return int(size[:-3]) * (2**10)
+        int_size = int(size[:-3]) * (2**10)
+        return int_size // 8 if size.endswith("b") else int_size
     if size.upper().endswith("PB"):
         int_size = int(size[:-2]) * (10**15)
         return int_size // 8 if size.endswith("b") else int_size

--- a/tests/test_py_utils.py
+++ b/tests/test_py_utils.py
@@ -13,6 +13,7 @@ import pytest
 from datasets.utils.py_utils import (
     NestedDataStructure,
     asdict,
+    convert_file_size_to_int,
     iflatmap_unordered,
     map_nested,
     string_to_dict,
@@ -288,3 +289,40 @@ def test_string_to_dict():
     file_name_parts = string_to_dict(file_name, cache_file_name_pattern)
     assert file_name_parts is not None
     assert file_name_parts == {"rank": f"{rank:05d}", "num_proc": f"{num_proc:05d}"}
+
+
+@pytest.mark.parametrize(
+    "size, expected",
+    [
+        # A lowercase trailing "b" is bits, so the byte count is an eighth of the same
+        # unit spelled with an uppercase "B". Both the decimal and the binary units say so.
+        ("1KB", 10**3),
+        ("1Kb", 10**3 // 8),
+        ("1MB", 10**6),
+        ("1Mb", 10**6 // 8),
+        ("1GB", 10**9),
+        ("1Gb", 10**9 // 8),
+        ("1TB", 10**12),
+        ("1Tb", 10**12 // 8),
+        ("1PB", 10**15),
+        ("1Pb", 10**15 // 8),
+        ("1KiB", 2**10),
+        ("1Kib", 2**10 // 8),
+        ("1MiB", 2**20),
+        ("1Mib", 2**20 // 8),
+        ("1GiB", 2**30),
+        ("1Gib", 2**30 // 8),
+        ("1TiB", 2**40),
+        ("1Tib", 2**40 // 8),
+        ("1PiB", 2**50),
+        ("1Pib", 2**50 // 8),
+        (1024, 1024),
+    ],
+)
+def test_convert_file_size_to_int(size, expected):
+    assert convert_file_size_to_int(size) == expected
+
+
+def test_convert_file_size_to_int_invalid_unit():
+    with pytest.raises(ValueError):
+        convert_file_size_to_int("1XB")


### PR DESCRIPTION
### Symptom

`convert_file_size_to_int()` treats a lowercase trailing `b` as bits and divides by 8, but only for the decimal units. The binary units ignore the suffix entirely:

```python
>>> from datasets.utils.py_utils import convert_file_size_to_int
>>> convert_file_size_to_int("1Gb")    # gigabit, correct
125000000
>>> convert_file_size_to_int("1Gib")   # gibibit, should be 2**30 // 8
1073741824
>>> convert_file_size_to_int("1GiB")   # gibibyte
1073741824
```

`"1Gib"` and `"1GiB"` return the same number, so a size given in gibibits is read as gibibytes and comes out 8x too large. The same holds for `Kib`, `Mib`, `Tib` and `Pib`.

### Root cause

Ten sibling branches in the same function, and only five of them apply the rule:

```python
if size.upper().endswith("GIB"):
    return int(size[:-3]) * (2**30)          # no bit handling
...
if size.upper().endswith("GB"):
    int_size = int(size[:-2]) * (10**9)
    return int_size // 8 if size.endswith("b") else int_size
```

This is not a judgement call about whether bit units should be supported: #4205 ("Fix `convert_file_size_to_int` for kilobits and megabits") established that they are, and gave the exact two-line form above. It only touched `KB`/`MB`/`GB`. #5171 later added `PB`/`TB` and copied the decimal shape, so those are right too. The `*iB` branches sit above them and were never updated.

### Fix

Apply the same two lines to the five binary branches, so all ten units agree on what a trailing `b` means. No other behaviour changes: an uppercase `B` takes the identical path it took before.

### Why it matters

The parsed value feeds `max_shard_size`, in `Dataset.save_to_disk`, `Dataset.push_to_hub`, `IterableDataset.push_to_hub`, `DatasetBuilder.download_and_prepare` and the Spark builder, plus `MAX_ROW_GROUP_SIZE` in `arrow_writer`. An 8x overshoot there is silent: it produces oversized shards rather than an error.

### Test

`tests/test_py_utils.py` had no coverage for this function. Added a parametrized `test_convert_file_size_to_int` over all ten units in both spellings (plus an `int` passthrough), and `test_convert_file_size_to_int_invalid_unit`.

```
# against this branch
$ python -m pytest tests/test_py_utils.py -k convert_file_size -q
22 passed, 74 deselected

# same tests against main
$ python -m pytest tests/test_py_utils.py -k convert_file_size -q
5 failed, 17 passed, 74 deselected
FAILED test_convert_file_size_to_int[1Kib-128]
FAILED test_convert_file_size_to_int[1Mib-131072]
FAILED test_convert_file_size_to_int[1Gib-134217728]
FAILED test_convert_file_size_to_int[1Tib-137438953472]
FAILED test_convert_file_size_to_int[1Pib-140737488355328]

# whole file
$ python -m pytest tests/test_py_utils.py -q
95 passed, 1 skipped
```

`ruff check` and `ruff format --check` are clean on both files.
