### PR TITLE
Check the row count of every source when concatenating on axis=1

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -7054,15 +7054,14 @@ def _concatenate_map_style_datasets(
     >>> ds3 = _concatenate_map_style_datasets([ds1, ds2])
     ```
     """
-    # Ignore datasets with no rows
-    if any(dset.num_rows > 0 for dset in dsets):
-        dsets = [dset for dset in dsets if dset.num_rows > 0]
-    else:
-        # Return first dataset if all datasets are empty
-        return dsets[0]
-
     # Perform checks (and a potential cast if axis=0)
     if axis == 0:
+        # Ignore datasets with no rows: they contribute no rows to a vertical concatenation
+        if any(dset.num_rows > 0 for dset in dsets):
+            dsets = [dset for dset in dsets if dset.num_rows > 0]
+        else:
+            # Return first dataset if all datasets are empty
+            return dsets[0]
         _check_if_features_can_be_aligned([dset.features for dset in dsets])
     else:
         if not all(dset.num_rows == dsets[0].num_rows for dset in dsets):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -3780,6 +3780,34 @@ def test_concatenate_datasets_duplicate_columns(dataset):
     assert "duplicated" in str(excinfo.value)
 
 
+def test_concatenate_datasets_axis_1_with_a_dataset_with_no_rows():
+    # A source with no rows still contributes its columns, so its row count must be checked
+    # like any other source. It used to be dropped before the check, which silently removed
+    # "col_2" from the result instead of raising.
+    dataset1 = Dataset.from_dict({"col_1": [0, 1, 2]})
+    dataset2 = Dataset.from_dict({"col_2": []}, features=Features({"col_2": Value("int64")}))
+    with pytest.raises(ValueError) as excinfo:
+        concatenate_datasets([dataset1, dataset2], axis=1)
+    assert "Number of rows must match" in str(excinfo.value)
+
+
+def test_concatenate_datasets_axis_1_when_every_dataset_has_no_rows():
+    dataset1 = Dataset.from_dict({"col_1": []}, features=Features({"col_1": Value("int64")}))
+    dataset2 = Dataset.from_dict({"col_2": []}, features=Features({"col_2": Value("string")}))
+    dataset = concatenate_datasets([dataset1, dataset2], axis=1)
+    assert dataset.num_rows == 0
+    assert dataset.column_names == ["col_1", "col_2"]
+    assert dataset.features == Features({"col_1": Value("int64"), "col_2": Value("string")})
+
+
+def test_concatenate_datasets_axis_0_still_ignores_datasets_with_no_rows():
+    dataset1 = Dataset.from_dict({"col_1": [0, 1, 2]})
+    dataset2 = Dataset.from_dict({"col_2": []}, features=Features({"col_2": Value("int64")}))
+    dataset = concatenate_datasets([dataset1, dataset2], axis=0)
+    assert dataset.column_names == ["col_1"]
+    assert dataset[:] == {"col_1": [0, 1, 2]}
+
+
 def test_interleave_datasets():
     d1 = Dataset.from_dict({"a": [0, 1, 2]})
     d2 = Dataset.from_dict({"a": [10, 11, 12, 13]})


### PR DESCRIPTION

Fixes #8572

A source with no rows still contributes its columns, so horizontal concatenation has to check its row count like any other source. The empty-source filter in `_concatenate_map_style_datasets` ran before the axis dispatch, so on `axis=1` a 0-row source was removed before the "Number of rows must match" check could see it, and its columns were dropped from the result without an error. When every source had 0 rows the function returned the first one, dropping the other sources' columns.

This moves the filter into the `axis=0` branch, where ignoring rowless sources is what it was written for. It restores the check that ran unconditionally before #3195.

### Behavior change

Over 19 input shapes per axis (mixed row counts, string and `ClassLabel` columns, multi-column sources, 0-row sources produced by `from_dict`, `.filter()` and `.select([])`, duplicate column names):

- `axis=0`: 0 of 19 changed.
- `axis=1`: 12 of 19 changed. Eight now raise `ValueError: Number of rows must match for all datasets` where they had silently dropped columns; four now return the union of columns when every source has 0 rows.

### Tests

```
python -m pytest tests/test_arrow_dataset.py -q
1 failed, 365 passed, 61 skipped

python -m pytest tests/test_iterable_dataset.py tests/test_table.py tests/test_dataset_dict.py tests/test_arrow_writer.py -q
4 failed, 873 passed, 54 skipped

ruff check tests src benchmarks utils setup.py    # All checks passed!
ruff format --check tests src benchmarks utils setup.py    # 236 files already formatted
```

The 5 failures are the same on unmodified `19f69de` with identical counts. All of them need PyTorch, which is not installed in this environment (`test_dataset_to_iterable_dataset`, `test_interleave_dataset_with_sharding`).

The two new behavior tests fail on `19f69de` with the tests applied and the source reverted:

```
FAILED test_concatenate_datasets_axis_1_with_a_dataset_with_no_rows - Failed: DID NOT RAISE ValueError
FAILED test_concatenate_datasets_axis_1_when_every_dataset_has_no_rows - AssertionError: assert ['col_1'] == ['col_1', 'col_2']
```

`test_concatenate_datasets_axis_0_still_ignores_datasets_with_no_rows` passes in both states; it guards the `axis=0` behavior this change leaves alone.

---
Drafted with Claude Opus / Fable 5.1. Reviewed by Muse Spark 1.3 and GLM 5.3 as judges before submission.
