### PR TITLE
feat(features): add BioSequence and BioStructure decodable features

### DIFF
--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -293,6 +293,14 @@ Dictionary with split names as keys ('train', 'test' for example), and `Iterable
 
 [[autodoc]] datasets.Nifti
 
+### BioSequence
+
+[[autodoc]] datasets.BioSequence
+
+### BioStructure
+
+[[autodoc]] datasets.BioStructure
+
 ## Filesystems
 
 [[autodoc]] datasets.filesystems.is_remote_filesystem

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,8 @@ DOCS_REQUIRE = [
 
 PDFS_REQUIRE = ["pdfplumber>=0.11.4"]
 
+BIO_REQUIRE = ["biopython>=1.80"]
+
 NIBABEL_REQUIRE = ["nibabel>=5.3.2", "ipyniivue==2.4.2"]
 
 ICEBERG_REQUIRE = ["pyiceberg>=0.7.0"]
@@ -241,6 +243,7 @@ EXTRAS_REQUIRE = {
     "benchmarks": BENCHMARKS_REQUIRE,
     "docs": DOCS_REQUIRE,
     "pdfs": PDFS_REQUIRE,
+    "bio": BIO_REQUIRE,
     "nibabel": NIBABEL_REQUIRE,
     "iceberg": ICEBERG_REQUIRE,
 }

--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -139,6 +139,8 @@ IS_MP3_SUPPORTED = True
 TORCHCODEC_AVAILABLE = importlib.util.find_spec("torchcodec") is not None
 TORCHVISION_AVAILABLE = importlib.util.find_spec("torchvision") is not None
 PDFPLUMBER_AVAILABLE = importlib.util.find_spec("pdfplumber") is not None
+# biopython is imported as ``Bio`` (the PyPI package name is ``biopython``).
+BIOPYTHON_AVAILABLE = importlib.util.find_spec("Bio") is not None
 NIBABEL_AVAILABLE = importlib.util.find_spec("nibabel") is not None
 TRIMESH_AVAILABLE = importlib.util.find_spec("trimesh") is not None
 TEICH_AVAILABLE = importlib.util.find_spec("teich") is not None

--- a/src/datasets/features/__init__.py
+++ b/src/datasets/features/__init__.py
@@ -1,5 +1,7 @@
 __all__ = [
     "Audio",
+    "BioSequence",
+    "BioStructure",
     "Array2D",
     "Array3D",
     "Array4D",
@@ -20,6 +22,8 @@ __all__ = [
     "Nifti",
 ]
 from .audio import Audio
+from .bio_sequence import BioSequence
+from .bio_structure import BioStructure
 from .features import Array2D, Array3D, Array4D, Array5D, ClassLabel, Features, Json, LargeList, List, Sequence, Value
 from .image import Image
 from .mesh import Mesh

--- a/src/datasets/features/bio_sequence.py
+++ b/src/datasets/features/bio_sequence.py
@@ -297,5 +297,7 @@ def _embed_bytes_path_struct(
         [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
         type=pa.string(),
     )
-    storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
+    # Row nullness comes from the input row, not from whether bytes were embedded: a
+    # path-only row with embedding disabled is still a valid row.
+    storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
     return array_cast(storage, pa_type)

--- a/src/datasets/features/bio_sequence.py
+++ b/src/datasets/features/bio_sequence.py
@@ -1,0 +1,304 @@
+import os
+from dataclasses import dataclass, field
+from io import StringIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+
+import pyarrow as pa
+
+from .. import config
+from ..download.download_config import DownloadConfig
+from ..table import array_cast
+from ..utils.file_utils import is_local_path, xopen
+from ..utils.py_utils import no_op_if_value_is_null, string_to_dict
+
+
+if TYPE_CHECKING:
+    from Bio.SeqRecord import SeqRecord
+
+    from .features import FeatureType
+
+
+def encode_bio_seqrecord(record: "SeqRecord", format: str = "fasta") -> dict:
+    """Serialize a ``SeqRecord`` back to the bytes of a single-record file."""
+    from Bio import SeqIO
+
+    buffer = StringIO()
+    SeqIO.write(record, buffer, format)
+    return {"path": None, "bytes": buffer.getvalue().encode("utf-8")}
+
+
+@dataclass
+class BioSequence:
+    """
+    **Experimental.**
+    BioSequence [`Feature`] to read biological sequence records from a sequence file.
+
+    A sequence file holds one or more records of residues with their identifiers and
+    annotations. FASTA, FASTQ and GenBank are the same shape at this level, differing
+    only in the parser used, so `format` selects the parser rather than the type.
+
+    Input: The BioSequence feature accepts as input:
+    - A `str`: Absolute path to the sequence file (i.e. random access is allowed).
+    - A `pathlib.Path`: path to the sequence file (i.e. random access is allowed).
+    - A `dict` with the keys:
+        - `path`: String with relative path of the sequence file in a dataset repository.
+        - `bytes`: Bytes of the sequence file.
+      This is useful for archived files with sequential access.
+
+    - A `Bio.SeqRecord.SeqRecord`: biopython sequence record.
+
+    Args:
+        format (`str`, defaults to `"fasta"`):
+            Name of the sequence format, as understood by `Bio.SeqIO`. Common values
+            are `"fasta"`, `"fastq"` and `"genbank"`.
+        decode (`bool`, defaults to `True`):
+            Whether to decode the sequence data. If `False`,
+            returns the underlying dictionary in the format `{"path": path, "bytes": bytes}`.
+
+    Examples:
+
+    ```py
+    >>> from datasets import Dataset, BioSequence
+    >>> ds = Dataset.from_dict({"seq": ["path/to/sequences.fasta"]}).cast_column("seq", BioSequence())
+    >>> ds.features["seq"]
+    BioSequence(format='fasta', decode=True)
+    >>> ds[0]["seq"]
+    SeqRecord(seq=Seq('ACGT'), id='seq1', name='seq1', description='seq1', dbxrefs=[])
+    >>> ds = ds.cast_column("seq", BioSequence(decode=False))
+    >>> ds[0]["seq"]
+    {'bytes': None,
+    'path': 'path/to/sequences.fasta'}
+    ```
+    """
+
+    format: str = "fasta"
+    decode: bool = True
+    id: Optional[str] = field(default=None, repr=False)
+
+    # Automatically constructed
+    dtype: ClassVar[str] = "Bio.SeqRecord.SeqRecord"
+    pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
+    _type: str = field(default="BioSequence", init=False, repr=False)
+
+    def __call__(self):
+        return self.pa_type
+
+    def encode_example(self, value: Union[str, bytes, bytearray, dict, "SeqRecord"]) -> dict:
+        """Encode example into a format for Arrow.
+
+        Args:
+            value (`str`, `bytes`, `Bio.SeqRecord.SeqRecord` or `dict`):
+                Data passed as input to BioSequence feature.
+
+        Returns:
+            `dict` with "path" and "bytes" fields
+        """
+        if config.BIOPYTHON_AVAILABLE:
+            from Bio.SeqRecord import SeqRecord
+        else:
+            SeqRecord = None
+
+        if isinstance(value, str):
+            return {"path": value, "bytes": None}
+        elif isinstance(value, Path):
+            return {"path": str(value.absolute()), "bytes": None}
+        elif isinstance(value, (bytes, bytearray)):
+            return {"path": None, "bytes": bytes(value)}
+        elif SeqRecord is not None and isinstance(value, SeqRecord):
+            return encode_bio_seqrecord(value, self.format)
+        elif value.get("path") is not None and os.path.isfile(value["path"]):
+            # we set "bytes": None to not duplicate the data if they're already available locally
+            return {"bytes": None, "path": value.get("path")}
+        elif value.get("bytes") is not None or value.get("path") is not None:
+            return {"bytes": value.get("bytes"), "path": value.get("path")}
+        else:
+            raise ValueError(
+                f"A sequence sample should have one of 'path' or 'bytes' but they are missing or None in {value}."
+            )
+
+    def decode_example(self, value: dict, token_per_repo_id=None) -> "SeqRecord":
+        """Decode example sequence file into a biopython record.
+
+        A file may hold many records; this returns the first, because one row is one
+        record. Use the packaged sequence loaders to expand a multi-record file into
+        one row per record.
+
+        Args:
+            value (`str` or `dict`):
+                A string with the absolute file path, or a dictionary with
+                keys:
+
+                - `path`: String with absolute or relative file path.
+                - `bytes`: The bytes of the file.
+
+            token_per_repo_id (`dict`, *optional*):
+                To access and decode files from private repositories on
+                the Hub, you can pass a dictionary
+                repo_id (`str`) -> token (`bool` or `str`).
+
+        Returns:
+            `Bio.SeqRecord.SeqRecord`
+        """
+        if not self.decode:
+            raise RuntimeError("Decoding is disabled for this feature. Please use BioSequence(decode=True) instead.")
+
+        if not config.BIOPYTHON_AVAILABLE:
+            raise ImportError("To support decoding biological sequences, please install 'biopython'.")
+
+        if token_per_repo_id is None:
+            token_per_repo_id = {}
+
+        path, bytes_ = value["path"], value["bytes"]
+        if bytes_ is None:
+            if path is None:
+                raise ValueError(f"A sequence should have one of 'path' or 'bytes' but both are None in {value}.")
+            if is_local_path(path):
+                with open(path, encoding="utf-8") as f:
+                    return self._first_record(f, path)
+            source_url = path.split("::")[-1]
+            pattern = (
+                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+            )
+            try:
+                repo_id = string_to_dict(source_url, pattern)["repo_id"]
+                token = token_per_repo_id.get(repo_id)
+            except ValueError:
+                token = None
+            download_config = DownloadConfig(token=token)
+            with xopen(path, "r", download_config=download_config) as f:
+                return self._first_record(f, path)
+        else:
+            with StringIO(bytes_.decode("utf-8")) as f:
+                return self._first_record(f, path)
+
+    def _first_record(self, handle, path: Optional[str]) -> "SeqRecord":
+        """Return the first record in ``handle``, or raise if the file holds none."""
+        from Bio import SeqIO
+
+        for record in SeqIO.parse(handle, self.format):
+            return record
+        raise ValueError(f"No {self.format} record found in {path if path is not None else 'the given bytes'}.")
+
+    def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
+        """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""
+        from .features import Value
+
+        return (
+            self
+            if self.decode
+            else {
+                "bytes": Value("binary"),
+                "path": Value("string"),
+            }
+        )
+
+    def cast_storage(self, storage: Union[pa.StringArray, pa.StructArray]) -> pa.StructArray:
+        """Cast an Arrow array to the BioSequence arrow storage type.
+        The Arrow types that can be converted to the BioSequence pyarrow storage type are:
+
+        - `pa.string()` - it must contain the "path" data
+        - `pa.binary()` - it must contain the file bytes
+        - `pa.struct({"bytes": pa.binary()})`
+        - `pa.struct({"path": pa.string()})`
+        - `pa.struct({"bytes": pa.binary(), "path": pa.string()})`  - order doesn't matter
+
+        Args:
+            storage (`Union[pa.StringArray, pa.StructArray]`):
+                PyArrow array to cast.
+
+        Returns:
+            `pa.StructArray`: Array in the BioSequence arrow storage type, that is
+                `pa.struct({"bytes": pa.binary(), "path": pa.string()})`.
+        """
+        return _cast_to_bytes_path_struct(storage, self.pa_type)
+
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
+        """Embed sequence files into the Arrow array.
+
+        Args:
+            storage (`pa.StructArray`):
+                PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`):
+                Whether to embed local files data in the array.
+            remote_files (`bool`, defaults to `True`):
+                Whether to embed remote files data in the array.
+
+        Returns:
+            `pa.StructArray`: Array in the BioSequence arrow storage type.
+        """
+        return _embed_bytes_path_struct(
+            storage, self.pa_type, token_per_repo_id, local_files=local_files, remote_files=remote_files
+        )
+
+
+def _cast_to_bytes_path_struct(storage, pa_type: pa.DataType) -> pa.StructArray:
+    """Cast a string, binary or struct array to the shared ``struct<bytes, path>`` storage.
+
+    BioSequence and BioStructure accept exactly the same inputs, so the conversion lives
+    here rather than being written out twice.
+    """
+    if pa.types.is_string(storage.type):
+        bytes_array = pa.array([None] * len(storage), type=pa.binary())
+        storage = pa.StructArray.from_arrays([bytes_array, storage], ["bytes", "path"], mask=storage.is_null())
+    elif pa.types.is_binary(storage.type):
+        path_array = pa.array([None] * len(storage), type=pa.string())
+        storage = pa.StructArray.from_arrays([storage, path_array], ["bytes", "path"], mask=storage.is_null())
+    elif pa.types.is_struct(storage.type):
+        if storage.type.get_field_index("bytes") >= 0:
+            bytes_array = storage.field("bytes")
+        else:
+            bytes_array = pa.array([None] * len(storage), type=pa.binary())
+        if storage.type.get_field_index("path") >= 0:
+            path_array = storage.field("path")
+        else:
+            path_array = pa.array([None] * len(storage), type=pa.string())
+        storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=storage.is_null())
+    return array_cast(storage, pa_type)
+
+
+def _embed_bytes_path_struct(
+    storage: pa.StructArray,
+    pa_type: pa.DataType,
+    token_per_repo_id=None,
+    local_files: bool = True,
+    remote_files: bool = True,
+) -> pa.StructArray:
+    """Read file contents into the ``bytes`` field, shared by both bio features."""
+    if token_per_repo_id is None:
+        token_per_repo_id = {}
+
+    @no_op_if_value_is_null
+    def path_to_bytes(path):
+        source_url = path.split("::")[-1]
+        pattern = (
+            config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+        )
+        source_url_fields = string_to_dict(source_url, pattern)
+        token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+        download_config = DownloadConfig(token=token)
+        with xopen(path, "rb", download_config=download_config) as f:
+            return f.read()
+
+    def should_embed(path: Optional[str]) -> bool:
+        if path is None:
+            return False
+        return local_files if is_local_path(path) else remote_files
+
+    bytes_array = pa.array(
+        [
+            (path_to_bytes(path) if should_embed(path) else bytes_)
+            for bytes_, path in zip(storage.field("bytes").to_pylist(), storage.field("path").to_pylist())
+        ],
+        type=pa.binary(),
+    )
+    path_array = pa.array(
+        [os.path.basename(path) if path is not None else None for path in storage.field("path").to_pylist()],
+        type=pa.string(),
+    )
+    storage = pa.StructArray.from_arrays([bytes_array, path_array], ["bytes", "path"], mask=bytes_array.is_null())
+    return array_cast(storage, pa_type)

--- a/src/datasets/features/bio_sequence.py
+++ b/src/datasets/features/bio_sequence.py
@@ -28,6 +28,18 @@ def encode_bio_seqrecord(record: "SeqRecord", format: str = "fasta") -> dict:
     return {"path": None, "bytes": buffer.getvalue().encode("utf-8")}
 
 
+def _resolve_token(path: str, token_per_repo_id: dict) -> Optional[str]:
+    """Return the token for the Hub repo that ``path`` points into, or ``None``.
+
+    ``string_to_dict`` returns ``None`` (it does not raise) when the URL is not a Hub
+    dataset URL, so a plain https or s3 path resolves to "no token" instead of failing.
+    """
+    source_url = path.split("::")[-1]
+    pattern = config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+    source_url_fields = string_to_dict(source_url, pattern)
+    return token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+
+
 @dataclass
 class BioSequence:
     """
