### PR TITLE
fix: Remove double-wrapping of storage_options in xPath.glob

### DIFF
--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -1152,9 +1152,7 @@ class xPath(type(Path())):
         else:
             # globbing inside a zip in a private repo requires authentication
             if rest_hops:
-                urlpath = rest_hops[0]
-                urlpath, storage_options = _prepare_path_and_storage_options(urlpath, download_config=download_config)
-                storage_options = {urlpath.split("://")[0]: storage_options}
+                urlpath, storage_options = _prepare_path_and_storage_options(rest_hops[0], download_config=download_config)
                 posix_path = "::".join([main_hop, urlpath, *rest_hops[1:]])
             else:
                 storage_options = None


### PR DESCRIPTION
## Description

The `xPath.glob` method was double-wrapping storage_options when calling `url_to_fs`. 

The `_prepare_path_and_storage_options` function already returns storage_options keyed by protocol (e.g., `{protocol: options}`), but the code was re-wrapping it as `{protocol: {protocol: options}}`, causing fsspec to not apply the authentication options correctly.

## Fix

Remove the redundant re-wrapping of storage_options. The storage_options returned by `_prepare_path_and_storage_options` is already in the correct format `{protocol: options}`.

## Related Issue

Fixes #8543

## Testing

The issue includes a reproduction script showing the double-wrapping problem:
```python
from unittest.mock import MagicMock, patch
from datasets.download.download_config import DownloadConfig
from datasets.utils.file_utils import xglob, xPath

download_config = DownloadConfig(storage_options={"https": {"block_size": "omit"}})

with patch("datasets.utils.file_utils.url_to_fs") as m:
    m.return_value = (MagicMock(glob=lambda _: [], protocol="zip"), "")
    list(xPath("zip://::https://domain.org/data.zip").glob("*", download_config=download_config))
# Before fix: {'https': {'https': {'block_size': 'omit', 'client_kwargs': {'trust_env': True}}}}
# After fix: {'https': {'block_size': 'omit', 'client_kwargs': {'trust_env': True}}}
```