### PR TITLE
Fix infinite repetition of empty iterable datasets

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -2203,10 +2203,19 @@ class RepeatExamplesIterable(_BaseExamplesIterable):
 
     def __iter__(self):
         repeat_index = self._state_dict["repeat_index"] if self._state_dict else 0
+        first_iteration = True
         while True:
             if self.num_times is not None and repeat_index >= max(self.num_times, 0):
                 break
-            yield from self.ex_iterable
+            has_examples = False
+            for key_example in self.ex_iterable:
+                has_examples = True
+                yield key_example
+            # The first iteration may resume at the end of a non-empty input.
+            # Check a full repetition after resetting it before deciding to stop.
+            if self.num_times is None and not has_examples and not first_iteration:
+                break
+            first_iteration = False
             repeat_index += 1
             if self._state_dict:
                 self._state_dict["repeat_index"] = repeat_index
@@ -2214,10 +2223,17 @@ class RepeatExamplesIterable(_BaseExamplesIterable):
 
     def _iter_arrow(self):
         repeat_index = self._state_dict["repeat_index"] if self._state_dict else 0
+        first_iteration = True
         while True:
             if self.num_times is not None and repeat_index >= max(self.num_times, 0):
                 break
-            yield from self.ex_iterable.iter_arrow()
+            has_examples = False
+            for key, pa_table in self.ex_iterable.iter_arrow():
+                has_examples = has_examples or len(pa_table) > 0
+                yield key, pa_table
+            if self.num_times is None and not has_examples and not first_iteration:
+                break
+            first_iteration = False
             repeat_index += 1
             if self._state_dict:
                 self._state_dict["repeat_index"] = repeat_index
