### PR TITLE
fix: accept pathlib.Path in save_to_disk and load_from_disk

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -1848,6 +1848,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             num_shards = min(len(self.data), num_shards)
 
         fs: fsspec.AbstractFileSystem
+        dataset_path = os.fspath(dataset_path)
         fs, _ = url_to_fs(dataset_path, **(storage_options or {}))
 
         if not is_remote_filesystem(fs):
@@ -2019,6 +2020,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```
         """
         fs: fsspec.AbstractFileSystem
+        dataset_path = os.fspath(dataset_path)
         fs, dataset_path = url_to_fs(dataset_path, **(storage_options or {}))
 
         dest_dataset_path = dataset_path

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -3,6 +3,7 @@ import copy
 import itertools
 import json
 import math
+import os
 import posixpath
 import random
 import re
@@ -1356,6 +1357,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         fs: fsspec.AbstractFileSystem
+        dataset_dict_path = os.fspath(dataset_dict_path)
         fs, _ = url_to_fs(dataset_dict_path, **(storage_options or {}))
 
         if num_shards is None:
@@ -1415,6 +1417,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         ```
         """
         fs: fsspec.AbstractFileSystem
+        dataset_dict_path = os.fspath(dataset_dict_path)
         fs, dataset_dict_path = url_to_fs(dataset_dict_path, **(storage_options or {}))
 
         dataset_dict_json_path = posixpath.join(dataset_dict_path, config.DATASETDICT_JSON_FILENAME)

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1770,6 +1770,7 @@ def load_from_disk(
     ```
     """
     fs: fsspec.AbstractFileSystem
+    dataset_path = os.fspath(dataset_path)
     fs, *_ = url_to_fs(dataset_path, **(storage_options or {}))
     if not fs.exists(dataset_path):
         raise FileNotFoundError(f"Directory {dataset_path} not found")

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -395,6 +395,16 @@ class BaseDatasetTest(TestCase):
                 self.assertDictEqual(dset.to_dict(), expected)
                 self.assertEqual(len(dset.cache_files), 2)
 
+    def test_save_and_load_from_disk_with_pathlib(self, in_memory, tmp_path):
+        dataset_path = Path(tmp_path) / "pathlib_dataset"
+        with self._create_dummy_dataset(in_memory, str(tmp_path)).select(range(5)) as dset:
+            dset.save_to_disk(dataset_path)
+        with Dataset.load_from_disk(dataset_path) as reloaded:
+            self.assertEqual(len(reloaded), 5)
+            self.assertDictEqual(reloaded.features, Features({"filename": Value("string")}))
+        with load_from_disk(dataset_path) as reloaded:
+            self.assertEqual(len(reloaded), 5)
+
     def test_dummy_dataset_load_from_disk(self, in_memory):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self._create_dummy_dataset(in_memory, tmp_dir).select(range(10)) as dset:


### PR DESCRIPTION
Fixes huggingface/datasets#6829

## Summary
- Convert path-like arguments with `os.fspath` before `url_to_fs` in Dataset, DatasetDict, and `load_from_disk`
- Add regression test for `pathlib.Path` round-trip

## Test plan
- [x] Added `test_save_and_load_from_disk_with_pathlib`