### PR TITLE
Forward max_buffer_input_shards from IterableDatasetDict.shuffle

### DIFF
--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -2088,6 +2088,7 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         seed=None,
         generator: Optional[np.random.Generator] = None,
         buffer_size: int = 1000,
+        max_buffer_input_shards: int = 10,
     ) -> "IterableDatasetDict":
         """
         Randomly shuffles the elements of this dataset.
@@ -2115,6 +2116,8 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
                 If `generator=None` (default), uses `np.random.default_rng` (the default BitGenerator (PCG64) of NumPy).
             buffer_size (`int`, defaults to `1000`):
                 Size of the buffer.
+            max_buffer_input_shards (`int`, defaults to `10`):
+                Maximum number of shards to use to feed the buffer at a time.
 
         Example:
 
@@ -2139,7 +2142,12 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
         """
         return IterableDatasetDict(
             {
-                k: dataset.shuffle(seed=seed, generator=generator, buffer_size=buffer_size)
+                k: dataset.shuffle(
+                    seed=seed,
+                    generator=generator,
+                    buffer_size=buffer_size,
+                    max_buffer_input_shards=max_buffer_input_shards,
+                )
                 for k, dataset in self.items()
             }
         )

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -3866,7 +3866,7 @@ class IterableDataset(DatasetInfoMixin):
                 If `generator=None` (default), uses `np.random.default_rng` (the default BitGenerator (PCG64) of NumPy).
             buffer_size (`int`, defaults to `1000`):
                 Size of the buffer.
-            max_buffer_input_shards (`int`, defaults to `101000`):
+            max_buffer_input_shards (`int`, defaults to `10`):
                 Maximum number of shards to use to feed the buffer at a time.
 
         Example:

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -17,6 +17,7 @@ from packaging import version
 
 from datasets import Dataset, config, load_dataset
 from datasets.combine import concatenate_datasets, interleave_datasets
+from datasets.dataset_dict import IterableDatasetDict
 from datasets.distributed import split_dataset_by_node
 from datasets.features import (
     ClassLabel,
@@ -2038,6 +2039,17 @@ def test_iterable_dataset_shuffle_buffer_uses_multiple_input_shards():
     shuffled_ds = ds.shuffle(buffer_size=10, seed=1234, max_buffer_input_shards=4)
     shard_indices_of_first_ten_examples = {i // 10 for i in shuffled_ds.take(10)["i"]}
     assert 2 < len(shard_indices_of_first_ten_examples) <= 5
+
+
+def test_iterable_dataset_dict_shuffle_forwards_max_buffer_input_shards():
+    ds = IterableDataset.from_dict({"i": range(100)}, num_shards=10)
+    dsets = IterableDatasetDict({"train": ds})
+
+    # Same assertion as test_iterable_dataset_shuffle_buffer_uses_multiple_input_shards: without the
+    # argument reaching the split, the buffer interleaves far more than two shards.
+    shuffled_dsets = dsets.shuffle(buffer_size=10, seed=1234, max_buffer_input_shards=1)
+    shard_indices_of_first_ten_examples = {i // 10 for i in shuffled_dsets["train"].take(10)["i"]}
+    assert len(shard_indices_of_first_ten_examples) <= 2
 
 
 def gen_with_value(shard, value):


### PR DESCRIPTION
## What breaks

`load_dataset(..., streaming=True)` without a split returns an `IterableDatasetDict`, and shuffling it cannot reach the shard-interleaving control:

```python
ds = load_dataset("HuggingFaceFW/fineweb", streaming=True)
ds = ds.shuffle(seed=42, buffer_size=10_000, max_buffer_input_shards=4)
# TypeError: IterableDatasetDict.shuffle() got an unexpected keyword argument 'max_buffer_input_shards'
```

#8194 added `max_buffer_input_shards` to `IterableDataset.shuffle` and updated `docs/source/stream.mdx`, but not `dataset_dict.py`, so the per-split method has the argument and the dict wrapper silently does not. Every other `IterableDatasetDict.shuffle` argument is forwarded.

## Second, smaller thing in the same argument

Its docstring entry in `iterable_dataset.py` reads

```
max_buffer_input_shards (`int`, defaults to `101000`):
```

The signature says `max_buffer_input_shards: int = 10`, and `stream.mdx` says "default is 10". `101000` is the `10` and the neighbouring `buffer_size` default of `1000` run together.

## The change

Accept the argument on `IterableDatasetDict.shuffle` with the same default, document it with the same wording, and pass it to each split. Fix the stated default in the `IterableDataset.shuffle` docstring.

## Test

`test_iterable_dataset_dict_shuffle_forwards_max_buffer_input_shards` in `tests/test_iterable_dataset.py`, next to the existing `test_iterable_dataset_shuffle_buffer_uses_multiple_input_shards` and using its assertion: with `max_buffer_input_shards=1` the first ten examples must come from at most two shards, which only holds if the argument reaches the split.

```
tests/test_iterable_dataset.py -k input_shards
  before: 1 failed, 1 passed
          TypeError: IterableDatasetDict.shuffle() got an unexpected keyword argument 'max_buffer_input_shards'
  after:  2 passed

tests/test_iterable_dataset.py tests/test_dataset_dict.py
  559 passed, 9 skipped
```

`ruff check` and `ruff format --check` are clean on the three files.
