### PR TITLE
Recover from invalid list offsets produced by the pyarrow JSON reader

### DIFF
--- a/src/datasets/packaged_modules/json/json.py
+++ b/src/datasets/packaged_modules/json/json.py
@@ -1,5 +1,6 @@
 import codecs
 import io
+import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -259,7 +260,7 @@ class Json(datasets.ArrowBasedBuilder):
                             except (AttributeError, io.UnsupportedOperation):
                                 batch += readline(f)
                             # PyArrow only accepts utf-8 encoded bytes
-                            if self.config.encoding != "utf-8":
+                            if self.config.encoding != "utf-8" or encoding_errors != "strict":
                                 batch = batch.decode(self.config.encoding, errors=encoding_errors).encode("utf-8")
                             # On first batch we check for lists of objects with arbitrary fields
                             if (
@@ -284,6 +285,7 @@ class Json(datasets.ArrowBasedBuilder):
                                 batch = "\n".join(ujson_dumps(example) for example in examples).encode()
                             # Disable parallelism if block size is ~ len(batch) to avoid segfault
                             block_size = len(batch) if len(batch) // 8 > block_size else block_size
+                            pa_table = None
                             try:
                                 while True:
                                     try:
@@ -314,21 +316,68 @@ class Json(datasets.ArrowBasedBuilder):
                                             block_size *= 2
                                         else:
                                             raise
-                            except pa.ArrowInvalid as e:
-                                if not allow_full_read:
+                                try:
+                                    pa_table.validate(full=True)
+                                except pa.ArrowInvalid as e:
+                                    logger.warning(
+                                        f"Table from file '{file}' failed Arrow validation: {e}. "
+                                        "The PyArrow JSON parser bug in datasets issue #5531 is a known cause of "
+                                        "invalid list offsets. Retrying the current batch in a single block."
+                                    )
+                                    pa_table = paj.read_json(
+                                        io.BytesIO(batch),
+                                        read_options=paj.ReadOptions(block_size=len(batch)),
+                                        parse_options=paj.ParseOptions(
+                                            explicit_schema=self.info.features.arrow_schema
+                                            if self.info.features is not None
+                                            else None
+                                        ),
+                                    )
+                                    pa_table.validate(full=True)
+                            except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
+                                invalid_table = pa_table is not None
+                                if not invalid_table and isinstance(e, pa.ArrowNotImplementedError):
+                                    raise
+                                if not invalid_table and not allow_full_read:
                                     raise FullReadDisallowed()
                                 try:
-                                    with open(
-                                        file, encoding=self.config.encoding, errors=self.config.encoding_errors
-                                    ) as f:
-                                        df = pandas_read_json(f)
+                                    if invalid_table:
+                                        # Use the normalized JSON Lines, including encoding
+                                        # and mixed-type transformations, for the fallback.
+                                        # Object dtype avoids pandas' automatic date parsing
+                                        # and rounding of nullable integers through floats.
+                                        # The standard decoder preserves float precision
+                                        # while accepting subnormals, unlike precise ujson.
+                                        df = pd.DataFrame(
+                                            (
+                                                json.loads(line.decode("utf-8-sig", errors=encoding_errors))
+                                                for line in batch.splitlines()
+                                                if line.strip()
+                                            ),
+                                            dtype=object,
+                                        )
+                                    else:
+                                        with open(
+                                            file, encoding=self.config.encoding, errors=self.config.encoding_errors
+                                        ) as f:
+                                            df = pandas_read_json(io.StringIO(f.read().removeprefix("\ufeff")))
                                 except ValueError:
                                     logger.error(f"Failed to load JSON from file '{file}' with error {type(e)}: {e}")
                                     raise e
                                 if df.columns.tolist() == [0]:
                                     df.columns = list(self.config.features) if self.config.features else ["text"]
                                 try:
+                                    schema = pa_table.schema if invalid_table else None
                                     pa_table = pa.Table.from_pandas(df, preserve_index=False)
+                                    if schema is not None and pa_table.schema != schema:
+                                        # Restore inferred types using Arrow's JSON conversions,
+                                        # which accept timestamp formats that table_cast rejects.
+                                        pa_table = paj.read_json(
+                                            io.BytesIO(batch),
+                                            read_options=paj.ReadOptions(block_size=len(batch)),
+                                            parse_options=paj.ParseOptions(explicit_schema=schema),
+                                        )
+                                    pa_table.validate(full=True)
                                 except pa.ArrowInvalid as e:
                                     logger.error(
                                         f"Failed to convert pandas DataFrame to Arrow Table from file '{file}' with error {type(e)}: {e}"
@@ -336,8 +385,9 @@ class Json(datasets.ArrowBasedBuilder):
                                     raise ValueError(
                                         f"Failed to convert pandas DataFrame to Arrow Table from file {file}."
                                     ) from None
-                                yield Key(shard_idx, 0), self._cast_table(pa_table)
-                                break
+                                if not invalid_table:
+                                    yield Key(shard_idx, 0), self._cast_table(pa_table)
+                                    break
                             yield (
                                 Key(shard_idx, batch_idx),
                                 self._cast_table(pa_table, json_field_paths=json_field_paths),

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -12,6 +12,7 @@ import pytest
 from datasets import Features, List, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
+from datasets.packaged_modules.json import json as json_module
 from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES, Json, JsonConfig
 
 from ..utils import require_teich
@@ -638,10 +639,10 @@ def test_json_invalid_list_offsets_batch_retry(tmp_path, retry, allow_full_read)
             return original_read(size)
 
         with (
-            patch("datasets.packaged_modules.json.json.open", return_value=f) as open_file,
+            patch.object(json_module, "open", return_value=f) as open_file,
             patch.object(f, "read", side_effect=bounded_read) as read,
             patch.object(paj, "read_json", wraps=paj.read_json) as read_json,
-            patch("datasets.packaged_modules.json.json.pd.DataFrame", wraps=pd.DataFrame) as dataframe,
+            patch.object(json_module.pd, "DataFrame", wraps=pd.DataFrame) as dataframe,
         ):
             generator = builder._generate_tables([path], [[path]], [path], allow_full_read=allow_full_read)
             tables = []
@@ -677,7 +678,7 @@ def test_json_invalid_table_warning(tmp_path):
     builder = Json()
     with (
         patch.object(paj, "read_json", side_effect=[invalid_table, valid_table]),
-        patch("datasets.packaged_modules.json.json.logger.warning") as warning,
+        patch.object(json_module.logger, "warning") as warning,
     ):
         tables = list(builder._generate_tables([path], [[path]], [path]))
     assert pa.concat_tables([table for _, table in tables]).to_pylist() == rows

--- a/tests/packaged_modules/test_json.py
+++ b/tests/packaged_modules/test_json.py
@@ -1,15 +1,30 @@
+import io
 import json
 import textwrap
+from datetime import datetime
+from unittest.mock import Mock, patch
 
+import pandas as pd
 import pyarrow as pa
+import pyarrow.json as paj
 import pytest
 
-from datasets import Features, Value, load_dataset
+from datasets import Features, List, Value, load_dataset
 from datasets.builder import InvalidConfigName
 from datasets.data_files import DataFilesList
 from datasets.packaged_modules.json.json import AGENT_TRACES_FEATURES, Json, JsonConfig
 
 from ..utils import require_teich
+
+
+def _pyarrow_has_invalid_list_offsets():
+    data = b'{"a":[1]}\n{"a":[null,2]}\n'
+    table = paj.read_json(io.BytesIO(data), read_options=paj.ReadOptions(block_size=len(data.splitlines()[1])))
+    try:
+        table.validate(full=True)
+    except pa.ArrowInvalid:
+        return True
+    return False
 
 
 @pytest.fixture
@@ -561,6 +576,242 @@ def test_json_generate_tables(file_fixture, config_kwargs, expected, request):
     pa_table = pa.concat_tables([table for _, table in generator])
     out = Features.from_arrow_schema(pa_table.schema).decode_batch(pa_table.to_pydict())
     assert out == expected
+
+
+@pytest.mark.parametrize("allow_full_read", [False, True])
+@pytest.mark.parametrize("value", [[None, 1], [None, {"label": "en", "prob": 0.5}]])
+def test_json_invalid_list_offsets(tmp_path, allow_full_read, value):
+    rows = [{"a": value}]
+    path = write_jsonl(tmp_path / "file.jsonl", rows)
+    builder = Json()
+    tables = []
+    for _, table in builder._generate_tables([path], [[path]], [path], allow_full_read=allow_full_read):
+        table.validate(full=True)
+        tables.append(table)
+    assert pa.concat_tables(tables).combine_chunks().to_pylist() == rows
+
+
+@pytest.mark.parametrize("chunksize", [64 << 10, (16 << 10) - 1])
+def test_json_invalid_list_offsets_multiple_blocks(tmp_path, chunksize):
+    rows = [
+        {"id": 0, "meta": {"line_identifications": [{"label": "en", "prob": 1.0}]}},
+        {"id": 1, "meta": {"line_identifications": [None, {"label": "en", "prob": 0.5}]}},
+    ]
+    path = tmp_path / "file.jsonl"
+    # Place each record in its own Arrow block. The second block infers the
+    # list's value type after its leading null, even though the first is typed.
+    path.write_text("".join(json.dumps(row).ljust((16 << 10) - 1) + "\n" for row in rows))
+    path = str(path)
+    builder = Json(chunksize=chunksize)
+    tables = []
+    for _, table in builder._generate_tables([path], [[path]], [path]):
+        table.validate(full=True)
+        tables.append(table)
+    assert pa.concat_tables(tables).combine_chunks().to_pylist() == rows
+
+
+@pytest.mark.skipif(not _pyarrow_has_invalid_list_offsets(), reason="PyArrow produces valid list offsets")
+@pytest.mark.parametrize("retry", ["single_block", "explicit_schema", "pandas"])
+@pytest.mark.parametrize("allow_full_read", [False, True])
+def test_json_invalid_list_offsets_batch_retry(tmp_path, retry, allow_full_read):
+    rows = [{"a": [i]} for i in range(6)]
+    rows[3]["a"].insert(0, None)
+    if retry != "single_block":
+        # A leading null in the first record also breaks single-block inference.
+        rows[2]["a"].insert(0, None)
+    # Two Arrow blocks per batch: only the second batch has leading nulls.
+    block_size = 16 << 10
+    lines = [(json.dumps(row).ljust(block_size - 1) + "\n").encode() for row in rows]
+    batches = [b"".join(lines[i : i + 2]) for i in range(0, len(lines), 2)]
+    path = tmp_path / "file.jsonl"
+    path.write_bytes(b"".join(batches))
+    path = str(path)
+    builder = Json(chunksize=len(batches[0]) - 1)
+    if retry == "explicit_schema":
+        # Features may have been inferred by _split_generators, not configured.
+        builder.info.features = Features({"a": List(Value("int64"))})
+    with open(path, "rb") as f:
+        original_read = f.read
+
+        def bounded_read(size=-1):
+            assert size >= 0, "Unbounded file read after a valid first batch"
+            return original_read(size)
+
+        with (
+            patch("datasets.packaged_modules.json.json.open", return_value=f) as open_file,
+            patch.object(f, "read", side_effect=bounded_read) as read,
+            patch.object(paj, "read_json", wraps=paj.read_json) as read_json,
+            patch("datasets.packaged_modules.json.json.pd.DataFrame", wraps=pd.DataFrame) as dataframe,
+        ):
+            generator = builder._generate_tables([path], [[path]], [path], allow_full_read=allow_full_read)
+            tables = []
+            for _, table in generator:
+                table.validate(full=True)
+                tables.append(table)
+    assert pa.concat_tables(tables).combine_chunks().to_pylist() == rows
+    assert open_file.call_count == 1
+    assert all(call.args == (builder.config.chunksize,) for call in read.call_args_list)
+    assert [call.args[0].getvalue() for call in read_json.call_args_list] == [
+        batches[0],
+        batches[1],
+        batches[1],
+        batches[2],
+    ]
+    retry_options = read_json.call_args_list[2].kwargs
+    assert retry_options["read_options"].block_size == len(batches[1])
+    if retry == "explicit_schema":
+        assert retry_options["parse_options"].explicit_schema == builder.info.features.arrow_schema
+    if retry == "pandas":
+        dataframe.assert_called_once()
+    else:
+        dataframe.assert_not_called()
+
+
+def test_json_invalid_table_warning(tmp_path):
+    rows = [{"a": [1]}]
+    path = write_jsonl(tmp_path / "file.jsonl", rows)
+    valid_table = pa.Table.from_pylist(rows)
+    invalid_table = Mock(wraps=valid_table)
+    error = pa.ArrowInvalid("synthetic validity bitmap error")
+    invalid_table.validate.side_effect = error
+    builder = Json()
+    with (
+        patch.object(paj, "read_json", side_effect=[invalid_table, valid_table]),
+        patch("datasets.packaged_modules.json.json.logger.warning") as warning,
+    ):
+        tables = list(builder._generate_tables([path], [[path]], [path]))
+    assert pa.concat_tables([table for _, table in tables]).to_pylist() == rows
+    message = warning.call_args.args[0]
+    assert "failed Arrow validation" in message
+    assert str(error) in message
+    assert "known cause of invalid list offsets" in message
+    assert "#5531" in message
+
+
+def test_json_valid_file_no_reread(jsonl_file):
+    builder = Json()
+    with patch.object(paj, "read_json", wraps=paj.read_json) as read_json:
+        tables = list(builder._generate_tables([jsonl_file], [[jsonl_file]], [jsonl_file]))
+    assert read_json.call_count == 1
+    assert pa.concat_tables([table for _, table in tables]).to_pydict() == EXPECTED_THREE
+
+
+@pytest.mark.parametrize("chunksize", [5, 64 << 10])
+@pytest.mark.parametrize("dtype", ["int64", "float16"])
+def test_json_invalid_list_offsets_with_features(tmp_path, chunksize, dtype):
+    rows = [{"a": []}, {"a": [None, 1]}]
+    path = write_jsonl(tmp_path / "file.jsonl", rows)
+    builder = Json(chunksize=chunksize, features=Features({"a": List(Value(dtype))}))
+    tables = []
+    for _, table in builder._generate_tables([path], [[path]], [path]):
+        table.validate(full=True)
+        tables.append(table)
+    assert pa.concat_tables(tables).combine_chunks().to_pylist() == rows
+
+
+@pytest.mark.parametrize("encoding", ["utf-8-sig", "utf-16"])
+def test_json_invalid_list_offsets_encoding(tmp_path, encoding):
+    path = tmp_path / "file.jsonl"
+    path.write_text('{"a":[null,1],"text":"caf\u00e9"}\n', encoding=encoding)
+    path = str(path)
+    tables = list(Json(encoding=encoding)._generate_tables([path], [[path]], [path]))
+    table = pa.concat_tables([table for _, table in tables])
+    table.validate(full=True)
+    assert table.to_pylist() == [{"a": [None, 1], "text": "caf\u00e9"}]
+
+
+@pytest.mark.parametrize("value", [1e-320, -1e-320, 5e-324, 0.12345678901234568])
+def test_json_invalid_list_offsets_preserve_floats(tmp_path, value):
+    rows = [{"a": [None, 1], "x": value}]
+    path = write_jsonl(tmp_path / "file.jsonl", rows)
+    tables = list(Json()._generate_tables([path], [[path]], [path], allow_full_read=False))
+    table = pa.concat_tables([table for _, table in tables])
+    table.validate(full=True)
+    assert table.to_pylist() == rows
+
+
+@pytest.mark.parametrize("encoding_errors, expected", [("replace", "caf\ufffd"), ("ignore", "caf")])
+def test_json_invalid_list_offsets_encoding_errors(tmp_path, encoding_errors, expected):
+    path = tmp_path / "file.jsonl"
+    path.write_bytes(b'{"a":[null,1],"text":"caf\xff"}\n')
+    path = str(path)
+    builder = Json(encoding_errors=encoding_errors)
+    tables = list(builder._generate_tables([path], [[path]], [path], allow_full_read=False))
+    table = pa.concat_tables([table for _, table in tables])
+    table.validate(full=True)
+    assert table.to_pylist() == [{"a": [None, 1], "text": expected}]
+
+
+@pytest.mark.parametrize("chunksize", [1, 64 << 10])
+@pytest.mark.parametrize("offset, hour", [("", 12), ("Z", 12), ("+00:00", 12), ("+01:00", 11)])
+def test_json_invalid_list_offsets_timestamp_schema(tmp_path, chunksize, offset, hour):
+    rows = [
+        {"a": [None, 1], "ts": f"2026-01-01T12:34:56{offset}"},
+        {"a": [2], "ts": "2026-01-02T12:34:56"},
+    ]
+    path = write_jsonl(tmp_path / "file.jsonl", rows)
+    dataset = load_dataset(
+        "json", data_files=path, split="train", chunksize=chunksize, cache_dir=str(tmp_path / "cache")
+    )
+    assert dataset.to_list() == [
+        {"a": [None, 1], "ts": datetime(2026, 1, 1, hour, 34, 56)},
+        {"a": [2], "ts": datetime(2026, 1, 2, 12, 34, 56)},
+    ]
+    assert dataset.features["ts"] == Value("timestamp[s]")
+
+
+@pytest.mark.parametrize("encoding_errors, expected", [("replace", "caf\ufffd"), ("ignore", "caf")])
+def test_json_invalid_list_offsets_nested_timestamp_encoding_errors(tmp_path, encoding_errors, expected):
+    path = tmp_path / "file.jsonl"
+    path.write_bytes(b'{"a":[null,{"ts":"2026-01-01T12:34:56+01:00","caf\xff":1}],"text":"caf\xff"}\n')
+    path = str(path)
+    builder = Json(encoding_errors=encoding_errors)
+    tables = list(builder._generate_tables([path], [[path]], [path], allow_full_read=False))
+    table = pa.concat_tables([table for _, table in tables])
+    table.validate(full=True)
+    assert table.to_pylist() == [
+        {"a": [None, {"ts": datetime(2026, 1, 1, 11, 34, 56), expected: 1}], "text": expected}
+    ]
+
+
+@pytest.mark.parametrize("chunksize", [1, 2, 3, 64 << 10])
+def test_json_invalid_list_offsets_utf8_bom(tmp_path, chunksize):
+    path = tmp_path / "file.jsonl"
+    path.write_text('{"a":[null,1]}\n', encoding="utf-8-sig")
+    dataset = load_dataset(
+        "json", data_files=str(path), split="train", chunksize=chunksize, cache_dir=str(tmp_path / "cache")
+    )
+    assert dataset.to_list() == [{"a": [None, 1]}]
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-8-sig", "utf-16"])
+def test_json_full_file_fallback_bom(tmp_path, encoding):
+    path = tmp_path / "file.json"
+    # Leading whitespace bypasses JSON array normalization, reaching the
+    # pre-existing whole-file pandas fallback even with a complete BOM.
+    path.write_text(' [{"a":[null,1]}]\n', encoding="utf-8-sig" if encoding == "utf-8" else encoding)
+    path = str(path)
+    builder = Json(encoding=encoding, on_mixed_types=None)
+    tables = list(builder._generate_tables([path], [[path]], [path]))
+    table = pa.concat_tables([table for _, table in tables])
+    table.validate(full=True)
+    assert table.to_pylist() == [{"a": [None, 1]}]
+
+
+@pytest.mark.parametrize("chunksize", [5, 64 << 10])
+@pytest.mark.parametrize("use_features", [False, True])
+def test_json_invalid_list_offsets_preserve_values(tmp_path, chunksize, use_features):
+    rows = [
+        {"a": [], "id": None, "timestamp": 1690000000000},
+        {"a": [None, 1], "id": 9007199254740993, "timestamp": 1690000000001},
+    ]
+    path = write_jsonl(tmp_path / "file.jsonl", rows)
+    features = Features({"a": List(Value("int64")), "id": Value("int64"), "timestamp": Value("int64")})
+    builder = Json(chunksize=chunksize, features=features if use_features else None)
+    tables = list(builder._generate_tables([path], [[path]], [path]))
+    table = pa.concat_tables([table for _, table in tables], promote_options="default")
+    table.validate(full=True)
+    assert table.to_pylist() == rows
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #5531

## Root cause

The invalid Arrow data comes from pyarrow's JSON reader, not from `datasets`: when a list column's first non-empty value in a block starts with `null` (e.g. `{"a": [null, 1]}`), type inference can drop the leading null while the offsets still count it, so the table's list offsets span more values than exist. `pa.Table.validate()` passes; `validate(full=True)`, `to_pylist()`, casting and saving fail. Reported upstream with a pyarrow-only reproducer: apache/arrow#51305.

## Fix

- Validate each batch returned by `paj.read_json` with `validate(full=True)`.
- On failure, re-parse the same batch as a single block, passing the known `features` as `explicit_schema` (which avoids the inference bug entirely); fall back to the per-batch pandas path only if the retry is still invalid. The retry is bounded to the batch, so streaming and files larger than 2 GiB are unaffected.
- The pandas fallback now applies the configured `encoding` / `encoding_errors` and BOM handling, preserves subnormal floats, and follows the already inferred column types so output does not depend on `chunksize`.
- The warning states the validation error and names #5531 only as the known cause of invalid list offsets.

## Tests

Synthetic JSONL inputs (no external data): leading-null lists across block boundaries, with and without `features`, several dtypes, encodings and `encoding_errors`, BOM, timestamps, subnormal floats, and a bounded-read check that a valid first batch is never followed by a full-file read. Tests that exercise the retry path detect whether the installed pyarrow reproduces the bug and skip otherwise, so they keep passing once apache/arrow#51305 is fixed.
