### PR TITLE
Resolve a legacy dataset name to its canonical repo id

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -583,9 +583,11 @@ class HubDatasetModuleFactory(_DatasetModuleFactory):
             library_version=__version__,
             user_agent=get_datasets_user_agent(self.download_config.user_agent),
         )
+        # a legacy name like "imdb" is still served by the Hub but is not a valid repo id in an hf:// URI
+        repo_id = self.name if "/" in self.name else api.dataset_info(self.name, revision=self.commit_hash).id
         try:
             dataset_readme_path = api.hf_hub_download(
-                repo_id=self.name,
+                repo_id=repo_id,
                 filename=config.REPOCARD_FILENAME,
                 repo_type="dataset",
                 revision=self.commit_hash,
@@ -598,7 +600,7 @@ class HubDatasetModuleFactory(_DatasetModuleFactory):
             download_config.download_desc = "Downloading standalone yaml"
         try:
             standalone_yaml_path = cached_path(
-                hf_dataset_url(self.name, config.REPOYAML_FILENAME, revision=self.commit_hash),
+                hf_dataset_url(repo_id, config.REPOYAML_FILENAME, revision=self.commit_hash),
                 download_config=download_config,
             )
             with open(standalone_yaml_path, encoding="utf-8") as f:
@@ -609,13 +611,13 @@ class HubDatasetModuleFactory(_DatasetModuleFactory):
                     dataset_card_data = DatasetCardData(**_dataset_card_data_dict)
         except FileNotFoundError:
             pass
-        base_path = f"hf://datasets/{self.name}@{self.commit_hash}/{self.data_dir or ''}".rstrip("/")
+        base_path = f"hf://datasets/{repo_id}@{self.commit_hash}/{self.data_dir or ''}".rstrip("/")
         metadata_configs = MetadataConfigs.from_dataset_card_data(dataset_card_data)
         dataset_infos = DatasetInfosDict.from_dataset_card_data(dataset_card_data)
         if config.USE_PARQUET_EXPORT and self.use_exported_dataset_infos:
             try:
                 exported_dataset_infos = _dataset_viewer.get_exported_dataset_infos(
-                    dataset=self.name, commit_hash=self.commit_hash, token=self.download_config.token
+                    dataset=repo_id, commit_hash=self.commit_hash, token=self.download_config.token
                 )
                 exported_dataset_infos = DatasetInfosDict(
                     {
@@ -672,8 +674,8 @@ class HubDatasetModuleFactory(_DatasetModuleFactory):
             default_config_name = None
         builder_kwargs = {
             "base_path": base_path,
-            "repo_id": self.name,
-            "dataset_name": camelcase_to_snakecase(Path(self.name).name),
+            "repo_id": repo_id,
+            "dataset_name": camelcase_to_snakecase(Path(repo_id).name),
         }
         if self.data_dir:
             builder_kwargs["data_files"] = data_files
@@ -683,7 +685,7 @@ class HubDatasetModuleFactory(_DatasetModuleFactory):
         try:
             # this file is deprecated and was created automatically in old versions of push_to_hub
             dataset_infos_path = cached_path(
-                hf_dataset_url(self.name, config.DATASETDICT_INFOS_FILENAME, revision=self.commit_hash),
+                hf_dataset_url(repo_id, config.DATASETDICT_INFOS_FILENAME, revision=self.commit_hash),
                 download_config=download_config,
             )
             with open(dataset_infos_path, encoding="utf-8") as f:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -55,11 +55,15 @@ SAMPLE_DATASET_IDENTIFIER3 = "hf-internal-testing/multi_dir_dataset"  # has mult
 SAMPLE_DATASET_IDENTIFIER4 = "hf-internal-testing/imagefolder_with_metadata"  # imagefolder with a metadata file inside the train/test directories
 SAMPLE_DATASET_IDENTIFIER5 = "hf-internal-testing/imagefolder_with_metadata_no_splits"  # imagefolder with a metadata file and no default split names in data files
 
+SAMPLE_LEGACY_DATASET_NAME = "imdb"  # a legacy name with no namespace, redirected by the Hub
+SAMPLE_LEGACY_DATASET_IDENTIFIER = "stanfordnlp/imdb"  # what the Hub redirects it to
+
 SAMPLE_DATASET_COMMIT_HASH = "0e1cee81e718feadf49560b287c4eb669c2efb1a"
 SAMPLE_DATASET_COMMIT_HASH2 = "c19550d35263090b1ec2bfefdbd737431fafec40"
 SAMPLE_DATASET_COMMIT_HASH3 = "aaa2d4bdd1d877d1c6178562cfc584bdfa90f6dc"
 SAMPLE_DATASET_COMMIT_HASH4 = "507fa72044169a5a1802b7ac2d6bd38d5f310739"
 SAMPLE_DATASET_COMMIT_HASH5 = "4971fa562942cab8263f56a448c3f831b18f1c27"
+SAMPLE_LEGACY_DATASET_COMMIT_HASH = "e6281661ce1c48d982bc483cf8a173c1bbeb5d31"
 
 SAMPLE_DATASET_NO_CONFIGS_IN_METADATA = "hf-internal-testing/audiofolder_no_configs_in_metadata"
 SAMPLE_DATASET_SINGLE_CONFIG_IN_METADATA = "hf-internal-testing/audiofolder_single_config_in_metadata"
@@ -518,6 +522,21 @@ class ModuleFactoryTest(TestCase):
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
         assert module_factory_result.builder_kwargs["base_path"].startswith("hf://")
+
+    @pytest.mark.integration
+    def test_HubDatasetModuleFactory_with_legacy_name(self):
+        factory = HubDatasetModuleFactory(
+            SAMPLE_LEGACY_DATASET_NAME,
+            commit_hash=SAMPLE_LEGACY_DATASET_COMMIT_HASH,
+            download_config=self.download_config,
+        )
+        module_factory_result = factory.get_module()
+        assert importlib.import_module(module_factory_result.module_path) is not None
+        assert module_factory_result.builder_kwargs["repo_id"] == SAMPLE_LEGACY_DATASET_IDENTIFIER
+        assert module_factory_result.builder_kwargs["base_path"] == (
+            f"hf://datasets/{SAMPLE_LEGACY_DATASET_IDENTIFIER}@{SAMPLE_LEGACY_DATASET_COMMIT_HASH}"
+        )
+        assert module_factory_result.builder_kwargs["dataset_name"] == SAMPLE_LEGACY_DATASET_NAME
 
     @pytest.mark.integration
     def test_HubDatasetModuleFactory_with_data_dir(self):


### PR DESCRIPTION
`load_dataset("imdb")` dies with an `HfUriError` about a `.huggingface.yaml` nobody asked for, and so do `squad`, `glue`, `rotten_tomatoes`, `ag_news`, `cnn_dailymail`, `mnist` and `wikitext`.

The Hub still redirects these names, so the first half of the load works: `hf_hub_download(repo_id="imdb", ...)` returns the card and a real sha. Then `get_module` puts that raw string into an `hf://` URI, and `parse_hf_uri` wants `namespace/name`.

So resolve it once at the top of `get_module` and use it for the two `hf_dataset_url` calls, `base_path`, the viewer lookup and `builder_kwargs`. `base_path` and `repo_id` have to move together: `DatasetBuilder.__init__` checks every data file sits under `hf://datasets/{repo_id}@`, so canonicalising one and not the other trips that check.

Only a name without a `/` pays for the extra `dataset_info` call, so namespaced datasets make the same number of Hub requests as before. I counted them on both sides to be sure.

One thing you may not expect: the viewer lookup 404s with "The dataset has been renamed" for these names, so `get_exported_dataset_infos` was raising and getting swallowed for every legacy name. It returns the export now. I checked that one by hand rather than in the test, since `use_exported_dataset_infos` is off by default in the factory, and for imdb the card carries the same features either way, so you would not have noticed from the outside.

Test is an integration one like the other `HubDatasetModuleFactory` tests, and it fails on main with the error above. I also checked the eight names load end to end, and that `"imdb"` and `"stanfordnlp/imdb"` land in the same cache directory.

Offline is still canonical-only: `HF_HUB_OFFLINE=1` plus `load_dataset("ag_news")` raises `ConnectionError` before any of this runs, same as it does today, since the cached-module lookup globs the cache by the name it was given. Left alone rather than guessed at.

Happy to turn this into a clear error naming the canonical id instead, if you'd rather these names stop resolving.

Fixes #8612
