### PR TITLE
Add a Tensor feature for arrays with fixed or dynamic shapes

### DIFF
--- a/docs/source/about_dataset_features.mdx
+++ b/docs/source/about_dataset_features.mdx
@@ -60,6 +60,35 @@ The array type also allows the first dimension of the array to be dynamic. This 
 >>> features = Features({'a': Array3D(shape=(None, 5, 2), dtype='int32')})
 ```
 
+Use [`Tensor`] for arrays whose sizes can vary along any dimension. For example,
+`Tensor(shape=(None, None, 3), dtype="uint8")` accepts images with different heights
+and widths while requiring three channels. Every row has the same number of
+dimensions. Use `Tensor(ndim=3)` (equivalent to `Tensor(shape=(None, None, None))`)
+when all three sizes may vary. Omitting both `shape` and `ndim` raises a
+`ValueError`.
+
+Values are decoded as NumPy arrays. Fully specified shapes use Arrow's canonical
+fixed shape tensor extension. Dynamic shapes use the canonical variable shape
+tensor extension, storing flattened data and a fixed-size shape list of length
+`ndim` per row. [`Array2D`] through [`Array5D`] remain available.
+
+Tensor formatting preserves the feature dtype, including booleans, unsigned
+64-bit integers and floating-point precision, unless an explicit format dtype is
+provided. NumPy, pandas and Polars return NumPy arrays; PyTorch and TensorFlow
+use their native tensor dtypes. PyTorch versions without native `uint64` support
+raise `ValueError`. JAX requires `jax_enable_x64=True` for 64-bit integers and
+floats; otherwise formatting raises `ValueError` instead of truncating values.
+These rules also apply to tensors nested in lists or dictionaries, and null
+rows remain `None`. Boolean encoding accepts only boolean values and numeric
+values exactly equal to 0 or 1.
+
+Arrow 25's Parquet reader cannot restore null fixed-size lists or fixed tensors
+with zero elements. For affected columns, Datasets writes plain list/struct
+storage and saves the canonical Arrow schema as base64-encoded IPC schema bytes
+in the file metadata key `huggingface:tensor_schema`. Datasets restores the tensor
+features when loading these files. Streaming Parquet writers use this fallback
+for all tensor columns because later batches may contain nulls.
+
 ## Audio feature
 
 Audio datasets have a column with type [`Audio`], which contains three important fields:

--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -257,6 +257,8 @@ Dictionary with split names as keys ('train', 'test' for example), and `Iterable
 
 ### Arrays
 
+[[autodoc]] datasets.Tensor
+
 [[autodoc]] datasets.Array2D
 
 [[autodoc]] datasets.Array3D

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -621,7 +621,7 @@ class ArrowWriter:
         _schema = (
             self._schema
             if self._schema is not None
-            else (pa.schema(self._features.type) if self._features is not None else None)
+            else (pa.schema(list(self._features.type)) if self._features is not None else None)
         )
         if self._disable_nullable and _schema is not None:
             _schema = pa.schema(pa.field(field.name, field.type, nullable=False) for field in _schema)
@@ -811,6 +811,9 @@ class ArrowWriter:
         pa_table = table_cast(pa_table, self._schema)
         if self.embed_local_files:
             pa_table = embed_table_storage(pa_table, local_files=True, remote_files=False)
+            # Embedding can normalize tensors read using a native extension
+            # registry. Align their storage with the writer's exact schema.
+            pa_table = table_cast(pa_table, self._schema)
         self._num_bytes += pa_table.nbytes
         self._num_examples += pa_table.num_rows
         if isinstance(self, ParquetWriter):

--- a/src/datasets/arrow_writer.py
+++ b/src/datasets/arrow_writer.py
@@ -41,6 +41,7 @@ from .features.features import (
     require_storage_embed,
     to_pyarrow_listarray,
 )
+from .features.tensor import contains_tensor, encode_tensor_storage, tensor_to_parquet_schema, tensor_to_parquet_table
 from .filesystems import is_remote_filesystem
 from .info import DatasetInfo
 from .table import array_cast, cast_array_to_feature, embed_table_storage, table_cast
@@ -320,13 +321,28 @@ class TypedSequence:
                 return pa.ExtensionArray.from_storage(pa_type, storage)
 
             # efficient np array to pyarrow array
-            if isinstance(data, np.ndarray):
+            if isinstance(data, np.ndarray) and not contains_tensor(type):
                 out = numpy_to_pyarrow_listarray(data)
-            elif isinstance(data, list) and data and isinstance(first_non_null_non_empty_value(data)[1], np.ndarray):
+            elif (
+                isinstance(data, list)
+                and data
+                and isinstance(first_non_null_non_empty_value(data)[1], np.ndarray)
+                and not contains_tensor(type)
+            ):
                 out = list_of_np_array_to_pyarrow_listarray(data)
             else:
                 trying_cast_to_python_objects = True
                 examples = data
+                if contains_tensor(type):
+                    # Normalize Tensor leaves before Arrow infers list ranks.
+                    # Siblings and new fields retain their values for the usual
+                    # JSON encoding, type inference and safe feature casting.
+                    try:
+                        examples = [encode_tensor_storage(type, value) for value in examples]
+                    except (TypeError, AttributeError, ValueError) as e:
+                        if self.trying_type:
+                            raise pa.ArrowInvalid(str(e)) from e
+                        raise
                 # find fields to json-encode
                 if self.on_mixed_types == "use_json" and type is None:
                     json_field_paths = find_mixed_struct_types_field_paths(examples, allow_root=True)
@@ -797,6 +813,8 @@ class ArrowWriter:
             pa_table = embed_table_storage(pa_table, local_files=True, remote_files=False)
         self._num_bytes += pa_table.nbytes
         self._num_examples += pa_table.num_rows
+        if isinstance(self, ParquetWriter):
+            pa_table = tensor_to_parquet_table(pa_table, self.pa_writer.schema)
         self.pa_writer.write_table(pa_table, writer_batch_size)
 
     def finalize(self, close_stream=True):
