### PR TITLE
[httpx migration] Import httpx from huggingface_hub, require huggingface_hub>=1.31.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: uv pip install --system --upgrade pyarrow huggingface-hub "dill<0.3.9"
       - name: Install dependencies (minimum versions)
         if: ${{ matrix.deps_versions != 'deps-latest' }}
-        run: uv pip install --system pyarrow==24.0.0 huggingface-hub==0.25.0 transformers dill==0.3.1.1
+        run: uv pip install --system pyarrow==24.0.0 huggingface-hub==1.31.0 transformers dill==0.3.1.1
       - name: Print dependencies
         run: uv pip list
       - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -116,9 +116,6 @@ REQUIRED_PKGS = [
     "dill>=0.3.0,<0.4.2",  # tmp pin until dill has official support for determinism see https://github.com/uqfoundation/dill/issues/19
     # For performance gains with apache arrow
     "pandas",
-    # for downloading datasets over HTTPS
-    "requests>=2.32.2",
-    "httpx<1.0.0",
     # progress bars in downloads and data operations
     "tqdm>=4.66.3",
     # for fast hashing
@@ -129,7 +126,9 @@ REQUIRED_PKGS = [
     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
     "fsspec[http]>=2023.1.0,<=2026.7.0",
     # To get datasets from the Datasets Hub on huggingface.co
-    "huggingface-hub>=0.25.0,<2.0",
+    # (also provides the HTTP client: `from huggingface_hub.utils import httpx`)
+    # minimum 1.31.0 for the `huggingface_hub.utils.httpx` re-export
+    "huggingface-hub>=1.31.0,<2.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     # To parse YAML metadata from dataset cards

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -71,8 +71,9 @@ from huggingface_hub import (
     HfFileSystem,
     HfFileSystemResolvedPath,
 )
-from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, RepositoryNotFoundError
-from packaging import version
+from huggingface_hub.errors import BucketNotFoundError
+from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
+from huggingface_hub.utils import HfHubHTTPError, RepositoryNotFoundError
 from tqdm.contrib.concurrent import thread_map
 
 from . import __version__, config
@@ -140,16 +141,6 @@ from .utils.py_utils import (
 from .utils.stratify import stratified_shuffle_split_generate_indices
 from .utils.tf_utils import dataset_to_tf, minimal_tf_collate_fn, multiprocess_dataset_to_tf
 from .utils.typing import ListLike, PathLike
-
-
-if config.HF_HUB_VERSION >= version.parse("1.6.0"):
-    from huggingface_hub.errors import BucketNotFoundError
-    from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
-
-else:
-    BucketNotFoundError = None
-    HfFileSystemResolvedBucketPath = None
-    HfFileSystemResolvedRepositoryPath = HfFileSystemResolvedPath
 
 
 if TYPE_CHECKING:
@@ -6212,8 +6203,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
-            if BucketNotFoundError is None:
-                raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
             _, _namespace, _bucket_name, *_path_segments = repo_id.split("/")
             try:
                 bucket_id = api.bucket_info(_namespace + "/" + _bucket_name).id
@@ -6759,10 +6748,7 @@ def _push_to_repo(
         dirfs = DirFileSystem(fs=hffs, path=hf_path)
 
         # Check the files to delete
-        try:
-            files_to_delete = dirfs.glob(f"{data_dir}/{split}-*", detail=True)
-        except EntryNotFoundError:  # needed for huggingface_hub<=1.7.1
-            files_to_delete = {}
+        files_to_delete = dirfs.glob(f"{data_dir}/{split}-*", detail=True)
 
         # Don't delete the new files
         deletions = [
@@ -6849,10 +6835,7 @@ def _push_to_bucket(
     dirfs = DirFileSystem(fs=hffs, path=hf_path)
 
     # Check the files to delete before uploading
-    try:
-        files_to_delete = dirfs.glob(f"{data_dir}/{split}-*", detail=True)
-    except EntryNotFoundError:  # needed for huggingface_hub<=1.7.1
-        files_to_delete = {}
+    files_to_delete = dirfs.glob(f"{data_dir}/{split}-*", detail=True)
 
     # Upload the Parquet files
     _, new_parquet_paths, features, split_info, uploaded_size = dset._push_parquet_shards_to_hub(

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -21,10 +21,10 @@ from huggingface_hub import (
     CommitOperationDelete,
     HfApi,
     HfFileSystem,
-    HfFileSystemResolvedPath,
 )
-from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, RepositoryNotFoundError
-from packaging import version
+from huggingface_hub.errors import BucketNotFoundError
+from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
+from huggingface_hub.utils import HfHubHTTPError, RepositoryNotFoundError
 
 from . import __version__, config
 from .arrow_dataset import (
@@ -40,16 +40,6 @@ from .table import Table
 from .utils import logging
 from .utils.doc_utils import is_documented_by
 from .utils.typing import PathLike
-
-
-if config.HF_HUB_VERSION >= version.parse("1.6.0"):
-    from huggingface_hub.errors import BucketNotFoundError
-    from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
-
-else:
-    BucketNotFoundError = None
-    HfFileSystemResolvedBucketPath = None
-    HfFileSystemResolvedRepositoryPath = HfFileSystemResolvedPath
 
 
 logger = logging.get_logger(__name__)
@@ -1764,8 +1754,6 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
-            if BucketNotFoundError is None:
-                raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
             _, _namespace, _bucket_name, *_path_segments = repo_id.split("/")
             try:
                 bucket_id = api.bucket_info(_namespace + "/" + _bucket_name).id
@@ -2471,8 +2459,6 @@ class IterableDatasetDict(dict[Union[str, NamedSplit], IterableDataset]):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
-            if BucketNotFoundError is None:
-                raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
             _, _namespace, _bucket_name, *_path_segments = repo_id.split("/")
             try:
                 bucket_id = api.bucket_info(_namespace + "/" + _bucket_name).id
@@ -2634,10 +2620,7 @@ def _push_to_repo(
         dirfs = DirFileSystem(fs=hffs, path=hf_path)
 
         # Check the files to delete
-        try:
-            files_to_delete = list(dirfs.glob(f"{data_dir}/*"))
-        except EntryNotFoundError:  # needed for huggingface_hub<=1.7.1
-            files_to_delete = []
+        files_to_delete = list(dirfs.glob(f"{data_dir}/*"))
 
         # Don't delete the new files
         deletions = [
@@ -2726,10 +2709,7 @@ def _push_to_bucket(
     uploaded_sizes: list[int] = []
 
     # Check the files to delete before uploading
-    try:
-        files_to_delete = list(dirfs.glob(f"{data_dir}/*"))
-    except EntryNotFoundError:  # needed for huggingface_hub<=1.7.1
-        files_to_delete = []
+    files_to_delete = list(dirfs.glob(f"{data_dir}/*"))
 
     for split in dset_dict:
         # Upload the Parquet files

--- a/src/datasets/download/download_config.py
+++ b/src/datasets/download/download_config.py
@@ -21,6 +21,8 @@ class DownloadConfig:
             If `True`, resume the download if an incompletely received file is
             found.
         proxies (`dict`, *optional*):
+            Deprecated and ignored. Set the `HTTP_PROXY` / `HTTPS_PROXY` environment variables or configure the
+            HTTP client with [`huggingface_hub.set_client_factory`] instead.
         user_agent (`str`, *optional*):
             Optional string or dict that will be appended to the user-agent on remote
             requests.

--- a/src/datasets/iterable_dataset.py
+++ b/src/datasets/iterable_dataset.py
@@ -31,8 +31,9 @@ from huggingface_hub import (
     HfFileSystem,
     HfFileSystemResolvedPath,
 )
+from huggingface_hub.errors import BucketNotFoundError
+from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
 from huggingface_hub.utils import RepositoryNotFoundError
-from packaging import version
 
 from . import __version__, config
 from .arrow_dataset import Dataset, DatasetInfoMixin, _push_to_bucket, _push_to_repo
@@ -77,15 +78,6 @@ from .utils.py_utils import (
 from .utils.sharding import _merge_gen_kwargs, _number_of_shards_in_gen_kwargs, _shuffle_gen_kwargs, _split_gen_kwargs
 from .utils.typing import PathLike
 
-
-if config.HF_HUB_VERSION >= version.parse("1.6.0"):
-    from huggingface_hub.errors import BucketNotFoundError
-    from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
-
-else:
-    BucketNotFoundError = None
-    HfFileSystemResolvedBucketPath = None
-    HfFileSystemResolvedRepositoryPath = HfFileSystemResolvedPath
 
 if TYPE_CHECKING:
     import sqlite3
@@ -5259,8 +5251,6 @@ class IterableDataset(DatasetInfoMixin):
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
         if repo_id.startswith("buckets/"):
-            if BucketNotFoundError is None:
-                raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
             _, _namespace, _bucket_name, *_path_segments = repo_id.split("/")
             try:
                 bucket_id = api.bucket_info(_namespace + "/" + _bucket_name).id

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from typing import Any, Literal, Optional, Union, overload
 
 import fsspec
-import httpx
 import requests
 import yaml
 from fsspec.core import url_to_fs
@@ -41,6 +40,7 @@ from huggingface_hub.utils import (
     RepositoryNotFoundError,
     RevisionNotFoundError,
     get_session,
+    httpx,
 )
 from packaging import version
 

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -28,10 +28,10 @@ from pathlib import Path
 from typing import Any, Literal, Optional, Union, overload
 
 import fsspec
-import requests
 import yaml
 from fsspec.core import url_to_fs
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi, HfFileSystem
+from huggingface_hub.errors import BucketNotFoundError
 from huggingface_hub.utils import (
     EntryNotFoundError,
     GatedRepoError,
@@ -42,7 +42,6 @@ from huggingface_hub.utils import (
     get_session,
     httpx,
 )
-from packaging import version
 
 from . import __version__, config
 from .arrow_dataset import Dataset
@@ -90,13 +89,6 @@ from .utils.logging import get_logger
 from .utils.metadata import MetadataConfigs
 from .utils.typing import PathLike
 from .utils.version import Version
-
-
-if config.HF_HUB_VERSION >= version.parse("1.6.0"):
-    from huggingface_hub.errors import BucketNotFoundError
-
-else:
-    BucketNotFoundError = None
 
 
 logger = get_logger(__name__)
@@ -597,7 +589,6 @@ class HubDatasetModuleFactory(_DatasetModuleFactory):
                 filename=config.REPOCARD_FILENAME,
                 repo_type="dataset",
                 revision=self.commit_hash,
-                proxies=self.download_config.proxies,
             )
             dataset_card_data = DatasetCard.load(dataset_readme_path).data
         except EntryNotFoundError:
@@ -1073,8 +1064,6 @@ def dataset_module_factory(
         ).get_module()
     # Try remotely
     elif path.startswith("buckets/"):
-        if BucketNotFoundError is None:
-            raise ImportError("Loading datasets from buckets requires huggingface_hub>=1.6.0")
         # We check that the bucket exists, and the directory exists, and authentication in one call
         api = HfApi(
             endpoint=config.HF_ENDPOINT,
@@ -1088,13 +1077,7 @@ def dataset_module_factory(
         prefix = "/".join(s for s in _path_segments if s)
         try:
             next(iter(api.list_bucket_tree(bucket_id, prefix)))
-        except (
-            OfflineModeIsEnabled,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
-            httpx.ConnectError,
-            httpx.TimeoutException,
-        ) as e:
+        except (OfflineModeIsEnabled, httpx.ConnectError, httpx.TimeoutException) as e:
             raise ConnectionError(f"Couldn't reach '{path}' on the Hub ({e.__class__.__name__})") from e
         except StopIteration as e:
             raise DatasetNotFoundError(f"Bucket directory at {path} doesn't exist") from e
@@ -1125,20 +1108,10 @@ def dataset_module_factory(
                     filename=config.REPOCARD_FILENAME,
                     repo_type="dataset",
                     revision=revision,
-                    proxies=download_config.proxies,
                 )
                 commit_hash = os.path.basename(os.path.dirname(dataset_readme_path))
             except LocalEntryNotFoundError as e:
-                if isinstance(
-                    e.__cause__,
-                    (
-                        OfflineModeIsEnabled,
-                        requests.exceptions.Timeout,
-                        requests.exceptions.ConnectionError,
-                        httpx.ConnectError,
-                        httpx.TimeoutException,
-                    ),
-                ):
+                if isinstance(e.__cause__, (OfflineModeIsEnabled, httpx.ConnectError, httpx.TimeoutException)):
                     raise ConnectionError(f"Couldn't reach '{path}' on the Hub ({e.__class__.__name__})") from e
                 else:
                     raise
@@ -1148,13 +1121,7 @@ def dataset_module_factory(
                     revision=revision,
                     timeout=100.0,
                 ).sha
-            except (
-                OfflineModeIsEnabled,
-                requests.exceptions.Timeout,
-                requests.exceptions.ConnectionError,
-                httpx.ConnectError,
-                httpx.TimeoutException,
-            ) as e:
+            except (OfflineModeIsEnabled, httpx.ConnectError, httpx.TimeoutException) as e:
                 raise ConnectionError(f"Couldn't reach '{path}' on the Hub ({e.__class__.__name__})") from e
             except GatedRepoError as e:
                 message = f"Dataset '{path}' is a gated dataset on the Hub."
@@ -1171,7 +1138,6 @@ def dataset_module_factory(
                     filename=filename,
                     repo_type="dataset",
                     revision=commit_hash,
-                    proxies=download_config.proxies,
                 )
                 raise RuntimeError(f"Dataset scripts are no longer supported, but found {filename}")
             except EntryNotFoundError:

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -27,13 +27,12 @@ from urllib.parse import urlparse
 from xml.etree import ElementTree as ET
 
 import fsspec
-import httpx
 import huggingface_hub
 import huggingface_hub.errors
 import requests
 from fsspec.core import strip_protocol, url_to_fs
 from fsspec.utils import can_be_local
-from huggingface_hub.utils import get_session, insecure_hashlib
+from huggingface_hub.utils import get_session, httpx, insecure_hashlib
 from packaging import version
 
 from .. import __version__, config

--- a/src/datasets/utils/file_utils.py
+++ b/src/datasets/utils/file_utils.py
@@ -29,7 +29,6 @@ from xml.etree import ElementTree as ET
 import fsspec
 import huggingface_hub
 import huggingface_hub.errors
-import requests
 from fsspec.core import strip_protocol, url_to_fs
 from fsspec.utils import can_be_local
 from huggingface_hub.utils import get_session, httpx, insecure_hashlib
@@ -63,8 +62,6 @@ T = TypeVar("T", str, Path)
 CONNECTION_ERRORS_TO_RETRY = (
     _AiohttpClientError,
     asyncio.TimeoutError,
-    requests.exceptions.ConnectionError,
-    requests.exceptions.Timeout,
     httpx.RequestError,
 )
 SERVER_UNAVAILABLE_CODE = 504
@@ -150,7 +147,7 @@ def cached_path(
         ConnectionError: in case of unreachable url
             and no cache on disk
         ValueError: if it couldn't parse the url or filename correctly
-        httpx.NetworkError or requests.exceptions.ConnectionError: in case of internet connection issue
+        httpx.NetworkError: in case of internet connection issue
     """
     if download_config is None:
         download_config = DownloadConfig(**download_kwargs)
@@ -190,7 +187,6 @@ def cached_path(
                     revision=resolved_path.revision,
                     filename=resolved_path.path_in_repo,
                     force_download=download_config.force_download,
-                    proxies=download_config.proxies,
                 )
             except (
                 huggingface_hub.utils.RepositoryNotFoundError,

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -5,19 +5,11 @@ from contextlib import contextmanager
 from typing import Optional
 
 import pytest
+from huggingface_hub.errors import BucketNotFoundError
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import HfHubHTTPError, RepositoryNotFoundError
 from huggingface_hub.utils._headers import _http_user_agent
-from packaging import version
 
-from datasets import config
-
-
-if config.HF_HUB_VERSION >= version.parse("1.6.0"):
-    from huggingface_hub.errors import BucketNotFoundError
-
-else:
-    BucketNotFoundError = None
 
 CI_HUB_USER = "__DUMMY_DATASETS_USER__"
 CI_HUB_USER_FULL_NAME = "Dummy User"
@@ -33,13 +25,6 @@ def ci_hub_config(monkeypatch):
     monkeypatch.setattr("datasets.config.HF_ENDPOINT", CI_HUB_ENDPOINT)
     monkeypatch.setattr("datasets.config.HUB_DATASETS_URL", CI_HUB_DATASETS_URL)
     monkeypatch.setattr("huggingface_hub.constants.HUGGINGFACE_CO_URL_TEMPLATE", CI_HFH_HUGGINGFACE_CO_URL_TEMPLATE)
-    try:
-        # for backward compatibility with huggingface_hub 0.x
-        monkeypatch.setattr(
-            "huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE", CI_HFH_HUGGINGFACE_CO_URL_TEMPLATE
-        )
-    except AttributeError:
-        pass
     old_environ = dict(os.environ)
     os.environ["HF_ENDPOINT"] = CI_HUB_ENDPOINT
     yield

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -12,8 +12,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
-from huggingface_hub import HfFileSystemResolvedPath
-from packaging import version
+from huggingface_hub.hf_file_system import HfFileSystemResolvedRepositoryPath
 
 from datasets import Dataset, config, load_dataset
 from datasets.combine import concatenate_datasets, interleave_datasets
@@ -68,15 +67,6 @@ from .utils import (
     require_torchdata_stateful_dataloader,
 )
 
-
-if config.HF_HUB_VERSION >= version.parse("1.6.0"):
-    from huggingface_hub.errors import BucketNotFoundError
-    from huggingface_hub.hf_file_system import HfFileSystemResolvedBucketPath, HfFileSystemResolvedRepositoryPath
-
-else:
-    BucketNotFoundError = None
-    HfFileSystemResolvedBucketPath = None
-    HfFileSystemResolvedRepositoryPath = HfFileSystemResolvedPath
 
 SAMPLE_DATASET_IDENTIFIER = "hf-internal-testing/dataset_with_data_files"
 

--- a/tests/test_offline_util.py
+++ b/tests/test_offline_util.py
@@ -1,7 +1,6 @@
 from tempfile import NamedTemporaryFile
 
 import pytest
-import requests
 from huggingface_hub import get_session
 from huggingface_hub.errors import OfflineModeIsEnabled
 from huggingface_hub.utils import httpx
@@ -9,7 +8,6 @@ from huggingface_hub.utils import httpx
 from datasets.utils.file_utils import fsspec_get, fsspec_head
 
 from .utils import (
-    IS_HF_HUB_1_x,
     OfflineSimulationMode,
     RequestWouldHangIndefinitelyError,
     offline,
@@ -20,7 +18,7 @@ from .utils import (
 @pytest.mark.integration
 @require_not_windows  # fsspec get keeps a file handle on windows that raises PermissionError
 def test_offline_with_timeout():
-    expected_exception = httpx.ReadTimeout if IS_HF_HUB_1_x else requests.ConnectTimeout
+    expected_exception = httpx.ReadTimeout
     with offline(OfflineSimulationMode.CONNECTION_TIMES_OUT):
         with pytest.raises(RequestWouldHangIndefinitelyError):
             get_session().request("GET", "https://huggingface.co")
@@ -35,7 +33,7 @@ def test_offline_with_timeout():
 @pytest.mark.integration
 @require_not_windows  # fsspec get keeps a file handle on windows that raises PermissionError
 def test_offline_with_connection_error():
-    expected_exception = httpx.ConnectError if IS_HF_HUB_1_x else requests.ConnectionError
+    expected_exception = httpx.ConnectError
     with offline(OfflineSimulationMode.CONNECTION_FAILS):
         with pytest.raises(expected_exception):
             get_session().request("GET", "https://huggingface.co")

--- a/tests/test_offline_util.py
+++ b/tests/test_offline_util.py
@@ -1,10 +1,10 @@
 from tempfile import NamedTemporaryFile
 
-import httpx
 import pytest
 import requests
 from huggingface_hub import get_session
 from huggingface_hub.errors import OfflineModeIsEnabled
+from huggingface_hub.utils import httpx
 
 from datasets.utils.file_utils import fsspec_get, fsspec_head
 

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -40,7 +40,6 @@ from datasets.utils.hub import hf_dataset_url
 from .fixtures.hub import CI_HUB_ENDPOINT, CI_HUB_USER, CI_HUB_USER_TOKEN
 from .utils import (
     for_all_test_methods,
-    require_buckets_support_in_huggingface_hub,
     require_pil,
     require_torchcodec,
     xfail_if_500_502_http_error,
@@ -363,7 +362,6 @@ class TestPushToHub:
             assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
             assert local_ds["train"].features == hub_ds["train"].features
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_dataset_dict_to_hub_bucket(self, temporary_bucket):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
@@ -382,7 +380,6 @@ class TestPushToHub:
             files = sorted(item.path for item in self._api.list_bucket_tree(bucket_id, token=self._token))
             assert files == ["README.md", "data/train-00000-of-00001.parquet"]
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_dataset_dict_to_hub_bucket_inside_dir(self, temporary_bucket):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
@@ -403,7 +400,6 @@ class TestPushToHub:
             )
             assert files == ["my-dir/README.md", "my-dir/data/train-00000-of-00001.parquet"]
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_dataset_to_hub_bucket(self, temporary_bucket):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
@@ -420,7 +416,6 @@ class TestPushToHub:
             files = sorted(item.path for item in self._api.list_bucket_tree(bucket_id, token=self._token))
             assert files == ["README.md", "data/train-00000-of-00001.parquet"]
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_dataset_to_hub_bucket_inside_dir(self, temporary_bucket):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 
@@ -1020,7 +1015,6 @@ class TestPushToHub:
             files = sorted(self._api.list_repo_files(ds_name, repo_type="dataset", token=self._token))
             assert files == [".gitattributes", "README.md", "data/train-00000-of-00001.parquet"]
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_iterable_dataset_dict_to_hub_bucket(self, temporary_bucket):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}).to_iterable_dataset()
         local_ds = IterableDatasetDict({"train": ds})
@@ -1038,7 +1032,6 @@ class TestPushToHub:
             files = sorted(item.path for item in self._api.list_bucket_tree(bucket_id, token=self._token))
             assert files == ["README.md", "data/train-00000-of-00001.parquet"]
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_iterable_dataset_to_hub_bucket(self, temporary_bucket):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}).to_iterable_dataset()
 
@@ -1055,7 +1048,6 @@ class TestPushToHub:
             files = sorted(item.path for item in self._api.list_bucket_tree(bucket_id, token=self._token))
             assert files == ["README.md", "data/train-00000-of-00001.parquet"]
 
-    @require_buckets_support_in_huggingface_hub
     def test_push_sharded_iterable_dataset_to_hub_bucket(self, temporary_bucket):
         local_ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]}).to_iterable_dataset(num_shards=3)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,7 +15,6 @@ from unittest.mock import Mock, patch
 
 import pyarrow as pa
 import pytest
-import requests
 from huggingface_hub.utils import httpx
 from packaging import version
 
@@ -67,22 +66,6 @@ require_numpy1_on_windows = pytest.mark.skipif(
     version.parse(importlib.metadata.version("numpy")) >= version.parse("2.0.0") and sys.platform == "win32",
     reason="test requires numpy < 2.0 on windows",
 )
-
-IS_HF_HUB_1_x = config.HF_HUB_VERSION >= version.parse("0.99")  # clunky but works with pre-releases
-
-
-def require_buckets_support_in_huggingface_hub(test_case):
-    """
-    Decorator marking a test that requires buckets support in huggingface_hub.
-
-    These tests are skipped when huggingface_hub's version doesn't support buckets.
-
-    """
-    try:
-        from huggingface_hub.utils import BucketNotFoundError  # noqa
-    except ImportError:
-        test_case = unittest.skip("test requires buckets support in huggingface_hub")(test_case)
-    return test_case
 
 
 def require_regex(test_case):
@@ -463,8 +446,7 @@ def offline(mode: OfflineSimulationMode):
     HF_HUB_OFFLINE_SET_TO_1: the HF_HUB_OFFLINE_SET_TO_1 environment variable is set to 1.
         This makes the http/ftp calls of the library instantly fail and raise an OfflineModeEnabled error.
 
-    The raised exceptions are either from the `requests` library (if `huggingface_hub<1.0.0`)
-    or from the `httpx` library (if `huggingface_hub>=1.0.0`).
+    The raised exceptions come from the `httpx` library used by `huggingface_hub`.
     """
     # Enable offline mode
     if mode is OfflineSimulationMode.HF_HUB_OFFLINE_SET_TO_1:
@@ -476,13 +458,13 @@ def offline(mode: OfflineSimulationMode):
 
     def error_response(*args, **kwargs):
         if mode is OfflineSimulationMode.CONNECTION_FAILS:
-            exc = httpx.ConnectError if IS_HF_HUB_1_x else requests.ConnectionError
+            exc = httpx.ConnectError
         elif mode is OfflineSimulationMode.CONNECTION_TIMES_OUT:
             if kwargs.get("timeout") is None:
                 raise RequestWouldHangIndefinitelyError(
                     "Tried an HTTP call in offline mode with no timeout set. Please set a timeout."
                 )
-            exc = httpx.ReadTimeout if IS_HF_HUB_1_x else requests.ConnectTimeout
+            exc = httpx.ReadTimeout
         else:
             raise ValueError("Please use a value from the OfflineSimulationMode enum.")
         raise exc(f"Offline mode {mode}")
@@ -492,21 +474,16 @@ def offline(mode: OfflineSimulationMode):
     for method in ["head", "get", "post", "put", "delete", "request", "stream"]:
         setattr(client_mock, method, Mock(side_effect=error_response))
 
-    # Patching is slightly different depending on hfh internals
-    if IS_HF_HUB_1_x:
-        # Patching `_GLOBAL_CLIENT` alone is not enough: `_http_backoff` re-fetches the client on
-        # every attempt, and `close_session()` (called on `httpx.ConnectError`) resets the global to
-        # `None`. The first attempt would hit the mock, then the retry would rebuild a real client
-        # through the factory and reach the network. Patch the factory too so any client rebuilt
-        # mid-retry is the mock as well.
-        with (
-            patch("huggingface_hub.utils._http._GLOBAL_CLIENT", client_mock),
-            patch("huggingface_hub.utils._http._GLOBAL_CLIENT_FACTORY", lambda: client_mock),
-        ):
-            yield
-    else:
-        with patch("huggingface_hub.utils._http._get_session_from_cache", return_value=client_mock):
-            yield
+    # Patching `_GLOBAL_CLIENT` alone is not enough: `_http_backoff` re-fetches the client on
+    # every attempt, and `close_session()` (called on `httpx.ConnectError`) resets the global to
+    # `None`. The first attempt would hit the mock, then the retry would rebuild a real client
+    # through the factory and reach the network. Patch the factory too so any client rebuilt
+    # mid-retry is the mock as well.
+    with (
+        patch("huggingface_hub.utils._http._GLOBAL_CLIENT", client_mock),
+        patch("huggingface_hub.utils._http._GLOBAL_CLIENT_FACTORY", lambda: client_mock),
+    ):
+        yield
 
 
 @contextmanager
@@ -550,7 +527,7 @@ def xfail_if_500_502_http_error(func):
     def _wrapper(func, *args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (requests.HTTPError, httpx.HTTPError) as err:
+        except httpx.HTTPError as err:
             if str(err).startswith("500") or str(err).startswith("502"):
                 pytest.xfail(str(err))
             raise err

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,10 +13,10 @@ from importlib.util import find_spec
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import httpx
 import pyarrow as pa
 import pytest
 import requests
+from huggingface_hub.utils import httpx
 from packaging import version
 
 from datasets import config


### PR DESCRIPTION
Direct httpx imports will break when huggingface_hub migrates to httpx2. This updates them to use the compatibility re-export introduced in https://github.com/huggingface/huggingface_hub/pull/4803, following the migration plan in https://github.com/huggingface/huggingface_hub/issues/4802. Goal is to make datasets compatible with both huggingface_hub 1.x and 2.x when the switch to httpx2 happens.

Following https://github.com/huggingface/datasets/pull/8598#issuecomment-5621739103, this also bumps the minimum `huggingface_hub` version and removes the code that was only there to keep working with older releases.

### Minimum version

Bumped to `1.31.0` (in `setup.py` and in the "minimum versions" CI job) rather than `1.30.0`: `huggingface_hub.utils.httpx` landed in 1.31.0, not in 1.30.0 as the migration plan anticipated.

`requests` and `httpx` are also gone from the dependencies. `requests` was only needed for huggingface_hub 0.x, and pinning `httpx<1.0.0` here would defeat the purpose of the re-export — datasets should not constrain the httpx major version, huggingface_hub owns that now.

### Legacy code removed

- the `config.HF_HUB_VERSION >= 1.6.0` gates in `arrow_dataset.py`, `dataset_dict.py`, `iterable_dataset.py`, `load.py`, `tests/fixtures/hub.py` and `tests/test_iterable_dataset.py`, with the `BucketNotFoundError = None` / `HfFileSystemResolvedRepositoryPath = HfFileSystemResolvedPath` fallbacks and the matching `raise ImportError("... requires huggingface_hub>=1.6.0")` guards
- `except EntryNotFoundError` around `dirfs.glob(...)`, marked `# needed for huggingface_hub<=1.7.1`
- the `requests` exceptions caught next to their `httpx` counterparts in `load.py` and in `CONNECTION_ERRORS_TO_RETRY`
- `proxies=download_config.proxies` passed to `hf_hub_download`, which huggingface_hub has silently ignored since 1.0. `DownloadConfig.proxies` is kept for backward compatibility, with a docstring pointing at `HTTP_PROXY` / `set_client_factory`
- in the test helpers: `IS_HF_HUB_1_x` and its two branches in `offline()`, `require_buckets_support_in_huggingface_hub` (buckets are always available now), the `requests` half of `xfail_if_500_502_http_error`, and the `huggingface_hub.file_download.HUGGINGFACE_CO_URL_TEMPLATE` monkeypatch fallback

Once huggingface_hub 2.0 is out, the last step of the plan is to widen the pin to `<3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
