### PR TITLE
docs(builder): drop the stale verification_mode param from as_dataset's docstring

### DIFF
--- a/src/datasets/builder.py
+++ b/src/datasets/builder.py
@@ -998,11 +998,6 @@ class DatasetBuilder:
         Args:
             split (`datasets.Split`):
                 Which subset of the data to return.
-            verification_mode ([`VerificationMode`] or `str`, defaults to `BASIC_CHECKS`):
-                Verification mode determining the checks to run on the
-                downloaded/processed dataset information (checksums/size/splits/...).
-
-                <Added version="2.9.1"/>
             in_memory (`bool`, defaults to `False`):
                 Whether to copy the data in-memory.
 


### PR DESCRIPTION
`GeneratorBasedBuilder.as_dataset(self, split=None, in_memory=False)`'s docstring documents a `verification_mode` parameter (with an `<Added version="2.9.1"/>` tag). The parameter belongs to `download_and_prepare`, not `as_dataset`. The stale block is removed (the `download_and_prepare` docstring's own entry is untouched). Docs-only.