### PR TITLE
Add a strategy argument to split_dataset_by_node for iterable datasets

### DIFF
--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -250,9 +250,9 @@ Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of t
 
 For iterable datasets:
 
-If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
-then the shards are evenly assigned across the nodes, which is the most optimized.
-Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`. The default `"auto"` assigns shards when
+the number of shards is divisible by `world_size` and otherwise assigns every `world_size`-th example. `"shards"`
+always assigns shards and requires divisibility, while `"examples"` always assigns examples.
 
 This can also be combined with a `torch.utils.data.DataLoader` if you want each node to use multiple workers to load the data.
 

--- a/docs/source/use_with_pytorch.mdx
+++ b/docs/source/use_with_pytorch.mdx
@@ -250,9 +250,11 @@ Each node is assigned a chunk of data, e.g. rank 0 is given the first chunk of t
 
 For iterable datasets:
 
-The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`. The default `"auto"` assigns shards when
-the number of shards is divisible by `world_size` and otherwise assigns every `world_size`-th example. `"shards"`
-always assigns shards and requires divisibility, while `"examples"` always assigns examples.
+The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`:
+
+* `"shards"`: shards are evenly assigned across the nodes
+* `"examples"`: each node keeps 1 example out of `world_size`, skipping the other examples
+* `"auto"` (default): uses `"shards"` if the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`), which is the most optimized. Otherwise uses `"examples"`.
 
 This can also be combined with a `torch.utils.data.DataLoader` if you want each node to use multiple workers to load the data.
 

--- a/src/datasets/distributed.py
+++ b/src/datasets/distributed.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 from .arrow_dataset import Dataset, _split_by_node_map_style_dataset
 from .iterable_dataset import IterableDataset, _split_by_node_iterable_dataset
@@ -7,7 +7,9 @@ from .iterable_dataset import IterableDataset, _split_by_node_iterable_dataset
 DatasetType = TypeVar("DatasetType", Dataset, IterableDataset)
 
 
-def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> DatasetType:
+def split_dataset_by_node(
+    dataset: DatasetType, rank: int, world_size: int, strategy: Literal["auto", "shards", "examples"] = "auto"
+) -> DatasetType:
     """
     Split a dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
@@ -18,9 +20,9 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
 
     For iterable datasets:
 
-    If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
-    then the shards are evenly assigned across the nodes, which is the most optimized.
-    Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+    The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`. The default `"auto"` assigns shards
+    when the number of shards is divisible by `world_size` and otherwise assigns every `world_size`-th example.
+    `"shards"` always assigns shards and requires divisibility, while `"examples"` always assigns examples.
 
     > [!WARNING]
     > If you shuffle your iterable dataset in a distributed setup, make sure to set a fixed `seed` in [`IterableDataset.shuffle`]
@@ -33,11 +35,18 @@ def split_dataset_by_node(dataset: DatasetType, rank: int, world_size: int) -> D
             Rank of the current node.
         world_size (`int`):
             Total number of nodes.
+        strategy (`str`, defaults to `"auto"`):
+            How to split an iterable dataset. Must be one of `"auto"`, `"shards"`, or `"examples"`.
+            Map-style datasets only support `"auto"`.
 
     Returns:
         [`Dataset`] or [`IterableDataset`]: The dataset to be used on the node at rank `rank`.
     """
+    if strategy not in {"auto", "shards", "examples"}:
+        raise ValueError(f"Invalid strategy {strategy!r}. Expected one of 'auto', 'shards', or 'examples'.")
     if isinstance(dataset, Dataset):
+        if strategy != "auto":
+            raise ValueError(f"Map-style datasets only support strategy='auto', but got strategy={strategy!r}.")
         return _split_by_node_map_style_dataset(dataset, rank=rank, world_size=world_size)
     else:
-        return _split_by_node_iterable_dataset(dataset, rank=rank, world_size=world_size)
+        return _split_by_node_iterable_dataset(dataset, rank=rank, world_size=world_size, strategy=strategy)

