### PR TITLE
Honor explicit Parquet compression and encoding options

### DIFF
--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -125,16 +125,21 @@ class ParquetDatasetWriter:
             schema=schema,
             use_content_defined_chunking=self.use_content_defined_chunking,
             write_page_index=self.write_page_index,
-            compression={
-                col: "none" if require_storage_embed(feature) else "snappy"
-                for col, feature in self.dataset.features.items()
-            },
-            use_dictionary=[
-                col for col, feature in self.dataset.features.items() if not require_storage_embed(feature)
-            ],
-            column_encoding={
-                col: "PLAIN" for col, feature in self.dataset.features.items() if require_storage_embed(feature)
-            },
+            compression=parquet_writer_kwargs.pop(
+                "compression",
+                {
+                    col: "none" if require_storage_embed(feature) else "snappy"
+                    for col, feature in self.dataset.features.items()
+                },
+            ),
+            use_dictionary=parquet_writer_kwargs.pop(
+                "use_dictionary",
+                [col for col, feature in self.dataset.features.items() if not require_storage_embed(feature)],
+            ),
+            column_encoding=parquet_writer_kwargs.pop(
+                "column_encoding",
+                {col: "PLAIN" for col, feature in self.dataset.features.items() if require_storage_embed(feature)},
+            ),
             **parquet_writer_kwargs,
         )
 

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -1,5 +1,6 @@
 import json
 import unittest.mock
+from io import BytesIO
 
 import fsspec
 import pyarrow.parquet as pq
@@ -205,6 +206,54 @@ def test_parquet_write(dataset, tmp_path):
     pf = pq.ParquetFile(tmp_path / "foo.parquet")
     output_table = pf.read()
     assert dataset.data.table == output_table
+
+
+@pytest.mark.parametrize("use_buffer", [False, True])
+@pytest.mark.parametrize(
+    "writer_kwargs, compressions, encodings",
+    [
+        ({}, ["SNAPPY", "SNAPPY"], ["RLE_DICTIONARY", "RLE_DICTIONARY"]),
+        ({"compression": "gzip"}, ["GZIP", "GZIP"], ["RLE_DICTIONARY", "RLE_DICTIONARY"]),
+        ({"compression": None}, ["UNCOMPRESSED", "UNCOMPRESSED"], ["RLE_DICTIONARY", "RLE_DICTIONARY"]),
+        (
+            {"compression": {"value": "gzip", "text": "snappy"}},
+            ["GZIP", "SNAPPY"],
+            ["RLE_DICTIONARY", "RLE_DICTIONARY"],
+        ),
+        ({"use_dictionary": False}, ["SNAPPY", "SNAPPY"], ["PLAIN", "PLAIN"]),
+        ({"use_dictionary": ["text"]}, ["SNAPPY", "SNAPPY"], ["PLAIN", "RLE_DICTIONARY"]),
+        (
+            {"use_dictionary": False, "column_encoding": "PLAIN"},
+            ["SNAPPY", "SNAPPY"],
+            ["PLAIN", "PLAIN"],
+        ),
+        (
+            {
+                "use_dictionary": False,
+                "column_encoding": {"value": "DELTA_BINARY_PACKED", "text": "DELTA_BYTE_ARRAY"},
+            },
+            ["SNAPPY", "SNAPPY"],
+            ["DELTA_BINARY_PACKED", "DELTA_BYTE_ARRAY"],
+        ),
+    ],
+)
+def test_dataset_to_parquet_writer_options(writer_kwargs, compressions, encodings, use_buffer, tmp_path):
+    dataset = Dataset.from_dict({"value": [1, 2, 3], "text": ["a", "b", "a"]})
+    destination = BytesIO() if use_buffer else tmp_path / "data.parquet"
+
+    assert dataset.to_parquet(destination, **writer_kwargs) > 0
+
+    if use_buffer:
+        destination.seek(0)
+    with pq.ParquetFile(destination) as parquet_file:
+        assert parquet_file.read() == dataset.data.table
+        row_group = parquet_file.metadata.row_group(0)
+        for i, (compression, encoding) in enumerate(zip(compressions, encodings)):
+            column = row_group.column(i)
+            assert column.compression == compression
+            assert encoding in column.encodings
+            if encoding != "RLE_DICTIONARY":
+                assert "RLE_DICTIONARY" not in column.encodings
 
 
 def test_parquet_write_uses_content_defined_chunking(dataset, tmp_path):


### PR DESCRIPTION
`Dataset.to_parquet(..., compression="gzip")` raises `TypeError: ParquetWriter() got multiple values for keyword argument 'compression'` on current main. Explicit `use_dictionary` and `column_encoding` options fail for the same reason: the writer supplies defaults as named arguments while leaving the caller's values in `**parquet_writer_kwargs`.

Pop these three options from the forwarded kwargs, using the existing feature-dependent defaults only when an option is absent. This lets callers choose compression and encoding, including explicit `None` and `False` values.

The regression tests write to both paths and binary buffers, read the data back, and inspect Parquet metadata for the requested codecs and encodings. They cover global/per-column compression, disabling compression, dictionary selection, and explicit column encodings, along with unchanged defaults.

Validation on Windows, Python 3.12.13, PyArrow 25.0.1:

- Before the fix: 14 new regression cases failed with the duplicate-keyword error; the two default-option controls passed.
- After the fix: `python -m pytest tests/io/test_parquet.py -q` — 72 passed.
- Ruff lint and format checks passed for both changed files; `git diff --check` passed.

Reproducer:

```python
from io import BytesIO
from datasets import Dataset

dataset = Dataset.from_dict({"value": [1, 2, 3]})
dataset.to_parquet(BytesIO(), compression="gzip")
```