@@ -833,7 +851,7 @@ class ParquetWriter(ArrowWriter):
         self._schema, self._features = self._build_schema(inferred_schema)
         self.pa_writer = pq.ParquetWriter(
             self.stream,
-            self._schema,
+            tensor_to_parquet_schema(self._schema),
             use_content_defined_chunking=self.use_content_defined_chunking,
             write_page_index=self.write_page_index,
             compression={

--- a/src/datasets/features/__init__.py
+++ b/src/datasets/features/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "Array3D",
     "Array4D",
     "Array5D",
+    "Tensor",
     "ClassLabel",
     "Features",
     "Json",
@@ -29,5 +30,6 @@ from .image import Image
 from .mesh import Mesh
 from .nifti import Nifti
 from .pdf import Pdf
+from .tensor import Tensor
 from .translation import Translation, TranslationVariableLanguages
 from .video import Video

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -54,6 +54,7 @@ from .tensor import (
     contains_tensor,
     contains_tensor_type,
     is_tensor_type,
+    normalize_tensor_arrow_type,
     normalize_tensor_type,
     tensor_from_parquet_schema,
 )
@@ -1983,7 +1984,9 @@ class Features(dict):
             :obj:`pyarrow.Schema`
         """
         hf_metadata = {"info": {"features": self.to_dict()}}
-        return pa.schema(self.type).with_metadata({"huggingface": json.dumps(hf_metadata)})
+        # Passing the StructType itself uses the C schema interface, which can
+        # replace Python tensor types with the canonical registry's native types.
+        return pa.schema(list(self.type)).with_metadata({"huggingface": json.dumps(hf_metadata)})
 
     @classmethod
     def from_arrow_schema(cls, pa_schema: pa.Schema) -> "Features":
@@ -2003,6 +2006,10 @@ class Features(dict):
             [`Features`]
         """
         pa_schema = tensor_from_parquet_schema(pa_schema)
+        pa_schema = pa.schema(
+            [field.with_type(normalize_tensor_arrow_type(field.type)) for field in pa_schema],
+            metadata=pa_schema.metadata,
+        )
         # try to load features from the arrow schema metadata
         metadata_features = Features()
         if pa_schema.metadata is not None and b"huggingface" in pa_schema.metadata:

--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -48,6 +48,15 @@ from .image import Image, encode_pil_image
 from .mesh import Mesh
 from .nifti import Nifti, encode_nibabel_image
 from .pdf import Pdf, encode_pdfplumber_pdf
+from .tensor import (
+    Tensor,
+    TensorPandasDtype,
+    contains_tensor,
+    contains_tensor_type,
+    is_tensor_type,
+    normalize_tensor_type,
+    tensor_from_parquet_schema,
+)
 from .translation import Translation, TranslationVariableLanguages
 from .video import Video
 
@@ -1002,6 +1011,8 @@ class PandasArrayExtensionArray(PandasExtensionArray):
 
 
 def pandas_types_mapper(dtype):
+    if contains_tensor_type(dtype):
+        return TensorPandasDtype()
     if isinstance(dtype, _ArrayXDExtensionType):
         return PandasArrayExtensionDtype(dtype.value_type)
 
@@ -1391,6 +1402,7 @@ FeatureType = Union[
     Array3D,
     Array4D,
     Array5D,
+    Tensor,
     Audio,
     Image,
     Mesh,
@@ -1479,6 +1491,8 @@ def encode_nested_example(schema, obj, level=0):
         else:
             if len(obj) > 0:
                 sub_schema = schema.feature
+                if contains_tensor(sub_schema):
+                    return [encode_nested_example(sub_schema, o, level=level + 1) for o in obj]
                 for first_elmt in obj:
                     if _check_non_null_non_empty_recursive(first_elmt, sub_schema):
                         break
@@ -1520,7 +1534,7 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Uni
                 for first_elmt in obj:
                     if _check_non_null_non_empty_recursive(first_elmt, sub_schema):
                         break
-                if decode_nested_example(sub_schema, first_elmt) != first_elmt:
+                if contains_tensor(sub_schema) or decode_nested_example(sub_schema, first_elmt) != first_elmt:
                     return [decode_nested_example(sub_schema, o) for o in obj]
             return list(obj)
     elif isinstance(schema, (LargeList, List)):
@@ -1534,7 +1548,7 @@ def decode_nested_example(schema, obj, token_per_repo_id: Optional[dict[str, Uni
                 for first_elmt in obj:
                     if _check_non_null_non_empty_recursive(first_elmt, sub_schema):
                         break
-                if decode_nested_example(sub_schema, first_elmt) != first_elmt:
+                if contains_tensor(sub_schema) or decode_nested_example(sub_schema, first_elmt) != first_elmt:
                     return [decode_nested_example(sub_schema, o) for o in obj]
             return list(obj)
     # Object with special decoding:
@@ -1555,6 +1569,7 @@ _FEATURE_TYPES: dict[str, FeatureType] = {
     Array3D.__name__: Array3D,
     Array4D.__name__: Array4D,
     Array5D.__name__: Array5D,
+    Tensor.__name__: Tensor,
     Audio.__name__: Audio,
     Image.__name__: Image,
     Mesh.__name__: Mesh,
@@ -1642,6 +1657,16 @@ def generate_from_arrow_type(pa_type: pa.DataType) -> FeatureType:
     elif isinstance(pa_type, _ArrayXDExtensionType):
         array_feature = [None, None, Array2D, Array3D, Array4D, Array5D][pa_type.ndims]
         return array_feature(shape=pa_type.shape, dtype=pa_type.value_type)
+    elif is_tensor_type(pa_type):
+        pa_type = normalize_tensor_type(pa_type)
+        if pa_type.dim_names:
+            raise ValueError("Tensor does not support dimension names")
+        shape = pa_type.shape if isinstance(pa_type, pa.FixedShapeTensorType) else pa_type.uniform_shape
+        if shape is None:
+            shape = (None,) * pa_type.ndim
+        if pa_type.permutation and list(pa_type.permutation) != list(range(len(shape))):
+            raise ValueError("Tensor does not support permuted dimensions")
+        return Tensor(tuple(shape), _arrow_to_datasets_dtype(pa_type.value_type))
     elif isinstance(pa_type, pa.JsonType):
         return Json()
     elif isinstance(pa_type, pa.DataType):
@@ -1977,6 +2002,7 @@ class Features(dict):
         Returns:
             [`Features`]
         """
+        pa_schema = tensor_from_parquet_schema(pa_schema)
         # try to load features from the arrow schema metadata
         metadata_features = Features()
         if pa_schema.metadata is not None and b"huggingface" in pa_schema.metadata:

--- a/src/datasets/features/tensor.py
+++ b/src/datasets/features/tensor.py
@@ -1,0 +1,524 @@
+# Copyright 2026 The HuggingFace Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NumPy tensors backed by Arrow tensor extensions."""
+
+import base64
+import json
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+import pyarrow as pa
+from pandas.api.extensions import ExtensionDtype
+
+
+def _normalize_shape(shape, allow_unknown_dims=False):
+    if not isinstance(shape, (tuple, list, np.ndarray)):
+        raise ValueError(f"Invalid Tensor shape: {shape!r}")
+    if any(
+        not (dim is None and allow_unknown_dims)
+        and (isinstance(dim, (bool, np.bool_)) or not isinstance(dim, (int, np.integer)) or not 0 <= dim <= 2**31 - 1)
+        for dim in shape
+    ):
+        raise ValueError(f"Invalid Tensor shape: {shape!r}; dimensions must be nonnegative integers")
+    return tuple(int(dim) if dim is not None else None for dim in shape)
+
+
+class VariableShapeTensorType(pa.ExtensionType):
+    """Python representation of the variable tensor layout.
+
+    Data is flattened in C order. Absent permutation and dimension names mean
+    identity order and unnamed dimensions. uniform_shape constrains the
+    rank and any known dimensions.
+
+    The canonical storage is struct<data: list<value_type>,
+    shape: fixed_size_list<int32>[ndim]>. Arrow 25 provides the C++ reader but
+    no Python constructor, so this class implements its Python representation.
+    """
+
+    def __init__(self, value_type, uniform_shape=None, *, ndim=None, permutation=None, dim_names=None):
+        self.value_type = value_type
+        self.uniform_shape = (
+            _normalize_shape(uniform_shape, allow_unknown_dims=True) if uniform_shape is not None else None
+        )
+        if ndim is None and self.uniform_shape is not None:
+            ndim = len(self.uniform_shape)
+        if isinstance(ndim, (bool, np.bool_)) or not isinstance(ndim, (int, np.integer)) or not 0 <= ndim <= 2**31 - 1:
+            raise ValueError("Tensor ndim must be a nonnegative integer; provide a shape with None entries or ndim=")
+        self.ndim = int(ndim)
+        self.permutation = permutation
+        self.dim_names = dim_names
+        if self.uniform_shape is not None and len(self.uniform_shape) != self.ndim:
+            raise ValueError("Tensor uniform_shape must match the storage rank")
+        shape_type = pa.list_(pa.int32(), self.ndim)
+        storage_type = pa.struct([("data", pa.list_(value_type)), ("shape", shape_type)])
+        super().__init__(storage_type, "arrow.variable_shape_tensor")
+
+    def __arrow_ext_serialize__(self):
+        metadata = {}
+        if self.permutation is not None:
+            metadata["permutation"] = self.permutation
+        if self.dim_names is not None:
+            metadata["dim_names"] = self.dim_names
+        if self.uniform_shape is not None:
+            metadata["uniform_shape"] = self.uniform_shape
+        return json.dumps(metadata, separators=(",", ":")).encode()
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        metadata = json.loads(serialized)
+        if not isinstance(storage_type, pa.StructType) or storage_type.names != ["data", "shape"]:
+            raise ValueError(f"Unsupported Tensor storage type: {storage_type}")
+        data_type = storage_type.field("data").type
+        shape_type = storage_type.field("shape").type
+        if not pa.types.is_list(data_type) or not (
+            pa.types.is_fixed_size_list(shape_type) and shape_type.value_type == pa.int32()
+        ):
+            raise ValueError(f"Unsupported Tensor storage type: {storage_type}")
+        return cls(
+            data_type.value_type,
+            metadata.get("uniform_shape"),
+            ndim=shape_type.list_size,
+            permutation=metadata.get("permutation"),
+            dim_names=metadata.get("dim_names"),
+        )
+
+    def __eq__(self, other):
+        if not is_tensor_type(other) or other.extension_name != self.extension_name:
+            return NotImplemented
+        other = normalize_tensor_type(other)
+        # Arrow delegates schema and array type equality to this method.
+        # Storage alone only describes value_type and rank.
+        return self.storage_type == other.storage_type and json.loads(self.__arrow_ext_serialize__()) == json.loads(
+            other.__arrow_ext_serialize__()
+        )
+
+    def __ne__(self, other):
+        equal = self.__eq__(other)
+        return NotImplemented if equal is NotImplemented else not equal
+
+    def __reduce__(self):
+        return self.__arrow_ext_deserialize__, (self.storage_type, self.__arrow_ext_serialize__())
+
+
+# Arrow 25 registers the C++ canonical type even without exposing a Python
+# constructor. Register the Python representation of the same canonical layout.
+try:
+    pa.register_extension_type(VariableShapeTensorType(pa.float32(), ndim=1))
+except pa.ArrowKeyError:
+    pa.unregister_extension_type("arrow.variable_shape_tensor")
+    pa.register_extension_type(VariableShapeTensorType(pa.float32(), ndim=1))
+
+
+def is_tensor_type(arrow_type):
+    return isinstance(arrow_type, pa.BaseExtensionType) and arrow_type.extension_name in (
+        "arrow.fixed_shape_tensor",
+        "arrow.variable_shape_tensor",
+    )
+
+
+def normalize_tensor_type(arrow_type):
+    """Recover parameters even for a C++ type read before Datasets was imported."""
+    if isinstance(arrow_type, (pa.FixedShapeTensorType, VariableShapeTensorType)):
+        return arrow_type
+    if is_tensor_type(arrow_type):
+        # BaseExtensionType has no Python metadata accessor in Arrow 25.
+        # IPC preserves the canonical serialized metadata; read it through the
+        # registered deserializer to recover all parameters, including layout.
+        schema = pa.schema([("tensor", arrow_type)])
+        restored = pa.ipc.read_schema(pa.BufferReader(schema.serialize())).field("tensor").type
+        if isinstance(restored, (pa.FixedShapeTensorType, VariableShapeTensorType)):
+            return restored
+    raise ValueError(f"Unsupported Tensor extension type: {arrow_type}")
+
+
+def contains_tensor_type(arrow_type):
+    """Whether an Arrow field contains tensors at any nesting depth."""
+    if is_tensor_type(arrow_type):
+        return True
+    if pa.types.is_struct(arrow_type):
+        return any(contains_tensor_type(field.type) for field in arrow_type)
+    if pa.types.is_list(arrow_type) or pa.types.is_large_list(arrow_type) or pa.types.is_fixed_size_list(arrow_type):
+        return contains_tensor_type(arrow_type.value_type)
+    return False
+
+
+@dataclass
+class Tensor:
+    """An array with a fixed number of dimensions and optionally variable sizes.
+
+    Args:
+        shape (optional tuple of optional int):
+            Size of each dimension. None dimensions may vary between rows.
+            If omitted, ndim must specify the number of dimensions.
+        dtype (str, defaults to "float32"):
+            NumPy boolean, integer, or floating-point dtype. Values are converted
+            to this dtype; invalid values and lossy integer conversions raise
+            ValueError.
+        ndim (optional int):
+            Number of dimensions, required when shape is omitted. If both are
+            provided, ndim must equal len(shape). All rows have this rank.
+
+    Examples:
+        >>> from datasets import Dataset, Features, Tensor
+        >>> features = Features({"x": Tensor(shape=(None, None, 3), dtype="uint8")})
+        >>> dataset = Dataset.from_dict({"x": [[[[0, 1, 2]]]]}, features=features)
+        >>> dataset[0]["x"].shape
+        (1, 1, 3)
+    """
+
+    shape: Optional[tuple[Optional[int], ...]] = None
+    dtype: str = "float32"
+    ndim: Optional[int] = None
+    _type: str = field(default="Tensor", init=False, repr=False)
+
+    def __post_init__(self):
+        if self.ndim is not None and (
+            isinstance(self.ndim, (bool, np.bool_))
+            or not isinstance(self.ndim, (int, np.integer))
+            or not 0 <= self.ndim <= 2**31 - 1
+        ):
+            raise ValueError("Tensor ndim must be a nonnegative integer")
+        if self.shape is None:
+            if self.ndim is None:
+                raise ValueError(
+                    "Tensor requires a shape with None entries for dynamic dimensions or an explicit ndim="
+                )
+            self.shape = (None,) * self.ndim
+        else:
+            self.shape = _normalize_shape(self.shape, allow_unknown_dims=True)
+            if self.ndim is not None and self.ndim != len(self.shape):
+                raise ValueError(f"Tensor ndim={self.ndim} does not match shape {self.shape}")
+        self.ndim = len(self.shape)
+        try:
+            dtype = np.dtype(self.dtype)
+            if dtype.kind not in "biuf" or not dtype.isnative:
+                raise ValueError
+            pa.from_numpy_dtype(dtype)
+        except (TypeError, ValueError, pa.ArrowNotImplementedError) as e:
+            raise ValueError(
+                f"Invalid Tensor dtype: {self.dtype!r}; expected a boolean, integer or floating dtype"
+            ) from e
+        self.dtype = dtype.name
+
+    def __call__(self):
+        value_type = pa.from_numpy_dtype(np.dtype(self.dtype))
+        if all(dim is not None for dim in self.shape):
+            return pa.fixed_shape_tensor(value_type, self.shape)
+        return VariableShapeTensorType(
+            value_type, self.shape if any(dim is not None for dim in self.shape) else None, ndim=self.ndim
+        )
+
+    def _validate_shape(self, shape):
+        if len(shape) != self.ndim or any(
+            expected is not None and actual != expected for actual, expected in zip(shape, self.shape)
+        ):
+            raise ValueError(f"Tensor shape {tuple(shape)} does not match expected shape {self.shape}")
+
+    def encode_example(self, value):
+        from .features import cast_to_python_objects
+
+        if value is None:
+            return None
+        value = cast_to_python_objects(value, optimize_list_casting=False)
+        try:
+            raw_data = value["data"] if isinstance(value, dict) else value
+            python_integers = np.dtype(self.dtype).kind in "iu" and not isinstance(raw_data, np.ndarray)
+            array = np.asarray(raw_data, dtype=object if python_integers else None)
+            if python_integers:
+                # NumPy infers float64 for Python integers mixing small values
+                # and values above int64's maximum. Validate before conversion
+                # so these inputs cannot silently lose uint64 precision.
+                bounds = np.iinfo(self.dtype)
+                integers = []
+                for item in array.flat:
+                    if not isinstance(item, (bool, int, float, np.bool_, np.integer, np.floating)):
+                        raise ValueError("expected numeric or boolean values")
+                    integer = int(item)
+                    if integer != item or not bounds.min <= integer <= bounds.max:
+                        raise ValueError(f"value {item!r} cannot be represented as {self.dtype}")
+                    integers.append(integer)
+                array = np.asarray(integers, dtype=self.dtype).reshape(array.shape)
+            if isinstance(value, dict):
+                shape = _normalize_shape(value["shape"])
+                self._validate_shape(shape)
+                array = array.reshape(shape)
+            if array.dtype.kind not in "biuf":
+                raise ValueError("expected numeric or boolean values")
+            self._validate_shape(array.shape)
+            if self.dtype == "bool" and not np.all((array == 0) | (array == 1)):
+                raise ValueError("values must be exactly 0 or 1 to be represented as bool")
+            target_type = pa.from_numpy_dtype(np.dtype(self.dtype))
+            if np.dtype(self.dtype).kind in "iu":
+                # Arrow's safe cast rejects fractional values and integer overflow.
+                data = pa.array(array.reshape(-1)).cast(target_type).to_numpy(zero_copy_only=False)
+            else:
+                with np.errstate(over="raise", invalid="raise"):
+                    data = array.astype(self.dtype).reshape(-1)
+        except (KeyError, TypeError, ValueError, OverflowError, FloatingPointError, pa.ArrowException) as e:
+            raise ValueError(f"Cannot encode Tensor with dtype {self.dtype} and shape {self.shape}: {e}") from e
+        if isinstance(self(), pa.FixedShapeTensorType):
+            # Preserve rank until the writer builds Arrow storage. A flat user
+            # value must never be mistaken for an already encoded fixed tensor.
+            return data.reshape(array.shape)
+        return {"data": data, "shape": list(array.shape)}
+
+    def decode_example(self, value, token_per_repo_id=None):
+        if value is None:
+            return None
+        try:
+            if isinstance(value, dict):
+                shape = _normalize_shape(value["shape"])
+                data = value["data"]
+            else:
+                data = np.asarray(value, dtype=self.dtype)
+                # Fixed tensor storage is flattened; decoded arrays already
+                # carry their shape. Variable storage always includes a shape.
+                shape = self.shape if isinstance(self(), pa.FixedShapeTensorType) and data.ndim == 1 else data.shape
+            self._validate_shape(shape)
+            return tensor_to_backend(np.asarray(data, dtype=self.dtype).reshape(shape))
+        except (KeyError, TypeError, ValueError, OverflowError) as e:
+            raise ValueError(f"Cannot decode Tensor with dtype {self.dtype} and shape {self.shape}: {e}") from e
+
+    def cast_storage(self, storage):
+        from .features import generate_from_arrow_type
+
+        arrow_type = self()
+        if isinstance(storage, pa.ExtensionArray):
+            if normalize_tensor_type(storage.type) == arrow_type:
+                # Native and Python implementations can have identical canonical
+                # parameters while Arrow refuses a direct extension-to-extension
+                # cast. Rewrap the storage without copying its buffers.
+                return arrow_type.wrap_array(storage.storage)
+            source = generate_from_arrow_type(storage.type)
+            values = [source.decode_example(value) for value in storage.to_pylist()]
+        else:
+            values = storage.to_pylist()
+            if (
+                isinstance(arrow_type, pa.FixedShapeTensorType)
+                and (pa.types.is_list(storage.type) or pa.types.is_fixed_size_list(storage.type))
+                and not pa.types.is_nested(storage.type.value_type)
+            ):
+                # Reshape storage without converting dtype before validation.
+                values = [
+                    np.asarray(value, dtype=storage.type.value_type.to_pandas_dtype()).reshape(self.shape)
+                    if value is not None
+                    else None
+                    for value in values
+                ]
+        values = [encode_tensor_storage(self, value) for value in values]
+        return pa.array(values, type=arrow_type)
+
+    def embed_storage(
+        self, storage: pa.ExtensionArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
+    ) -> pa.ExtensionArray:
+        """Return the tensor extension unchanged; all tensor data is already embedded."""
+        return storage
+
+
+class TensorPandasDtype(ExtensionDtype):
+    """Use the existing pandas array container after restoring tensor shapes."""
+
+    type = np.ndarray
+    kind = "O"
+    name = "tensor"
+
+    def __from_arrow__(self, array):
+        from .features import PandasArrayExtensionArray, generate_from_arrow_type
+
+        feature = generate_from_arrow_type(array.type)
+        # Restore only Tensor leaves here. The pandas feature decoder uses
+        # the original metadata to decode siblings, including Json(decode=False).
+        values = [_map_nested_tensor(feature, value, Tensor.decode_example) for value in array.to_pylist()]
+        if (
+            values
+            and isinstance(values[0], np.ndarray)
+            and values[0].ndim > 0
+            and all(isinstance(value, np.ndarray) and value.shape == values[0].shape for value in values)
+        ):
+            data = np.stack(values)
+        else:
+            data = np.empty(len(values), dtype=object)
+            data[:] = values
+        return PandasArrayExtensionArray(data)
+
+
+def _tensor_parquet_type(arrow_type):
+    """Storage fallback for Arrow's Parquet reader bug with null fixed-size lists."""
+    if is_tensor_type(arrow_type):
+        arrow_type = normalize_tensor_type(arrow_type)
+    if isinstance(arrow_type, pa.FixedShapeTensorType):
+        return pa.list_(arrow_type.storage_type.value_field)
+    if isinstance(arrow_type, VariableShapeTensorType):
+        return pa.struct(
+            [
+                arrow_type.storage_type.field("data"),
+                arrow_type.storage_type.field("shape").with_type(pa.list_(pa.int32())),
+            ]
+        )
+    if pa.types.is_struct(arrow_type):
+        return pa.struct([field.with_type(_tensor_parquet_type(field.type)) for field in arrow_type])
+    if pa.types.is_list(arrow_type):
+        return pa.list_(arrow_type.value_field.with_type(_tensor_parquet_type(arrow_type.value_type)))
+    if pa.types.is_large_list(arrow_type):
+        return pa.large_list(arrow_type.value_field.with_type(_tensor_parquet_type(arrow_type.value_type)))
+    if pa.types.is_fixed_size_list(arrow_type):
+        value_type = _tensor_parquet_type(arrow_type.value_type)
+        if value_type != arrow_type.value_type:
+            return pa.list_(arrow_type.value_field.with_type(value_type))
+    return arrow_type
+
+
+def _requires_tensor_parquet_storage(array, parent_nulls=False):
+    if isinstance(array, pa.ChunkedArray):
+        return any(_requires_tensor_parquet_storage(chunk, parent_nulls) for chunk in array.chunks)
+    has_nulls = parent_nulls or array.null_count > 0
+    if is_tensor_type(array.type):
+        return has_nulls or (
+            isinstance(array.type, pa.FixedShapeTensorType) and array.type.storage_type.list_size == 0
+        )
+    if pa.types.is_struct(array.type):
+        return any(_requires_tensor_parquet_storage(array.field(field.name), has_nulls) for field in array.type)
+    if pa.types.is_list(array.type) or pa.types.is_large_list(array.type) or pa.types.is_fixed_size_list(array.type):
+        return _requires_tensor_parquet_storage(array.values, has_nulls)
+    return False
+
+
+def tensor_to_parquet_schema(schema, table=None):
+    # Preserve canonical extensions whenever the complete table proves safe.
+    # Streaming writers cannot rule out nulls in future batches, so use storage.
+    fields = [
+        field.with_type(_tensor_parquet_type(field.type))
+        if table is None or _requires_tensor_parquet_storage(table[field.name])
+        else field
+        for field in schema
+    ]
+    if all(field.type == original.type for field, original in zip(fields, schema)):
+        return schema
+    # Keep the canonical schema separately: applying it as ARROW:schema would
+    # trigger Arrow 25's fixed-size-list reader bug. Plain Arrow can read both
+    # the storage table and this serialized schema without importing Datasets.
+    metadata = {
+        **(schema.metadata or {}),
+        b"huggingface:tensor_schema": base64.b64encode(schema.serialize().to_pybytes()),
+    }
+    return pa.schema(fields, metadata=metadata)
+
+
+def tensor_from_parquet_schema(schema):
+    metadata = schema.metadata or {}
+    if b"huggingface:tensor_schema" not in metadata:
+        return schema
+    canonical_schema = pa.ipc.read_schema(
+        pa.BufferReader(base64.b64decode(metadata[b"huggingface:tensor_schema"], validate=True))
+    )
+    canonical_fields = {field.name: field for field in canonical_schema}
+    # Respect projections and schema changes made by other Arrow consumers.
+    fields = [
+        canonical_fields[field.name]
+        if field.name in canonical_fields and field.type == _tensor_parquet_type(canonical_fields[field.name].type)
+        else field
+        for field in schema
+    ]
+    return pa.schema(
+        fields, metadata={key: value for key, value in metadata.items() if key != b"huggingface:tensor_schema"}
+    )
+
+
+def tensor_to_parquet_table(table, schema=None):
+    from ..table import array_cast
+
+    if schema is None:
+        schema = tensor_to_parquet_schema(table.schema, table)
+    if schema == table.schema:
+        return table
+    arrays = [
+        column if field.type == column.type else array_cast(column, field.type)
+        for field, column in zip(schema, table.columns)
+    ]
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def contains_tensor(feature):
+    from .features import LargeList, List
+
+    if isinstance(feature, Tensor):
+        return True
+    if isinstance(feature, dict):
+        return any(contains_tensor(subfeature) for subfeature in feature.values())
+    if isinstance(feature, (list, tuple)):
+        return any(contains_tensor(subfeature) for subfeature in feature)
+    if isinstance(feature, (LargeList, List)):
+        return contains_tensor(feature.feature)
+    return False
+
+
+def _map_nested_tensor(feature, value, function):
+    """Apply a conversion only to Tensor leaves, preserving sibling fields."""
+    from .features import LargeList, List
+
+    if value is None:
+        return None
+    if isinstance(feature, Tensor):
+        return function(feature, value)
+    if isinstance(feature, dict):
+        return {key: _map_nested_tensor(feature.get(key), item, function) for key, item in value.items()}
+    if isinstance(feature, (List, LargeList)):
+        return [_map_nested_tensor(feature.feature, item, function) for item in value]
+    if isinstance(feature, (list, tuple)):
+        return [_map_nested_tensor(feature[0], item, function) for item in value]
+    return value
+
+
+def encode_tensor_storage(feature, value):
+    """Normalize Tensor leaves before Arrow infers nested list ranks."""
+
+    def encode(feature, value):
+        encoded = feature.encode_example(value)
+        return encoded.reshape(-1) if isinstance(feature(), pa.FixedShapeTensorType) else encoded
+
+    return _map_nested_tensor(feature, value, encode)
+
+
+def tensor_to_backend(value, backend="numpy", **kwargs):
+    """Convert a decoded Tensor without applying a formatter's default dtype.
+
+    Pandas and Polars keep NumPy arrays in their object columns. Native backends
+    infer the same dtype from NumPy. JAX requires x64 mode for 64-bit values;
+    reject unsupported conversions instead of silently truncating them.
+    Explicit formatter dtype arguments still override the feature dtype.
+    """
+    if backend == "numpy":
+        return np.asarray(value, **kwargs)
+    if backend == "torch":
+        import torch
+
+        if value.dtype == np.uint64 and not hasattr(torch, "uint64"):
+            raise ValueError("Tensor dtype uint64 requires a PyTorch version with native uint64 support")
+        return torch.tensor(value, **kwargs)
+    if backend == "tensorflow":
+        import tensorflow as tf
+
+        return tf.convert_to_tensor(value, **kwargs)
+    if backend == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        dtype = kwargs.get("dtype", value.dtype)
+        if np.dtype(dtype).itemsize == 8 and np.dtype(dtype).kind in "iuf" and not jax.config.jax_enable_x64:
+            raise ValueError(f"Tensor dtype {np.dtype(dtype).name} requires jax_enable_x64=True")
+        with jax.default_device(kwargs.pop("device", None)):
+            return jnp.asarray(value, **{"dtype": value.dtype, **kwargs})
+    raise ValueError(f"Unsupported Tensor backend: {backend}")

--- a/src/datasets/features/tensor.py
+++ b/src/datasets/features/tensor.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
 from pandas.api.extensions import ExtensionDtype
 
 
@@ -519,6 +520,32 @@ def tensor_from_parquet_schema(schema):
     )
 
 
+def _compact_parquet_storage(array, parent_nulls=None, nullable=True):
+    """Remove values hidden by null lists or struct parents before Parquet writes."""
+    if isinstance(array, pa.ChunkedArray):
+        return pa.chunked_array([_compact_parquet_storage(chunk) for chunk in array.chunks], type=array.type)
+    nulls = array.is_null()
+    if parent_nulls is not None:
+        nulls = pc.or_(nulls, parent_nulls)
+    # Required fields must retain their validity beneath null struct parents.
+    mask = nulls if nullable else array.is_null()
+    if pa.types.is_struct(array.type):
+        return pa.StructArray.from_arrays(
+            [_compact_parquet_storage(array.field(i), nulls, field.nullable) for i, field in enumerate(array.type)],
+            fields=list(array.type),
+            mask=mask,
+        )
+    if pa.types.is_list(array.type) or pa.types.is_large_list(array.type):
+        # Normalize the offset buffer's slice before supplying a separate mask.
+        masked = type(array).from_arrays(np.asarray(array.offsets), array.values, type=array.type, mask=nulls)
+        # Unlike a fixed-size-list cast, these offsets give null rows zero length.
+        offsets = pa.concat_arrays(
+            [pa.array([0], type=array.offsets.type), pc.cumulative_sum(pc.fill_null(masked.value_lengths(), 0))]
+        )
+        return type(array).from_arrays(offsets, _compact_parquet_storage(masked.flatten()), type=array.type, mask=mask)
+    return array
+
+
 def tensor_to_parquet_table(table, schema=None):
     from ..table import array_cast
 
@@ -532,6 +559,14 @@ def tensor_to_parquet_table(table, schema=None):
         if contains_tensor_type(field.type) or contains_tensor_type(column.type) or field.type != column.type
         else column
         for field, column in zip(schema, table.columns)
+    ]
+    # Parquet writers may reject non-zero spans hidden by null rows even though
+    # the Arrow arrays produced by fixed-size-list casts are valid.
+    arrays = [
+        _compact_parquet_storage(array)
+        if contains_tensor_type(column.type) and not contains_tensor_type(field.type)
+        else array
+        for field, column, array in zip(schema, table.columns, arrays)
     ]
     return pa.Table.from_arrays(arrays, schema=schema)
 

--- a/src/datasets/features/tensor.py
+++ b/src/datasets/features/tensor.py
@@ -15,6 +15,7 @@
 """NumPy tensors backed by Arrow tensor extensions."""
 
 import base64
+import ctypes
 import json
 from dataclasses import dataclass, field
 from typing import Optional
@@ -98,12 +99,7 @@ class VariableShapeTensorType(pa.ExtensionType):
     def __eq__(self, other):
         if not is_tensor_type(other) or other.extension_name != self.extension_name:
             return NotImplemented
-        other = normalize_tensor_type(other)
-        # Arrow delegates schema and array type equality to this method.
-        # Storage alone only describes value_type and rank.
-        return self.storage_type == other.storage_type and json.loads(self.__arrow_ext_serialize__()) == json.loads(
-            other.__arrow_ext_serialize__()
-        )
+        return tensor_types_equal(self, other)
 
     def __ne__(self, other):
         equal = self.__eq__(other)
@@ -113,13 +109,12 @@ class VariableShapeTensorType(pa.ExtensionType):
         return self.__arrow_ext_deserialize__, (self.storage_type, self.__arrow_ext_serialize__())
 
 
-# Arrow 25 registers the C++ canonical type even without exposing a Python
-# constructor. Register the Python representation of the same canonical layout.
+# Some Arrow builds register the canonical C++ type without a Python wrapper.
+# Respect that registration (or another library's implementation).
 try:
     pa.register_extension_type(VariableShapeTensorType(pa.float32(), ndim=1))
 except pa.ArrowKeyError:
-    pa.unregister_extension_type("arrow.variable_shape_tensor")
-    pa.register_extension_type(VariableShapeTensorType(pa.float32(), ndim=1))
+    pass
 
 
 def is_tensor_type(arrow_type):
@@ -129,19 +124,90 @@ def is_tensor_type(arrow_type):
     )
 
 
+class _ArrowSchema(ctypes.Structure):
+    # Arrow C Data Interface ABI. The capsule owns the exported schema and
+    # releases it after metadata has been copied into Python bytes.
+    _fields_ = [
+        ("format", ctypes.c_void_p),
+        ("name", ctypes.c_void_p),
+        ("metadata", ctypes.c_void_p),
+        ("flags", ctypes.c_int64),
+        ("n_children", ctypes.c_int64),
+        ("children", ctypes.c_void_p),
+        ("dictionary", ctypes.c_void_p),
+        ("release", ctypes.c_void_p),
+        ("private_data", ctypes.c_void_p),
+    ]
+
+
+def _serialized_tensor_metadata(arrow_type):
+    if isinstance(arrow_type, pa.ExtensionType):
+        return arrow_type.__arrow_ext_serialize__()
+    # BaseExtensionType has no metadata accessor in Arrow 24/25. Reading IPC
+    # through its registry would return the same opaque native type again.
+    capsule = arrow_type.__arrow_c_schema__()
+    get_pointer = ctypes.pythonapi.PyCapsule_GetPointer
+    get_pointer.restype = ctypes.c_void_p
+    get_pointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+    schema = ctypes.cast(get_pointer(capsule, b"arrow_schema"), ctypes.POINTER(_ArrowSchema)).contents
+    address = schema.metadata
+    if address:
+        # C schema metadata is a count followed by length-prefixed key/value
+        # byte strings, with native-endian int32 counts and lengths.
+        count = ctypes.c_int32.from_address(address).value
+        address += 4
+        for _ in range(count):
+            pair = []
+            for _ in range(2):
+                length = ctypes.c_int32.from_address(address).value
+                address += 4
+                pair.append(ctypes.string_at(address, length))
+                address += length
+            if pair[0] == b"ARROW:extension:metadata":
+                return pair[1]
+    raise ValueError(f"Missing Tensor extension metadata: {arrow_type}")
+
+
 def normalize_tensor_type(arrow_type):
-    """Recover parameters even for a C++ type read before Datasets was imported."""
+    """Recover canonical parameters independently of the extension registry."""
     if isinstance(arrow_type, (pa.FixedShapeTensorType, VariableShapeTensorType)):
         return arrow_type
-    if is_tensor_type(arrow_type):
-        # BaseExtensionType has no Python metadata accessor in Arrow 25.
-        # IPC preserves the canonical serialized metadata; read it through the
-        # registered deserializer to recover all parameters, including layout.
-        schema = pa.schema([("tensor", arrow_type)])
-        restored = pa.ipc.read_schema(pa.BufferReader(schema.serialize())).field("tensor").type
-        if isinstance(restored, (pa.FixedShapeTensorType, VariableShapeTensorType)):
-            return restored
-    raise ValueError(f"Unsupported Tensor extension type: {arrow_type}")
+    if not is_tensor_type(arrow_type):
+        raise ValueError(f"Unsupported Tensor extension type: {arrow_type}")
+    serialized = _serialized_tensor_metadata(arrow_type)
+    if arrow_type.extension_name == "arrow.variable_shape_tensor":
+        return VariableShapeTensorType.__arrow_ext_deserialize__(arrow_type.storage_type, serialized)
+    metadata = json.loads(serialized)
+    if not pa.types.is_fixed_size_list(arrow_type.storage_type):
+        raise ValueError(f"Unsupported Tensor storage type: {arrow_type.storage_type}")
+    normalized = pa.fixed_shape_tensor(
+        arrow_type.storage_type.value_type,
+        metadata["shape"],
+        permutation=metadata.get("permutation"),
+        dim_names=metadata.get("dim_names"),
+    )
+    if normalized.storage_type != arrow_type.storage_type:
+        raise ValueError(f"Tensor shape does not match storage type: {arrow_type.storage_type}")
+    return normalized
+
+
+def tensor_types_equal(left, right):
+    """Compare canonical parameters, without relying on implementation classes."""
+    if not is_tensor_type(left) or not is_tensor_type(right) or left.extension_name != right.extension_name:
+        return False
+    if left.storage_type != right.storage_type:
+        return False
+    left, right = normalize_tensor_type(left), normalize_tensor_type(right)
+    if left.extension_name == "arrow.fixed_shape_tensor":
+        left_shape, right_shape = tuple(left.shape), tuple(right.shape)
+    else:
+        left_shape = left.uniform_shape if left.uniform_shape is not None else (None,) * left.ndim
+        right_shape = right.uniform_shape if right.uniform_shape is not None else (None,) * right.ndim
+    return (
+        left_shape == right_shape
+        and tuple(left.permutation or range(len(left_shape))) == tuple(right.permutation or range(len(right_shape)))
+        and tuple(left.dim_names or ()) == tuple(right.dim_names or ())
+    )
 
 
 def contains_tensor_type(arrow_type):
@@ -153,6 +219,20 @@ def contains_tensor_type(arrow_type):
     if pa.types.is_list(arrow_type) or pa.types.is_large_list(arrow_type) or pa.types.is_fixed_size_list(arrow_type):
         return contains_tensor_type(arrow_type.value_type)
     return False
+
+
+def normalize_tensor_arrow_type(arrow_type):
+    """Normalize tensor leaves, including those inside lists and structs."""
+    if is_tensor_type(arrow_type):
+        return normalize_tensor_type(arrow_type)
+    if not contains_tensor_type(arrow_type):
+        return arrow_type
+    if pa.types.is_struct(arrow_type):
+        return pa.struct([field.with_type(normalize_tensor_arrow_type(field.type)) for field in arrow_type])
+    field = arrow_type.value_field.with_type(normalize_tensor_arrow_type(arrow_type.value_type))
+    if pa.types.is_fixed_size_list(arrow_type):
+        return pa.list_(field, arrow_type.list_size)
+    return pa.large_list(field) if pa.types.is_large_list(arrow_type) else pa.list_(field)
 
 
 @dataclass
@@ -297,11 +377,13 @@ class Tensor:
 
         arrow_type = self()
         if isinstance(storage, pa.ExtensionArray):
-            if normalize_tensor_type(storage.type) == arrow_type:
+            if tensor_types_equal(storage.type, arrow_type):
+                if type(storage.type) is type(arrow_type):
+                    return storage
                 # Native and Python implementations can have identical canonical
                 # parameters while Arrow refuses a direct extension-to-extension
                 # cast. Rewrap the storage without copying its buffers.
-                return arrow_type.wrap_array(storage.storage)
+                return pa.ExtensionArray.from_storage(arrow_type, storage.storage)
             source = generate_from_arrow_type(storage.type)
             values = [source.decode_example(value) for value in storage.to_pylist()]
         else:
@@ -324,8 +406,8 @@ class Tensor:
     def embed_storage(
         self, storage: pa.ExtensionArray, token_per_repo_id=None, local_files: bool = True, remote_files: bool = True
     ) -> pa.ExtensionArray:
-        """Return the tensor extension unchanged; all tensor data is already embedded."""
-        return storage
+        """Keep embedded data in the feature's canonical tensor representation."""
+        return self.cast_storage(storage)
 
 
 class TensorPandasDtype(ExtensionDtype):
@@ -387,7 +469,7 @@ def _requires_tensor_parquet_storage(array, parent_nulls=False):
     has_nulls = parent_nulls or array.null_count > 0
     if is_tensor_type(array.type):
         return has_nulls or (
-            isinstance(array.type, pa.FixedShapeTensorType) and array.type.storage_type.list_size == 0
+            array.type.extension_name == "arrow.fixed_shape_tensor" and array.type.storage_type.list_size == 0
         )
     if pa.types.is_struct(array.type):
         return any(_requires_tensor_parquet_storage(array.field(field.name), has_nulls) for field in array.type)
@@ -442,10 +524,13 @@ def tensor_to_parquet_table(table, schema=None):
 
     if schema is None:
         schema = tensor_to_parquet_schema(table.schema, table)
-    if schema == table.schema:
+    has_tensors = any(contains_tensor_type(field.type) for field in (*schema, *table.schema))
+    if not has_tensors and schema == table.schema:
         return table
     arrays = [
-        column if field.type == column.type else array_cast(column, field.type)
+        array_cast(column, field.type)
+        if contains_tensor_type(field.type) or contains_tensor_type(column.type) or field.type != column.type
+        else column
         for field, column in zip(schema, table.columns)
     ]
     return pa.Table.from_arrays(arrays, schema=schema)

--- a/src/datasets/formatting/formatting.py
+++ b/src/datasets/formatting/formatting.py
@@ -24,8 +24,9 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from ..features import Features
+from ..features import Features, LargeList, List
 from ..features.features import _ArrayXDExtensionType, _is_zero_copy_only, decode_nested_example, pandas_types_mapper
+from ..features.tensor import Tensor, contains_tensor, contains_tensor_type, tensor_to_backend
 from ..table import Table
 from ..utils.py_utils import no_op_if_value_is_null
 
@@ -164,6 +165,13 @@ class NumpyArrowExtractor(BaseArrowExtractor[dict, np.ndarray, dict]):
         return {col: self._arrow_array_to_numpy(pa_table[col]) for col in pa_table.column_names}
 
     def _arrow_array_to_numpy(self, pa_array: pa.Array) -> np.ndarray:
+        if contains_tensor_type(pa_array.type):
+            # Keep one storage value per row for the feature decoder, including
+            # nulls and scalars. It restores shape and dtype before tensorization.
+            values = pa_array.to_pylist()
+            array = np.empty(len(values), dtype=object)
+            array[:] = values
+            return array
         if isinstance(pa_array, pa.ChunkedArray):
             if isinstance(pa_array.type, _ArrayXDExtensionType):
                 # don't call to_pylist() to preserve dtype of the fixed-size array
@@ -255,27 +263,26 @@ class PandasFeaturesDecoder:
         self.features = features
 
     def decode_row(self, row: pd.DataFrame) -> pd.DataFrame:
-        decode = (
-            {
-                column_name: no_op_if_value_is_null(partial(decode_nested_example, feature))
-                for column_name, feature in self.features.items()
-                if self.features._column_requires_decoding[column_name]
-            }
-            if self.features
-            else {}
-        )
-        if decode:
-            row[list(decode.keys())] = row.transform(decode)
+        for column_name in row:
+            row[column_name] = self.decode_column(row[column_name], column_name)
         return row
 
     def decode_column(self, column: pd.Series, column_name: str) -> pd.Series:
         decode = (
             no_op_if_value_is_null(partial(decode_nested_example, self.features[column_name]))
-            if self.features and column_name in self.features and self.features._column_requires_decoding[column_name]
+            if self.features
+            and column_name in self.features
+            and self.features._column_requires_decoding[column_name]
+            and not isinstance(self.features[column_name], Tensor)
             else None
         )
         if decode:
-            column = column.transform(decode)
+            # TensorPandasDtype restores tensors using the Arrow schema. Sibling
+            # features (e.g. Image) still need the original feature metadata.
+            if contains_tensor(self.features[column_name]):
+                column = column.map(decode)
+            else:
+                column = column.transform(decode)
         return column
 
     def decode_batch(self, batch: pd.DataFrame) -> pd.DataFrame:
@@ -443,6 +450,33 @@ class Formatter(Generic[RowFormat, ColumnFormat, BatchFormat]):
 class TensorFormatter(Formatter[RowFormat, ColumnFormat, BatchFormat]):
     def recursive_tensorize(self, data_struct: dict):
         raise NotImplementedError
+
+    def _tensorize_with_features(self, value, feature):
+        if not contains_tensor(feature):
+            return self.recursive_tensorize(value)
+        if value is None:
+            return None
+        if isinstance(feature, Tensor):
+            return tensor_to_backend(value, self._tensor_backend, **self._tensor_kwargs)
+        if isinstance(feature, dict):
+            return {name: self._tensorize_with_features(item, feature.get(name)) for name, item in value.items()}
+        if isinstance(feature, (List, LargeList)):
+            return self._consolidate([self._tensorize_with_features(item, feature.feature) for item in value])
+        if isinstance(feature, (list, tuple)):
+            return self._consolidate([self._tensorize_with_features(item, feature[0]) for item in value])
+        return self.recursive_tensorize(value)
+
+    def tensorize_row(self, row):
+        return self._tensorize_with_features(row, self.features)
+
+    def tensorize_column(self, column, column_name):
+        feature = self.features.get(column_name) if self.features else None
+        if contains_tensor(feature):
+            return [self._tensorize_with_features(value, feature) for value in column]
+        return self.recursive_tensorize(column)
+
+    def tensorize_batch(self, batch):
+        return {name: self.tensorize_column(column, name) for name, column in batch.items()}
 
 
 class TableFormatter(Formatter[RowFormat, ColumnFormat, BatchFormat]):

--- a/src/datasets/formatting/jax_formatter.py
+++ b/src/datasets/formatting/jax_formatter.py
@@ -62,6 +62,11 @@ class JaxFormatter(TensorFormatter[Mapping, "jax.Array", Mapping]):
             )
             self.device = str(jax.devices()[0])
         self.jnp_array_kwargs = jnp_array_kwargs
+        self._tensor_backend = "jax"
+
+    @property
+    def _tensor_kwargs(self):
+        return {"device": DEVICE_MAPPING[self.device], **self.jnp_array_kwargs}
 
     @staticmethod
     def _map_devices_to_str() -> dict[str, "jaxlib.xla_extension.Device"]:
@@ -156,19 +161,19 @@ class JaxFormatter(TensorFormatter[Mapping, "jax.Array", Mapping]):
     def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
         row = self.python_features_decoder.decode_row(row)
-        return self.recursive_tensorize(row)
+        return self.tensorize_row(row)
 
     def format_column(self, pa_table: pa.Table) -> "jax.Array":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
-        column = self.recursive_tensorize(column)
+        column = self.tensorize_column(column, pa_table.column_names[0])
         column = self._consolidate(column)
         return column
 
     def format_batch(self, pa_table: pa.Table) -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
         batch = self.python_features_decoder.decode_batch(batch)
-        batch = self.recursive_tensorize(batch)
+        batch = self.tensorize_batch(batch)
         for column_name in batch:
             batch[column_name] = self._consolidate(batch[column_name])
         return batch

--- a/src/datasets/formatting/np_formatter.py
+++ b/src/datasets/formatting/np_formatter.py
@@ -27,6 +27,8 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
     def __init__(self, features=None, token_per_repo_id=None, **np_array_kwargs):
         super().__init__(features=features, token_per_repo_id=token_per_repo_id)
         self.np_array_kwargs = np_array_kwargs
+        self._tensor_backend = "numpy"
+        self._tensor_kwargs = np_array_kwargs
 
     def _consolidate(self, column):
         if isinstance(column, list):
@@ -54,7 +56,8 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
         default_dtype = {}
 
         if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
-            default_dtype = {"dtype": np.int64}
+            # uint64 cannot be represented losslessly by the signed default.
+            default_dtype = {"dtype": np.uint64 if value.dtype == np.uint64 else np.int64}
         elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
             default_dtype = {"dtype": np.float32}
 
@@ -102,19 +105,19 @@ class NumpyFormatter(TensorFormatter[Mapping, np.ndarray, Mapping]):
     def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
         row = self.python_features_decoder.decode_row(row)
-        return self.recursive_tensorize(row)
+        return self.tensorize_row(row)
 
     def format_column(self, pa_table: pa.Table) -> np.ndarray:
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
-        column = self.recursive_tensorize(column)
+        column = self.tensorize_column(column, pa_table.column_names[0])
         column = self._consolidate(column)
         return column
 
     def format_batch(self, pa_table: pa.Table) -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
         batch = self.python_features_decoder.decode_batch(batch)
-        batch = self.recursive_tensorize(batch)
+        batch = self.tensorize_batch(batch)
         for column_name in batch:
             batch[column_name] = self._consolidate(batch[column_name])
         return batch

--- a/src/datasets/formatting/polars_formatter.py
+++ b/src/datasets/formatting/polars_formatter.py
@@ -21,6 +21,7 @@ import pyarrow as pa
 from .. import config
 from ..features import Features
 from ..features.features import decode_nested_example
+from ..features.tensor import contains_tensor
 from ..utils.py_utils import no_op_if_value_is_null
 from .formatting import BaseArrowExtractor, TableFormatter
 
@@ -108,17 +109,42 @@ class PolarsFormatter(TableFormatter["pl.DataFrame", "pl.Series", "pl.DataFrame"
         self.polars_features_decoder = PolarsFeaturesDecoder(features)
         import polars as pl  # noqa: F401 - import pl at initialization
 
+    def _format_tensor_table(self, pa_table: pa.Table) -> "pl.DataFrame":
+        import polars as pl
+
+        columns = []
+        for name in pa_table.column_names:
+            feature = self.features.get(name)
+            if contains_tensor(feature):
+                columns.append(
+                    pl.Series(
+                        name,
+                        [decode_nested_example(feature, value) for value in pa_table[name].to_pylist()],
+                        dtype=pl.Object,
+                    )
+                )
+            else:
+                column = self.polars_arrow_extractor().extract_column(pa_table.select([name]))
+                columns.append(self.polars_features_decoder.decode_column(column, name))
+        return pl.DataFrame(columns)
+
     def format_row(self, pa_table: pa.Table) -> "pl.DataFrame":
+        if self.features and any(contains_tensor(self.features.get(name)) for name in pa_table.column_names):
+            return self._format_tensor_table(pa_table.slice(length=1))
         row = self.polars_arrow_extractor().extract_row(pa_table)
         row = self.polars_features_decoder.decode_row(row)
         return row
 
     def format_column(self, pa_table: pa.Table) -> "pl.Series":
+        if self.features and contains_tensor(self.features.get(pa_table.column_names[0])):
+            return self._format_tensor_table(pa_table)[pa_table.column_names[0]]
         column = self.polars_arrow_extractor().extract_column(pa_table)
         column = self.polars_features_decoder.decode_column(column, pa_table.column_names[0])
         return column
 
     def format_batch(self, pa_table: pa.Table) -> "pl.DataFrame":
+        if self.features and any(contains_tensor(self.features.get(name)) for name in pa_table.column_names):
+            return self._format_tensor_table(pa_table)
         row = self.polars_arrow_extractor().extract_batch(pa_table)
         row = self.polars_features_decoder.decode_batch(row)
         return row

--- a/src/datasets/formatting/tf_formatter.py
+++ b/src/datasets/formatting/tf_formatter.py
@@ -33,6 +33,8 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
     def __init__(self, features=None, token_per_repo_id=None, **tf_tensor_kwargs):
         super().__init__(features=features, token_per_repo_id=token_per_repo_id)
         self.tf_tensor_kwargs = tf_tensor_kwargs
+        self._tensor_backend = "tensorflow"
+        self._tensor_kwargs = tf_tensor_kwargs
         import tensorflow as tf  # noqa: F401 - import tf at initialization
 
     def _consolidate(self, column):
@@ -111,19 +113,19 @@ class TFFormatter(TensorFormatter[Mapping, "tf.Tensor", Mapping]):
     def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
         row = self.python_features_decoder.decode_row(row)
-        return self.recursive_tensorize(row)
+        return self.tensorize_row(row)
 
     def format_column(self, pa_table: pa.Table) -> "tf.Tensor":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
-        column = self.recursive_tensorize(column)
+        column = self.tensorize_column(column, pa_table.column_names[0])
         column = self._consolidate(column)
         return column
 
     def format_batch(self, pa_table: pa.Table) -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
         batch = self.python_features_decoder.decode_batch(batch)
-        batch = self.recursive_tensorize(batch)
+        batch = self.tensorize_batch(batch)
         for column_name in batch:
             batch[column_name] = self._consolidate(batch[column_name])
         return batch

--- a/src/datasets/formatting/torch_formatter.py
+++ b/src/datasets/formatting/torch_formatter.py
@@ -33,6 +33,8 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
     def __init__(self, features=None, token_per_repo_id=None, **torch_tensor_kwargs):
         super().__init__(features=features, token_per_repo_id=token_per_repo_id)
         self.torch_tensor_kwargs = torch_tensor_kwargs
+        self._tensor_backend = "torch"
+        self._tensor_kwargs = torch_tensor_kwargs
         import torch  # noqa import torch at initialization
 
     def _consolidate(self, column):
@@ -57,10 +59,11 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
         default_dtype = {}
 
         if isinstance(value, (np.number, np.ndarray)) and np.issubdtype(value.dtype, np.integer):
-            default_dtype = {"dtype": torch.int64}
+            # Preserve the unsigned range instead of wrapping values above 2**63.
+            default_dtype = {"dtype": torch.uint64 if value.dtype == np.uint64 else torch.int64}
 
             # Convert dtype to np.int64 if it's either np.uint16 or np.uint32 to ensure compatibility.
-            # np.uint64 is excluded from this conversion as there is no compatible PyTorch dtype that can handle it without loss.
+            # np.uint64 uses torch.uint64 to preserve its full range.
             if value.dtype in [np.uint16, np.uint32]:
                 value = value.astype(np.int64)
 
@@ -112,19 +115,19 @@ class TorchFormatter(TensorFormatter[Mapping, "torch.Tensor", Mapping]):
     def format_row(self, pa_table: pa.Table) -> Mapping:
         row = self.numpy_arrow_extractor().extract_row(pa_table)
         row = self.python_features_decoder.decode_row(row)
-        return self.recursive_tensorize(row)
+        return self.tensorize_row(row)
 
     def format_column(self, pa_table: pa.Table) -> "torch.Tensor":
         column = self.numpy_arrow_extractor().extract_column(pa_table)
         column = self.python_features_decoder.decode_column(column, pa_table.column_names[0])
-        column = self.recursive_tensorize(column)
+        column = self.tensorize_column(column, pa_table.column_names[0])
         column = self._consolidate(column)
         return column
 
     def format_batch(self, pa_table: pa.Table) -> Mapping:
         batch = self.numpy_arrow_extractor().extract_batch(pa_table)
         batch = self.python_features_decoder.decode_batch(batch)
-        batch = self.recursive_tensorize(batch)
+        batch = self.tensorize_batch(batch)
         for column_name in batch:
             batch[column_name] = self._consolidate(batch[column_name])
         return batch

--- a/src/datasets/io/parquet.py
+++ b/src/datasets/io/parquet.py
@@ -8,6 +8,7 @@ import pyarrow.parquet as pq
 from .. import Dataset, Features, NamedSplit, config
 from ..arrow_writer import get_writer_batch_size_from_data_size, get_writer_batch_size_from_features
 from ..features.features import require_storage_embed
+from ..features.tensor import tensor_to_parquet_schema, tensor_to_parquet_table
 from ..formatting import query_table
 from ..packaged_modules import _PACKAGED_DATASETS_MODULES
 from ..packaged_modules.parquet.parquet import Parquet
@@ -118,7 +119,7 @@ class ParquetDatasetWriter:
         """
         written = 0
         _ = parquet_writer_kwargs.pop("path_or_buf", None)
-        schema = self.dataset.features.arrow_schema
+        schema = tensor_to_parquet_schema(self.dataset.features.arrow_schema, self.dataset.data.table)
 
         writer = pq.ParquetWriter(
             file_obj,
@@ -148,7 +149,7 @@ class ParquetDatasetWriter:
                 key=slice(offset, offset + batch_size),
                 indices=self.dataset._indices,
             )
-            writer.write_table(batch)
+            writer.write_table(tensor_to_parquet_table(batch, schema))
             written += batch.nbytes
 
         # TODO(kszucs): we may want to persist multiple parameters

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1883,19 +1883,30 @@ def _combine_list_array_offsets_with_mask(array: pa.ListArray) -> pa.Array:
     return offsets
 
 
-def _storage_type(type: pa.DataType) -> pa.DataType:
-    """Convert a (possibly nested) `pa.ExtensionType` to its storage type."""
-    if isinstance(type, pa.BaseExtensionType):
-        return _storage_type(type.storage_type)
-    elif isinstance(type, pa.StructType):
-        return pa.struct([field.with_type(_storage_type(field.type)) for field in type])
-    elif isinstance(type, pa.ListType):
-        return pa.list_(type.value_field.with_type(_storage_type(type.value_type)))
-    elif isinstance(type, pa.LargeListType):
-        return pa.large_list(type.value_field.with_type(_storage_type(type.value_type)))
-    elif isinstance(type, pa.FixedSizeListType):
-        return pa.list_(type.value_field.with_type(_storage_type(type.value_type)), type.list_size)
-    return type
+def _fixed_size_list_from_list(array: pa.Array, list_size: int) -> pa.Array:
+    """Fill null rows with null children without retaining their hidden offsets."""
+    indices = np.asarray(array.offsets)[:-1, None] + np.arange(list_size, dtype=np.int64)
+    indices = pa.array(indices.reshape(-1), mask=np.repeat(array.is_null().to_numpy(zero_copy_only=False), list_size))
+    values = pc.take(array.values, indices)
+    # An explicit validity bitmap also supports list_size=0 and sliced inputs.
+    return pa.Array.from_buffers(
+        pa.list_(array.type.value_field, list_size),
+        len(array),
+        [array.is_valid().buffers()[1]],
+        children=[values],
+    )
+
+
+def _fixed_size_list_with_values(
+    array: pa.Array, values: pa.Array, list_size: int, pa_type: Optional[pa.DataType] = None
+) -> pa.Array:
+    # FixedSizeListArray.from_arrays cannot construct zero-length lists.
+    return pa.Array.from_buffers(
+        pa_type if pa_type is not None else pa.list_(values.type, list_size),
+        len(array),
+        [array.is_valid().buffers()[1]],
+        children=[values],
+    )
 
 
 def _short_str(value: Any) -> str:
@@ -1939,12 +1950,14 @@ def array_cast(
     Returns:
         `List[pyarrow.Array]`: the casted array
     """
+    from .features.tensor import contains_tensor_type
+
     _c = partial(array_cast, allow_primitive_to_str=allow_primitive_to_str, allow_decimal_to_str=allow_decimal_to_str)
     if isinstance(array, pa.ExtensionArray):
         array = array.storage
     if isinstance(pa_type, pa.BaseExtensionType):
         return pa_type.wrap_array(_c(array, pa_type.storage_type))
-    elif array.type == pa_type:
+    elif not contains_tensor_type(array.type) and not contains_tensor_type(pa_type) and array.type == pa_type:
         return array
     elif pa.types.is_struct(array.type):
         if pa.types.is_struct(pa_type) and ({field.name for field in pa_type} == {field.name for field in array.type}):
@@ -1956,49 +1969,42 @@ def array_cast(
         if pa.types.is_fixed_size_list(pa_type):
             if _are_list_values_of_length(array, pa_type.list_size):
                 if array.null_count > 0:
-                    # Ensure each null value in the array translates to [null] * pa_type.list_size in the array's values array
-                    array_type = array.type
-                    storage_type = _storage_type(array_type)
-                    if array_type != storage_type:
-                        # Temporarily convert to the storage type to support extension types in the slice operation
-                        array = _c(array, storage_type)
-                        array = pc.list_slice(array, 0, pa_type.list_size, return_fixed_size_list=True)
-                        array = _c(array, array_type)
-                    else:
-                        array = pc.list_slice(array, 0, pa_type.list_size, return_fixed_size_list=True)
+                    array = _fixed_size_list_from_list(array, pa_type.list_size)
                     array_values = array.values
-                    return pa.FixedSizeListArray.from_arrays(
-                        _c(array_values, pa_type.value_type), pa_type.list_size, mask=array.is_null()
+                    return _fixed_size_list_with_values(
+                        array, _c(array_values, pa_type.value_type), pa_type.list_size, pa_type=pa_type
                     )
                 else:
-                    array_values = array.values[
-                        array.offset * pa_type.list_size : (array.offset + len(array)) * pa_type.list_size
-                    ]
-                    return pa.FixedSizeListArray.from_arrays(_c(array_values, pa_type.value_type), pa_type.list_size)
+                    array_values = array.values[array.offsets[0].as_py() : array.offsets[-1].as_py()]
+                    return _fixed_size_list_with_values(
+                        array, _c(array_values, pa_type.value_type), pa_type.list_size, pa_type=pa_type
+                    )
         elif pa.types.is_list(pa_type):
             # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
             array_offsets = _combine_list_array_offsets_with_mask(array)
-            return pa.ListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type))
+            return pa.ListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type), type=pa_type)
         elif pa.types.is_large_list(pa_type):
             # Merge offsets with the null bitmap to avoid the "Null bitmap with offsets slice not supported" ArrowNotImplementedError
             array_offsets = _combine_list_array_offsets_with_mask(array)
-            return pa.LargeListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type))
+            return pa.LargeListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type), type=pa_type)
     elif pa.types.is_fixed_size_list(array.type):
         if pa.types.is_fixed_size_list(pa_type):
             if pa_type.list_size == array.type.list_size:
                 array_values = array.values[
                     array.offset * array.type.list_size : (array.offset + len(array)) * array.type.list_size
                 ]
