### PR TITLE
Preserve dataset metadata when map recombines shards

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -3651,7 +3651,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             result = all_transformed_shards[0]
         else:
             logger.info(f"Concatenating {num_shards} shards")
-            result = _concatenate_map_style_datasets(all_transformed_shards)
+            info = self.info.copy()
+            info.features = None
+            result = _concatenate_map_style_datasets(all_transformed_shards, info=info, split=self.split)
 
         # update fingerprint if the dataset changed
         result._fingerprint = (

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -4680,6 +4680,41 @@ def test_dataset_with_torch_dataloader(dataset, batch_size):
         assert getitem_call_count == len(dataset) // batch_size + int(len(dataset) % batch_size > 0)
 
 
+@pytest.mark.parametrize("num_proc", [None, 2])
+@pytest.mark.parametrize("null_first_shard", [False, True])
+@pytest.mark.parametrize("in_memory", [False, True])
+@pytest.mark.parametrize("feature", [Value("int64"), ClassLabel(names=["zero", "one", "two", "three"])])
+def test_map_preserves_metadata(tmp_path, num_proc, null_first_shard, in_memory, feature):
+    dataset = Dataset.from_dict(
+        {"text": ["0", "1", "2", "3"]},
+        info=DatasetInfo(config_name="clean", description="test description"),
+        split="validation",
+    )
+
+    def add_number(example):
+        number = int(example["text"])
+        return {"number": None if null_first_shard and number < 2 else number}
+
+    cache_file_name = None if in_memory else str(tmp_path / "mapped.arrow")
+    features = Features({"text": Value("string"), "number": feature})
+    for _ in range(1 if in_memory else 2):
+        mapped = dataset.map(
+            add_number,
+            num_proc=num_proc,
+            cache_file_name=cache_file_name,
+            features=features if isinstance(feature, ClassLabel) else None,
+        )
+        assert mapped.config_name == "clean"
+        assert mapped.split == "validation"
+        assert mapped.info.description == "test description"
+        assert mapped.features == features
+        assert mapped["number"][:] == ([None, None, 2, 3] if null_first_shard else [0, 1, 2, 3])
+        assert_arrow_metadata_are_synced_with_dataset_features(mapped)
+    assert dataset.features == Features({"text": Value("string")})
+    assert dataset.config_name == "clean"
+    assert dataset.split == "validation"
+
+
 @pytest.mark.parametrize("return_lazy_dict", [True, False, "mix"])
 def test_map_cases(return_lazy_dict):
     def f(x):


### PR DESCRIPTION
Fixes #5967.

When `Dataset.map()` recombines multiple shards, it drops the source split. It also loses metadata such as `config_name` when the shards infer different compatible features (for example, a new column is null throughout the first shard and integer-valued in the second).

Pass a copy of the source info and split into the shard concatenation, leaving features unset on that copy so they are inferred from the transformed table's aligned schema and metadata.

Validation:
- New regression tests: 8 failed / 8 passed before the fix. They cover single-process controls, multiprocessing, in-memory and cached results, a null first shard, explicit `ClassLabel` features, and unchanged source metadata/features.
- `PYTHONPATH=src HF_HUB_OFFLINE=1 HF_DATASETS_OFFLINE=1 .venv/bin/python -m pytest tests/test_arrow_dataset.py -k 'test_map_preserves_metadata or test_map_multiprocessing or test_map_new_features or test_map_remove_columns or test_concatenate' -q`: 49 passed, 391 deselected.
- `make quality`, `make style` and `git diff --check` passed.

Tested with Python 3.13.13 and PyArrow 25.0.1 using local data only. The full suite and Hub/network tests were not run.

Implemented and tested with OpenAI Codex, with independent read-only review by another Codex agent. [Issue coordination](https://github.com/huggingface/datasets/issues/5967#issuecomment-5604691865).
