### PR TITLE
Bump fsspec upper bound to 2026.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ REQUIRED_PKGS = [
     "multiprocess<0.70.20",  # to align with dill<0.3.9 (see above)
     # to save datasets locally or on any filesystem
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
-    "fsspec[http]>=2023.1.0,<=2026.6.0",
+    "fsspec[http]>=2023.1.0,<=2026.7.0",
     # To get datasets from the Datasets Hub on huggingface.co
     "huggingface-hub>=0.25.0,<2.0",
     # Utilities from PyPA to e.g., compare versions


### PR DESCRIPTION
## Summary

- bump the fsspec upper bound from 2026.6.0 to 2026.7.0
- keep the existing minimum version unchanged

Fixes #8560

## Tests

- python -m pytest -q tests/test_filesystem.py (8 passed, 2 skipped)
- python -m pytest -q tests/test_file_utils.py tests/test_data_files.py tests/test_streaming_download_manager.py tests/io/test_csv.py tests/io/test_json.py tests/io/test_parquet.py (524 passed, 7 skipped)
- verified installed datasets metadata allows fsspec 2026.7.0 and the environment imports fsspec 2026.7.0
- ruff check setup.py
- ruff format --check setup.py
- git diff --check