-                return pa.FixedSizeListArray.from_arrays(
-                    _c(array_values, pa_type.value_type), pa_type.list_size, mask=array.is_null()
+                return _fixed_size_list_with_values(
+                    array, _c(array_values, pa_type.value_type), pa_type.list_size, pa_type=pa_type
                 )
         elif pa.types.is_list(pa_type):
             array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
-            return pa.ListArray.from_arrays(array_offsets, _c(array.values, pa_type.value_type), mask=array.is_null())
+            return pa.ListArray.from_arrays(
+                array_offsets, _c(array.values, pa_type.value_type), type=pa_type, mask=array.is_null()
+            )
         elif pa.types.is_large_list(pa_type):
             array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
             return pa.LargeListArray.from_arrays(
-                array_offsets, _c(array.values, pa_type.value_type), mask=array.is_null()
+                array_offsets, _c(array.values, pa_type.value_type), type=pa_type, mask=array.is_null()
             )
     else:
         if pa.types.is_string(pa_type):
@@ -2050,7 +2056,7 @@ def cast_array_to_feature(
         array (`pyarrow.Array`): the casted array
     """
     from .features.features import LargeList, List, get_nested_type
-    from .features.tensor import Tensor, is_tensor_type
+    from .features.tensor import Tensor, contains_tensor_type, is_tensor_type
 
     _c = partial(
         cast_array_to_feature,
@@ -2079,7 +2085,11 @@ def cast_array_to_feature(
         # feature must be either List(subfeature) or LargeList(subfeature)
         if isinstance(feature, LargeList):
             casted_array_values = _c(array.values, feature.feature)
-            if pa.types.is_large_list(array.type) and casted_array_values.type == array.values.type:
+            if (
+                pa.types.is_large_list(array.type)
+                and not contains_tensor_type(array.type)
+                and casted_array_values.type == array.values.type
+            ):
                 # Both array and feature have equal large_list type and values (within the list) type
                 return array
             else:
@@ -2090,39 +2100,20 @@ def cast_array_to_feature(
             if feature.length > -1:
                 if _are_list_values_of_length(array, feature.length):
                     if array.null_count > 0:
-                        # Ensure each null value in the array translates to [null] * pa_type.list_size in the array's values array
-                        array_type = array.type
-                        storage_type = _storage_type(array_type)
-                        if array_type != storage_type:
-                            # Temporarily convert to the storage type to support extension types in the slice operation
-                            array = array_cast(
-                                array,
-                                storage_type,
-                                allow_primitive_to_str=allow_primitive_to_str,
-                                allow_decimal_to_str=allow_decimal_to_str,
-                            )
-                            array = pc.list_slice(array, 0, feature.length, return_fixed_size_list=True)
-                            array = array_cast(
-                                array,
-                                array_type,
-                                allow_primitive_to_str=allow_primitive_to_str,
-                                allow_decimal_to_str=allow_decimal_to_str,
-                            )
-                        else:
-                            array = pc.list_slice(array, 0, feature.length, return_fixed_size_list=True)
+                        array = _fixed_size_list_from_list(array, feature.length)
                         array_values = array.values
                         casted_array_values = _c(array_values, feature.feature)
-                        return pa.FixedSizeListArray.from_arrays(
-                            casted_array_values, feature.length, mask=array.is_null()
-                        )
+                        return _fixed_size_list_with_values(array, casted_array_values, feature.length)
                     else:
-                        array_values = array.values[
-                            array.offset * feature.length : (array.offset + len(array)) * feature.length
-                        ]
-                        return pa.FixedSizeListArray.from_arrays(_c(array_values, feature.feature), feature.length)
+                        array_values = array.values[array.offsets[0].as_py() : array.offsets[-1].as_py()]
+                        return _fixed_size_list_with_values(array, _c(array_values, feature.feature), feature.length)
             else:
                 casted_array_values = _c(array.values, feature.feature)
-                if pa.types.is_list(array.type) and casted_array_values.type == array.values.type:
+                if (
+                    pa.types.is_list(array.type)
+                    and not contains_tensor_type(array.type)
+                    and casted_array_values.type == array.values.type
+                ):
                     # Both array and feature have equal list type and values (within the list) type
                     return array
                 else:
@@ -2143,7 +2134,7 @@ def cast_array_to_feature(
                         array.offset * array.type.list_size : (array.offset + len(array)) * array.type.list_size
                     ]
                     casted_array_values = _c(array_values, feature.feature)
-                    return pa.FixedSizeListArray.from_arrays(casted_array_values, feature.length, mask=array.is_null())
+                    return _fixed_size_list_with_values(array, casted_array_values, feature.length)
             else:
                 array_offsets = (np.arange(len(array) + 1) + array.offset) * array.type.list_size
                 return pa.ListArray.from_arrays(array_offsets, _c(array.values, feature.feature), mask=array.is_null())
@@ -2308,6 +2299,7 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
         `pa.Table`: the casted table
     """
     from .features import Features
+    from .features.tensor import contains_tensor_type
 
     features = Features.from_arrow_schema(schema)
     table_column_names = set(table.column_names)
@@ -2323,6 +2315,10 @@ def cast_table_to_schema(table: pa.Table, schema: pa.Schema):
             feature,
         )
         for name, feature in features.items()
+    ]
+    arrays = [
+        array_cast(array, field.type) if contains_tensor_type(field.type) else array
+        for array, field in zip(arrays, schema)
     ]
     return pa.Table.from_arrays(arrays, schema=schema)
 
