### PR TITLE
Fix docstring argument names that don't match signatures

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5017,10 +5017,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             load_from_cache_file (`Optional[bool]`, defaults to `True` if caching is enabled):
                 If a cache file storing the splits indices
                 can be identified, use it instead of recomputing.
-            train_cache_file_name (`str`, *optional*):
+            train_indices_cache_file_name (`str`, *optional*):
                 Provide the name of a path for the cache file. It is used to store the
                 train split indices instead of the automatically generated cache file name.
-            test_cache_file_name (`str`, *optional*):
+            test_indices_cache_file_name (`str`, *optional*):
                 Provide the name of a path for the cache file. It is used to store the
                 test split indices instead of the automatically generated cache file name.
             writer_batch_size (`int`, defaults to `1000`):

--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -998,11 +998,6 @@ class DatasetBuilder:
         Args:
             split (`datasets.Split`):
                 Which subset of the data to return.
-            verification_mode ([`VerificationMode`] or `str`, defaults to `BASIC_CHECKS`):
-                Verification mode determining the checks to run on the
-                downloaded/processed dataset information (checksums/size/splits/...).
-
-                <Added version="2.9.1"/>
             in_memory (`bool`, defaults to `False`):
                 Whether to copy the data in-memory.
 

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -2292,8 +2292,8 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
     Args:
         table (`pa.Table`):
             PyArrow table to cast.
-        features ([`Features`]):
-            Target features.
+        schema (`pa.Schema`):
+            Target schema.
 
     Returns:
         `pa.Table`: the casted table


### PR DESCRIPTION
Three docstrings document parameters that don't exist on the function, so the rendered docs advertise arguments that raise `TypeError`.

| Location | Documented | Actual signature |
|---|---|---|
| `Dataset.train_test_split` | `train_cache_file_name`, `test_cache_file_name` | `train_indices_cache_file_name`, `test_indices_cache_file_name` |
| `DatasetBuilder.as_dataset` | `verification_mode` | `(split, in_memory)` |
| `cast_table_to_schema` | `features` | `(table, schema)` |

The `train_test_split` one is the most user-visible, since it's a commonly used entry point. Python's own suggestion confirms the intended name:

```python
>>> ds.train_test_split(test_size=0.5, train_cache_file_name="/tmp/x")
TypeError: Dataset.train_test_split() got an unexpected keyword argument
'train_cache_file_name'. Did you mean 'train_indices_cache_file_name'?
```

`as_dataset` takes only `(split, in_memory)`, so the `verification_mode` entry (and its `<Added version="2.9.1"/>` note) describes an argument the method never accepts — I removed it rather than guessing at intent. `cast_table_to_schema(table, schema)` documented `features`; the body derives `features` from the schema internally, which is likely where the name came from.

Found by comparing every typed `Args:` entry against the actual signatures across `src/`, then reviewing each hit by hand. After this change that audit reports zero remaining mismatches.

Docstrings only, no behavior change.

## Test log

```
$ pytest tests/test_arrow_dataset.py -k "train_test_split" -q
4 passed, 420 deselected in 0.55s

$ ruff check src/datasets/arrow_dataset.py src/datasets/builder.py src/datasets/table.py
All checks passed!

$ ruff format --check src/datasets/arrow_dataset.py src/datasets/builder.py src/datasets/table.py
3 files already formatted
```

---

Disclosure: I used an AI assistant to help run the audit and draft these edits. I reviewed every changed line, confirmed each mismatch against the real signatures, and ran the checks above.