### PR TITLE
Better error when a column written as null gets values in a later batch

### DIFF
--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -712,6 +712,23 @@ class ArrowWriter:
         self.write_examples_on_file()  # in case there are buffered examples to write first
         self._write_batch(batch_examples, writer_batch_size=writer_batch_size, try_original_type=try_original_type)
 
+    def _check_null_column(self, col: str, values):
+        """Raise an informative error if a column written as null gets values that are not None.
+
+        The schema is fixed when the first batch is written, so a column that only has None values
+        in the first batch keeps the null type for the rest of the file and can't hold values later.
+        """
+        if isinstance(values, (pa.Array, pa.ChunkedArray)):
+            has_values = values.null_count < len(values)
+        else:
+            has_values = any(value is not None for value in values)
+        if has_values:
+            raise TypeError(
+                f"Couldn't write column '{col}': its type in this file is null, because the first "
+                f"{self._num_examples} values written for it were all None. Set the type of '{col}' "
+                f"with features=, or make sure the first batch written contains a value that is not None."
+            )
+
     def _write_batch(
         self,
         batch_examples: dict[str, list],
@@ -736,6 +753,8 @@ class ArrowWriter:
         for col in cols:
             col_values = batch_examples[col]
             col_type = features[col] if features else None
+            if isinstance(col_type, Value) and col_type.dtype == "null":
+                self._check_null_column(col, col_values)
             if isinstance(col_values, (pa.Array, pa.ChunkedArray)):
                 array = cast_array_to_feature(col_values, col_type) if col_type is not None else col_values
                 arrays.append(array)
@@ -770,6 +789,9 @@ class ArrowWriter:
         if self.pa_writer is None:
             self._build_writer(inferred_schema=pa_table.schema)
         pa_table = pa_table.combine_chunks()
+        for field in self._schema:
+            if pa.types.is_null(field.type) and field.name in pa_table.column_names:
+                self._check_null_column(field.name, pa_table[field.name])
         pa_table = table_cast(pa_table, self._schema)
         if self.embed_local_files:
             pa_table = embed_table_storage(pa_table, local_files=True, remote_files=False)

--- a/tests/test_arrow_writer.py
+++ b/tests/test_arrow_writer.py
@@ -203,6 +203,36 @@ def test_write_row(fields, writer_batch_size):
     _check_output(output.getvalue(), expected_num_chunks=num_examples if writer_batch_size == 1 else 1)
 
 
+def test_write_batch_null_column_stays_null():
+    output = pa.BufferOutputStream()
+    with ArrowWriter(stream=output) as writer:
+        writer.write_batch({"col_1": ["foo", "bar"], "col_2": [None, None]})
+        writer.write_batch({"col_1": ["foobar"], "col_2": [None]})
+        num_examples, _ = writer.finalize()
+    assert num_examples == 3
+    assert writer._schema.field("col_2").type == pa.null()
+
+
+def test_write_batch_null_column_then_values():
+    output = pa.BufferOutputStream()
+    with ArrowWriter(stream=output) as writer:
+        writer.write_batch({"col_1": ["foo", "bar"], "col_2": [None, None]})
+        with pytest.raises(TypeError) as excinfo:
+            writer.write_batch({"col_1": ["foobar"], "col_2": [1]})
+    assert "the first 2 values written for it were all None" in str(excinfo.value)
+    assert "set the type of 'col_2' with features=" in str(excinfo.value).lower()
+
+
+def test_write_table_null_column_then_values():
+    output = pa.BufferOutputStream()
+    with ArrowWriter(stream=output) as writer:
+        writer.write_table(pa.Table.from_pydict({"col_1": ["foo", "bar"], "col_2": [None, None]}))
+        with pytest.raises(TypeError) as excinfo:
+            writer.write_table(pa.Table.from_pydict({"col_1": ["foobar"], "col_2": [1]}))
+    assert "the first 2 values written for it were all None" in str(excinfo.value)
+    assert "set the type of 'col_2' with features=" in str(excinfo.value).lower()
+
+
 def test_write_file():
     with tempfile.TemporaryDirectory() as tmp_dir:
         fields = {"col_1": pa.string(), "col_2": pa.int64()}


### PR DESCRIPTION
On #2831 the map still fails at HEAD, as `TypeError: Couldn't cast array of type double to null` now rather than `ArrowInvalid`. Your 2021 comment on that issue has the mechanism and both workarounds; the error itself says none of it.

So this does not change what the writer accepts. Before the cast, `ArrowWriter` now checks whether the schema has the column as null while the batch has values that are not None, and raises:

```
Couldn't write column 'labels': its type in this file is null, because the first 1000 values
written for it were all None. Set the type of 'labels' with features=, or make sure the first
batch written contains a value that is not None.
```

Both remedies are the ones from your comment and I ran them against the csv in the issue.

I did not try to promote the column instead. The stream schema is fixed once the first batch is on disk, so widening it means rewriting what is already written, and #4485 reads like a deliberate call that this cast should refuse rather than drop values.

The check sits in `_write_batch` and in `_write_table`, since both reach the cast and a batched map over arrow tables only goes through the second one.

Two tests, one per path, both fail on main. A third pins that a column which stays all None is still written as null.

Refs #2831
