### PR TITLE
Fix the repeat docstring examples

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -4660,7 +4660,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         ```py
         >>> from datasets import load_dataset
         >>> ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
-        >>> ds = ds.take(2).repeat(2)
+        >>> ds = ds.take(3).repeat(2)
         >>> list(ds)
         [{'label': 1,
          'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'},

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3919,8 +3919,8 @@ class IterableDataset(DatasetInfoMixin):
         Example:
         ```py
         >>> from datasets import load_dataset
-        >>> ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train")
-        >>> ds = ds.take(2).repeat(2)
+        >>> ds = load_dataset("cornell-movie-review-data/rotten_tomatoes", split="train", streaming=True)
+        >>> ds = ds.take(3).repeat(2)
         >>> list(ds)
         [{'label': 1,
          'text': 'the rock is destined to be the 21st century\'s new " conan " and that he\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .'},


### PR DESCRIPTION
### What is wrong

`Dataset.repeat`'s example calls `ds.take(2).repeat(2)`, which returns **four** rows, but the output printed under it has **six**: three distinct reviews, each twice.

`IterableDataset.repeat` carries the same example, and its `load_dataset` call is missing `streaming=True`, so it builds a `Dataset` and never reaches the method being documented. (Its `take` sibling right below does pass `streaming=True`.)

### Why

The printed output is what `take(3).repeat(2)` returns; the call was edited down to `take(2)` without touching the output.

### What changed

`take(2)` -> `take(3)` in both examples, and `streaming=True` added to the `IterableDataset` one. Docs only.

### Test

Against `cornell-movie-review-data/rotten_tomatoes`:

- rows 0, 1, 2 are the three reviews the example prints (row 2 is `effective but too-tepid biopic`)
- `len(list(ds.take(2).repeat(2)))` is 4, `len(list(ds.take(3).repeat(2)))` is 6
- with `streaming=True`, `load_dataset(...)` gives an `IterableDataset`; without it, a `Dataset`