### PR TITLE
Write pushed features to card when re-pushing a split

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -6938,6 +6938,9 @@ def _get_updated_dataset_card(
             repo_info.size_in_bytes = repo_info.download_size + repo_info.dataset_size
             repo_info.splits.pop(split, None)
             repo_info.splits[split] = split_info
+        # the pushed features win: reaching here with other splits on the repo means
+        # they already matched, so this only takes effect when the push replaces them all
+        repo_info.features = features
         info_to_dump = repo_info
     else:
         info_to_dump = DatasetInfo(

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -194,3 +194,71 @@ def test_get_updated_dataset_card_keeps_existing_splits_when_appending():
 
     data_files = MetadataConfigs.from_dataset_card_data(dataset_card.data)["default"]["data_files"]
     assert [entry["split"] for entry in data_files] == ["train", "test"]
+
+
+README_WITH_FEATURES = (
+    "---\nconfigs:\n- config_name: default\n  data_files:\n  - split: train\n    path: data/train-*\n"
+    "dataset_info:\n  features:\n  - name: x\n    dtype: int64\n  - name: dropped\n    dtype: string\n"
+    "  splits:\n  - name: train\n    num_bytes: 40\n    num_examples: 5\n"
+    "  download_size: 40\n  dataset_size: 40\n---\n"
+)
+
+
+@pytest.mark.unit
+def test_get_updated_dataset_card_updates_features_when_replacing_sole_split():
+    mem = MemoryFileSystem(skip_instance_cache=True)
+    fs = DirFileSystem("/refeature", fs=mem)
+
+    with fs.open(config.REPOCARD_FILENAME, "w") as f:
+        f.write(README_WITH_FEATURES)
+
+    # re-pushing the only split with different columns: the shards no longer carry
+    # "dropped", so a card that still declares it makes the dataset fail to cast
+    new_features = Features({"x": Value("int64"), "added": Value("int64")})
+    dataset_card, _ = _get_updated_dataset_card(
+        fs=fs,
+        config_name="default",
+        splits_info=[SplitInfo(name="train", num_bytes=80, num_examples=7)],
+        features=new_features,
+        data_dir="data",
+        set_default=None,
+        uploaded_sizes=[80],
+        deleted_sizes=[40],
+        remove_other_splits=False,
+    )
+
+    dataset_info = DatasetInfosDict.from_dataset_card_data(dataset_card.data)["default"]
+    assert dataset_info.features == new_features
+    assert dataset_info.splits["train"].num_examples == 7
+
+
+@pytest.mark.unit
+def test_get_updated_dataset_card_rejects_features_mismatch_against_other_splits():
+    mem = MemoryFileSystem(skip_instance_cache=True)
+    fs = DirFileSystem("/mismatch", fs=mem)
+
+    with fs.open(config.REPOCARD_FILENAME, "w") as f:
+        f.write(
+            README_WITH_FEATURES.replace(
+                "  - split: train\n    path: data/train-*\n",
+                "  - split: train\n    path: data/train-*\n  - split: test\n    path: data/test-*\n",
+            ).replace(
+                "  - name: train\n    num_bytes: 40\n    num_examples: 5\n",
+                "  - name: train\n    num_bytes: 40\n    num_examples: 5\n"
+                "  - name: test\n    num_bytes: 20\n    num_examples: 2\n",
+            )
+        )
+
+    # "test" keeps the old columns, so accepting the push would leave the splits disagreeing
+    with pytest.raises(ValueError, match="don't match the features of the existing splits"):
+        _get_updated_dataset_card(
+            fs=fs,
+            config_name="default",
+            splits_info=[SplitInfo(name="train", num_bytes=80, num_examples=7)],
+            features=Features({"x": Value("int64"), "added": Value("int64")}),
+            data_dir="data",
+            set_default=None,
+            uploaded_sizes=[80],
+            deleted_sizes=[40],
+            remove_other_splits=False,
+        )


### PR DESCRIPTION
Fixes #8608.

`_get_updated_dataset_card` updates the splits and sizes of the existing `dataset_info` when
a config is re-pushed, but never assigns the pushed `features` to it. Re-pushing a dataset's
only split with different columns therefore leaves the card declaring the previous schema
while the shards hold the new one, and the dataset fails to cast on load:

```
CastError: Couldn't cast ... because column names don't match
```

The existing mismatch guard doesn't catch this because it only runs when *other* splits are
present (`any(s != split for s in repo_info.splits)`), which is never true for a single-split
dataset being replaced. The card ends up half-updated - `num_examples` from the new push,
`features` from the old one - so the push looks like it worked.

### The change

```diff
            repo_info.splits[split] = split_info
+       repo_info.features = features
        info_to_dump = repo_info
```

Reaching that line with other splits on the repo means the features already matched, or the
guard above would have raised, so the assignment is a no-op in that case. The only behaviour
change is the case the guard deliberately skips: a push that replaces every split the card
describes, where the pushed features are the authoritative ones.

Both `Dataset.push_to_hub` and `DatasetDict.push_to_hub` go through this function, so one
change covers both.

### Tests

Two unit tests alongside the existing `_get_updated_dataset_card` tests in
`tests/test_buckets.py`, using the same in-memory filesystem pattern:

- `test_get_updated_dataset_card_updates_features_when_replacing_sole_split` - the new
  features reach the card, and the split count still updates. Fails on `main`, passes here.
- `test_get_updated_dataset_card_rejects_features_mismatch_against_other_splits` - the
  existing `ValueError` still raises when a second split would be left disagreeing.

`pytest tests/test_buckets.py tests/test_info.py tests/test_metadata_util.py` passes (33
tests), and `ruff check` / `ruff format --check` are clean on both files. I have not run
`tests/test_upstream_hub.py`, which needs the CI Hub token.

### Open question

I went with silently writing the new features, since that matches what the shards actually
contain. If you'd rather the user were told that the declared schema changed under an
existing config, a warning at that point would be easy to add - happy to adjust.
