### PR TITLE
Accept a single string for metadata_filenames in folder builders

### DIFF
--- a/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
+++ b/src/datasets/packaged_modules/folder_based_builder/folder_based_builder.py
@@ -32,11 +32,16 @@ class FolderBasedBuilderConfig(datasets.BuilderConfig):
     features: Optional[datasets.Features] = None
     drop_labels: bool = None
     drop_metadata: bool = None
-    metadata_filenames: list[str] = None
+    metadata_filenames: Union[str, list[str]] = None
     filters: Optional[Union[ds.Expression, list[tuple], list[list[tuple]]]] = None
 
     def __post_init__(self):
         super().__post_init__()
+        if isinstance(self.metadata_filenames, str):
+            # It is only ever used as `os.path.basename(file) in metadata_filenames`, so a
+            # bare string silently becomes a substring test: with "metadata.csv" a file
+            # called "data.csv" matches, and gets read as the metadata file.
+            self.metadata_filenames = [self.metadata_filenames]
 
 
 class FolderBasedBuilder(datasets.GeneratorBasedBuilder):

--- a/tests/packaged_modules/test_folder_based_builder.py
+++ b/tests/packaged_modules/test_folder_based_builder.py
@@ -568,6 +568,22 @@ def test_data_files_with_metadata_legitimate_subdir_reference(cache_dir, tmp_pat
     assert all(os.path.isfile(example["base"]) for example in examples)
 
 
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("metadata.csv", ["metadata.csv"]),
+        (["metadata.csv"], ["metadata.csv"]),
+        (["a.csv", "b.csv"], ["a.csv", "b.csv"]),
+        (None, None),
+    ],
+)
+def test_config_normalises_metadata_filenames(given, expected):
+    """A bare string is wrapped, because it is used with `in` and would otherwise
+    match on substrings -- "data.csv" is a substring of "metadata.csv"."""
+    config = FolderBasedBuilderConfig(name="name", metadata_filenames=given)
+    assert config.metadata_filenames == expected
+
+
 def test_data_files_with_custom_file_name_column_in_metadata_file(cache_dir, tmp_path, auto_text_file):
     data_dir = tmp_path / "data_dir_with_custom_file_name_metadata"
     data_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### The bug

`metadata_filenames` is only ever used as a membership test:

```python
metadata_filenames = self.config.metadata_filenames or self.METADATA_FILENAMES
...
elif os.path.basename(original_file) in metadata_filenames:
```

If it is a bare string rather than a list, `in` becomes a **substring** test:

```python
"data.csv"     in "metadata.csv"     ->  True     # wrong
"ata.csv"      in "metadata.csv"     ->  True     # wrong
"data.csv"     in ["metadata.csv"]   ->  False    # correct
```

`"data.csv"` is a substring of `"metadata.csv"`, and `data.csv` is a very ordinary filename to have sitting next to your images.

End to end, with one image and one `data.csv` in the folder:

```python
load_dataset("imagefolder", data_dir=d, metadata_filenames="metadata.csv", split="train")
# ValueError: `file_name`, `*_file_name`, `file_names` or `*_file_names` must be
#             present as dictionary key in metadata

load_dataset("imagefolder", data_dir=d, metadata_filenames=["metadata.csv"], split="train")
# rows=1 cols=['image']
```

The string form picks up `data.csv` as the metadata file and then complains that the metadata is missing a `file_name` column — sending you to inspect a file that is not metadata at all. There is nothing in the error about `metadata_filenames`.

### The fix

Wrap a string into a one-element list in `__post_init__`, and widen the annotation to `Union[str, list[str]]` to match.

I chose normalising over rejecting because it is what the library already does for the analogous arguments — `remove_columns`, `select_columns` and `input_columns` all accept `Union[str, list[str]]` and wrap a bare string. Happy to make it a `TypeError` instead if you would rather keep the type strict; it is the same one-line spot either way.

### Verification

New test covers a string, a one-element list, a multi-element list and `None`. It fails on `main` and passes with the change (1 failed -> 4 passed).

`test_folder_based_builder.py`, `test_imagefolder.py` and `test_audiofolder.py` together: **102 passed, 30 skipped**, unchanged from before.
