### PR TITLE
Fix decode(num_threads) busy-poll: bridge ThreadPool results to asyncio with callbacks

### DIFF
--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -5547,12 +5547,30 @@ def _split_by_node_iterable_dataset(
 
 
 async def _apply_async(pool, func, x):
-    future = pool.apply_async(func, (x,))
-    while True:
-        if future.ready():
-            return future.get()
-        else:
-            await asyncio.sleep(0)
+    # Bridge the pool result to asyncio with callbacks rather than polling `future.ready()`
+    # in an `await asyncio.sleep(0)` loop: one such hot loop per in-flight example keeps the
+    # event loop thread holding the GIL, starving the pool threads it is waiting on (#8595).
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    def _set_result(result):
+        if not future.done():
+            future.set_result(result)
+
+    def _set_exception(exc):
+        if not future.done():
+            future.set_exception(exc)
+
+    def _on_result(result):
+        if not loop.is_closed():
+            loop.call_soon_threadsafe(_set_result, result)
+
+    def _on_error(exc):
+        if not loop.is_closed():
+            loop.call_soon_threadsafe(_set_exception, exc)
+
+    pool.apply_async(func, (x,), callback=_on_result, error_callback=_on_error)
+    return await future
 
 
 def _batch_fn(unbatched):

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -3422,6 +3422,26 @@ def test_decode():
     assert DecodableFeature.decode_example_num_calls == 4
 
 
+def test_decode_num_threads_yields_all_examples():
+    data = [{"i": str(i)} for i in range(50)]
+    features = Features({"i": DecodableFeature()})
+    ds = IterableDataset.from_generator(lambda: (x for x in data), features=features)
+    ds = ds.decode(num_threads=4)
+    assert [example["i"] for example in ds] == ["decoded"] * 50
+
+
+def test_decode_num_threads_propagates_errors():
+    class FailingDecodableFeature(DecodableFeature):
+        def decode_example(self, example, token_per_repo_id=None):
+            raise ValueError("failed to decode")
+
+    features = Features({"i": FailingDecodableFeature()})
+    ds = IterableDataset.from_generator(lambda: iter([{"i": "0"}]), features=features)
+    ds = ds.decode(num_threads=2)
+    with pytest.raises(ValueError, match="failed to decode"):
+        list(ds)
+
+
 ############################
 #
 #   IterableColumn tests


### PR DESCRIPTION
Fixes #8595.

`_apply_async` polled `future.ready()` in an `await asyncio.sleep(0)` loop. With the in-flight cap at `2 * num_threads`, that many hot loops keep the event loop thread holding the GIL, starving the ThreadPool threads it is waiting on — in stack dumps a pool worker took 45+ seconds to get through `ssl.create_default_context` (a ~50 ms operation). On remote (`hf://` path-referenced) audio, `decode(num_threads=32)` yielded **0 rows** where sequential iteration worked fine, and `num_threads=4` was slower than `num_threads=0`.

This PR replaces the poll with callback-based bridging: `pool.apply_async(..., callback=..., error_callback=...)` resolves an asyncio future via `loop.call_soon_threadsafe`, so the event loop sleeps until a result actually arrives. Worker exceptions propagate through `error_callback` → `future.set_exception`, preserving the old `future.get()` semantics.

Measured on the public reproduction from #8595 (400 examples, audio referenced as `hf://datasets/datasets-examples/doc-audio-1/*.wav`, same machine):

| variant | throughput |
|---|---|
| sequential (`num_threads=0`) | 2.3 ex/s |
| `decode(num_threads=32)`, before | 0 rows in 155 s (killed) |
| `decode(num_threads=32)`, after | **45.5 ex/s, t_first 1.6 s** |

That is 19x over sequential — matching the ~20x reported when the feature was introduced in #7450.

Tests: added `test_decode_num_threads_yields_all_examples` (full iteration, `num_threads=4`) and `test_decode_num_threads_propagates_errors` (the `error_callback` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)