### PR TITLE
fix: Raise ValueError for batch_size <= 0 in Dataset.batch and IterableDataset.batch

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4112,6 +4112,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """
         if batch_size is None and by_column is None:
             raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+        if batch_size is not None and batch_size <= 0:
+            raise ValueError(f"batch_size must be a positive integer, but got {batch_size}.")
         if by_column is not None:
             if num_proc:
                 raise NotImplementedError("Multiprocessed batching by column is not implemented yet")

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4472,6 +4472,8 @@ class IterableDataset(DatasetInfoMixin):
         """
         if batch_size is None and by_column is None:
             raise ValueError("IterableDataset.batch() misses `batch_size` or `by_column` argument.")
+        if batch_size is not None and batch_size <= 0:
+            raise ValueError(f"batch_size must be a positive integer, but got {batch_size}.")
         if self.features:
             features = Features({col: List(feature) for col, feature in self.features.items()})
         else:


### PR DESCRIPTION
## Description

`batch(0)` and `batch(-1)` silently returned the whole dataset instead of raising an error. This is dangerous because a batch_size computed at runtime that comes out as 0 (e.g., from an empty config or integer division) would silently return the entire dataset.

The fix adds validation to both `Dataset.batch` and `IterableDataset.batch` to raise `ValueError` when batch_size is not a positive integer.

## Example

```python
from datasets import Dataset

ds = Dataset.from_dict({"a": list(range(5))})

# Before fix: returns all 5 rows silently
# After fix: raises ValueError
ds.batch(0)

ds.batch(-1)  # Also raises ValueError
```

## Related Issue

Fixes #8472