--- a/src/datasets/distributed.py
+++ b/src/datasets/distributed.py
@@ -20,9 +20,12 @@ def split_dataset_by_node(
 
     For iterable datasets:
 
-    The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`. The default `"auto"` assigns shards
-    when the number of shards is divisible by `world_size` and otherwise assigns every `world_size`-th example.
-    `"shards"` always assigns shards and requires divisibility, while `"examples"` always assigns examples.
+    The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`:
+
+    * `"shards"`: shards are evenly assigned across the nodes
+    * `"examples"`: each node keeps 1 example out of `world_size`, skipping the other examples
+    * `"auto"` (default): uses `"shards"` if the dataset has a number of shards that is a factor of `world_size`
+    (i.e. if `dataset.num_shards % world_size == 0`), which is the most optimized. Otherwise uses `"examples"`.
 
     > [!WARNING]
     > If you shuffle your iterable dataset in a distributed setup, make sure to set a fixed `seed` in [`IterableDataset.shuffle`]

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2467,6 +2467,7 @@ class FormattedExamplesIterable(_BaseExamplesIterable):
 class DistributedConfig:
     rank: int
     world_size: int
+    strategy: Literal["auto", "shards", "examples"] = "auto"
 
 
 def _maybe_add_torch_iterable_dataset_parent_class(cls):
@@ -2707,7 +2708,11 @@ class IterableDataset(DatasetInfoMixin):
 
     @property
     def num_shards(self) -> int:
-        if self._distributed and self._ex_iterable.num_shards % self._distributed.world_size == 0:
+        if (
+            self._distributed
+            and self._distributed.strategy != "examples"
+            and self._ex_iterable.num_shards % self._distributed.world_size == 0
+        ):
             return self._ex_iterable.num_shards // self._distributed.world_size
         return self._ex_iterable.num_shards
 
@@ -2796,7 +2801,16 @@ class IterableDataset(DatasetInfoMixin):
         if self._distributed:
             rank = self._distributed.rank
             world_size = self._distributed.world_size
-            if ex_iterable.num_shards % world_size == 0:
+            strategy = self._distributed.strategy
+            if strategy == "shards" and ex_iterable.num_shards % world_size != 0:
+                # The shard count can change after the split (shuffle, shard, map with
+                # reshuffling), so the divisibility that "shards" requires is checked
+                # here, at iteration time, as well as when the split was requested.
+                raise ValueError(
+                    f"Cannot iterate with strategy='shards': the dataset now has num_shards={ex_iterable.num_shards}, "
+                    f"which is not divisible by world_size={world_size}."
+                )
+            if strategy == "shards" or (strategy == "auto" and ex_iterable.num_shards % world_size == 0):
                 if self._is_main_process():
                     num_shards_per_node = ex_iterable.num_shards // world_size
                     plural = "s" if num_shards_per_node > 1 else ""
@@ -2809,11 +2823,12 @@ class IterableDataset(DatasetInfoMixin):
                     logger.info(
                         f"Assigning 1 out of {world_size} examples of the dataset to each node. The others are skipped during the iteration."
                     )
-                    logger.info(
-                        f"It is more optimized to distribute the dataset shards (or data sources) across nodes. "
-                        f"You can do that by using a dataset with number of shards that is a factor of world_size={world_size}. "
-                        f"The current dataset has {ex_iterable.num_shards} which is not a factor of {world_size}"
-                    )
+                    if strategy == "auto":
+                        logger.info(
+                            f"It is more optimized to distribute the dataset shards (or data sources) across nodes. "
+                            f"You can do that by using a dataset with number of shards that is a factor of world_size={world_size}. "
+                            f"The current dataset has {ex_iterable.num_shards} which is not a factor of {world_size}"
+                        )
                 ex_iterable = StepExamplesIterable(ex_iterable, step=world_size, offset=rank)
 
         if ex_iterable.iter_arrow:
@@ -5394,13 +5409,18 @@ def _interleave_iterable_datasets(
     )
 
 
-def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_size: int) -> IterableDataset:
+def _split_by_node_iterable_dataset(
+    dataset: IterableDataset,
+    rank: int,
+    world_size: int,
+    strategy: Literal["auto", "shards", "examples"] = "auto",
+) -> IterableDataset:
     """
     Split an iterable dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
-    If the dataset has a number of shards that is a factor of `world_size` (i.e. if `dataset.num_shards % world_size == 0`),
-    then the shards are evenly assigned across the nodes, which is the most optimized.
-    Otherwise, each node keeps 1 example out of `world_size`, skipping the other examples.
+    The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`. The default `"auto"` assigns shards
+    when the number of shards is divisible by `world_size` and otherwise assigns every `world_size`-th example.
+    `"shards"` always assigns shards and requires divisibility, while `"examples"` always assigns examples.
 
     Args:
         dataset ([`IterableDataset`]):
@@ -5409,14 +5429,28 @@ def _split_by_node_iterable_dataset(dataset: IterableDataset, rank: int, world_s
             Rank of the current node.
         world_size (`int`):
             Total number of nodes.
+        strategy (`str`, defaults to `"auto"`):
+            How to split the iterable dataset. Must be one of `"auto"`, `"shards"`, or `"examples"`.
 
     Returns:
         [`IterableDataset`]: The iterable dataset to be used on the node at rank `rank`.
     """
     if dataset._distributed:
