### PR TITLE
Fix the xml loader, which cannot load any file

### DIFF
--- a/src/datasets/packaged_modules/xml/xml.py
+++ b/src/datasets/packaged_modules/xml/xml.py
@@ -40,8 +40,13 @@ class Xml(datasets.ArrowBasedBuilder):
         for split_name, files in data_files.items():
             if isinstance(files, str):
                 files = [files]
-            files = [dl_manager.iter_files(file) for file in files]
-            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
+            files_iterables = [dl_manager.iter_files(file) for file in files]
+            splits.append(
+                datasets.SplitGenerator(
+                    name=split_name,
+                    gen_kwargs={"base_files": files, "files_iterables": files_iterables},
+                )
+            )
         return splits
 
     def _cast_table(self, pa_table: pa.Table) -> pa.Table:
@@ -57,14 +62,15 @@ class Xml(datasets.ArrowBasedBuilder):
         else:
             return pa_table.cast(pa.schema({"xml": pa.string()}))
 
-    def _generate_shards(self, files):
-        yield from files
+    def _generate_shards(self, base_files, files_iterables):
+        yield from base_files
 
-    def _generate_tables(self, files):
+    def _generate_tables(self, base_files, files_iterables):
         pa_table_names = list(self.config.features) if self.config.features is not None else ["xml"]
-        for file_idx, file in enumerate(files):
-            # open in text mode, by default translates universal newlines ("\n", "\r\n" and "\r") into "\n"
-            with open(file, encoding=self.config.encoding, errors=self.config.encoding_errors) as f:
-                xml = f.read()
-                pa_table = pa.Table.from_arrays([pa.array([xml])], names=pa_table_names)
-                yield (file_idx, 0), self._cast_table(pa_table)
+        for shard_idx, files_iterable in enumerate(files_iterables):
+            for file_idx, file in enumerate(files_iterable):
+                # open in text mode, by default translates universal newlines ("\n", "\r\n" and "\r") into "\n"
+                with open(file, encoding=self.config.encoding, errors=self.config.encoding_errors) as f:
+                    xml = f.read()
+                    pa_table = pa.Table.from_arrays([pa.array([xml])], names=pa_table_names)
+                    yield (shard_idx, file_idx), self._cast_table(pa_table)

--- a/tests/packaged_modules/test_xml.py
+++ b/tests/packaged_modules/test_xml.py
@@ -1,0 +1,69 @@
+import textwrap
+
+import pytest
+
+from datasets import load_dataset
+from datasets.builder import InvalidConfigName
+from datasets.data_files import DataFilesList
+from datasets.packaged_modules.xml.xml import XmlConfig
+
+
+@pytest.fixture
+def xml_file(tmp_path):
+    filename = tmp_path / "file.xml"
+    data = textwrap.dedent(
+        """\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <catalog>
+          <book id="1"><title>First</title></book>
+          <book id="2"><title>Second</title></book>
+        </catalog>
+        """
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def second_xml_file(tmp_path):
+    filename = tmp_path / "other.xml"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("<catalog><book id=\"3\"><title>Third</title></book></catalog>\n")
+    return str(filename)
+
+
+def test_config_raises_when_invalid_name() -> None:
+    with pytest.raises(InvalidConfigName, match="Bad characters"):
+        _ = XmlConfig(name="name-with-*-invalid-character")
+
+
+@pytest.mark.parametrize("data_files", ["str_path", ["str_path"], DataFilesList(["str_path"], [()])])
+def test_config_raises_when_invalid_data_files(data_files) -> None:
+    with pytest.raises(ValueError, match="Expected a DataFilesDict"):
+        _ = XmlConfig(name="name", data_files=data_files)
+
+
+def test_xml_load_single_file(xml_file):
+    """The whole document is read into one row under an `xml` column."""
+    ds = load_dataset("xml", data_files=xml_file, split="train")
+    assert ds.column_names == ["xml"]
+    assert ds.num_rows == 1
+    assert "<title>First</title>" in ds[0]["xml"]
+    assert "<title>Second</title>" in ds[0]["xml"]
+
+
+def test_xml_load_multiple_files(xml_file, second_xml_file):
+    """One row per file, in the order the files were given."""
+    ds = load_dataset("xml", data_files=[xml_file, second_xml_file], split="train")
+    assert ds.num_rows == 2
+    assert "<title>First</title>" in ds[0]["xml"]
+    assert "<title>Third</title>" in ds[1]["xml"]
+
+
+def test_xml_respects_encoding(tmp_path):
+    filename = tmp_path / "latin.xml"
+    with open(filename, "w", encoding="latin-1") as f:
+        f.write("<root><a>café</a></root>")
+    ds = load_dataset("xml", data_files=str(filename), split="train", encoding="latin-1")
+    assert "café" in ds[0]["xml"]


### PR DESCRIPTION
### The bug

`load_dataset("xml", ...)` fails for **every** input:

```python
open("a.xml", "w").write("<root><a>1</a></root>")
load_dataset("xml", data_files="a.xml", split="train")
```

```
DatasetGenerationError: An error occurred while generating the dataset
  caused by
FileNotFoundError: [Errno 2] No such file or directory:
  '<datasets.utils.file_utils.FilesIterable object at 0x10e41f260>'
```

The path in that message is a `repr`, which is the tell: a `FilesIterable` is being passed to `open()`.

### Cause

`_split_generators` wraps each file:

```python
files = [dl_manager.iter_files(file) for file in files]
```

so `gen_kwargs["files"]` is a list of `FilesIterable`, not paths. `_generate_tables` used to flatten it, but #7943 ("Add `_generate_shards`") removed that:

```diff
-        for file_idx, file in enumerate(itertools.chain.from_iterable(files)):
+        for file_idx, file in enumerate(files):
```

The `_split_generators` side was left wrapping, so the loop now opens the wrappers. `_generate_shards` has the same problem — it yields `FilesIterable` objects where the builder expects paths, so shard identifiers are wrong too.

### The fix

Every other module that calls `iter_files` — `text`, `csv`, `json`, `conll` — takes `base_files` and `files_iterables` and iterates the latter, yielding `base_files` for shards. The modules that keep the single-argument `files` form — `arrow`, `hdf5`, `pandas`, `cache`, `tsfile` — don't call `iter_files` at all.

`xml` was the only module with one foot in each convention. Moving it to the `base_files`/`files_iterables` form fixes both methods and matches its peers. Restoring the single `chain.from_iterable` call would fix loading but leave `_generate_shards` yielding wrappers.

### Verification

There was no `tests/packaged_modules/test_xml.py`, which is how this stayed broken. Added one covering a single file, multiple files, and `encoding`.

Against `main`: **3 failed, 4 passed** (the 4 are config-validation tests that never reach the loader). With the change: **7 passed**.
