### PR TITLE
docs: surface repository structure guide earlier in docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -17,6 +17,8 @@
     title: Preprocess
   - local: create_dataset
     title: Create a dataset
+  - local: repository_structure
+    title: Structure your repository
   - local: upload_dataset
     title: Share a dataset to the Hub
   title: "Tutorials"

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -8,6 +8,8 @@ Load a dataset in a single line of code, and use our powerful data processing an
 
 Find your dataset today on the [Hugging Face Hub](https://huggingface.co/datasets), and take an in-depth look inside of it with the live viewer.
 
+New to creating datasets? The [repository structure](./repository_structure) guide shows the simplest way to publish a dataset on the Hub without writing a loading script.
+
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">
     <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./tutorial"

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -16,6 +16,10 @@ specific language governing permissions and limitations under the License.
 
 This quickstart is intended for developers who are ready to dive into the code and see an example of how to integrate 🤗 Datasets into their model training workflow. If you're a beginner, we recommend starting with our [tutorials](./tutorial), where you'll get a more thorough introduction.
 
+> **Tip**
+>
+> To create and share your own dataset without a loading script, start with [Structure your repository](./repository_structure).
+
 Each dataset is unique, and depending on the task, some datasets may require additional steps to prepare it for training. But you can always use 🤗 Datasets tools to load and process a dataset. The fastest and easiest way to get started is by loading an existing dataset from the [Hugging Face Hub](https://huggingface.co/datasets). There are thousands of datasets to choose from, spanning many tasks. Choose the type of dataset you want to work with, and let's get started!
 
 <div class="mt-4">


### PR DESCRIPTION
Fixes huggingface/datasets#5971

## Summary
- Add repository structure to the Tutorials section in the docs navigation
- Link the guide from the docs index and quickstart

## Test plan
- [x] Docs navigation and links reviewed locally

Made with [Cursor](https://cursor.com)