@@ -156,17 +168,8 @@ class BioSequence:
             if is_local_path(path):
                 with open(path, encoding="utf-8") as f:
                     return self._first_record(f, path)
-            source_url = path.split("::")[-1]
-            pattern = (
-                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
-            )
-            try:
-                repo_id = string_to_dict(source_url, pattern)["repo_id"]
-                token = token_per_repo_id.get(repo_id)
-            except ValueError:
-                token = None
-            download_config = DownloadConfig(token=token)
-            with xopen(path, "r", download_config=download_config) as f:
+            download_config = DownloadConfig(token=_resolve_token(path, token_per_repo_id))
+            with xopen(path, "r", encoding="utf-8", download_config=download_config) as f:
                 return self._first_record(f, path)
         else:
             with StringIO(bytes_.decode("utf-8")) as f:
@@ -274,13 +277,7 @@ def _embed_bytes_path_struct(
 
     @no_op_if_value_is_null
     def path_to_bytes(path):
-        source_url = path.split("::")[-1]
-        pattern = (
-            config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
-        )
-        source_url_fields = string_to_dict(source_url, pattern)
-        token = token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
-        download_config = DownloadConfig(token=token)
+        download_config = DownloadConfig(token=_resolve_token(path, token_per_repo_id))
         with xopen(path, "rb", download_config=download_config) as f:
             return f.read()
 

--- a/src/datasets/features/bio_structure.py
+++ b/src/datasets/features/bio_structure.py
@@ -9,8 +9,7 @@ import pyarrow as pa
 from .. import config
 from ..download.download_config import DownloadConfig
 from ..utils.file_utils import is_local_path, xopen
-from ..utils.py_utils import string_to_dict
-from .bio_sequence import _cast_to_bytes_path_struct, _embed_bytes_path_struct
+from .bio_sequence import _cast_to_bytes_path_struct, _embed_bytes_path_struct, _resolve_token
 
 
 if TYPE_CHECKING:
@@ -19,15 +18,26 @@ if TYPE_CHECKING:
     from .features import FeatureType
 
 
-# Parser class name in Bio.PDB for each supported structure format.
-_PARSERS: dict[str, str] = {"pdb": "PDBParser", "mmcif": "MMCIFParser"}
+# (parser, writer) class names in Bio.PDB for each supported structure format. Encode and
+# decode both go through this table so a format that cannot be read is never written.
+_FORMATS: dict[str, tuple[str, str]] = {"pdb": ("PDBParser", "PDBIO"), "mmcif": ("MMCIFParser", "MMCIFIO")}
+
+
+def _resolve_format(format: str) -> tuple[str, str]:
+    try:
+        return _FORMATS[format]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported structure format '{format}'. Supported formats are: {sorted(_FORMATS)}."
+        ) from None
 
 
 def encode_bio_structure(structure: "Structure", format: str = "pdb") -> dict:
     """Serialize a ``Structure`` back to the bytes of a structure file."""
