### PR TITLE
fix: Handle negative percent split boundaries correctly

### DIFF
--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -439,8 +439,16 @@ def _rel_to_abs_instr(rel_instr, name2len):
     from_ = rel_instr.from_
     to = rel_instr.to
     if rel_instr.unit == "%":
-        from_ = 0 if from_ is None else pct_to_abs(from_, num_examples)
-        to = num_examples if to is None else pct_to_abs(to, num_examples)
+        # Handle negative percentages: -x% means (100-x)% from start
+        # This preserves the sign before rounding
+        if from_ is not None and from_ < 0:
+            from_ = pct_to_abs(100 + from_, num_examples)
+        else:
+            from_ = 0 if from_ is None else pct_to_abs(from_, num_examples)
+        if to is not None and to < 0:
+            to = pct_to_abs(100 + to, num_examples)
+        else:
+            to = num_examples if to is None else pct_to_abs(to, num_examples)
     else:
         from_ = 0 if from_ is None else from_
         to = num_examples if to is None else to

--- a/src/datasets/arrow_reader.py
+++ b/src/datasets/arrow_reader.py
@@ -439,14 +439,14 @@ def _rel_to_abs_instr(rel_instr, name2len):
     from_ = rel_instr.from_
     to = rel_instr.to
     if rel_instr.unit == "%":
-        # Handle negative percentages: -x% means (100-x)% from start
-        # This preserves the sign before rounding
+        # Decide end-relative addressing from the written sign before rounding.
+        # Otherwise a small negative percentage can round to zero and lose its sign.
         if from_ is not None and from_ < 0:
-            from_ = pct_to_abs(100 + from_, num_examples)
+            from_ = num_examples + pct_to_abs(from_, num_examples)
         else:
             from_ = 0 if from_ is None else pct_to_abs(from_, num_examples)
         if to is not None and to < 0:
-            to = pct_to_abs(100 + to, num_examples)
+            to = num_examples + pct_to_abs(to, num_examples)
         else:
             to = num_examples if to is None else pct_to_abs(to, num_examples)
     else:

--- a/tests/test_arrow_reader.py
+++ b/tests/test_arrow_reader.py
@@ -172,6 +172,7 @@ def test_make_file_instructions_basic():
         {"filename": os.path.join(prefix_path, f"{name}-train.arrow"), "skip": 0, "take": 33}
     ]
 
+
     split_infos = [SplitInfo(name="train", num_examples=100, shard_lengths=[10] * 10)]
     file_instructions = make_file_instructions(name, split_infos, instruction, filetype_suffix, prefix_path)
     assert isinstance(file_instructions, FileInstructions)
@@ -182,6 +183,15 @@ def test_make_file_instructions_basic():
         {"filename": os.path.join(prefix_path, f"{name}-train-00002-of-00010.arrow"), "skip": 0, "take": -1},
         {"filename": os.path.join(prefix_path, f"{name}-train-00003-of-00010.arrow"), "skip": 0, "take": 3},
     ]
+
+
+@pytest.mark.parametrize(
+    "spec, size, expected",
+    [("train[-1%:]", 30, (30, 30)), ("train[:-1%]", 30, (0, 30)), ("train[-10%:]", 150, (135, 150))],
+)
+def test_negative_percent_boundaries_preserve_end_relative_rounding(spec, size, expected):
+    absolute = ReadInstruction.from_spec(spec).to_absolute({"train": size})[0]
+    assert (absolute.from_, absolute.to) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

When using negative percentages like `train[-1%:]`, the sign was lost after rounding. For example, -1% of 30 examples rounds to 0, so `train[-1%:]` would return the whole dataset instead of the last 1%.

The fix converts negative percentages to their positive equivalents (`100 + from_%`) before rounding, preserving the "from the end" semantics.

## Example

```python
from datasets.arrow_reader import ReadInstruction

name2len = {"train": 30}

# Before fix: train[-1%:] -> (0, 30) (whole dataset)
# After fix: train[-1%:] -> (30, 30) (last 1%, ~0 rows)
spec = "train[-1%:]"
abs_ = ReadInstruction.from_spec(spec).to_absolute(name2len)[0]
print(f"{spec} -> ({abs_.from_}, {abs_.to})")
```

## Related Issue

Fixes #8473