### PR TITLE
Support JPEG XL images via pillow-jxl-plugin

### DIFF
--- a/src/datasets/config.py
+++ b/src/datasets/config.py
@@ -134,6 +134,7 @@ SQLALCHEMY_AVAILABLE = importlib.util.find_spec("sqlalchemy") is not None
 
 # Optional tools for file parsing and feature decoding
 PIL_AVAILABLE = importlib.util.find_spec("PIL") is not None
+PILLOW_JXL_AVAILABLE = importlib.util.find_spec("pillow_jxl") is not None
 IS_OPUS_SUPPORTED = True
 IS_MP3_SUPPORTED = True
 TORCHCODEC_AVAILABLE = importlib.util.find_spec("torchcodec") is not None

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -43,6 +43,17 @@ _VALID_IMAGE_ARRAY_DTPYES = [
 ]
 
 
+def _import_pil_plugins() -> None:
+    """Import the third-party Pillow plugins that are installed.
+
+    Pillow only registers its built-in formats on its own. Plugins register their format (and its file signature,
+    so that extensionless files are recognized too) when they are imported, so import them here to make
+    `PIL.Image.open` accept these formats.
+    """
+    if config.PILLOW_JXL_AVAILABLE:
+        import pillow_jxl  # noqa: F401  # JPEG XL
+
+
 @dataclass
 class Image:
     """Image [`Feature`] to read image data from an image file.
@@ -160,6 +171,8 @@ class Image:
         if config.PIL_AVAILABLE:
             import PIL.Image
             import PIL.ImageOps
+
+            _import_pil_plugins()
         else:
             raise ImportError("To support decoding images, please install 'Pillow'.")
 

--- a/src/datasets/packaged_modules/imagefolder/imagefolder.py
+++ b/src/datasets/packaged_modules/imagefolder/imagefolder.py
@@ -99,5 +99,7 @@ IMAGE_EXTENSIONS = [
     ".emf",
     ".xbm",
     ".xpm",
+    # Formats handled by third-party Pillow plugins (see `datasets.features.image`):
+    ".jxl",  # pillow-jxl-plugin
 ]
 ImageFolder.EXTENSIONS = IMAGE_EXTENSIONS

--- a/src/datasets/packaged_modules/webdataset/webdataset.py
+++ b/src/datasets/packaged_modules/webdataset/webdataset.py
@@ -225,6 +225,8 @@ IMAGE_EXTENSIONS = [
     "emf",
     "xbm",
     "xpm",
+    # Formats handled by third-party Pillow plugins (see `datasets.features.image`):
+    "jxl",  # pillow-jxl-plugin
 ]
 WebDataset.IMAGE_EXTENSIONS = IMAGE_EXTENSIONS
 

--- a/tests/features/test_image.py
+++ b/tests/features/test_image.py
@@ -1,16 +1,19 @@
 import os
 import shutil
+import sys
 import tarfile
+import types
 import warnings
 from io import BytesIO
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
 
-from datasets import Column, Dataset, Features, Image, List, Value, concatenate_datasets, load_dataset
+from datasets import Column, Dataset, Features, Image, List, Value, concatenate_datasets, config, load_dataset
 from datasets.features.image import encode_np_array, image_to_bytes
 
 from ..utils import require_pil
@@ -92,6 +95,43 @@ def test_image_decode_example(shared_datadir):
 
     with pytest.raises(RuntimeError):
         Image(decode=False).decode_example(image_path)
+
+
+@require_pil
+def test_image_decode_example_imports_pil_plugins(shared_datadir, monkeypatch):
+    # third-party Pillow plugins register their formats on import, so `decode_example` imports the installed ones
+    import PIL.Image
+
+    monkeypatch.delitem(sys.modules, "pillow_jxl", raising=False)
+    plugin = types.ModuleType("pillow_jxl")
+    monkeypatch.setitem(sys.modules, "pillow_jxl", plugin)
+    monkeypatch.setattr(config, "PILLOW_JXL_AVAILABLE", True)
+
+    image_path = str(shared_datadir / "test_image_rgb.jpg")
+    with (
+        patch.dict(sys.modules, {"pillow_jxl": plugin}),
+        patch("builtins.__import__", wraps=__import__) as mock_import,
+    ):
+        decoded_example = Image().decode_example({"path": image_path, "bytes": None})
+    assert isinstance(decoded_example, PIL.Image.Image)
+    assert "pillow_jxl" in [call.args[0] for call in mock_import.call_args_list]
+
+
+@require_pil
+def test_image_decode_example_jxl(tmp_path):
+    pytest.importorskip("pillow_jxl")
+    import PIL.Image
+
+    jxl_path = tmp_path / "image.jxl"
+    PIL.Image.new("RGB", (8, 8), (200, 30, 30)).save(jxl_path)
+    blob_path = tmp_path / "blob"  # like the files in the Hub cache, which have no extension
+    blob_path.write_bytes(jxl_path.read_bytes())
+
+    for path in [jxl_path, blob_path]:
+        decoded_example = Image().decode_example({"path": str(path), "bytes": None})
+        assert isinstance(decoded_example, PIL.Image.Image)
+        assert decoded_example.format == "JXL"
+        assert decoded_example.size == (8, 8)
 
 
 @require_pil


### PR DESCRIPTION
Fixes #8537.

## What

- `.jxl` added to the `imagefolder` and `webdataset` image extensions.
- `Image.decode_example` now imports the third-party Pillow plugins that are installed (`pillow_jxl` for now) before calling `PIL.Image.open`, via a small `_import_pil_plugins()` helper and a `config.PILLOW_JXL_AVAILABLE` flag, same pattern as the other optional deps.

## Why the second part

Answering the open question in #8537: it is neither the plugin nor a limitation of Pillow's plugin system, the plugin just never gets imported. Pillow only registers its built-in formats on its own; `pillow_jxl` registers `JXL` (with its file signature, so extensionless files are fine) when the module is imported, and nothing in the `load_dataset` path did that. Checked with a fresh interpreter and a `.jxl` file copied to an extensionless path like the Hub cache blobs:

```
no-import:            UnidentifiedImageError
with-import:          JXL (8, 8)
with-import + .jxl:   JXL
```

(`pillow-jxl-plugin` 1.3.8, Pillow 12.3.0)

So with only the extension change, `load_dataset` on a JXL imagefolder still fails at decode time unless the user remembers to `import pillow_jxl` in their own script. With the import, `pip install pillow-jxl-plugin` is all that is needed. If you'd rather keep this PR to the extension change and document the import instead, I'll drop the helper.

## Tests

- `test_image_decode_example_imports_pil_plugins`: stubs `pillow_jxl` and checks `decode_example` imports it.
- `test_image_decode_example_jxl`: real round trip with `pillow-jxl-plugin` (skipped when it is not installed), on both a `.jxl` path and an extensionless copy.

```
$ pytest tests/features/test_image.py tests/packaged_modules/test_imagefolder.py -q
83 passed, 1 skipped
```
(81 passed, 1 skipped on main before the change.) `ruff check` and `ruff format --check` clean.