@@ -3955,6 +3971,8 @@ class IterableDataset(DatasetInfoMixin):
     def repeat(self, num_times: Optional[int]) -> "IterableDataset":
         """
         Create a new [`IterableDataset`] that repeats the underlying dataset `num_times` times.
+
+        An empty input terminates even when `num_times` is `None`.
 
         N.B. The effect of calling shuffle after repeat depends significantly on buffer size.
         With buffer_size 1, duplicate data is never seen in the same iteration, even after shuffling:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -1508,6 +1508,95 @@ def test_repeat_examples_iterable_without_arrow_stays_without_arrow():
     assert ex_iterable.iter_arrow is None
 
 
+@pytest.mark.parametrize("source_kind", ["examples", "arrow", "empty_arrow_table"])
+@pytest.mark.parametrize("with_state", [False, True])
+def test_repeat_empty_examples_iterable(source_kind, with_state):
+    starts = 0
+
+    def generate_empty():
+        nonlocal starts
+        starts += 1
+        if starts > 2:
+            pytest.fail("An empty input was restarted indefinitely")
+        if source_kind == "empty_arrow_table":
+            yield "empty", pa.table({"id": pa.array([], type=pa.int64())})
+
+    base_cls = ExamplesIterable if source_kind == "examples" else ArrowExamplesIterable
+    ex_iterable = RepeatExamplesIterable(base_cls(generate_empty, {}), num_times=None)
+    if with_state:
+        ex_iterable._init_state_dict()
+    if source_kind == "examples":
+        assert list(ex_iterable) == []
+    else:
+        assert [row for _, table in ex_iterable.iter_arrow() for row in table.to_pylist()] == []
+
+
+@pytest.mark.parametrize("source_kind", ["examples", "arrow"])
+@pytest.mark.parametrize("consume", [1, 3, 4, 6])
+def test_repeat_forever_resumes_at_repetition_boundary(source_kind, consume):
+    def generate():
+        for i in range(3):
+            yield {"id": i}
+
+    if source_kind == "examples":
+        base = IterableDataset.from_generator(generate)
+    else:
+        base = Dataset.from_dict({"id": list(range(3))}).to_iterable_dataset().with_format("arrow")
+
+    def take_ids(iterator, n):
+        return [row["id"][0].as_py() if isinstance(row, pa.Table) else row["id"] for row in islice(iterator, n)]
+
+    ds = base.repeat(None)
+    iterator = iter(ds)
+    assert take_ids(iterator, consume) == [i % 3 for i in range(consume)]
+    state = ds.state_dict()
+    resumed = base.repeat(None)
+    resumed.load_state_dict(state)
+    assert take_ids(resumed, 8) == [i % 3 for i in range(consume, consume + 8)]
+
+
+@pytest.mark.parametrize("num_times", [None, 2, 3])
+def test_repeat_dynamic_empty_first_iteration(num_times):
+    starts = 0
+
+    def generate():
+        nonlocal starts
+        starts += 1
+        if starts > 1:
+            yield 0, {"id": starts}
+
+    ex_iterable = RepeatExamplesIterable(ExamplesIterable(generate, {}), num_times=num_times)
+    if num_times is None:
+        assert [row for _, row in islice(ex_iterable, 3)] == [{"id": i} for i in range(2, 5)]
+    else:
+        assert [row for _, row in ex_iterable] == [{"id": i} for i in range(2, num_times + 1)]
+
+
+@pytest.mark.parametrize("format_type", [None, "arrow"])
+@pytest.mark.parametrize("rank", [0, 1])
+def test_iterable_dataset_repeat_filtered_empty_rank(format_type, rank):
+    calls = 0
+
+    def keep_second_shard(batch):
+        nonlocal calls
+        calls += 1
+        if calls > 4:
+            pytest.fail("An empty rank was restarted indefinitely")
+        if isinstance(batch, pa.Table):
+            return batch.filter(pc.greater_equal(batch["id"], 3))
+        return [i >= 3 for i in batch["id"]]
+
+    base = Dataset.from_dict({"id": list(range(6))}).to_iterable_dataset(num_shards=2)
+    ds = split_dataset_by_node(base, rank=rank, world_size=2).with_format(format_type)
+    transform = ds.map if format_type == "arrow" else ds.filter
+    ds = transform(keep_second_shard, batched=True, batch_size=3).repeat(None).take(4)
+    if format_type == "arrow":
+        rows = [row for table in ds for row in table.to_pylist()]
+    else:
+        rows = list(ds)
+    assert rows == ([] if rank == 0 else [{"id": i} for i in [3, 4, 5, 3]])
+
+
 def test_vertically_concatenated_examples_iterable():
     ex_iterable1 = ExamplesIterable(generate_examples_fn, {"label": 10})
     ex_iterable2 = ExamplesIterable(generate_examples_fn, {"label": 5})


### PR DESCRIPTION
Infinite repetition currently restarts an empty input indefinitely. For example, a streaming dataset filtered down to zero rows hangs in `dataset.repeat(None).take(1)` instead of finishing. The same problem affects an empty distributed shard and an Arrow input containing only zero-row tables.

Stop infinite repetition when a fresh pass over the input produces no examples. Allow the first pass to finish and reset before applying the check, because a restored checkpoint can be positioned just after the last example of a non-empty repetition. Keep the existing state dictionary schema and finite-repeat behavior unchanged, and count Arrow rows rather than yielded tables as progress.

Added regression coverage for empty example/Arrow inputs, zero-row tables, checkpoint restoration at and between repetition boundaries, dynamic inputs with an empty first pass, and filtered empty/non-empty ranks.

Validation:

- Six bounded empty-input regressions fail against the original runtime and pass with the fix. An independent subprocess also reproduces the public-API hang on the baseline.
- `python -m pytest -q tests/test_iterable_dataset.py -m "not integration"`: **484 passed, 32 skipped, 2 deselected** on Python 3.12 / Windows with CPU PyTorch. The two deselected tests require network integration; optional-dependency/platform skips remain.
- Both commands from `make quality` pass: `ruff check tests src benchmarks utils setup.py` and `ruff format --check tests src benchmarks utils setup.py` (236 files).
- `git diff --check` passes.

This change was implemented, tested, and independently reviewed with Codex assistance. Infinite repetition is not a polling API: a dynamic input that remains empty for a complete restarted pass now terminates.
