### PR TITLE
Fix PandasArrayExtensionDtype comparison against strings

### DIFF
--- a/src/datasets/features/features.py
+++ b/src/datasets/features/features.py
@@ -880,6 +880,22 @@ class PandasArrayExtensionDtype(PandasExtensionDtype):
     def construct_array_type(cls):
         return PandasArrayExtensionArray
 
+    @classmethod
+    def construct_from_string(cls, string: str) -> "PandasArrayExtensionDtype":
+        # `name` is an instance property (`array[<dtype>]`), so the base
+        # implementation's `assert isinstance(cls.name, str)` fails. Pandas
+        # treats TypeError as "not this dtype" in ExtensionDtype.__eq__.
+        if not isinstance(string, str):
+            raise TypeError(f"'construct_from_string' expects a string, got {type(string)}")
+        match = re.fullmatch(r"array\[(.+)\]", string)
+        if match is None:
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
+        try:
+            value_type = np.dtype(match.group(1))
+        except TypeError:
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'") from None
+        return cls(value_type)
+
     @property
     def type(self) -> type:
         return np.ndarray

--- a/tests/features/test_array_xd.py
+++ b/tests/features/test_array_xd.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from absl.testing import parameterized
+from pandas.api.types import is_string_dtype
 
 import datasets
 from datasets.arrow_writer import ArrowWriter
@@ -365,6 +366,34 @@ def test_table_to_pandas(dtype, dummy_value):
     assert isinstance(df.foo.dtype, PandasArrayExtensionDtype)
     arr = df.foo.to_numpy()
     np.testing.assert_equal(arr, np.array([[[dummy_value] * 2] * 2], dtype=np.dtype(dtype)))
+
+
+@pytest.mark.parametrize("dtype", ["int32", "bool", "float64"])
+def test_pandas_array_extension_dtype_construct_from_string(dtype):
+    constructed = PandasArrayExtensionDtype.construct_from_string(f"array[{dtype}]")
+    assert isinstance(constructed, PandasArrayExtensionDtype)
+    assert constructed.value_type == np.dtype(dtype)
+
+
+@pytest.mark.parametrize("string", ["string", "int64", "array[]", "array[not_a_dtype]", "not_an_array[int32]"])
+def test_pandas_array_extension_dtype_construct_from_string_rejects(string):
+    # Pandas relies on TypeError to mean "not my dtype" when comparing a dtype to a string.
+    with pytest.raises(TypeError):
+        PandasArrayExtensionDtype.construct_from_string(string)
+
+
+@pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])
+def test_table_to_pandas_dtype_compares_to_string(dtype, dummy_value):
+    # Pandas compares dtypes against plain strings throughout its internals (`is_string_dtype`
+    # and friends). Without construct_from_string the base implementation asserts on
+    # cls.name, which is a property here.
+    features = datasets.Features({"foo": datasets.Array2D(dtype=dtype, shape=(2, 2))})
+    dataset = datasets.Dataset.from_dict({"foo": [[[dummy_value] * 2] * 2]}, features=features)
+    df = dataset._data.to_pandas()
+
+    assert (df.foo.dtype == "string") is False
+    assert is_string_dtype(df.foo.dtype) is False
+    assert df.astype(object).shape == (1, 1)
 
 
 @pytest.mark.parametrize("dtype, dummy_value", [("int32", 1), ("bool", True), ("float64", 1)])


### PR DESCRIPTION
## Summary

Implement `construct_from_string` on `PandasArrayExtensionDtype`: parse `array[<dtype>]` into a `PandasArrayExtensionDtype`, and raise `TypeError` for anything else (how pandas spells "not my dtype" in `__eq__`). Provenance: pandas extension-dtype docs, and the reproduction on `main` in #8467 (pandas 3.0.5).

`PandasArrayExtensionDtype.name` is an instance property (`array[float64]`), so the inherited `ExtensionDtype.construct_from_string` asserts on a `property` object. Pandas compares dtypes to strings throughout its internals (`is_string_dtype`, `astype_is_view`), so any Array2D/3D/4D/5D column that reaches pandas raises `AssertionError` on `dtype == "string"`, `is_string_dtype`, and `df.astype(object)`.

This PR does not change `_metadata` from `"value_type"` to `("value_type",)`. That is #8375 / #8464, a distinct contract bug.

Landing `construct_from_string` and the `_metadata` tuple in one PR would also stop `dtype == "array[float64]"` (the dtype's own name) from raising. With only this change, `dtype == "string"` is `False` and `df.astype(object)` works; own-name comparison still hits the `_metadata` `AttributeError`. Can fold the tuple in if you would rather land them together.

Fixes #8467

## Test plan

- [x] `tests/features/test_array_xd.py` construct-from-string round-trip (`array[int32]` / `array[bool]` / `array[float64]`)
- [x] `construct_from_string` raises `TypeError` for `string`, `int64`, `array[]`, `array[not_a_dtype]`, `not_an_array[int32]`
- [x] `test_table_to_pandas_dtype_compares_to_string`: `dtype == "string"` is False, `is_string_dtype` is False, `df.astype(object)` works
- [x] The 11 new cases fail on `main` (`AssertionError: (PandasArrayExtensionDtype, <class 'property'>)`) and pass here; full `tests/features/test_array_xd.py` is 114 passed