@@ -2383,7 +2379,9 @@ def table_cast(table: pa.Table, schema: pa.Schema):
     Returns:
         table (`pyarrow.Table`): the casted table
     """
-    if table.schema != schema:
+    from .features.tensor import contains_tensor_type
+
+    if any(contains_tensor_type(field.type) for field in (*table.schema, *schema)) or table.schema != schema:
         return cast_table_to_schema(table, schema)
     elif table.schema.metadata != schema.metadata:
         return table.replace_schema_metadata(schema.metadata)

--- a/src/datasets/table.py
+++ b/src/datasets/table.py
@@ -1885,14 +1885,16 @@ def _combine_list_array_offsets_with_mask(array: pa.ListArray) -> pa.Array:
 
 def _storage_type(type: pa.DataType) -> pa.DataType:
     """Convert a (possibly nested) `pa.ExtensionType` to its storage type."""
-    if isinstance(type, pa.ExtensionType):
+    if isinstance(type, pa.BaseExtensionType):
         return _storage_type(type.storage_type)
     elif isinstance(type, pa.StructType):
-        return pa.struct([pa.field(field.name, _storage_type(field.type)) for field in type])
+        return pa.struct([field.with_type(_storage_type(field.type)) for field in type])
     elif isinstance(type, pa.ListType):
-        return pa.list_(_storage_type(type.value_type))
+        return pa.list_(type.value_field.with_type(_storage_type(type.value_type)))
+    elif isinstance(type, pa.LargeListType):
+        return pa.large_list(type.value_field.with_type(_storage_type(type.value_type)))
     elif isinstance(type, pa.FixedSizeListType):
-        return pa.list_(_storage_type(type.value_type), type.list_size)
+        return pa.list_(type.value_field.with_type(_storage_type(type.value_type)), type.list_size)
     return type
 
 
@@ -1940,7 +1942,7 @@ def array_cast(
     _c = partial(array_cast, allow_primitive_to_str=allow_primitive_to_str, allow_decimal_to_str=allow_decimal_to_str)
     if isinstance(array, pa.ExtensionArray):
         array = array.storage
-    if isinstance(pa_type, pa.ExtensionType):
+    if isinstance(pa_type, pa.BaseExtensionType):
         return pa_type.wrap_array(_c(array, pa_type.storage_type))
     elif array.type == pa_type:
         return array
@@ -2048,12 +2050,16 @@ def cast_array_to_feature(
         array (`pyarrow.Array`): the casted array
     """
     from .features.features import LargeList, List, get_nested_type
