### PR TITLE
Print the repr these feature examples actually produce

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -2325,8 +2325,8 @@ class Features(dict):
 
             >>> from datasets import Features, List, Value
             >>> # let's say we have two features with a different order of nested fields (for a and b for example)
-            >>> f1 = Features({"root": {"a": Value("string"), "b": Value("string")}})
-            >>> f2 = Features({"root": {"b": Value("string"), "a": Value("string")}})
+            >>> f1 = Features({"root": List({"a": Value("string"), "b": Value("string")})})
+            >>> f2 = Features({"root": List({"b": Value("string"), "a": Value("string")})})
             >>> assert f1.type != f2.type
             >>> # re-ordering keeps the base structure (here List is defined at the root level), but makes the fields order match
             >>> f1.reorder_fields_as(f2)
@@ -2378,8 +2378,8 @@ class Features(dict):
         >>> from datasets import load_dataset
         >>> ds = load_dataset("rajpurkar/squad", split="train")
         >>> ds.features.flatten()
-        {'answers.answer_start': List(Value('int32'), id=None),
-         'answers.text': List(Value('string'), id=None),
+        {'answers.answer_start': List(Value('int32')),
+         'answers.text': List(Value('string')),
          'context': Value('string'),
          'id': Value('string'),
          'question': Value('string'),

--- a/src/datasets/features/image.py
+++ b/src/datasets/features/image.py
@@ -75,10 +75,11 @@ class Image:
     >>> from datasets import load_dataset, Image
     >>> ds = load_dataset("AI-Lab-Makerere/beans", split="train")
     >>> ds.features["image"]
-    Image(decode=True, id=None)
+    Image(mode=None, decode=True)
     >>> ds[0]["image"]
     <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=500x500 at 0x15E52E7F0>
     >>> ds = ds.cast_column('image', Image(decode=False))
+    >>> ds[0]["image"]
     {'bytes': None,
      'path': '/root/.cache/huggingface/datasets/downloads/extracted/b0a21163f78769a2cf11f58dfc767fb458fc7cea5c05dccc0144a2c0f0bc1292/train/healthy/healthy_train.85.jpg'}
     ```

--- a/src/datasets/features/nifti.py
+++ b/src/datasets/features/nifti.py
@@ -86,7 +86,7 @@ class Nifti:
     >>> from datasets import Dataset, Nifti
     >>> ds = Dataset.from_dict({"nifti": ["path/to/file.nii.gz"]}).cast_column("nifti", Nifti())
     >>> ds.features["nifti"]
-    Nifti(decode=True, id=None)
+    Nifti(decode=True)
     >>> ds[0]["nifti"]
     <nibabel.nifti1.Nifti1Image object at 0x7f8a1c2d8f40>
     >>> ds = ds.cast_column("nifti", Nifti(decode=False))

--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -54,7 +54,7 @@ class Pdf:
     >>> from datasets import Dataset, Pdf
     >>> ds = Dataset.from_dict({"pdf": ["path/to/pdf/file.pdf"]}).cast_column("pdf", Pdf())
     >>> ds.features["pdf"]
-    Pdf(decode=True, id=None)
+    Pdf(decode=True)
     >>> ds[0]["pdf"]
     <pdfplumber.pdf.PDF object at 0x7f8a1c2d8f40>
     >>> ds = ds.cast_column("pdf", Pdf(decode=False))

--- a/src/datasets/features/video.py
+++ b/src/datasets/features/video.py
@@ -70,7 +70,7 @@ class Video:
     >>> from datasets import Dataset, Video
     >>> ds = Dataset.from_dict({"video":["path/to/Screen Recording.mov"]}).cast_column("video", Video())
     >>> ds.features["video"]
-    Video(decode=True, id=None)
+    Video(decode=True, stream_index=None, dimension_order='NCHW', num_ffmpeg_threads=1, device='cpu', seek_mode='exact')
     >>> ds[0]["video"]
     <torchcodec.decoders._video_decoder.VideoDecoder object at 0x14a61e080>
     >>> video = ds[0]["video"]
@@ -81,7 +81,7 @@ class Video:
             0.4333], dtype=torch.float64)
     duration_seconds: tensor([0.0167, 0.0167, 0.0167, 0.0167, 0.0167, 0.0167, 0.0167, 0.0167, 0.0167,
             0.0167], dtype=torch.float64)
-    >>> ds.cast_column('video', Video(decode=False))[0]["video]
+    >>> ds.cast_column('video', Video(decode=False))[0]["video"]
     {'bytes': None,
      'path': 'path/to/Screen Recording.mov'}
     ```

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -4264,7 +4264,7 @@ class IterableDataset(DatasetInfoMixin):
         >>> from datasets import load_dataset, Audio
         >>> ds = load_dataset("PolyAI/minds14", name="en-US", split="train", streaming=True)
         >>> ds.features
-        {'audio': Audio(sampling_rate=8000, mono=True, decode=True, id=None),
+        {'audio': Audio(sampling_rate=8000, decode=True, num_channels=None, stream_index=None),
          'english_transcription': Value('string'),
          'intent_class': ClassLabel(num_classes=14, names=['abroad', 'address', 'app_error', 'atm_limit', 'balance', 'business_loan',  'card_issues', 'cash_deposit', 'direct_debit', 'freeze', 'high_value_payment', 'joint_account', 'latest_transactions', 'pay_bill']),
          'lang_id': ClassLabel(num_classes=14, names=['cs-CZ', 'de-DE', 'en-AU', 'en-GB', 'en-US', 'es-ES', 'fr-FR', 'it-IT', 'ko-KR',  'nl-NL', 'pl-PL', 'pt-PT', 'ru-RU', 'zh-CN']),
@@ -4272,7 +4272,7 @@ class IterableDataset(DatasetInfoMixin):
          'transcription': Value('string')}
         >>> ds = ds.cast_column("audio", Audio(sampling_rate=16000))
         >>> ds.features
-        {'audio': Audio(sampling_rate=16000, mono=True, decode=True, id=None),
+        {'audio': Audio(sampling_rate=16000, decode=True, num_channels=None, stream_index=None),
          'english_transcription': Value('string'),
          'intent_class': ClassLabel(num_classes=14, names=['abroad', 'address', 'app_error', 'atm_limit', 'balance', 'business_loan',  'card_issues', 'cash_deposit', 'direct_debit', 'freeze', 'high_value_payment', 'joint_account', 'latest_transactions', 'pay_bill']),
          'lang_id': ClassLabel(num_classes=14, names=['cs-CZ', 'de-DE', 'en-AU', 'en-GB', 'en-US', 'es-ES', 'fr-FR', 'it-IT', 'ko-KR',  'nl-NL', 'pl-PL', 'pt-PT', 'ru-RU', 'zh-CN']),
@@ -4377,7 +4377,7 @@ class IterableDataset(DatasetInfoMixin):
         'text': 'A distant celestial object with an icy crust, displaying a light blue shade, covered with round pits and rugged terrains.'}
         >>> ds = ds.decode(False)
         >>> ds.features
-        {'image': Image(mode=None, decode=False, id=None),
+        {'image': Image(mode=None, decode=False),
         'text': Value('string')}
         >>> next(iter(ds))
         {


### PR DESCRIPTION
### What breaks

Four feature classes show a repr in their `Examples` block that they cannot print.

```
>>> ds.features["image"]
Image(decode=True, id=None)
```

`Image`, `Pdf`, `Nifti` and `Video` all declare `id: Optional[str] = field(default=None, repr=False)`, so `id=None` never appears. On top of that `Image` has a `mode` field the example omits, and `Video` has five more fields that do print.

What they actually print:

| documented | actual |
|---|---|
| `Image(decode=True, id=None)` | `Image(mode=None, decode=True)` |
| `Pdf(decode=True, id=None)` | `Pdf(decode=True)` |
| `Nifti(decode=True, id=None)` | `Nifti(decode=True)` |
| `Video(decode=True, id=None)` | `Video(decode=True, stream_index=None, dimension_order='NCHW', num_ffmpeg_threads=1, device='cpu', seek_mode='exact')` |

Two more in the same blocks:

- `video.py` ends with `...[0]["video]` (unterminated string), so that line does not parse.
- `image.py`'s last block prints a dict directly after `ds = ds.cast_column(...)`, which is an assignment and outputs nothing. `pdf.py` and `nifti.py` have the `>>> ds[0]["image"]` line it is missing.

### What changed

Docs only, no code. Each shown repr replaced with what the class prints, the string literal closed, and the missing line added.

### Verification

By execution, not by eye: the four classes were built from this branch's source and their `repr()` compared against the docstring text, and every `>>>` line in the four blocks was `compile()`d.

**4 wrong reprs and 1 line that does not compile on main, 0 and 0 after.**

`ruff format --check` and `ruff check` clean on all four files.
