### PR TITLE
docs: add EvalPort ResultSet example to nested-field JSON loading

### DIFF
--- a/docs/source/loading.mdx
+++ b/docs/source/loading.mdx
@@ -110,6 +110,24 @@ Another JSON format you may encounter is a nested field, in which case you'll ne
 >>> dataset = load_dataset("json", data_files="my_file.json", field="data")
 ```
 
+A common example of this shape is the output of an evaluation or benchmark run, where the individual results live under a top-level key like `"results"`:
+
+```py
+{"version": "1.1.0",
+ "suite_id": "image-description-suite",
+ "run_id": "openai-gpt-4.1-run",
+ "results": [
+     {"test_case_id": "great_wave_off_kanagawa", "passed": true, "grader_results": [...]},
+     {"test_case_id": "starry_night", "passed": true, "grader_results": [...]}
+ ]
+}
+
+>>> from datasets import load_dataset
+>>> dataset = load_dataset("json", data_files="my_run.json", field="results")
+```
+
+This works out of the box for any log file shaped this way, including [EvalPort](https://github.com/adhabnr-ux/evalport) `ResultSet` documents — an open JSON schema for portable LLM eval/benchmark results, designed so a run's output can be loaded the same way regardless of which framework produced it.
+
 To load remote JSON files via HTTP, pass the URLs instead:
 
 ```py


### PR DESCRIPTION
### What

Adds a small worked example to the "nested field" JSON section of the loading guide (`docs/source/loading.mdx`), right after the existing `field="data"` example, showing the same mechanism applied to an eval/benchmark run's results file:

```py
{"version": "1.1.0",
 "suite_id": "image-description-suite",
 "run_id": "openai-gpt-4.1-run",
 "results": [
     {"test_case_id": "great_wave_off_kanagawa", "passed": true, "grader_results": [...]},
     {"test_case_id": "starry_night", "passed": true, "grader_results": [...]}
 ]
}

>>> from datasets import load_dataset
>>> dataset = load_dataset("json", data_files="my_run.json", field="results")
```

No code changes — `field=` was already fully general and handles this today.

### Why

This follows up on Discussion #8506, where I proposed that [EvalPort](https://github.com/adhabnr-ux/evalport) (an open JSON schema for portable LLM eval/benchmark results — a `ResultSet` document is `{version, suite_id, run_id, results: [...]}`) could be loaded as a `Dataset` with zero new code on this side, just this existing `field=` argument. `@demirciberk` replied confirming the approach but explicitly flagged that they hadn't run it against a real file:

> I did not run the `load_dataset("json", ..., field="results")` example above against an actual EvalPort file... you should verify it against a real ResultSet JSON before publishing it as a guaranteed-working example.

I did that verification before opening this PR. Locally, with `datasets==5.0.1`, against a real, schema-valid EvalPort `ResultSet` document (validated with `openeval.validate.validate_result_set()`, `valid=True`):

```
>>> from datasets import load_dataset
>>> ds = load_dataset('json', data_files='sample_results.json', field='results')
>>> ds
DatasetDict({
    train: Dataset({
        features: ['test_case_id', 'actual_output', 'passed', 'duration_ms', 'grader_results'],
        num_rows: 3
    })
})
```

Confirmed: 3 rows, correct columns, `grader_results` (a list of structs) loads correctly as a nested column. So the doc claim is now a verified fact, not a guess.

### Scope

Documentation only — one file, one new paragraph + one new code example, inserted at the natural spot in the existing JSON section. No new dependencies, no code paths touched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtocdH3tKifGdkiCZxxV3F