### PR TITLE
Keep every value of nested columns in Dataset.to_csv()

### DIFF
--- a/src/datasets/io/csv.py
+++ b/src/datasets/io/csv.py
@@ -1,8 +1,10 @@
 import multiprocessing
 import os
-from typing import BinaryIO, Optional, Union
+from typing import Any, BinaryIO, Optional, Union
 
 import fsspec
+import numpy as np
+import pyarrow as pa
 
 from .. import Dataset, Features, NamedSplit, config
 from ..formatting import query_table
@@ -10,6 +12,18 @@ from ..packaged_modules.csv.csv import Csv
 from ..utils import tqdm as hf_tqdm
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
+
+
+def _arrays_to_lists(obj: Any) -> Any:
+    """Replace the numpy arrays inside `obj` by lists, recursively."""
+    if isinstance(obj, np.ndarray):
+        return _arrays_to_lists(obj.tolist())
+    elif isinstance(obj, list):
+        return [_arrays_to_lists(value) for value in obj]
+    elif isinstance(obj, dict):
+        return {key: _arrays_to_lists(value) for key, value in obj.items()}
+    else:
+        return obj
 
 
 class CsvDatasetReader(AbstractDatasetReader):
@@ -105,9 +119,12 @@ class CsvDatasetWriter:
             key=slice(offset, offset + self.batch_size),
             indices=self.dataset._indices,
         )
-        csv_str = batch.to_pandas(integer_object_nulls=True).to_csv(
-            path_or_buf=None, header=header if (offset == 0) else False, index=index, **to_csv_kwargs
-        )
+        df = batch.to_pandas(integer_object_nulls=True)
+        for field in batch.schema:
+            # pandas renders an array-valued cell with numpy's repr, which elides values past numpy's threshold
+            if pa.types.is_nested(field.type) or isinstance(field.type, pa.ExtensionType):
+                df[field.name] = [_arrays_to_lists(value) for value in df[field.name]]
+        csv_str = df.to_csv(path_or_buf=None, header=header if (offset == 0) else False, index=index, **to_csv_kwargs)
         return csv_str.encode(self.encoding)
 
     def _write(self, file_obj: BinaryIO, header, index, **to_csv_kwargs) -> int:

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -1,10 +1,11 @@
+import ast
 import csv
 import os
 
 import fsspec
 import pytest
 
-from datasets import Dataset, DatasetDict, Features, NamedSplit, Value
+from datasets import Array2D, Dataset, DatasetDict, Features, NamedSplit, Value
 from datasets.io.csv import CsvDatasetReader, CsvDatasetWriter
 
 from ..utils import assert_arrow_memory_doesnt_increase, assert_arrow_memory_increases
@@ -189,3 +190,38 @@ def test_dataset_to_csv_preserves_nullable_int(dtype, big, tmp_path):
     with open(output_csv, newline="") as f:
         rows = list(csv.DictReader(f))
     assert [row["a"] for row in rows] == [str(big), "", "5"]
+
+
+def _written_cells(dataset, tmp_path, column):
+    output_csv = os.path.join(tmp_path, "out.csv")
+    CsvDatasetWriter(dataset, output_csv, num_proc=1).write()
+    with open(output_csv, newline="") as f:
+        return [row[column] for row in csv.DictReader(f)]
+
+
+# 1500 is above numpy's summarization threshold, 3 is below it
+@pytest.mark.parametrize("length", [3, 1500])
+def test_dataset_to_csv_keeps_every_value_of_a_list_column(length, tmp_path):
+    dataset = Dataset.from_dict({"a": [list(range(length))]})
+    cells = _written_cells(dataset, tmp_path, "a")
+    assert ast.literal_eval(cells[0]) == list(range(length))
+
+
+def test_dataset_to_csv_keeps_every_value_of_a_struct_column(tmp_path):
+    dataset = Dataset.from_dict({"a": [{"xs": list(range(1500)), "n": 1}]})
+    cells = _written_cells(dataset, tmp_path, "a")
+    assert ast.literal_eval(cells[0]) == {"xs": list(range(1500)), "n": 1}
+
+
+def test_dataset_to_csv_keeps_every_value_of_a_nested_list_column(tmp_path):
+    dataset = Dataset.from_dict({"a": [[[1, 2], [3, 4]]]})
+    cells = _written_cells(dataset, tmp_path, "a")
+    assert ast.literal_eval(cells[0]) == [[1, 2], [3, 4]]
+
+
+def test_dataset_to_csv_keeps_every_value_of_an_array_2d_column(tmp_path):
+    values = [[list(range(40)) for _ in range(40)]]
+    features = Features({"a": Array2D(shape=(40, 40), dtype="int64")})
+    dataset = Dataset.from_dict({"a": values}, features=features)
+    cells = _written_cells(dataset, tmp_path, "a")
+    assert ast.literal_eval(cells[0]) == values[0]


### PR DESCRIPTION
`to_csv()` hands the Arrow batch to pandas, and pandas renders a list cell with numpy's repr. So it comes out space separated, and past numpy's summarization threshold of 1000 the middle is elided: a 1500-element list is written as `[   0    1    2 ... 1497 1498 1499]` and 1494 values are gone. Struct columns and ArrayXD columns lose values the same way. `to_json()` on the same column round-trips exactly.

This replaces the numpy arrays with lists before pandas sees the frame, so `str()` prints all of them. Cells come out as `[0, 1, 2]` instead of `[0 1 2]`, which is what Dref360's `apply(list)` workaround in the issue produces, done in the writer instead.

It is a change to to_csv output for those columns, and Dref360 flagged that as wanting a greenlight from HF first. If you'd rather have `json.dumps` there, or not have it at all, say so and I'll change it.

Left `to_sql` alone: it doesn't lose anything, sqlite stored my 1500-element column as the array's raw buffer.

Tests cover a list of 3 and of 1500, a struct holding a list, a list of lists, and an Array2D. All five fail on main. `tests/io/` and the csv tests in `tests/test_arrow_dataset.py` still pass, ruff is clean.

Fixes #6778
