### PR TITLE
Preserve formatting selections when flattening nested columns

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -2317,6 +2317,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         """Flatten the table.
         Each column with a struct type is flattened into one column per struct field.
         Other columns are left unchanged.
+        Subfields inherit their parent column's formatting selection.
 
         Args:
             new_fingerprint (`str`, *optional*):
@@ -2354,6 +2355,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 break
         dataset.info.features = self._info.features.flatten(max_depth=max_depth)
         dataset.info.features = Features({col: dataset.info.features[col] for col in dataset.data.column_names})
+        if self._format_columns is not None:
+            formatted_features = Features({col: self._info.features[col] for col in self._format_columns})
+            dataset._format_columns = list(formatted_features.flatten(max_depth=max_depth))
         dataset._data = update_metadata_with_features(dataset._data, dataset.features)
         logger.info(f"Flattened dataset from depth {depth} to depth {1 if depth + 1 < max_depth else 'unknown'}.")
         dataset._fingerprint = new_fingerprint

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -997,6 +997,39 @@ class BaseDatasetTest(TestCase):
                         self.assertNotEqual(dset._fingerprint, fingerprint)
                         assert_arrow_metadata_are_synced_with_dataset_features(dset)
 
+    def test_flatten_formatted(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with Dataset.from_dict(
+                {"meta": [{"score": 1}, {"score": 2}], "label": ["a", "b"], "meta.extra": [3, 4]}
+            ) as dset:
+                with self._to(in_memory, tmp_dir, dset) as dset:
+                    dset.set_format("numpy", columns=["meta"], dtype=np.int32)
+                    with dset.flatten() as flattened:
+                        batch = flattened[:]
+                        self.assertEqual(set(batch), {"meta.score"})
+                        self.assertIsInstance(batch["meta.score"], np.ndarray)
+                        self.assertEqual(batch["meta.score"].dtype, np.int32)
+                        npt.assert_array_equal(batch["meta.score"], [1, 2])
+                    self.assertEqual(set(dset[:]), {"meta"})
+
+    def test_flatten_unformatted_struct(self, in_memory):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with Dataset.from_dict({"meta": [{"score": 1}, {"score": 2}], "label": [10, 20]}) as dset:
+                with self._to(in_memory, tmp_dir, dset) as dset:
+                    for output_all_columns in [False, True]:
+                        dset.set_format(
+                            "numpy", columns=["label"], dtype=np.int32, output_all_columns=output_all_columns
+                        )
+                        with self.subTest(output_all_columns=output_all_columns), dset.flatten() as flattened:
+                            batch = flattened[:]
+                            npt.assert_array_equal(batch["label"], [10, 20])
+                            self.assertEqual(batch["label"].dtype, np.int32)
+                            if output_all_columns:
+                                self.assertEqual(set(batch), {"label", "meta.score"})
+                                self.assertEqual(batch["meta.score"], [1, 2])
+                            else:
+                                self.assertEqual(set(batch), {"label"})
+
     @require_pil
     def test_flatten_complex_image(self, in_memory):
         # decoding turned on


### PR DESCRIPTION
## What this changes

I've fixed `flatten()` losing a selected struct's formatted columns. Its old name stays in the selection after flattening, so indexing can return an empty batch instead of the selected values.

The fix flattens the selected features alongside the schema. It keeps unselected descendants excluded and handles literal dotted column names without guessing from prefixes. The regressions cover in-memory and on-disk datasets, including `output_all_columns=True`.

Related: #4493.

## Tests

- Flatten/format/column-operation tests: 51 passed, 19 skipped, 4 subtests passed. Skips were optional-framework cases; one image-downcast warning was reported.
- Offline checks covered partial flattening, empty selections, excluded structs, dotted names and save/load round-trips.
- `make style` and `make quality` passed on the complete checkout.

Tested on Linux/CPU. The full Datasets suite was not run.

I used AI for this patch; this has been manually reviewed.