+    from .features.tensor import Tensor, is_tensor_type
 
     _c = partial(
         cast_array_to_feature,
         allow_primitive_to_str=allow_primitive_to_str,
         allow_decimal_to_str=allow_decimal_to_str,
     )
+
+    if isinstance(feature, Tensor) and is_tensor_type(array.type):
+        return feature.cast_storage(array)
 
     if isinstance(array, pa.ExtensionArray):
         array = array.storage
@@ -2062,12 +2068,12 @@ def cast_array_to_feature(
 
     if pa.types.is_struct(array.type):
         # feature must be a dict
-        if isinstance(feature, dict) and (array_fields := {field.name for field in array.type}) <= set(feature):
+        if isinstance(feature, dict) and {field.name for field in array.type} <= set(feature):
             null_array = pa.array([None] * len(array))
-            arrays = [
-                _c(array.field(name) if name in array_fields else null_array, subfeature)
-                for name, subfeature in feature.items()
-            ]
+            # Flatten combines the parent and child validity bitmaps. Hidden
+            # placeholder children beneath null structs must not be validated.
+            children = dict(zip(array.type.names, array.flatten()))
+            arrays = [_c(children.get(name, null_array), subfeature) for name, subfeature in feature.items()]
             return pa.StructArray.from_arrays(arrays, names=list(feature), mask=array.is_null())
     elif pa.types.is_list(array.type) or pa.types.is_large_list(array.type):
         # feature must be either List(subfeature) or LargeList(subfeature)
@@ -2198,14 +2204,17 @@ def embed_array_storage(
     if not local_files and not remote_files:
         return array
 
-    from .features import LargeList, List
+    from .features.features import LargeList, List, require_storage_embed
+
+    # A sibling may require embedding while this feature's data is already
+    # self-contained. Preserve its extension type and buffers in that case.
+    if not require_storage_embed(feature):
+        return array
 
     _e = partial(
         embed_array_storage, token_per_repo_id=token_per_repo_id, local_files=local_files, remote_files=remote_files
     )
 
-    if isinstance(array, pa.ExtensionArray):
-        array = array.storage
     if hasattr(feature, "embed_storage"):
         return feature.embed_storage(
             array, token_per_repo_id=token_per_repo_id, local_files=local_files, remote_files=remote_files

--- a/tests/features/test_tensor.py
+++ b/tests/features/test_tensor.py
@@ -454,6 +454,8 @@ def test_tensor_validates_encoded_storage(value):
     "metadata", [b"{}", b'{"uniform_shape":[null,3]}', b'{"permutation":[1,0],"dim_names":["x","y"]}']
 )
 def test_tensor_registration_preserves_canonical_schema_reading(metadata):
+    from datasets.features.tensor import normalize_tensor_type
+
     storage = pa.struct([("data", pa.list_(pa.float32())), ("shape", pa.list_(pa.int32(), 2))])
     schema = pa.schema(
         [
@@ -469,7 +471,9 @@ def test_tensor_registration_preserves_canonical_schema_reading(metadata):
     )
     restored = pa.ipc.read_schema(pa.BufferReader(schema.serialize()))
     assert restored.field("x").type.storage_type == storage
-    assert json.loads(restored.field("x").type.__arrow_ext_serialize__()) == json.loads(metadata)
+    assert json.loads(normalize_tensor_type(restored.field("x").type).__arrow_ext_serialize__()) == json.loads(
+        metadata
+    )
 
 
 @pytest.mark.parametrize(
@@ -576,16 +580,15 @@ def test_tensor_plain_arrow_interop(shape, file_format, with_null, tmp_path):
     else:
         dataset.to_parquet(str(path), batch_size=1)
     extension_name = "arrow.fixed_shape_tensor" if shape == (2, 3) else "arrow.variable_shape_tensor"
-    # -S excludes site customizations and installed Datasets; PYTHONPATH exposes
-    # only the directory containing PyArrow. The child never imports Datasets.
+    # -S excludes site customizations; PYTHONPATH exposes PyArrow's directory,
+    # which may also contain Datasets. The child must never import Datasets.
     reader = """
 import base64
-import importlib.util
 import json
 import sys
 import pyarrow as pa
 import pyarrow.parquet as pq
-assert importlib.util.find_spec("datasets") is None
+assert "datasets" not in sys.modules
 path, file_format, extension_name, expected_json = sys.argv[1:]
 table = pa.ipc.open_file(path).read_all() if file_format == "ipc" else pq.read_table(path)
 tensor_type = table.column("x").type
@@ -1094,3 +1097,208 @@ def test_tensor_map_detaches_torch_gradients(batched, shape, nested):
     actual = mapped[0]["x"]["t"] if nested else mapped[0]["x"]
     np.testing.assert_array_equal(actual, [1.0, 2.0])
     assert mapped.features == dataset.features
+
+
+@pytest.mark.parametrize("fixed", [False, True])
+@pytest.mark.parametrize("strict_equality", [False, True])
+def test_tensor_external_canonical_registration(fixed, strict_equality, tmp_path):
+    # A different implementation must retain its registration and interoperate
+    # without Arrow attempting an extension-to-extension cast.
+    script = """
+import json
+import sys
+
+import numpy as np
+import pyarrow as pa
+
+assert "datasets" not in sys.modules
+fixed = sys.argv[1] == "True"
+name = "arrow.fixed_shape_tensor" if fixed else "arrow.variable_shape_tensor"
+
+class ExternalTensorType(pa.ExtensionType):
+    def __init__(self, storage_type, serialized):
+        self.serialized = serialized
+        super().__init__(storage_type, name)
+
+    def __arrow_ext_serialize__(self):
+        return self.serialized
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        return cls(storage_type, serialized)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ExternalTensorType)
+            and self.storage_type == other.storage_type
+            and json.loads(self.serialized) == json.loads(other.serialized)
+        )
+
+if sys.argv[2] == "False":
+    del ExternalTensorType.__eq__
+
+storage_type = pa.list_(pa.int32(), 6) if fixed else pa.struct([
+    ("data", pa.list_(pa.int32())), ("shape", pa.list_(pa.int32(), 2))
+])
+metadata = {"shape": [2, 3]} if fixed else {"uniform_shape": [None, 3]}
+external = ExternalTensorType(storage_type, json.dumps(metadata).encode())
+try:
+    pa.unregister_extension_type(name)
+except pa.ArrowKeyError:
+    pass
+pa.register_extension_type(external)
+
+from datasets import Dataset, Features, List, Tensor
+from datasets.features.tensor import normalize_tensor_type, tensor_to_parquet_table
+from datasets.table import array_cast, cast_array_to_feature, embed_array_storage, table_cast
+
+schema = pa.schema([("x", external)])
+restored = pa.ipc.read_schema(pa.BufferReader(schema.serialize()))
+assert isinstance(restored.field("x").type, ExternalTensorType), "Datasets replaced the existing registration"
+feature = Tensor((2, 3) if fixed else (None, 3), "int32")
+assert Features.from_arrow_schema(restored) == Features({"x": feature})
+assert normalize_tensor_type(external) == feature()
+values = [[0, 1, 2, 3, 4, 5], None] if fixed else [
+    {"data": [0, 1, 2, 3, 4, 5], "shape": [2, 3]}, None
+]
+array = pa.ExtensionArray.from_storage(external, pa.array(values, type=storage_type))
+for result in [cast_array_to_feature(array, feature), embed_array_storage(array, feature)]:
+    assert result.type == feature()
+    assert result.storage.to_pylist() == values
+    assert result.storage.buffers() == array.storage.buffers()
+local = cast_array_to_feature(array, feature)
+assert array_cast(local, external).storage.to_pylist() == values
+assert table_cast(pa.table({"x": local}), schema).column("x").to_pylist() == values
+assert tensor_to_parquet_table(pa.table({"x": local}), schema).column("x").to_pylist() == values
+
+dataset = Dataset(pa.Table.from_arrays([array], schema=restored))
+for shape in [(2, 3), (None, 3), (None, None)]:
+    casted = dataset.cast_column("x", Tensor(shape, "float64"))
+    assert casted[0]["x"].tolist() == [[0, 1, 2], [3, 4, 5]]
+    assert casted[0]["x"].dtype == np.float64
+    assert casted[1]["x"] is None
+try:
+    dataset.cast_column("x", Tensor((None, 4), "int32"))
+except ValueError:
+    pass
+else:
+    raise AssertionError("Incompatible uniform_shape was accepted")
+
+for fmt in [None, "numpy", "pandas"]:
+    formatted = dataset.with_format(fmt)
+    row = formatted[0]["x"]
+    if fmt == "pandas":
+        row = row.iloc[0]
+    assert row.tolist() == [[0, 1, 2], [3, 4, 5]]
+    assert len(formatted[:]["x"]) == 2
+
+value = np.arange(6, dtype=np.int32).reshape(2, 3)
+features = Features({"x": List(feature)})
+nested = Dataset.from_dict({"x": [[value, value], None]}, features=features)
+nested = nested.cast(Features({"x": List(feature, length=2)}))
+assert nested[1]["x"] is None
+assert nested[0]["x"][0].tolist() == value.tolist()
+mapped = nested.map(lambda row: row, features=nested.features)
+assert mapped[0]["x"][0].tolist() == value.tolist()
+assert mapped[1]["x"] is None
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(fixed), str(strict_equality)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("sliced", [False, True])
+def test_tensor_nullable_list_with_hidden_children(shape, sliced):
+    from datasets.table import array_cast, cast_array_to_feature
+
+    feature = Tensor(shape, "int32")
+    value = np.arange(6, dtype=np.int32).reshape(2, 3)
+    tensors = Dataset.from_dict({"x": [value] * 6}, features=Features({"x": feature})).data.column("x").chunk(0)
+    array = pa.ListArray.from_arrays([0, 2, 4, 6], tensors, mask=pa.array([False, True, False]))
+    if sliced:
+        array = array.slice(1)
+    target = List(feature, length=2)
+    for result in [array_cast(array, pa.list_(feature(), 2)), cast_array_to_feature(array, target)]:
+        result.validate(full=True)
+        assert result.is_null().to_pylist() == ([True, False] if sliced else [False, True, False])
+        assert result.to_pylist() == array.to_pylist()
+
+
+@pytest.mark.parametrize("variable_list", [False, True])
+def test_tensor_cast_zero_length_list(variable_list):
+    from datasets.table import array_cast, cast_array_to_feature, table_cast
+
+    feature = Tensor((None, 3), "int32")
+    child = pa.ExtensionArray.from_storage(feature(), pa.array([], type=feature().storage_type))
+    target = pa.list_(feature(), 0)
+    array = (
+        pa.ListArray.from_arrays([0, 0, 0, 0], child, mask=pa.array([False, True, False]))
+        if variable_list
+        else pa.Array.from_buffers(target, 3, [pa.array([True, False, True]).buffers()[1]], children=[child])
+    )
+    for casted in [array_cast(array, target), cast_array_to_feature(array, List(feature, length=0))]:
+        casted.validate(full=True)
+        assert casted.to_pylist() == [[], None, []]
+    table = table_cast(pa.table({"x": array}), pa.schema([("x", target)]))
+    assert table.column("x").to_pylist() == [[], None, []]
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("native_target", [False, True])
+def test_tensor_parquet_table_canonical_schema(shape, native_target):
+    from datasets.features.tensor import tensor_to_parquet_table
+
+    feature = Tensor(shape, "int32")
+    schema = Features({"x": feature}).arrow_schema
+    native = pa.ipc.read_schema(pa.BufferReader(schema.serialize()))
+    source_schema, target_schema = (schema, native) if native_target else (native, schema)
+    source_type = source_schema.field("x").type
+    values = [[0, 1, 2, 3, 4, 5]] if shape == (2, 3) else [{"data": [0, 1, 2, 3, 4, 5], "shape": [2, 3]}]
+    array = pa.ExtensionArray.from_storage(source_type, pa.array(values, type=source_type.storage_type))
+    table = tensor_to_parquet_table(pa.Table.from_arrays([array], schema=source_schema), target_schema)
+    assert table.column("x").to_pylist() == values
+    assert Features.from_arrow_schema(table.schema) == Features({"x": feature})
+
+
+@pytest.mark.parametrize("list_kind", ["list", "large_list", "fixed_size_list"])
+def test_tensor_array_cast_preserves_list_value_field(list_kind):
+    from datasets.table import array_cast
+
+    feature = Tensor((None, 3), "int32")
+    child = pa.ExtensionArray.from_storage(
+        feature(), pa.array([{"data": [1, 2, 3], "shape": [1, 3]}], type=feature().storage_type)
+    )
+    field = pa.field("custom", feature(), nullable=False, metadata={"unit": "test"})
+    if list_kind == "fixed_size_list":
+        target = pa.list_(field, 1)
+        array = pa.Array.from_buffers(target, 1, [None], children=[child])
+    else:
+        target = pa.large_list(field) if list_kind == "large_list" else pa.list_(field)
+        array_class = pa.LargeListArray if list_kind == "large_list" else pa.ListArray
+        array = array_class.from_arrays([0, 1], child, type=target)
+    casted = array_cast(array, target)
+    assert casted.type.value_field.equals(field, check_metadata=True)
+    assert casted.to_pylist() == [[{"data": [1, 2, 3], "shape": [1, 3]}]]
+
+
+@pytest.mark.parametrize("large", [False, True])
+def test_tensor_list_cast_slice_after_null(large):
+    from datasets.table import array_cast, cast_array_to_feature
+
+    feature = Tensor((None, 1), "int32")
+    values = [{"data": [i], "shape": [1, 1]} for i in range(4)]
+    children = pa.ExtensionArray.from_storage(feature(), pa.array(values, type=feature().storage_type))
+    array_class = pa.LargeListArray if large else pa.ListArray
+    array = array_class.from_arrays([0, 0, 2, 4], children, mask=pa.array([True, False, False])).slice(1)
+    for casted in [
+        array_cast(array, pa.list_(feature(), 2)),
+        cast_array_to_feature(array, List(feature, length=2)),
+    ]:
+        casted.validate(full=True)
+        assert casted.to_pylist() == [values[:2], values[2:]]

--- a/tests/features/test_tensor.py
+++ b/tests/features/test_tensor.py
@@ -1,0 +1,1096 @@
+import json
+import os
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from datasets import Dataset, Features, List, Tensor, Value, config, load_from_disk
+
+from ..utils import require_jax, require_polars, require_tf, require_torch
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (2, None), (None, None), ()])
+def test_tensor_features_round_trip(shape):
+    feature = Tensor(shape, "int32")
+    features = Features({"x": feature})
+    assert Features.from_dict(json.loads(json.dumps(features.to_dict()))) == features
+    assert Features.from_arrow_schema(features.arrow_schema.remove_metadata()) == features
+    assert pickle.loads(pickle.dumps(feature)) == feature
+    assert features.flatten() == features
+    assert Features({"nested": {"x": feature}}).flatten() == Features({"nested.x": feature})
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_arrow_storage(shape):
+    feature = Tensor(shape)
+    arrow_type = feature()
+    if shape == (2, 3):
+        assert arrow_type == pa.fixed_shape_tensor(pa.float32(), (2, 3))
+    else:
+        assert arrow_type.extension_name == "arrow.variable_shape_tensor"
+        assert arrow_type.storage_type == pa.struct(
+            [("data", pa.list_(pa.float32())), ("shape", pa.list_(pa.int32(), len(shape)))]
+        )
+        metadata = json.loads(arrow_type.__arrow_ext_serialize__())
+        assert metadata == ({"uniform_shape": [None, 3]} if shape == (None, 3) else {})
+        assert (
+            pa.ipc.read_schema(pa.BufferReader(pa.schema([("x", arrow_type)]).serialize())).field("x").type
+            == arrow_type
+        )
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+@pytest.mark.parametrize("dtype", ["bool", "int8", "uint8", "int64", "uint64", "float16", "float32", "float64"])
+def test_tensor_encode_decode(shape, dtype):
+    feature = Tensor(shape, dtype)
+    expected = np.asarray([[0, 1, 0], [1, 0, 1]], dtype=dtype)
+    for value in [expected, expected.tolist(), tuple(map(tuple, expected.tolist()))]:
+        decoded = feature.decode_example(feature.encode_example(value))
+        assert isinstance(decoded, np.ndarray)
+        assert decoded.dtype == expected.dtype
+        np.testing.assert_array_equal(decoded, expected)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("representation", ["nested_lists", "row_arrays", "ndarray", "mixed_rows"])
+@pytest.mark.parametrize(
+    "dtype,values",
+    [
+        ("int32", [[1, 2, 3], [4, 5, 6]]),
+        ("int64", [[0, 2**53 + 1, 2**63 - 1], [-(2**63), 1, 2]]),
+        ("uint64", [[0, 2**63 + 1, 2**64 - 1], [1, 2, 3]]),
+        ("bool", [[True, False, True], [False, True, False]]),
+        ("float32", [[1, 2, 3], [4, 5, 6]]),
+    ],
+)
+def test_tensor_encode_input_representations(shape, representation, dtype, values):
+    expected = np.asarray(values, dtype=dtype)
+    value = values
+    if representation == "row_arrays":
+        value = [np.asarray(row, dtype="uint64" if dtype == "uint64" else None) for row in values]
+    elif representation == "ndarray":
+        value = expected
+    elif representation == "mixed_rows":
+        value = [values[0], expected[1]]
+    feature = Tensor(shape, dtype)
+    encoded = feature.encode_example(value)
+    decoded = feature.decode_example(encoded)
+    assert decoded.dtype == expected.dtype
+    assert decoded.tolist() == values
+    dataset = Dataset.from_dict({"x": [value]}, features=Features({"x": feature}))
+    assert dataset[0]["x"].dtype == expected.dtype
+    assert dataset[0]["x"].tolist() == values
+
+
+@pytest.mark.parametrize("dtype", ["string", "object", "complex64", "datetime64[ns]", "not_a_dtype"])
+def test_tensor_invalid_dtype(dtype):
+    with pytest.raises(ValueError, match="dtype"):
+        Tensor((None,), dtype=dtype)
+
+
+@pytest.mark.parametrize("shape", [(-1, 3), (1.5, 3), (True, 3), "bad", 2])
+def test_tensor_invalid_shape(shape):
+    with pytest.raises(ValueError, match="shape"):
+        Tensor(shape)
+
+
+@pytest.mark.parametrize(
+    "shape,value",
+    [
+        ((2, 3), [[1, 2], [3, 4]]),
+        ((None, 3), [1, 2, 3]),
+        ((None, 3), [[[1, 2, 3]]]),
+        ((None, 3), [[1, 2]]),
+    ],
+)
+def test_tensor_rejects_wrong_shape(shape, value):
+    with pytest.raises(ValueError, match="shape"):
+        Tensor(shape).encode_example(value)
+
+
+@pytest.mark.parametrize(
+    "dtype,value",
+    [
+        ("int32", ["hello"]),
+        ("int8", [128]),
+        ("uint8", [-1]),
+        ("int32", [1.5]),
+        ("float32", [1 + 2j]),
+        ("float32", [[1], [2, 3]]),
+    ],
+)
+def test_tensor_rejects_invalid_values(dtype, value):
+    with pytest.raises(ValueError, match="Tensor|dtype"):
+        Tensor((None,), dtype=dtype).encode_example(value)
+
+
+@pytest.mark.parametrize(
+    "shape,values",
+    [
+        ((2, 3), [np.arange(6).reshape(2, 3), None, np.ones((2, 3))]),
+        ((None, 3), [None, np.ones((2, 3)), np.ones((4, 3))]),
+        ((2, None), [np.ones((2, 3)), np.ones((2, 4)), None]),
+        ((None, None, 3), [np.ones((1, 2, 3)), np.ones((2, 1, 3)), None]),
+        ((None, None, None), [np.empty((0, 3, 2)), np.empty((2, 0, 4)), None]),
+        ((), [np.array(7), None]),
+        ((0, 3), [np.empty((0, 3)), None]),
+    ],
+)
+def test_tensor_dataset_and_batch(shape, values):
+    feature = Tensor(shape, "float32")
+    features = Features({"x": feature})
+    encoded = features.encode_batch({"x": values})
+    decoded = features.decode_batch(encoded)["x"]
+    dataset = Dataset.from_dict({"x": values}, features=features)
+    assert dataset.features == features
+    assert dataset.flatten().features == features
+    for actual_values in [decoded, dataset[:]["x"], dataset["x"][:]]:
+        for actual, expected in zip(actual_values, values):
+            if expected is None:
+                assert actual is None
+            else:
+                assert actual.shape == expected.shape
+                assert actual.dtype == np.float32
+                np.testing.assert_array_equal(actual, expected)
+
+
+def test_tensor_fixed_rank_validates_every_row():
+    with pytest.raises(ValueError, match="shape"):
+        Dataset.from_dict({"x": [np.ones((2, 3)), np.ones((2, 3, 1))]}, features=Features({"x": Tensor((None, 3))}))
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_nulls_and_empty_dataset(shape):
+    features = Features({"x": Tensor(shape)})
+    assert Tensor(shape).encode_example(None) is None
+    assert Tensor(shape).decode_example(None) is None
+    for values in [[], [None, None]]:
+        dataset = Dataset.from_dict({"x": values}, features=features)
+        assert dataset[:]["x"] == values
+        assert dataset.with_format("numpy")[:]["x"].tolist() == values
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_disk_and_parquet_round_trip(shape, tmp_path):
+    feature = Tensor(shape, "int64")
+    values = [np.full((2, 3), 2**53 + 1, dtype=np.int64), None, np.ones((2, 3), dtype=np.int64)]
+    if shape != (2, 3):
+        values.append(np.ones((4, 3), dtype=np.int64))
+    dataset = Dataset.from_dict({"x": values}, features=Features({"x": feature}))
+    dataset.save_to_disk(str(tmp_path / "saved"))
+    dataset.to_parquet(str(tmp_path / "tensor.parquet"))
+    restored_datasets = [
+        load_from_disk(str(tmp_path / "saved")),
+        Dataset.from_parquet(str(tmp_path / "tensor.parquet"), cache_dir=str(tmp_path / "cache")),
+    ]
+    for restored in restored_datasets:
+        assert restored.features == dataset.features
+        for actual, expected in zip(restored["x"], values):
+            if expected is None:
+                assert actual is None
+            else:
+                assert actual.dtype == np.int64
+                np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("nesting", ["struct", "list", "large_list", "fixed_size_list"])
+@pytest.mark.parametrize("operation", ["array", "table", "disk", "hub_preparation"])
+def test_tensor_embed_with_image_sibling(shape, nesting, operation, image_file, tmp_path):
+    from PIL import Image as PILImage
+
+    from datasets import Image, LargeList
+    from datasets.table import embed_array_storage, embed_table_storage
+
+    image_bytes = Path(image_file).read_bytes()
+    image_path = tmp_path / "image.jpg"
+    image_path.write_bytes(image_bytes)
+    expected = np.arange(6, dtype=np.float32).reshape(2, 3)
+    feature = {"img": Image(), "t": Tensor(shape)}
+    value = {"img": str(image_path), "t": expected}
+    empty = {"img": None, "t": None}
+    if nesting == "struct":
+        rows = [None, value, empty]
+    else:
+        feature = (
+            LargeList(feature)
+            if nesting == "large_list"
+            else List(feature, length=3 if nesting == "fixed_size_list" else -1)
+        )
+        rows = [None, [value, None, empty]]
+    features = Features({"x": feature})
+    dataset = Dataset.from_dict({"x": rows}, features=features)
+    table = dataset.data.table
+    if operation == "array":
+        embedded = embed_array_storage(table["x"].chunk(0), feature, local_files=True, remote_files=False)
+        assert embedded.type == table["x"].type
+        restored = Dataset(pa.Table.from_arrays([embedded], schema=features.arrow_schema))
+    elif operation == "table":
+        embedded = embed_table_storage(table, local_files=True, remote_files=False)
+        assert embedded.schema == features.arrow_schema
+        restored = Dataset(embedded)
+    elif operation == "disk":
+        dataset.save_to_disk(str(tmp_path / "saved"))
+        restored = load_from_disk(str(tmp_path / "saved"))
+    else:
+        # Exercise the local embedding and Parquet preparation used by push_to_hub.
+        embedded = dataset.with_format("arrow").map(
+            embed_table_storage,
+            batched=True,
+            keep_in_memory=True,
+            fn_kwargs={"local_files": True, "remote_files": False},
+        )
+        path = str(tmp_path / "shard.parquet")
+        embedded.to_parquet(path)
+        restored = Dataset.from_parquet(path, cache_dir=str(tmp_path / "cache"))
+    image_path.unlink()
+    assert restored.features == features
+    assert restored.data.schema == features.arrow_schema
+    assert restored[0]["x"] is None
+    actual = restored[1]["x"]
+    storage = restored.data.table["x"].to_pylist()[1]
+    if nesting != "struct":
+        assert actual[1] is None
+        assert actual[2] == empty
+        actual = actual[0]
+        storage = storage[0]
+    else:
+        assert restored[2]["x"] == empty
+    assert storage["img"]["bytes"] == image_bytes
+    assert isinstance(actual["img"], PILImage.Image)
+    with PILImage.open(image_file) as expected_image:
+        np.testing.assert_array_equal(np.asarray(actual["img"]), np.asarray(expected_image))
+    assert actual["t"].dtype == expected.dtype
+    np.testing.assert_array_equal(actual["t"], expected)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+def test_tensor_embed_storage_is_noop(shape):
+    from datasets.table import embed_array_storage
+
+    feature = Tensor(shape)
+    dataset = Dataset.from_dict({"x": [None, np.ones((2, 3))]}, features=Features({"x": feature}))
+    array = dataset.data.table["x"].chunk(0)
+    assert feature.embed_storage(array) is array
+    assert embed_array_storage(array, feature) is array
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+@pytest.mark.parametrize("ragged", [False, True])
+def test_tensor_numpy_and_pandas(shape, ragged):
+    if shape == (2, 3) and ragged:
+        pytest.skip("A fixed shape cannot be ragged")
+    values = [np.arange(6).reshape(2, 3), np.ones((4 if ragged else 2, 3))]
+    dataset = Dataset.from_dict({"x": values}, features=Features({"x": Tensor(shape)}))
+    formatted = dataset.with_format("numpy")
+    np.testing.assert_array_equal(formatted[0]["x"], values[0])
+    batch = formatted[:]["x"]
+    assert batch.shape == ((2,) if ragged else (2, 2, 3))
+    if ragged:
+        assert batch.dtype == object
+    for frame in [dataset.to_pandas(), dataset.with_format("pandas")[:]]:
+        assert isinstance(frame, pd.DataFrame)
+        for actual, expected in zip(frame["x"], values):
+            assert isinstance(actual, np.ndarray)
+            np.testing.assert_array_equal(actual, expected)
+
+
+@require_torch
+def test_tensor_torch_format():
+    import torch
+
+    _check_native_format("torch", torch.Tensor)
+
+
+@require_tf
+def test_tensor_tf_format():
+    import tensorflow as tf
+
+    _check_native_format("tensorflow", tf.Tensor)
+
+
+@require_jax
+def test_tensor_jax_format():
+    import jax
+
+    _check_native_format("jax", jax.Array)
+
+
+def _check_native_format(format_name, tensor_type):
+    for shape in [(2, 3), (None, 3), (None, None)]:
+        values = [np.ones((2, 3)), np.ones((2, 3))]
+        dataset = Dataset.from_dict({"x": values}, features=Features({"x": Tensor(shape)})).with_format(format_name)
+        assert isinstance(dataset[0]["x"], tensor_type)
+        assert tuple(dataset[:]["x"].shape) == (2, 2, 3)
+        np.testing.assert_array_equal(np.asarray(dataset[0]["x"]), values[0])
+        if shape != (2, 3):
+            values[1] = np.ones((4, 3))
+            dataset = Dataset.from_dict({"x": values}, features=Features({"x": Tensor(shape)})).with_format(
+                format_name
+            )
+            for actual, expected in zip(dataset[:]["x"], values):
+                np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+@require_polars
+def test_tensor_polars_format():
+    import polars as pl
+
+    for shape in [(2, 3), (None, 3), (None, None)]:
+        values = [np.ones((2, 3)), None]
+        dataset = Dataset.from_dict({"x": values}, features=Features({"x": Tensor(shape)}))
+        for frame in [dataset.with_format("polars")[:], dataset.with_format("polars")[0]]:
+            assert isinstance(frame, pl.DataFrame)
+            np.testing.assert_array_equal(frame["x"][0], values[0])
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_nested_lists(shape):
+    features = Features({"x": List(Tensor(shape))})
+    values = [[np.ones((2, 3)), None, np.zeros((2, 3))]]
+    dataset = Dataset.from_dict({"x": values}, features=features)
+    assert dataset[0]["x"][1] is None
+    np.testing.assert_array_equal(dataset[0]["x"][0], values[0][0])
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None,), (None, None)])
+def test_tensor_map_and_cast(shape):
+    value = np.arange(3 if shape == (None,) else 6, dtype=np.int32)
+    if shape != (None,):
+        value = value.reshape(2, 3)
+    dataset = Dataset.from_dict({"x": [value, None]}, features=Features({"x": Tensor(shape, "int32")}))
+    mapped = dataset.map(lambda row: {"x": row["x"] + 1} if row["x"] is not None else row)
+    assert mapped.features == dataset.features
+    np.testing.assert_array_equal(mapped[0]["x"], value + 1)
+    casted = dataset.cast(Features({"x": Tensor(shape, "float64")}))
+    assert casted[0]["x"].dtype == np.float64
+    np.testing.assert_array_equal(casted[0]["x"], value)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_pandas_nulls_and_precision(shape):
+    value = np.full((2, 3), 2**53 + 1, dtype=np.int64)
+    dataset = Dataset.from_dict({"x": [None, value]}, features=Features({"x": Tensor(shape, "int64")}))
+    for frame in [dataset.to_pandas(), dataset.with_format("pandas")[:]]:
+        assert frame["x"].iloc[0] is None
+        assert frame["x"].iloc[1].dtype == np.int64
+        np.testing.assert_array_equal(frame["x"].iloc[1], value)
+    for actual in dataset.with_format("numpy")[:]["x"]:
+        if actual is not None:
+            np.testing.assert_array_equal(actual, value)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_parquet_writer_and_nested_round_trip(shape, tmp_path):
+    from datasets.arrow_writer import ParquetWriter
+
+    feature = Tensor(shape, "int32")
+    features = Features({"nested": {"x": List(feature)}})
+    values = {"nested": [{"x": [np.ones((2, 3), dtype=np.int32), None]}, None]}
+    dataset = Dataset.from_dict(values, features=features)
+    path = str(tmp_path / "nested.parquet")
+    with ParquetWriter(features=features, path=path) as writer:
+        writer.write_table(dataset.data.table)
+    restored = Dataset.from_parquet(path, cache_dir=str(tmp_path / "cache"))
+    assert restored.features == features
+    assert restored[1]["nested"] is None
+    assert restored[0]["nested"]["x"][1] is None
+    np.testing.assert_array_equal(restored[0]["nested"]["x"][0], values["nested"][0]["x"][0])
+
+
+@pytest.mark.parametrize("shape", [(), (0, 3), (None, 3), (None, None)])
+def test_tensor_empty_and_scalar_persistence(shape, tmp_path):
+    value = np.array(7, dtype=np.int32) if shape == () else np.empty((0, 3), dtype=np.int32)
+    dataset = Dataset.from_dict({"x": [None, value]}, features=Features({"x": Tensor(shape, "int32")}))
+    path = str(tmp_path / "edge.parquet")
+    dataset.to_parquet(path)
+    restored = Dataset.from_parquet(path, cache_dir=str(tmp_path / "cache"))
+    assert restored.features == dataset.features
+    assert restored[0]["x"] is None
+    assert restored[1]["x"].shape == value.shape
+    assert restored[1]["x"].dtype == value.dtype
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+def test_tensor_deeply_nested(shape):
+    value = np.ones((2, 3), dtype=np.float32)
+    features = Features({"x": List(List(Tensor(shape)))})
+    dataset = Dataset.from_dict({"x": [[[value, None]]]}, features=features)
+    assert dataset[0]["x"][0][1] is None
+    np.testing.assert_array_equal(dataset[0]["x"][0][0], value)
+
+
+def test_tensor_cast_preserves_source_shape():
+    value = np.arange(6, dtype=np.int32).reshape(2, 3)
+    dataset = Dataset.from_dict({"x": [value, None]}, features=Features({"x": Tensor((2, 3), "int32")}))
+    for shape in [(None, 3), (None, None), (2, 3)]:
+        casted = dataset.cast_column("x", Tensor(shape, "float64"))
+        assert casted[0]["x"].shape == (2, 3)
+        np.testing.assert_array_equal(casted[0]["x"], value)
+        assert casted[1]["x"] is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"data": [1.5], "shape": [1]},
+        {"data": [1], "shape": [-1]},
+        {"data": [1], "shape": None},
+        {"data": [1], "shape": [True]},
+    ],
+)
+def test_tensor_validates_encoded_storage(value):
+    with pytest.raises(ValueError):
+        Tensor((None,), dtype="int32").encode_example(value)
+
+
+@pytest.mark.parametrize(
+    "metadata", [b"{}", b'{"uniform_shape":[null,3]}', b'{"permutation":[1,0],"dim_names":["x","y"]}']
+)
+def test_tensor_registration_preserves_canonical_schema_reading(metadata):
+    storage = pa.struct([("data", pa.list_(pa.float32())), ("shape", pa.list_(pa.int32(), 2))])
+    schema = pa.schema(
+        [
+            pa.field(
+                "x",
+                storage,
+                metadata={
+                    b"ARROW:extension:name": b"arrow.variable_shape_tensor",
+                    b"ARROW:extension:metadata": metadata,
+                },
+            )
+        ]
+    )
+    restored = pa.ipc.read_schema(pa.BufferReader(schema.serialize()))
+    assert restored.field("x").type.storage_type == storage
+    assert json.loads(restored.field("x").type.__arrow_ext_serialize__()) == json.loads(metadata)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"data": [1.0], "shape": [1]},
+        {"data": [1.0], "shape": [-1]},
+        {"data": [1.0], "shape": None},
+        {"data": None, "shape": [1, 3]},
+        {"data": [1.0], "shape": [1, 3]},
+    ],
+)
+def test_tensor_cast_validates_storage(value):
+    from datasets.table import cast_array_to_feature
+
+    raw = pa.array([value], type=pa.struct([("data", pa.list_(pa.float32())), ("shape", pa.list_(pa.int32()))]))
+    with pytest.raises(ValueError):
+        cast_array_to_feature(raw, Tensor((None, 3)))
+
+
+@pytest.mark.parametrize("shape", [()])
+def test_tensor_pandas_scalar_precision(shape):
+    value = np.array(2**53 + 1, dtype=np.int64)
+    for values in [[None, value], [value, value]]:
+        dataset = Dataset.from_dict({"x": values}, features=Features({"x": Tensor(shape, "int64")}))
+        for frame in [dataset.to_pandas(), dataset.with_format("pandas")[:]]:
+            for actual, expected in zip(frame["x"], values):
+                if expected is None:
+                    assert actual is None
+                else:
+                    assert isinstance(actual, np.ndarray)
+                    assert actual.shape == ()
+                    assert actual.dtype == np.int64
+                    assert actual.item() == 2**53 + 1
+
+
+def test_tensor_parquet_uint64(tmp_path):
+    value = np.array([0, 2**63 + 1], dtype=np.uint64)
+    features = Features({"x": Tensor((2,), "uint64"), "nested": List(Tensor((2,), "uint64"))})
+    dataset = Dataset.from_dict({"x": [value, None], "nested": [[value, None], None]}, features=features)
+    path = str(tmp_path / "uint64.parquet")
+    dataset.to_parquet(path)
+    restored = Dataset.from_parquet(path, cache_dir=str(tmp_path / "cache"))
+    assert restored[0]["x"].dtype == np.uint64
+    np.testing.assert_array_equal(restored[0]["x"], value)
+    np.testing.assert_array_equal(restored[0]["nested"][0], value)
+
+
+def test_tensor_nested_map_with_dynamic_shapes():
+    values = [np.ones((2, 3), dtype=np.float32), np.ones((4, 2), dtype=np.float32)]
+    dataset = Dataset.from_dict({"x": [values]}, features=Features({"x": List(Tensor((None, None)))}))
+    mapped = dataset.map(lambda row: {"x": row["x"]})
+    assert mapped.features == dataset.features
+    for actual, expected in zip(mapped[0]["x"], values):
+        np.testing.assert_array_equal(actual, expected)
+
+
+def test_tensor_requires_ndim():
+    with pytest.raises(ValueError, match="shape.*None.*ndim"):
+        Tensor(shape=None)
+
+
+@pytest.mark.parametrize("ndim", [0, 1, 2, 3])
+def test_tensor_explicit_ndim(ndim):
+    feature = Tensor(ndim=ndim)
+    assert feature.shape == (None,) * ndim
+    assert feature.ndim == ndim
+    features = Features({"x": feature})
+    assert Features.from_dict(json.loads(json.dumps(features.to_dict()))) == features
+    assert Features.from_arrow_schema(features.arrow_schema.remove_metadata()) == features
+    value = np.ones((2,) * ndim, dtype=np.float32)
+    np.testing.assert_array_equal(feature.decode_example(feature.encode_example(value)), value)
+    with pytest.raises(ValueError, match="shape"):
+        feature.encode_example(np.ones((2,) * (ndim + 1)))
+
+
+@pytest.mark.parametrize("ndim", [-1, 1.5, True, "2", 2**31])
+def test_tensor_invalid_ndim(ndim):
+    with pytest.raises(ValueError, match="ndim"):
+        Tensor(ndim=ndim)
+
+
+def test_tensor_ndim_matches_shape():
+    assert Tensor((None, None, 3)).ndim == 3
+    assert Tensor((None, 3), ndim=2) == Tensor((None, 3))
+    with pytest.raises(ValueError, match="ndim"):
+        Tensor((None, None, 3), ndim=2)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+@pytest.mark.parametrize("file_format", ["ipc", "parquet"])
+@pytest.mark.parametrize("with_null", [False, True])
+def test_tensor_plain_arrow_interop(shape, file_format, with_null, tmp_path):
+    values = [np.arange(6, dtype=np.int32).reshape(2, 3)]
+    if shape != (2, 3):
+        values.append(np.arange(12, dtype=np.int32).reshape(4, 3))
+    if with_null:
+        values.insert(1, None)
+    dataset = Dataset.from_dict({"x": values}, features=Features({"x": Tensor(shape, "int32")}))
+    path = tmp_path / ("tensor." + file_format)
+    if file_format == "ipc":
+        with pa.ipc.new_file(str(path), dataset.data.schema) as writer:
+            writer.write_table(dataset.data.table)
+    else:
+        dataset.to_parquet(str(path), batch_size=1)
+    extension_name = "arrow.fixed_shape_tensor" if shape == (2, 3) else "arrow.variable_shape_tensor"
+    # -S excludes site customizations and installed Datasets; PYTHONPATH exposes
+    # only the directory containing PyArrow. The child never imports Datasets.
+    reader = """
+import base64
+import importlib.util
+import json
+import sys
+import pyarrow as pa
+import pyarrow.parquet as pq
+assert importlib.util.find_spec("datasets") is None
+path, file_format, extension_name, expected_json = sys.argv[1:]
+table = pa.ipc.open_file(path).read_all() if file_format == "ipc" else pq.read_table(path)
+tensor_type = table.column("x").type
+fallback = b"huggingface:tensor_schema" in (table.schema.metadata or {})
+if fallback:
+    assert not isinstance(tensor_type, pa.BaseExtensionType), tensor_type
+    schema = pa.ipc.read_schema(pa.BufferReader(base64.b64decode(table.schema.metadata[b"huggingface:tensor_schema"])))
+    tensor_type = schema.field("x").type
+assert isinstance(tensor_type, pa.BaseExtensionType), tensor_type
+assert not isinstance(tensor_type, pa.ExtensionType), tensor_type
+assert tensor_type.extension_name == extension_name, tensor_type
+values = table.column("x").to_pylist()
+expected = json.loads(expected_json)
+if extension_name == "arrow.variable_shape_tensor":
+    assert pa.types.is_fixed_size_list(tensor_type.storage_type.field("shape").type)
+    assert tensor_type.storage_type.field("shape").type.list_size == 2
+    assert values == expected
+else:
+    assert isinstance(tensor_type, pa.FixedShapeTensorType)
+    assert list(tensor_type.shape) == [2, 3]
+    assert values == [value["data"] if value is not None else None for value in expected]
+assert "datasets" not in sys.modules
+print(f"{file_format}: {tensor_type}; rows={table.num_rows}; storage_fallback={fallback}; datasets_imported=False")
+"""
+    expected = [
+        {"data": value.reshape(-1).tolist(), "shape": list(value.shape)} if value is not None else None
+        for value in values
+    ]
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", reader, str(path), file_format, extension_name, json.dumps(expected)],
+        env={**os.environ, "PYTHONPATH": str(Path(pa.__file__).parent.parent)},
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    print(result.stdout, end="")
+
+
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+def test_tensor_uint64_mixed_magnitudes(shape):
+    feature = Tensor(shape, "uint64")
+    expected = np.array([0, 2**63 + 1], dtype=np.uint64)
+    for value in [expected, expected.tolist(), {"data": expected.tolist(), "shape": [2]}]:
+        np.testing.assert_array_equal(feature.decode_example(feature.encode_example(value)), expected)
+    dataset = Dataset.from_dict({"x": [expected, None]}, features=Features({"x": feature}))
+    np.testing.assert_array_equal(dataset[0]["x"], expected)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+def test_tensor_parquet_fixed_length_outer_list(shape, tmp_path):
+    value = [np.ones((2, 3), dtype=np.float32)] * 2
+    features = Features({"x": List(Tensor(shape), length=2)})
+    dataset = Dataset.from_dict({"x": [value, None]}, features=features)
+    path = str(tmp_path / "outer_list.parquet")
+    dataset.to_parquet(path, batch_size=1)
+    import pyarrow.parquet as pq
+
+    storage = pq.read_table(path)
+    assert storage["x"].to_pylist()[1] is None
+    restored = Dataset.from_parquet(path, cache_dir=str(tmp_path / "cache"))
+    assert restored.features == features
+    assert restored[1]["x"] is None
+    assert len(restored[0]["x"]) == 2
+    for actual, expected in zip(restored[0]["x"], value):
+        np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+def test_tensor_cast_nullable_list_to_fixed_length(shape):
+    features = Features({"x": List(Tensor(shape))})
+    value = np.ones((2, 3), dtype=np.float32)
+    dataset = Dataset.from_dict({"x": [[value, value], None]}, features=features)
+    target = Features({"x": List(Tensor(shape), length=2)})
+    casted = dataset.cast(target)
+    assert casted.features == target
+    assert casted[1]["x"] is None
+    for actual in casted[0]["x"]:
+        np.testing.assert_array_equal(actual, value)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"uniform_shape": (None, 4)},
+        {"permutation": [1, 0]},
+        {"dim_names": ["row", "column"]},
+        {"value_type": pa.int32()},
+        {"uniform_shape": (None, 3, None), "ndim": 3},
+    ],
+)
+def test_tensor_variable_equality_parameters(kwargs):
+    from datasets.features.tensor import VariableShapeTensorType
+
+    original = Tensor((None, 3))()
+    different = VariableShapeTensorType(**{"value_type": pa.float32(), "uniform_shape": (None, 3), **kwargs})
+    assert original != different
+    assert not original.equals(different)
+    assert pa.schema([("x", original)]) != pa.schema([("x", different)])
+
+
+def test_tensor_cast_rejects_incompatible_uniform_shape():
+    dataset = Dataset.from_dict({"x": [np.ones((2, 3))]}, features=Features({"x": Tensor((None, 3))}))
+    with pytest.raises(ValueError, match="shape"):
+        dataset.cast_column("x", Tensor((None, 4)))
+
+
+@pytest.mark.parametrize("fixed", [False, True])
+@pytest.mark.parametrize("metadata", [{"permutation": [1, 0]}, {"dim_names": ["row", "column"]}])
+def test_tensor_cast_rejects_unsupported_metadata(fixed, metadata):
+    from datasets.features.tensor import VariableShapeTensorType
+    from datasets.table import cast_array_to_feature
+
+    feature = Tensor((2, 3) if fixed else (None, 3))
+    arrow_type = (
+        pa.fixed_shape_tensor(pa.float32(), (2, 3), **metadata)
+        if fixed
+        else VariableShapeTensorType(pa.float32(), (None, 3), **metadata)
+    )
+    values = [[0, 1, 2, 3, 4, 5]] if fixed else [{"data": [0, 1, 2, 3, 4, 5], "shape": [2, 3]}]
+    array = pa.ExtensionArray.from_storage(arrow_type, pa.array(values, type=arrow_type.storage_type))
+    with pytest.raises(ValueError, match="permut|dimension names"):
+        cast_array_to_feature(array, feature)
+
+
+@pytest.mark.parametrize("dtype,large", [("int64", 2**53 + 1), ("uint64", 2**63 + 1)])
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+@pytest.mark.parametrize("batched", [False, True])
+def test_tensor_map_python_integer_precision(dtype, large, shape, batched):
+    features = Features({"x": Tensor(shape, dtype)})
+    dataset = Dataset.from_dict({"x": [[0, large]]}, features=features)
+    assert dataset[0]["x"].tolist() == [0, large]
+    mapped = dataset.map(lambda _: {"x": [[0, large]] if batched else [0, large]}, batched=batched, features=features)
+    assert mapped[0]["x"].tolist() == [0, large]
+
+
+@pytest.mark.parametrize("dtype,large", [("int64", 2**53 + 1), ("uint64", 2**63 + 1)])
+@pytest.mark.parametrize("shape", [(1,), (None,)])
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("format_name", ["numpy", "torch", "pandas", "to_pandas"])
+def test_tensor_nullable_integer_formats(dtype, large, shape, nested, format_name):
+    if format_name == "torch":
+        pytest.importorskip("torch")
+    feature = Tensor(shape, dtype)
+    value = np.array([large], dtype=dtype)
+    features = Features({"x": List(feature) if nested else feature})
+    dataset = Dataset.from_dict({"x": [[value, None]] if nested else [value, None]}, features=features)
+    for current in [dataset, dataset.map(lambda row: row, features=features)]:
+        if format_name == "to_pandas":
+            rows = [current.to_pandas()["x"].iloc[0]]
+        elif format_name == "pandas":
+            formatted = current.with_format(format_name)
+            rows = [formatted[0]["x"].iloc[0], formatted[:]["x"].iloc[0], formatted["x"][:].iloc[0]]
+        else:
+            formatted = current.with_format(format_name)
+            rows = [formatted[0]["x"], formatted[:]["x"][0], formatted["x"][:][0]]
+        for row in rows:
+            if nested:
+                assert row[1] is None
+                row = row[0]
+            assert row.tolist() == [large]
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("depth", [1, 2])
+def test_tensor_null_struct_parent(shape, depth):
+    feature = Tensor(shape)
+    value = np.ones((2, 3), dtype=np.float32)
+    for _ in range(depth):
+        feature = {"t": feature}
+        value = {"t": value}
+    features = Features({"x": feature})
+    for rows in [[None], [None, value]]:
+        dataset = Dataset.from_dict({"x": rows}, features=features)
+        assert dataset[0]["x"] is None
+        assert dataset.map(lambda row: row, features=features)[0]["x"] is None
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("batched", [False, True])
+def test_tensor_map_infers_replacement_type(shape, batched):
+    from datasets import Value
+
+    dataset = Dataset.from_dict({"x": [np.ones((2, 3))]}, features=Features({"x": Tensor(shape)}))
+
+    def replace(_):
+        return {"x": ["hello"] if batched else "hello"}
+
+    mapped = dataset.map(replace, batched=batched)
+    assert mapped.features == Features({"x": Value("string")})
+    assert mapped[0]["x"] == "hello"
+    with pytest.raises((ValueError, TypeError), match="Tensor"):
+        dataset.map(replace, batched=batched, features=dataset.features)
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_tensor_map_rejects_flat_value_for_higher_rank(batched):
+    features = Features({"x": Tensor((2, 3), "int32")})
+    dataset = Dataset.from_dict({"x": [np.arange(6).reshape(2, 3)]}, features=features)
+    with pytest.raises(ValueError, match="shape"):
+        dataset.map(
+            lambda _: {"x": [[0, 1, 2, 3, 4, 5]] if batched else [0, 1, 2, 3, 4, 5]},
+            features=features,
+            batched=batched,
+        )
+    storage = {"data": [0, 1, 2, 3, 4, 5], "shape": [2, 3]}
+    mapped = dataset.map(lambda _: {"x": [storage] if batched else storage}, features=features, batched=batched)
+    assert mapped[0]["x"].tolist() == [[0, 1, 2], [3, 4, 5]]
+
+
+@pytest.mark.parametrize("fixed", [False, True])
+@pytest.mark.parametrize("layout", [{}, {"permutation": [0, 1]}, {"permutation": [1, 0]}, {"dim_names": ["r", "c"]}])
+def test_tensor_schema_created_before_datasets_import(fixed, layout, tmp_path):
+    reader = """
+import json
+import sys
+import pyarrow as pa
+assert "datasets" not in sys.modules
+fixed = sys.argv[1] == "True"
+layout = json.loads(sys.argv[2])
+metadata = {"shape": [2, 3]} if fixed else {"uniform_shape": [None, 3]}
+metadata.update(layout)
+storage = pa.list_(pa.int64(), 6) if fixed else pa.struct(
+    [("data", pa.list_(pa.int64())), ("shape", pa.list_(pa.int32(), 2))]
+)
+schema = pa.schema([pa.field("x", storage, metadata={
+    b"ARROW:extension:name": b"arrow.fixed_shape_tensor" if fixed else b"arrow.variable_shape_tensor",
+    b"ARROW:extension:metadata": json.dumps(metadata).encode(),
+})])
+schema = pa.ipc.read_schema(pa.BufferReader(schema.serialize()))
+assert isinstance(schema.field("x").type, pa.BaseExtensionType)
+assert not isinstance(schema.field("x").type, pa.ExtensionType)
+from datasets import Dataset, Features, Tensor
+if layout.get("dim_names") or layout.get("permutation") == [1, 0]:
+    try:
+        Features.from_arrow_schema(schema)
+    except ValueError as error:
+        assert "dimension" in str(error), str(error)
+    else:
+        raise AssertionError("Unsupported tensor layout was silently discarded")
+    sys.exit(0)
+features = Features.from_arrow_schema(schema)
+assert features == Features({"x": Tensor((2, 3) if fixed else (None, 3), "int64")})
+values = [[9007199254740993] * 6] if fixed else [{"data": [9007199254740993] * 6, "shape": [2, 3]}]
+array = pa.ExtensionArray.from_storage(schema.field("x").type, pa.array(values, type=storage))
+dataset = Dataset(pa.Table.from_arrays([array], schema=schema))
+assert dataset[0]["x"].tolist() == [[9007199254740993] * 3] * 2
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", reader, str(fixed), json.dumps(layout)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+TENSOR_FORMATS = [
+    "numpy",
+    pytest.param("torch", marks=pytest.mark.skipif(not config.TORCH_AVAILABLE, reason="Requires torch")),
+    pytest.param("tensorflow", marks=pytest.mark.skipif(not config.TF_AVAILABLE, reason="Requires tensorflow")),
+    pytest.param("jax", marks=pytest.mark.skipif(not config.JAX_AVAILABLE, reason="Requires jax")),
+    "pandas",
+    pytest.param("polars", marks=pytest.mark.skipif(not config.POLARS_AVAILABLE, reason="Requires polars")),
+]
+
+
+def _nest_tensor(feature, value, nesting):
+    if nesting == "list":
+        return List(feature), [value, None]
+    if nesting == "struct":
+        return {"t": feature}, {"t": value}
+    if nesting == "list_struct":
+        return List({"t": List(feature)}), [{"t": [value, None]}, None]
+    return feature, value
+
+
+@pytest.mark.parametrize("format_name", TENSOR_FORMATS)
+@pytest.mark.parametrize(
+    "dtype,values", [("bool", [True, False]), ("uint64", [0, 2**63 + 1]), ("float64", [0.5, 1.5])]
+)
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+@pytest.mark.parametrize("nesting", ["top", "list", "struct", "list_struct"])
+def test_tensor_format_preserves_dtype_and_nulls(format_name, dtype, values, shape, nesting):
+    expected = np.asarray(values, dtype=dtype)
+    feature, value = _nest_tensor(Tensor(shape, dtype), expected, nesting)
+    dataset = Dataset.from_dict(
+        {"x": [value, None], "other": [1, 2]}, features=Features({"x": feature, "other": Value("int64")})
+    )
+    formatted = dataset.with_format(format_name)
+
+    def get_rows():
+        if format_name == "pandas":
+            return [formatted[0]["x"].iloc[0], formatted[:]["x"].iloc[0], formatted["x"][:].iloc[0]], [
+                formatted[1]["x"].iloc[0],
+                formatted[:]["x"].iloc[1],
+                formatted["x"][:].iloc[1],
+            ]
+        if format_name == "polars":
+            return [formatted[0]["x"][0], formatted[:]["x"][0], formatted["x"][:][0]], [
+                formatted[1]["x"][0],
+                formatted[:]["x"][1],
+                formatted["x"][:][1],
+            ]
+        return [formatted[0]["x"], formatted[:]["x"][0], formatted["x"][:][0]], [
+            formatted[1]["x"],
+            formatted[:]["x"][1],
+            formatted["x"][:][1],
+        ]
+
+    if format_name == "jax" and dtype in ("uint64", "float64"):
+        import jax
+
+        with jax.experimental.enable_x64(True):
+            rows, nulls = get_rows()
+    else:
+        rows, nulls = get_rows()
+    assert all(row is None for row in nulls)
+    for row in rows:
+        if nesting == "list_struct":
+            assert row[1] is None
+            row = row[0]["t"]
+        if nesting in ("list", "list_struct"):
+            assert row[1] is None
+            row = row[0]
+        elif nesting == "struct":
+            row = row["t"]
+        if format_name in ("numpy", "pandas", "polars"):
+            assert isinstance(row, np.ndarray)
+        actual = np.asarray(row)
+        assert actual.dtype == expected.dtype
+        np.testing.assert_array_equal(actual, expected)
+
+
+@require_polars
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("nesting", ["list", "struct", "list_struct"])
+def test_tensor_polars_nested_arrays(shape, nesting):
+    expected = np.arange(6, dtype=np.float32).reshape(2, 3)
+    feature, value = _nest_tensor(Tensor(shape), expected, nesting)
+    formatted = Dataset.from_dict({"x": [value, None]}, features=Features({"x": feature})).with_format("polars")
+    for column in [formatted[:]["x"], formatted["x"][:]]:
+        assert column[1] is None
+        row = column[0]
+        if nesting == "list_struct":
+            assert row[1] is None
+            row = row[0]["t"]
+        if nesting in ("list", "list_struct"):
+            assert row[1] is None
+            row = row[0]
+        else:
+            row = row["t"]
+        assert isinstance(row, np.ndarray)
+        np.testing.assert_array_equal(row, expected)
+
+
+@pytest.mark.parametrize("value", [[0, 1, 2], [0.5], [float("nan")], [-1], [float("inf")]])
+@pytest.mark.parametrize("representation", ["list", "array", "storage"])
+def test_tensor_bool_rejects_lossy_values(value, representation):
+    if representation == "array":
+        value = np.asarray(value)
+    elif representation == "storage":
+        value = {"data": value, "shape": [len(value)]}
+    with pytest.raises(ValueError, match="bool"):
+        Tensor((None,), "bool").encode_example(value)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3)])
+@pytest.mark.parametrize("nesting", ["list", "struct", "list_struct"])
+@pytest.mark.parametrize("batched", [False, True])
+def test_tensor_nested_map_infers_scalar_replacement(shape, nesting, batched):
+    feature, value = _nest_tensor(Tensor(shape), np.ones((2, 3)), nesting)
+    dataset = Dataset.from_dict({"x": [value]}, features=Features({"x": feature}))
+
+    def replace(_):
+        return {"x": [0] if batched else 0}
+
+    mapped = dataset.map(replace, batched=batched)
+    assert mapped.features == Features({"x": Value("int64")})
+    assert mapped[0]["x"] == 0
+    with pytest.raises((ValueError, TypeError, AttributeError)):
+        dataset.map(replace, batched=batched, features=dataset.features)
+
+
+@require_jax
+@pytest.mark.parametrize("enabled", [False, True])
+def test_tensor_jax_uint64_requires_x64(enabled):
+    import jax
+
+    with jax.experimental.enable_x64(enabled):
+        dataset = Dataset.from_dict(
+            {"x": [[0, 2**63 + 1]]}, features=Features({"x": Tensor((2,), "uint64")})
+        ).with_format("jax")
+        if enabled:
+            actual = np.asarray(dataset[0]["x"])
+            assert actual.dtype == np.uint64
+            assert actual.tolist() == [0, 2**63 + 1]
+        else:
+            with pytest.raises(ValueError, match="uint64.*jax_enable_x64"):
+                dataset[0]
+
+
+def test_tensor_pandas_decodes_sibling_features():
+    from PIL import Image as PILImage
+
+    from datasets import Image
+
+    expected = np.zeros((2, 2, 3), dtype=np.uint8)
+    features = Features({"x": {"t": Tensor((2,), "bool"), "image": Image()}})
+    dataset = Dataset.from_dict(
+        {"x": [{"t": [True, False], "image": PILImage.fromarray(expected)}, None]}, features=features
+    ).with_format("pandas")
+    for column in [dataset[0]["x"], dataset[:]["x"], dataset["x"][:]]:
+        value = column.iloc[0]
+        assert isinstance(value["image"], PILImage.Image)
+        np.testing.assert_array_equal(np.asarray(value["image"]), expected)
+        assert value["t"].dtype == np.bool_
+        assert value["t"].tolist() == [True, False]
+    assert dataset[1]["x"].iloc[0] is None
+    assert dataset[:]["x"].iloc[1] is None
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_tensor_map_preserves_fractional_sibling(batched):
+    features = Features({"x": {"t": Tensor((2,)), "n": Value("int64")}})
+    dataset = Dataset.from_dict({"x": [{"t": [1.0, 2.0], "n": 1}]}, features=features)
+    value = {"t": [1.0, 2.0], "n": 1.5}
+    mapped = dataset.map(lambda _: {"x": [value] if batched else value}, batched=batched)
+    assert mapped[0]["x"]["n"] == 1.5
+    assert mapped.features["x"]["n"] == Value("float64")
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_tensor_map_preserves_added_sibling(batched):
+    features = Features({"x": {"t": Tensor((2,))}})
+    dataset = Dataset.from_dict({"x": [{"t": [1.0, 2.0]}]}, features=features)
+    value = {"t": [1.0, 2.0], "added": 42}
+    mapped = dataset.map(lambda _: {"x": [value] if batched else value}, batched=batched)
+    assert "added" in mapped[0]["x"]
+    assert mapped[0]["x"]["added"] == 42
+    assert mapped.features["x"]["added"] == Value("int64")
+
+
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+def test_tensor_map_preserves_json_sibling(batched, shape):
+    from datasets import Json
+
+    features = Features({"x": {"t": Tensor(shape, "int64"), "j": Json()}})
+    dataset = Dataset.from_dict({"x": [{"t": [1, 2], "j": {"a": 1}}]}, features=features)
+    mapped = dataset.map(lambda row: {"x": row["x"]}, batched=batched)
+    assert mapped.features == features
+    assert mapped[0]["x"]["j"] == {"a": 1}
+    np.testing.assert_array_equal(mapped[0]["x"]["t"], [1, 2])
+
+
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+@pytest.mark.parametrize("json_value", [{"a": 1}, [1, "two"], "text", None])
+def test_tensor_pandas_decodes_json_sibling_once(shape, json_value):
+    from datasets import Json
+
+    features = Features({"x": {"t": Tensor(shape, "int64"), "j": Json()}})
+    dataset = Dataset.from_dict({"x": [{"t": [1, 2], "j": json_value}, None]}, features=features)
+    formatted = dataset.with_format("pandas")
+    for column in [formatted[0]["x"], formatted[:]["x"], formatted["x"][:]]:
+        value = column.iloc[0]
+        assert value["j"] == json_value
+        np.testing.assert_array_equal(value["t"], [1, 2])
+        assert value["t"].dtype == np.int64
+    assert formatted[1]["x"].iloc[0] is None
+
+
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+def test_tensor_large_list_construction_and_map(shape):
+    from datasets import LargeList
+
+    features = Features({"x": LargeList(Tensor(shape, "int64"))})
+    dataset = Dataset.from_dict({"x": [[[1, 2]], None, [None]]}, features=features)
+    for current in [dataset, dataset.map(lambda row: row, features=features)]:
+        assert current.features == features
+        np.testing.assert_array_equal(current[0]["x"][0], [1, 2])
+        assert current[1]["x"] is None
+        assert current[2]["x"] == [None]
+
+
+@require_torch
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("shape", [(2,), (None,)])
+@pytest.mark.parametrize("nested", [False, True])
+def test_tensor_map_detaches_torch_gradients(batched, shape, nested):
+    import torch
+
+    feature = {"t": Tensor(shape)} if nested else Tensor(shape)
+    value = {"t": [1.0, 2.0]} if nested else [1.0, 2.0]
+    dataset = Dataset.from_dict({"x": [value]}, features=Features({"x": feature}))
+
+    def replace(_):
+        value = torch.tensor([1.0, 2.0], requires_grad=True)
+        if nested:
+            value = {"t": value}
+        return {"x": [value] if batched else value}
+
+    mapped = dataset.map(replace, features=dataset.features, batched=batched)
+    actual = mapped[0]["x"]["t"] if nested else mapped[0]["x"]
+    np.testing.assert_array_equal(actual, [1.0, 2.0])
+    assert mapped.features == dataset.features

--- a/tests/features/test_tensor.py
+++ b/tests/features/test_tensor.py
@@ -1266,6 +1266,70 @@ def test_tensor_parquet_table_canonical_schema(shape, native_target):
     assert Features.from_arrow_schema(table.schema) == Features({"x": feature})
 
 
+@pytest.mark.parametrize("shape", [(2, 3), (None, 3), (None, None)])
+@pytest.mark.parametrize("native_source", [False, True])
+@pytest.mark.parametrize("sliced", [False, True])
+@pytest.mark.parametrize("nesting", ["top", "list", "json_sibling", "required_fields"])
+def test_tensor_parquet_null_storage(shape, native_source, sliced, nesting, tmp_path):
+    import pyarrow.parquet as pq
+
+    from datasets.features.tensor import tensor_to_parquet_table
+
+    schema = Features({"x": Tensor(shape, "int64")}).arrow_schema
+    if native_source:
+        schema = pa.ipc.read_schema(pa.BufferReader(schema.serialize()))
+    arrow_type = schema.field("x").type
+    values = [list(range(6)), [2**53 + 1] * 6, None, list(range(6)), None]
+    if shape != (2, 3):
+        values = [{"data": value, "shape": [2, 3]} if value is not None else None for value in values]
+    array = pa.ExtensionArray.from_storage(arrow_type, pa.array(values, type=arrow_type.storage_type))
+    if sliced:
+        array = array.slice(1)
+        values = values[1:]
+    if nesting == "list":
+        array = pa.ListArray.from_arrays([0, len(array), len(array)], array, mask=pa.array([False, True]))
+        values = [values, None]
+    elif nesting == "json_sibling":
+        json_array = pa.array(['{"a":1}'] * len(array), type=pa.json_())
+        array = pa.StructArray.from_arrays([array, json_array], names=["t", "j"])
+        values = [{"t": value, "j": '{"a":1}'} for value in values]
+    elif nesting == "required_fields":
+        # Required children may have valid values beneath a null struct parent.
+        mask = array.is_null()
+        filled = pa.ExtensionArray.from_storage(
+            arrow_type,
+            pa.array([value if value is not None else values[0] for value in values], type=arrow_type.storage_type),
+        )
+        array = pa.StructArray.from_arrays(
+            [filled, pa.array([1] * len(array))],
+            fields=[pa.field("t", array.type, nullable=False), pa.field("n", pa.int64(), nullable=False)],
+            mask=mask,
+        )
+        values = [{"t": value, "n": 1} if value is not None else None for value in values]
+    schema = pa.schema([schema.field("x").with_type(array.type)])
+    table = tensor_to_parquet_table(pa.Table.from_arrays([array], schema=schema))
+    path = tmp_path / "null_tensor.parquet"
+    pq.write_table(table, path)
+    reader = """
+import json
+import sys
+import pyarrow.parquet as pq
+assert "datasets" not in sys.modules
+table = pq.read_table(sys.argv[1])
+assert table.column("x").to_pylist() == json.loads(sys.argv[2])
+assert "datasets" not in sys.modules
+"""
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", reader, str(path), json.dumps(values)],
+        env={**os.environ, "PYTHONPATH": str(Path(pa.__file__).parent.parent)},
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 @pytest.mark.parametrize("list_kind", ["list", "large_list", "fixed_size_list"])
 def test_tensor_array_cast_preserves_list_value_field(list_kind):
     from datasets.table import array_cast

--- a/tests/features/test_tensor.py
+++ b/tests/features/test_tensor.py
@@ -3,6 +3,7 @@ import os
 import pickle
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
@@ -13,6 +14,18 @@ import pytest
 from datasets import Dataset, Features, List, Tensor, Value, config, load_from_disk
 
 from ..utils import require_jax, require_polars, require_tf, require_torch
+
+
+@contextmanager
+def _jax_enable_x64(enabled):
+    import jax
+
+    previous = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", enabled)
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", previous)
 
 
 @pytest.mark.parametrize("shape", [(2, 3), (None, 3), (2, None), (None, None), ()])
@@ -902,9 +915,7 @@ def test_tensor_format_preserves_dtype_and_nulls(format_name, dtype, values, sha
         ]
 
     if format_name == "jax" and dtype in ("uint64", "float64"):
-        import jax
-
-        with jax.experimental.enable_x64(True):
+        with _jax_enable_x64(True):
             rows, nulls = get_rows()
     else:
         rows, nulls = get_rows()
@@ -978,9 +989,7 @@ def test_tensor_nested_map_infers_scalar_replacement(shape, nesting, batched):
 @require_jax
 @pytest.mark.parametrize("enabled", [False, True])
 def test_tensor_jax_uint64_requires_x64(enabled):
-    import jax
-
-    with jax.experimental.enable_x64(enabled):
+    with _jax_enable_x64(enabled):
         dataset = Dataset.from_dict(
             {"x": [[0, 2**63 + 1]]}, features=Features({"x": Tensor((2,), "uint64")})
         ).with_format("jax")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from datasets.features import Array2D, ClassLabel, Features, Image, LargeList, List, Value
+from datasets.features import Array2D, ClassLabel, Features, Image, Json, LargeList, List, Value
 from datasets.features.features import Array2DExtensionType, get_nested_type
 from datasets.table import (
     ConcatenationTable,
@@ -1411,6 +1411,28 @@ def test_embed_table_storage(image_file):
     embedded_images_table = embed_table_storage(table)
     assert isinstance(embedded_images_table.to_pydict()["image"][0]["path"], str)
     assert isinstance(embedded_images_table.to_pydict()["image"][0]["bytes"], bytes)
+
+
+@pytest.mark.parametrize(
+    "feature,storage",
+    [
+        (Array2D((2, 3), "int32"), [[[1, 2, 3], [4, 5, 6]], None]),
+        (Json(), ['{"answer":42}', None]),
+    ],
+)
+def test_embed_storage_preserves_extension_without_external_files(feature, storage, image_file):
+    array = pa.array(storage, type=feature())
+    embedded = embed_array_storage(array, feature)
+    assert embedded.type == array.type
+    assert embedded.equals(array)
+    features = Features({"x": {"img": Image(), "value": feature}})
+    images = pa.array([{"path": image_file}, None], type=Image.pa_type)
+    nested = pa.StructArray.from_arrays([images, array], names=["img", "value"])
+    table = pa.Table.from_arrays([nested], schema=features.arrow_schema)
+    embedded_table = embed_table_storage(table, local_files=True, remote_files=False)
+    assert embedded_table.schema == features.arrow_schema
+    assert embedded_table["x"].chunk(0).field("value").equals(array)
+    assert isinstance(embedded_table["x"].to_pylist()[0]["img"]["bytes"], bytes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #7738.

This adds a `Tensor(shape, dtype)` feature for multi-dimensional arrays whose dimensions can vary from row to row, following the direction discussed in the issue: fixed shapes use Arrow's canonical `arrow.fixed_shape_tensor` extension, and shapes with unknown dimensions (or an explicit `ndim`) use the canonical `arrow.variable_shape_tensor` layout (`struct<data: list<T>, shape: fixed_size_list<int32>[ndim]>` with the spec's metadata). pyarrow 25 has no Python wrapper for the variable-shape type yet, so datasets registers the extension itself; files written this way read back in a pyarrow-only process as the canonical types, which is how interoperability was verified.

What it does:

- Encoding accepts numpy arrays and nested lists, validates dtype and every fixed dimension, keeps integer precision (int64 / uint64 never go through float64), and rejects out-of-range or non-boolean values.
- Decoding returns numpy arrays. The numpy, torch, tensorflow, jax, pandas and polars formatters return native tensors with the declared dtype, including nested `List(Tensor)` and dict columns, with `None` rows preserved.
- Tensor takes part in the standard encoding pipeline, so sibling fields, keys added by `map`, `Json` siblings, `LargeList` nesting, torch tensors with `requires_grad`, and the writer's type inference behave as for other features; the extension also survives `embed_table_storage`.
- `Features.from_arrow_schema` recognises the canonical types regardless of import order.
- `Array2D`..`Array5D` are unchanged.

Tests live in `tests/features/test_tensor.py` (fixed and dynamic shapes, dtype validation, nulls, batched paths, save_to_disk / parquet round trips, each formatter, precision, nested layouts, canonical interop from a pyarrow-only subprocess).
