### PR TITLE
Add append=True to push_to_hub for incremental dataset updates

### DIFF
--- a/docs/source/upload_dataset.mdx
+++ b/docs/source/upload_dataset.mdx
@@ -105,6 +105,35 @@ To set your dataset as private, set the `private` parameter to `True`. This para
 
 To add a new configuration (or subset) to a dataset or to add a new split (train/validation/test), please refer to the [`Dataset.push_to_hub`] documentation.
 
+To append rows to an existing dataset repository, use `append=True` with [`Dataset.push_to_hub`] or
+[`DatasetDict.push_to_hub`]. The new rows must have the same features as the existing configuration.
+
+```py
+>>> new_rows.push_to_hub("stevhliu/processed_demo", split="train", append=True)
+>>> new_splits.push_to_hub("stevhliu/processed_demo", append=True, max_shard_size="500MB")
+```
+
+When the card has dataset statistics, appending downloads only the last Parquet shard selected by the
+configuration's `data_files` mapping for the requested split, following the mapping's order across all
+listed directories. It preserves that file's existing encoded row groups and adds the new rows. If the
+resulting file would exceed `max_shard_size`, the existing shard is kept and the new rows are written to
+additional shards. A single row can exceed this limit. Unchanged shards are renamed with server-side copies only when the shard
+count changes. PyArrow 21 and later enable content-defined chunking for the appended row groups so Xet
+can reuse existing chunks.
+
+With `num_shards`, specify the split's total shard count after appending, across all mapped directories.
+It cannot be smaller than the current count; keeping the same count extends the last shard without a
+size limit. Other splits and configurations are preserved. New or renumbered shards use `data_dir`, and
+the dataset card's row and size counts are updated. A new split is uploaded normally. If another push
+changes the repository during an append, the commit fails instead of overwriting those changes; retry
+against the updated repository.
+`append=False` (the default) keeps the usual replacement behavior. Appending is supported for dataset
+repositories, not buckets.
+
+If statistics are missing, they are recovered from the configuration's mapped files. Recovering byte
+counts requires reading those files in batches to measure Arrow memory sizes; Parquet encoding sizes
+are not used as dataset memory sizes.
+
 ### Privacy
 
 A private dataset is only accessible by you. Similarly, if you share a dataset within your organization, then members of the organization can also access the dataset.

--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -18,6 +18,7 @@
 import asyncio
 import contextlib
 import copy
+import fnmatch
 import glob
 import inspect
 import itertools
@@ -64,6 +65,7 @@ from fsspec.implementations.dirfs import DirFileSystem
 from huggingface_hub import (
     CommitInfo,
     CommitOperationAdd,
+    CommitOperationCopy,
     CommitOperationDelete,
     DatasetCard,
     DatasetCardData,
@@ -78,7 +80,11 @@ from tqdm.contrib.concurrent import thread_map
 from . import __version__, config
 from .arrow_reader import ArrowReader
 from .arrow_writer import ArrowWriter, OptimizedTypedSequence
-from .data_files import sanitize_patterns
+from .data_files import (
+    _is_inside_unrequested_special_dir,
+    _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir,
+    sanitize_patterns,
+)
 from .download.streaming_download_manager import xgetsize
 from .features import Audio, ClassLabel, Features, Image, List, Value, Video
 from .features.features import (
@@ -6062,14 +6068,17 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                     kwargs_iterable=kwargs_iterable,
                 )
             )
+            completed_jobs = {}
             for job_id, done, content in update_stream:
                 if not done:
                     pbar.update(content)
                 else:
-                    job_additions, job_new_parquet_paths, job_uploaded_size = content
-                    additions += job_additions
-                    new_parquet_paths += job_new_parquet_paths
-                    uploaded_size += job_uploaded_size
+                    completed_jobs[job_id] = content
+            for job_id in sorted(completed_jobs):
+                job_additions, job_new_parquet_paths, job_uploaded_size = completed_jobs[job_id]
+                additions += job_additions
+                new_parquet_paths += job_new_parquet_paths
+                uploaded_size += job_uploaded_size
 
         split_info = SplitInfo(name=split, num_bytes=dataset_nbytes, num_examples=len(self))
         return additions, new_parquet_paths, self.features, split_info, uploaded_size
@@ -6091,6 +6100,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         num_shards: Optional[int] = None,
         embed_external_files: bool = True,
         num_proc: Optional[int] = None,
