### PR TITLE
Reject a non-callable generator in GeneratorConfig

### DIFF
--- a/src/datasets/packaged_modules/generator/generator.py
+++ b/src/datasets/packaged_modules/generator/generator.py
@@ -17,6 +17,11 @@ class GeneratorConfig(datasets.BuilderConfig):
         super().__post_init__()
         if self.generator is None:
             raise ValueError("generator must be specified")
+        if not callable(self.generator):
+            # Otherwise it is only called during generation, and the failure arrives as a
+            # bare "'X' object is not callable" wrapped in a DatasetGenerationError, which
+            # never mentions `generator`. Passing the data itself is an easy mistake.
+            raise TypeError(f"generator must be callable, but got {type(self.generator).__name__}")
 
         if self.gen_kwargs is None:
             self.gen_kwargs = {}

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4302,6 +4302,14 @@ def test_dataset_from_generator_features(features, data_generator, tmp_path):
     _check_generator_dataset(dataset, expected_features, NamedSplit("train"))
 
 
+@pytest.mark.parametrize("not_callable", ["a string", [{"a": 1}], 5, {"a": 1}])
+def test_dataset_from_generator_rejects_a_non_callable(not_callable):
+    """Passing the data instead of a function used to fail during generation, as a bare
+    "object is not callable" that never mentioned `generator`."""
+    with pytest.raises(TypeError, match="generator must be callable"):
+        Dataset.from_generator(not_callable)
+
+
 @pytest.mark.parametrize(
     "split",
     [None, NamedSplit("train"), "train", NamedSplit("foo"), "foo"],


### PR DESCRIPTION
### The bug

`GeneratorConfig` checks that `generator` is not `None`, but not that it is callable. A wrong type is only discovered during generation:

```python
Dataset.from_generator([{"a": 1}])
```

```
DatasetGenerationError: An error occurred while generating the dataset
  caused by
TypeError: 'list' object is not callable
```

Passing the data itself instead of a function that yields it is an easy mistake — `from_generator` reads like it takes a generator, and a list or a generator *object* both look plausible. Neither message names `generator`, so there is nothing pointing at the argument.

### The fix

Check it next to the existing `None` check, which is already in `__post_init__` for exactly this reason:

```
TypeError: generator must be callable, but got list
```

### Verification

The new test covers a string, a list, an int and a dict. All four fail on `main` and pass with the change:

```
without the fix:  FFFF
with the fix:     ....
```

The existing `from_generator` tests are unaffected — 18 passed. The diff to `tests/test_arrow_dataset.py` is purely additive; no existing test or parametrization is touched.