+        if strategy not in ("auto", dataset._distributed.strategy):
+            raise ValueError(
+                "Cannot change the strategy when splitting an already distributed iterable dataset. "
+                f"The existing strategy is {dataset._distributed.strategy!r} and the new strategy is {strategy!r}."
+            )
+        strategy = dataset._distributed.strategy
         rank = world_size * dataset._distributed.rank + rank
         world_size = world_size * dataset._distributed.world_size
-    distributed = DistributedConfig(rank=rank, world_size=world_size)
+    if strategy == "shards" and dataset._ex_iterable.num_shards % world_size != 0:
+        raise ValueError(
+            f"Cannot split an iterable dataset with num_shards={dataset._ex_iterable.num_shards} "
+            f"across world_size={world_size} nodes "
+            "with strategy='shards' because the number of shards must be divisible by world_size."
+        )
+    distributed = DistributedConfig(rank=rank, world_size=world_size, strategy=strategy)
     return IterableDataset(
         ex_iterable=dataset._ex_iterable,
         info=dataset._info.copy(),

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2708,12 +2708,15 @@ class IterableDataset(DatasetInfoMixin):
 
     @property
     def num_shards(self) -> int:
-        if (
-            self._distributed
-            and self._distributed.strategy != "examples"
-            and self._ex_iterable.num_shards % self._distributed.world_size == 0
-        ):
-            return self._ex_iterable.num_shards // self._distributed.world_size
+        if self._distributed:
+            strategy = self._distributed.strategy
+            world_size = self._distributed.world_size
+            if strategy == "shards" or (strategy == "auto" and self._ex_iterable.num_shards % world_size == 0):
+                return len(
+                    self._ex_iterable.split_shard_indices_by_worker(
+                        num_shards=world_size, index=self._distributed.rank, contiguous=False
+                    )
+                )
         return self._ex_iterable.num_shards
 
     @property
@@ -2802,13 +2805,13 @@ class IterableDataset(DatasetInfoMixin):
             rank = self._distributed.rank
             world_size = self._distributed.world_size
             strategy = self._distributed.strategy
-            if strategy == "shards" and ex_iterable.num_shards % world_size != 0:
+            if strategy == "shards" and ex_iterable.num_shards < world_size:
                 # The shard count can change after the split (shuffle, shard, map with
-                # reshuffling), so the divisibility that "shards" requires is checked
-                # here, at iteration time, as well as when the split was requested.
+                # reshuffling), so this is checked at iteration time as well as when the
+                # split was requested.
                 raise ValueError(
                     f"Cannot iterate with strategy='shards': the dataset now has num_shards={ex_iterable.num_shards}, "
-                    f"which is not divisible by world_size={world_size}."
+                    f"which is lower than world_size={world_size}, so some nodes would not be assigned any shard."
                 )
             if strategy == "shards" or (strategy == "auto" and ex_iterable.num_shards % world_size == 0):
                 if self._is_main_process():
@@ -2817,6 +2820,11 @@ class IterableDataset(DatasetInfoMixin):
                     logger.info(
                         f"Assigning {num_shards_per_node} shard{plural} (or data source{plural}) of the dataset to each node."
                     )
+                    if ex_iterable.num_shards % world_size != 0:
+                        logger.info(
+                            f"The number of shards ({ex_iterable.num_shards}) is not a factor of world_size={world_size}, "
+                            "so some nodes are assigned one more shard than the others."
+                        )
                 ex_iterable = ex_iterable.shard_data_sources(num_shards=world_size, index=rank, contiguous=False)
             else:
                 if self._is_main_process():
@@ -5418,9 +5426,12 @@ def _split_by_node_iterable_dataset(
     """
     Split an iterable dataset for the node at rank `rank` in a pool of nodes of size `world_size`.
 
-    The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`. The default `"auto"` assigns shards
-    when the number of shards is divisible by `world_size` and otherwise assigns every `world_size`-th example.
-    `"shards"` always assigns shards and requires divisibility, while `"examples"` always assigns examples.
+    The splitting `strategy` can be `"auto"`, `"shards"`, or `"examples"`:
+
+    * `"shards"`: shards are evenly assigned across the nodes
+    * `"examples"`: each node keeps 1 example out of `world_size`, skipping the other examples
+    * `"auto"` (default): uses `"shards"` if the dataset has a number of shards that is a factor of `world_size`
+    (i.e. if `dataset.num_shards % world_size == 0`), which is the most optimized. Otherwise uses `"examples"`.
 
     Args:
         dataset ([`IterableDataset`]):
@@ -5444,11 +5455,11 @@ def _split_by_node_iterable_dataset(
         strategy = dataset._distributed.strategy
         rank = world_size * dataset._distributed.rank + rank
         world_size = world_size * dataset._distributed.world_size
-    if strategy == "shards" and dataset._ex_iterable.num_shards % world_size != 0:
+    if strategy == "shards" and dataset._ex_iterable.num_shards < world_size:
         raise ValueError(
             f"Cannot split an iterable dataset with num_shards={dataset._ex_iterable.num_shards} "
-            f"across world_size={world_size} nodes "
-            "with strategy='shards' because the number of shards must be divisible by world_size."
+            f"across world_size={world_size} nodes with strategy='shards' "
+            "because some nodes would not be assigned any shard."
         )
     distributed = DistributedConfig(rank=rank, world_size=world_size, strategy=strategy)
     return IterableDataset(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -21,6 +21,20 @@ def test_split_dataset_by_node_map_style():
     assert len({tuple(x.values()) for ds in datasets_per_rank for x in ds}) == full_size
 
 
+def test_split_dataset_by_node_map_style_with_examples_strategy():
+    full_ds = Dataset.from_dict({"i": range(17)})
+
+    with pytest.raises(ValueError, match="Map-style datasets only support strategy='auto'"):
+        split_dataset_by_node(full_ds, rank=0, world_size=3, strategy="examples")
+
+
+def test_split_dataset_by_node_invalid_strategy():
+    full_ds = IterableDataset.from_generator(lambda: ({"i": i} for i in range(17)))
+
+    with pytest.raises(ValueError, match="Invalid strategy"):
+        split_dataset_by_node(full_ds, rank=0, world_size=3, strategy="invalid")
+
+
 def test_split_dataset_by_node_iterable():
     def gen():
         return ({"i": i} for i in range(17))
@@ -53,6 +67,72 @@ def test_split_dataset_by_node_iterable_sharded(shards_per_node):
     assert [ds.num_shards for ds in datasets_per_rank] == [shards_per_node] * world_size
     assert sum(len(list(ds)) for ds in datasets_per_rank) == full_size
     assert len({tuple(x.values()) for ds in datasets_per_rank for x in ds}) == full_size
+
+
+def test_split_dataset_by_node_iterable_with_examples_strategy():
+    def gen(shards):
+        for shard in shards:
+            yield from ({"i": 2 * shard + i} for i in range(2))
+
+    world_size = 3
+    full_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(6))})
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size, strategy="examples")
+        for rank in range(world_size)
+    ]
+
+    assert [ds.num_shards for ds in datasets_per_rank] == [full_ds.num_shards] * world_size
+    assert [[example["i"] for example in ds] for ds in datasets_per_rank] == [
+        list(range(rank, 12, world_size)) for rank in range(world_size)
+    ]
+    assert {example["i"] for ds in datasets_per_rank for example in ds} == set(range(12))
+
+
+def test_split_dataset_by_node_iterable_with_shards_strategy():
+    def gen(shards):
+        yield from ({"shard": shard} for shard in shards)
+
+    world_size = 3
+    full_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(6))})
+    datasets_per_rank = [
+        split_dataset_by_node(full_ds, rank=rank, world_size=world_size, strategy="shards")
+        for rank in range(world_size)
+    ]
+    shards_per_rank = [{example["shard"] for example in ds} for ds in datasets_per_rank]
+
+    assert [ds.num_shards for ds in datasets_per_rank] == [2] * world_size
+    assert all(shards_per_rank[rank].isdisjoint(shards_per_rank[other]) for rank in range(3) for other in range(rank))
+    assert set.union(*shards_per_rank) == set(range(6))
+
+    non_divisible_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(2))})
+    with pytest.raises(ValueError, match="num_shards=2.*world_size=3"):
+        split_dataset_by_node(non_divisible_ds, rank=0, world_size=world_size, strategy="shards")
+
+
+def test_split_dataset_by_node_iterable_nested_strategy():
+    full_ds = IterableDataset.from_generator(lambda: ({"i": i} for i in range(16)))
+    ds = split_dataset_by_node(full_ds, rank=1, world_size=2, strategy="examples")
+    nested_ds = split_dataset_by_node(ds, rank=0, world_size=2)
+
+    assert [example["i"] for example in nested_ds] == list(range(2, 16, 4))
+    same_ds = split_dataset_by_node(ds, rank=0, world_size=2, strategy="examples")
+    assert [example["i"] for example in same_ds] == list(range(2, 16, 4))
+    with pytest.raises(ValueError, match="Cannot change the strategy"):
+        split_dataset_by_node(ds, rank=0, world_size=2, strategy="shards")
+
+
+def test_split_dataset_by_node_iterable_shards_strategy_checked_at_iteration():
+    """The shard count can change after the split; a forced "shards" split must fail clearly, not with IndexError."""
+
+    def gen(shards):
+        yield from ({"shard": shard} for shard in shards)
+
+    full_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(6))})
+    ds = split_dataset_by_node(full_ds, rank=1, world_size=3, strategy="shards")
+    # shuffle() builds a dataset over a single shuffled source, which prepares the
+    # iterable eagerly; the check fails there rather than mid-iteration.
+    with pytest.raises(ValueError, match="num_shards=1.*world_size=3"):
+        ds.shuffle(seed=0, buffer_size=4)
 
 
 def test_split_dataset_by_node_iterable_distributed():

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -104,9 +104,21 @@ def test_split_dataset_by_node_iterable_with_shards_strategy():
     assert all(shards_per_rank[rank].isdisjoint(shards_per_rank[other]) for rank in range(3) for other in range(rank))
     assert set.union(*shards_per_rank) == set(range(6))
 
-    non_divisible_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(2))})
+    # "shards" does not require num_shards to be a factor of world_size: shards are then assigned unevenly
+    uneven_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(5))})
+    datasets_per_rank = [
+        split_dataset_by_node(uneven_ds, rank=rank, world_size=world_size, strategy="shards")
+        for rank in range(world_size)
+    ]
+    shards_per_rank = [[example["shard"] for example in ds] for ds in datasets_per_rank]
+
+    assert [ds.num_shards for ds in datasets_per_rank] == [2, 2, 1]
+    assert shards_per_rank == [[0, 3], [1, 4], [2]]
+
+    # but every node must be assigned at least one shard
+    too_few_shards_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(2))})
     with pytest.raises(ValueError, match="num_shards=2.*world_size=3"):
-        split_dataset_by_node(non_divisible_ds, rank=0, world_size=world_size, strategy="shards")
+        split_dataset_by_node(too_few_shards_ds, rank=0, world_size=world_size, strategy="shards")
 
 
 def test_split_dataset_by_node_iterable_nested_strategy():
@@ -129,7 +141,7 @@ def test_split_dataset_by_node_iterable_shards_strategy_checked_at_iteration():
 
     full_ds = IterableDataset.from_generator(gen, gen_kwargs={"shards": list(range(6))})
     ds = split_dataset_by_node(full_ds, rank=1, world_size=3, strategy="shards")
-    # shuffle() builds a dataset over a single shuffled source, which prepares the
+    # shuffle() interleaves the shards into a single source, which prepares the
     # iterable eagerly; the check fails there rather than mid-iteration.
     with pytest.raises(ValueError, match="num_shards=1.*world_size=3"):
         ds.shuffle(seed=0, buffer_size=4)


### PR DESCRIPTION
Closes #8253 by adding the explicit splitting-strategy argument that @lhoestq asked for in that thread.

```python
split_dataset_by_node(ds, rank, world_size, strategy="auto" | "shards" | "examples")
```

- `"auto"`: unchanged. Shards are assigned when `num_shards % world_size == 0`, otherwise each node keeps one example in `world_size`.
- `"shards"`: always assigns shards. Raises `ValueError` naming `num_shards` and `world_size` when they do not divide, at split time and again when the iterable is prepared, because `shuffle()` or `shard()` can change the shard count afterwards.
- `"examples"`: always keeps one example in `world_size`, for the case in the issue where shard-level assignment is possible but the shards are imbalanced.

The value is stored on `DistributedConfig`, so every path that copies the config (`shuffle`, `shard`, `map`, `filter`, `take`, `skip`, `interleave_datasets`) keeps it. A nested `split_dataset_by_node` inherits the strategy; passing the same value again is accepted, a different explicit value raises. Map-style datasets accept only `"auto"`. `num_shards` reports the full shard count under `"examples"`.

Tests in `tests/test_distributed.py` cover both new strategies, the union over ranks, the non-divisible error, the nested cases, the post-shuffle check, invalid values, and the map-style rejection. Docs updated in `use_with_pytorch.mdx`.

Three behaviors were checked and found identical on `main` for the existing example-level path, so they are unchanged here and left for separate issues if wanted: `concatenate_datasets` drops the distributed config; `take`/`skip` after an example-level split apply before the per-node step; DataLoader worker sharding under an example-level split does not partition the node's examples evenly.