+        append: bool = False,
     ) -> CommitInfo:
         """Pushes the dataset to the hub as a Parquet dataset.
         The dataset is pushed using HTTP requests and does not need to have neither git or git-lfs installed.
@@ -6160,6 +6170,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
 
                 <Added version="4.0.0"/>
 
+            append (`bool`, defaults to `False`):
+                Append rows to existing splits, preserving their features and rows. Only the last Parquet
+                shard in the card's mapping order, across all listed directories, is downloaded and
+                extended. If it would exceed `max_shard_size`, it is kept and
+                the new rows are written to new shards. With `num_shards`, specify the total number
+                of shards in the split after appending; it cannot be smaller than the existing count.
+                New or renumbered shards use `data_dir`. Other splits and configurations are preserved.
+                Supported for dataset repositories only.
+
         Return:
             huggingface_hub.CommitInfo
 
@@ -6211,6 +6230,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
             data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
+        if append and repo_id.startswith("buckets/"):
+            raise ValueError("append=True is only supported for dataset repositories, not buckets.")
         if repo_id.startswith("buckets/"):
             if BucketNotFoundError is None:
                 raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
@@ -6266,6 +6287,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 num_shards=num_shards,
                 embed_external_files=embed_external_files,
                 num_proc=num_proc,
+                append=append,
             )
 
     @transmit_format
@@ -6662,6 +6684,319 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
         return self.map(process_label_ids, features=features, batched=True, desc="Aligning the labels")
 
 
+def _get_available_parquet_split_name(split: str, data_dir: str, occupied_paths: set[str]) -> str:
+    """Reserve a filename prefix without changing the card's logical split name."""
+    prefix = "" if data_dir == "." else data_dir + "/"
+    name, generation = split, 0
+    while any(path.startswith(f"{prefix}{name}-") for path in occupied_paths):
+        generation += 1
+        name = f"{split}-append-{generation}"
+    return name
+
+
+def _prepare_parquet_append(
+    dset: "Dataset",
+    files: list,
+    fs: DirFileSystem,
+    temporary_dir: str,
+    data_dir: str,
+    split: str,
+    parent_commit: str,
+    max_shard_size: Optional[Union[int, str]],
+    num_shards: Optional[int],
+    embed_external_files: bool,
+    occupied_paths: set[str],
+    shared_paths: set[str],
+) -> tuple[list, int, int, dict[str, str]]:
+    """Prepare additions, byte counts, and path replacements within this split."""
+    from .io.parquet import _append_parquet_file, _get_parquet_features, _get_parquet_temporal_writer_options
+
+    old_count = len(files)
+    path_prefix = "" if data_dir == "." else data_dir + "/"
+    if num_shards is not None and num_shards < old_count:
+        raise ValueError(f"num_shards must be at least {old_count} when appending to split {split!r}.")
+    last = files[-1]
+    original = os.path.join(temporary_dir, "original.parquet")
+    fs.get_file(last.path, original)
+    import pyarrow.parquet as pq
+
+    old_features = Features.from_arrow_schema(pq.read_schema(original))
+    writer_options = _get_parquet_temporal_writer_options(pq.read_metadata(original))
+    if _get_parquet_features(dset.features, **writer_options) != _get_parquet_features(old_features, **writer_options):
+        raise ValueError(f"Features of appended rows must match the existing split: {dset.features} != {old_features}")
+    if not len(dset):
+        return [], 0, 0, {}
+
+    if embed_external_files and any(
+        require_decoding(feature, ignore_decode_attribute=True) for feature in dset.features.values()
+    ):
+        from .arrow_writer import get_writer_batch_size_from_features
+
+        batch_size = get_writer_batch_size_from_features(dset.features) or config.DEFAULT_MAX_BATCH_SIZE
+        dset = dset.with_format("arrow").map(
+            embed_table_storage,
+            batched=True,
+            batch_size=batch_size,
+            writer_batch_size=batch_size,
+            cache_file_name=os.path.join(temporary_dir, "embedded.arrow"),
+        )
+
+    max_size = convert_file_size_to_int(max_shard_size or config.MAX_SHARD_SIZE)
+    if max_size <= 0:
+        raise ValueError("max_shard_size must be greater than zero.")
+    appended = os.path.join(temporary_dir, "appended.parquet")
+    if num_shards is None or num_shards == old_count:
+        _append_parquet_file(dset, original, appended)
+        if num_shards == old_count or os.path.getsize(appended) <= max_size:
+            new_path = last.path
+            if last.path in shared_paths:
+                shard_name = _get_available_parquet_split_name(split, data_dir, occupied_paths)
+                new_path = f"{path_prefix}{shard_name}-{old_count - 1:05d}-of-{old_count:05d}.parquet"
+            return (
+                [CommitOperationAdd(path_in_repo=new_path, path_or_fileobj=appended)],
+                os.path.getsize(appended),
+                last.size,
+                {last.path: new_path} if new_path != last.path else {},
+            )
+
+    # Overflow leaves the old tail intact. Only new rows need to be partitioned.
+    new_files = []
+
+    def write_shard(shard):
+        path = os.path.join(temporary_dir, f"new-{len(new_files)}.parquet")
+        shard.to_parquet(path)
+        if num_shards is None and os.path.getsize(path) > max_size and len(shard) > 1:
+            # Estimates alone cannot bound compressed Parquet files (especially their footers).
+            middle = len(shard) // 2
+            write_shard(shard.select(range(middle)))
+            write_shard(shard.select(range(middle, len(shard))))
+        else:
+            new_files.append(path)
+
+    new_count = (
+        num_shards - old_count if num_shards is not None else max(1, int(dset._estimate_nbytes() / max_size) + 1)
+    )
+    new_count = min(new_count, len(dset)) if num_shards is None else new_count
+    for index in range(new_count):
+        write_shard(dset.shard(num_shards=new_count, index=index, contiguous=True))
+    total = old_count + len(new_files)
+    # Card mappings can partition a filename layout between splits/configurations.
+    # Allocate a fresh layout if the usual names would overwrite an unrelated file.
+    occupied_paths = occupied_paths - ({file.path for file in files} - shared_paths)
+    shard_name = _get_available_parquet_split_name(split, data_dir, occupied_paths)
+    new_paths = [f"{path_prefix}{shard_name}-{index:05d}-of-{total:05d}.parquet" for index in range(total)]
+    operations = []
+    for index, file in enumerate(files):
+        new_path = new_paths[index]
+        if file.path != new_path:
+            operations.append(
+                CommitOperationCopy(src_path_in_repo=file.path, path_in_repo=new_path, src_revision=parent_commit)
+            )
+    operations.extend(
+        CommitOperationDelete(path_in_repo=file.path)
+        for file in files
+        if file.path not in new_paths and file.path not in shared_paths
+    )
+    for index, path in enumerate(new_files, start=old_count):
+        operations.append(CommitOperationAdd(path_in_repo=new_paths[index], path_or_fileobj=path))
+    renames = {op.src_path_in_repo: op.path_in_repo for op in operations if isinstance(op, CommitOperationCopy)}
+    return operations, sum(os.path.getsize(path) for path in new_files), 0, renames
+
+
+def _append_to_repo(
+    dset_dict: dict[str, "Dataset"],
+    repo_id: str,
+    config_name: str,
+    set_default: Optional[bool],
+    data_dir: str,
+    commit_message: Optional[str],
+    commit_description: Optional[str],
+    token: Optional[str],
+    revision: Optional[str],
+    create_pr: Optional[bool],
+    max_shard_size: Optional[Union[int, str]],
+    num_shards: Optional[dict[str, Optional[int]]],
+    embed_external_files: bool,
+    num_proc: Optional[int],
+) -> CommitInfo:
+    """Append against a single snapshot so a concurrent push cannot silently discard rows."""
+    data_dir = posixpath.normpath(data_dir).lstrip("/") or "."
+    path_prefix = "" if data_dir == "." else data_dir + "/"
+    api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
+    parent_commit = api.repo_info(repo_id, repo_type="dataset", revision=revision).sha
+    snapshot = HfFileSystemResolvedRepositoryPath(
+        repo_id=repo_id, repo_type="dataset", revision=parent_commit, path_in_repo=""
+    )
+    fs = DirFileSystem(fs=HfFileSystem(endpoint=config.HF_ENDPOINT, token=token), path=snapshot.unresolve())
+    output = HfFileSystemResolvedRepositoryPath(
+        repo_id=repo_id, repo_type="dataset", revision=revision or "main", path_in_repo=""
+    )
+    try:
+        tree = list(
+            api.list_repo_tree(
+                repo_id,
+                repo_type="dataset",
+                revision=parent_commit,
+                recursive=True,
+            )
+        )
+    except EntryNotFoundError:
+        tree = []
+    try:
+        metadata_configs = MetadataConfigs.from_dataset_card_data(
+            DatasetCard(fs.read_text(config.REPOCARD_FILENAME, encoding="utf-8")).data
+        )
+    except FileNotFoundError:
+        metadata_configs = MetadataConfigs()
+    configured_data_files = metadata_configs.get(config_name, {}).get("data_files")
+    data_files = sanitize_patterns(configured_data_files) if configured_data_files is not None else None
+    file_owners = {}
+    for owner_config, metadata_config in metadata_configs.items():
+        for owner_split, patterns in sanitize_patterns(metadata_config.get("data_files", {})).items():
+            for path in _resolve_parquet_paths_for_append(fs, owner_split, patterns):
+                file_owners.setdefault(path, set()).add((owner_config, owner_split))
+    tree_by_path = {file.path: file for file in tree}
+    splits_info = [
+        SplitInfo(name=split, num_bytes=dset._estimate_nbytes() if len(dset) else 0, num_examples=len(dset))
+        for split, dset in dset_dict.items()
+    ]
+    features = next(iter(dset_dict.values())).features
+    # Validate card features before uploading anything, including when a different data_dir is used.
+    validated_card, _ = _get_updated_dataset_card(
+        fs,
+        config_name,
+        splits_info,
+        features,
+        data_dir,
+        set_default,
+        [0] * len(splits_info),
+        [0] * len(splits_info),
+        False,
+        append=True,
+    )
+    card_features = DatasetInfosDict.from_dataset_card_data(validated_card.data)[config_name].features
+    operations, additions, uploaded_sizes, deleted_sizes = [], [], [], []
+    split_parquet_paths, renamed_parquet_paths = {}, {}
+    with tempfile.TemporaryDirectory() as temporary_dir:
+        for index, (split, dset) in enumerate(dset_dict.items()):
+            if dset.features != card_features:
+                # Parquet-normalized types may agree while the card has a coarser
+                # logical unit. Use the reader's safe cast before preparing uploads.
+                dset = dset.cast(card_features, cache_file_name=os.path.join(temporary_dir, f"{split}.arrow"))
+                splits_info[index].num_bytes = dset._estimate_nbytes() if len(dset) else 0
+            pattern = re.compile(rf"{re.escape(path_prefix)}{re.escape(split)}-(\d{{5,}})-of-(\d{{5,}})\.parquet")
+            if data_files is not None:
+                paths = _resolve_parquet_paths_for_append(fs, split, data_files.get(split, []))
+                files = [tree_by_path[path] for path in paths]
+            else:
+                files = sorted(
+                    (file for file in tree if pattern.fullmatch(file.path)),
+                    key=lambda file: int(pattern.fullmatch(file.path)[1]),
+                )
+            if files:
+                if data_files is None:
+                    indices = [int(pattern.fullmatch(file.path)[1]) for file in files]
+                    totals = {int(pattern.fullmatch(file.path)[2]) for file in files}
+                    if indices != list(range(len(files))) or totals != {len(files)}:
+                        raise ValueError(
+                            f"Cannot append to split {split!r}: inconsistent Parquet shard numbering in {data_dir!r}."
+                        )
+                split_dir = os.path.join(temporary_dir, split)
+                os.makedirs(split_dir)
+                split_operations, uploaded_size, deleted_size, renames = _prepare_parquet_append(
+                    dset,
+                    files,
+                    fs,
+                    split_dir,
+                    data_dir,
+                    split,
+                    parent_commit,
+                    max_shard_size,
+                    (num_shards or {}).get(split),
+                    embed_external_files,
+                    set(tree_by_path) | {op.path_in_repo for op in operations},
+                    {path for path, owners in file_owners.items() if owners - {(config_name, split)}},
+                )
+                additions.extend(op for op in split_operations if isinstance(op, CommitOperationAdd))
+            else:
+                # Serialize a new split normally, reserving names before preupload
+                # so an unrelated file with a conventional name cannot be replaced.
+                shard_name = _get_available_parquet_split_name(
+                    split, data_dir, set(tree_by_path) | {op.path_in_repo for op in operations}
+                )
+                split_operations, _, _, _, uploaded_size = dset._push_parquet_shards_to_hub(
+                    resolved_output_path=output,
+                    data_dir=data_dir,
+                    split=shard_name,
+                    token=token,
+                    create_pr=create_pr,
+                    max_shard_size=max_shard_size,
+                    num_shards=(num_shards or {}).get(split),
+                    embed_external_files=embed_external_files,
+                    num_proc=num_proc,
+                )
+                deleted_size = 0
+                renames = {}
+            renamed_parquet_paths[split] = renames
+            split_parquet_paths[split] = list(
+                dict.fromkeys(
+                    [renames.get(file.path, file.path) for file in files]
+                    + [op.path_in_repo for op in split_operations if isinstance(op, CommitOperationAdd)]
+                )
+            )
+            operations.extend(split_operations)
+            uploaded_sizes.append(uploaded_size)
+            deleted_sizes.append(deleted_size)
+
+        final_parquet_paths = sorted(
+            (
+                {file.path for file in tree if file.path.endswith(".parquet")}
+                - {op.path_in_repo for op in operations if isinstance(op, CommitOperationDelete)}
+            )
+            | {op.path_in_repo for op in operations if isinstance(op, (CommitOperationAdd, CommitOperationCopy))}
+        )
+        card, legacy_infos = _get_updated_dataset_card(
+            fs,
+            config_name,
+            splits_info,
+            features,
+            data_dir,
+            set_default,
+            uploaded_sizes,
+            deleted_sizes,
+            False,
+            append=True,
+            new_parquet_paths=final_parquet_paths,
+            split_parquet_paths=split_parquet_paths,
+            renamed_parquet_paths=renamed_parquet_paths,
+        )
+        # New-split additions have already been preuploaded by the normal writer.
+        if additions:
+            api.preupload_lfs_files(
+                repo_id, additions=additions, repo_type="dataset", revision=revision, create_pr=create_pr
+            )
+        operations.append(
+            CommitOperationAdd(path_in_repo=config.REPOCARD_FILENAME, path_or_fileobj=str(card).encode())
+        )
+        if legacy_infos:
+            operations.append(
+                CommitOperationAdd(
+                    path_in_repo=config.DATASETDICT_INFOS_FILENAME,
+                    path_or_fileobj=json.dumps(legacy_infos).encode("utf-8"),
+                )
+            )
+        return api.create_commit(
+            repo_id,
+            operations=operations,
+            commit_message=commit_message or "Append dataset",
+            commit_description=commit_description,
+            repo_type="dataset",
+            revision=revision,
+            create_pr=create_pr,
+            parent_commit=parent_commit,
+        )
+
+
 def _push_to_repo(
     dset: Union["Dataset", "IterableDataset"],
     repo_id: str,
@@ -6678,7 +7013,25 @@ def _push_to_repo(
     num_shards: Optional[int] = None,
     embed_external_files: bool = True,
     num_proc: Optional[int] = None,
+    append: bool = False,
 ) -> CommitInfo:
+    if append:
+        return _append_to_repo(
+            {split: dset},
+            repo_id=repo_id,
+            config_name=config_name,
+            set_default=set_default,
+            data_dir=data_dir,
+            commit_message=commit_message,
+            commit_description=commit_description,
+            token=token,
+            revision=revision,
+            create_pr=create_pr,
+            max_shard_size=max_shard_size,
+            num_shards={split: num_shards},
+            embed_external_files=embed_external_files,
+            num_proc=num_proc,
+        )
     api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
     resolved_output_path = HfFileSystemResolvedRepositoryPath(
         repo_id=repo_id, repo_type="dataset", revision=revision or "main", path_in_repo=""
@@ -6899,6 +7252,150 @@ def _push_to_bucket(
     )
 
 
+def _get_parquet_patterns_for_append(
+    fs: DirFileSystem, config_name: str, data_dir: str, metadata_configs: MetadataConfigs
+) -> dict[str, list[str]]:
+    """Keep existing patterns, inferring the standard shard layout when metadata is absent."""
+    metadata_config = metadata_configs.get(config_name, {})
+    if "data_files" in metadata_config:
+        return sanitize_patterns(metadata_config["data_files"])
+    data_files = {}
+    # Only cards without a mapping need layout inference. An explicit mapping
+    # defines the configuration boundary, even if other splits share a directory.
+    directories = list(dict.fromkeys([config_name if config_name != "default" else "data", data_dir]))
+    for directory in directories:
+        prefix = "" if directory == "." else directory + "/"
+        pattern = re.compile(rf"{re.escape(prefix)}(.+)-\d{{5,}}-of-\d{{5,}}\.parquet")
+        try:
+            paths = fs.glob(f"{prefix}*.parquet")
+        except EntryNotFoundError:
+            paths = []
+        for path in paths:
+            if match := pattern.fullmatch(path):
+                inferred = data_files.setdefault(match[1], [])
+                split_pattern = f"{prefix}{match[1]}-*"
+                if split_pattern not in inferred:
+                    inferred.append(split_pattern)
+    return data_files
+
+
+def _resolve_parquet_paths_for_append(fs: DirFileSystem, split: str, patterns: list[str]) -> list[str]:
+    """Resolve every mapped Parquet file in card order, regardless of its filename."""
+    return list(
+        dict.fromkeys(
+            posixpath.normpath(path)
+            for pattern in patterns
+            for path in sorted(fs.glob(posixpath.normpath(pattern)))
+            if path.endswith(".parquet")
+            if not _is_inside_unrequested_special_dir(path, pattern)
+            if not _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir(path, pattern)
+        )
+    )
+
+
+def _get_parquet_info_for_append(
+    fs: DirFileSystem,
+    config_name: str,
+    data_dir: str,
+    metadata_configs: MetadataConfigs,
+    existing_info: Optional[DatasetInfo] = None,
+) -> DatasetInfo:
+    """Recover missing statistics within the configuration, decoding only unknown Arrow sizes."""
+    import pyarrow.parquet as pq
+
+    data_files = _get_parquet_patterns_for_append(fs, config_name, data_dir, metadata_configs)
+    info = DatasetInfo(config_name=config_name, splits=SplitDict(), download_size=0, dataset_size=0)
+    for split, patterns in data_files.items():
+        paths = _resolve_parquet_paths_for_append(fs, split, patterns)
+        if not paths:
+            continue
+        existing_split = (existing_info.splits or {}).get(split) if existing_info is not None else None
+        known_bytes = existing_split.num_bytes if existing_split is not None else None
+        split_info = SplitInfo(name=split, num_examples=0, num_bytes=known_bytes or 0)
+        for path in paths:
+            with fs.open(path, "rb") as file:
+                parquet = pq.ParquetFile(file)
+                metadata = parquet.metadata
+                if known_bytes is None:
+                    # Parquet's uncompressed sizes include encoding overhead. Decode
+                    # in bounded batches and discard redundant all-valid bitmaps so
+                    # these counts use Arrow buffers, just like newly appended rows.
+                    for batch in parquet.iter_batches():
+                        split_info.num_bytes += sum(pa.concat_arrays([column]).nbytes for column in batch.columns)
+            features = Features.from_arrow_schema(metadata.schema.to_arrow_schema())
+            if info.features is not None and info.features != features:
+                raise ValueError("Features of existing Parquet shards must match before appending.")
+            info.features = features
+            split_info.num_examples += metadata.num_rows
+            info.download_size += fs.size(path)
+        info.splits.add(split_info)
+        info.dataset_size += split_info.num_bytes
+    return info
+
+
+def _matches_repo_glob(path: str, pattern: str) -> bool:
+    """Match repo paths with directory-aware * and recursive **, as in data_files globs."""
+    if _is_inside_unrequested_special_dir(path, pattern) or (
+        _is_unrequested_hidden_file_or_is_inside_unrequested_hidden_dir(path, pattern)
+    ):
+        return False
+    path_parts, pattern_parts = path.split("/"), pattern.split("/")
+
+    def matches(parts, patterns):
+        if not patterns:
+            return not parts
+        if patterns[0] == "**":
+            return matches(parts, patterns[1:]) or bool(parts) and matches(parts[1:], patterns)
+        return bool(parts) and fnmatch.fnmatchcase(parts[0], patterns[0]) and matches(parts[1:], patterns[1:])
+
+    return matches(path_parts, pattern_parts)
+
+
+def _update_parquet_patterns_for_append(
+    fs: DirFileSystem,
+    split: str,
+    patterns: list[str],
+    paths: list[str],
+    renames: dict[str, str],
+    all_paths: list[str],
+    prefix: str,
+) -> list[str]:
+    """Replace renamed paths in place and cover only this split's added files."""
+    updated = []
+    insertion_index = None
+    for pattern in patterns:
+        matched = _resolve_parquet_paths_for_append(fs, split, [pattern])
+        if any(path in renames for path in matched) or any(
+            _matches_repo_glob(path, posixpath.normpath(pattern)) and path not in paths and path not in matched
+            for path in all_paths
+        ):
+            # Materialize globs that also include another split, so readers resolve
+            # the same files that were selected for this append.
+            updated.extend(renames.get(path, path) for path in matched)
+        else:
+            updated.append(pattern)
+        if any(path in renames or path in paths for path in matched):
+            insertion_index = len(updated)
+    uncovered = [
+        path for path in paths if not any(_matches_repo_glob(path, posixpath.normpath(pattern)) for pattern in updated)
+    ]
+    insertion_index = len(updated) if insertion_index is None else insertion_index
+    updated[insertion_index:insertion_index] = uncovered
+
+    # Use the conventional glob only when it resolves to exactly the same ordered
+    # files. In particular, never widen an explicit mapping into another split.
+    glob_paths = sorted(path for path in all_paths if _matches_repo_glob(path, prefix + "*"))
+    indices = [index for index, pattern in enumerate(updated) if pattern in glob_paths]
+    if (
+        indices
+        and updated != patterns
+        and indices == list(range(indices[0], indices[-1] + 1))
+        and [updated[index] for index in indices] == glob_paths
+    ):
+        updated[indices[0] : indices[-1] + 1] = [prefix + "*"]
+    return list(dict.fromkeys(updated))
+
+
 def _get_updated_dataset_card(
     fs: DirFileSystem,
     config_name: str,
@@ -6909,8 +7406,15 @@ def _get_updated_dataset_card(
     uploaded_sizes: list[int],
     deleted_sizes: list[int],
     remove_other_splits: bool,
+    append: bool = False,
+    new_parquet_paths: Optional[list[str]] = None,
+    split_parquet_paths: Optional[dict[str, list[str]]] = None,
+    renamed_parquet_paths: Optional[dict[str, dict[str, str]]] = None,
 ) -> tuple[DatasetCard, Optional[dict]]:
     """Update a dataset card in push_to_hub"""
+    if append:
+        from .io.parquet import _get_parquet_features
+
     # get the deprecated dataset_infos.json to update them
     try:
         legacy_dataset_info: dict = json.loads(fs.read_text(config.DATASETDICT_INFOS_FILENAME, encoding="utf-8")).get(
@@ -6928,23 +7432,61 @@ def _get_updated_dataset_card(
         dataset_infos: DatasetInfosDict = DatasetInfosDict.from_dataset_card_data(dataset_card_data)
         if dataset_infos and config_name in dataset_infos:
             repo_info = dataset_infos[config_name]
-        else:
+        elif not append:
             repo_info = None
     except FileNotFoundError:
         dataset_card = None
         dataset_card_data = DatasetCardData()
         metadata_configs = MetadataConfigs()
+    if append and "data_files" not in metadata_configs.get(config_name, {}):
+        inferred_patterns = _get_parquet_patterns_for_append(fs, config_name, data_dir, metadata_configs)
+        if inferred_patterns:
+            metadata_configs.setdefault(config_name, {})["data_files"] = [
+                {"split": split, "path": patterns} for split, patterns in inferred_patterns.items()
+            ]
+    if append and (
+        repo_info is None
+        or repo_info.features is None
+        or repo_info.splits is None
+        or repo_info.download_size is None
+        or repo_info.dataset_size is None
+    ):
+        recovered_info = _get_parquet_info_for_append(fs, config_name, data_dir, metadata_configs, repo_info)
+        if recovered_info.splits:
+            if repo_info is None:
+                repo_info = recovered_info
+            else:
+                if repo_info.features is None:
+                    repo_info.features = recovered_info.features
+                if repo_info.splits is None:
+                    repo_info.splits = recovered_info.splits
+                if repo_info.download_size is None:
+                    repo_info.download_size = recovered_info.download_size
+                if repo_info.dataset_size is None:
+                    repo_info.dataset_size = sum(split.num_bytes for split in repo_info.splits.values())
+
+    if append and repo_info is not None and repo_info.splits is None:
+        repo_info.splits = SplitDict()
+
     # update the total info to dump from existing info
     if repo_info is not None and not remove_other_splits:
         logger.info("Updating downloaded metadata with the new split" + ("s." if len(splits_info) > 1 else "."))
         for split_info, deleted_size, uploaded_size in zip(splits_info, deleted_sizes, uploaded_sizes):
             split = split_info.name
-            if repo_info.splits and any(s != split for s in repo_info.splits):
-                if features != repo_info.features:
+            if append or (repo_info.splits and any(s != split for s in repo_info.splits)):
+                if features != repo_info.features and (
+                    not append
+                    or repo_info.features is None
+                    or _get_parquet_features(features) != _get_parquet_features(repo_info.features)
+                ):
                     raise ValueError(
                         f"Features of the new split don't match the features of the existing splits on the hub: {features} != {repo_info.features}"
                     )
 
+            if append and split in repo_info.splits:
+                split_info = copy.deepcopy(split_info)
+                split_info.num_examples += repo_info.splits[split].num_examples
+                split_info.num_bytes += repo_info.splits[split].num_bytes
             if split in repo_info.splits:
                 repo_info.download_size -= deleted_size
                 repo_info.dataset_size -= repo_info.splits.get(split, SplitInfo()).num_bytes or 0
@@ -6990,15 +7532,30 @@ def _get_updated_dataset_card(
         # add the new splits
         for split_info in splits_info:
             split = split_info.name
-            data_files_to_dump[split] = [f"{data_dir}/{split}-*"]
+            if append:
+                prefix = ("" if data_dir == "." else data_dir + "/") + split + "-"
+                patterns = data_files_to_dump.setdefault(split, [])
+                if split_parquet_paths is not None:
+                    data_files_to_dump[split] = _update_parquet_patterns_for_append(
+                        fs,
+                        split,
+                        patterns,
+                        split_parquet_paths[split],
+                        (renamed_parquet_paths or {}).get(split, {}),
+                        new_parquet_paths or [],
+                        prefix,
+                    )
+            else:
+                data_files_to_dump[split] = [f"{data_dir}/{split}-*"]
         metadata_config_to_dump = {
+            **(metadata_config if append else {}),
             "data_files": [
                 {
                     "split": _split,
                     "path": _pattern[0] if len(_pattern) == 1 else _pattern,
                 }
                 for _split, _pattern in data_files_to_dump.items()
-            ]
+            ],
         }
     else:
         metadata_config_to_dump = {
@@ -7007,6 +7564,38 @@ def _get_updated_dataset_card(
             ]
         }
     configs_to_dump = {config_name: metadata_config_to_dump}
+    if append and new_parquet_paths is not None:
+        # Keep unmodified owners on their original ordered files. Retaining a
+        # shared source alone is insufficient if their glob also matches its copies.
+        for owner_config, original_config in metadata_configs.items():
+            if "data_files" not in original_config:
+                continue
+            updated_config = copy.deepcopy(configs_to_dump.get(owner_config, original_config))
+            updated_files = sanitize_patterns(updated_config["data_files"])
+            changed = False
+            for owner_split, patterns in sanitize_patterns(original_config["data_files"]).items():
+                if owner_config == config_name and owner_split in (split_parquet_paths or {}):
+                    continue
+                updated_patterns = []
+                for pattern in patterns:
+                    original_paths = _resolve_parquet_paths_for_append(fs, owner_split, [pattern])
+                    final_paths = [
+                        path for path in new_parquet_paths if _matches_repo_glob(path, posixpath.normpath(pattern))
+                    ]
+                    if original_paths != final_paths:
+                        # Every original match is retained, in the same order.
+                        updated_patterns.extend(original_paths)
+                    else:
+                        updated_patterns.append(pattern)
+                if updated_patterns != patterns:
+                    updated_files[owner_split] = updated_patterns
+                    changed = True
+            if changed:
+                updated_config["data_files"] = [
+                    {"split": split, "path": patterns[0] if len(patterns) == 1 else patterns}
+                    for split, patterns in updated_files.items()
+                ]
+                configs_to_dump[owner_config] = updated_config
     if set_default and config_name != "default":
         if metadata_configs:
             current_default_config_name = metadata_configs.get_default_config_name()

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -29,6 +29,7 @@ from packaging import version
 from . import __version__, config
 from .arrow_dataset import (
     Dataset,
+    _append_to_repo,
     _get_updated_dataset_card,
 )
 from .features import Features
@@ -1646,6 +1647,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
         num_shards: Optional[dict[str, int]] = None,
         embed_external_files: bool = True,
         num_proc: Optional[int] = None,
+        append: bool = False,
     ) -> Optional[CommitInfo]:
         """Pushes the [`DatasetDict`] to the hub as a Parquet dataset.
         The [`DatasetDict`] is pushed using HTTP requests and does not need to have neither git or git-lfs installed.
@@ -1716,6 +1718,15 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
 
                 <Added version="4.0.0"/>
 
+            append (`bool`, defaults to `False`):
+                Append rows to existing splits, preserving their features and rows. Only the last Parquet
+                shard in the card's mapping order, across all listed directories, is downloaded and
+                extended. If it would exceed `max_shard_size`, it is kept and
+                the new rows are written to new shards. With `num_shards`, specify the total number
+                of shards in the split after appending; it cannot be smaller than the existing count.
+                New or renumbered shards use `data_dir`. Other splits and configurations are preserved.
+                Supported for dataset repositories only.
+
         Return:
             huggingface_hub.CommitInfo
 
@@ -1763,6 +1774,8 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
             data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
 
         api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
+        if append and repo_id.startswith("buckets/"):
+            raise ValueError("append=True is only supported for dataset repositories, not buckets.")
         if repo_id.startswith("buckets/"):
             if BucketNotFoundError is None:
                 raise ImportError("Pushing datasets to buckets requires huggingface_hub>=1.6.0")
@@ -1816,6 +1829,7 @@ class DatasetDict(dict[Union[str, NamedSplit], "Dataset"]):
                 num_shards=num_shards,
                 embed_external_files=embed_external_files,
                 num_proc=num_proc,
+                append=append,
             )
 
 
@@ -2541,7 +2555,25 @@ def _push_to_repo(
     num_shards: Optional[dict[str, Optional[int]]] = None,
     embed_external_files: bool = True,
     num_proc: Optional[int] = None,
+    append: bool = False,
 ) -> CommitInfo:
+    if append:
+        return _append_to_repo(
+            dset_dict,
+            repo_id=repo_id,
+            config_name=config_name,
+            set_default=set_default,
+            data_dir=data_dir,
+            commit_message=commit_message,
+            commit_description=commit_description,
+            token=token,
+            revision=revision,
+            create_pr=create_pr,
+            max_shard_size=max_shard_size,
+            num_shards=num_shards,
+            embed_external_files=embed_external_files,
+            num_proc=num_proc,
+        )
     api = HfApi(endpoint=config.HF_ENDPOINT, token=token, library_name="datasets", library_version=__version__)
     resolved_output_path = HfFileSystemResolvedRepositoryPath(
         repo_id=repo_id, repo_type="dataset", revision=revision or "main", path_in_repo=""

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -3,7 +3,9 @@ import os
 from typing import BinaryIO, Optional, Union
 
 import fsspec
+import pyarrow as pa
 import pyarrow.parquet as pq
+from packaging import version
 
 from .. import Dataset, Features, NamedSplit, config
 from ..arrow_writer import get_writer_batch_size_from_data_size, get_writer_batch_size_from_features
@@ -14,6 +16,125 @@ from ..packaged_modules.parquet.parquet import Parquet
 from ..utils import tqdm as hf_tqdm
 from ..utils.typing import NestedDataStructureLike, PathLike
 from .abc import AbstractDatasetReader
+
+
+def _get_parquet_features(features: Features, **writer_options) -> Features:
+    """Round-trip feature metadata through the schema conversion used by the Parquet reader."""
+    buffer = pa.BufferOutputStream()
+    pq.write_metadata(features.arrow_schema, buffer, **writer_options)
+    return Features.from_arrow_schema(pq.read_schema(pa.BufferReader(buffer.getvalue())))
+
+
+def _get_parquet_temporal_writer_options(metadata: pq.FileMetaData) -> dict:
+    """Recover temporal annotations from every physical leaf, including nested columns."""
+    logical_types = [json.loads(metadata.schema.column(i).logical_type.to_json()) for i in range(metadata.num_columns)]
+    options = {}
+    if any(logical.get("Type") == "Time" and logical["isAdjustedToUTC"] for logical in logical_types):
+        options["write_time_adjusted_to_utc"] = True
+    timestamp_units = {logical["timeUnit"] for logical in logical_types if logical.get("Type") == "Timestamp"}
+    if len(timestamp_units) == 1:
+        unit = {"milliseconds": "ms", "microseconds": "us"}.get(next(iter(timestamp_units)))
+        if unit is not None:
+            # The footer stores the effective precision, not the original truncation
+            # policy. Quantize new values to that precision, as the original writer did.
+            options.update(coerce_timestamps=unit, allow_truncated_timestamps=True)
+    return options
+
+
+def _append_parquet_file(dataset: Dataset, original: str, destination: str) -> None:
+    """Preserve the encoded row groups and page indexes, then append rows and a combined footer."""
+    metadata = pq.read_metadata(original)
+    schema = metadata.schema.to_arrow_schema()
+    row_group_size = max(
+        (metadata.row_group(i).num_rows for i in range(metadata.num_row_groups)),
+        default=0,
+    ) or get_writer_batch_size_from_data_size(len(dataset), dataset._estimate_nbytes())
+    writer_options = (
+        {"use_content_defined_chunking": True} if config.PYARROW_VERSION >= version.parse("21.0.0") else {}
+    )
+    writer_options.update(_get_parquet_temporal_writer_options(metadata))
+    # Preserve the physical list schema of shards produced before Arrow's compliant-list default.
+    writer_options["use_compliant_nested_type"] = not any(
+        ".list." in metadata.schema.column(i).path
+        and metadata.schema.column(i).path.split(".list.", 1)[1].split(".")[0] != "element"
+        for i in range(metadata.num_columns)
+    )
+    writer_options["use_deprecated_int96_timestamps"] = any(
+        metadata.schema.column(i).physical_type == "INT96" for i in range(metadata.num_columns)
+    )
+    writer_options["store_decimal_as_integer"] = any(
+        metadata.schema.column(i).converted_type == "DECIMAL"
+        and metadata.schema.column(i).physical_type in {"INT32", "INT64"}
+        for i in range(metadata.num_columns)
+    )
+    writer_options["version"] = metadata.format_version
+    if metadata.num_row_groups:
+        # Properties are per physical leaf, including nested columns. Reuse the
+        # tail's codecs and encodings rather than the Dataset writer's defaults.
+        row_group = metadata.row_group(metadata.num_row_groups - 1)
+        columns = [row_group.column(i) for i in range(metadata.num_columns)]
+        dictionary_columns = [
+            column.path_in_schema
+            for column in columns
+            if {"PLAIN_DICTIONARY", "RLE_DICTIONARY"}.intersection(column.encodings)
+        ]
+        writer_options.update(
+            compression={
+                column.path_in_schema: "none" if column.compression == "UNCOMPRESSED" else column.compression.lower()
+                for column in columns
+            },
+            use_dictionary=dictionary_columns,
+            column_encoding={
+                column.path_in_schema: encoding
+                for column in columns
+                if column.path_in_schema not in dictionary_columns
+                for encoding in column.encodings
+                if encoding
+                in {"PLAIN", "BYTE_STREAM_SPLIT", "DELTA_BINARY_PACKED", "DELTA_LENGTH_BYTE_ARRAY", "DELTA_BYTE_ARRAY"}
+            },
+            write_statistics=[column.path_in_schema for column in columns if column.is_stats_set],
+            write_page_index=any(column.has_column_index or column.has_offset_index for column in columns),
+        )
+    new_metadata = []
+    with open(original, "rb") as source, pa.OSFile(destination, "wb") as sink:
+        source.seek(-8, os.SEEK_END)
+        footer_size = int.from_bytes(source.read(4), "little")
+        prefix_size = source.tell() - 4 - footer_size
+        source.seek(4)  # The writer emits the initial PAR1 magic itself.
+        with pq.ParquetWriter(
+            sink,
+            schema=schema,
+            metadata_collector=new_metadata,
+            **writer_options,
+        ) as writer:
+            # Write through the same Arrow sink so the new column/page offsets include the old bytes.
+            # Re-encoding old row groups would move their page indexes and could change their encoding.
+            remaining = prefix_size - 4
+            while remaining:
+                block = source.read(min(remaining, 1024 * 1024))
+                if not block:
+                    raise ValueError("Unexpected end of the existing Parquet shard")
+                sink.write(block)
+                remaining -= len(block)
+            for batch in dataset.with_format("arrow").iter(batch_size=row_group_size):
+                writer.write_table(
+                    batch.select(schema.names).cast(
+                        schema, safe=not writer_options.get("allow_truncated_timestamps", False)
+                    ),
+                    row_group_size=row_group_size,
+                )
+
+    metadata.append_row_groups(new_metadata[0])
+    footer = pa.BufferOutputStream()
+    metadata.write_metadata_file(footer)
+    # Replace the new-only footer with the combined footer. All column and page-index offsets
+    # already refer to their final positions; neither the old nor new data needs to be moved.
+    with open(destination, "r+b") as output:
+        output.seek(-8, os.SEEK_END)
+        footer_size = int.from_bytes(output.read(4), "little")
+        output.seek(-footer_size - 8, os.SEEK_END)
+        output.write(footer.getvalue().slice(4))  # Skip the metadata-only file's PAR1 header.
+        output.truncate()
 
 
 class ParquetDatasetReader(AbstractDatasetReader):

--- a/tests/test_push_to_hub_append.py
+++ b/tests/test_push_to_hub_append.py
@@ -1,5 +1,6 @@
 import fnmatch
 import json
+import posixpath
 import socket
 from contextlib import nullcontext
 from datetime import datetime, time
@@ -253,7 +254,9 @@ def test_review_append_nonstandard_glob(hub, tmp_path, paths):
     Dataset.from_dict({"x": [0, 1]}).push_to_hub(hub.repo_id, num_shards=len(paths))
     for old_path, path in zip(hub.files(), paths):
         hub.fs.mv(hub.root + "/" + old_path, hub.root + "/" + path)
-    patterns = [str(Path(path).parent / "*.parquet") for path in paths]
+    # Hub paths are POSIX; never build them with os-native Path (backslashes on Windows).
+    patterns = [posixpath.dirname(path) + "/*.parquet" for path in paths]
+    assert all("\\" not in pattern for pattern in patterns)
     card = hub.card()
     configs = MetadataConfigs.from_dataset_card_data(card.data)
     configs["default"]["data_files"] = [{"split": "train", "path": patterns}]

--- a/tests/test_push_to_hub_append.py
+++ b/tests/test_push_to_hub_append.py
@@ -1,0 +1,1091 @@
+import fnmatch
+import json
+import socket
+from contextlib import nullcontext
+from datetime import datetime, time
+from decimal import Decimal
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pyarrow.parquet as pq
+import pytest
+from fsspec.implementations.memory import MemoryFileSystem
+from huggingface_hub import CommitOperationAdd, CommitOperationCopy, CommitOperationDelete, DatasetCard
+
+from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
+from datasets.data_files import sanitize_patterns
+from datasets.info import DatasetInfosDict
+from datasets.utils.metadata import MetadataConfigs
+
+
+@pytest.fixture
+def hub(monkeypatch):
+    """Run real serialization and card updates, replacing only Hub I/O."""
+
+    def no_network(*args, **kwargs):
+        raise AssertionError("Append unit tests must not access the network")
+
+    monkeypatch.setattr(socket.socket, "connect", no_network)
+    fs = MemoryFileSystem(skip_instance_cache=True)
+    monkeypatch.setattr(fs, "store", {})
+    monkeypatch.setattr(fs, "pseudo_dirs", [""])
+    root = "/datasets/append-test/data@sha"
+    fs.makedirs(root)
+    uploads, commits, downloads = [], [], []
+    staged = {}
+
+    class Api:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def repo_info(self, repo_id, **kwargs):
+            return SimpleNamespace(id=repo_id, sha="sha")
+
+        def create_branch(self, *args, **kwargs):
+            pass
+
+        def list_repo_tree(self, repo_id, path_in_repo=None, **kwargs):
+            assert kwargs["revision"] == "sha"
+            return [
+                SimpleNamespace(path=path[len(root) + 1 :], size=fs.size(path))
+                for path in fs.find(root)
+                if path_in_repo is None or path.startswith(root + "/" + path_in_repo + "/")
+            ]
+
+        def hf_hub_download(self, repo_id, filename, **kwargs):
+            raise AssertionError("Use the snapshot filesystem for downloads")
+
+        def preupload_lfs_files(self, repo_id, additions, **kwargs):
+            for operation in additions:
+                with operation.as_file() as file:
+                    staged[id(operation)] = file.read()
+                uploads.append(operation.path_in_repo)
+
+        def create_commit(self, repo_id, operations, **kwargs):
+            assert kwargs.get("parent_commit") == "sha"
+            commits.append(operations)
+            # Copy from the parent snapshot, even if deletions precede copies.
+            copies = {
+                op.path_in_repo: fs.cat_file(root + "/" + op.src_path_in_repo)
+                for op in operations
+                if isinstance(op, CommitOperationCopy)
+            }
+            for op in operations:
+                path = root + "/" + op.path_in_repo
+                if isinstance(op, CommitOperationAdd):
+                    if id(op) in staged:
+                        data = staged[id(op)]
+                    else:
+                        with op.as_file() as file:
+                            data = file.read()
+                    fs.pipe_file(path, data)
+                elif isinstance(op, CommitOperationCopy):
+                    fs.pipe_file(path, copies[op.path_in_repo])
+                else:
+                    assert isinstance(op, CommitOperationDelete)
+                    fs.rm(path)
+            return SimpleNamespace(oid="sha", commit_url="https://example.invalid/commit/sha")
+
+    original_get_file = fs.get_file
+
+    def get_file(remote, local, **kwargs):
+        downloads.append(remote[len(root) + 1 :].lstrip("/"))
+        return original_get_file(remote, local, **kwargs)
+
+    monkeypatch.setattr(fs, "get_file", get_file)
+    for module in ["datasets.arrow_dataset", "datasets.dataset_dict"]:
+        monkeypatch.setattr(module + ".HfApi", Api)
+        monkeypatch.setattr(module + ".HfFileSystem", lambda **kwargs: fs)
+
+    def files(pattern="*.parquet"):
+        return {
+            path[len(root) + 1 :]: fs.cat_file(path)
+            for path in fs.find(root)
+            if fnmatch.fnmatch(path[len(root) + 1 :], pattern)
+        }
+
+    def card():
+        return DatasetCard(fs.cat_file(root + "/README.md").decode())
+
+    return SimpleNamespace(
+        repo_id="append-test/data",
+        fs=fs,
+        root=root,
+        files=files,
+        card=card,
+        uploads=uploads,
+        commits=commits,
+        downloads=downloads,
+    )
+
+
+def parquet_prefix(data):
+    return data[: -8 - int.from_bytes(data[-8:-4], "little")]
+
+
+def rows(files):
+    return [row for path, data in sorted(files.items()) for row in pq.read_table(BytesIO(data)).to_pylist()]
+
+
+def configured_rows(hub, config_name="default"):
+    data_files = MetadataConfigs.from_dataset_card_data(hub.card().data)[config_name]["data_files"]
+    return {
+        split: [
+            row
+            for pattern in patterns
+            for path in hub.fs.glob(hub.root + "/" + pattern)
+            if path.endswith(".parquet")
+            for row in pq.read_table(BytesIO(hub.fs.cat_file(path))).to_pylist()
+        ]
+        for split, patterns in sanitize_patterns(data_files).items()
+    }
+
+
+def load_local_hub(hub, tmp_path, config_name="default"):
+    repo = tmp_path / "repo"
+    for path, data in hub.files("*").items():
+        destination = repo / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(data)
+    return load_dataset(str(repo), name=config_name, cache_dir=str(tmp_path / "cache"))
+
+
+def seed_train_directories(hub, directories=("data", "more"), explicit_paths=False):
+    """Build a mapped parent snapshot without relying on append's directory selection."""
+    Dataset.from_dict({"x": [0, 1]}).push_to_hub(hub.repo_id, num_shards=2)
+    paths = [f"{directory}/train-00000-of-00001.parquet" for directory in directories]
+    for index, path in enumerate(paths):
+        hub.fs.mv(hub.root + f"/data/train-{index:05d}-of-00002.parquet", hub.root + "/" + path)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [
+        {"split": "train", "path": paths if explicit_paths else [f"{directory}/train-*" for directory in directories]}
+    ]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    return paths
+
+
+@pytest.mark.parametrize("num_shards", [None, 2])
+@pytest.mark.parametrize("config_name", ["default", "fr"])
+@pytest.mark.parametrize("train_path", ["data/train-00000-of-00002.parquet", "data/custom.parquet"])
+def test_append_respects_explicit_split_files(hub, tmp_path, num_shards, config_name, train_path):
+    DatasetDict(train=Dataset.from_dict({"x": [0]}), test=Dataset.from_dict({"x": [1]})).push_to_hub(
+        hub.repo_id, config_name=config_name, data_dir="data"
+    )
+    test_path = "data/train-00001-of-00002.parquet"
+    hub.fs.mv(hub.root + "/data/train-00000-of-00001.parquet", hub.root + "/" + train_path)
+    hub.fs.mv(hub.root + "/data/test-00000-of-00001.parquet", hub.root + "/" + test_path)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs[config_name]["data_files"] = [
+        {"split": "train", "path": train_path},
+        {"split": "test", "path": test_path},
+    ]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    test_bytes = hub.files()[test_path]
+    hub.uploads.clear()
+    Dataset.from_dict({"x": [2]}).push_to_hub(
+        hub.repo_id, config_name=config_name, data_dir="data", append=True, num_shards=num_shards
+    )
+    assert configured_rows(hub, config_name) == {"train": [{"x": 0}, {"x": 2}], "test": [{"x": 1}]}
+    assert hub.files()[test_path] == test_bytes
+    assert hub.downloads == [train_path]
+    assert len(hub.uploads) == 1
+    result = load_local_hub(hub, tmp_path, config_name)
+    assert list(result["train"]["x"]) == [0, 2]
+    assert list(result["test"]["x"]) == [1]
+
+
+def test_append_explicit_split_mapping_keeps_rows_and_counts(hub, tmp_path):
+    DatasetDict(train=Dataset.from_dict({"x": [0]}), test=Dataset.from_dict({"x": [1]})).push_to_hub(hub.repo_id)
+    paths = [f"data/train-{index:05d}-of-00002.parquet" for index in range(2)]
+    for split, path in zip(["train", "test"], paths):
+        hub.fs.mv(hub.root + f"/data/{split}-00000-of-00001.parquet", hub.root + "/" + path)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [
+        {"split": split, "path": path} for split, path in zip(["train", "test"], paths)
+    ]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    test_bytes = hub.files()[paths[1]]
+
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, split="train", append=True)
+
+    assert configured_rows(hub) == {"train": [{"x": 0}, {"x": 2}], "test": [{"x": 1}]}
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert {split: stats.num_examples for split, stats in info.splits.items()} == {"train": 2, "test": 1}
+    assert hub.files()[paths[1]] == test_bytes
+    result = load_local_hub(hub, tmp_path)
+    assert list(result["train"]["x"]) == [0, 2]
+    assert list(result["test"]["x"]) == [1]
+
+
+def test_review_append_wrong_split_shard(hub, tmp_path):
+    DatasetDict(train=Dataset.from_dict({"x": [0]}), test=Dataset.from_dict({"x": [1]})).push_to_hub(hub.repo_id)
+    paths = [f"data/train-{index:05d}-of-00002.parquet" for index in range(2)]
+    for split, path in zip(["train", "test"], paths):
+        hub.fs.mv(hub.root + f"/data/{split}-00000-of-00001.parquet", hub.root + "/" + path)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [
+        {"split": split, "path": path} for split, path in zip(["train", "test"], paths)
+    ]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    original_test = hub.files()[paths[1]]
+
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, split="train", append=True)
+
+    result = load_local_hub(hub, tmp_path)
+    assert list(result["train"]["x"]) == [0, 2]
+    assert list(result["test"]["x"]) == [1]
+    assert hub.files()[paths[1]] == original_test
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert {split: stats.num_examples for split, stats in info.splits.items()} == {"train": 2, "test": 1}
+
+
+@pytest.mark.parametrize("paths", [["data/part-0.parquet"], ["z/part-0.parquet", "a/part-1.parquet"]])
+def test_review_append_nonstandard_glob(hub, tmp_path, paths):
+    Dataset.from_dict({"x": [0, 1]}).push_to_hub(hub.repo_id, num_shards=len(paths))
+    for old_path, path in zip(hub.files(), paths):
+        hub.fs.mv(hub.root + "/" + old_path, hub.root + "/" + path)
+    patterns = [str(Path(path).parent / "*.parquet") for path in paths]
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [{"split": "train", "path": patterns}]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    hub.uploads.clear()
+
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, append=True)
+
+    assert configured_rows(hub) == {"train": [{"x": 0}, {"x": 1}, {"x": 2}]}
+    assert sanitize_patterns(MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"]) == {
+        "train": patterns
+    }
+    assert hub.downloads == hub.uploads == [paths[-1]]
+    assert list(load_local_hub(hub, tmp_path)["train"]["x"]) == [0, 1, 2]
+
+
+@pytest.mark.parametrize(
+    "shared_pattern", ["data/train-00000-of-00001.parquet", "data/*-of-00001.parquet", "data/train-*", "**/*.parquet"]
+)
+@pytest.mark.parametrize("num_shards", [None, 2])
+def test_review_append_shared_file(hub, tmp_path, shared_pattern, num_shards):
+    Dataset.from_dict({"x": [0]}).push_to_hub(hub.repo_id)
+    path = "data/train-00000-of-00001.parquet"
+    original = hub.files()[path]
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["other"] = {"data_files": [{"split": "train", "path": shared_pattern}]}
+    configs.to_dataset_card_data(card.data)
+    infos = DatasetInfosDict.from_dataset_card_data(card.data)
+    infos["other"] = infos["default"].copy()
+    infos["other"].config_name = "other"
+    infos.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id, append=True, num_shards=num_shards)
+
+    assert hub.files().get(path) == original
+    assert configured_rows(hub) == {"train": [{"x": 0}, {"x": 1}]}
+    assert configured_rows(hub, "other") == {"train": [{"x": 0}]}
+    other = MetadataConfigs.from_dataset_card_data(hub.card().data)["other"]
+    # A broad pattern may be narrowed only to its complete original file set.
+    assert other == configs["other"] or sanitize_patterns(other["data_files"]) == {"train": [path]}
+    assert DatasetInfosDict.from_dataset_card_data(hub.card().data)["other"] == infos["other"]
+    assert list(load_local_hub(hub, tmp_path, "other")["train"]["x"]) == [0]
+
+
+@pytest.mark.parametrize("directory", [".staging", "__staging", "_staging"])
+@pytest.mark.parametrize("explicit", [False, True])
+def test_review_append_hidden_directories(hub, tmp_path, directory, explicit):
+    Dataset.from_dict({"x": [0]}).push_to_hub(hub.repo_id)
+    visible = "data/train-00000-of-00001.parquet"
+    hidden = f"data/z/{directory}/train-00000-of-00001.parquet"
+    buffer = BytesIO()
+    Dataset.from_dict({"x": [1]}).to_parquet(buffer)
+    hub.fs.pipe_file(hub.root + "/" + hidden, buffer.getvalue())
+    requested = explicit or directory == "_staging"
+    patterns = [visible, hidden] if explicit else ["data/**/*.parquet"]
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [{"split": "train", "path": patterns}]
+    configs.to_dataset_card_data(card.data)
+    info = card.data["dataset_info"]
+    info["splits"][0]["num_examples"] = 2 if requested else 1
+    info["splits"][0]["num_bytes"] = info["dataset_size"] = 16 if requested else 8
+    if requested:
+        info["download_size"] += len(buffer.getvalue())
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    hub.uploads.clear()
+
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, append=True)
+
+    assert hub.downloads == [hidden if requested else visible]
+    assert hub.uploads == hub.downloads
+    assert list(load_local_hub(hub, tmp_path)["train"]["x"]) == ([0, 1, 2] if requested else [0, 2])
+    assert sanitize_patterns(MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"]) == {
+        "train": patterns
+    }
+
+
+def test_review_append_new_split_worker_order(hub, tmp_path, monkeypatch):
+    Dataset.from_dict({"x": [-1]}).push_to_hub(hub.repo_id)
+
+    def reversed_workers(pool, function, kwargs_iterable):
+        # Execute real shard writers, deterministically delivering worker 1 first.
+        for kwargs in reversed(kwargs_iterable):
+            yield from function(**kwargs)
+
+    monkeypatch.setattr("datasets.arrow_dataset.iflatmap_unordered", reversed_workers)
+    monkeypatch.setattr(
+        "datasets.arrow_dataset.mp.get_context",
+        lambda method: SimpleNamespace(Pool=lambda num_proc: nullcontext(object())),
+    )
+    Dataset.from_dict({"x": [0, 1, 2, 3]}).push_to_hub(
+        hub.repo_id, split="validation", append=True, num_shards=2, num_proc=2
+    )
+
+    assert list(load_local_hub(hub, tmp_path)["validation"]["x"]) == [0, 1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "dtype,values",
+    [
+        ("date64", [datetime(2020, 1, 1), datetime(2020, 1, 2)]),
+        ("time32[s]", [time(1, 2, 3), time(4, 5, 6)]),
+        ("timestamp[s]", [datetime(2020, 1, 1), datetime(2020, 1, 2)]),
+    ],
+)
+@pytest.mark.parametrize("recover_info", [False, True])
+def test_review_append_temporal_normalization(hub, tmp_path, dtype, values, recover_info):
+    features = Features({"x": Value(dtype)})
+    Dataset.from_dict({"x": values[:1]}, features=features).push_to_hub(hub.repo_id)
+    if recover_info:
+        card = hub.card()
+        card.data.pop("dataset_info")
+        hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    original = hub.files()
+    assert load_local_hub(hub, tmp_path / "before")["train"].num_rows == 1
+
+    error = None
+    try:
+        Dataset.from_dict({"x": values[1:]}, features=features).push_to_hub(hub.repo_id, append=True)
+    except ValueError as caught:
+        error = caught
+    assert error is None, str(error)
+
+    path = next(iter(original))
+    assert hub.files()[path].startswith(parquet_prefix(original[path]))
+    result = load_local_hub(hub, tmp_path / "after")["train"]
+    assert result.num_rows == 2
+    expected = Dataset.from_dict({"x": values}, features=features).cast(result.features)
+    assert result.to_dict() == expected.to_dict()
+
+
+@pytest.mark.parametrize(
+    "old_dtype,new_dtype,old_value,new_value",
+    [
+        ("time32[s]", "time32[ms]", time(1, 2, 3), time(1, 2, 3, 123000)),
+        ("timestamp[s]", "timestamp[ms]", datetime(2020, 1, 1), datetime(2020, 1, 1, microsecond=123000)),
+    ],
+)
+def test_review_append_temporal_card_precision(hub, old_dtype, new_dtype, old_value, new_value):
+    Dataset.from_dict({"x": [old_value]}, features=Features({"x": Value(old_dtype)})).push_to_hub(hub.repo_id)
+    original = hub.files("*")
+    error = None
+    try:
+        Dataset.from_dict({"x": [new_value]}, features=Features({"x": Value(new_dtype)})).push_to_hub(
+            hub.repo_id, append=True
+        )
+    except ValueError as caught:
+        error = caught
+    assert error is not None, "Append must reject rows that cannot be loaded with the card's features"
+    assert hub.files("*") == original
+
+
+@pytest.mark.parametrize(
+    "dtype,values,writer_options",
+    [
+        ("time64[us]", [time(1, 2, 3), time(4, 5, 6)], {"write_time_adjusted_to_utc": True}),
+        ("time64[ns]", [time(1, 2, 3), time(4, 5, 6)], {"write_time_adjusted_to_utc": True}),
+        (
+            "timestamp[ns]",
+            [datetime(2020, 1, 1, microsecond=123456), datetime(2020, 1, 2, microsecond=654321)],
+            {"coerce_timestamps": "ms", "allow_truncated_timestamps": True},
+        ),
+        (
+            "timestamp[ns, tz=UTC]",
+            [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+            {"coerce_timestamps": "us", "allow_truncated_timestamps": True},
+        ),
+    ],
+)
+@pytest.mark.parametrize("nested", [False, True])
+def test_review_append_temporal_writer_properties(hub, tmp_path, dtype, values, writer_options, nested):
+    features = Features({"x": {"times": [Value(dtype)]} if nested else Value(dtype)})
+    values = [{"times": [value]} for value in values] if nested else values
+    data = Dataset.from_dict({"x": values}, features=features)
+    data.select([0]).push_to_hub(hub.repo_id)
+    path = next(iter(hub.files()))
+    buffer = BytesIO()
+    pq.write_table(data.select([0]).data.table, buffer, **writer_options)
+    original = buffer.getvalue()
+    hub.fs.pipe_file(hub.root + "/" + path, original)
+    card = hub.card()
+    card.data["dataset_info"]["download_size"] = len(original)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+
+    error = None
+    try:
+        data.select([1]).push_to_hub(hub.repo_id, append=True)
+    except (ValueError, RuntimeError) as caught:
+        error = caught
+    assert error is None, str(error)
+
+    appended = hub.files()[path]
+    assert appended.startswith(parquet_prefix(original))
+    assert pq.read_metadata(BytesIO(appended)).schema.equals(pq.read_metadata(BytesIO(original)).schema)
+    expected = BytesIO()
+    pq.write_table(data.data.table, expected, **writer_options)
+    assert pq.read_table(BytesIO(appended)).to_pydict() == pq.read_table(expected).to_pydict()
+    assert load_local_hub(hub, tmp_path)["train"].num_rows == 2
+
+
+@pytest.mark.parametrize("directories", [("data", "more"), ("z", "a"), ("data", "data/nested")])
+@pytest.mark.parametrize("explicit_paths", [False, True])
+@pytest.mark.parametrize("num_shards", [None, 3])
+def test_append_uses_last_mapped_shard_across_directories(hub, tmp_path, directories, explicit_paths, num_shards):
+    paths = seed_train_directories(hub, directories, explicit_paths)
+    original = hub.files()[paths[0]]
+    hub.uploads.clear()
+
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, append=True, num_shards=num_shards)
+
+    assert configured_rows(hub) == {"train": [{"x": 0}, {"x": 1}, {"x": 2}]}
+    assert list(load_local_hub(hub, tmp_path)["train"]["x"]) == [0, 1, 2]
+    assert hub.downloads == [paths[1]]
+    if num_shards is None:
+        assert hub.files()[paths[0]] == original
+        assert hub.uploads == [paths[1]]
+    else:
+        assert len(hub.files()) == 3
+        assert len(hub.uploads) == 1
+
+
+@pytest.mark.parametrize("explicit_paths", [False, True])
+def test_append_empty_preserves_pattern_order(hub, tmp_path, explicit_paths):
+    old = Dataset.from_dict({"x": [0]})
+    seed_train_directories(hub, explicit_paths=explicit_paths)
+    before = hub.files("*")
+    old.select([]).push_to_hub(hub.repo_id, data_dir="data", append=True)
+    assert configured_rows(hub) == {"train": [{"x": 0}, {"x": 1}]}
+    assert hub.files("*") == before
+    assert list(load_local_hub(hub, tmp_path)["train"]["x"]) == [0, 1]
+
+
+def test_append_new_split_preserves_foreign_filename(hub, tmp_path):
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id, split="test")
+    path = "data/train-00000-of-00001.parquet"
+    hub.fs.mv(hub.root + "/data/test-00000-of-00001.parquet", hub.root + "/" + path)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [{"split": "test", "path": path}]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    original = hub.files()[path]
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, split="train", append=True)
+    assert configured_rows(hub) == {"train": [{"x": 2}], "test": [{"x": 1}]}
+    assert hub.files()[path] == original
+    result = load_local_hub(hub, tmp_path)
+    assert list(result["train"]["x"]) == [2]
+    assert list(result["test"]["x"]) == [1]
+
+
+@pytest.mark.parametrize("pattern", ["data/*.parquet", "data/**", "**/*.parquet", "data/*-00000-of-*.parquet"])
+@pytest.mark.parametrize("append_options", [{}, {"num_shards": 3}, {"max_shard_size": 1}])
+@pytest.mark.parametrize("recover_info", [False, True])
+def test_append_bare_glob_keeps_all_mapped_files(hub, tmp_path, pattern, append_options, recover_info):
+    DatasetDict(train=Dataset.from_dict({"x": [0]}), test=Dataset.from_dict({"x": [1]})).push_to_hub(hub.repo_id)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"][0]["path"] = pattern
+    configs.to_dataset_card_data(card.data)
+    # The glob includes the test file in train too. Its rows must remain visible
+    # in both splits, with statistics describing what load_dataset actually reads.
+    test_path = "data/test-00000-of-00001.parquet"
+    test_bytes = hub.files()[test_path]
+    info = card.data["dataset_info"]
+    info["splits"][0].update(num_examples=2, num_bytes=16)
+    info["dataset_size"] = 24
+    info["download_size"] += len(test_bytes)
+    if recover_info:
+        card.data.pop("dataset_info")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    before = load_local_hub(hub, tmp_path / "before")
+    assert list(before["train"]["x"]) == [1, 0]
+    assert list(before["test"]["x"]) == [1]
+    hub.uploads.clear()
+
+    Dataset.from_dict({"x": [2, 3]}).push_to_hub(hub.repo_id, append=True, **append_options)
+
+    assert configured_rows(hub) == {"train": [{"x": 1}, {"x": 0}, {"x": 2}, {"x": 3}], "test": [{"x": 1}]}
+    assert hub.files()[test_path] == test_bytes
+    assert hub.downloads == ["data/train-00000-of-00001.parquet"]
+    assert all(path.startswith("data/train-") for path in hub.uploads)
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert {split: stats.num_examples for split, stats in info.splits.items()} == {"train": 4, "test": 1}
+    assert info.dataset_size == 40
+    configs = MetadataConfigs.from_dataset_card_data(hub.card().data)
+    assert info.download_size == sum(
+        hub.fs.size(path)
+        for patterns in sanitize_patterns(configs["default"]["data_files"]).values()
+        for pattern in patterns
+        for path in hub.fs.glob(hub.root + "/" + pattern)
+        if path.endswith(".parquet")
+    )
+    result = load_local_hub(hub, tmp_path / "after")
+    assert list(result["train"]["x"]) == [1, 0, 2, 3]
+    assert list(result["test"]["x"]) == [1]
+
+
+def test_append_recovery_respects_config_boundaries(hub, tmp_path):
+    Dataset.from_dict({"x": [0]}).push_to_hub(hub.repo_id)
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id, config_name="other", data_dir="data", split="test")
+    card = hub.card()
+    other_config = MetadataConfigs.from_dataset_card_data(card.data)["other"]
+    other_info = DatasetInfosDict.from_dataset_card_data(card.data)["other"]
+    for info in card.data["dataset_info"]:
+        if info["config_name"] == "default":
+            info.pop("download_size")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    test_bytes = hub.files("data/test-*")
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, append=True)
+    configs = MetadataConfigs.from_dataset_card_data(hub.card().data)
+    assert configs["default"]["data_files"] == [{"split": "train", "path": "data/train-*"}]
+    assert configs["other"] == other_config
+    infos = DatasetInfosDict.from_dataset_card_data(hub.card().data)
+    assert infos["other"] == other_info
+    assert infos["default"].download_size == sum(map(len, hub.files("data/train-*").values()))
+    assert hub.files("data/test-*") == test_bytes
+    result = load_local_hub(hub, tmp_path)
+    assert set(result) == {"train"}
+    assert list(result["train"]["x"]) == [0, 2]
+
+
+def test_append_recovery_uses_arrow_byte_counts(hub):
+    Dataset.from_dict({"x": [0]}).push_to_hub(hub.repo_id)
+    card = hub.card()
+    card.data.pop("dataset_info")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id, append=True)
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.splits["train"].num_bytes == 16
+    assert info.dataset_size == 16
+    assert info.splits["train"].num_examples == 2
+    assert info.download_size == sum(map(len, hub.files().values()))
+
+
+@pytest.mark.parametrize("missing_field", ["dataset_info", "features"])
+@pytest.mark.parametrize(
+    "feature,values",
+    [
+        (ClassLabel(names=["negative", "positive"]), [0, 1]),
+        (Image(decode=False), [{"bytes": b"old image", "path": None}, {"bytes": b"new image", "path": None}]),
+        (Audio(decode=False), [{"bytes": b"old audio", "path": None}, {"bytes": b"new audio", "path": None}]),
+    ],
+    ids=["class_label", "image", "audio"],
+)
+def test_append_recovers_huggingface_features(hub, tmp_path, missing_field, feature, values):
+    features = Features({"x": feature})
+    # Cast encoded storage so audio coverage does not require a codec installation.
+    Dataset.from_dict({"x": values[:1]}).cast(features).push_to_hub(hub.repo_id)
+    card = hub.card()
+    if missing_field == "dataset_info":
+        card.data.pop("dataset_info")
+    else:
+        card.data["dataset_info"].pop("features")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+
+    error = None
+    try:
+        Dataset.from_dict({"x": values[1:]}).cast(features).push_to_hub(hub.repo_id, append=True)
+    except ValueError as caught:
+        error = caught
+    assert error is None, str(error)
+
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.features == features
+    assert info.splits["train"].num_examples == 2
+    result = load_local_hub(hub, tmp_path)
+    assert result["train"].features == features
+    assert list(result["train"]["x"]) == values
+
+
+@pytest.mark.parametrize("null_splits", [False, True])
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_append_missing_splits_without_parquet(hub, tmp_path, null_splits, as_dict):
+    Dataset.from_dict({"x": [0]}).push_to_hub(hub.repo_id)
+    card = hub.card()
+    info = card.data["dataset_info"]
+    info.pop("splits")
+    if null_splits:
+        info["splits"] = None
+    info.pop("download_size")
+    info.pop("dataset_size")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    for path in hub.files():
+        hub.fs.rm(hub.root + "/" + path)
+
+    new = Dataset.from_dict({"x": [2]})
+    error = None
+    try:
+        (DatasetDict(train=new) if as_dict else new).push_to_hub(hub.repo_id, append=True)
+    except TypeError as caught:
+        error = caught
+    assert error is None, str(error)
+
+    assert configured_rows(hub) == {"train": [{"x": 2}]}
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.splits["train"].num_examples == 1
+    assert info.splits["train"].num_bytes == info.dataset_size == 8
+    assert info.download_size == sum(map(len, hub.files().values()))
+    assert list(load_local_hub(hub, tmp_path)["train"]["x"]) == [2]
+
+
+@pytest.mark.parametrize("precision", [8, 16, 25])
+def test_append_preserves_decimal_writer_properties(hub, precision):
+    features = Features({"x": Value(f"decimal128({precision}, 2)"), "y": Value("int64")})
+    old = Dataset.from_dict({"x": [Decimal("1.23")], "y": [0]}, features=features)
+    old.push_to_hub(hub.repo_id)
+    path = next(iter(hub.files()))
+    buffer = BytesIO()
+    pq.write_table(
+        old.data.table,
+        buffer,
+        store_decimal_as_integer=True,
+        compression={"x": "gzip", "y": "zstd"},
+        use_dictionary=False,
+    )
+    original = buffer.getvalue()
+    hub.fs.pipe_file(hub.root + "/" + path, original)
+    card = hub.card()
+    card.data["dataset_info"]["download_size"] = len(original)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    error = None
+    try:
+        Dataset.from_dict({"x": [Decimal("4.56")], "y": [1]}, features=features).push_to_hub(hub.repo_id, append=True)
+    except RuntimeError as caught:
+        error = caught
+    assert error is None, str(error)
+    appended = hub.files()[path]
+    assert appended.startswith(parquet_prefix(original))
+    assert rows(hub.files()) == [{"x": Decimal("1.23"), "y": 0}, {"x": Decimal("4.56"), "y": 1}]
+    metadata = pq.read_metadata(BytesIO(appended))
+    assert metadata.schema.equals(pq.read_metadata(BytesIO(original)).schema)
+    for column in range(metadata.num_columns):
+        assert metadata.row_group(1).column(column).compression == metadata.row_group(0).column(column).compression
+        assert metadata.row_group(1).column(column).encodings == metadata.row_group(0).column(column).encodings
+
+
+@pytest.mark.parametrize("config_name,data_dir", [("default", None), ("fr", None), ("fr", "custom/nested")])
+def test_append_preserves_prefix_rows_and_card(hub, config_name, data_dir):
+    old = Dataset.from_dict({"x": list(range(7))})
+    kwargs = {"config_name": config_name, "data_dir": data_dir}
+    old.push_to_hub(hub.repo_id, **kwargs)
+    original = hub.files()
+    path = next(iter(original))
+    # Exercise several row groups, including a partial last row group and page indexes.
+    buffer = BytesIO()
+    old.to_parquet(buffer, batch_size=3)
+    hub.fs.pipe_file(hub.root + "/" + path, buffer.getvalue())
+    card = hub.card()
+    infos = DatasetInfosDict.from_dataset_card_data(card.data)
+    infos[config_name].download_size = len(buffer.getvalue())
+    infos.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    hub.uploads.clear()
+    for values in ([7, 8], [9]):
+        Dataset.from_dict({"x": values}).push_to_hub(hub.repo_id, append=True, **kwargs)
+    result = hub.files()
+    assert list(result) == [path]
+    assert result[path].startswith(parquet_prefix(buffer.getvalue()))
+    assert rows(result) == [{"x": i} for i in range(10)]
+    metadata = pq.read_metadata(BytesIO(result[path]))
+    assert [metadata.row_group(i).num_rows for i in range(metadata.num_row_groups)] == [3, 3, 1, 2, 1]
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)[config_name]
+    assert info.splits["train"].num_examples == 10
+    assert info.splits["train"].num_bytes == 80
+    assert info.dataset_size == 80
+    assert info.download_size == len(result[path])
+    assert hub.uploads == [path, path]
+    assert all(not isinstance(op, (CommitOperationCopy, CommitOperationDelete)) for op in hub.commits[-1])
+
+
+def test_append_feature_mismatch_leaves_repository_unchanged(hub):
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id)
+    before = hub.files("*")
+    with pytest.raises(ValueError, match="[Ff]eatures.*match"):
+        Dataset.from_dict({"x": ["wrong"]}).push_to_hub(hub.repo_id, append=True)
+    assert hub.files("*") == before
+
+
+def test_append_overflow_renumbers_using_copies(hub):
+    old = Dataset.from_dict({"x": list(range(8))})
+    old.push_to_hub(hub.repo_id, num_shards=2)
+    original = hub.files()
+    hub.uploads.clear()
+    Dataset.from_dict({"x": [8, 9]}).push_to_hub(
+        hub.repo_id, append=True, max_shard_size=max(map(len, original.values()))
+    )
+    result = hub.files()
+    assert sorted(result) == [f"data/train-{i:05d}-of-00003.parquet" for i in range(3)]
+    for i, data in enumerate(original.values()):
+        assert result[f"data/train-{i:05d}-of-00003.parquet"] == data
+    assert rows(result) == [{"x": i} for i in range(10)]
+    assert hub.uploads == ["data/train-00002-of-00003.parquet"]
+    assert sum(isinstance(op, CommitOperationCopy) for op in hub.commits[-1]) == 2
+    assert sum(isinstance(op, CommitOperationDelete) for op in hub.commits[-1]) == 2
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.splits["train"].num_examples == 10
+    assert info.splits["train"].num_bytes == 80
+    assert info.download_size == sum(map(len, result.values()))
+
+
+def test_append_dict_preserves_other_splits_configs_and_paths(hub):
+    old = Dataset.from_dict({"x": [0, 1]})
+    DatasetDict(train=old, test=old).push_to_hub(hub.repo_id)
+    old.push_to_hub(hub.repo_id, config_name="fr")
+    before = hub.files()
+    DatasetDict(train=Dataset.from_dict({"x": [2]}), validation=old).push_to_hub(
+        hub.repo_id, append=True, data_dir="more"
+    )
+    for path, data in before.items():
+        if path == "data/train-00000-of-00001.parquet":
+            assert hub.files()[path].startswith(parquet_prefix(data))
+        else:
+            assert hub.files()[path] == data
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert {name: split.num_examples for name, split in info.splits.items()} == {
+        "train": 3,
+        "test": 2,
+        "validation": 2,
+    }
+    configs = MetadataConfigs.from_dataset_card_data(hub.card().data)
+    assert configs["default"]["data_files"] == [
+        {"split": "train", "path": "data/train-*"},
+        {"split": "test", "path": "data/test-*"},
+        {"split": "validation", "path": "more/validation-*"},
+    ]
+    assert "fr" in configs
+    assert configured_rows(hub) == {
+        "train": [{"x": 0}, {"x": 1}, {"x": 2}],
+        "test": [{"x": 0}, {"x": 1}],
+        "validation": [{"x": 0}, {"x": 1}],
+    }
+
+
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_append_false_is_identical_to_default(hub, as_dict):
+    data = Dataset.from_dict({"x": [1, 2]})
+    dset = DatasetDict(train=data) if as_dict else data
+    dset.push_to_hub(hub.repo_id)
+    expected = hub.files("*")
+    dset.push_to_hub(hub.repo_id, append=False)
+    assert hub.files("*") == expected
+    new = Dataset.from_dict({"x": [3]})
+    (DatasetDict(train=new) if as_dict else new).push_to_hub(hub.repo_id, append=False)
+    assert rows(hub.files()) == [{"x": 3}]
+
+
+def test_append_new_split_is_normal_push(hub):
+    data = Dataset.from_dict({"x": [1, 2]})
+    data.push_to_hub(hub.repo_id, append=True)
+    appended = hub.files("*")
+    data.push_to_hub(hub.repo_id)
+    assert hub.files("*") == appended
+
+
+def test_append_num_shards_is_total_and_cannot_remove_shards(hub):
+    data = Dataset.from_dict({"x": [1, 2]})
+    data.push_to_hub(hub.repo_id, num_shards=2)
+    with pytest.raises(ValueError, match="num_shards"):
+        data.push_to_hub(hub.repo_id, append=True, num_shards=1)
+    data.push_to_hub(hub.repo_id, append=True, num_shards=3)
+    assert len(hub.files()) == 3
+    assert rows(hub.files()) == [{"x": 1}, {"x": 2}, {"x": 1}, {"x": 2}]
+
+
+def test_append_empty_keeps_data(hub):
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id)
+    before = hub.files("*")
+    Dataset.from_dict({"x": []}, features=Features({"x": Value("int64")})).push_to_hub(hub.repo_id, append=True)
+    assert hub.files("*") == before
+
+
+def test_append_only_downloads_and_uploads_last_shard(hub):
+    Dataset.from_dict({"x": list(range(6))}).push_to_hub(hub.repo_id, num_shards=3)
+    before = hub.files()
+    hub.uploads.clear()
+    Dataset.from_dict({"x": [6]}).with_format("numpy").push_to_hub(hub.repo_id, append=True)
+    paths = sorted(before)
+    assert hub.downloads == [paths[-1]]
+    assert hub.uploads == [paths[-1]]
+    assert all(hub.files()[path] == before[path] for path in paths[:-1])
+    assert hub.files()[paths[-1]].startswith(parquet_prefix(before[paths[-1]]))
+    assert rows(hub.files()) == [{"x": i} for i in range(7)]
+
+
+def test_append_updates_explicit_card_paths_when_renumbering(hub):
+    Dataset.from_dict({"x": [1, 2]}).push_to_hub(hub.repo_id)
+    old_path = next(iter(hub.files()))
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [{"split": "train", "path": old_path}]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [3]}).push_to_hub(hub.repo_id, append=True, num_shards=2)
+    data_files = MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"]
+    assert data_files == [{"split": "train", "path": "data/train-*"}]
+    assert rows(hub.files()) == [{"x": 1}, {"x": 2}, {"x": 3}]
+
+
+def test_append_without_card_info_preserves_counts(hub):
+    Dataset.from_dict({"x": [1, 2]}).push_to_hub(hub.repo_id)
+    card = hub.card()
+    card.data.pop("dataset_info")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [3]}).push_to_hub(hub.repo_id, append=True)
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.splits["train"].num_examples == 3
+    assert info.download_size == sum(map(len, hub.files().values()))
+
+
+def test_append_updates_legacy_info(hub):
+    from dataclasses import asdict
+
+    Dataset.from_dict({"x": [1, 2]}).push_to_hub(hub.repo_id)
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    hub.fs.pipe_file(hub.root + "/dataset_infos.json", json.dumps({"default": asdict(info)}).encode())
+    Dataset.from_dict({"x": [3]}).push_to_hub(hub.repo_id, append=True)
+    legacy = json.loads(hub.fs.cat_file(hub.root + "/dataset_infos.json"))["default"]
+    assert legacy["splits"]["train"]["num_examples"] == 3
+    assert legacy["splits"]["train"]["num_bytes"] == 24
+    assert legacy["download_size"] == sum(map(len, hub.files().values()))
+
+
+def test_append_embeds_media(hub, tmp_path):
+    from datasets import Image
+
+    features = Features({"image": Image(decode=False)})
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"local image contents")
+    Dataset.from_dict({"image": [str(image_path)]}, features=features).push_to_hub(hub.repo_id)
+    before = next(iter(hub.files().values()))
+    Dataset.from_dict({"image": [str(image_path)]}, features=features).push_to_hub(hub.repo_id, append=True)
+    assert next(iter(hub.files().values())).startswith(parquet_prefix(before))
+    assert [row["image"]["bytes"] for row in rows(hub.files())] == [b"local image contents"] * 2
+
+
+@pytest.mark.parametrize("arrow_version,cdc", [("20.0.0", False), ("21.0.0", True)])
+def test_append_parquet_cdc_version_gate(hub, tmp_path, monkeypatch, arrow_version, cdc):
+    from packaging.version import parse
+
+    from datasets import config
+    from datasets.io.parquet import _append_parquet_file
+
+    original = tmp_path / "original.parquet"
+    destination = tmp_path / "appended.parquet"
+    Dataset.from_dict({"x": [1]}).to_parquet(original)
+    writer = pq.ParquetWriter
+    options = []
+
+    def checked_writer(*args, **kwargs):
+        options.append(kwargs)
+        return writer(*args, **kwargs)
+
+    monkeypatch.setattr(config, "PYARROW_VERSION", parse(arrow_version))
+    monkeypatch.setattr(pq, "ParquetWriter", checked_writer)
+    _append_parquet_file(Dataset.from_dict({"x": [2]}), str(original), str(destination))
+    assert options[0].get("use_content_defined_chunking", False) is cdc
+    assert destination.read_bytes().startswith(parquet_prefix(original.read_bytes()))
+    assert pq.read_table(destination).to_pydict() == {"x": [1, 2]}
+
+
+@pytest.mark.parametrize("data_dir", ["./data", "data/", ".", "./custom/nested/"])
+def test_append_normalizes_data_dir_without_replacing_rows(hub, data_dir):
+    Dataset.from_dict({"x": [1, 2]}).push_to_hub(hub.repo_id, data_dir=Path(data_dir).as_posix())
+    Dataset.from_dict({"x": [3]}).push_to_hub(hub.repo_id, data_dir=data_dir, append=True)
+    assert rows(hub.files()) == [{"x": 1}, {"x": 2}, {"x": 3}]
+    assert len(hub.files()) == 1
+
+
+@pytest.mark.parametrize("pattern", ["data/*.parquet", "data/**", "**/*.parquet", "./data/train-*.parquet"])
+def test_append_card_patterns_do_not_duplicate_rows(hub, pattern):
+    Dataset.from_dict({"x": [1, 2]}).push_to_hub(hub.repo_id)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [{"split": "train", "path": pattern}]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [3]}).push_to_hub(hub.repo_id, append=True)
+    paths = MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"][0]["path"]
+    patterns = paths if isinstance(paths, list) else [paths]
+    resolved = [
+        path
+        for pattern in patterns
+        for path in hub.fs.glob(hub.root + "/" + pattern.removeprefix("./"))
+        if path.endswith(".parquet")
+    ]
+    assert len(resolved) == len(set(resolved)) == 1
+
+
+def test_append_old_nested_parquet_encoding(hub, tmp_path):
+    from datasets.io.parquet import _append_parquet_file
+
+    old = Dataset.from_dict({"x": [[1, 2], [3]]})
+    original, appended = tmp_path / "old.parquet", tmp_path / "appended.parquet"
+    pq.write_table(old.data.table, original, use_compliant_nested_type=False)
+    _append_parquet_file(Dataset.from_dict({"x": [[4]]}), str(original), str(appended))
+    assert appended.read_bytes().startswith(parquet_prefix(original.read_bytes()))
+    assert pq.read_table(appended).to_pydict() == {"x": [[1, 2], [3], [4]]}
+
+
+def test_append_recovers_only_missing_card_fields(hub):
+    DatasetDict(train=Dataset.from_dict({"x": [1, 2]}), test=Dataset.from_dict({"x": [0]})).push_to_hub(hub.repo_id)
+    card = hub.card()
+    card.data["dataset_info"].pop("download_size")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [3]}).push_to_hub(hub.repo_id, append=True)
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.splits["train"].num_bytes == 24
+    assert info.splits["test"].num_bytes == 8
+    assert info.dataset_size == 32
+    assert info.download_size == sum(map(len, hub.files().values()))
+    assert MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"] == [
+        {"split": "train", "path": "data/train-*"},
+        {"split": "test", "path": "data/test-*"},
+    ]
+
+
+def test_append_new_non_train_split_is_normal_push(hub):
+    data = Dataset.from_dict({"x": [1]})
+    data.push_to_hub(hub.repo_id, append=True, split="test")
+    assert MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"] == [
+        {"split": "test", "path": "data/test-*"}
+    ]
+
+
+def test_append_dict_updates_existing_splits_additively(hub):
+    data = Dataset.from_dict({"x": [0, 1]})
+    DatasetDict(train=data, validation=data, test=data).push_to_hub(hub.repo_id)
+    test_path = "data/test-00000-of-00001.parquet"
+    test_bytes = hub.files()[test_path]
+    DatasetDict(train=Dataset.from_dict({"x": [2]}), validation=Dataset.from_dict({"x": [3, 4]})).push_to_hub(
+        hub.repo_id, append=True
+    )
+    assert rows(hub.files("data/train-*")) == [{"x": 0}, {"x": 1}, {"x": 2}]
+    assert rows(hub.files("data/validation-*")) == [{"x": 0}, {"x": 1}, {"x": 3}, {"x": 4}]
+    assert hub.files()[test_path] == test_bytes
+    info = DatasetInfosDict.from_dataset_card_data(hub.card().data)["default"]
+    assert info.dataset_size == 72
+    assert info.download_size == sum(map(len, hub.files().values()))
+    assert {name: split.num_examples for name, split in info.splits.items()} == {
+        "train": 3,
+        "validation": 4,
+        "test": 2,
+    }
+
+
+def test_append_overflow_splits_large_new_data(hub):
+    Dataset.from_dict({"x": list(range(8))}).push_to_hub(hub.repo_id)
+    original = next(iter(hub.files().values()))
+    limit = len(original)
+    Dataset.from_dict({"x": list(range(8, 208))}).push_to_hub(hub.repo_id, append=True, max_shard_size=limit)
+    files = hub.files()
+    assert len(files) > 2
+    assert all(len(data) <= limit for data in files.values())
+    assert next(iter(files.values())) == original
+    assert rows(files) == [{"x": i} for i in range(208)]
+
+
+def test_append_empty_media_keeps_data(hub):
+    from datasets import Image
+
+    features = Features({"image": Image(decode=False)})
+    Dataset.from_dict({"image": [{"bytes": b"image", "path": None}]}, features=features).push_to_hub(hub.repo_id)
+    before = hub.files("*")
+    Dataset.from_dict({"image": []}, features=features).push_to_hub(hub.repo_id, append=True)
+    assert hub.files("*") == before
+
+
+def test_append_old_int96_parquet_encoding(hub, tmp_path):
+    from datetime import datetime
+
+    from datasets.io.parquet import _append_parquet_file
+
+    data = Dataset.from_dict({"x": [datetime(2020, 1, 1)]}, features=Features({"x": Value("timestamp[ns]")}))
+    original, appended = tmp_path / "old.parquet", tmp_path / "appended.parquet"
+    pq.write_table(data.data.table, original, use_deprecated_int96_timestamps=True)
+    _append_parquet_file(data, str(original), str(appended))
+    assert appended.read_bytes().startswith(parquet_prefix(original.read_bytes()))
+    assert pq.read_table(appended).num_rows == 2
+
+
+def test_append_card_patterns_cover_untouched_shards_once(hub):
+    Dataset.from_dict({"x": [0, 1]}).push_to_hub(hub.repo_id, num_shards=2)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [
+        {"split": "train", "path": ["data/*-00000-of-*.parquet", "data/train-00001-of-00002.parquet"]}
+    ]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [2]}).push_to_hub(hub.repo_id, append=True)
+    patterns = MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"][0]["path"]
+    patterns = patterns if isinstance(patterns, list) else [patterns]
+    paths = [path for pattern in patterns for path in hub.fs.glob(hub.root + "/" + pattern)]
+    assert len(paths) == len(set(paths)) == 2
+
+
+def test_append_card_patterns_include_nested_directory(hub):
+    Dataset.from_dict({"x": [0]}).push_to_hub(hub.repo_id)
+    card = hub.card()
+    configs = MetadataConfigs.from_dataset_card_data(card.data)
+    configs["default"]["data_files"] = [{"split": "train", "path": "data/*.parquet"}]
+    configs.to_dataset_card_data(card.data)
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    Dataset.from_dict({"x": [1]}).push_to_hub(hub.repo_id, append=True, data_dir="data/nested", num_shards=2)
+    patterns = MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"][0]["path"]
+    patterns = patterns if isinstance(patterns, list) else [patterns]
+    paths = [path for pattern in patterns for path in hub.fs.glob(hub.root + "/" + pattern)]
+    assert len(paths) == len(set(paths)) == 2
+
+
+@pytest.mark.parametrize("config_name", ["default", "fr"])
+def test_append_without_configs_keeps_other_splits(hub, config_name):
+    data = Dataset.from_dict({"x": [0]})
+    DatasetDict(train=data, test=data).push_to_hub(hub.repo_id, config_name=config_name)
+    card = hub.card()
+    card.data.pop("configs")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    data.push_to_hub(hub.repo_id, config_name=config_name, append=True)
+    data_files = MetadataConfigs.from_dataset_card_data(hub.card().data)[config_name]["data_files"]
+    assert {item["split"] for item in data_files} == {"train", "test"}
+
+
+def test_append_infers_both_known_directories_without_configs(hub):
+    data = Dataset.from_dict({"x": [2]})
+    seed_train_directories(hub)
+    card = hub.card()
+    card.data.pop("configs")
+    hub.fs.pipe_file(hub.root + "/README.md", str(card).encode())
+    data.push_to_hub(hub.repo_id, data_dir="more", append=True)
+    patterns = MetadataConfigs.from_dataset_card_data(hub.card().data)["default"]["data_files"][0]["path"]
+    assert set(patterns) == {"data/train-*", "more/train-*"}
+    assert configured_rows(hub) == {"train": [{"x": 0}, {"x": 1}, {"x": 2}]}

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -56,6 +56,28 @@ class TestPushToHub:
     _api = HfApi(endpoint=CI_HUB_ENDPOINT)
     _token = CI_HUB_USER_TOKEN
 
