### PR TITLE
Fix language name for ISO code 'blk' (#8505)

### DIFF
--- a/src/datasets/utils/resources/languages.json
+++ b/src/datasets/utils/resources/languages.json
@@ -802,7 +802,7 @@
     "blh": "Kuwaa",
     "bli": "Bolia",
     "blj": "Bolongan",
-    "blk": "Pa'o Karen; Pa'O",
+    "blk": "Pa'O",
     "bll": "Biloxi",
     "blm": "Beli (South Sudan)",
     "bln": "Southern Catanduanes Bikol",


### PR DESCRIPTION
The `blk` entry listed "Pa'o Karen; Pa'O". Per the request from a native speaker in #8505, "Karen" is an external administrative classification rather than a self-designation, so the entry now uses the self-identified name "Pa'O".