### PR TITLE
fix: Normalize negative indices in Dataset.select to fix OverflowError

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4583,6 +4583,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         else:
             return self._select_contiguous(0, 0, new_fingerprint=new_fingerprint)
 
+        # Normalize negative indices to positive (pyarrow uint64 can't hold negative values)
+        indices = [idx if idx >= 0 else size + idx for idx in indices]
+
         indices_array = pa.array(indices, type=pa.uint64())
         # Check if we need to convert indices
         if self._indices is not None:


### PR DESCRIPTION
## Description

Dataset.select raised OverflowError for negative indices like -1, even though they are valid (e.g., -1 means last element). The issue was that pyarrow's uint64 array can't hold negative values.

The fix normalizes negative indices to positive ones after validation but before converting to pyarrow array.

## Example

```python
from datasets import Dataset

ds = Dataset.from_dict({"x": list(range(10))})

# Before fix: OverflowError
# After fix: returns the last row (same as ds[[-1]])
ds.select([-1])  # {'x': [9]}

ds.select([0, -1])  # {'x': [0, 9]}
```

## Related Issue

Fixes #8475