+    def test_push_to_hub_append(self, temporary_repo):
+        with temporary_repo() as repo_id:
+            DatasetDict(
+                train=Dataset.from_dict({"x": [1, 2]}),
+                test=Dataset.from_dict({"x": [0]}),
+            ).push_to_hub(repo_id, token=self._token)
+            Dataset.from_dict({"x": [3]}).push_to_hub(repo_id, append=True, token=self._token)
+            DatasetDict(train=Dataset.from_dict({"x": [4]})).push_to_hub(
+                repo_id, append=True, num_shards={"train": 2}, token=self._token
+            )
+            result = load_dataset(repo_id, token=self._token, download_mode="force_redownload")
+            assert result["train"]["x"] == [1, 2, 3, 4]
+            assert result["test"]["x"] == [0]
+            assert result["train"].info.splits["train"].num_examples == 4
+            assert sorted(self._api.list_repo_files(repo_id, repo_type="dataset", token=self._token)) == [
+                ".gitattributes",
+                "README.md",
+                "data/test-00000-of-00001.parquet",
+                "data/train-00000-of-00002.parquet",
+                "data/train-00001-of-00002.parquet",
+            ]
+
     def test_push_dataset_dict_to_hub_no_token(self, temporary_repo, set_ci_hub_access_token):
         ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
 