-    from Bio.PDB import MMCIFIO, PDBIO
+    import Bio.PDB
 
-    io = PDBIO() if format == "pdb" else MMCIFIO()
+    _, writer_name = _resolve_format(format)
+    io = getattr(Bio.PDB, writer_name)()
     io.set_structure(structure)
     buffer = StringIO()
     io.save(buffer)
@@ -85,6 +95,9 @@ class BioStructure:
     dtype: ClassVar[str] = "Bio.PDB.Structure.Structure"
     pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
     _type: str = field(default="BioStructure", init=False, repr=False)
+
+    def __post_init__(self):
+        _resolve_format(self.format)
 
     def __call__(self):
         return self.pa_type
@@ -159,17 +172,8 @@ class BioStructure:
             if is_local_path(path):
                 with open(path, encoding="utf-8") as f:
                     return self._parse(f, structure_id)
-            source_url = path.split("::")[-1]
-            pattern = (
-                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
-            )
-            try:
-                repo_id = string_to_dict(source_url, pattern)["repo_id"]
-                token = token_per_repo_id.get(repo_id)
-            except ValueError:
-                token = None
-            download_config = DownloadConfig(token=token)
-            with xopen(path, "r", download_config=download_config) as f:
+            download_config = DownloadConfig(token=_resolve_token(path, token_per_repo_id))
+            with xopen(path, "r", encoding="utf-8", download_config=download_config) as f:
                 return self._parse(f, structure_id)
         else:
             with StringIO(bytes_.decode("utf-8")) as f:
