### PR TITLE
Let TranslationVariableLanguages encode without declared languages

### DIFF
--- a/src/datasets/features/translation.py
+++ b/src/datasets/features/translation.py
@@ -97,10 +97,11 @@ class TranslationVariableLanguages:
         return pa.struct({"language": pa.list_(pa.string()), "translation": pa.list_(pa.string())})
 
     def encode_example(self, translation_dict):
-        lang_set = set(self.languages)
+        # `languages` is optional, so only build the valid set when there is one to build.
+        lang_set = set(self.languages) if self.languages else set()
         if set(translation_dict) == {"language", "translation"}:
             return translation_dict
-        elif self.languages and set(translation_dict) - lang_set:
+        elif lang_set and set(translation_dict) - lang_set:
             raise ValueError(
                 f"Some languages in example ({', '.join(sorted(set(translation_dict) - lang_set))}) are not in valid set ({', '.join(lang_set)})."
             )

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -469,6 +469,27 @@ def test_encode_column_dict_with_none():
     assert encoded_column == [{"a": 0, "b": 1}, None]
 
 
+def test_translation_variable_languages_encode_example_without_languages():
+    """`languages` is optional, so encoding must not require it."""
+    feature = TranslationVariableLanguages()
+    assert feature.languages is None
+
+    encoded = feature.encode_example({"en": "the cat", "fr": "le chat"})
+    assert encoded == {"language": ("en", "fr"), "translation": ("the cat", "le chat")}
+
+    dset = Dataset.from_dict(
+        {"col": [{"en": "the cat", "fr": "le chat"}]},
+        features=Features({"col": TranslationVariableLanguages()}),
+    )
+    assert dset[0]["col"] == {"language": ["en", "fr"], "translation": ["the cat", "le chat"]}
+
+
+def test_translation_variable_languages_still_validates_declared_languages():
+    feature = TranslationVariableLanguages(languages=["en", "fr"])
+    with pytest.raises(ValueError, match="are not in valid set"):
+        feature.encode_example({"en": "the cat", "de": "die katze"})
+
+
 @pytest.mark.parametrize(
     "feature",
     [


### PR DESCRIPTION
### What is wrong

`TranslationVariableLanguages` declares `languages` as optional, but building one without it makes every example fail to encode.

```python
>>> from datasets import Dataset, Features
>>> from datasets.features.translation import TranslationVariableLanguages
>>> TranslationVariableLanguages().encode_example({"en": "the cat", "fr": "le chat"})
TypeError: 'NoneType' object is not iterable
>>> Dataset.from_dict({"tr": [{"en": "the cat", "fr": "le chat"}]},
...                   features=Features({"tr": TranslationVariableLanguages()}))
TypeError: 'NoneType' object is not iterable
```

`languages: Optional[list] = None` is the declared default, `__post_init__` leaves it `None`, and `encode_example` already guards with `elif self.languages and ...` before validating. It just builds the set one line too early:

```python
lang_set = set(self.languages)          # raises when languages is None
if set(translation_dict) == {"language", "translation"}:
    return translation_dict
elif self.languages and set(translation_dict) - lang_set:
```

The guard on the next line shows `None` is expected here; only the eager `set()` call is not.

### What changed

Build the set only when there is one to build, and key the guard off it.

```python
lang_set = set(self.languages) if self.languages else set()
...
elif lang_set and set(translation_dict) - lang_set:
```

Validation with declared languages is unchanged, error message included.

### Test

Two tests in `tests/features/test_features.py`: one encodes without languages and round-trips through `Dataset.from_dict`, one pins that declared languages are still validated.

```
$ pytest tests/features/test_features.py -k translation_variable_languages
  on main:   1 failed, 1 passed   (TypeError: 'NoneType' object is not iterable)
  with this: 2 passed

$ pytest tests/features/test_features.py
  205 passed
```

`ruff check` and `ruff format --check` are clean on both files. Every existing test for this feature passes an explicit `languages=[...]`, which is why the default path was never exercised.
