### PR TITLE
Fix double-wrapped storage options in xPath.glob

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1154,7 +1154,6 @@ class xPath(type(Path())):
             if rest_hops:
                 urlpath = rest_hops[0]
                 urlpath, storage_options = _prepare_path_and_storage_options(urlpath, download_config=download_config)
-                storage_options = {urlpath.split("://")[0]: storage_options}
                 posix_path = "::".join([main_hop, urlpath, *rest_hops[1:]])
             else:
                 storage_options = None

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -766,6 +766,15 @@ class TestxPath:
         output_paths = sorted([str(path) for path in xPath(input_path).glob(pattern)])
         assert output_paths == expected_paths
 
+    def test_xpath_glob_storage_options(self):
+        download_config = DownloadConfig(storage_options={"https": {"block_size": "omit"}})
+        with patch("datasets.utils.file_utils.url_to_fs") as mock_url_to_fs:
+            mock_url_to_fs.return_value = (DummyTestFS(), "")
+            list(xPath("zip://::https://domain.org/data.zip").glob("*", download_config=download_config))
+        assert mock_url_to_fs.call_args.kwargs == {
+            "https": {"client_kwargs": {"trust_env": True}, "block_size": "omit"}
+        }
+
     @pytest.mark.parametrize(
         "input_path, pattern, expected_paths",
         [


### PR DESCRIPTION
Fixes #8543

### Root cause

`_prepare_path_and_storage_options` returns storage options already keyed by protocol. That contract is stated in the docstring of `_prepare_single_hop_path_and_storage_options` ("Storage options are formatted in the form {protocol: storage_options_for_protocol}") and applied just before it returns.

`xPath.glob` keyed the returned value a second time before splatting it into `url_to_fs`, so fsspec got `https={'https': {...}}` and the options for the remote hop sat one level too deep to be applied. `xPath.rglob` delegates to `glob`, so it had the same behaviour.

The other four callers that glob or walk a remote path (`xglob`, `xwalk`, `xlistdir`, and `resolve_pattern` in `data_files.py`) all pass the returned value straight through, so this removes the one place that did not.

### The fix

Drop the extra wrap at `file_utils.py:1157`. The only reader of that value in the function is the `url_to_fs` call three lines below.

### Verification

- New `test_xpath_glob_storage_options` fails on `main` with `{'https': {'https': ...}}` and passes here.
- `tests/test_file_utils.py`, `test_data_files.py`, `test_download_manager.py` and `test_streaming_download_manager.py`: 394 passed on Python 3.10 and 393 on 3.14, in a clean container.
- `ruff check` and `ruff format --check` over `tests src benchmarks utils setup.py` are clean.
- I did not run this against a real private archive over the network, so the effect on authentication is read from the `url_to_fs` call rather than observed. The double keying itself is measured.
