### PR TITLE
Fix async map checkpoint accounting across repeated resumes

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -1582,6 +1582,8 @@ class MappedExamplesIterable(_BaseExamplesIterable):
                 if self._state_dict:
                     previous_state = self.ex_iterable.state_dict()
                     self._state_dict["previous_state"] = previous_state
+                    # Replayed outputs are counted again below, including those skipped on resume.
+                    self._state_dict["num_examples_since_previous_state"] = 0
                     previous_state_task = None
                     previous_state_example_idx = self._state_dict["previous_state_example_idx"]
                 indices: Union[list[int], list[list[int]]] = []

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1336,6 +1336,38 @@ def test_map_async():
     assert next(iter(out))["y"] == 1
 
 
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("use_arrow", [False, True])
+@pytest.mark.parametrize("max_concurrency", [2, 1000])
+@pytest.mark.parametrize("wrapper", [lambda function: function, _wrap_async])
+def test_map_resume_multiple_times(batched, use_arrow, max_concurrency, wrapper, monkeypatch):
+    monkeypatch.setattr(config, "MAX_NUM_RUNNING_ASYNC_MAP_FUNCTIONS_IN_PARALLEL", max_concurrency)
+
+    def build():
+        if use_arrow:
+            dataset = Dataset.from_dict({"id": list(range(30))}).to_iterable_dataset(num_shards=3)
+        else:
+            dataset = IterableDataset(ExamplesIterable(generate_examples_fn, {"n": 30}))
+        return dataset.map(
+            wrapper(lambda example, indices: {"index": indices}),
+            with_indices=True,
+            batched=batched,
+            batch_size=7,
+        )
+
+    expected = list(build())
+    dataset = build()
+    actual = []
+    for consume in [2, 3, 7]:
+        iterator = iter(dataset)
+        actual.extend(islice(iterator, consume))
+        state = pickle.loads(pickle.dumps(dataset.state_dict()))
+        dataset = build()
+        dataset.load_state_dict(state)
+    actual.extend(dataset)
+    assert actual == expected
+
+
 def test_filter_async():
     dset = Dataset.from_dict({"x": range(100)}).to_iterable_dataset()
 


### PR DESCRIPTION
Resuming an iterable dataset with an asynchronous map function works once, but a checkpoint captured during the resumed iteration can skip additional examples on the next resume. A deterministic identity coroutine over IDs 0–9, checkpointed after two outputs and again after one more output, produces `[0, 1, 2, 5, 6, 7, 8, 9]` on main at `19f69de53015525126e6d3f96859acb90498e364`.

The asynchronous output iterator restores the source snapshot without clearing `num_examples_since_previous_state`. Replayed outputs, including the ones skipped for the current resume, are counted again on top of the loaded value. Reset this counter when establishing the asynchronous snapshot, keeping the separately captured skip count intact.

The regression test covers repeated serialized checkpoints with synchronous and asynchronous callbacks, Arrow and Python sources, batched and unbatched maps, indices, and concurrency limits of 2 and 1000. Six of its sixteen cases fail before the change; all pass after it.

Validation on macOS ARM64 / Python 3.14.7 / PyArrow 25.0.1:

- Targeted regression plus existing async and index tests: 30 passed.
- `tests/test_iterable_dataset.py -m unit -k 'not test_interleave_dataset_with_sharding'`: 461 passed, 45 skipped, 6 deselected. Optional frameworks such as torch are not installed; this is not full cross-platform or distributed validation.
- Ruff 0.11.8 lint and format checks, and `git diff --check`: pass.
- Additional local async scenarios improve from 29/120 exact sequences to 119/120. One batched Arrow filter scenario fails identically before and after this patch. It was reduced to repeated checkpoints on RebatchedArrowExamplesIterable without map/filter/async: a partially consumed chunk is counted twice. A diagnostic intervention on that separate chunk counter removes the filter failure but does not fix the async-map reproduction. That rebatching issue is not included in this patch. No claim is made that all checkpoint problems are resolved.

This appears distinct from #8295, which repaired stale state references after loading, and from #8408, which addresses shuffle buffers. Open PR #7656 also concerns map checkpointing, but its current diff delegates state methods to the source rather than fixing this asynchronous replay counter. The original #7630 reproduction already returns the expected continuation on this main revision. This patch addresses checkpoints taken after an async resume. Please advise if coordination with that work is needed.

AI assistance: I used Codex to help investigate the issue and prepare the fix and regression tests. I have reviewed the code, tests, and investigation results. The validation reported above was executed locally.