### PR DESCRIPTION
Resolves #6290.

`push_to_hub` replaced every shard of a split on each call, so growing a dataset meant re-uploading all of it. This adds `append=True` to `Dataset.push_to_hub` and `DatasetDict.push_to_hub`, following the approach discussed in the issue: download the last Parquet shard of the target split, copy its row groups byte-for-byte, write the new rows after them, and let Xet's content defined chunking re-upload only the new tail. A new shard is started only when `max_shard_size` would be crossed; when the shard count changes, existing shards are renumbered with server-side copies so nothing is re-uploaded.

Details worth knowing:

- Shard discovery follows the card's `data_files` mapping for the target config, across every directory it lists, with hidden directories excluded the way the loader does. Files referenced by another config are never deleted.
- The card's split sizes and `data_files` entries are updated additively; other configs and splits are untouched.
- Features must match the existing split (compared after Parquet normalisation, so `date64` or `timestamp[s]` round trips are fine); a mismatch raises before anything is uploaded.
- Commits are pinned to the snapshot that was read, so a concurrent push fails instead of silently overwriting rows.
- With `num_proc > 1` new shards keep their index order.
- Content defined chunking is requested from pyarrow when the installed version is 21 or newer; older versions still append correctly, just without the dedup benefit.
- `append=False` is unchanged.

Tests: offline unit tests in `tests/test_push_to_hub_append.py` (byte-prefix preservation, overflow, renumbering, card updates, multi-config and multi-directory layouts, temporal types, `append=False`), plus one integration test in `tests/test_upstream_hub.py`. The actual Xet chunk reuse on the Hub is not measured here; lex00's notebook in the issue thread measured 98.8% reuse for this file layout.
