### PR TITLE
Shard the sources when skipping a distributed IterableDataset

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2121,7 +2121,12 @@ class SkipExamplesIterable(_BaseExamplesIterable):
                 split_when_sharding=self.split_when_sharding,
             )
         else:
-            return self
+            return SkipExamplesIterable(
+                self.ex_iterable.shard_data_sources(num_shards, index, contiguous=contiguous),
+                n=self.n,
+                block_sources_order_when_shuffling=self.block_sources_order_when_shuffling,
+                split_when_sharding=self.split_when_sharding,
+            )
 
     def reshard_data_sources(self) -> "SkipExamplesIterable":
         return SkipExamplesIterable(

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -2417,11 +2417,10 @@ def test_iterable_dataset_skip_or_take_after_split_by_node(method, after_split_b
     if after_split_by_node:
         distributed_dataset = split_dataset_by_node(distributed_dataset, rank=rank, world_size=world_size)
         distributed_dataset = distributed_dataset.skip(count) if method == "skip" else distributed_dataset.take(count)
-        assert (
-            list(true_distributed_dataset)[count:]
-            if method == "skip"
-            else list(true_distributed_dataset)[:count] == list(distributed_dataset)
+        expected = (
+            list(true_distributed_dataset)[count:] if method == "skip" else list(true_distributed_dataset)[:count]
         )
+        assert expected == list(distributed_dataset)
     else:
         distributed_dataset = distributed_dataset.skip(count) if method == "skip" else distributed_dataset.take(count)
         distributed_dataset = split_dataset_by_node(distributed_dataset, rank=rank, world_size=world_size)


### PR DESCRIPTION
`SkipExamplesIterable.shard_data_sources` returned `self` when `split_when_sharding` is False, so a `.skip()` applied after `split_dataset_by_node` threw the sharding away and every rank iterated the whole dataset. `TakeExamplesIterable` already handles that branch by sharding the sources and leaving `n` alone, so this just mirrors it.

The test meant to cover this, `test_iterable_dataset_skip_or_take_after_split_by_node`, has its conditional expression parenthesised so that the skip half asserts a non-empty list rather than comparing it, which is why it stayed green. Fixed the parentheses too, and the three skip cases fail on main once they actually compare.

`tests/test_iterable_dataset.py` and `tests/test_distributed.py` are otherwise unchanged in outcome for me. I could not run the interleave sharding cases locally, they need torch and my env does not have it, so CI should tell.

Fixes #8568
