### PR TITLE
Publish extraction caches atomically so concurrent jobs never read partial output

### DIFF
--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -1,10 +1,12 @@
 import bz2
 import gzip
+import hashlib
 import lzma
 import os
 import shutil
 import struct
 import tarfile
+import tempfile
 import warnings
 import zipfile
 from abc import ABC, abstractmethod
@@ -39,18 +41,17 @@ class ExtractManager:
         abs_path = os.path.abspath(path)
         return os.path.join(self.extract_dir, hash_url_to_filename(abs_path))
 
-    def _do_extract(self, output_path: str, force_extract: bool) -> bool:
-        return force_extract or (
-            not os.path.isfile(output_path) and not (os.path.isdir(output_path) and os.listdir(output_path))
-        )
-
     def extract(self, input_path: str, force_extract: bool = False) -> str:
+        """Return the extracted cache path, reusing it unless ``force_extract=True``.
+
+        Complete final outputs can be reused without writing to the cache directory.
+        Extraction and publication use a lock. Unrecognized formats are returned unchanged.
+        """
         extractor_format = self.extractor.infer_extractor_format(input_path)
         if not extractor_format:
             return input_path
         output_path = self._get_output_path(input_path)
-        if self._do_extract(output_path, force_extract):
-            self.extractor.extract(input_path, output_path, extractor_format)
+        self.extractor.extract(input_path, output_path, extractor_format, force_extract=force_extract)
         return output_path
 
 
@@ -450,13 +451,84 @@ class Extractor:
         input_path: Union[Path, str],
         output_path: Union[Path, str],
         extractor_format: str,
