### PR TITLE
Decode BioSequence and BioStructure records with universal newlines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,8 @@ BENCHMARKS_REQUIRE = [
 ]
 
 TESTS_REQUIRE = [
+    # optional decoders exercised by the feature tests
+    "biopython>=1.80",
     # fix pip install issues for windows
     "numba>=0.56.4; python_version < '3.14'",  # to get recent versions of llvmlite for windows ci, not available on 3.14
     # test dependencies

--- a/src/datasets/features/bio_sequence.py
+++ b/src/datasets/features/bio_sequence.py
@@ -172,7 +172,7 @@ class BioSequence:
             with xopen(path, "r", encoding="utf-8", download_config=download_config) as f:
                 return self._first_record(f, path)
         else:
-            with StringIO(bytes_.decode("utf-8")) as f:
+            with StringIO(bytes_.decode("utf-8"), newline=None) as f:
                 return self._first_record(f, path)
 
     def _first_record(self, handle, path: Optional[str]) -> "SeqRecord":

--- a/src/datasets/features/bio_structure.py
+++ b/src/datasets/features/bio_structure.py
@@ -176,7 +176,7 @@ class BioStructure:
             with xopen(path, "r", encoding="utf-8", download_config=download_config) as f:
                 return self._parse(f, structure_id)
         else:
-            with StringIO(bytes_.decode("utf-8")) as f:
+            with StringIO(bytes_.decode("utf-8"), newline=None) as f:
                 return self._parse(f, structure_id)
 
     def _parse(self, handle, structure_id: str) -> "Structure":

--- a/tests/features/test_bio.py
+++ b/tests/features/test_bio.py
@@ -140,6 +140,31 @@ def test_bio_sequence_decodes_from_bytes(fasta_path):
 
 
 @require_biopython
+@pytest.mark.parametrize("format", ["fasta", "fastq"])
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"], ids=["lf", "crlf", "cr"])
+@pytest.mark.parametrize("source", ["bytes", "path"])
+def test_bio_sequence_decodes_universal_newlines(format, newline, source, tmp_path):
+    from Bio.SeqRecord import SeqRecord
+
+    data = (b">a\nACGT\n" if format == "fasta" else b"@a\nACGT\n+\nIIII\n").replace(b"\n", newline)
+    path = tmp_path / f"seq.{format}"
+    if source == "path":
+        path.write_bytes(data)
+    value = str(path) if source == "path" else data
+    ds = Dataset.from_dict({"seq": [value]}, features=Features({"seq": BioSequence(format=format)}))
+
+    record = ds[0]["seq"]
+    assert isinstance(record, SeqRecord)
+    assert (record.id, str(record.seq)) == ("a", "ACGT")
+    if format == "fastq":
+        assert record.letter_annotations["phred_quality"] == [40, 40, 40, 40]
+    raw = ds.cast_column("seq", BioSequence(format=format, decode=False))[0]["seq"]
+    assert raw == {"path": str(path) if source == "path" else None, "bytes": None if source == "path" else data}
+    if source == "path":
+        assert path.read_bytes() == data
+
+
+@require_biopython
 def test_bio_structure_decodes_to_structure(pdb_path):
     from Bio.PDB.Structure import Structure
 
@@ -148,6 +173,33 @@ def test_bio_structure_decodes_to_structure(pdb_path):
     assert isinstance(structure, Structure)
     assert [chain.id for chain in structure.get_chains()] == ["A"]
     assert len(list(structure.get_atoms())) == 2
+
+
+@require_biopython
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n", b"\r"], ids=["lf", "crlf", "cr"])
+@pytest.mark.parametrize("source", ["bytes", "path"])
+def test_bio_structure_decodes_universal_newlines(newline, source, tmp_path):
+    from Bio.PDB.Structure import Structure
+
+    data = PDB_BYTES.replace(b"\n", newline)
+    path = tmp_path / "structure.pdb"
+    if source == "path":
+        path.write_bytes(data)
+    value = str(path) if source == "path" else data
+    ds = Dataset.from_dict({"st": [value]}, features=Features({"st": BioStructure()}))
+
+    structure = ds[0]["st"]
+    assert isinstance(structure, Structure)
+    assert structure.id == "structure"
+    assert [chain.id for chain in structure.get_chains()] == ["A"]
+    atoms = list(structure.get_atoms())
+    assert [atom.id for atom in atoms] == ["N", "CA"]
+    assert atoms[0].coord.tolist() == pytest.approx([11.104, 13.207, 10.567])
+    assert atoms[1].coord.tolist() == pytest.approx([12.560, 13.099, 10.500])
+    raw = ds.cast_column("st", BioStructure(decode=False))[0]["st"]
+    assert raw == {"path": str(path) if source == "path" else None, "bytes": None if source == "path" else data}
+    if source == "path":
+        assert path.read_bytes() == data
 
 
 @require_biopython


### PR DESCRIPTION
`BioSequence.decode_example` and `BioStructure.decode_example` wrap the stored bytes in `StringIO` with its default newline handling, which only splits on `\n`. A record with bare-CR line endings therefore reaches Biopython as one line: FASTQ fails with "Unexpected end of file", FASTA decodes to an empty sequence, and a PDB record loses atoms. CRLF happened to work because a `\n` is present.

Both decoders now open the text with universal newlines. The stored bytes are not touched, so `decode=False` still returns the file exactly as read.

Tests cover LF, CRLF and CR inputs for FASTA, FASTQ and PDB, from bytes and from a path. `biopython` is added to the test requirements so these and the existing decode tests in `tests/features/test_bio.py` run in CI instead of being skipped.

Found while reviewing the loader adaptations in #7923 and #7924, where the `record` column keeps the file's original line endings.
