### PR TITLE
docs: drop duplicated 'a' in the HubBucketDatasetModuleFactory docstring

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -844,7 +844,7 @@ class CachedDatasetModuleFactory(_DatasetModuleFactory):
 
 class HubBucketDatasetModuleFactory(_DatasetModuleFactory):
     """
-    Get the module of a dataset loaded from data files of a a Storage Bucket.
+    Get the module of a dataset loaded from data files of a Storage Bucket.
     The dataset builder module to use is inferred from the data files extensions.
     """
 


### PR DESCRIPTION
`src/datasets/load.py`: "dataset loaded from data files of **a a** Storage Bucket" → "of a Storage Bucket". Docs-only.