### PR TITLE
Fix Pdf.decode_example raising TypeError on remote non-Hub paths

### DIFF
--- a/src/datasets/features/pdf.py
+++ b/src/datasets/features/pdf.py
@@ -154,11 +154,10 @@ class Pdf:
                         if source_url.startswith(config.HF_ENDPOINT)
                         else config.HUB_DATASETS_HFFS_URL
                     )
-                    try:
-                        repo_id = string_to_dict(source_url, pattern)["repo_id"]
-                        token = token_per_repo_id.get(repo_id)
-                    except ValueError:
-                        token = None
+                    source_url_fields = string_to_dict(source_url, pattern)
+                    token = (
+                        token_per_repo_id.get(source_url_fields["repo_id"]) if source_url_fields is not None else None
+                    )
                     download_config = DownloadConfig(token=token)
                     f = xopen(path, "rb", download_config=download_config)
                     return pdfplumber.open(f)

--- a/tests/features/test_pdf.py
+++ b/tests/features/test_pdf.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,18 @@ def test_pdf_feature_encode_example(shared_datadir, build_example):
     assert encoded_example.keys() == {"bytes", "path"}
     assert encoded_example["bytes"] is not None or encoded_example["path"] is not None
     decoded_example = pdf.decode_example(encoded_example)
+    assert isinstance(decoded_example, pdfplumber.pdf.PDF)
+
+
+@require_pdfplumber
+def test_pdf_feature_decode_example_remote_non_hub_url(shared_datadir, monkeypatch):
+    import pdfplumber
+
+    pdf_path = shared_datadir / "test_pdf.pdf"
+    monkeypatch.setattr("datasets.features.pdf.xopen", lambda *args, **kwargs: BytesIO(pdf_path.read_bytes()))
+
+    decoded_example = Pdf().decode_example({"path": "https://example.com/a.pdf", "bytes": None})
+
     assert isinstance(decoded_example, pdfplumber.pdf.PDF)
 
 


### PR DESCRIPTION
`Pdf.decode_example` on a remote path outside the Hub raised before any download:

```
>>> Pdf().decode_example({"path": "https://example.com/a.pdf", "bytes": None})
TypeError: 'NoneType' object is not subscriptable   # src/datasets/features/pdf.py:158
```

`string_to_dict` returns `None` when the URL does not match the Hub pattern; it does not raise, so the surrounding `except ValueError` never ran. The lookup now checks for `None`, matching `Pdf.embed_storage` and the Image, Audio, Video and Nifti decoders, which already do this. Verified by execution that https, s3 and `hf://…@revision` paths all decode after the change.

Regression test added in `tests/features/test_pdf.py` (monkeypatched `xopen`, real test PDF). The one failing test in that file on `main`, `test_dataset_with_pdf_feature`, is unrelated (`Column` vs `list` assertion) and unchanged here.

Out of scope, shared by every decoder: a revisionless `hf://datasets/{repo}/{path}` URL does not match `HUB_DATASETS_HFFS_URL` (which requires `@{revision}`), so an explicit per-repo token is not applied for that form.
