### PR TITLE
fix: Add per-element validation to ClassLabel.str2int and int2str

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -1095,8 +1095,10 @@ class ClassLabel:
         output = [self._strval2int(value) for value in values]
         return output if return_list else output[0]
 
-    def _strval2int(self, value: str) -> int:
+    def _strval2int(self, value: Union[str, int]) -> int:
         failed_parse = False
+        if not isinstance(value, str):
+            raise ValueError(f"Invalid string class label {value}")
         value = str(value)
         # first attempt - raw string value
         int_value = self._str2int.get(value)
@@ -1140,7 +1142,7 @@ class ClassLabel:
             return_list = False
 
         for v in values:
-            if not 0 <= v < self.num_classes:
+            if not isinstance(v, int) or not 0 <= v < self.num_classes:
                 raise ValueError(f"Invalid integer class label {v:d}")
 
         output = [self._int2str[int(v)] for v in values]


### PR DESCRIPTION
## Description

ClassLabel.str2int and int2str were validating only the container (the list), not the elements inside it. This caused silent failures:

- `str2int([1])` returned `[1]` instead of raising ValueError
- `int2str([1.7])` returned `['pos']` (truncated float) instead of raising ValueError

## Fix

1. **str2int**: Added validation in `_strval2int` to check if the input is a string before processing. Non-string inputs now raise `ValueError`.

2. **int2str**: Added `isinstance(v, int)` check in the validation loop. Non-int inputs (including floats) now raise `ValueError`.

## Related Issue

Fixes #8481

## Testing

```python
from datasets import ClassLabel
cl = ClassLabel(names=["neg", "pos"])

# Before fix: returns [1] silently
# After fix: raises ValueError
cl.str2int([1])

# Before fix: returns ['pos'] (1.7 truncated to 1)
# After fix: raises ValueError  
cl.int2str([1.7])
```