+        force_extract: bool = True,
     ) -> None:
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        """Extract into a staging path and publish the completed output under a lock.
+
+        Direct callers rebuild by default for backward compatibility. Pass
+        ``force_extract=False`` to reuse a final cached file or nonempty directory,
+        as :class:`ExtractManager` does by default. Failed extractions leave only
+        staging data and preserve any previously published output.
+
+        Temporary siblings use the reserved prefix ``.tmp-extract-<sha256>-``, where
+        the digest identifies the normalized output basename, followed by tempfile's
+        random component. Only this output's temporary namespace is cleaned under its
+        lock; arbitrary ``.old`` and ``.incomplete`` siblings are never touched.
+
+        Replacing directories requires renaming the old output aside first, including
+        on Windows. The final path is briefly absent between renames; readers of a
+        previously returned path do not hold the extraction lock during this interval.
+        """
+
+        def remove_path(path):
+            if os.path.islink(path) or os.path.isfile(path):
+                os.unlink(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+
+        def is_cached():
+            try:
+                return os.path.isfile(output_path) or (os.path.isdir(output_path) and os.listdir(output_path))
+            except (FileNotFoundError, NotADirectoryError):
+                # A forced rebuild may rename the final output during this check.
+                return False
+
+        output_path = Path(os.fspath(output_path))
+        # Resolve parent symlinks before collapsing "..", without following a final
+        # symlink that publication should replace rather than extract through.
+        output_path = os.path.normpath(os.path.join(os.path.realpath(output_path.parent), output_path.name))
+        # Atomic publication makes a final cache hit safe without opening a writable lock.
+        if not force_extract and is_cached():
+            return
+        output_dir = os.path.dirname(output_path) or "."
+        os.makedirs(output_dir, exist_ok=True)
         # Prevent parallel extractions
         lock_path = str(Path(output_path).with_suffix(".lock"))
         with FileLock(lock_path):
-            if os.path.islink(output_path):
-                os.unlink(output_path)
-            shutil.rmtree(output_path, ignore_errors=True)
+            # Only the final path is a cache hit: partial extractions are never published.
+            if not force_extract and is_cached():
+                return
+            output_id = hashlib.sha256(os.fsencode(os.path.normcase(os.path.basename(output_path)))).hexdigest()
+            tmp_prefix = f".tmp-extract-{output_id}-"
+            try:
+                temporary_names = os.listdir(output_dir)
+            except PermissionError:
+                # A writable/searchable parent need not be readable. Fresh unique
+                # staging is still safe; defer garbage collection in that case.
+                temporary_names = []
+            for name in temporary_names:
+                if name.startswith(tmp_prefix):
+                    remove_path(os.path.join(output_dir, name))
+
+            def temporary_path():
+                path = tempfile.mkdtemp(prefix=tmp_prefix, dir=output_dir)
+                # Remove only our empty reservation so either a file or directory can
+                # take its place, with the extractor's usual permissions. The lock
+                # protects this output's temporary namespace until publication.
+                os.rmdir(path)
+                return path
+
+            incomplete_path = temporary_path()
             extractor = cls.extractors[extractor_format]
-            return extractor.extract(input_path, output_path)
+            extractor.extract(input_path, incomplete_path)
+
+            # Retire directories before deleting them so an interrupted removal
+            # cannot leave a partial final cache. Also handle file/directory changes.
+            old_path = None
+            if os.path.isdir(output_path) or (os.path.isdir(incomplete_path) and os.path.lexists(output_path)):
+                old_path = temporary_path()
+                os.replace(output_path, old_path)
+            # Staging is on the same filesystem; never fall back to copying in place.
+            os.replace(incomplete_path, output_path)
+            if old_path is not None:
+                remove_path(old_path)

--- a/src/datasets/utils/extract.py
+++ b/src/datasets/utils/extract.py
@@ -483,17 +483,18 @@ class Extractor:
                 # A forced rebuild may rename the final output during this check.
                 return False
 
-        output_path = Path(os.fspath(output_path))
-        # Resolve parent symlinks before collapsing "..", without following a final
-        # symlink that publication should replace rather than extract through.
-        output_path = os.path.normpath(os.path.join(os.path.realpath(output_path.parent), output_path.name))
+        # Strip trailing separators without resolving symlinks or collapsing "..":
+        # the OS must resolve the output and its temporary siblings the same way.
+        drive, tail = os.path.splitdrive(os.fspath(output_path))
+        output_path = drive + (tail.rstrip(os.sep + (os.altsep or "")) or tail)
         # Atomic publication makes a final cache hit safe without opening a writable lock.
         if not force_extract and is_cached():
             return
         output_dir = os.path.dirname(output_path) or "."
         os.makedirs(output_dir, exist_ok=True)
-        # Prevent parallel extractions
-        lock_path = str(Path(output_path).with_suffix(".lock"))
+        # Canonicalize only the lock filename so aliases share a lock before
+        # FileLock applies abspath. Output and temporary paths stay uncollapsed.
+        lock_path = os.path.realpath(str(Path(output_path).with_suffix(".lock")))
         with FileLock(lock_path):
             # Only the final path is a cache hit: partial extractions are never published.
             if not force_extract and is_cached():
@@ -512,6 +513,9 @@ class Extractor:
 
             def temporary_path():
                 path = tempfile.mkdtemp(prefix=tmp_prefix, dir=output_dir)
+                # mkdtemp may return an abspath that collapses "..". Keep the
+                # allocated basename in the caller's uncollapsed parent instead.
+                path = os.path.join(output_dir, os.path.basename(path))
                 # Remove only our empty reservation so either a file or directory can
                 # take its place, with the extractor's usual permissions. The lock
                 # protects this output's temporary namespace until publication.

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -8,6 +8,7 @@ from threading import Event
 from unittest.mock import patch
 
 import pytest
+from filelock import Timeout
 
 from datasets.utils._filelock import FileLock
 from datasets.utils.extract import (
@@ -113,24 +114,98 @@ def test_extractor_output_path(tmp_path, monkeypatch, two_member_zip, path_type)
         assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
 
 
-def test_extractor_output_with_symlink_parent(tmp_path, gz_file, text_file):
+@pytest.mark.parametrize(
+    "compression_format, parent_type", [("gzip", "symlink"), ("gzip", "directory"), ("zip", "directory")]
+)
+@pytest.mark.parametrize("path_type", ["pathlib", "relative", "trailing_separator"])
+def test_extractor_output_with_dot_dot_parent(
+    tmp_path, monkeypatch, two_member_zip, gz_file, text_file_content, compression_format, parent_type, path_type
+):
+    input_path = two_member_zip if compression_format == "zip" else gz_file
+    target = tmp_path / "real" / "child"
+    target.mkdir(parents=True)
+    alias = tmp_path / "alias"
+    if parent_type == "symlink":
+        alias.symlink_to(target, target_is_directory=True)
+    else:
+        alias.mkdir()
+    output_path = alias / ".." / "output"
+    # POSIX follows the symlink before ".."; ordinary Windows paths collapse
+    # "alias/.." lexically. A real directory has the lexical result on both.
+    if parent_type == "symlink" and os.name != "nt":
+        expected_path = target.parent / "output"
+        unrelated_path = tmp_path / "output"
+    else:
+        expected_path = tmp_path / "output"
+        unrelated_path = target.parent / "output"
+    unrelated_path.write_text("unrelated user data")
+
+    # The base extractor writes directly to the caller's path, as upstream did.
+    Extractor.extractors[compression_format].extract(input_path, output_path)
+    assert output_path.samefile(expected_path)
+    assert unrelated_path.read_text() == "unrelated user data"
+    if compression_format == "zip":
+        shutil.rmtree(output_path)
+    else:
+        output_path.unlink()
+
+    if path_type == "relative":
+        monkeypatch.chdir(tmp_path)
+        argument = os.path.join("alias", "..", "output")
+    elif path_type == "trailing_separator":
+        argument = str(output_path) + os.sep * 2
+    else:
+        argument = output_path
+    # Exercise initial staging and publication, then retirement and replacement.
+    for _ in range(2):
+        Extractor.extract(input_path, argument, compression_format)
+        assert output_path.samefile(expected_path)
+        if compression_format == "zip":
+            assert {p.name: p.read_text() for p in expected_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+        else:
+            assert expected_path.read_bytes() == text_file_content.encode("utf-8")
+        assert unrelated_path.read_text() == "unrelated user data"
+        assert not list(expected_path.parent.glob(".tmp-extract-*"))
+
+
+def test_extractor_output_aliases_share_lock(tmp_path, monkeypatch, gz_file, text_file_content):
     target = tmp_path / "real" / "child"
     target.mkdir(parents=True)
     alias = tmp_path / "alias"
     alias.symlink_to(target, target_is_directory=True)
     output_path = alias / ".." / "output"
-    unrelated_path = tmp_path / "output"
-    unrelated_path.write_text("unrelated user data")
+    expected_path = (tmp_path if os.name == "nt" else target.parent) / "output"
+    original_extract = GzipExtractor.extract
+    calls = []
 
+    def extract(input_path, staging_path):
+        calls.append(staging_path)
+        assert len(calls) == 1, "another caller entered the active extraction's temporary namespace"
+        Path(staging_path).write_bytes(b"partial data")
+        # A second spelling of the same destination must contend on the real lock
+        # before cleanup can remove the first caller's active staging file.
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            second = pool.submit(Extractor.extract, input_path, expected_path, "gzip", force_extract=False)
+            with pytest.raises(Timeout):
+                second.result(timeout=60)
+        assert Path(staging_path).read_bytes() == b"partial data"
+        original_extract(input_path, staging_path)
+
+    def file_lock(path):
+        lock = FileLock(path)
+        lock.timeout = 0
+        return lock
+
+    monkeypatch.setattr("datasets.utils.extract.FileLock", file_lock)
+    monkeypatch.setattr(GzipExtractor, "extract", staticmethod(extract))
     Extractor.extract(gz_file, output_path, "gzip")
-
-    assert unrelated_path.read_text() == "unrelated user data"
-    assert output_path.read_bytes() == text_file.read_bytes()
+    assert output_path.samefile(expected_path)
+    assert expected_path.read_bytes() == text_file_content.encode("utf-8")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="requires POSIX directory permissions")
 @pytest.mark.parametrize("compression_format", ["zip", "gzip"])
-def test_extractor_unlistable_output_parent(tmp_path, two_member_zip, gz_file, text_file, compression_format):
+def test_extractor_unlistable_output_parent(tmp_path, two_member_zip, gz_file, text_file_content, compression_format):
     input_path = two_member_zip if compression_format == "zip" else gz_file
     output_dir = tmp_path / "unlistable"
     output_dir.mkdir()
@@ -144,13 +219,13 @@ def test_extractor_unlistable_output_parent(tmp_path, two_member_zip, gz_file, t
         if compression_format == "zip":
             assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
         else:
-            assert output_path.read_bytes() == text_file.read_bytes()
+            assert output_path.read_bytes() == text_file_content.encode("utf-8")
     finally:
         output_dir.chmod(original_mode)
 
 
 @pytest.mark.parametrize("compression_format", ["zip", "gzip"])
-def test_extractor_long_output_basename(tmp_path, two_member_zip, gz_file, text_file, compression_format):
+def test_extractor_long_output_basename(tmp_path, two_member_zip, gz_file, text_file_content, compression_format):
     input_path = two_member_zip if compression_format == "zip" else gz_file
     output_path = tmp_path / ("x" * 250)
     for _ in range(2):
@@ -158,7 +233,7 @@ def test_extractor_long_output_basename(tmp_path, two_member_zip, gz_file, text_
         if compression_format == "zip":
             assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
         else:
-            assert output_path.read_bytes() == text_file.read_bytes()
+            assert output_path.read_bytes() == text_file_content.encode("utf-8")
 
 
 def test_extract_manager_concurrent_cache_reuse(tmp_path, monkeypatch, two_member_zip):
@@ -294,7 +369,7 @@ def _extract_and_crash(input_path, output_path, compression_format, staging_path
 
 
 @pytest.mark.parametrize("compression_format", ["zip", "gzip"])
-def test_extract_manager_discards_incomplete(tmp_path, compression_format, two_member_zip, gz_file, text_file):
+def test_extract_manager_discards_incomplete(tmp_path, compression_format, two_member_zip, gz_file, text_file_content):
     input_path = str(two_member_zip if compression_format == "zip" else gz_file)
     manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
     output_path = Path(manager._get_output_path(input_path))
@@ -328,14 +403,14 @@ def test_extract_manager_discards_incomplete(tmp_path, compression_format, two_m
     if compression_format == "zip":
         assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
     else:
-        assert output_path.read_bytes() == text_file.read_bytes()
+        assert output_path.read_bytes() == text_file_content.encode("utf-8")
     assert not incomplete_path.exists()
 
 
 @pytest.mark.parametrize("compression_format", ["zip", "gzip"])
 @pytest.mark.parametrize("force_extract", [False, True])
 def test_extract_manager_interrupted_extraction(
-    tmp_path, monkeypatch, two_member_zip, gz_file, text_file, compression_format, force_extract
+    tmp_path, monkeypatch, two_member_zip, gz_file, text_file_content, compression_format, force_extract
 ):
     input_path = str(two_member_zip if compression_format == "zip" else gz_file)
     manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
@@ -360,7 +435,7 @@ def test_extract_manager_interrupted_extraction(
         if compression_format == "zip":
             assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
         else:
-            assert output_path.read_bytes() == text_file.read_bytes()
+            assert output_path.read_bytes() == text_file_content.encode("utf-8")
     else:
         assert not output_path.exists(), "failed extraction left a partial final cache"
 
@@ -368,7 +443,7 @@ def test_extract_manager_interrupted_extraction(
     if compression_format == "zip":
         assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
     else:
-        assert output_path.read_bytes() == text_file.read_bytes()
+        assert output_path.read_bytes() == text_file_content.encode("utf-8")
 
 
 @pytest.mark.parametrize("compression_format", ["zip", "gzip"])

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,9 +1,18 @@
 import os
+import shutil
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import get_context
+from pathlib import Path
+from threading import Event
+from unittest.mock import patch
 
 import pytest
 
+from datasets.utils._filelock import FileLock
 from datasets.utils.extract import (
     Bzip2Extractor,
+    ExtractManager,
     Extractor,
     GzipExtractor,
     Lz4Extractor,
@@ -15,6 +24,402 @@ from datasets.utils.extract import (
 )
 
 from .utils import require_lz4, require_py7zr, require_zstandard
+
+
+@pytest.fixture
+def two_member_zip(tmp_path):
+    archive = tmp_path / "input.zip"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("a.txt", "first")
+        zip_file.writestr("b.txt", "second")
+    return archive
+
+
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+@pytest.mark.parametrize("sibling_type", ["file", "directory", "symlink"])
+def test_extractor_preserves_unrelated_siblings(tmp_path, two_member_zip, gz_file, compression_format, sibling_type):
+    input_path = two_member_zip if compression_format == "zip" else gz_file
+    output_path = tmp_path / "output"
+    unrelated_file = tmp_path / "unrelated.txt"
+    unrelated_file.write_text("unrelated user data")
+    siblings = [tmp_path / "output.old", tmp_path / "output.incomplete"]
+    for sibling in siblings:
+        if sibling_type == "directory":
+            sibling.mkdir()
+            (sibling / "data.txt").write_text("unrelated user data")
+        elif sibling_type == "symlink":
+            sibling.symlink_to(unrelated_file)
+        else:
+            sibling.write_text("unrelated user data")
+
+    # Exercise both initial publication and retirement of an existing output.
+    for _ in range(2):
+        Extractor.extract(input_path, output_path, compression_format)
+        for sibling in siblings:
+            assert sibling.exists(), "deleted an unrelated sibling"
+            if sibling_type == "directory":
+                assert (sibling / "data.txt").read_text() == "unrelated user data"
+            else:
+                assert sibling.read_text() == "unrelated user data"
+                assert sibling.is_symlink() == (sibling_type == "symlink")
+        assert unrelated_file.read_text() == "unrelated user data"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX directory and file permissions")
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+@pytest.mark.parametrize("readonly_target", ["directory", "lock"])
+def test_extract_manager_readonly_cache(tmp_path, two_member_zip, gz_file, compression_format, readonly_target):
+    input_path = str(two_member_zip if compression_format == "zip" else gz_file)
+    manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    output_path = Path(manager.extract(input_path))
+    lock_path = output_path.with_suffix(".lock")
+    lock_path.unlink(missing_ok=True)
+    if readonly_target == "directory":
+        readonly_path = output_path.parent
+        mode = 0o555
+    else:
+        lock_path.write_text("unheld lock")
+        readonly_path = lock_path
+        mode = 0o444
+    original_mode = readonly_path.stat().st_mode
+    readonly_path.chmod(mode)
+    try:
+        if os.access(readonly_path, os.W_OK):
+            pytest.skip("requires a user that cannot write chmod-protected paths")
+        assert manager.extract(input_path) == str(output_path)
+        Extractor.extract(input_path, output_path, compression_format, force_extract=False)
+        if compression_format == "zip":
+            assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+        else:
+            assert output_path.stat().st_size > 0
+        with pytest.raises(PermissionError):
+            manager.extract(input_path, force_extract=True)
+    finally:
+        readonly_path.chmod(original_mode)
+
+
+@pytest.mark.parametrize("path_type", ["trailing_separator", "pathlib", "relative"])
+def test_extractor_output_path(tmp_path, monkeypatch, two_member_zip, path_type):
+    output_path = tmp_path / "output"
+    if path_type == "trailing_separator":
+        argument = str(output_path) + os.sep
+    elif path_type == "relative":
+        monkeypatch.chdir(tmp_path)
+        argument = "output"
+    else:
+        argument = output_path
+    for _ in range(2):
+        Extractor.extract(two_member_zip, argument, "zip")
+        assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+
+
+def test_extractor_output_with_symlink_parent(tmp_path, gz_file, text_file):
+    target = tmp_path / "real" / "child"
+    target.mkdir(parents=True)
+    alias = tmp_path / "alias"
+    alias.symlink_to(target, target_is_directory=True)
+    output_path = alias / ".." / "output"
+    unrelated_path = tmp_path / "output"
+    unrelated_path.write_text("unrelated user data")
+
+    Extractor.extract(gz_file, output_path, "gzip")
+
+    assert unrelated_path.read_text() == "unrelated user data"
+    assert output_path.read_bytes() == text_file.read_bytes()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX directory permissions")
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+def test_extractor_unlistable_output_parent(tmp_path, two_member_zip, gz_file, text_file, compression_format):
+    input_path = two_member_zip if compression_format == "zip" else gz_file
+    output_dir = tmp_path / "unlistable"
+    output_dir.mkdir()
+    original_mode = output_dir.stat().st_mode
+    output_dir.chmod(0o333)
+    output_path = output_dir / "output"
+    try:
+        if os.access(output_dir, os.R_OK):
+            pytest.skip("requires a user that cannot read chmod-protected directories")
+        Extractor.extract(input_path, output_path, compression_format)
+        if compression_format == "zip":
+            assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+        else:
+            assert output_path.read_bytes() == text_file.read_bytes()
+    finally:
+        output_dir.chmod(original_mode)
+
+
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+def test_extractor_long_output_basename(tmp_path, two_member_zip, gz_file, text_file, compression_format):
+    input_path = two_member_zip if compression_format == "zip" else gz_file
+    output_path = tmp_path / ("x" * 250)
+    for _ in range(2):
+        Extractor.extract(input_path, output_path, compression_format)
+        if compression_format == "zip":
+            assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+        else:
+            assert output_path.read_bytes() == text_file.read_bytes()
+
+
+def test_extract_manager_concurrent_cache_reuse(tmp_path, monkeypatch, two_member_zip):
+    archive = two_member_zip
+
+    first_member_extracted = Event()
+    release_extraction = Event()
+    second_observed = Event()
+    extraction_calls = []
+    original_acquire = FileLock.acquire
+
+    def acquire(self, *args, **kwargs):
+        if first_member_extracted.is_set():
+            second_observed.set()
+        return original_acquire(self, *args, **kwargs)
+
+    def extract(input_path, output_path):
+        extraction_calls.append(input_path)
+        with zipfile.ZipFile(input_path) as zip_file:
+            zip_file.extract("a.txt", output_path)
+            first_member_extracted.set()
+            assert release_extraction.wait(60), "timed out waiting to finish extraction"
+            zip_file.extract("b.txt", output_path)
+
+    monkeypatch.setattr(FileLock, "acquire", acquire)
+    monkeypatch.setattr(ZipExtractor, "extract", staticmethod(extract))
+    first_manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    second_manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(first_manager.extract, str(archive))
+        try:
+            assert first_member_extracted.wait(60), "first extraction did not start"
+            second = pool.submit(second_manager.extract, str(archive))
+            # Observe either the second caller trying to acquire the lock, or
+            # returning early from the cache check without acquiring it.
+            second.add_done_callback(lambda future: second_observed.set())
+            assert second_observed.wait(60), "second extraction did not start"
+            assert not second.done(), "returned an incomplete extraction cache"
+            assert not Path(first_manager._get_output_path(str(archive))).exists()
+        finally:
+            release_extraction.set()
+        output_path = first.result(timeout=60)
+        assert second.result(timeout=60) == output_path
+
+    assert (Path(output_path) / "a.txt").read_text() == "first"
+    assert (Path(output_path) / "b.txt").read_text() == "second"
+    assert extraction_calls == [str(archive)]
+
+
+def _extract_in_process(
+    archive, cache_dir, first_member_extracted, release_extraction, second_observed, calls, results
+):
+    original_acquire = FileLock.acquire
+
+    def acquire(self, *args, **kwargs):
+        if first_member_extracted.is_set():
+            second_observed.set()
+        return original_acquire(self, *args, **kwargs)
+
+    def extract(input_path, output_path):
+        with calls.get_lock():
+            calls.value += 1
+        with zipfile.ZipFile(input_path) as zip_file:
+            zip_file.extract("a.txt", output_path)
+            first_member_extracted.set()
+            assert release_extraction.wait(60), "timed out waiting to finish extraction"
+            zip_file.extract("b.txt", output_path)
+
+    with patch.object(FileLock, "acquire", acquire), patch.object(ZipExtractor, "extract", staticmethod(extract)):
+        output_path = ExtractManager(cache_dir=cache_dir).extract(archive)
+        second_observed.set()  # Also observe a premature cache hit without a lock.
+        results.put((output_path, {p.name: p.read_text() for p in Path(output_path).iterdir()}))
+
+
+def test_extract_manager_concurrent_processes(tmp_path, two_member_zip):
+    # Spawn also exercises independent imports and works on Windows.
+    context = get_context("spawn")
+    first_member_extracted = context.Event()
+    release_extraction = context.Event()
+    second_observed = context.Event()
+    calls = context.Value("i", 0)
+    results = context.Queue()
+    cache_dir = str(tmp_path / "cache")
+    args = (
+        str(two_member_zip),
+        cache_dir,
+        first_member_extracted,
+        release_extraction,
+        second_observed,
+        calls,
+        results,
+    )
+    processes = [context.Process(target=_extract_in_process, args=args) for _ in range(2)]
+    output_path = ExtractManager(cache_dir=cache_dir)._get_output_path(str(two_member_zip))
+    try:
+        processes[0].start()
+        assert first_member_extracted.wait(60), "first extraction did not start"
+        processes[1].start()
+        assert second_observed.wait(60), "second extraction did not start"
+        assert not Path(output_path).exists(), "partial extraction was published"
+        release_extraction.set()
+        expected = (output_path, {"a.txt": "first", "b.txt": "second"})
+        assert results.get(timeout=60) == expected
+        assert results.get(timeout=60) == expected
+        for process in processes:
+            process.join(timeout=60)
+            assert process.exitcode == 0
+        assert calls.value == 1
+    finally:
+        release_extraction.set()
+        for process in processes:
+            if process.pid is not None:
+                if process.is_alive():
+                    process.terminate()
+                process.join(timeout=60)
+        results.close()
+        results.join_thread()
+
+
+def _extract_and_crash(input_path, output_path, compression_format, staging_path):
+    def extract(input_path, output_path):
+        if compression_format == "zip":
+            Path(output_path).mkdir(exist_ok=True)
+            (Path(output_path) / "stale.txt").write_text("left over from a crashed extraction")
+        else:
+            Path(output_path).write_text("partial data")
+        staging_path.send(str(output_path))
+        staging_path.close()
+        os._exit(17)  # Skip Python cleanup and release the file lock by exiting.
+
+    with patch.object(Extractor.extractors[compression_format], "extract", staticmethod(extract)):
+        Extractor.extract(input_path, output_path, compression_format)
+
+
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+def test_extract_manager_discards_incomplete(tmp_path, compression_format, two_member_zip, gz_file, text_file):
+    input_path = str(two_member_zip if compression_format == "zip" else gz_file)
+    manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    output_path = Path(manager._get_output_path(input_path))
+    context = get_context("spawn")
+    receive_path, send_path = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_extract_and_crash, args=(input_path, str(output_path), compression_format, send_path)
+    )
+    try:
+        process.start()
+        send_path.close()
+        assert receive_path.poll(60), "extraction did not start"
+        incomplete_path = Path(receive_path.recv())
+        process.join(timeout=60)
+        assert process.exitcode == 17
+    finally:
+        if process.pid is not None:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=60)
+        receive_path.close()
+        send_path.close()
+    assert incomplete_path.exists()
+    assert not output_path.exists(), "crashed extraction published partial data"
+
+    # Cleanup for a different output in the same parent must leave this staging alone.
+    Extractor.extract(input_path, output_path.parent / "other-output", compression_format)
+    assert incomplete_path.exists()
+
+    assert manager.extract(input_path) == str(output_path)
+    if compression_format == "zip":
+        assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+    else:
+        assert output_path.read_bytes() == text_file.read_bytes()
+    assert not incomplete_path.exists()
+
+
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+@pytest.mark.parametrize("force_extract", [False, True])
+def test_extract_manager_interrupted_extraction(
+    tmp_path, monkeypatch, two_member_zip, gz_file, text_file, compression_format, force_extract
+):
+    input_path = str(two_member_zip if compression_format == "zip" else gz_file)
+    manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    output_path = Path(manager._get_output_path(input_path))
+    if force_extract:
+        manager.extract(input_path)
+
+    def extract_then_fail(input_path, output_path):
+        if compression_format == "zip":
+            with zipfile.ZipFile(input_path) as zip_file:
+                zip_file.extract("a.txt", output_path)
+        else:
+            Path(output_path).write_bytes(b"partial data")
+        raise RuntimeError("interrupted extraction")
+
+    with monkeypatch.context() as patch_extractor:
+        patch_extractor.setattr(Extractor.extractors[compression_format], "extract", staticmethod(extract_then_fail))
+        with pytest.raises(RuntimeError, match="interrupted extraction"):
+            manager.extract(input_path, force_extract=force_extract)
+
+    if force_extract:
+        if compression_format == "zip":
+            assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+        else:
+            assert output_path.read_bytes() == text_file.read_bytes()
+    else:
+        assert not output_path.exists(), "failed extraction left a partial final cache"
+
+    assert manager.extract(input_path) == str(output_path)
+    if compression_format == "zip":
+        assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+    else:
+        assert output_path.read_bytes() == text_file.read_bytes()
+
+
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+def test_extractor_force_extract_default(tmp_path, compression_format, zip_file, gz_file):
+    input_path = {"zip": zip_file, "gzip": gz_file}[compression_format]
+    output_path = tmp_path / "extracted"
+    Extractor.extract(input_path, output_path, compression_format)
+    extracted_file = next(output_path.iterdir()) if output_path.is_dir() else output_path
+    original = extracted_file.read_bytes()
+    extracted_file.write_bytes(b"changed")
+
+    Extractor.extract(input_path, output_path, compression_format, force_extract=False)
+    assert extracted_file.read_bytes() == b"changed"
+    Extractor.extract(input_path, output_path, compression_format)
+    assert extracted_file.read_bytes() == original
+
+
+def test_extract_manager_interrupted_cache_removal(tmp_path, monkeypatch, two_member_zip):
+    manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    output_path = Path(manager.extract(str(two_member_zip)))
+
+    def remove_then_fail(path, *args, **kwargs):
+        (Path(path) / "b.txt").unlink()
+        raise RuntimeError("interrupted cache removal")
+
+    with monkeypatch.context() as patch_removal:
+        patch_removal.setattr(shutil, "rmtree", remove_then_fail)
+        with pytest.raises(RuntimeError, match="interrupted cache removal"):
+            manager.extract(str(two_member_zip), force_extract=True)
+
+    # Retire the old directory before deleting it so an interrupted deletion
+    # cannot leave a partial directory at the final cache path either.
+    if output_path.exists():
+        assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+    assert manager.extract(str(two_member_zip)) == str(output_path)
+    assert {p.name: p.read_text() for p in output_path.iterdir()} == {"a.txt": "first", "b.txt": "second"}
+
+
+@pytest.mark.parametrize("compression_format", ["zip", "gzip"])
+def test_extract_manager_force_extract(tmp_path, compression_format, zip_file, gz_file):
+    input_path = {"zip": zip_file, "gzip": gz_file}[compression_format]
+    manager = ExtractManager(cache_dir=str(tmp_path / "cache"))
+    output_path = Path(manager.extract(input_path))
+    extracted_file = next(output_path.iterdir()) if output_path.is_dir() else output_path
+    original = extracted_file.read_bytes()
+    extracted_file.write_bytes(b"changed")
+
+    assert manager.extract(input_path) == str(output_path)
+    assert extracted_file.read_bytes() == b"changed"
+    assert manager.extract(input_path, force_extract=True) == str(output_path)
+    assert extracted_file.read_bytes() == original
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #4661

## Root cause

`ExtractManager.extract` decided "already extracted" (output file exists, or output directory non-empty) **before** `Extractor.extract` took the per-output `FileLock`, and the extractor wrote straight into the final path. With two jobs sharing a cache directory, job B saw job A's half-written directory as a complete cache and read a member that was not there yet (the `FileNotFoundError` in the issue). The same in-place write meant a crashed or killed extraction left a partial directory that every later call accepted as a valid cache.

## Fix

- Extract into a unique temporary sibling and publish with `os.replace` under the existing lock. An existing output is first retired to another temporary sibling so directories can be replaced atomically on Windows as well, then removed after publication. A failure mid-extraction can only leave a temporary sibling behind, never a partial final path, and never destroys a previously good cache.
- Because publication is atomic, a complete final path can be trusted without the lock: the cache check runs first (no write access needed, so read-only caches keep working), and the lock is taken only when extraction is needed, with the check repeated under it.
- Temporary names use a fixed prefix, a digest of the output basename and tempfile's random part: they cannot collide with caller-owned siblings, do not grow with the output name (no `ENAMETOOLONG`), and are the only names this code ever removes. Output paths are normalized so a trailing separator or a `pathlib.Path` behaves like the plain string.
- `Extractor.extract(..., force_extract=True)` keeps its "always rebuild" behaviour for direct callers; `ExtractManager` passes `force_extract=False`.

## Tests

`tests/test_extract.py`: two threads and two processes extracting the same archive into one cache directory both get the complete output; a leftover temporary sibling is discarded and re-extracted; a crash mid-extraction leaves the final path absent and the next call extracts fully; a previously published output survives a failed re-extraction; read-only complete caches are reused; trailing separator, `pathlib.Path`, long basenames and unrelated `.old`/`.incomplete` siblings are preserved; file-vs-directory transitions across all six formats. 47 passed locally.