### PR TITLE
docs: point #map anchor links at the process guide

### DIFF
--- a/docs/source/about_map_batch.mdx
+++ b/docs/source/about_map_batch.mdx
@@ -8,7 +8,7 @@ The primary objective of batch mapping is to speed up processing. Often times, i
 
 ## Input size != output size
 
-The ability to control the size of the generated dataset can be leveraged for many interesting use-cases. In the How-to [map](#map) section, there are examples of using batch mapping to:
+The ability to control the size of the generated dataset can be leveraged for many interesting use-cases. In the How-to [map](/process#map) section, there are examples of using batch mapping to:
 
 - Split long sentences into shorter chunks.
 - Augment a dataset with additional tokens.

--- a/docs/source/stream.mdx
+++ b/docs/source/stream.mdx
@@ -448,7 +448,7 @@ You can filter rows in the dataset based on a predicate function using [`Dataset
 The `batch` method transforms your `IterableDataset` into an iterable of batches. This is particularly useful when you want to work with batches in your training loop or when using frameworks that expect batched inputs.
 
 > [!TIP]
-> There is also a "Batch Processing" option when using the `map` function to apply a function to batches of data, which is discussed in the [Map section](#map) above. The `batch` method described here is different and provides a more direct way to create batches from your dataset.
+> There is also a "Batch Processing" option when using the `map` function to apply a function to batches of data, which is discussed in the [Map section](/process#map). The `batch` method described here is different and provides a more direct way to create batches from your dataset.
 
 You can use the `batch` method like this:
 


### PR DESCRIPTION
`docs/source/about_map_batch.mdx` and `docs/source/stream.mdx` both link an in-page `#map` anchor, but neither file has a Map heading — the "Map" section lives in `docs/source/process.mdx` (`## Map`). Both links now target `/process#map` (doc-builder cross-file style).