### PR TITLE
fix(typing): Use Sequence instead of List for path_or_paths type annotations

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -35,8 +35,7 @@ import time
 import warnings
 import weakref
 from collections import Counter, defaultdict
-from collections.abc import Iterable, Iterator, Mapping
-from collections.abc import Sequence as Sequence_
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from copy import deepcopy
 from functools import partial, wraps
 from math import ceil, floor
@@ -644,7 +643,7 @@ class NonExistentDatasetError(Exception):
     pass
 
 
-class Column(Sequence_):
+class Column(Sequence):
     """
     An iterable for a specific column of a [`Dataset`].
 
@@ -1290,7 +1289,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_csv(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1430,7 +1429,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_json(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1489,7 +1488,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -1586,7 +1585,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
     @staticmethod
     def from_text(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         cache_dir: str = None,
@@ -4705,8 +4704,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
     @fingerprint_transform(inplace=False, ignore_kwargs=["load_from_cache_file", "indices_cache_file_name"])
     def sort(
         self,
-        column_names: Union[str, Sequence_[str]],
-        reverse: Union[bool, Sequence_[bool]] = False,
+        column_names: Union[str, Sequence[str]],
+        reverse: Union[bool, Sequence[bool]] = False,
         null_placement: str = "at_end",
         keep_in_memory: bool = False,
         load_from_cache_file: Optional[bool] = None,

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import time
 from collections import Counter
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from copy import copy, deepcopy
 from dataclasses import dataclass
 from functools import partial
@@ -3252,7 +3252,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_csv(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3295,7 +3295,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_json(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3342,7 +3342,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_parquet(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,
@@ -3427,7 +3427,7 @@ class IterableDataset(DatasetInfoMixin):
 
     @staticmethod
     def from_text(
-        path_or_paths: Union[PathLike, list[PathLike]],
+        path_or_paths: Union[PathLike, Sequence[PathLike]],
         split: Optional[NamedSplit] = None,
         features: Optional[Features] = None,
         keep_in_memory: bool = False,


### PR DESCRIPTION
This fixes mypy errors when passing list of paths to `Dataset.from_parquet()`, `from_csv()`, `from_json()`, `from_text()`, and `IterableDataset` equivalents.

**Problem**: `List` is invariant while `Sequence` is covariant, so passing a `List[str]` to a function expecting `Union[PathLike, List[PathLike]]` fails type checking.

**Solution**: Change `Union[PathLike, list[PathLike]]` to `Union[PathLike, Sequence[PathLike]]` in type annotations.

**Changes**:
- `src/datasets/arrow_dataset.py`: Updated imports and 5 method signatures (+ `sort()` method)
- `src/datasets/iterable_dataset.py`: Updated imports and 4 method signatures

Closes #5354