@@ -179,12 +183,7 @@ class BioStructure:
         """Parse ``handle`` with the parser for this feature's format."""
         import Bio.PDB
 
-        try:
-            parser_name = _PARSERS[self.format]
-        except KeyError:
-            raise ValueError(
-                f"Unsupported structure format '{self.format}'. Supported formats are: {sorted(_PARSERS)}."
-            ) from None
+        parser_name, _ = _resolve_format(self.format)
         # QUIET silences the discontinuity warnings that most real PDB entries trigger.
         parser = getattr(Bio.PDB, parser_name)(QUIET=True)
         return parser.get_structure(structure_id, handle)

--- a/src/datasets/features/bio_structure.py
+++ b/src/datasets/features/bio_structure.py
@@ -1,0 +1,245 @@
+import os
+from dataclasses import dataclass, field
+from io import StringIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+
+import pyarrow as pa
+
+from .. import config
+from ..download.download_config import DownloadConfig
+from ..utils.file_utils import is_local_path, xopen
+from ..utils.py_utils import string_to_dict
+from .bio_sequence import _cast_to_bytes_path_struct, _embed_bytes_path_struct
+
+
+if TYPE_CHECKING:
+    from Bio.PDB.Structure import Structure
+
+    from .features import FeatureType
+
+
+# Parser class name in Bio.PDB for each supported structure format.
+_PARSERS: dict[str, str] = {"pdb": "PDBParser", "mmcif": "MMCIFParser"}
+
+
+def encode_bio_structure(structure: "Structure", format: str = "pdb") -> dict:
+    """Serialize a ``Structure`` back to the bytes of a structure file."""
+    from Bio.PDB import MMCIFIO, PDBIO
+
+    io = PDBIO() if format == "pdb" else MMCIFIO()
+    io.set_structure(structure)
+    buffer = StringIO()
+    io.save(buffer)
+    return {"path": None, "bytes": buffer.getvalue().encode("utf-8")}
+
+
+@dataclass
+class BioStructure:
+    """
+    **Experimental.**
+    BioStructure [`Feature`] to read macromolecular structures from a structure file.
+
+    A structure file holds the three-dimensional coordinates of a molecule's atoms,
+    grouped into chains and residues. PDB and mmCIF describe the same objects and
+    differ only in the parser used, so `format` selects the parser rather than the type.
+
+    Input: The BioStructure feature accepts as input:
+    - A `str`: Absolute path to the structure file (i.e. random access is allowed).
+    - A `pathlib.Path`: path to the structure file (i.e. random access is allowed).
+    - A `dict` with the keys:
+        - `path`: String with relative path of the structure file in a dataset repository.
+        - `bytes`: Bytes of the structure file.
+      This is useful for archived files with sequential access.
+
+    - A `Bio.PDB.Structure.Structure`: biopython structure.
+
+    Args:
+        format (`str`, defaults to `"pdb"`):
+            Structure format, either `"pdb"` or `"mmcif"`.
+        decode (`bool`, defaults to `True`):
+            Whether to decode the structure data. If `False`,
+            returns the underlying dictionary in the format `{"path": path, "bytes": bytes}`.
+
+    Examples:
+
+    ```py
+    >>> from datasets import Dataset, BioStructure
+    >>> ds = Dataset.from_dict({"st": ["path/to/1abc.pdb"]}).cast_column("st", BioStructure())
+    >>> ds.features["st"]
+    BioStructure(format='pdb', decode=True)
+    >>> ds[0]["st"]
+    <Structure id=1abc>
+    >>> ds = ds.cast_column("st", BioStructure(decode=False))
+    >>> ds[0]["st"]
+    {'bytes': None,
+    'path': 'path/to/1abc.pdb'}
+    ```
+    """
+
+    format: str = "pdb"
+    decode: bool = True
+    id: Optional[str] = field(default=None, repr=False)
+
+    # Automatically constructed
+    dtype: ClassVar[str] = "Bio.PDB.Structure.Structure"
+    pa_type: ClassVar[Any] = pa.struct({"bytes": pa.binary(), "path": pa.string()})
+    _type: str = field(default="BioStructure", init=False, repr=False)
+
+    def __call__(self):
+        return self.pa_type
+
+    def encode_example(self, value: Union[str, bytes, bytearray, dict, "Structure"]) -> dict:
+        """Encode example into a format for Arrow.
+
+        Args:
+            value (`str`, `bytes`, `Bio.PDB.Structure.Structure` or `dict`):
+                Data passed as input to BioStructure feature.
+
+        Returns:
+            `dict` with "path" and "bytes" fields
+        """
+        if config.BIOPYTHON_AVAILABLE:
+            from Bio.PDB.Structure import Structure
+        else:
+            Structure = None
+
+        if isinstance(value, str):
+            return {"path": value, "bytes": None}
+        elif isinstance(value, Path):
+            return {"path": str(value.absolute()), "bytes": None}
+        elif isinstance(value, (bytes, bytearray)):
+            return {"path": None, "bytes": bytes(value)}
+        elif Structure is not None and isinstance(value, Structure):
+            return encode_bio_structure(value, self.format)
+        elif value.get("path") is not None and os.path.isfile(value["path"]):
+            # we set "bytes": None to not duplicate the data if they're already available locally
+            return {"bytes": None, "path": value.get("path")}
+        elif value.get("bytes") is not None or value.get("path") is not None:
+            return {"bytes": value.get("bytes"), "path": value.get("path")}
+        else:
+            raise ValueError(
+                f"A structure sample should have one of 'path' or 'bytes' but they are missing or None in {value}."
+            )
+
+    def decode_example(self, value: dict, token_per_repo_id=None) -> "Structure":
+        """Decode example structure file into a biopython structure.
+
+        Args:
+            value (`str` or `dict`):
+                A string with the absolute file path, or a dictionary with
+                keys:
+
+                - `path`: String with absolute or relative file path.
+                - `bytes`: The bytes of the file.
+
+            token_per_repo_id (`dict`, *optional*):
+                To access and decode files from private repositories on
+                the Hub, you can pass a dictionary
+                repo_id (`str`) -> token (`bool` or `str`).
+
+        Returns:
+            `Bio.PDB.Structure.Structure`
+        """
+        if not self.decode:
+            raise RuntimeError("Decoding is disabled for this feature. Please use BioStructure(decode=True) instead.")
+
+        if not config.BIOPYTHON_AVAILABLE:
+            raise ImportError("To support decoding macromolecular structures, please install 'biopython'.")
+
+        if token_per_repo_id is None:
+            token_per_repo_id = {}
+
+        path, bytes_ = value["path"], value["bytes"]
+        structure_id = os.path.splitext(os.path.basename(path))[0] if path else "structure"
+
+        if bytes_ is None:
+            if path is None:
+                raise ValueError(f"A structure should have one of 'path' or 'bytes' but both are None in {value}.")
+            if is_local_path(path):
+                with open(path, encoding="utf-8") as f:
+                    return self._parse(f, structure_id)
+            source_url = path.split("::")[-1]
+            pattern = (
+                config.HUB_DATASETS_URL if source_url.startswith(config.HF_ENDPOINT) else config.HUB_DATASETS_HFFS_URL
+            )
+            try:
+                repo_id = string_to_dict(source_url, pattern)["repo_id"]
+                token = token_per_repo_id.get(repo_id)
+            except ValueError:
+                token = None
+            download_config = DownloadConfig(token=token)
+            with xopen(path, "r", download_config=download_config) as f:
+                return self._parse(f, structure_id)
+        else:
+            with StringIO(bytes_.decode("utf-8")) as f:
+                return self._parse(f, structure_id)
+
+    def _parse(self, handle, structure_id: str) -> "Structure":
+        """Parse ``handle`` with the parser for this feature's format."""
+        import Bio.PDB
+
+        try:
+            parser_name = _PARSERS[self.format]
+        except KeyError:
+            raise ValueError(
+                f"Unsupported structure format '{self.format}'. Supported formats are: {sorted(_PARSERS)}."
+            ) from None
+        # QUIET silences the discontinuity warnings that most real PDB entries trigger.
+        parser = getattr(Bio.PDB, parser_name)(QUIET=True)
+        return parser.get_structure(structure_id, handle)
+
+    def flatten(self) -> Union["FeatureType", dict[str, "FeatureType"]]:
+        """If in the decodable state, return the feature itself, otherwise flatten the feature into a dictionary."""
+        from .features import Value
+
+        return (
+            self
+            if self.decode
+            else {
+                "bytes": Value("binary"),
+                "path": Value("string"),
+            }
+        )
+
+    def cast_storage(self, storage: Union[pa.StringArray, pa.StructArray]) -> pa.StructArray:
+        """Cast an Arrow array to the BioStructure arrow storage type.
+        The Arrow types that can be converted to the BioStructure pyarrow storage type are:
+
+        - `pa.string()` - it must contain the "path" data
+        - `pa.binary()` - it must contain the file bytes
+        - `pa.struct({"bytes": pa.binary()})`
+        - `pa.struct({"path": pa.string()})`
+        - `pa.struct({"bytes": pa.binary(), "path": pa.string()})`  - order doesn't matter
+
+        Args:
+            storage (`Union[pa.StringArray, pa.StructArray]`):
+                PyArrow array to cast.
+
+        Returns:
+            `pa.StructArray`: Array in the BioStructure arrow storage type, that is
+                `pa.struct({"bytes": pa.binary(), "path": pa.string()})`.
+        """
+        return _cast_to_bytes_path_struct(storage, self.pa_type)
+
+    def embed_storage(
+        self, storage: pa.StructArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.StructArray:
+        """Embed structure files into the Arrow array.
+
+        Args:
+            storage (`pa.StructArray`):
+                PyArrow array to embed.
+            token_per_repo_id (`dict`, optional):
+                Dictionary repo_id -> token to fetch the files bytes.
+            local_files (`bool`, defaults to `True`):
+                Whether to embed local files data in the array.
+            remote_files (`bool`, defaults to `True`):
+                Whether to embed remote files data in the array.
+
+        Returns:
+            `pa.StructArray`: Array in the BioStructure arrow storage type.
+        """
+        return _embed_bytes_path_struct(
+            storage, self.pa_type, token_per_repo_id, local_files=local_files, remote_files=remote_files
+        )

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -42,6 +42,8 @@ from ..utils import experimental, logging
 from ..utils.json import ujson_dumps, ujson_loads
 from ..utils.py_utils import asdict, first_non_null_value, zip_dict
 from .audio import Audio
+from .bio_sequence import BioSequence, encode_bio_seqrecord
+from .bio_structure import BioStructure, encode_bio_structure
 from .image import Image, encode_pil_image
 from .mesh import Mesh
 from .nifti import Nifti, encode_nibabel_image
@@ -321,6 +323,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
     if config.NIBABEL_AVAILABLE and "nibabel" in sys.modules:
         import nibabel as nib
 
+    if config.BIOPYTHON_AVAILABLE and "Bio" in sys.modules:
+        from Bio.PDB.Structure import Structure
+        from Bio.SeqRecord import SeqRecord
+
     if config.TORCHCODEC_AVAILABLE and "torchcodec" in sys.modules:
         from torchcodec.decoders import AudioDecoder, VideoDecoder
 
@@ -396,6 +402,10 @@ def _cast_to_python_objects(obj: Any, only_1d_for_numpy: bool, optimize_list_cas
         return encode_pdfplumber_pdf(obj), True
     elif config.NIBABEL_AVAILABLE and "nibabel" in sys.modules and isinstance(obj, nib.analyze.AnalyzeImage):
         return encode_nibabel_image(obj, force_bytes=True), True
+    elif config.BIOPYTHON_AVAILABLE and "Bio" in sys.modules and isinstance(obj, SeqRecord):
+        return encode_bio_seqrecord(obj), True
+    elif config.BIOPYTHON_AVAILABLE and "Bio" in sys.modules and isinstance(obj, Structure):
+        return encode_bio_structure(obj), True
     elif isinstance(obj, pd.Series):
         return (
             _cast_to_python_objects(
@@ -1387,6 +1397,8 @@ FeatureType = Union[
     Video,
     Pdf,
     Nifti,
+    BioSequence,
+    BioStructure,
 ]
 
 
@@ -1549,6 +1561,8 @@ _FEATURE_TYPES: dict[str, FeatureType] = {
     Video.__name__: Video,
     Pdf.__name__: Pdf,
     Nifti.__name__: Nifti,
+    BioSequence.__name__: BioSequence,
+    BioStructure.__name__: BioStructure,
     Json.__name__: Json,
 }
 

--- a/tests/features/test_bio.py
+++ b/tests/features/test_bio.py
@@ -159,3 +159,38 @@ def test_bio_sequence_format_is_configurable(tmp_path):
     record = ds[0]["seq"]
     assert record.id == "r1"
     assert record.letter_annotations["phred_quality"] == [40, 40, 40, 40]
+
+
+@pytest.mark.parametrize("bad_format", ["PDB", "cif", "mmCIF", "xyz"])
+def test_bio_structure_rejects_unknown_format_at_construction(bad_format):
+    """A format outside the supported table must fail before any bytes are written.
+
+    Regression: encode_bio_structure() used to write mmCIF for every non-"pdb" value
+    while decode_example() rejected the same value, so a mis-cased format stored bytes
+    that could never be read back.
+    """
+    with pytest.raises(ValueError, match="Unsupported structure format"):
+        BioStructure(format=bad_format)
+
+
+def test_bio_structure_encodes_structure_in_declared_format(pdb_path):
+    """The bytes written for a Structure follow the feature's format, for both formats."""
+    from Bio.PDB import PDBParser
+
+    structure = PDBParser(QUIET=True).get_structure("x", str(pdb_path))
+    pdb_bytes = BioStructure(format="pdb").encode_example(structure)["bytes"]
+    cif_bytes = BioStructure(format="mmcif").encode_example(structure)["bytes"]
+    assert pdb_bytes.startswith(b"ATOM")
+    assert cif_bytes.startswith(b"data_")
+    assert BioStructure(format="mmcif").decode_example({"path": None, "bytes": cif_bytes}).id == "structure"
+
+
+def test_resolve_token_returns_none_for_non_hub_url():
+    """string_to_dict() returns None for a URL that is not a Hub dataset URL; that must
+    not surface as a TypeError when the remote path is plain https or s3."""
+    from datasets.features.bio_sequence import _resolve_token
+
+    tokens = {"user/repo": "hf_secret"}
+    assert _resolve_token("https://example.com/data/seqs.fasta", tokens) is None
+    assert _resolve_token("s3://bucket/seqs.fasta", tokens) is None
+    assert _resolve_token("hf://datasets/user/repo@main/seqs.fasta", tokens) == "hf_secret"

--- a/tests/features/test_bio.py
+++ b/tests/features/test_bio.py
@@ -173,6 +173,7 @@ def test_bio_structure_rejects_unknown_format_at_construction(bad_format):
         BioStructure(format=bad_format)
 
 
+@require_biopython
 def test_bio_structure_encodes_structure_in_declared_format(pdb_path):
     """The bytes written for a Structure follow the feature's format, for both formats."""
     from Bio.PDB import PDBParser

--- a/tests/features/test_bio.py
+++ b/tests/features/test_bio.py
@@ -1,0 +1,161 @@
+"""Tests for the BioSequence and BioStructure feature types."""
+
+import pytest
+
+from datasets import Dataset, Features
+from datasets.features import BioSequence, BioStructure
+
+
+FASTA_BYTES = b">seq1 first record\nACGTACGTAC\n>seq2 second record\nTTTTGGGGCC\n"
+
+# Minimal well-formed PDB: two atoms of one residue in one chain.
+PDB_BYTES = (
+    b"ATOM      1  N   MET A   1      11.104  13.207  10.567  1.00 20.00           N\n"
+    b"ATOM      2  CA  MET A   1      12.560  13.099  10.500  1.00 20.00           C\n"
+    b"TER       3      MET A   1\n"
+    b"END\n"
+)
+
+
+@pytest.fixture
+def fasta_path(tmp_path):
+    path = tmp_path / "seqs.fasta"
+    path.write_bytes(FASTA_BYTES)
+    return str(path)
+
+
+@pytest.fixture
+def pdb_path(tmp_path):
+    path = tmp_path / "struct.pdb"
+    path.write_bytes(PDB_BYTES)
+    return str(path)
+
+
+# --------------------------------------------------------------------------
+# Storage and encoding. These hold whether or not biopython is installed,
+# because they never decode.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_storage_type_is_bytes_path_struct(feature_cls):
+    """Both features store the same struct<bytes, path> as Audio, Image and Pdf do."""
+    import pyarrow as pa
+
+    assert feature_cls().pa_type == pa.struct({"bytes": pa.binary(), "path": pa.string()})
+    assert feature_cls()() == feature_cls().pa_type
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_encode_example_from_path(feature_cls, tmp_path):
+    path = str(tmp_path / "x.dat")
+    assert feature_cls().encode_example(path) == {"path": path, "bytes": None}
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_encode_example_from_bytes(feature_cls):
+    assert feature_cls().encode_example(b"raw") == {"path": None, "bytes": b"raw"}
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_encode_example_rejects_empty_dict(feature_cls):
+    with pytest.raises(ValueError, match="should have one of 'path' or 'bytes'"):
+        feature_cls().encode_example({"path": None, "bytes": None})
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_decode_false_returns_raw_and_never_decodes(feature_cls, tmp_path):
+    """With decode=False the user gets bytes back and biopython is never needed."""
+    path = str(tmp_path / "x.dat")
+    (tmp_path / "x.dat").write_bytes(b"payload")
+    feature = feature_cls(decode=False)
+    ds = Dataset.from_dict({"col": [path]}, features=Features({"col": feature}))
+    assert ds[0]["col"] == {"bytes": None, "path": path}
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_decode_example_raises_when_decode_disabled(feature_cls):
+    with pytest.raises(RuntimeError, match="Decoding is disabled"):
+        feature_cls(decode=False).decode_example({"path": "x", "bytes": b"y"})
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_flatten_when_not_decoding(feature_cls):
+    from datasets.features import Value
+
+    assert feature_cls(decode=False).flatten() == {
+        "bytes": Value("binary"),
+        "path": Value("string"),
+    }
+    assert feature_cls(decode=True).flatten() == feature_cls(decode=True)
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_feature_roundtrips_through_dict(feature_cls):
+    """A feature must survive Features.to_dict/from_dict, which is how it lands in dataset_info.json."""
+    features = Features({"col": feature_cls()})
+    assert Features.from_dict(features.to_dict()) == features
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_cast_storage_from_string_and_binary(feature_cls):
+    import pyarrow as pa
+
+    feature = feature_cls()
+    from_str = feature.cast_storage(pa.array(["a.fa", "b.fa"], type=pa.string()))
+    assert from_str.type == feature.pa_type
+    assert from_str.to_pylist() == [{"bytes": None, "path": "a.fa"}, {"bytes": None, "path": "b.fa"}]
+
+    from_bin = feature.cast_storage(pa.array([b"x"], type=pa.binary()))
+    assert from_bin.to_pylist() == [{"bytes": b"x", "path": None}]
+
+
+# --------------------------------------------------------------------------
+# Decoding. Requires biopython.
+# --------------------------------------------------------------------------
+
+require_biopython = pytest.mark.skipif(
+    not __import__("datasets").config.BIOPYTHON_AVAILABLE, reason="biopython is not installed"
+)
+
+
+@require_biopython
+def test_bio_sequence_decodes_to_seqrecord(fasta_path):
+    from Bio.SeqRecord import SeqRecord
+
+    ds = Dataset.from_dict({"seq": [fasta_path]}, features=Features({"seq": BioSequence()}))
+    record = ds[0]["seq"]
+    assert isinstance(record, SeqRecord)
+    assert record.id == "seq1"
+    assert str(record.seq) == "ACGTACGTAC"
+
+
+@require_biopython
+def test_bio_sequence_decodes_from_bytes(fasta_path):
+    ds = Dataset.from_dict(
+        {"seq": [{"bytes": FASTA_BYTES, "path": "seqs.fasta"}]},
+        features=Features({"seq": BioSequence()}),
+    )
+    assert str(ds[0]["seq"].seq) == "ACGTACGTAC"
+
+
+@require_biopython
+def test_bio_structure_decodes_to_structure(pdb_path):
+    from Bio.PDB.Structure import Structure
+
+    ds = Dataset.from_dict({"st": [pdb_path]}, features=Features({"st": BioStructure()}))
+    structure = ds[0]["st"]
+    assert isinstance(structure, Structure)
+    assert [chain.id for chain in structure.get_chains()] == ["A"]
+    assert len(list(structure.get_atoms())) == 2
+
+
+@require_biopython
+def test_bio_sequence_format_is_configurable(tmp_path):
+    """The sequence format is a field, so FASTQ and GenBank reuse the same feature."""
+    path = tmp_path / "r.fastq"
+    path.write_bytes(b"@r1\nACGT\n+\nIIII\n")
+    ds = Dataset.from_dict({"seq": [str(path)]}, features=Features({"seq": BioSequence(format="fastq")}))
+    record = ds[0]["seq"]
+    assert record.id == "r1"
+    assert record.letter_annotations["phred_quality"] == [40, 40, 40, 40]

--- a/tests/features/test_bio.py
+++ b/tests/features/test_bio.py
@@ -194,3 +194,14 @@ def test_resolve_token_returns_none_for_non_hub_url():
     assert _resolve_token("https://example.com/data/seqs.fasta", tokens) is None
     assert _resolve_token("s3://bucket/seqs.fasta", tokens) is None
     assert _resolve_token("hf://datasets/user/repo@main/seqs.fasta", tokens) == "hf_secret"
+
+
+@pytest.mark.parametrize("feature_cls", [BioSequence, BioStructure])
+def test_embed_storage_keeps_path_only_rows_when_embedding_is_off(feature_cls):
+    """With local_files=False a local path-only row is left as is, not nulled (as Image does)."""
+    import pyarrow as pa
+
+    feature = feature_cls()
+    storage = pa.array([{"bytes": None, "path": "/data/seqs.fasta"}, None], type=feature.pa_type)
+    embedded = feature.embed_storage(storage, local_files=False, remote_files=False)
+    assert embedded.to_pylist() == [{"bytes": None, "path": "seqs.fasta"}, None]


### PR DESCRIPTION
Adds two decodable feature types that store a biological file as bytes and decode it to the biopython object the format describes.

| Type | Module | `decode_example` returns | Serves |
|---|---|---|---|
| `BioSequence` | `features/bio_sequence.py` | `Bio.SeqRecord.SeqRecord` | FASTA #7923, FASTQ #7924, GenBank #7951 |
| `BioStructure` | `features/bio_structure.py` | `Bio.PDB.Structure.Structure` | mmCIF #7925, PDB #7926 |

Both follow the contract `Audio`, `Image`, `Pdf` and `Nifti` already use: storage is `struct<bytes, path>`, `decode=False` returns that struct unchanged, and decoding raises `ImportError` when biopython is absent.

### Why two types

One general type would return a different class depending on which file it was handed, which pushes an isinstance check onto every caller. Five would be one class per file format, but FASTA, FASTQ and GenBank all decode to `SeqRecord` and differ only in the parser, so the format is a field rather than a type. The split follows the boundary biopython itself draws between `Bio.SeqIO` and `Bio.PDB`, which is also where the optional imports divide.

Naming agreed with @lhoestq in https://github.com/huggingface/datasets/pull/7923#issuecomment-5451746802.

### biopython stays optional

Declared as the `bio` extra and probed through `config.BIOPYTHON_AVAILABLE`, which checks the import name `Bio` rather than the distribution name `biopython`. Users who never touch biological data pay nothing: the availability flag is a `find_spec` call, and the lazy isinstance dispatch in `_cast_to_python_objects` is additionally guarded on `"Bio" in sys.modules`, so having the package installed never forces the import.

### Registration

Registered everywhere the other decodable features are, so a dataset carrying one survives a round trip through `dataset_info.json`: the `FeatureType` union, the `_FEATURE_TYPES` registry, `features/__init__.py`, the object dispatch that encodes a live `SeqRecord` or `Structure` passed straight to `Dataset.from_dict`, and the docs under `main_classes.mdx`.

### Verification

- 22 tests in `tests/features/test_bio.py`, covering storage type, encoding from path, bytes and dict, the `decode=False` path, `flatten`, `cast_storage`, and the `Features.to_dict` round trip for both types without biopython present, plus decoding to `SeqRecord` and `Structure` when it is.
- Confirmed the tests fail without the implementation (`ImportError: cannot import name 'BioSequence'`) before making them pass.
- `tests/features/test_bio.py` + `tests/features/test_features.py`: 222 passed, 3 skipped, no regressions.
- `ruff check` and `ruff format` clean.

This is the foundation for the five bio-format loaders; wiring each loader to these types follows in their own PRs.
