### PR TITLE
Keep the declared dtype for an empty column under numpy format

### DIFF
--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -151,19 +151,31 @@ class PythonArrowExtractor(BaseArrowExtractor[dict, list, dict]):
 
 
 def _numpy_dtype_from_arrow_type(pa_type: pa.DataType) -> Optional[np.dtype]:
-    """The numpy dtype an arrow type maps to, or None if it has no direct equivalent.
+    """The numpy dtype an arrow type maps to, or None if arrow declines to convert it.
 
     Used only for empty columns. A zero-length Python list carries no type, so
     ``np.asarray([])`` yields float64 regardless of what the column was declared
     as, and the numpy formatter's float default then narrows that to float32.
-    Taking the dtype from the arrow type keeps an empty column matching a
-    non-empty one, which is what the pandas and arrow extractors already do.
+    Taking the dtype from a zero-length arrow array of the column's own type
+    keeps an empty column matching a non-empty one, which is what the pandas and
+    arrow extractors already do.
+
+    Arrow has to be the one asked, rather than ``pa_type.to_pandas_dtype()``:
+    pandas has no day-resolution datetime64, so it reports date32 as
+    ``datetime64[ms]`` while every other path here renders it as
+    ``datetime64[D]``.
+
+    Nested types are not excluded from this path: arrow converts list, map and
+    struct columns to object, so they land here rather than falling through. It
+    does not close the gap for them - an empty ``list<int64>`` column is object
+    where a filled one is int64, because the filled side takes its dtype from the
+    stacking path above rather than from here.
     """
     try:
-        return np.dtype(pa_type.to_pandas_dtype())
+        return pa.array([], type=pa_type).to_numpy(zero_copy_only=False).dtype
     except (NotImplementedError, TypeError, ValueError):
-        # Nested and extension types have no single numpy dtype; leave those to
-        # the existing path rather than guessing at one.
+        # ArrowNotImplementedError subclasses NotImplementedError and ArrowInvalid
+        # subclasses ValueError, so arrow's own errors land here.
         return None
 
 

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -150,6 +150,23 @@ class PythonArrowExtractor(BaseArrowExtractor[dict, list, dict]):
         return pa_table.to_pydict()
 
 
+def _numpy_dtype_from_arrow_type(pa_type: pa.DataType) -> Optional[np.dtype]:
+    """The numpy dtype an arrow type maps to, or None if it has no direct equivalent.
+
+    Used only for empty columns. A zero-length Python list carries no type, so
+    ``np.asarray([])`` yields float64 regardless of what the column was declared
+    as, and the numpy formatter's float default then narrows that to float32.
+    Taking the dtype from the arrow type keeps an empty column matching a
+    non-empty one, which is what the pandas and arrow extractors already do.
+    """
+    try:
+        return np.dtype(pa_type.to_pandas_dtype())
+    except (NotImplementedError, TypeError, ValueError):
+        # Nested and extension types have no single numpy dtype; leave those to
+        # the existing path rather than guessing at one.
+        return None
+
+
 class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
     def __init__(self, **np_array_kwargs):
         self.np_array_kwargs = np_array_kwargs
@@ -212,6 +229,10 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
                             return np.asarray(array, dtype=object)
                         return np.array(array, copy=False, dtype=object)
                     break
+        if len(array) == 0:
+            dtype = _numpy_dtype_from_arrow_type(pa_array.type)
+            if dtype is not None:
+                return np.empty(0, dtype=dtype)
         if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
             return np.asarray(array)
         else:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -293,6 +293,45 @@ class FormatterTest(TestCase):
         np.testing.assert_equal(batch, {"a": np.array(_COL_A), "b": np.array(_COL_B), "c": np.array(_COL_C)})
         assert batch["c"].shape == np.array(_COL_C).shape
 
+    def test_numpy_formatter_empty_column_keeps_dtype(self):
+        # A zero-length python list carries no type, so np.asarray([]) used to hand
+        # back float64 whatever the column was declared as, and the formatter's float
+        # default then narrowed it to float32. Any filter matching nothing hits this.
+        for arrow_type, values, expected in [
+            (pa.int64(), [1, 2, 3], np.int64),
+            (pa.int32(), [1, 2, 3], np.int32),
+            (pa.float64(), [1.0, 2.0, 3.0], np.float64),
+            (pa.bool_(), [True, False, True], np.bool_),
+        ]:
+            with self.subTest(arrow_type=str(arrow_type)):
+                schema = pa.schema({"a": arrow_type})
+                empty = InMemoryTable.from_arrays([pa.array([], type=arrow_type)], schema=schema)
+                col = NumpyArrowExtractor().extract_column(empty.table)
+                self.assertEqual(len(col), 0)
+                self.assertEqual(col.dtype, np.dtype(expected))
+
+                # and the non-empty column of the same type agrees
+                filled = InMemoryTable.from_arrays([pa.array(values, type=arrow_type)], schema=schema)
+                self.assertEqual(NumpyArrowExtractor().extract_column(filled.table).dtype, np.dtype(expected))
+
+    def test_numpy_formatter_empty_string_column_is_not_float(self):
+        # A string column coming back as a float dtype is the same bug, more obvious.
+        schema = pa.schema({"a": pa.string()})
+        empty = InMemoryTable.from_arrays([pa.array([], type=pa.string())], schema=schema)
+        col = NumpyArrowExtractor().extract_column(empty.table)
+        self.assertEqual(len(col), 0)
+        self.assertFalse(np.issubdtype(col.dtype, np.floating))
+        self.assertEqual(col.dtype, np.dtype(object))
+
+    def test_numpy_formatter_empty_column_does_not_promote_on_concatenate(self):
+        # The practical consequence: one empty batch promoted the whole result to float.
+        schema = pa.schema({"a": pa.int64()})
+        empty = InMemoryTable.from_arrays([pa.array([], type=pa.int64())], schema=schema)
+        filled = InMemoryTable.from_arrays([pa.array([1, 2, 3], type=pa.int64())], schema=schema)
+        extractor = NumpyArrowExtractor()
+        joined = np.concatenate([extractor.extract_column(empty.table), extractor.extract_column(filled.table)])
+        self.assertEqual(joined.dtype, np.dtype(np.int64))
+
     def test_numpy_formatter_np_array_kwargs(self):
         pa_table = self._create_dummy_table().drop(["b"])
         formatter = NumpyFormatter(dtype=np.float16)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -302,6 +302,11 @@ class FormatterTest(TestCase):
             (pa.int32(), [1, 2, 3], np.int32),
             (pa.float64(), [1.0, 2.0, 3.0], np.float64),
             (pa.bool_(), [True, False, True], np.bool_),
+            (pa.date32(), [datetime.date(2020, 1, 1)], np.dtype("datetime64[D]")),
+            (pa.date64(), [datetime.date(2020, 1, 1)], np.dtype("datetime64[ms]")),
+            (pa.timestamp("s"), [datetime.datetime(2020, 1, 1)], np.dtype("datetime64[s]")),
+            (pa.duration("s"), [datetime.timedelta(seconds=5)], np.dtype("timedelta64[s]")),
+            (pa.time32("s"), [datetime.time(1, 2, 3)], np.dtype(object)),
         ]:
             with self.subTest(arrow_type=str(arrow_type)):
                 schema = pa.schema({"a": arrow_type})
@@ -322,6 +327,21 @@ class FormatterTest(TestCase):
         self.assertEqual(len(col), 0)
         self.assertFalse(np.issubdtype(col.dtype, np.floating))
         self.assertEqual(col.dtype, np.dtype(object))
+
+    def test_numpy_formatter_empty_date32_column_keeps_day_resolution(self):
+        # date32 is day resolution, and that is what arrow renders a non-empty column at.
+        # Reading the dtype off pandas instead would report datetime64[ms] here, since
+        # pandas has no day-resolution datetime64, and an empty batch would then silently
+        # change the unit of the result it was concatenated into.
+        schema = pa.schema({"a": pa.date32()})
+        empty = InMemoryTable.from_arrays([pa.array([], type=pa.date32())], schema=schema)
+        filled = InMemoryTable.from_arrays([pa.array([datetime.date(2020, 1, 1)], type=pa.date32())], schema=schema)
+        extractor = NumpyArrowExtractor()
+        empty_col = extractor.extract_column(empty.table)
+        filled_col = extractor.extract_column(filled.table)
+        self.assertEqual(empty_col.dtype, np.dtype("datetime64[D]"))
+        self.assertEqual(empty_col.dtype, filled_col.dtype)
+        self.assertEqual(np.concatenate([empty_col, filled_col]).dtype, np.dtype("datetime64[D]"))
 
     def test_numpy_formatter_empty_column_does_not_promote_on_concatenate(self):
         # The practical consequence: one empty batch promoted the whole result to float.


### PR DESCRIPTION
Fixes #8469.

Under numpy format a column holding zero rows came back as float32 no matter what dtype it was declared with, while the same column kept its dtype as soon as it held one row. pandas and arrow were unaffected.

```python
feats = Features({"a": Value("int64")})
ds = Dataset.from_dict({"a": [1, 2, 3]}, features=feats).with_format("numpy")

ds.filter(lambda x: x["a"] > 1)[:]["a"].dtype    # int64
ds.filter(lambda x: x["a"] > 99)[:]["a"].dtype   # float32
```

I reproduced the whole table from the issue - int64, int32, bool and string all came back float32 when empty. float64 only looked right because it was already floating.

Two steps produce it. _arrow_array_to_numpy builds a python list and calls np.asarray on it, and a zero-length list carries no type, so you get float64 regardless of the column. NumpyFormatter._tensorize then sees a floating dtype and applies its np.float32 default.

The fix takes the dtype from the arrow type when the column is empty, which is effectively what the pandas and arrow extractors already do. Types with no single numpy equivalent - nested and extension types - return None from the helper and fall through to the existing path rather than getting a guessed dtype, so ArrayXD columns are untouched.

What this fixes in practice, since the dtype changed with how many rows survived a filter:

```python
np.concatenate([unmatched, matched]).dtype   # was float64 from int64 data, now int64
```

One behaviour change worth calling out: an empty string column now comes back as object rather than float32. That's what arrow and pandas give and it's well defined for a zero-length array, whereas the non-empty <U1 isn't - there's no natural width for an empty one. Happy to do something different there if you'd rather.

Tests: three new ones in tests/test_formatting.py covering the dtype round-trip across int64/int32/float64/bool, the string case specifically, and the concatenate promotion. All five assertions fail on main and pass with the change.

tests/test_formatting.py: 27 passed, 30 skipped. ruff check and ruff format clean.

One pre-existing failure I ran into while checking wider: tests/test_arrow_dataset.py::test_dataset_to_iterable_dataset fails identically on unmodified main in my environment, and a lot of tests/features/ errors out on missing optional video and audio dependencies.