### PR TITLE
Raise clear errors for missing folder metadata files

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -1568,7 +1568,10 @@ class GeneratorBasedBuilder(DatasetBuilder):
             # Ignore the writer's error for no examples written to the file if this error was caused by the error in _generate_examples before the first example was yielded
             if isinstance(e, SchemaInferenceError) and e.__context__ is not None:
                 e = e.__context__
-            raise DatasetGenerationError("An error occurred while generating the dataset") from e
+            message = "An error occurred while generating the dataset"
+            if isinstance(e, FileNotFoundError):
+                message += f": {e}"
+            raise DatasetGenerationError(message) from e
 
         yield (
             job_id,

--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -15,7 +15,7 @@ import datasets
 from datasets import config
 from datasets.builder import Key
 from datasets.features.features import FeatureType, _visit, _visit_with_path, _VisitPath, require_storage_cast
-from datasets.utils.file_utils import readline
+from datasets.utils.file_utils import is_local_path, readline
 
 
 logger = datasets.utils.logging.get_logger(__name__)
@@ -401,6 +401,7 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                         )
                     elif len(feature_path) == 0:
                         if item is not None:
+                            original_item = item
                             # Guard against path traversal (CWE-22): a crafted `file_name` such as
                             # "../../etc/passwd" or an absolute path must not be able to escape the
                             # metadata file's directory and read arbitrary files on the host.
@@ -432,6 +433,13 @@ class FolderBasedBuilder(datasets.GeneratorBasedBuilder):
                                     f"not allowed."
                                 )
                             item = os.path.join(downloaded_metadata_dir, file_relpath)
+                            # Keep remote datasets lazy instead of issuing one existence request per metadata row.
+                            # Missing remote files still raise when the feature is decoded.
+                            if is_local_path(item) and not os.path.isfile(item):
+                                metadata_file = original_metadata_file or downloaded_metadata_file
+                                raise FileNotFoundError(
+                                    f"File '{original_item}' referenced in metadata file '{metadata_file}' does not exist"
+                                )
                     return item
 
                 for pa_metadata_table in self._read_metadata(downloaded_metadata_file, metadata_ext=metadata_ext):

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -349,24 +349,6 @@ def test_generate_examples_drop_metadata(file_with_metadata, drop_metadata, drop
         assert example[column] is not None
 
 
-def test_generate_examples_raises_for_missing_file_referenced_by_metadata(tmp_path, auto_text_file, cache_dir):
-    data_dir = tmp_path / "data_dir_with_missing_metadata_reference"
-    data_dir.mkdir()
-    shutil.copyfile(auto_text_file, data_dir / "present.txt")
-    metadata_filename = data_dir / "metadata.jsonl"
-    metadata_filename.write_text(
-        '{"file_name": "missing.txt", "additional_feature": "Missing file"}\n', encoding="utf-8"
-    )
-    data_files = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
-    autofolder = DummyFolderBasedBuilder(data_files=data_files, cache_dir=cache_dir)
-    gen_kwargs = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
-
-    with pytest.raises(FileNotFoundError) as error:
-        list(autofolder._generate_examples(**gen_kwargs))
-
-    assert str(error.value) == (f"File 'missing.txt' referenced in metadata file '{metadata_filename}' does not exist")
-
-
 @pytest.mark.parametrize("remote", [True, False])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
 def test_data_files_with_different_levels_no_metadata(

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -349,6 +349,24 @@ def test_generate_examples_drop_metadata(file_with_metadata, drop_metadata, drop
         assert example[column] is not None
 
 
+def test_generate_examples_raises_for_missing_file_referenced_by_metadata(tmp_path, auto_text_file, cache_dir):
+    data_dir = tmp_path / "data_dir_with_missing_metadata_reference"
+    data_dir.mkdir()
+    shutil.copyfile(auto_text_file, data_dir / "present.txt")
+    metadata_filename = data_dir / "metadata.jsonl"
+    metadata_filename.write_text(
+        '{"file_name": "missing.txt", "additional_feature": "Missing file"}\n', encoding="utf-8"
+    )
+    data_files = DataFilesDict.from_patterns(get_data_patterns(str(data_dir)), data_dir.as_posix())
+    autofolder = DummyFolderBasedBuilder(data_files=data_files, cache_dir=cache_dir)
+    gen_kwargs = autofolder._split_generators(StreamingDownloadManager())[0].gen_kwargs
+
+    with pytest.raises(FileNotFoundError) as error:
+        list(autofolder._generate_examples(**gen_kwargs))
+
+    assert str(error.value) == (f"File 'missing.txt' referenced in metadata file '{metadata_filename}' does not exist")
+
+
 @pytest.mark.parametrize("remote", [True, False])
 @pytest.mark.parametrize("drop_labels", [None, True, False])
 def test_data_files_with_different_levels_no_metadata(

--- a/tests/packaged_modules/test_imagefolder.py
+++ b/tests/packaged_modules/test_imagefolder.py
@@ -4,10 +4,11 @@ import textwrap
 import numpy as np
 import pytest
 
-from datasets import ClassLabel, Features, Image
+from datasets import ClassLabel, Features, Image, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesDict, DataFilesList, get_data_patterns
 from datasets.download.streaming_download_manager import StreamingDownloadManager
+from datasets.exceptions import DatasetGenerationError
 from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder, ImageFolderConfig
 
 from ..utils import require_pil
@@ -390,6 +391,23 @@ def test_data_files_with_wrong_metadata_file_name(cache_dir, tmp_path, image_fil
     dataset = imagefolder.as_dataset(split="train")
     # check that there are no metadata, since the metadata file name doesn't have the right name
     assert "caption" not in dataset.column_names
+
+
+@require_pil
+def test_load_dataset_raises_for_missing_file_referenced_by_metadata(cache_dir, tmp_path, image_file):
+    data_dir = tmp_path / "data_dir_with_missing_metadata_reference"
+    data_dir.mkdir()
+    shutil.copyfile(image_file, data_dir / "present.jpg")
+    metadata_filename = data_dir / "metadata.csv"
+    metadata_filename.write_text("file_name,caption\nmissing.jpg,Missing image\n", encoding="utf-8")
+
+    with pytest.raises(DatasetGenerationError) as error:
+        load_dataset("imagefolder", data_dir=str(data_dir), cache_dir=cache_dir)
+
+    expected_message = f"File 'missing.jpg' referenced in metadata file '{metadata_filename}' does not exist"
+    assert str(error.value) == f"An error occurred while generating the dataset: {expected_message}"
+    assert isinstance(error.value.__cause__, FileNotFoundError)
+    assert str(error.value.__cause__) == expected_message
 
 
 @require_pil


### PR DESCRIPTION
## Summary

- validate local files referenced by folder metadata during example generation
- report both the missing file and the metadata file that references it
- preserve lazy access for remote files

## Testing

- `pytest -q tests/packaged_modules/test_folder_based_builder.py tests/packaged_modules/test_imagefolder.py tests/packaged_modules/test_audiofolder.py`
- `ruff check src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py tests/packaged_modules/test_folder_based_builder.py`
- `ruff format --check src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py tests/packaged_modules/test_folder_based_builder.py`

Fixes #7369