### PR TITLE
Fingerprint functions from the user's own modules by value

### DIFF
--- a/src/datasets/utils/_dill.py
+++ b/src/datasets/utils/_dill.py
@@ -15,6 +15,8 @@
 
 import os
 import sys
+import sysconfig
+from functools import lru_cache
 from io import BytesIO
 from types import CodeType, FunctionType
 
@@ -25,9 +27,63 @@ from packaging import version
 from .. import config
 
 
+@lru_cache(maxsize=1)
+def _installed_module_roots() -> tuple[str, ...]:
+    roots = set()
+    for key in ("stdlib", "platstdlib", "purelib", "platlib"):
+        path = sysconfig.get_paths().get(key)
+        if path:
+            roots.add(os.path.realpath(path))
+    return tuple(sorted(roots))
+
+
+@lru_cache(maxsize=None)
+def _is_installed_module(module_name: str) -> bool:
+    """Whether `module_name` lives in the standard library or in site-packages.
+
+    Such a module only changes when its package is reinstalled, so referring to its
+    functions by name is enough to notice a change. Anything else is source the user
+    edits in place.
+    """
+    module_file = getattr(sys.modules.get(module_name), "__file__", None)
+    if module_file is None:
+        # Built-in, frozen, or namespace package: not user-editable source.
+        return True
+    return os.path.realpath(module_file).startswith(_installed_module_roots())
+
+
 class Pickler(dill.Pickler):
     dispatch = dill._dill.MetaCatchingDict(dill.Pickler.dispatch.copy())
     _legacy_no_dict_keys_sorting = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._by_value_functions: dict[int, tuple[FunctionType, FunctionType]] = {}
+
+    def _by_value(self, obj):
+        """Return a stand-in for `obj` that `dill` dumps by value, or `obj` unchanged.
+
+        `dill` dumps a function it can import as a module-qualified name, so the dump
+        carries the name and not the body. Functions from the user's own modules are
+        dumped by value instead, which is what already happens to the same function
+        defined in `__main__`.
+        """
+        module_name = getattr(obj, "__module__", None)
+        if module_name is None or module_name == "__main__" or _is_installed_module(module_name):
+            return obj
+        cached = self._by_value_functions.get(id(obj))
+        if cached is not None and cached[0] is obj:
+            return cached[1]
+        copied = FunctionType(obj.__code__, obj.__globals__, obj.__name__, obj.__defaults__, obj.__closure__)
+        copied.__module__ = None
+        copied.__qualname__ = obj.__qualname__
+        copied.__kwdefaults__ = obj.__kwdefaults__
+        copied.__dict__.update(obj.__dict__)
+        # Hold on to the original so its `id` cannot be reused mid-dump, and reuse one
+        # stand-in per function so a function reachable from its own globals is
+        # memoized rather than followed forever.
+        self._by_value_functions[id(obj)] = (obj, copied)
+        return copied
 
     def save(self, obj, save_persistent_id=True):
         obj_type = type(obj)
@@ -68,6 +124,7 @@ class Pickler(dill.Pickler):
         # Unwrap `torch.compile`-ed functions
         if obj_type is FunctionType:
             obj = getattr(obj, "_torchdynamo_orig_callable", obj)
+            obj = self._by_value(obj)
         dill.Pickler.save(self, obj, save_persistent_id=save_persistent_id)
 
     def _batch_setitems(self, items, *args, **kwargs):

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -49,6 +49,10 @@ class DatasetChild(datasets.Dataset):
         return DatasetChild(self.data, fingerprint=new_fingerprint)
 
 
+def _a_function_dumped_by_value(example):
+    return example
+
+
 class UnpicklableCallable:
     def __init__(self, callable):
         self.callable = callable
@@ -416,6 +420,59 @@ def test_move_script_doesnt_change_hash(tmp_path: Path):
     fingerprint1 = subprocess.check_output(["python", str(script_path1)])
     fingerprint2 = subprocess.check_output(["python", str(script_path2)])
     assert fingerprint1 == fingerprint2
+
+
+def test_hash_of_imported_function_changes_when_its_body_changes(tmp_path: Path):
+    module_path = tmp_path / "module_under_edit.py"
+    script_path = tmp_path / "script.py"
+    with script_path.open("w") as f:
+        f.write(
+            dedent(
+                f"""
+    import sys
+    sys.path.insert(0, {str(tmp_path)!r})
+    from datasets.fingerprint import Hasher
+    import module_under_edit
+    print(Hasher.hash(module_under_edit.func))
+    """
+            )
+        )
+
+    def hash_with_body(body: str) -> bytes:
+        with module_path.open("w") as f:
+            f.write(
+                dedent(f"""
+    def func(example):
+        return {body}
+    """)
+            )
+        return subprocess.check_output(["python", "-B", str(script_path)])
+
+    assert hash_with_body("example[:4]") != hash_with_body("example[:2]")
+
+
+def test_hash_of_installed_module_function_stays_by_reference():
+    from datasets.utils._dill import _is_installed_module, dumps
+
+    assert _is_installed_module("os") is True
+    assert _is_installed_module("dill") is True
+    # A built-in module has no `__file__` and holds no user-editable source.
+    assert _is_installed_module("sys") is True
+    # A by-reference dump carries the module and the qualified name, never the body,
+    # so the constant inside `os.path.join` is absent from it.
+    assert b"sep" not in dumps(os.path.join)
+
+
+def test_by_value_function_is_dumped_once_per_dump():
+    from datasets.utils._dill import _is_installed_module, dumps
+
+    # The test suite is not an installed package, so its functions are dumped by value.
+    assert _is_installed_module(_a_function_dumped_by_value.__module__) is False
+    once = dumps([_a_function_dumped_by_value])
+    twice = dumps([_a_function_dumped_by_value, _a_function_dumped_by_value])
+    # The second reference is memoized rather than dumped a second time, which is also
+    # what stops a function reachable from its own globals from being followed forever.
+    assert len(twice) < 2 * len(once)
 
 
 def test_fingerprint_in_multiprocessing():


### PR DESCRIPTION
`Hasher.hash` builds the `map()` fingerprint from `_dill.dumps`, and dill dumps a function it can import as a module-qualified name. For a mapping function imported from the user's own module the dump is 35 bytes of module and qualname with no code object in it, so editing the body leaves the fingerprint unchanged and `map()` reloads the previous run's data, with no warning. The same function defined in `__main__` is already dumped by value, body included.

`Pickler.save` already intercepts `FunctionType` to unwrap `torch.compile` wrappers. A function whose defining module lives outside the standard library and site-packages is now dumped by value there. That is the split you suggested on the issue in 2021: a module that only changes when its package is reinstalled stays by reference, source the user edits in place does not.

One consequence worth your call: fingerprints change for any `map()` that takes a function imported from a local module, so those caches are recomputed once after upgrading.

Verified:
- The new test in `tests/test_fingerprint.py` fails without the change. Reverting only the one-line call and keeping the new helpers still fails it, so it is pinned to the fix rather than to the rest of the diff.
- End to end on an on-disk dataset, editing the imported function returns the stale rows on main and the correct rows here.
- `tests/test_fingerprint.py` 26 passed, `tests/test_py_utils.py` 72 passed, `tests/test_arrow_dataset.py -k map` 50 passed, and both `check_code_quality` steps, on Python 3.10.

I have not measured the hashing cost for a function with very large globals. An editable install counts as local source, so its functions are dumped by value too.

Fixes #3297
