### PR TITLE
Restore `_legacy_no_dict_keys_sorting` so `_check_legacy_cache2` can find 2.15.0 caches.

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -71,6 +71,8 @@ class Pickler(dill.Pickler):
         dill.Pickler.save(self, obj, save_persistent_id=save_persistent_id)
 
     def _batch_setitems(self, items, *args, **kwargs):
+        if self._legacy_no_dict_keys_sorting:
+            return super()._batch_setitems(items, *args, **kwargs)
         # Ignore the order of keys in a dict
         try:
             # Faster, but fails for unorderable elements

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -18,6 +18,7 @@ import datasets
 from datasets import config
 from datasets.fingerprint import Hasher, fingerprint_transform
 from datasets.table import InMemoryTable
+from datasets.utils._dill import Pickler
 
 from .utils import (
     require_not_windows,
@@ -231,6 +232,18 @@ class HashingTest(TestCase):
         hash3 = Hasher.hash("there")
         self.assertEqual(hash1, hash2)
         self.assertNotEqual(hash1, hash3)
+
+    def test_hash_dict_legacy_no_dict_keys_sorting(self):
+        # _check_legacy_cache2 patches this flag to reproduce 2.15.0's unsorted dict hashes
+        insertion_order = {"train": ["train.csv"], "test": ["test.csv"]}
+        sorted_order = {"test": ["test.csv"], "train": ["train.csv"]}
+        self.assertEqual(Hasher.hash(insertion_order), Hasher.hash(sorted_order))
+        with patch.object(Pickler, "_legacy_no_dict_keys_sorting", True):
+            legacy_insertion = Hasher.hash(insertion_order)
+            legacy_sorted = Hasher.hash(sorted_order)
+        self.assertNotEqual(legacy_insertion, legacy_sorted)
+        self.assertNotEqual(legacy_insertion, Hasher.hash(insertion_order))
+        self.assertEqual(legacy_sorted, Hasher.hash(sorted_order))
 
     def test_hash_class_instance(self):
         hash1 = Hasher.hash(Foo("hello"))


### PR DESCRIPTION
## Summary

Restore the early return in `Pickler._batch_setitems` that honours `_legacy_no_dict_keys_sorting`, keeping the `*args` / `**kwargs` passthrough from `#7817`. `#7817` updated `Pickler._batch_setitems` for Python 3.14's extra argument and, in the same hunk, dropped that return. `_check_legacy_cache2` still patches `_legacy_no_dict_keys_sorting` to recompute the `config_id` datasets 2.15.0 would have written, so since 4.4.0 the lookup hashes dicts with sorted keys and misses old cache directories when `data_files` keys are not already sorted (`{"train": ..., "test": ...}`).

With `_legacy_no_dict_keys_sorting` set, `Hasher.hash({"train": ["train.csv"], "test": ["test.csv"]})` is again `711511d8f1d9bc25`, the value measured from 2.15.0 (issue author, Python 3.11) and reproduced here on 3.12. Default hashing is unchanged: the same two dicts still hash equal without the flag.

Chose option 1 on #8410: restore the reader rather than delete the 2.14/2.15 compat path (option 2). That is what `#6514` implemented and is two lines to revert. Can drop `_check_legacy_cache2` / the flag instead if you would rather retire that layout.

Fixes #8410

## Test plan

- [x] `tests/test_fingerprint.py::HashingTest::test_hash_dict_legacy_no_dict_keys_sorting` fails without the early return (`cfd3b51f0f8e9fd8` == `cfd3b51f0f8e9fd8`) and passes with it
- [x] Default (unpatched) hashing of the same two dicts remains equal
- [x] Neighbouring `HashingTest` cases that do not need optional extras: 9 passed, 6 deselected
- [ ] Optional: load a dataset whose 2.15.0 cache dir used dict-valued `data_files` with unsorted keys and confirm `builder.cache_dir` points at that directory
