### PR TITLE
Actually drop malformed splits in DatasetInfo._from_yaml_dict

### DIFF
--- a/src/datasets/info.py
+++ b/src/datasets/info.py
@@ -320,6 +320,7 @@ class DatasetInfo:
                 yaml_data["splits"] = SplitDict._from_yaml_list(yaml_data["splits"])
             except ValueError as e:
                 logger.warning(f"Ignoring part of dataset_info from the dataset card: {e}")
+                del yaml_data["splits"]
         field_names = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in yaml_data.items() if k in field_names})
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -92,6 +92,23 @@ def test_dataset_info_to_yaml_dict_empty():
     assert dataset_info_yaml_dict == {}
 
 
+def test_dataset_info_from_yaml_dict_with_splits_that_are_not_dicts(caplog):
+    yaml_data = {"config_name": "default", "splits": ["train", "test"]}
+    with caplog.at_level("WARNING", logger="datasets.info"):
+        dataset_info = DatasetInfo._from_yaml_dict(yaml_data)
+    assert dataset_info.splits is None
+    assert dataset_info.config_name == "default"
+    assert "Ignoring part of dataset_info" in caplog.text
+
+
+def test_dataset_info_from_yaml_dict_with_splits_missing_num_bytes(caplog):
+    yaml_data = {"config_name": "default", "splits": [{"name": "train", "num_examples": 42}]}
+    with caplog.at_level("WARNING", logger="datasets.info"):
+        dataset_info = DatasetInfo._from_yaml_dict(yaml_data)
+    assert dataset_info.splits is None
+    assert dataset_info.config_name == "default"
+
+
 @pytest.mark.parametrize(
     "dataset_infos_dict",
     [


### PR DESCRIPTION
`DatasetInfo._from_yaml_dict` logs "Ignoring part of dataset_info from the dataset card" but does not ignore it. The `except ValueError` added in #8462 leaves the raw value in `yaml_data`, and `splits` is a field name, so the next line still passes it to the constructor:

```python
if yaml_data.get("splits") is not None:
    try:
        yaml_data["splits"] = SplitDict._from_yaml_list(yaml_data["splits"])
    except ValueError as e:
        logger.warning(f"Ignoring part of dataset_info from the dataset card: {e}")
field_names = {f.name for f in dataclasses.fields(cls)}
return cls(**{k: v for k, v in yaml_data.items() if k in field_names})
```

`__post_init__` then calls `SplitDict.from_split_dict(self.splits)`, which starts with `split_infos[0].get("dataset_name")`. So a card whose YAML reads `splits: [train, test]`, the shape the guard is there to catch, still fails, with `AttributeError: 'str' object has no attribute 'get'` raised one frame after the warning said the field had been ignored.

The fix drops the key in the handler. A card with a malformed `splits` list then produces a `DatasetInfo` equal to the one you get from a card with no `splits` field at all.

One behaviour change to flag: an entry that is a dict but omits `num_bytes` or `num_examples` currently survives the warning and loads with both defaulted to 0, since `SplitInfo` defaults them. With this change it is ignored, which is what the warning claims. If you would rather those cards kept loading, the better place is the check in `SplitDict._from_yaml_list`, not this handler, so I left it alone: the three field names are spelled out in your error message and that reads deliberate.

I have not measured how often real dataset cards carry a malformed `splits` list, so I am not claiming a frequency for it.

### Verification

- Two tests in `tests/test_info.py`, one per case above. Both fail on main (`AttributeError`, and a populated `splits`) and pass here.
- `tests/test_info.py` and the `tests/test_load.py` unit selection pass, 92 tests.
- `ruff check` and `ruff format --check` clean on `tests src benchmarks utils setup.py`.
- Checked on Python 3.10 and 3.14. I did not run the integration marker or the Windows legs.
